### PR TITLE
fix: Do not allow cron workflow names with more than 52 chars

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -82,6 +82,10 @@ const (
 	anyWorkflowOutputParameterMagicValue = "workflow.outputs.parameters.*"
 	anyWorkflowOutputArtifactMagicValue  = "workflow.outputs.artifacts.*"
 	maxCharsInObjectName                 = 63
+	// CronWorkflows have fewer max chars allowed in their name because when workflows are created from them, they
+	// are appended with the unix timestamp (`-1615836720`). This lower character allowance allows for that timestamp
+	// to still fit within the 63 character maximum.
+	maxCharsInCronWorkflowName           = 52
 )
 
 var placeholderGenerator = common.NewPlaceholderGenerator()
@@ -269,8 +273,12 @@ func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTem
 
 // ValidateCronWorkflow validates a CronWorkflow
 func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cronWf *wfv1.CronWorkflow) error {
-	if len(cronWf.Name) > maxCharsInObjectName {
-		return fmt.Errorf("cron workflow name %q must not be more than 63 characters long (currently %d)", cronWf.Name, len(cronWf.Name))
+
+	// CronWorkflows have fewer max chars allowed in their name because when workflows are created from them, they
+	// are appended with the unix timestamp (`-1615836720`). This lower character allowance allows for that timestamp
+	// to still fit within the 63 character maximum.
+	if len(cronWf.Name) > maxCharsInCronWorkflowName {
+		return fmt.Errorf("cron workflow name %q must not be more than 52 characters long (currently %d)", cronWf.Name, len(cronWf.Name))
 	}
 
 	if _, err := cron.ParseStandard(cronWf.Spec.Schedule); err != nil {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -85,7 +85,7 @@ const (
 	// CronWorkflows have fewer max chars allowed in their name because when workflows are created from them, they
 	// are appended with the unix timestamp (`-1615836720`). This lower character allowance allows for that timestamp
 	// to still fit within the 63 character maximum.
-	maxCharsInCronWorkflowName           = 52
+	maxCharsInCronWorkflowName = 52
 )
 
 var placeholderGenerator = common.NewPlaceholderGenerator()
@@ -273,7 +273,6 @@ func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTem
 
 // ValidateCronWorkflow validates a CronWorkflow
 func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cronWf *wfv1.CronWorkflow) error {
-
 	// CronWorkflows have fewer max chars allowed in their name because when workflows are created from them, they
 	// are appended with the unix timestamp (`-1615836720`). This lower character allowance allows for that timestamp
 	// to still fit within the 63 character maximum.

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2697,7 +2697,7 @@ func TestMaxLengthName(t *testing.T) {
 	_, err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl)
 	assert.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
-	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
+	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 60)}}
 	err = ValidateCronWorkflow(wftmplGetter, cwftmplGetter, cwf)
-	assert.EqualError(t, err, "cron workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
+	assert.EqualError(t, err, "cron workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 52 characters long (currently 60)")
 }


### PR DESCRIPTION
CronWorkflows have fewer max chars allowed in their name because when workflows are created from them, they are appended with the unix timestamp (`-1615836720`). This lower character allowance allows for that timestamp to still fit within the 63 character maximum.