### PR TITLE
fix: avoid short names in deployment manifests

### DIFF
--- a/manifests/base/argo-server/argo-server-deployment.yaml
+++ b/manifests/base/argo-server/argo-server-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: argo-server
       containers:
         - name: argo-server
-          image: argoproj/argocli:latest
+          image: docker.io/argoproj/argocli:latest
           securityContext:
             capabilities:
               drop:

--- a/manifests/base/workflow-controller/workflow-controller-deployment.yaml
+++ b/manifests/base/workflow-controller/workflow-controller-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: argo
       containers:
         - name: workflow-controller
-          image: argoproj/workflow-controller:latest
+          image: docker.io/argoproj/workflow-controller:latest
           securityContext:
             capabilities:
               drop:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -550,7 +550,7 @@ spec:
       containers:
       - args:
         - server
-        image: argoproj/argocli:latest
+        image: docker.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -605,7 +605,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: argoproj/workflow-controller:latest
+        image: docker.io/argoproj/workflow-controller:latest
         livenessProbe:
           httpGet:
             path: /metrics

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -444,7 +444,7 @@ spec:
       - args:
         - server
         - --namespaced
-        image: argoproj/argocli:latest
+        image: docker.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -500,7 +500,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: argoproj/workflow-controller:latest
+        image: docker.io/argoproj/workflow-controller:latest
         livenessProbe:
           httpGet:
             path: /metrics

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -768,7 +768,7 @@ spec:
         - server
         - --auth-mode
         - client
-        image: argoproj/argocli:latest
+        image: docker.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -873,7 +873,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: argoproj/workflow-controller:latest
+        image: docker.io/argoproj/workflow-controller:latest
         livenessProbe:
           httpGet:
             path: /metrics

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -812,7 +812,7 @@ spec:
         - server
         - --auth-mode
         - client
-        image: argoproj/argocli:latest
+        image: docker.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -962,7 +962,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: argoproj/workflow-controller:latest
+        image: docker.io/argoproj/workflow-controller:latest
         livenessProbe:
           httpGet:
             path: /metrics

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -812,7 +812,7 @@ spec:
         - server
         - --auth-mode
         - client
-        image: argoproj/argocli:latest
+        image: docker.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -954,7 +954,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: argoproj/workflow-controller:latest
+        image: docker.io/argoproj/workflow-controller:latest
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
- Using short names is subject to the risk of hitting squatted registry namespaces
- If a user's configuration is set to pull images from somewhere other then Dockerhub, the user may unknowingly pull a malicious image.

possibly part of https://github.com/argoproj/argoproj/issues/40


Signed-off-by: Shoubhik Bose <shbose@redhat.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
