### PR TITLE
fix: Add logging to aid troubleshooting

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 
 	argoerrs "github.com/argoproj/argo-workflows/v3/errors"
@@ -17,7 +18,13 @@ func IsTransientErr(err error) bool {
 		return false
 	}
 	err = argoerrs.Cause(err)
-	return isExceededQuotaErr(err) || apierr.IsTooManyRequests(err) || isResourceQuotaConflictErr(err) || isTransientNetworkErr(err) || apierr.IsServerTimeout(err) || apierr.IsServiceUnavailable(err) || matchTransientErrPattern(err)
+	isTransient := isExceededQuotaErr(err) || apierr.IsTooManyRequests(err) || isResourceQuotaConflictErr(err) || isTransientNetworkErr(err) || apierr.IsServerTimeout(err) || apierr.IsServiceUnavailable(err) || matchTransientErrPattern(err)
+	if (isTransient) {
+		log.Infof("Transient error: %v", err)
+	} else {
+		log.Errorf("Fatal error: %v", err)
+	}
+	return isTransient
 }
 
 func matchTransientErrPattern(err error) bool {

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -19,7 +19,7 @@ func IsTransientErr(err error) bool {
 	}
 	err = argoerrs.Cause(err)
 	isTransient := isExceededQuotaErr(err) || apierr.IsTooManyRequests(err) || isResourceQuotaConflictErr(err) || isTransientNetworkErr(err) || apierr.IsServerTimeout(err) || apierr.IsServiceUnavailable(err) || matchTransientErrPattern(err)
-	if (isTransient) {
+	if isTransient {
 		log.Infof("Transient error: %v", err)
 	} else {
 		log.Errorf("Non-transient error: %v", err)

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -22,7 +22,7 @@ func IsTransientErr(err error) bool {
 	if (isTransient) {
 		log.Infof("Transient error: %v", err)
 	} else {
-		log.Errorf("Fatal error: %v", err)
+		log.Errorf("Non-transient error: %v", err)
 	}
 	return isTransient
 }


### PR DESCRIPTION
While investigating stability issues we discovered that Argo wasn't retrying various failing k8s api calls. We didn't really understand what was going on until we deployed an experimental Argo build containing additional logging. 

Therefore we propose make the root cause of failures more obvious and indicate if an error is considered to be transient or not.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

