### PR TITLE
ci: Try ubuntu-18.04

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -36,7 +36,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     # test-api: 7m (1m10s locally)
     # test-cli: 12m (4m locally)
     # test-cron: 8m


### PR DESCRIPTION
All tests pass largely reliably when run locally. But seemingly out K3S on Github Action sometimes becomes unresponsive for >30s, manifesting as pods not getting created, causing the running test to fail, and therefore the suite and job to fail.

Maybe it is due to ubuntu-18.04 -> ubuntu-20.04?