### PR TITLE
feat: Improve OSS artifact driver usability when load/save directories 

### DIFF
--- a/workflow/artifacts/oss/oss.go
+++ b/workflow/artifacts/oss/oss.go
@@ -51,9 +51,11 @@ func (ossDriver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string)
 			if origErr == nil {
 				return true, nil
 			}
-			if origErr.(oss.ServiceError).Code != "NoSuchKey" {
-				log.Warnf("Failed to get file: %v", origErr)
-				return false, nil
+			if ossErr, ok := origErr.(oss.ServiceError); ok {
+				if ossErr.Code != "NoSuchKey" {
+					log.Warnf("Failed to get file: %v", origErr)
+					return false, nil
+				}
 			}
 			// If we get here, the error was a NoSuchKey. The key might be a directory.
 			// There is only one method in OSS for downloading objects that does not differentiate between a file

--- a/workflow/artifacts/oss/oss.go
+++ b/workflow/artifacts/oss/oss.go
@@ -2,9 +2,11 @@ package oss
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/argoproj/pkg/file"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -45,7 +47,18 @@ func (ossDriver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string)
 				return false, err
 			}
 			objectName := inputArtifact.OSS.Key
-			err = bucket.GetObjectToFile(objectName, path)
+			origErr := bucket.GetObjectToFile(objectName, path)
+			if origErr == nil {
+				return true, nil
+			}
+			if origErr.(oss.ServiceError).Code != "NoSuchKey" {
+				log.Warnf("Failed to get file: %v", origErr)
+				return false, nil
+			}
+			// If we get here, the error was a NoSuchKey. The key might be a directory.
+			// There is only one method in OSS for downloading objects that does not differentiate between a file
+			// and a directory so we append the a trailing slash here to differentiate that prior to downloading.
+			err = bucket.GetObjectToFile(objectName+"/", path)
 			if err != nil {
 				return false, err
 			}
@@ -82,6 +95,16 @@ func (ossDriver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact
 				return false, err
 			}
 			objectName := outputArtifact.OSS.Key
+			isDir, err := file.IsDirectory(path)
+			if err != nil {
+				log.Warnf("Failed to test if %s is a directory: %v", path, err)
+				return false, nil
+			}
+			// There is only one method in OSS for uploading objects that does not differentiate between a file and a directory
+			// so we append the a trailing slash here to differentiate that prior to uploading.
+			if isDir && !strings.HasSuffix(objectName, "/") {
+				objectName += "/"
+			}
 			err = bucket.PutObjectFromFile(objectName, path)
 			if err != nil {
 				return false, err


### PR DESCRIPTION
Currently if we miss a trailing slash in the OSS key when the object is a directory, we'll get `oss: service returned error: StatusCode=404, ErrorCode=NoSuchKey, ErrorMessage="The specified key does not exist"`, which is pretty misleading and takes a while for new users to debug. 

Note that I am following the existing retry mechanism. Even though it's not ideal but it's consistent with existing behavior. The retry mechanism and error catalog will probably be improved separately in https://github.com/argoproj/argo-workflows/issues/5220. 

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
