### PR TITLE
feat: Retry creating wftmpl that references another wftmpl in the same operation

### DIFF
--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -3,6 +3,8 @@ package template
 import (
 	"log"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/argoproj/pkg/json"
 	"github.com/spf13/cobra"
@@ -38,6 +40,17 @@ func NewCreateCommand() *cobra.Command {
 	return command
 }
 
+var templateErrorRegex *regexp.Regexp = nil
+
+// Compiling regex is expensive, only compile this once if we need it
+func getTemplateErrorRegex() *regexp.Regexp {
+	if templateErrorRegex != nil {
+		return templateErrorRegex
+	}
+	templateErrorRegex = regexp.MustCompile(`template reference (.+?) not found`)
+	return templateErrorRegex
+}
+
 func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 	if cliOpts == nil {
 		cliOpts = &cliCreateOpts{}
@@ -61,7 +74,47 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 		os.Exit(1)
 	}
 
+	var retryWorkflowTemplates []wfv1.WorkflowTemplate
+
+main:
 	for _, wftmpl := range workflowTemplates {
+		if wftmpl.Namespace == "" {
+			wftmpl.Namespace = client.Namespace()
+		}
+		created, err := serviceClient.CreateWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateCreateRequest{
+			Namespace: wftmpl.Namespace,
+			Template:  &wftmpl,
+		})
+
+		if err != nil {
+
+			// If we are trying to create a template that references another template that is about to be created with this
+			// operation (but has not been created yet), that template will fail with a "reference not found" error. If
+			// a template returns that error, we check to see if the reference is indeed about to be created in this operation.
+			// If it is, we add this template to a list and then retry to create it once all templates have had a chance
+			// to be created.
+			re := getTemplateErrorRegex()
+			// Check if the error received matches a "reference not found" error.
+			if referenceNotFoundErrorMatch := re.FindStringSubmatch(err.Error()); len(referenceNotFoundErrorMatch) > 0 {
+				reference := referenceNotFoundErrorMatch[1]
+				// Check if the template referenced is indeed in this operation
+				for _, w := range workflowTemplates {
+					if strings.HasPrefix(reference, w.Name) || strings.HasSuffix(reference, w.GenerateName) {
+						// Add this template to the list of references to retry
+						retryWorkflowTemplates = append(retryWorkflowTemplates, w)
+						continue main
+					}
+				}
+			}
+
+			log.Fatalf("Failed to create workflow template: %v", err)
+		}
+		printWorkflowTemplate(created, cliOpts.output)
+	}
+
+	// Retry the workflow templates that were not created due to "reference not found" error (see above). This will usually
+	// be empty and not run.
+	for _, wftmpl := range retryWorkflowTemplates {
 		if wftmpl.Namespace == "" {
 			wftmpl.Namespace = client.Namespace()
 		}


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo-workflows/issues/5173

Looking for feedback for this solution. If feedback is good, then I will move to clean the code, add it to other similar areas (e.g. `ClusterWorkflowTemplates`), and add test.

I initially considered doing topographical sorting on all the workflow templates before attempting to create this. However, that gets a bit messy (have to consider, for example, all steps of all templates of all WorkflowTemplates to look for references). Also, since I expect this use case to come up infrequently, I prefer a "lazy" approach where we only engage this code if we need to.