### PR TITLE
fix(cli): Only append parse result when not nil to avoid panic

### DIFF
--- a/workflow/common/parse.go
+++ b/workflow/common/parse.go
@@ -46,7 +46,10 @@ func ParseObjects(body []byte, strict bool) []ParseResult {
 			continue
 		}
 		v, err := toWorkflowTypeYAML([]byte(text), un.GetKind(), strict)
-		res = append(res, ParseResult{v, err})
+		if v != nil {
+			// only append when this is a Kubernetes object
+			res = append(res, ParseResult{v, err})
+		}
 	}
 	return res
 }

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -12,24 +12,8 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
-// TestFindOverlappingVolume tests logic of TestFindOverlappingVolume
-func TestFindOverlappingVolume(t *testing.T) {
-	volMnt := corev1.VolumeMount{
-		Name:      "workdir",
-		MountPath: "/user-mount",
-	}
-	templateWithVolMount := &wfv1.Template{
-		Container: &corev1.Container{
-			VolumeMounts: []corev1.VolumeMount{volMnt},
-		},
-	}
-	assert.Equal(t, &volMnt, FindOverlappingVolume(templateWithVolMount, "/user-mount"))
-	assert.Equal(t, &volMnt, FindOverlappingVolume(templateWithVolMount, "/user-mount/subdir"))
-	assert.Nil(t, FindOverlappingVolume(templateWithVolMount, "/user-mount-coincidental-prefix"))
-}
-
-func TestUnknownFieldEnforcerForWorkflowStep(t *testing.T) {
-	validWf := `apiVersion: argoproj.io/v1alpha1
+const (
+	validWf = `apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   name: test-custom-enforcer
@@ -46,10 +30,7 @@ spec:
       command: [cowsay]
       args: ["hello world"]
 `
-	_, err := SplitWorkflowYAMLFile([]byte(validWf), false)
-	assert.NoError(t, err)
-
-	invalidWf := `apiVersion: argoproj.io/v1alpha1
+	invalidWf = `apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   name: test-custom-enforcer
@@ -68,8 +49,42 @@ spec:
       args: ["hello world"]
 
 `
+)
+
+// TestFindOverlappingVolume tests logic of TestFindOverlappingVolume
+func TestFindOverlappingVolume(t *testing.T) {
+	volMnt := corev1.VolumeMount{
+		Name:      "workdir",
+		MountPath: "/user-mount",
+	}
+	templateWithVolMount := &wfv1.Template{
+		Container: &corev1.Container{
+			VolumeMounts: []corev1.VolumeMount{volMnt},
+		},
+	}
+	assert.Equal(t, &volMnt, FindOverlappingVolume(templateWithVolMount, "/user-mount"))
+	assert.Equal(t, &volMnt, FindOverlappingVolume(templateWithVolMount, "/user-mount/subdir"))
+	assert.Nil(t, FindOverlappingVolume(templateWithVolMount, "/user-mount-coincidental-prefix"))
+}
+
+func TestUnknownFieldEnforcerForWorkflowStep(t *testing.T) {
+	_, err := SplitWorkflowYAMLFile([]byte(validWf), false)
+	assert.NoError(t, err)
+
 	_, err = SplitWorkflowYAMLFile([]byte(invalidWf), false)
 	assert.EqualError(t, err, `json: unknown field "doesNotExist"`)
+}
+
+func TestParseObjects(t *testing.T) {
+	assert.Equal(t, 1, len(ParseObjects([]byte(validWf), false)))
+
+	res := ParseObjects([]byte(invalidWf), false)
+	assert.Equal(t, 1, len(res))
+	assert.NotNil(t, res[0].Object)
+	assert.EqualError(t, res[0].Err, "json: unknown field \"doesNotExist\"")
+
+	invalidObj := []byte(`<div class="blah" style="display: none; outline: none;" tabindex="0"></div>`)
+	assert.Empty(t, ParseObjects(invalidObj, false))
 }
 
 func TestDeletePod(t *testing.T) {


### PR DESCRIPTION
Instead of seeing a nil pointer panic (e.g. in https://github.com/argoproj/argo-workflows/issues/5422), we should avoid appending results that are nil (which is not what `SplitWorkflowYAMLFile()` expects from each parse result) so the error message would be more readable. Example output after this change:

```
dist/argo submit -n argo --watch https://github.com/argoproj/argo-workflows/blob/master/examples/volumes-pvc.yaml --serviceaccount argo
INFO[2021-03-16T23:34:30.665Z] No Workflow found in given files
```

There are obviously multiple ways to fix this so I am open to suggestions on the best way.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
