### PR TITLE
fix: Disallow object names with more than 63 chars

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -108,6 +108,10 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 	var wfTmplRef *wfv1.TemplateRef
 	var err error
 
+	if len(wf.Name) > 63 {
+		return nil, fmt.Errorf("workflow name '%s' must not be more than 63 characters long (currently %d)", wf.Name, len(wf.Name))
+	}
+
 	entrypoint := wf.Spec.Entrypoint
 
 	hasWorkflowTemplateRef := wf.Spec.WorkflowTemplateRef != nil
@@ -232,6 +236,11 @@ func ValidateWorkflowTemplateRefFields(wfSpec wfv1.WorkflowSpec) error {
 
 // ValidateWorkflowTemplate accepts a workflow template and performs validation against it.
 func ValidateWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wftmpl *wfv1.WorkflowTemplate) (*wfv1.Conditions, error) {
+
+	if len(wftmpl.Name) > 63 {
+		return nil, fmt.Errorf("workflow template name '%s' must not be more than 63 characters long (currently %d)", wftmpl.Name, len(wftmpl.Name))
+	}
+
 	wf := &wfv1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
 			Labels:      wftmpl.ObjectMeta.Labels,
@@ -244,6 +253,11 @@ func ValidateWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNa
 
 // ValidateClusterWorkflowTemplate accepts a cluster workflow template and performs validation against it.
 func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cwftmpl *wfv1.ClusterWorkflowTemplate) (*wfv1.Conditions, error) {
+
+	if len(cwftmpl.Name) > 63 {
+		return nil, fmt.Errorf("cluster workflow template name '%s' must not be more than 63 characters long (currently %d)", cwftmpl.Name, len(cwftmpl.Name))
+	}
+
 	wf := &wfv1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
 			Labels:      cwftmpl.ObjectMeta.Labels,
@@ -256,6 +270,11 @@ func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTem
 
 // ValidateCronWorkflow validates a CronWorkflow
 func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cronWf *wfv1.CronWorkflow) error {
+
+	if len(cronWf.Name) > 63 {
+		return fmt.Errorf("cron workflow name '%s' must not be more than 63 characters long (currently %d)", cronWf.Name, len(cronWf.Name))
+	}
+
 	if _, err := cron.ParseStandard(cronWf.Spec.Schedule); err != nil {
 		return errors.Errorf(errors.CodeBadRequest, "cron schedule is malformed: %s", err)
 	}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -81,6 +81,7 @@ const (
 	anyItemMagicValue                    = "item.*"
 	anyWorkflowOutputParameterMagicValue = "workflow.outputs.parameters.*"
 	anyWorkflowOutputArtifactMagicValue  = "workflow.outputs.artifacts.*"
+	maxCharsInObjectName                 = 63
 )
 
 var placeholderGenerator = common.NewPlaceholderGenerator()
@@ -108,8 +109,8 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 	var wfTmplRef *wfv1.TemplateRef
 	var err error
 
-	if len(wf.Name) > 63 {
-		return nil, fmt.Errorf("workflow name '%s' must not be more than 63 characters long (currently %d)", wf.Name, len(wf.Name))
+	if len(wf.Name) > maxCharsInObjectName {
+		return nil, fmt.Errorf("workflow name %q must not be more than 63 characters long (currently %d)", wf.Name, len(wf.Name))
 	}
 
 	entrypoint := wf.Spec.Entrypoint
@@ -236,9 +237,8 @@ func ValidateWorkflowTemplateRefFields(wfSpec wfv1.WorkflowSpec) error {
 
 // ValidateWorkflowTemplate accepts a workflow template and performs validation against it.
 func ValidateWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wftmpl *wfv1.WorkflowTemplate) (*wfv1.Conditions, error) {
-
-	if len(wftmpl.Name) > 63 {
-		return nil, fmt.Errorf("workflow template name '%s' must not be more than 63 characters long (currently %d)", wftmpl.Name, len(wftmpl.Name))
+	if len(wftmpl.Name) > maxCharsInObjectName {
+		return nil, fmt.Errorf("workflow template name %q must not be more than 63 characters long (currently %d)", wftmpl.Name, len(wftmpl.Name))
 	}
 
 	wf := &wfv1.Workflow{
@@ -253,9 +253,8 @@ func ValidateWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNa
 
 // ValidateClusterWorkflowTemplate accepts a cluster workflow template and performs validation against it.
 func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cwftmpl *wfv1.ClusterWorkflowTemplate) (*wfv1.Conditions, error) {
-
-	if len(cwftmpl.Name) > 63 {
-		return nil, fmt.Errorf("cluster workflow template name '%s' must not be more than 63 characters long (currently %d)", cwftmpl.Name, len(cwftmpl.Name))
+	if len(cwftmpl.Name) > maxCharsInObjectName {
+		return nil, fmt.Errorf("cluster workflow template name %q must not be more than 63 characters long (currently %d)", cwftmpl.Name, len(cwftmpl.Name))
 	}
 
 	wf := &wfv1.Workflow{
@@ -270,9 +269,8 @@ func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTem
 
 // ValidateCronWorkflow validates a CronWorkflow
 func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cronWf *wfv1.CronWorkflow) error {
-
-	if len(cronWf.Name) > 63 {
-		return fmt.Errorf("cron workflow name '%s' must not be more than 63 characters long (currently %d)", cronWf.Name, len(cronWf.Name))
+	if len(cronWf.Name) > maxCharsInObjectName {
+		return fmt.Errorf("cron workflow name %q must not be more than 63 characters long (currently %d)", cronWf.Name, len(cronWf.Name))
 	}
 
 	if _, err := cron.ParseStandard(cronWf.Spec.Schedule); err != nil {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2687,17 +2687,17 @@ func TestValidActiveDeadlineSecondsArgoVariable(t *testing.T) {
 func TestMaxLengthName(t *testing.T) {
 	wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
-	assert.EqualError(t, err, "workflow name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+	assert.EqualError(t, err, "workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	wftmpl := &wfv1.WorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	_, err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl)
-	assert.EqualError(t, err, "workflow template name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+	assert.EqualError(t, err, "workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwftmpl := &wfv1.ClusterWorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	_, err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl)
-	assert.EqualError(t, err, "cluster workflow template name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+	assert.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	err = ValidateCronWorkflow(wftmplGetter, cwftmplGetter, cwf)
-	assert.EqualError(t, err, "cron workflow name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+	assert.EqualError(t, err, "cron workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 }

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2681,4 +2682,22 @@ spec:
 func TestValidActiveDeadlineSecondsArgoVariable(t *testing.T) {
 	err := validateWorkflowTemplate(validActiveDeadlineSecondsArgoVariable)
 	assert.NoError(t, err)
+}
+
+func TestMaxLengthName(t *testing.T) {
+	wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
+	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	assert.EqualError(t, err, "workflow name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+
+	wftmpl := &wfv1.WorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
+	_, err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl)
+	assert.EqualError(t, err, "workflow template name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+
+	cwftmpl := &wfv1.ClusterWorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
+	_, err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl)
+	assert.EqualError(t, err, "cluster workflow template name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
+
+	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
+	err = ValidateCronWorkflow(wftmplGetter, cwftmplGetter, cwf)
+	assert.EqualError(t, err, "cron workflow name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' must not be more than 63 characters long (currently 70)")
 }


### PR DESCRIPTION
Fixes: https://github.com/argoproj/argo-workflows/issues/5318

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
