### PR TITLE
feat(controller): Add last hit timestamp to memoization caches

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -84,6 +84,9 @@ const (
 	// LabelKeyOnExit is a label applied to Pods that are run from onExit nodes, so that they are not shut down when stopping a Workflow
 	LabelKeyOnExit = workflow.WorkflowFullName + "/on-exit"
 
+	// LabelKeyCacheLastHitTimestamp is the timestamp when the memoization cache is last hit.
+	LabelKeyCacheLastHitTimestamp = "last-hit-timestamp"
+
 	// ExecutorArtifactBaseDir is the base directory in the init container in which artifacts will be copied to.
 	// Each artifact will be named according to its input name (e.g: /argo/inputs/artifacts/CODE)
 	ExecutorArtifactBaseDir = "/argo/inputs/artifacts"

--- a/workflow/controller/cache/cache.go
+++ b/workflow/controller/cache/cache.go
@@ -22,6 +22,7 @@ type Entry struct {
 	NodeID            string        `json:"nodeID"`
 	Outputs           *wfv1.Outputs `json:"outputs"`
 	CreationTimestamp metav1.Time   `json:"creationTimestamp"`
+	LastHitTimestamp  metav1.Time   `json:"lastHitTimestamp"`
 }
 
 func (e *Entry) Hit() bool {

--- a/workflow/controller/cache/configmap_cache.go
+++ b/workflow/controller/cache/configmap_cache.go
@@ -118,10 +118,14 @@ func (c *configMapCache) Save(ctx context.Context, key string, nodeId string, va
 		}
 	}
 
+	creationTime := time.Now()
+	cache.SetLabels(map[string]string{common.LabelKeyCacheLastHitTimestamp: creationTime.Format(time.RFC3339)})
+
 	newEntry := Entry{
 		NodeID:            nodeId,
 		Outputs:           value,
-		CreationTimestamp: metav1.Time{Time: time.Now()},
+		CreationTimestamp: metav1.Time{Time: creationTime},
+		LastHitTimestamp:  metav1.Time{Time: creationTime},
 	}
 
 	entryJSON, err := json.Marshal(newEntry)

--- a/workflow/controller/cache_test.go
+++ b/workflow/controller/cache_test.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/controller/cache"
 )
 
@@ -45,8 +47,20 @@ func TestConfigMapCacheLoadHit(t *testing.T) {
 	_, err := controller.kubeclientset.CoreV1().ConfigMaps("default").Create(ctx, &sampleConfigMapCacheEntry, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	c := cache.NewConfigMapCache("default", controller.kubeclientset, "whalesay-cache")
+
+	cm, err := controller.kubeclientset.CoreV1().ConfigMaps("default").Get(ctx, sampleConfigMapCacheEntry.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Nil(t, cm.Labels)
+
 	entry, err := c.Load(ctx, "hi-there-world")
 	assert.NoError(t, err)
+
+	cm, err = controller.kubeclientset.CoreV1().ConfigMaps("default").Get(ctx, sampleConfigMapCacheEntry.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	lastHitTimestamp, err := time.Parse(time.RFC3339, cm.Labels[common.LabelKeyCacheLastHitTimestamp])
+	assert.NoError(t, err)
+	assert.True(t, lastHitTimestamp.After(cm.CreationTimestamp.Time))
+
 	outputs := entry.Outputs
 	assert.NoError(t, err)
 	if assert.Len(t, outputs.Parameters, 1) {

--- a/workflow/controller/cache_test.go
+++ b/workflow/controller/cache_test.go
@@ -60,6 +60,7 @@ func TestConfigMapCacheLoadHit(t *testing.T) {
 	lastHitTimestamp, err := time.Parse(time.RFC3339, cm.Labels[common.LabelKeyCacheLastHitTimestamp])
 	assert.NoError(t, err)
 	assert.True(t, lastHitTimestamp.After(cm.CreationTimestamp.Time))
+	assert.Equal(t, lastHitTimestamp.Format(time.RFC3339), entry.LastHitTimestamp.Time.Format(time.RFC3339))
 
 	outputs := entry.Outputs
 	assert.NoError(t, err)

--- a/workflow/controller/cache_test.go
+++ b/workflow/controller/cache_test.go
@@ -108,6 +108,6 @@ func TestConfigMapCacheSave(t *testing.T) {
 	var entry cache.Entry
 	err = json.Unmarshal([]byte(cm.Data["hi-there-world"]), &entry)
 	assert.NoError(t, err)
-	assert.Equal(t, lastHitTimestampLabel, entry.LastHitTimestamp.Time)
-	assert.Equal(t, lastHitTimestampLabel, entry.CreationTimestamp.Time)
+	assert.Equal(t, lastHitTimestampLabel.Format(time.RFC3339), entry.LastHitTimestamp.Time.Format(time.RFC3339))
+	assert.Equal(t, lastHitTimestampLabel.Format(time.RFC3339), entry.CreationTimestamp.Time.Format(time.RFC3339))
 }


### PR DESCRIPTION
This is the first step mentioned in https://github.com/argoproj/argo-workflows/issues/5406. 

Controller to manage GC of configmaps based on this timestamp will be added as a follow-up PR later as it requires additional work. We can start using this timestamp in our cluster and experiment with different options in the meantime (hopefully gather more experience and feedback on GC strategies through the process). **Our immediate need is to have a better way to tell whether a cache is still useful.**

cc @simster7 Could you take a look when you get a chance?

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
