### PR TITLE
docs: fixed the typo, `The submit ...` doesn't make sense

### DIFF
--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -255,10 +255,18 @@ argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/master/exa
 > 2.7 and after
 
 Then submit a `WorkflowTemplate` as a `Workflow`:
+
 ```sh
 argo submit --from workflowtemplate/workflow-template-submittable
-
 ```
+
+If you need to submit a `WorkflowTemplate` as a `Workflow` with parameters:
+
+```sh
+argo submit --from workflowtemplate/workflow-template-submittable -p param1=value1
+```
+
+
 
 ### `kubectl`
 

--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -246,13 +246,15 @@ You can create some example templates as follows:
 argo template create https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/workflow-template/templates.yaml
 ```
 
-The submit a workflow using one of those templates:
+Then submit a workflow using one of those templates:
 
 ```
 argo submit https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/workflow-template/hello-world.yaml
 ```
+
 > 2.7 and after
-The submit a `WorkflowTemplate` as a `Workflow`:
+
+Then submit a `WorkflowTemplate` as a `Workflow`:
 ```sh
 argo submit --from workflowtemplate/workflow-template-submittable
 


### PR DESCRIPTION

Improved the document of `WorkflowTemplate`, by 

- Fixed the type `The submit ...` to `Then submit ...`
- Added example of submitting a `Workflow` from the existing `WorkflowTemplate`, because most of the `WorkflowTemplate` should have parameters


Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
