### PR TITLE
docs: correct the typo

### DIFF
--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -246,13 +246,13 @@ You can create some example templates as follows:
 argo template create https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/workflow-template/templates.yaml
 ```
 
-The submit a workflow using one of those templates:
+Then submit a workflow using one of those templates:
 
 ```
 argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/workflow-template/hello-world.yaml
 ```
 > 2.7 and after
-The submit a `WorkflowTemplate` as a `Workflow`:
+Then submit a `WorkflowTemplate` as a `Workflow`:
 ```sh
 argo submit --from workflowtemplate/workflow-template-submittable
 


### PR DESCRIPTION
Fixed the type spelling of `Then`

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
