### PR TITLE
feat: Build dev-* branches as engineering builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
       - v*
     branches:
       - master
+      - dev-*
 
 defaults:
   run:


### PR DESCRIPTION
Need an engineering or dev build? Push your branch to `origin` with a `dev-` prefix and GitHub will build it for you!

You will need write access to repo for this.

```
git push origin dev-feature
```
