### PR TITLE
fix: Do not display pagination warning when there is no pagination

### DIFF
--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -23,7 +23,7 @@ export class PaginationPanel extends React.Component<{pagination: Pagination; on
                     }>
                     Next page <i className='fa fa-chevron-right' />
                 </button>
-                {this.props.pagination.limit <= this.props.numRecords ? (
+                {this.props.pagination.limit > 0 && this.props.pagination.limit <= this.props.numRecords ? (
                     <>
                         <WarningIcon /> Workflows cannot be globally sorted when paginated
                     </>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/614838/109238723-e9668600-7788-11eb-9cc7-fad4e3f3452b.png)

After:
![image](https://user-images.githubusercontent.com/614838/109238730-eff4fd80-7788-11eb-904b-3bfa6fcc890a.png)
