### PR TITLE
fix(controller): Add permissions to create/update configmaps for memoization in quick-start manifests

### DIFF
--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -429,6 +429,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - argoproj.io
   resources:
   - workflows

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -429,6 +429,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - argoproj.io
   resources:
   - workflows

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -429,6 +429,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
   - argoproj.io
   resources:
   - workflows

--- a/manifests/quick-start/base/workflow-role.yaml
+++ b/manifests/quick-start/base/workflow-role.yaml
@@ -30,6 +30,15 @@ rules:
       - pods/exec
     verbs:
       - create
+  # Only needed if you are using ConfigMap-based cache for memoization.
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - update
   # This allows one workflow to create another.
   # This is only needed for resource templates.
   - apiGroups:


### PR DESCRIPTION
These are required to run the memoization example: https://github.com/argoproj/argo-workflows/blob/master/examples/memoize-simple.yaml

```
time="2021-03-18T14:11:42.810Z" level=info msg="Saving ConfigMap cache entry" key=test-5 name=my-config namespace=argo nodeId=memoized-simple-workflow-6mftb
time="2021-03-18T14:11:42.814Z" level=info msg="Create configmaps 403"
time="2021-03-18T14:11:42.814Z" level=error msg="Failed to save node outputs to cache" error="could not save to config map cache: configmaps is forbidden: User \"system:serviceaccount:argo:argo\" cannot create resource \"configmaps\" in API group \"\" in the namespace \"argo\"" namespace=argo nodeID=memoized-simple-workflow-6mftb workflow=memoized-simple-workflow-6mftb

time="2021-03-18T14:31:01.181Z" level=info msg="Update configmaps 403"
time="2021-03-18T14:31:01.182Z" level=error msg="Failed to save node outputs to cache" error="error creating cache entry: configmaps \"my-config\" is forbidden: User \"system:serviceaccount:argo:argo\" cannot update resource \"configmaps\" in API group \"\" in the namespace \"argo\"" namespace=argo nodeID=memoized-simple-workflow-bqtfb workflow=memoized-simple-workflow-bqtfb
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
