### PR TITLE
docs: workflow-controller-configmap.md entry about argo-server.

### DIFF
--- a/docs/workflow-controller-configmap.md
+++ b/docs/workflow-controller-configmap.md
@@ -9,7 +9,7 @@ For a detailed example, please see [`workflow-controller-configmap.yaml`](./work
 ## Setting the Configmap
 
 The configmap should be saved as a K8s Configmap on the cluster in the same namespace as the `workflow-controller`.
-It should then be referenced by the `workflow-controller` as an command argument:
+It should then be referenced by the `workflow-controller` and `argo-server` as a command argument:
 
 ```yaml
 apiVersion: apps/v1
@@ -39,6 +39,47 @@ spec:
       serviceAccountName: argo
       nodeSelector:
               kubernetes.io/os: linux
+```
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-server
+spec:
+  selector:
+    matchLabels:
+      app: argo-server
+  template:
+    metadata:
+      labels:
+        app: argo-server
+    spec:
+      containers:
+      - args:
+        - server
+        - --configmap
+        - workflow-controller-configmap   # Set configmap name here
+        image: argoproj/argocli:latest
+        name: argo-server
+        ports:
+        - containerPort: 2746
+          name: web
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 2746
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 20
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+      nodeSelector:
+        kubernetes.io/os: linux
 ```
 
 ## Alternate Structure


### PR DESCRIPTION
If you create your own configmap for workflow-controller you have to also specify it to argo-server.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
