### PR TITLE
feat: Allow to specify the max number of requeues of pods in GC queue

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -16,6 +16,7 @@ Note that these environment variables may be removed at any time.
 | `LEADER_ELECTION_IDENTITY` | `string` | The ID used for workflow controllers to elect a leader. |
 | `MAX_OPERATION_TIME` | `time.Duration` | The maximum time a workflow operation is allowed to run for before requeuing the workflow onto the work queue. |
 | `OFFLOAD_NODE_STATUS_TTL` | `time.Duration` | The TTL to delete the offloaded node status. Currently only used for testing. |
+| `POD_GC_TRANSIENT_ERROR_MAX_REQUEUES` | `int` | The maximum number of requeues of pods in the GC queue when encountering transient errors. |
 | `RECENTLY_STARTED_POD_DURATION` | `time.Duration` | The duration of a pod before the pod is considered to be recently started. |
 | `RETRY_BACKOFF_DURATION` | `time.Duration` | The retry backoff duration when retrying API calls. |
 | `RETRY_BACKOFF_FACTOR` | `float` | The retry backoff factor when retrying API calls. |

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -450,7 +450,8 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 	}()
 	if err != nil {
 		logCtx.WithError(err).Warn("failed to clean-up pod")
-		if errorsutil.IsTransientErr(err) {
+		podGCMaxRequeues := env.LookupEnvIntOr("POD_GC_TRANSIENT_ERROR_MAX_REQUEUES", 2)
+		if errorsutil.IsTransientErr(err) && wfc.podCleanupQueue.NumRequeues(key) > podGCMaxRequeues {
 			wfc.podCleanupQueue.AddRateLimited(key)
 		}
 	}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -451,7 +451,7 @@ func (wfc *WorkflowController) processNextPodCleanupItem(ctx context.Context) bo
 	if err != nil {
 		logCtx.WithError(err).Warn("failed to clean-up pod")
 		podGCMaxRequeues := env.LookupEnvIntOr("POD_GC_TRANSIENT_ERROR_MAX_REQUEUES", 2)
-		if errorsutil.IsTransientErr(err) && wfc.podCleanupQueue.NumRequeues(key) > podGCMaxRequeues {
+		if errorsutil.IsTransientErr(err) && wfc.podCleanupQueue.NumRequeues(key) < podGCMaxRequeues {
 			wfc.podCleanupQueue.AddRateLimited(key)
 		}
 	}


### PR DESCRIPTION
One issue we've been observing is that due to nature of our clusters (e.g. under custom pod eviction rules), some of the pods in GC queue cannot be deleted successfully and those pods get re-queued again and again due to constant failures, which results in a huge pile of pods in the GC queue that cannot be deleted unless by admins. This causes significant delays for the deletion of other pods in the queue.

This PR adds an environment variable that controls the maximum number of requeues.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
