### PR TITLE
fix(controller): Backward compatible workflowTemplateRef from 2.11.x to  2.12.x

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3187,7 +3187,10 @@ func (woc *wfOperationCtx) setStoredWfSpec() error {
 	if wfDefault == nil {
 		wfDefault = &wfv1.Workflow{}
 	}
-	if woc.wf.Status.StoredWorkflowSpec == nil {
+	// woc.wf.Status.StoredWorkflowSpec.Entrypoint == "" check is mainly to support  backward compatible with 2.11.x workflow to 2.12.x
+	// Need to recalculate StoredWorkflowSpec in 2.12.x format.
+	// This check can be removed once all user migrated from 2.11.x to 2.12.x
+	if woc.wf.Status.StoredWorkflowSpec == nil || woc.wf.Status.StoredWorkflowSpec.Entrypoint == "" {
 		wftHolder, err := woc.fetchWorkflowSpec()
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Saravanan Balasubramanian <sarabala1979@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
fixes #5292