### PR TITLE
fix(controller): Use node.Name instead of node.DisplayName for onExit nodes

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1806,6 +1806,15 @@ func (n NodeStatus) GetDuration() time.Duration {
 	return n.FinishedAt.Sub(n.StartedAt.Time)
 }
 
+func (n NodeStatus) HasChild(childID string) bool {
+	for _, nodeID := range n.Children {
+		if childID == nodeID {
+			return true
+		}
+	}
+	return false
+}
+
 // S3Bucket contains the access information required for interfacing with an S3 bucket
 type S3Bucket struct {
 	// Endpoint is the hostname of the bucket endpoint

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -825,3 +825,12 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, suspendTmpl.Data)
 	})
 }
+
+func TestHasChild(t *testing.T) {
+	node := NodeStatus{
+		Children: []string{"a", "b"},
+	}
+	assert.True(t, node.HasChild("a"))
+	assert.False(t, node.HasChild("c"))
+	assert.False(t, node.HasChild(""))
+}

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -327,6 +327,6 @@ func GetTemplateHolderString(tmplHolder wfv1.TemplateReferenceHolder) string {
 	}
 }
 
-func GenerateOnExitNodeName(parentDisplayName string) string {
-	return fmt.Sprintf("%s.onExit", parentDisplayName)
+func GenerateOnExitNodeName(parentNodeName string) string {
+	return fmt.Sprintf("%s.onExit", parentNodeName)
 }

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -303,7 +303,7 @@ func withAnnotation(key, val string) with {
 
 // createRunningPods creates the pods that are marked as running in a given test so that they can be accessed by the
 // pod assessor
-func createRunningPods(ctx context.Context, woc *wfOperationCtx, with ...with) {
+func createRunningPods(ctx context.Context, woc *wfOperationCtx) {
 	podcs := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace())
 	for _, node := range woc.wf.Status.Nodes {
 		if node.Type == wfv1.NodeTypePod && node.Phase == wfv1.NodeRunning {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -253,7 +253,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			if taskNode.Completed() {
 				// Run the node's onExit node, if any. Since this is a target task, we don't need to consider the status
 				// of the onExit node before continuing. That will be done in assesDAGPhase
-				_, _, err := woc.runOnExitNode(ctx, dagCtx.GetTask(taskName).OnExit, taskNode.Name, taskNode.DisplayName, dagCtx.boundaryID, dagCtx.tmplCtx)
+				_, _, err := woc.runOnExitNode(ctx, dagCtx.GetTask(taskName).OnExit, taskName, taskNode.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
 				if err != nil {
 					return node, err
 				}
@@ -342,7 +342,7 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 
 		if node.Completed() {
 			// Run the node's onExit node, if any.
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, task.OnExit, node.Name, node.DisplayName, dagCtx.boundaryID, dagCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, task.OnExit, task.Name, node.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				return

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -253,7 +253,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			if taskNode.Completed() {
 				// Run the node's onExit node, if any. Since this is a target task, we don't need to consider the status
 				// of the onExit node before continuing. That will be done in assesDAGPhase
-				_, _, err := woc.runOnExitNode(ctx, dagCtx.GetTask(taskName).OnExit, taskNode.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
+				_, _, err := woc.runOnExitNode(ctx, dagCtx.GetTask(taskName).OnExit, taskNode.Name, taskNode.DisplayName, dagCtx.boundaryID, dagCtx.tmplCtx)
 				if err != nil {
 					return node, err
 				}
@@ -342,7 +342,7 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 
 		if node.Completed() {
 			// Run the node's onExit node, if any.
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, task.OnExit, node.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, task.OnExit, node.Name, node.DisplayName, dagCtx.boundaryID, dagCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				return

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -253,7 +253,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			if taskNode.Completed() {
 				// Run the node's onExit node, if any. Since this is a target task, we don't need to consider the status
 				// of the onExit node before continuing. That will be done in assesDAGPhase
-				_, _, err := woc.runOnExitNode(ctx, dagCtx.GetTask(taskName).OnExit, taskName, taskNode.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
+				_, _, err := woc.runOnExitNode(ctx, dagCtx.GetTask(taskName).OnExit, taskNode.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
 				if err != nil {
 					return node, err
 				}
@@ -342,7 +342,7 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 
 		if node.Completed() {
 			// Run the node's onExit node, if any.
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, task.OnExit, task.Name, node.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, task.OnExit, node.Name, dagCtx.boundaryID, dagCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				return
@@ -695,7 +695,7 @@ func (d *dagContext) evaluateDependsLogic(taskName string) (bool, bool, error) {
 		}
 
 		// If a task happens to have an onExit node, don't proceed until the onExit node is fulfilled
-		if onExitNode := d.wf.GetNodeByName(common.GenerateOnExitNodeName(taskName)); onExitNode != nil {
+		if onExitNode := d.wf.GetNodeByName(common.GenerateOnExitNodeName(depNode.Name)); onExitNode != nil {
 			if !onExitNode.Fulfilled() {
 				return false, false, nil
 			}

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -701,6 +701,19 @@ func (d *dagContext) evaluateDependsLogic(taskName string) (bool, bool, error) {
 			}
 		}
 
+		// Previously we used `depNode.DisplayName` to generate all onExit node names. However, as these can be non-unique
+		// we transitioned to using `depNode.Name` instead, which are guaranteed to be unique. In order to not disrupt
+		// running workflows during upgrade time, we do an additional check to see if there is an onExit node with the old
+		// name (`depNode.DisplayName`).
+		// TODO: This scaffold code should be removed after a couple of "grace period" version upgrades to allow transitions. It was introduced in v3.0.0
+		// See more: https://github.com/argoproj/argo-workflows/issues/5502
+		legacyOnExitNodeName := common.GenerateOnExitNodeName(depNode.DisplayName)
+		if onExitNode := d.wf.GetNodeByName(legacyOnExitNodeName); onExitNode != nil && d.wf.GetNodeByName(depNode.Name).HasChild(onExitNode.ID) {
+			if !onExitNode.Fulfilled() {
+				return false, false, nil
+			}
+		}
+
 		evalTaskName := strings.Replace(taskName, "-", "_", -1)
 		if _, ok := evalScope[evalTaskName]; ok {
 			continue

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -1802,7 +1802,7 @@ func TestOnExitDAGPhase(t *testing.T) {
 		assert.Equal(t, wfv1.NodeRunning, retryNode.Phase)
 	}
 
-	retryNode = woc.wf.GetNodeByName("B.onExit")
+	retryNode = woc.wf.GetNodeByName("dag-diamond-88trp.B.onExit")
 	if assert.NotNil(t, retryNode) {
 		assert.Equal(t, wfv1.NodePending, retryNode.Phase)
 	}
@@ -1927,7 +1927,7 @@ func TestOnExitNonLeaf(t *testing.T) {
 	woc := newWorkflowOperationCtx(wf, controller)
 
 	woc.operate(ctx)
-	retryNode := woc.wf.GetNodeByName("step-2.onExit")
+	retryNode := woc.wf.GetNodeByName("exit-handler-bug-example.step-2.onExit")
 	if assert.NotNil(t, retryNode) {
 		assert.Equal(t, wfv1.NodePending, retryNode.Phase)
 	}
@@ -2195,7 +2195,7 @@ func TestDagTargetTaskOnExit(t *testing.T) {
 	woc := newWorkflowOperationCtx(wf, controller)
 
 	woc.operate(ctx)
-	onExitNode := woc.wf.GetNodeByName("A.onExit")
+	onExitNode := woc.wf.GetNodeByName("dag-primay-branch-6bnnl.A.onExit")
 	if assert.NotNil(t, onExitNode) {
 		assert.Equal(t, wfv1.NodePending, onExitNode.Phase)
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2937,7 +2937,7 @@ func (woc *wfOperationCtx) createTemplateContext(scope wfv1.ResourceScope, resou
 	}
 }
 
-func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, parentNodeName, parentNodeDisplayName, boundaryID string, tmplCtx *templateresolution.Context) (bool, *wfv1.NodeStatus, error) {
+func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, parentNodeDisplayName, parentNodeName, boundaryID string, tmplCtx *templateresolution.Context) (bool, *wfv1.NodeStatus, error) {
 	if templateRef != "" && woc.GetShutdownStrategy().ShouldExecute(true) {
 		woc.log.Infof("Running OnExit handler: %s", templateRef)
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2937,11 +2937,11 @@ func (woc *wfOperationCtx) createTemplateContext(scope wfv1.ResourceScope, resou
 	}
 }
 
-func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, parentNodeDisplayName, parentNodeName, boundaryID string, tmplCtx *templateresolution.Context) (bool, *wfv1.NodeStatus, error) {
+func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, parentDisplayName, parentNodeName, boundaryID string, tmplCtx *templateresolution.Context) (bool, *wfv1.NodeStatus, error) {
 	if templateRef != "" && woc.GetShutdownStrategy().ShouldExecute(true) {
 		woc.log.Infof("Running OnExit handler: %s", templateRef)
 
-		// Previously we used `parentNodeDisplayName` to generate all onExit node names. However, as these can be non-unique
+		// Previously we used `parentDisplayName` to generate all onExit node names. However, as these can be non-unique
 		// we transitioned to using `parentNodeName` instead, which are guaranteed to be unique. In order to not disrupt
 		// running workflows during upgrade time, we first check if there is an onExit node that currently exists with the
 		// legacy name AND said node is a child of the parent node. If it does, we continue execution with the legacy name.
@@ -2953,7 +2953,7 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, paren
 		//
 		// See more: https://github.com/argoproj/argo-workflows/issues/5502
 		onExitNodeName := common.GenerateOnExitNodeName(parentNodeName)
-		legacyOnExitNodeName := common.GenerateOnExitNodeName(parentNodeDisplayName)
+		legacyOnExitNodeName := common.GenerateOnExitNodeName(parentDisplayName)
 		if legacyNameNode := woc.wf.GetNodeByName(legacyOnExitNodeName); legacyNameNode != nil && woc.wf.GetNodeByName(parentNodeName).HasChild(legacyNameNode.ID) {
 			onExitNodeName = legacyOnExitNodeName
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2937,10 +2937,10 @@ func (woc *wfOperationCtx) createTemplateContext(scope wfv1.ResourceScope, resou
 	}
 }
 
-func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, parentDisplayName, parentNodeName, boundaryID string, tmplCtx *templateresolution.Context) (bool, *wfv1.NodeStatus, error) {
+func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, parentNodeName, boundaryID string, tmplCtx *templateresolution.Context) (bool, *wfv1.NodeStatus, error) {
 	if templateRef != "" && woc.GetShutdownStrategy().ShouldExecute(true) {
 		woc.log.Infof("Running OnExit handler: %s", templateRef)
-		onExitNodeName := common.GenerateOnExitNodeName(parentDisplayName)
+		onExitNodeName := common.GenerateOnExitNodeName(parentNodeName)
 		onExitNode, err := woc.executeTemplate(ctx, onExitNodeName, &wfv1.WorkflowStep{Template: templateRef}, tmplCtx, woc.execWf.Spec.Arguments, &executeTemplateOpts{
 			boundaryID:     boundaryID,
 			onExitTemplate: true,

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2650,21 +2650,6 @@ func (woc *wfOperationCtx) addChildNode(parent string, child string) {
 	woc.updated = true
 }
 
-func (woc *wfOperationCtx) isChildNode(parent string, child string) bool {
-	parentID := woc.wf.NodeID(parent)
-	childID := woc.wf.NodeID(child)
-	node, ok := woc.wf.Status.Nodes[parentID]
-	if !ok {
-		panic(fmt.Sprintf("parent node %s not initialized", parent))
-	}
-	for _, nodeID := range node.Children {
-		if childID == nodeID {
-			return true
-		}
-	}
-	return false
-}
-
 // executeResource is runs a kubectl command against a manifest
 func (woc *wfOperationCtx) executeResource(ctx context.Context, nodeName string, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
 	node := woc.wf.GetNodeByName(nodeName)
@@ -2969,7 +2954,7 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, templateRef, paren
 		// See more: https://github.com/argoproj/argo-workflows/issues/5502
 		onExitNodeName := common.GenerateOnExitNodeName(parentNodeName)
 		legacyOnExitNodeName := common.GenerateOnExitNodeName(parentNodeDisplayName)
-		if legacyNameNode := woc.wf.GetNodeByName(legacyOnExitNodeName); legacyNameNode != nil && woc.isChildNode(parentNodeName, legacyOnExitNodeName) {
+		if legacyNameNode := woc.wf.GetNodeByName(legacyOnExitNodeName); legacyNameNode != nil && woc.wf.GetNodeByName(parentNodeName).HasChild(legacyNameNode.ID) {
 			onExitNodeName = legacyOnExitNodeName
 		}
 

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -6490,7 +6490,8 @@ func TestOnExitNameBackwardsCompatibility(t *testing.T) {
 	}
 }
 
-const testOnExitDAGStatusCompatibility = `apiVersion: argoproj.io/v1alpha1
+const testOnExitDAGStatusCompatibility = `
+apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   name: dag-diamond-8xw8l

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -260,7 +260,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		if !childNode.Fulfilled() {
 			completed = false
 		} else if childNode.Completed() {
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, childNode.Name, childNode.DisplayName, stepsCtx.boundaryID, stepsCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, step.Name, childNode.Name, stepsCtx.boundaryID, stepsCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				completed = false

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -260,7 +260,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		if !childNode.Fulfilled() {
 			completed = false
 		} else if childNode.Completed() {
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, childNode.Name, stepsCtx.boundaryID, stepsCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, childNode.Name, node.DisplayName, stepsCtx.boundaryID, stepsCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				completed = false

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -260,7 +260,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		if !childNode.Fulfilled() {
 			completed = false
 		} else if childNode.Completed() {
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, childNode.Name, node.DisplayName, stepsCtx.boundaryID, stepsCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, childNode.Name, childNode.DisplayName, stepsCtx.boundaryID, stepsCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				completed = false

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -260,7 +260,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		if !childNode.Fulfilled() {
 			completed = false
 		} else if childNode.Completed() {
-			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, step.Name, childNode.Name, stepsCtx.boundaryID, stepsCtx.tmplCtx)
+			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.OnExit, childNode.Name, stepsCtx.boundaryID, stepsCtx.tmplCtx)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.
 				completed = false


### PR DESCRIPTION
Split from https://github.com/argoproj/argo-workflows/pull/5478