### PR TITLE
feat: Allow to specify grace period for pod GC

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,8 +93,10 @@ type Config struct {
 	PodSpecLogStrategy PodSpecLogStrategy `json:"podSpecLogStrategy,omitempty"`
 
 	// PodGCGracePeriodSeconds specifies the duration in seconds before the pods in the GC queue get deleted.
-	// Value must be non-negative integer. Defaults to zero, which indicates delete immediately.
-	PodGCGracePeriodSeconds int64 `json:"podGCGracePeriodSeconds,omitempty"`
+	// Value must be non-negative integer. A zero value indicates that the pods will be deleted immediately
+	// as soon as they arrived in the pod GC queue.
+	// Defaults to 30 seconds.
+	PodGCGracePeriodSeconds *int64 `json:"podGCGracePeriodSeconds,omitempty"`
 
 	// WorkflowRestrictions restricts the controller to executing Workflows that meet certain restrictions
 	WorkflowRestrictions *WorkflowRestrictions `json:"workflowRestrictions,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,10 @@ type Config struct {
 	// PodSpecLogStrategy enables the logging of podspec on controller log.
 	PodSpecLogStrategy PodSpecLogStrategy `json:"podSpecLogStrategy,omitempty"`
 
+	// PodGCGracePeriodSeconds specifies the duration in seconds before the pods in the GC queue get deleted.
+	// Value must be non-negative integer. Defaults to zero, which indicates delete immediately.
+	PodGCGracePeriodSeconds int64 `json:"podGCGracePeriodSeconds,omitempty"`
+
 	// WorkflowRestrictions restricts the controller to executing Workflows that meet certain restrictions
 	WorkflowRestrictions *WorkflowRestrictions `json:"workflowRestrictions,omitempty"`
 

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -788,6 +788,7 @@ type Artifact struct {
 type PodGC struct {
 	// Strategy is the strategy to use. One of "OnPodCompletion", "OnPodSuccess", "OnWorkflowCompletion", "OnWorkflowSuccess"
 	Strategy PodGCStrategy `json:"strategy,omitempty" protobuf:"bytes,1,opt,name=strategy,casttype=PodGCStrategy"`
+	GracePeriodSeconds *int64 `json:"gracePeriodSeconds,omitempty" protobuf:"bytes,2,opt,name=gracePeriodSeconds"`
 }
 
 // VolumeClaimGC describes how to delete volumes from completed Workflows

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -788,7 +788,6 @@ type Artifact struct {
 type PodGC struct {
 	// Strategy is the strategy to use. One of "OnPodCompletion", "OnPodSuccess", "OnWorkflowCompletion", "OnWorkflowSuccess"
 	Strategy PodGCStrategy `json:"strategy,omitempty" protobuf:"bytes,1,opt,name=strategy,casttype=PodGCStrategy"`
-	GracePeriodSeconds *int64 `json:"gracePeriodSeconds,omitempty" protobuf:"bytes,2,opt,name=gracePeriodSeconds"`
 }
 
 // VolumeClaimGC describes how to delete volumes from completed Workflows

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/argoproj/argo-workflows/v3/util/env"
 
 	"github.com/argoproj/pkg/errors"
@@ -443,7 +441,7 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 			propagation := metav1.DeletePropagationBackground
 			err := pods.Delete(ctx, podName, metav1.DeleteOptions{
 				PropagationPolicy:  &propagation,
-				GracePeriodSeconds: pointer.Int64Ptr(wfc.Config.PodGCGracePeriodSeconds)})
+				GracePeriodSeconds: wfc.Config.PodGCGracePeriodSeconds})
 			if err != nil && !apierr.IsNotFound(err) {
 				return err
 			}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -439,7 +439,7 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 			}
 		case deletePod:
 			propagation := metav1.DeletePropagationBackground
-			err := pods.Delete(ctx, podName, metav1.DeleteOptions{PropagationPolicy: &propagation})
+			err := pods.Delete(ctx, podName, metav1.DeleteOptions{PropagationPolicy: &propagation, GracePeriodSeconds: })
 			if err != nil && !apierr.IsNotFound(err) {
 				return err
 			}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/argoproj/argo-workflows/v3/util/env"
 
 	"github.com/argoproj/pkg/errors"
@@ -439,7 +441,9 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 			}
 		case deletePod:
 			propagation := metav1.DeletePropagationBackground
-			err := pods.Delete(ctx, podName, metav1.DeleteOptions{PropagationPolicy: &propagation, GracePeriodSeconds: })
+			err := pods.Delete(ctx, podName, metav1.DeleteOptions{
+				PropagationPolicy:  &propagation,
+				GracePeriodSeconds: pointer.Int64Ptr(wfc.Config.PodGCGracePeriodSeconds)})
 			if err != nil && !apierr.IsNotFound(err) {
 				return err
 			}


### PR DESCRIPTION
Use case: we need some grace period to allow other services to complete the pod information collection (e.g. log and db persistence), especially during high load where those services have certain amount of delays.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
