### PR TITLE
fix(executor): Surface error when wait container fails to establish pod watch

### DIFF
--- a/util/logs/log-k8s-requests.go
+++ b/util/logs/log-k8s-requests.go
@@ -1,7 +1,6 @@
 package logs
 
 import (
-	"io/ioutil"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -17,16 +16,8 @@ type k8sLogRoundTripper struct {
 func (m k8sLogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	x, err := m.roundTripper.RoundTrip(r)
 	if x != nil {
-		statusCode := x.StatusCode
-		var response string
-		if responseBody := x.Body; (200 > statusCode || statusCode >= 300) && responseBody != nil {
-			bytes, err := ioutil.ReadAll(responseBody)
-			if err == nil {
-				response = string(bytes)
-			}
-		}
 		verb, kind := k8s.ParseRequest(r)
-		log.Infof("%s %s %d %s", verb, kind, statusCode, response)
+		log.Infof("%s %s %d", verb, kind, x.StatusCode)
 	}
 	return x, err
 }

--- a/util/logs/log-k8s-requests.go
+++ b/util/logs/log-k8s-requests.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"io/ioutil"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -16,8 +17,16 @@ type k8sLogRoundTripper struct {
 func (m k8sLogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	x, err := m.roundTripper.RoundTrip(r)
 	if x != nil {
+		statusCode := x.StatusCode
+		var response string
+		if responseBody := x.Body; (200 > statusCode || statusCode >= 300) && responseBody != nil {
+			bytes, err := ioutil.ReadAll(responseBody)
+			if err == nil {
+				response = string(bytes)
+			}
+		}
 		verb, kind := k8s.ParseRequest(r)
-		log.Infof("%s %s %d", verb, kind, x.StatusCode)
+		log.Infof("%s %s %d %s", verb, kind, statusCode, response)
 	}
 	return x, err
 }

--- a/workflow/executor/k8sapi/client.go
+++ b/workflow/executor/k8sapi/client.go
@@ -129,15 +129,7 @@ func (c *k8sAPIClient) until(ctx context.Context, f func(pod *corev1.Pod) bool) 
 					}
 					pod, ok := event.Object.(*corev1.Pod)
 					if !ok {
-						// If it's not a pod, try convert to status first
-						// and exit the loop if its status is failure.
-						status, ok := event.Object.(*metav1.Status)
-						if ok {
-							if status.Status == "Failure" {
-								return true, fmt.Errorf(status.Message)
-							}
-						}
-						return false, apierrors.FromObject(event.Object)
+						return true, apierrors.FromObject(event.Object)
 					}
 					done := f(pod)
 					if done {


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/5371. 

The log would look like the following instead of `"Watch pods 403"` after this change:
```
time="2021-03-11T22:49:01.704Z" level=info msg="Watch pods 403 {\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"pods \\\"resubmit-5dnvx-1087928915\\\" is forbidden: User \\\"system:serviceaccount:argo:default\\\" cannot watch resource \\\"pods\\\" in API group \\\"\\\" in the namespace \\\"argo\\\"\",\"reason\":\"Forbidden\",\"details\":{\"name\":\"resubmit-5dnvx-1087928915\",\"kind\":\"pods\"},\"code\":403}\n"
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
