### PR TITLE
docs: Add missing -r to correct expectation for k8s-jobs.yaml example

### DIFF
--- a/examples/k8s-jobs.yaml
+++ b/examples/k8s-jobs.yaml
@@ -49,7 +49,7 @@ spec:
         valueFrom:
           jsonPath: '{.metadata.name}'
       # job-obj is extracted using a jq filter and is equivalent to:
-      # `kubectl get job <jobname> -o json | jq -c '.'
+      # `kubectl get job <jobname> -o json | jq -rc '.'
       # which returns the entire job object in json format
       - name: job-obj
         valueFrom:


### PR DESCRIPTION
The current implementation [uses `-r` in addition to `-c`](https://github.com/argoproj/argo-workflows/blob/8af359547d8b192a0527b77c3afebd27e8a74b2d/workflow/executor/resource.go#L363) to output raw strings instead of JSON text so we should correct the comment in this example to avoid confusion.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
