### PR TITLE
fix: Fix swapped artifact repository key and ref in error message

### DIFF
--- a/workflow/artifactrepositories/artifactrepositories.go
+++ b/workflow/artifactrepositories/artifactrepositories.go
@@ -87,7 +87,7 @@ func (s *artifactRepositories) get(ctx context.Context, ref *wfv1.ArtifactReposi
 	key := ref.GetKeyOr(cm.Annotations["workflows.argoproj.io/default-artifact-repository"])
 	value, ok := cm.Data[key]
 	if !ok {
-		return nil, nil, fmt.Errorf(`config map missing key %s for artifact repository ref "%v"`, ref, key)
+		return nil, nil, fmt.Errorf(`config map missing key "%s" for artifact repository ref "%v"`, key, ref)
 	}
 	repo := &config.ArtifactRepository{}
 	// we need the fully filled out ref so we can store it in the workflow status and it will never change


### PR DESCRIPTION
Key and ref are incorrectly swapped. Also added quotes around key so the error message is easier to read.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
