### PR TITLE
fix: parse username from git url when using SSH key auth

### DIFF
--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -34,13 +34,13 @@ var _ common.ArtifactDriver = &ArtifactDriver{}
 
 var sshURLRegex = regexp.MustCompile("^(ssh://)?([^/:]*?)@[^@]+$")
 
-func GetUser(url string) (string, bool) {
+func GetUser(url string) string {
 	matches := sshURLRegex.FindStringSubmatch(url)
 	if len(matches) > 2 {
-		return matches[2], true
+		return matches[2]
 	}
 	// default to `git` user unless username is specified in SSH url
-	return "git", false
+	return "git"
 }
 
 func (g *ArtifactDriver) auth(sshUser string) (func(), transport.AuthMethod, []string, error) {
@@ -112,7 +112,7 @@ func (g *ArtifactDriver) Save(string, *wfv1.Artifact) error {
 }
 
 func (g *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) error {
-	sshUser, _ := GetUser(path)
+	sshUser := GetUser(path)
 	closer, auth, env, err := g.auth(sshUser)
 	if err != nil {
 		return err

--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -32,9 +32,7 @@ type ArtifactDriver struct {
 
 var _ common.ArtifactDriver = &ArtifactDriver{}
 
-var (
-	sshURLRegex = regexp.MustCompile("^(ssh://)?([^/:]*?)@[^@]+$")
-)
+var sshURLRegex = regexp.MustCompile("^(ssh://)?([^/:]*?)@[^@]+$")
 
 func GetUser(url string) (string, bool) {
 	matches := sshURLRegex.FindStringSubmatch(url)

--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -112,7 +112,7 @@ func (g *ArtifactDriver) Save(string, *wfv1.Artifact) error {
 }
 
 func (g *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) error {
-	sshUser, _ := GetUser(repoURL)
+	sshUser, _ := GetUser(path)
 	closer, auth, env, err := g.auth(sshUser)
 	if err != nil {
 		return err

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -98,3 +98,19 @@ func TestGitArtifactDriverLoad_SSL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUser(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		url  string
+		user bool
+	}{
+		{"Username in SSH url", "gitaly@github.com:argoproj/argo-workflows.git", "gitaly"},
+		{"Default username", "https://github.com/argoproj/argo-workflows.git", "git"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sshUser, _ := GetUser(tt.url)
+			assert.Equal(sshUser, tt.user)
+		})
+	}
+}

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -103,14 +103,14 @@ func TestGetUser(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		url  string
-		user bool
+		user string
 	}{
 		{"Username in SSH url", "gitaly@github.com:argoproj/argo-workflows.git", "gitaly"},
 		{"Default username", "https://github.com/argoproj/argo-workflows.git", "git"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			sshUser, _ := GetUser(tt.url)
-			assert.Equal(sshUser, tt.user)
+			assert.Equal(t, sshUser, tt.user)
 		})
 	}
 }

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -109,7 +109,7 @@ func TestGetUser(t *testing.T) {
 		{"Default username", "https://github.com/argoproj/argo-workflows.git", "git"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			sshUser, _ := GetUser(tt.url)
+			sshUser := GetUser(tt.url)
 			assert.Equal(t, sshUser, tt.user)
 		})
 	}


### PR DESCRIPTION
Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

#5147
 
<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
