### PR TITLE
fix(test): TestWorkflowTemplateRefWithShutdownAndSuspend flakiness

### DIFF
--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -289,9 +289,11 @@ func TestWorkflowTemplateRefGetArtifactsFromTemplate(t *testing.T) {
 func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 	cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
 	defer cancel()
-	t.Run("EntrypointMissingInStoredWfSpec", func(t *testing.T) {
+	t.Run("EntryPointMissingInStoredWfSpec", func(t *testing.T) {
 		ctx := context.Background()
-		woc := newWorkflowOperationCtx(unmarshalWF(wfWithTmplRef), controller)
+		wf := unmarshalWF(wfWithTmplRef)
+		wf.Name = "EntryPointMissingInStoredWfSpec"
+		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Nil(t, woc.wf.Status.StoredWorkflowSpec.Suspend)
 		wf1 := woc.wf.DeepCopy()
@@ -306,7 +308,9 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 
 	t.Run("WorkflowTemplateRefWithSuspend", func(t *testing.T) {
 		ctx := context.Background()
-		woc := newWorkflowOperationCtx(unmarshalWF(wfWithTmplRef), controller)
+		wf := unmarshalWF(wfWithTmplRef)
+		wf.Name = "WorkflowTemplateRefWithSuspend"
+		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Nil(t, woc.wf.Status.StoredWorkflowSpec.Suspend)
 		wf1 := woc.wf.DeepCopy()
@@ -320,7 +324,9 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 	})
 	t.Run("WorkflowTemplateRefWithShutdownTerminate", func(t *testing.T) {
 		ctx := context.Background()
-		woc := newWorkflowOperationCtx(unmarshalWF(wfWithTmplRef), controller)
+		wf := unmarshalWF(wfWithTmplRef)
+		wf.Name = "WorkflowTemplateRefWithShutdownTerminate"
+		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Empty(t, woc.wf.Status.StoredWorkflowSpec.Shutdown)
 		wf1 := woc.wf.DeepCopy()
@@ -340,7 +346,9 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 	})
 	t.Run("WorkflowTemplateRefWithShutdownStop", func(t *testing.T) {
 		ctx := context.Background()
-		woc := newWorkflowOperationCtx(unmarshalWF(wfWithTmplRef), controller)
+		wf := unmarshalWF(wfWithTmplRef)
+		wf.Name = "WorkflowTemplateRefWithShutdownStop"
+		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Empty(t, woc.wf.Status.StoredWorkflowSpec.Shutdown)
 		wf1 := woc.wf.DeepCopy()

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -287,9 +287,9 @@ func TestWorkflowTemplateRefGetArtifactsFromTemplate(t *testing.T) {
 }
 
 func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
-	cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
-	defer cancel()
 	t.Run("EntryPointMissingInStoredWfSpec", func(t *testing.T) {
+		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		defer cancel()
 		ctx := context.Background()
 		wf := unmarshalWF(wfWithTmplRef)
 		wf.Name = "EntryPointMissingInStoredWfSpec"
@@ -307,6 +307,8 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 	})
 
 	t.Run("WorkflowTemplateRefWithSuspend", func(t *testing.T) {
+		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		defer cancel()
 		ctx := context.Background()
 		wf := unmarshalWF(wfWithTmplRef)
 		wf.Name = "WorkflowTemplateRefWithSuspend"
@@ -323,6 +325,8 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		assert.True(t, *woc1.wf.Status.StoredWorkflowSpec.Suspend)
 	})
 	t.Run("WorkflowTemplateRefWithShutdownTerminate", func(t *testing.T) {
+		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		defer cancel()
 		ctx := context.Background()
 		wf := unmarshalWF(wfWithTmplRef)
 		wf.Name = "WorkflowTemplateRefWithShutdownTerminate"
@@ -345,6 +349,8 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		}
 	})
 	t.Run("WorkflowTemplateRefWithShutdownStop", func(t *testing.T) {
+		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		defer cancel()
 		ctx := context.Background()
 		wf := unmarshalWF(wfWithTmplRef)
 		wf.Name = "WorkflowTemplateRefWithShutdownStop"

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -288,11 +288,10 @@ func TestWorkflowTemplateRefGetArtifactsFromTemplate(t *testing.T) {
 
 func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 	t.Run("EntryPointMissingInStoredWfSpec", func(t *testing.T) {
-		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		wf := unmarshalWF(wfWithTmplRef)
+		cancel, controller := newController(wf, unmarshalWFTmpl(wfTmpl))
 		defer cancel()
 		ctx := context.Background()
-		wf := unmarshalWF(wfWithTmplRef)
-		wf.Name = "EntryPointMissingInStoredWfSpec"
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Nil(t, woc.wf.Status.StoredWorkflowSpec.Suspend)
@@ -307,11 +306,10 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 	})
 
 	t.Run("WorkflowTemplateRefWithSuspend", func(t *testing.T) {
-		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		wf := unmarshalWF(wfWithTmplRef)
+		cancel, controller := newController(wf, unmarshalWFTmpl(wfTmpl))
 		defer cancel()
 		ctx := context.Background()
-		wf := unmarshalWF(wfWithTmplRef)
-		wf.Name = "WorkflowTemplateRefWithSuspend"
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Nil(t, woc.wf.Status.StoredWorkflowSpec.Suspend)
@@ -325,11 +323,10 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		assert.True(t, *woc1.wf.Status.StoredWorkflowSpec.Suspend)
 	})
 	t.Run("WorkflowTemplateRefWithShutdownTerminate", func(t *testing.T) {
-		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		wf := unmarshalWF(wfWithTmplRef)
+		cancel, controller := newController(wf, unmarshalWFTmpl(wfTmpl))
 		defer cancel()
 		ctx := context.Background()
-		wf := unmarshalWF(wfWithTmplRef)
-		wf.Name = "WorkflowTemplateRefWithShutdownTerminate"
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Empty(t, woc.wf.Status.StoredWorkflowSpec.Shutdown)
@@ -349,11 +346,10 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		}
 	})
 	t.Run("WorkflowTemplateRefWithShutdownStop", func(t *testing.T) {
-		cancel, controller := newController(unmarshalWF(wfWithTmplRef), unmarshalWFTmpl(wfTmpl))
+		wf := unmarshalWF(wfWithTmplRef)
+		cancel, controller := newController(wf, unmarshalWFTmpl(wfTmpl))
 		defer cancel()
 		ctx := context.Background()
-		wf := unmarshalWF(wfWithTmplRef)
-		wf.Name = "WorkflowTemplateRefWithShutdownStop"
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Empty(t, woc.wf.Status.StoredWorkflowSpec.Shutdown)


### PR DESCRIPTION
Signed-off-by: Saravanan Balasubramanian <sarabala1979@gmail.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
Based on the log the Last testcase didn't create POD because the previous testcase POD was in the process of deleting.  Add workflow name for each testcase so it will create a new POD name for each testcase

```
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2446
time="2021-03-17T23:22:51Z" level=info msg="Updated phase  -> Running" namespace=default workflow=workflow-template-hello-world
2447
time="2021-03-17T23:22:51Z" level=info msg="Pod node workflow-template-hello-world initialized Pending" namespace=default workflow=workflow-template-hello-world
2448
time="2021-03-17T23:22:51Z" level=info msg="Created pod: workflow-template-hello-world (workflow-template-hello-world)" namespace=default workflow=workflow-template-hello-world
2449
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Running resourceVersion= workflow=workflow-template-hello-world
2450
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2451
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Running resourceVersion= workflow=workflow-template-hello-world
2452
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2453
time="2021-03-17T23:22:51Z" level=info msg="Updated phase  -> Running" namespace=default workflow=workflow-template-hello-world
2454
time="2021-03-17T23:22:51Z" level=info msg="Pod node workflow-template-hello-world initialized Pending" namespace=default workflow=workflow-template-hello-world
2455
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Running resourceVersion= workflow=workflow-template-hello-world
2456
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2457
time="2021-03-17T23:22:51Z" level=info msg="workflow suspended" namespace=default workflow=workflow-template-hello-world
2458
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Running resourceVersion= workflow=workflow-template-hello-world
2459
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2460
time="2021-03-17T23:22:51Z" level=info msg="Updated phase  -> Running" namespace=default workflow=workflow-template-hello-world
2461
time="2021-03-17T23:22:51Z" level=info msg="Pod node workflow-template-hello-world initialized Pending" namespace=default workflow=workflow-template-hello-world
2462
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Running resourceVersion= workflow=workflow-template-hello-world
2463
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2464
time="2021-03-17T23:22:51Z" level=info msg="Deleting Pending pod default/workflow-template-hello-world as part of workflow shutdown with strategy: Terminate" namespace=default workflow=workflow-template-hello-world
2465
time="2021-03-17T23:22:51Z" level=info msg="node workflow-template-hello-world phase Pending -> Failed" namespace=default workflow=workflow-template-hello-world
2466
time="2021-03-17T23:22:51Z" level=info msg="node workflow-template-hello-world message: workflow shutdown with strategy:  Terminate" namespace=default workflow=workflow-template-hello-world
2467
time="2021-03-17T23:22:51Z" level=info msg="node workflow-template-hello-world finished: 2021-03-17 23:22:51.291962304 +0000 UTC" namespace=default workflow=workflow-template-hello-world
2468
time="2021-03-17T23:22:51Z" level=info msg="Updated phase Running -> Failed" namespace=default workflow=workflow-template-hello-world
2469
time="2021-03-17T23:22:51Z" level=info msg="Updated message  -> Stopped with strategy 'Terminate'" namespace=default workflow=workflow-template-hello-world
2470
time="2021-03-17T23:22:51Z" level=info msg="Marking workflow completed" namespace=default workflow=workflow-template-hello-world
2471
time="2021-03-17T23:22:51Z" level=info msg="Checking daemoned children of " namespace=default workflow=workflow-template-hello-world
2472
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Failed resourceVersion= workflow=workflow-template-hello-world
2473
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2474
time="2021-03-17T23:22:51Z" level=info msg="Updated phase  -> Running" namespace=default workflow=workflow-template-hello-world
2475
time="2021-03-17T23:22:51Z" level=info msg="Pod node workflow-template-hello-world initialized Pending" namespace=default workflow=workflow-template-hello-world
2476
time="2021-03-17T23:22:51Z" level=info msg="Workflow update successful" namespace=default phase=Running resourceVersion= workflow=workflow-template-hello-world
2477
time="2021-03-17T23:22:51Z" level=info msg="Processing workflow" namespace=default workflow=workflow-template-hello-world
2478
time="2021-03-17T23:22:51Z" level=info msg="Deleting Pending pod default/workflow-template-hello-world as part of workflow shutdown with strategy: Stop" namespace=default workflow=workflow-template-hello-world
2479
time="2021-03-17T23:22:51Z" level=warning msg="Failed to delete default/workflow-template-hello-world: pods \"workflow-template-hello-world\" not found" namespace=default workflow=workflow-template-hello-world
```
