### PR TITLE
fix: Specify where in YAML validation error occurred

### DIFF
--- a/examples/validator.go
+++ b/examples/validator.go
@@ -64,7 +64,7 @@ func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[s
 		if !result.Valid() {
 			errorDescriptions := []string{}
 			for _, err := range result.Errors() {
-				errorDescriptions = append(errorDescriptions, err.Description())
+				errorDescriptions = append(errorDescriptions, fmt.Sprintf("%s in %s", err.Description(), err.Context().String()))
 			}
 			failed[path] = errorDescriptions
 		}

--- a/examples/validator.go
+++ b/examples/validator.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Before (unhelpful):

```
        Validation failed - data-transformations.yaml: Must validate one and only one schema (oneOf)
        key is required
```

After (helpful):

```
        Validation failed - data-transformations.yaml: Must validate one and only one schema (oneOf) in (root)
        key is required in (root).spec.templates.1.data.source.artifactPaths.s3
```