### PR TITLE
fix: certs in non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,11 +157,13 @@ FROM scratch as argocli
 
 USER 8737
 
+WORKDIR /home/argo
+
 COPY hack/ssh_known_hosts /etc/ssh/
 COPY hack/nsswitch.conf /etc/
 COPY --from=argocli-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=argocli-build --chown=8737 /go/src/github.com/argoproj/argo-workflows/argo-server.crt /
-COPY --from=argocli-build --chown=8737 /go/src/github.com/argoproj/argo-workflows/argo-server.key /
+COPY --from=argocli-build --chown=8737 /go/src/github.com/argoproj/argo-workflows/argo-server.crt /home/argo/
+COPY --from=argocli-build --chown=8737 /go/src/github.com/argoproj/argo-workflows/argo-server.key /home/argo/
 COPY --from=argocli-build /go/src/github.com/argoproj/argo-workflows/dist/argo /bin/
 
 ENTRYPOINT [ "argo" ]


### PR DESCRIPTION
Before making this fix, I kept getting `level=fatal msg="open argo-server.key: permission denied"` on OpenShift. 
After making this fix, I've been able to successfully deploy argo-server.

Signed-off-by: Shoubhik Bose <shbose@redhat.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
