### PR TITLE
fix(controller): Only set global parameters after workflow validation succeeded to avoid panics

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -241,8 +241,6 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		woc.preExecutionNodePhases[node.ID] = node.Phase
 	}
 
-	woc.setGlobalParameters(woc.execWf.Spec.Arguments)
-
 	// Perform one-time workflow validation
 	if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
 		woc.markWorkflowRunning(ctx)
@@ -263,6 +261,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 			woc.markWorkflowFailed(ctx, msg)
 			return
 		}
+		woc.setGlobalParameters(woc.execWf.Spec.Arguments)
 		// If we received conditions during validation (such as SpecWarnings), add them to the Workflow object
 		if len(*wfConditions) > 0 {
 			woc.wf.Status.Conditions.JoinConditions(wfConditions)
@@ -285,6 +284,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		}
 		woc.wf.Status.EstimatedDuration = woc.estimateWorkflowDuration()
 	} else {
+		woc.setGlobalParameters(woc.execWf.Spec.Arguments)
 		woc.workflowDeadline = woc.getWorkflowDeadline()
 		err := woc.podReconciliation(ctx)
 		if err == nil {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -534,9 +534,38 @@ spec:
       args: ["Global 1: {{workflow.parameters.message1}} Input 1: {{inputs.parameters.message1}} Input 2/Steps Input 1/Global 1: {{inputs.parameters.message2}} Input 3/Global 2: {{inputs.parameters.message3}} Input4/Steps Input 2 internal/Global 1: {{inputs.parameters.message4}}"]
 `
 
+var unsuppliedArgValue = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: step-with-unsupplied-param-
+spec:
+  arguments:
+    parameters:
+    - name: missing
+  entrypoint: whalesay
+  templates:
+  - arguments: {}
+    container:
+      args:
+      - hello world
+      command:
+      - cowsay
+      image: docker/whalesay:latest
+      name: ""
+      resources: {}
+    inputs: {}
+    metadata: {}
+    name: whalesay
+    outputs: {}
+`
+
 func TestGlobalParam(t *testing.T) {
 	_, err := validate(globalParam)
 	assert.NoError(t, err)
+
+	_, err = validate(unsuppliedArgValue)
+	assert.EqualError(t, err, "spec.arguments.missing.value is required")
 }
 
 var invalidTemplateNames = `


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/5473.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
