### PR TITLE
add -o short option for argo cli get command

### DIFF
--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -93,14 +93,14 @@ func TestPrintNode(t *testing.T) {
 	}
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", nodeMessage, ""), node, getArgs)
 
-	getArgs.output = "short"
-	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", nodeMessage), node, getArgs)
-
 	getArgs.output = "wide"
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", getArtifactsString(node), nodeMessage, ""), node, getArgs)
 
 	node.Type = wfv1.NodeTypePod
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t%s\n", jobStatusIconMap[wfv1.NodeRunning], nodeName, nodeTemplateRefName, nodeTemplateRefName, nodeID, "0s", getArtifactsString(node), nodeMessage, "", kubernetesNodeName), node, getArgs)
+
+	getArgs.output = "short"
+	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, nodeID, "0s", nodeMessage, kubernetesNodeName), node, getArgs)
 
 	getArgs.status = "foobar"
 	testPrintNodeImpl(t, "", node, getArgs)

--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -93,6 +93,9 @@ func TestPrintNode(t *testing.T) {
 	}
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", nodeMessage, ""), node, getArgs)
 
+	getArgs.output = "short"
+	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", nodeMessage), node, getArgs)
+
 	getArgs.output = "wide"
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t\n", nodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", getArtifactsString(node), nodeMessage, ""), node, getArgs)
 

--- a/docs/cli/argo_get.md
+++ b/docs/cli/argo_get.md
@@ -29,7 +29,7 @@ argo get WORKFLOW... [flags]
       --no-color                     Disable colorized output
       --no-utf8                      Use plain 7-bits ascii characters
       --node-field-selector string   selector of node to display, eg: --node-field-selector phase=abc
-  -o, --output string                Output format. One of: json|yaml|wide
+  -o, --output string                Output format. One of: json|yaml|short|wide
       --status string                Filter by status (Pending, Running, Succeeded, Skipped, Failed, Error)
 ```
 


### PR DESCRIPTION
Closes #3090

Adds `short` option to `-o` flag to `argo get` command:
```
$: ./argo get hello-world-44bzs -o short
STEP                  TEMPLATE  PODNAME            DURATION  MESSAGE            NODENAME
 ◷ hello-world-44bzs  whalesay  hello-world-44bzs  1m        ContainerCreating  microk8s-vm
```