### PR TITLE
feat: Allow transient errors in StopWorkflow()

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -863,9 +863,23 @@ func IsWorkflowSuspended(wf *wfv1.Workflow) bool {
 
 // TerminateWorkflow terminates a workflow by setting its spec.shutdown to ShutdownStrategyTerminate
 func TerminateWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface, name string) error {
+	return patchShutdownStrategy(ctx, wfClient, name, wfv1.ShutdownStrategyTerminate)
+}
+
+// StopWorkflow terminates a workflow by setting its spec.shutdown to ShutdownStrategyStop
+// Or terminates a single resume step referenced by nodeFieldSelector
+func StopWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface, hydrator hydrator.Interface, name string, nodeFieldSelector string, message string) error {
+	if len(nodeFieldSelector) > 0 {
+		return updateSuspendedNode(ctx, wfClient, hydrator, name, nodeFieldSelector, SetOperationValues{Phase: wfv1.NodeFailed, Message: message})
+	}
+	return patchShutdownStrategy(ctx, wfClient, name, wfv1.ShutdownStrategyStop)
+}
+
+// patchShutdownStrategy patches the shutdown strategy to a workflow.
+func patchShutdownStrategy(ctx context.Context, wfClient v1alpha1.WorkflowInterface, name string, strategy wfv1.ShutdownStrategy) error {
 	patchObj := map[string]interface{}{
 		"spec": map[string]interface{}{
-			"shutdown": wfv1.ShutdownStrategyTerminate,
+			"shutdown": strategy,
 		},
 	}
 	var err error
@@ -881,37 +895,6 @@ func TerminateWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface,
 		return !errorsutil.IsTransientErr(err), err
 	})
 	return err
-}
-
-// StopWorkflow terminates a workflow by setting its spec.shutdown to ShutdownStrategyStop
-// Or terminates a single resume step referenced by nodeFieldSelector
-func StopWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface, hydrator hydrator.Interface, name string, nodeFieldSelector string, message string) error {
-	if len(nodeFieldSelector) > 0 {
-		return updateSuspendedNode(ctx, wfClient, hydrator, name, nodeFieldSelector, SetOperationValues{Phase: wfv1.NodeFailed, Message: message})
-	} else {
-		patchObj := map[string]interface{}{
-			"spec": map[string]interface{}{
-				"shutdown": wfv1.ShutdownStrategyStop,
-			},
-		}
-		var err error
-		patch, err := json.Marshal(patchObj)
-		if err != nil {
-			return errors.InternalWrapError(err)
-		}
-		for attempt := 0; attempt < 10; attempt++ {
-			_, err = wfClient.Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
-			if err != nil {
-				if !apierr.IsConflict(err) {
-					return err
-				}
-			} else {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		return err
-	}
 }
 
 func SetWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface, hydrator hydrator.Interface, name string, nodeFieldSelector string, values SetOperationValues) error {


### PR DESCRIPTION
Currently `StopWorkflow()` replies on a for loop and only resilient to `apierr.IsConflict` errors. This PR does a small refactoring and allows `StopWorkflow()` to account for other transient errors similar to `TerminateWorkflow`.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
