### PR TITLE
docs: Document the new OnTransientError retry policy

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -811,7 +811,7 @@ spec:
 ```
 
 * `limit` is the maximum number of times the container will be retried.
-* `retryPolicy` specifies if a container will be retried on failure, error, or both. "Always" retries on both errors and failures. Also available: "OnFailure" (default), "OnError"
+* `retryPolicy` specifies if a container will be retried on failure, error, both, or only transient errors (e.g. i/o or TLS handshake timeout). "Always" retries on both errors and failures. Also available: "OnFailure" (default), "OnError", and "OnTransientError" (available after v3.0.0-rc2).
 * `backoff` is an exponential backoff
 * `nodeAntiAffinity` prevents running steps on the same host.  Current implementation allows only empty `nodeAntiAffinity` (i.e. `nodeAntiAffinity: {}`) and by default it uses label `kubernetes.io/hostname` as the selector.
 

--- a/examples/retry-on-error.yaml
+++ b/examples/retry-on-error.yaml
@@ -9,7 +9,7 @@ spec:
   - name: error-container
     retryStrategy:
       limit: "2"
-      retryPolicy: "Always"   # Retry on errors AND failures. Also available: "OnFailure" (default), "OnError"
+      retryPolicy: "Always"   # Retry on errors AND failures. Also available: "OnFailure" (default), "OnError", and "OnTransientError" (retry only on transient errors such as i/o or TLS handshake timeout. Available after v3.0.0-rc2)
     container:
       image: python
       command: ["python", "-c"]


### PR DESCRIPTION
Document the new retry policy introduced in https://github.com/argoproj/argo-workflows/pull/4999. This was brought up in https://github.com/argoproj/argo-workflows/issues/4493#issuecomment-785614925. 

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
