### PR TITLE
fix: Only retry on transient errors for OSS artifact driver

### DIFF
--- a/workflow/artifacts/oss/oss_test.go
+++ b/workflow/artifacts/oss/oss_test.go
@@ -1,0 +1,24 @@
+package oss
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransientOSSErr(t *testing.T) {
+	for _, errCode := range ossTransientErrorCodes {
+		err := oss.ServiceError{Code: errCode}
+		assert.True(t, isTransientOSSErr(err))
+	}
+
+	err := oss.ServiceError{Code: "NonTransientErrorCode"}
+	assert.False(t, isTransientOSSErr(err))
+
+	nonOSSErr := errors.New("Non-OSS error")
+	assert.False(t, isTransientOSSErr(nonOSSErr))
+
+	assert.False(t, isTransientOSSErr(nil))
+}


### PR DESCRIPTION
This is related to https://github.com/argoproj/argo-workflows/issues/5220 but with a focus on OSS artifact driver.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
