### PR TITLE
feat: Emit WorkflowNodeRunning Event

### DIFF
--- a/docs/workflow-events.md
+++ b/docs/workflow-events.md
@@ -13,14 +13,15 @@ Workflow state change:
 * `WorkflowFailed`
 * `WorkflowTimedOut`
 
-Node completion
+Node state change:
 
+* `WorkflowNodeRunning`
 * `WorkflowNodeSucceeded`
 * `WorkflowNodeFailed`
 * `WorkflowNodeError`
 
 
-The involved object is the workflow in both cases. Additionally, for node completion events, annotations indicate the name and type of the involved node:
+The involved object is the workflow in both cases. Additionally, for node state change events, annotations indicate the name and type of the involved node:
 
 ```yaml
 metadata:

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -200,7 +200,7 @@ func (s *FunctionalSuite) TestEventOnNodeFail() {
 		}).
 		ExpectAuditEvents(
 			fixtures.HasInvolvedObject(workflow.WorkflowKind, uid),
-			2,
+			4,
 			func(t *testing.T, es []corev1.Event) {
 				for _, e := range es {
 					switch e.Reason {
@@ -235,9 +235,10 @@ func (s *FunctionalSuite) TestEventOnWorkflowSuccess() {
 		}).
 		ExpectAuditEvents(
 			fixtures.HasInvolvedObject(workflow.WorkflowKind, uid),
-			3,
+			4,
 			func(t *testing.T, es []corev1.Event) {
 				for _, e := range es {
+					println(e.Reason, e.Message)
 					switch e.Reason {
 					case "WorkflowNodeRunning":
 						assert.Contains(t, e.Message, "Running node success-event-")

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -204,6 +204,8 @@ func (s *FunctionalSuite) TestEventOnNodeFail() {
 			func(t *testing.T, es []corev1.Event) {
 				for _, e := range es {
 					switch e.Reason {
+					case "WorkflowNodeRunning":
+						assert.Contains(t, e.Message, "Running node failed-step-event-")
 					case "WorkflowRunning":
 					case "WorkflowNodeFailed":
 						assert.Contains(t, e.Message, "Failed node failed-step-event-")
@@ -237,6 +239,8 @@ func (s *FunctionalSuite) TestEventOnWorkflowSuccess() {
 			func(t *testing.T, es []corev1.Event) {
 				for _, e := range es {
 					switch e.Reason {
+					case "WorkflowNodeRunning":
+						assert.Contains(t, e.Message, "Running node success-event-")
 					case "WorkflowRunning":
 					case "WorkflowNodeSucceeded":
 						assert.Contains(t, e.Message, "Succeeded node success-event-")

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -168,7 +168,7 @@ func newController(options ...interface{}) (context.CancelFunc, *WorkflowControl
 		wfArchive:            sqldb.NullWorkflowArchive,
 		hydrator:             hydratorfake.Noop,
 		estimatorFactory:     estimation.DummyEstimatorFactory,
-		eventRecorderManager: &testEventRecorderManager{eventRecorder: record.NewFakeRecorder(16)},
+		eventRecorderManager: &testEventRecorderManager{eventRecorder: record.NewFakeRecorder(64)},
 		archiveLabelSelector: labels.Everything(),
 		cacheFactory:         controllercache.NewCacheFactory(kube, "default"),
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2114,30 +2114,27 @@ func (woc *wfOperationCtx) recordNodePhaseChangeEvents(old *wfv1.Nodes, new *wfv
 		return
 	}
 	oldNodes := *old
-	newNodes := *new
 
 	// Check for newly added nodes; send an event for new nodes
-	for nodeName, newNode := range newNodes {
+	for nodeName, newNode := range *new {
 		oldNode, exists := oldNodes[nodeName]
 		if exists {
 			if oldNode.Phase == newNode.Phase {
 				continue
 			}
 			if oldNode.Phase == wfv1.NodePending && newNode.Completed() {
-				origPhase := newNode.Phase
-				newNode.Phase = wfv1.NodeRunning
-				woc.recordNodePhaseEvent(&newNode)
-				newNode.Phase = origPhase
+				ephemeralNode := newNode.DeepCopy()
+				ephemeralNode.Phase = wfv1.NodeRunning
+				woc.recordNodePhaseEvent(ephemeralNode)
 			}
 			woc.recordNodePhaseEvent(&newNode)
 		} else {
 			if newNode.Phase == wfv1.NodeRunning {
 				woc.recordNodePhaseEvent(&newNode)
 			} else if newNode.Completed() {
-				origPhase := newNode.Phase
-				newNode.Phase = wfv1.NodeRunning
-				woc.recordNodePhaseEvent(&newNode)
-				newNode.Phase = origPhase
+				ephemeralNode := newNode.DeepCopy()
+				ephemeralNode.Phase = wfv1.NodeRunning
+				woc.recordNodePhaseEvent(ephemeralNode)
 				woc.recordNodePhaseEvent(&newNode)
 			}
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -554,6 +554,10 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.controller.hydrator.HydrateWithNodes(woc.wf, nodes)
 	}
 
+	// The workflow returned from wfClient.Update doesn't have a TypeMeta associated
+	// with it, so copy from the original workflow.
+	woc.wf.TypeMeta = woc.orig.TypeMeta
+
 	// Create WorkflowNode* events for nodes that have changed phase
 	woc.recordNodePhaseChangeEvents(&woc.orig.Status.Nodes, &woc.wf.Status.Nodes)
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -559,7 +559,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 	woc.wf.TypeMeta = woc.orig.TypeMeta
 
 	// Create WorkflowNode* events for nodes that have changed phase
-	woc.recordNodePhaseChangeEvents(&woc.orig.Status.Nodes, &woc.wf.Status.Nodes)
+	woc.recordNodePhaseChangeEvents(woc.orig.Status.Nodes, woc.wf.Status.Nodes)
 
 	if !woc.controller.hydrator.IsHydrated(woc.wf) {
 		panic("workflow should be hydrated")
@@ -2109,15 +2109,14 @@ func (woc *wfOperationCtx) recordNodePhaseEvent(node *wfv1.NodeStatus) {
 
 // recordNodePhaseChangeEvents creates WorkflowNode Kubernetes events for each node
 // that has changes logged during this execution of the operator loop.
-func (woc *wfOperationCtx) recordNodePhaseChangeEvents(old *wfv1.Nodes, new *wfv1.Nodes) {
+func (woc *wfOperationCtx) recordNodePhaseChangeEvents(old wfv1.Nodes, new wfv1.Nodes) {
 	if !woc.controller.Config.NodeEvents.IsEnabled() {
 		return
 	}
-	oldNodes := *old
 
 	// Check for newly added nodes; send an event for new nodes
-	for nodeName, newNode := range *new {
-		oldNode, exists := oldNodes[nodeName]
+	for nodeName, newNode := range new {
+		oldNode, exists := old[nodeName]
 		if exists {
 			if oldNode.Phase == newNode.Phase {
 				continue

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3224,7 +3224,7 @@ spec:
 			makePodsPhase(ctx, woc, apiv1.PodSucceeded)
 			woc = newWorkflowOperationCtx(woc.wf, controller)
 			woc.operate(ctx)
-			assert.Equal(t, want, getEvents(controller, len(want)))
+			assert.ElementsMatch(t, want, getEvents(controller, len(want)))
 		})
 	}
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3165,6 +3165,8 @@ spec:
         image: docker/whalesay:latest
 `: {
 			"Normal WorkflowRunning Workflow Running",
+			"Normal WorkflowNodeRunning Running node dag-events",
+			"Normal WorkflowNodeRunning Running node dag-events.a",
 			"Normal WorkflowNodeSucceeded Succeeded node dag-events.a",
 			"Normal WorkflowNodeSucceeded Succeeded node dag-events",
 			"Normal WorkflowSucceeded Workflow completed",
@@ -3185,9 +3187,30 @@ spec:
         image: docker/whalesay:latest
 `: {
 			"Normal WorkflowRunning Workflow Running",
+			"Normal WorkflowNodeRunning Running node steps-events",
+			"Normal WorkflowNodeRunning Running node steps-events[0]",
+			"Normal WorkflowNodeRunning Running node steps-events[0].a",
 			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
 			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0]",
 			"Normal WorkflowNodeSucceeded Succeeded node steps-events",
+			"Normal WorkflowSucceeded Workflow completed",
+		},
+		// no DAG or steps
+		`
+metadata:
+  name: no-dag-or-steps
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+`: {
+			"Normal WorkflowRunning Workflow Running",
+			"Normal WorkflowNodeRunning Running node no-dag-or-steps",
+			"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
 			"Normal WorkflowSucceeded Workflow completed",
 		},
 	} {


### PR DESCRIPTION
Signed-off-by: Kenny Trytek <kenneth.g.trytek@gmail.com>

### Checklist
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* [X] I am committing on my own time.

### Feature Request
This pull request adds a `Running` event to WorkflowNode execution, outlined in https://github.com/argoproj/argo-workflows/issues/5320.

### Testing This Change
Besides the updated unit and functional tests, I ran this change locally with Argo Events installed and a sensor and trigger set up to deliver webhooks to another locally-running server.

Below is a running log of my testing steps as I iterated on this change. Discrete thoughts/iterations are separated by a horizontal line.

------------

Running [the hello-world example](https://raw.githubusercontent.com/argoproj/argo/master/examples/hello-world.yaml), I have so far not seen any `WorkflowNodeRunning` event anywhere. I'm not sure why this is the case, but I will continue to look and see what I am missing. I thought writing to `woc.eventRecorder` would be sufficient to create these events, but maybe there is another step that I am not aware of.

------------

Running this example from the `operator_test.go`, I get a different result locally than in the test.

Workflow:
```
metadata:
  name: steps-events
spec:
  entrypoint: main
  templates:
    - name: main
      steps:
        - - name: a
            template: whalesay
    - name: whalesay
      container:
        image: docker/whalesay:latest
```

Test result in `operator_test.go`:
```
"Normal WorkflowRunning Workflow Running",
"Normal WorkflowNodeRunning Running node steps-events",
"Normal WorkflowNodeRunning Running node steps-events[0]",
"Normal WorkflowNodeRunning Running node steps-events[0].a",
"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
"Normal WorkflowNodeSucceeded Succeeded node steps-events[0]",
"Normal WorkflowNodeSucceeded Succeeded node steps-events",
"Normal WorkflowSucceeded Workflow completed",
```

Local result from `argo submit` of that workflow with an Argo Events sensor:
```
"Normal WorkflowRunning Workflow Running",
"Normal WorkflowNodeRunning Running node steps-events",
"Normal WorkflowNodeRunning Running node steps-events[0]",
"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
"Normal WorkflowNodeSucceeded Succeeded node steps-events[0]",
"Normal WorkflowNodeSucceeded Succeeded node steps-events",
"Normal WorkflowSucceeded Workflow completed",
```
Note that `"Normal WorkflowNodeRunning Running node steps-events[0].a"` is missing. I will continue to investigate why this occurs.

------------

Simplifying this test, I see the same results.
Workflow:
```
metadata:
  name: no-dag-or-steps
spec:
  entrypoint: whalesay
  templates:
  - name: whalesay
    container:
      image: docker/whalesay:latest
      command: [cowsay]
      args: ["hello world"]
```

`operator_test.go` result:
```
"Normal WorkflowRunning Workflow Running",
"Normal WorkflowNodeRunning Running node no-dag-or-steps",
"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
"Normal WorkflowSucceeded Workflow completed",
```

Local Argo result:
```
"Normal WorkflowRunning Workflow Running",
"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
"Normal WorkflowSucceeded Workflow completed",
```

------------

Okay, found it. It's this case where the node completes very quickly and is never registered as "running."
https://github.com/argoproj/argo-workflows/blob/d964fe4484c6ad4a313deb9994288d402a543018/workflow/controller/operator.go#L1598

Now to decide how to handle it. Should Argo _always_ emit a `WorkflowNodeRunning` event in the case the node ran to completion, even if the event is artificial? I think it should, so that the events emitted are predictable and not susceptible to race conditions.

------------

Okay, force-pushed my changes since this PR is still in draft.

Latest results running this workflow:
```
metadata:
  name: no-dag-or-steps
spec:
  entrypoint: whalesay
  templates:
  - name: whalesay
    container:
      image: docker/whalesay:latest
      command: [cowsay]
      args: ["hello world"]
```

With an Argo event source configured to send events to a locally-running web server, I get these results:
```
Headers:
{
  "x-argo-event-id": "65316463366232612d613536632d346433362d393232632d633734356233333865663832",
  "x-argo-event-time": "2021-03-30T02:52:28Z",
  "x-argo-event-type": "ADD"
}
Body:
{
  "message": "Workflow Running",
  "reason": "WorkflowRunning",
  "workflow": {
    "api_version": "argoproj.io/v1alpha1",
    "kind": "Workflow",
    "name": "no-dag-or-steps-8ssqw",
    "namespace": "argo",
    "resource_version": "2605483",
    "uid": "140ccd92-5481-4c5d-846b-3177464e4aea"
  }
}
INFO:     97.125.239.208:0 - "POST /api/v1/webhooks/echo HTTP/1.1" 200 OK
Headers:
{
  "x-argo-event-id": "65353539303135612d326337312d343133352d626632322d306630653338373831326666",
  "x-argo-event-time": "2021-03-30T02:52:36Z",
  "x-argo-event-type": "ADD"
}
Body:
{
  "message": "Running node no-dag-or-steps-8ssqw",
  "reason": "WorkflowNodeRunning",
  "workflow": {
    "api_version": "argoproj.io/v1alpha1",
    "kind": "Workflow",
    "name": "no-dag-or-steps-8ssqw",
    "namespace": "argo",
    "resource_version": "2605505",
    "uid": "140ccd92-5481-4c5d-846b-3177464e4aea"
  }
}
INFO:     97.125.239.208:0 - "POST /api/v1/webhooks/echo HTTP/1.1" 200 OK
Headers:
{
  "x-argo-event-id": "65393466646131652d366330312d343532652d626539612d613063333232336439613030",
  "x-argo-event-time": "2021-03-30T02:52:36Z",
  "x-argo-event-type": "ADD"
}
Body:
{
  "message": "Succeeded node no-dag-or-steps-8ssqw",
  "reason": "WorkflowNodeSucceeded",
  "workflow": {
    "api_version": "argoproj.io/v1alpha1",
    "kind": "Workflow",
    "name": "no-dag-or-steps-8ssqw",
    "namespace": "argo",
    "resource_version": "2605505",
    "uid": "140ccd92-5481-4c5d-846b-3177464e4aea"
  }
}
INFO:     97.125.239.208:0 - "POST /api/v1/webhooks/echo HTTP/1.1" 200 OK
Headers:
{
  "x-argo-event-id": "31623137393064652d623162332d343633382d383332652d313735633330613464363062",
  "x-argo-event-time": "2021-03-30T02:52:36Z",
  "x-argo-event-type": "ADD"
}
Body:
{
  "message": "Workflow completed",
  "reason": "WorkflowSucceeded",
  "workflow": {
    "api_version": "argoproj.io/v1alpha1",
    "kind": "Workflow",
    "name": "no-dag-or-steps-8ssqw",
    "namespace": "argo",
    "resource_version": "2605505",
    "uid": "140ccd92-5481-4c5d-846b-3177464e4aea"
  }
}
INFO:     97.125.239.208:0 - "POST /api/v1/webhooks/echo HTTP/1.1" 200 OK
```

The results here are exactly what was expected: WorkflowRunning, WorkflowNodeRunning, WorkflowNodeSucceeded, WorkflowSucceeded.

✅ 