### PR TITLE
fix(controller): Fixed wrong error message

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -363,13 +363,13 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	if woc.hasPodSpecPatch(tmpl) {
 		jsonstr, err := json.Marshal(pod.Spec)
 		if err != nil {
-			return nil, errors.Wrap(err, "", "Fail to marshal the Pod spec")
+			return nil, errors.Wrap(err, "", "Failed to marshal the Pod spec")
 		}
 
 		tmpl.PodSpecPatch, err = util.PodSpecPatchMerge(woc.wf, tmpl)
 
 		if err != nil {
-			return nil, errors.Wrap(err, "", "Fail to marshal the Pod spec")
+			return nil, errors.Wrap(err, "", "Failed to merge the workflow PodSpecPatch with the template PodSpecPatch due to invalid format")
 		}
 
 		// Final substitution for workflow level PodSpecPatch
@@ -379,7 +379,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 		}
 		tmpl, err := common.ProcessArgs(tmpl, &wfv1.Arguments{}, woc.globalParams, localParams, false)
 		if err != nil {
-			return nil, errors.Wrap(err, "", "Fail to substitute the PodSpecPatch variables")
+			return nil, errors.Wrap(err, "", "Failed to substitute the PodSpecPatch variables")
 		}
 
 		if err := json.Unmarshal([]byte(tmpl.PodSpecPatch), &apiv1.PodSpec{}); err != nil {


### PR DESCRIPTION
Signed-off-by: Peixuan Ding <dingpeixuan911@gmail.com>

When submitting a WF with an invalid PodSpecPatch:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: pod-spec-patch-
spec:
  entrypoint: whalesay
  templates:
  - name: whalesay
    podSpecPatch: '{"container"}'
    container:
      image: docker/whalesay:latest
      command: [cowsay]
      args: ["hello world"]
```

![Screen Shot 2021-03-12 at 11 11 11 PM](https://user-images.githubusercontent.com/1311594/111018693-3dc45500-8388-11eb-8cf1-c2c557e8ee76.png)


The error message incorrectly states `Fail to marshal the Pod spec`. I believe this is a mistake. This PR fixes it.

Also changed a bunch of `Fail to` to `Failed to` in order to be more consistent with other error messages.

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
