### PR TITLE
feat: Generate self-signed certs with SAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ endif
 argo-server.crt: argo-server.key
 
 argo-server.key:
-	openssl req -x509 -newkey rsa:4096 -keyout argo-server.key -out argo-server.crt -days 365 -nodes -subj /CN=localhost/O=ArgoProj
+	go run ./hack/certs
 
 .PHONY: cli-image
 cli-image: dist/argocli.image

--- a/hack/certs/generate_certs.go
+++ b/hack/certs/generate_certs.go
@@ -40,7 +40,7 @@ func main() {
 		BasicConstraintsValid: true,
 	}
 
-	for _, h := range []string{"localhost"} {
+	for _, h := range []string{"localhost", "127.0.0.1"} {
 		if ip := net.ParseIP(h); ip != nil {
 			template.IPAddresses = append(template.IPAddresses, ip)
 		} else {

--- a/hack/certs/generate_certs.go
+++ b/hack/certs/generate_certs.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	log "github.com/sirupsen/logrus"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+
+	keyUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("Failed to generate serial number: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"ArgoProj"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	for _, h := range []string{"localhost"} {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %v", err)
+	}
+
+	certOut, err := os.Create("argo-server.crt")
+	if err != nil {
+		log.Fatalf("Failed to open argo-server.crt for writing: %v", err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		log.Fatalf("Failed to write data to argo-server.crt: %v", err)
+	}
+	if err := certOut.Close(); err != nil {
+		log.Fatalf("Error closing argo-server.crt: %v", err)
+	}
+	log.Print("wrote argo-server.crt\n")
+
+	keyOut, err := os.OpenFile("argo-server.key", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		log.Fatalf("Failed to open argo-server.key for writing: %v", err)
+		return
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		log.Fatalf("Unable to marshal private key: %v", err)
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		log.Fatalf("Failed to write data to argo-server.key: %v", err)
+	}
+	if err := keyOut.Close(); err != nil {
+		log.Fatalf("Error closing argo-server.key: %v", err)
+	}
+	log.Print("wrote argo-server.key\n")
+}

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/soheilhy/cmux"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 
@@ -271,8 +272,13 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 	}
 	dialOpts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize)),
-		grpc.WithInsecure(),
 	}
+	if as.tlsConfig != nil {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(as.tlsConfig)))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	}
+
 	webhookInterceptor := webhook.Interceptor(as.clients.Kubernetes)
 
 	// HTTP 1.1+JSON Server


### PR DESCRIPTION
This should fix the `CN certificate invalid` issue.

Taking Golang's lead from https://github.com/golang/go/blob/ba9e10889976025ee1d027db6b1cad383ec56de8/src/crypto/tls/generate_cert.go as suggested by https://github.com/golang/go/issues/39568#issuecomment-671424481