### PR TITLE
fix: Use React state to avoid new page load in Workflow view

### DIFF
--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -41,7 +41,7 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
     const queryParams = new URLSearchParams(location.search);
 
     const [namespace] = useState(match.params.namespace);
-    const [name] = useState(match.params.name);
+    const [name, setName] = useState(match.params.name);
     const [tab, setTab] = useState(queryParams.get('tab') || 'workflow');
     const [nodeId, setNodeId] = useState(queryParams.get('nodeId'));
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel'));
@@ -81,8 +81,7 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
                                         if (workflowOperation.title === 'DELETE') {
                                             navigation.goto(uiUrl(`workflows/${workflow.metadata.namespace}`));
                                         } else {
-                                            // navigation.goto does not seem to work here
-                                            document.location.href = uiUrl(`workflows/${wf.metadata.namespace}/${wf.metadata.name}`);
+                                            setName(wf.metadata.name);
                                         }
                                     })
                                     .catch(setError);


### PR DESCRIPTION
When using `document.location.href = ...` we cause a new page to be loaded. This takes resources and flashes a white blank page to the user, which is bad UX.

By using the page's existing React state infrastructure, we can avoid this page load.

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
