### PR TITLE
chore: K8s RoundTrip logger should be debug

### DIFF
--- a/util/logs/log-k8s-requests.go
+++ b/util/logs/log-k8s-requests.go
@@ -17,7 +17,7 @@ func (m k8sLogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	x, err := m.roundTripper.RoundTrip(r)
 	if x != nil {
 		verb, kind := k8s.ParseRequest(r)
-		log.Infof("%s %s %d", verb, kind, x.StatusCode)
+		log.Debugf("Made kubernetes request %s %s, response %d", verb, kind, x.StatusCode)
 	}
 	return x, err
 }


### PR DESCRIPTION
`Info` polutes the logs, particulalry with a "Renew/Got leases 200" every 5 seconds

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
