### PR TITLE
fix(controller): Take labels change into account in SignificantPodChange()

### DIFF
--- a/workflow/controller/pod/significant.go
+++ b/workflow/controller/pod/significant.go
@@ -13,13 +13,14 @@ func SignificantPodChange(from *apiv1.Pod, to *apiv1.Pod) bool {
 		from.Status.Message != to.Status.Message ||
 		from.Status.PodIP != to.Status.PodIP ||
 		from.GetDeletionTimestamp() != to.GetDeletionTimestamp() ||
-		significantAnnotationChange(from.Annotations, to.Annotations) ||
+		significantMetadataChange(from.Annotations, to.Annotations) ||
+		significantMetadataChange(from.Labels, to.Labels) ||
 		significantContainerStatusesChange(from.Status.ContainerStatuses, to.Status.ContainerStatuses) ||
 		significantContainerStatusesChange(from.Status.InitContainerStatuses, to.Status.InitContainerStatuses) ||
 		significantConditionsChange(from.Status.Conditions, to.Status.Conditions)
 }
 
-func significantAnnotationChange(from map[string]string, to map[string]string) bool {
+func significantMetadataChange(from map[string]string, to map[string]string) bool {
 	if len(from) != len(to) {
 		return true
 	}

--- a/workflow/controller/pod/significant_test.go
+++ b/workflow/controller/pod/significant_test.go
@@ -27,6 +27,11 @@ func Test_SgnificantPodChange(t *testing.T) {
 		assert.True(t, SignificantPodChange(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}}}, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"foo": "baz"}}}), "changed annotation")
 		assert.True(t, SignificantPodChange(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}}}, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}), "deleted annotation")
 	})
+	t.Run("Labels", func(t *testing.T) {
+		assert.True(t, SignificantPodChange(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}}), "new label")
+		assert.True(t, SignificantPodChange(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}}, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "baz"}}}), "changed label")
+		assert.True(t, SignificantPodChange(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}}, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}), "deleted label")
+	})
 	t.Run("Spec", func(t *testing.T) {
 		assert.True(t, SignificantPodChange(&corev1.Pod{}, &corev1.Pod{Spec: corev1.PodSpec{NodeName: "from"}}), "Node name change")
 	})


### PR DESCRIPTION
For pod GC strategy with label selector as implemented in https://github.com/argoproj/argo-workflows/pull/5090, the completed pods may not be added to `woc.completedPods` when the completed pods do not match with the given label selector during pod reconciliation. 

For example, depending on the infra setup, the completed pods might be only marked with certain labels after we've done collecting all the meta information from those completed pods, which means we would miss that earlier pod reconciliation. Once we miss that earlier pod reconciliation loop, there aren't other changes besides the additional labels so `SignificantPodChange()` always returns `false`. 

This PR makes sure that we take the labels change into account. We cannot use `ALL_POD_CHANGES_SIGNIFICANT` because that would hurt the performance of the overall pod reconciliation. 

cc @alexec WDYT?

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
