### PR TITLE
fix: Allow setting workflow input parameters in UI. Fixes #4234

### DIFF
--- a/ui/src/app/cluster-workflow-templates/components/cluster-workflow-template-details/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/components/cluster-workflow-template-details/cluster-workflow-template-details.tsx
@@ -130,6 +130,7 @@ export const ClusterWorkflowTemplateDetails = ({history, location, match}: Route
                         name={template.metadata.name}
                         entrypoint={template.spec.entrypoint}
                         templates={template.spec.templates || []}
+                        workflowParameters={template.spec.arguments.parameters || []}
                     />
                 </SlidingPanel>
             )}

--- a/ui/src/app/cluster-workflow-templates/components/cluster-workflow-template-details/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/components/cluster-workflow-template-details/cluster-workflow-template-details.tsx
@@ -129,8 +129,7 @@ export const ClusterWorkflowTemplateDetails = ({history, location, match}: Route
                         namespace={namespace}
                         name={template.metadata.name}
                         entrypoint={template.spec.entrypoint}
-                        entrypoints={(template.spec.templates || []).map(t => t.name)}
-                        parameters={template.spec.arguments.parameters || []}
+                        templates={template.spec.templates || []}
                     />
                 </SlidingPanel>
             )}

--- a/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
@@ -128,6 +128,7 @@ export const WorkflowTemplateDetails = ({history, location, match}: RouteCompone
                             name={name}
                             entrypoint={template.spec.entrypoint}
                             templates={template.spec.templates || []}
+                            workflowParameters={template.spec.arguments.parameters || []}
                         />
                     )}
                     {sidePanel === 'share' && <WidgetGallery namespace={namespace} label={'workflows.argoproj.io/workflow-template=' + name} />}

--- a/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
@@ -127,8 +127,7 @@ export const WorkflowTemplateDetails = ({history, location, match}: RouteCompone
                             namespace={namespace}
                             name={name}
                             entrypoint={template.spec.entrypoint}
-                            entrypoints={(template.spec.templates || []).map(t => t.name)}
-                            parameters={template.spec.arguments.parameters || []}
+                            templates={template.spec.templates || []}
                         />
                     )}
                     {sidePanel === 'share' && <WidgetGallery namespace={namespace} label={'workflows.argoproj.io/workflow-template=' + name} />}

--- a/ui/src/app/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/submit-workflow-panel.tsx
@@ -13,6 +13,7 @@ interface Props {
     name: string;
     entrypoint: string;
     templates: Template[];
+    workflowParameters: Parameter[];
 }
 
 interface State {
@@ -25,15 +26,23 @@ interface State {
     error?: Error;
 }
 
+const workflowEntrypoint = '<default>';
+
 export class SubmitWorkflowPanel extends React.Component<Props, State> {
     constructor(props: any) {
         super(props);
+        const defaultTemplate: Template = {
+            name: workflowEntrypoint,
+            inputs: {
+                parameters: this.props.workflowParameters
+            }
+        };
         const state = {
-            entrypoint: this.props.entrypoint || (this.props.templates.length > 0 && this.props.templates[0].name),
+            entrypoint: workflowEntrypoint,
             entrypoints: this.props.templates.map(t => t.name),
-            selectedTemplate: this.props.templates.length > 0 && this.props.templates[0],
-            parameters: (this.props.templates.length > 0 && this.props.templates[0].inputs.parameters) || [],
-            templates: this.props.templates,
+            selectedTemplate: defaultTemplate,
+            parameters: this.props.workflowParameters || [],
+            templates: [defaultTemplate].concat(this.props.templates),
             labels: ['submit-from-ui=true']
         };
         this.state = state;
@@ -150,7 +159,7 @@ export class SubmitWorkflowPanel extends React.Component<Props, State> {
     private submit() {
         services.workflows
             .submit(this.props.kind, this.props.name, this.props.namespace, {
-                entryPoint: this.state.entrypoint,
+                entryPoint: this.state.entrypoint === workflowEntrypoint ? null : this.state.entrypoint,
                 parameters: this.state.parameters.map(p => p.name + '=' + p.value),
                 labels: this.state.labels.join(',')
             })

--- a/ui/src/app/workflows/components/workflow-creator.tsx
+++ b/ui/src/app/workflows/components/workflow-creator.tsx
@@ -90,8 +90,7 @@ export const WorkflowCreator = ({namespace, onCreate}: {namespace: string; onCre
                         namespace={workflowTemplate.metadata.namespace}
                         name={workflowTemplate.metadata.name}
                         entrypoint={workflowTemplate.spec.entrypoint}
-                        entrypoints={(workflowTemplate.spec.templates || []).map(t => t.name)}
-                        parameters={workflowTemplate.spec.arguments.parameters || []}
+                        templates={workflowTemplate.spec.templates || []}
                     />
                     <a onClick={() => setStage('full-editor')}>
                         Edit using full workflow options <i className='fa fa-caret-right' />

--- a/ui/src/app/workflows/components/workflow-creator.tsx
+++ b/ui/src/app/workflows/components/workflow-creator.tsx
@@ -91,6 +91,7 @@ export const WorkflowCreator = ({namespace, onCreate}: {namespace: string; onCre
                         name={workflowTemplate.metadata.name}
                         entrypoint={workflowTemplate.spec.entrypoint}
                         templates={workflowTemplate.spec.templates || []}
+                        workflowParameters={workflowTemplate.spec.arguments.parameters || []}
                     />
                     <a onClick={() => setStage('full-editor')}>
                         Edit using full workflow options <i className='fa fa-caret-right' />


### PR DESCRIPTION
Signed-off-by: Kenny Trytek <kenneth.g.trytek@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
I am committing on my own time.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->

Local testing showing this fix in action:

<details><summary>Using this WorkflowTemplate</summary>
<p>

```
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: whalesay-test
spec:
  entrypoint: whalesay-template
  arguments:
    parameters:
      - name: message
        value: hello
  templates:
    - name: whalesay-template
      inputs:
        parameters:
          - name: message-param-1
      container:
        image: argoproj/argosay:v2
        args: ["echo", "{{inputs.parameters.message-param-1}}"]
        imagePullPolicy: IfNotPresent
    - name: whalesay-template-two
      inputs:
        parameters:
          - name: message-two
      container:
        image: argoproj/argosay:v2
        args: ["echo", "{{inputs.parameters.message-two}}"]
        imagePullPolicy: IfNotPresent
```

</p>
</details>

![submit-wf-template](https://user-images.githubusercontent.com/6892590/110228852-1eca4c80-7eca-11eb-81a0-d2de53a24724.gif)
