### PR TITLE
build: Fix path to golangci-lint binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,7 @@ lint: server/static/files.go $(GOPATH)/bin/golangci-lint
 	# Tidy Go modules
 	go mod tidy
 	# Lint Go files
-	golangci-lint run --fix --verbose --concurrency 4 --timeout 5m
+	$(GOPATH)/bin/golangci-lint run --fix --verbose --concurrency 4 --timeout 5m
 	# Lint UI files
 ifeq ($(STATIC_FILES),true)
 	yarn --cwd ui lint


### PR DESCRIPTION
This wasn't an issue earlier and only came up recently when using a different version of golangci-lint since https://github.com/argoproj/argo-workflows/pull/5072 requires a newer version for various linters.

cc @alexec 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
