### PR TITLE
fix(artifacts): only retry on transient S3 errors

### DIFF
--- a/workflow/artifacts/s3/error_codes.go
+++ b/workflow/artifacts/s3/error_codes.go
@@ -1,0 +1,14 @@
+package s3
+
+// s3TransientErrorCodes is a list of S3 error codes that are transient (retryable)
+// Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
+var s3TransientErrorCodes = []string{
+	"InternalError",
+	"RequestTimeout",
+	"Throttling",
+	"ThrottlingException",
+	"RequestLimitExceeded",
+	"RequestThrottled",
+	"InternalError",
+	"SlowDown",
+}

--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -1,5 +1,7 @@
 package s3
 
+import argos3 "github.com/argoproj/pkg/s3"
+
 // s3TransientErrorCodes is a list of S3 error codes that are transient (retryable)
 // Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
 var s3TransientErrorCodes = []string{
@@ -11,4 +13,17 @@ var s3TransientErrorCodes = []string{
 	"RequestThrottled",
 	"InternalError",
 	"SlowDown",
+}
+
+// isTransientS3Err checks if an minio.ErrorResponse error is transient (retryable)
+func isTransientS3Err(err error) bool {
+	if err == nil {
+		return false
+	}
+	for _, transientErrCode := range s3TransientErrorCodes {
+		if argos3.IsS3ErrCode(err, transientErrCode) {
+			return true
+		}
+	}
+	return false
 }

--- a/workflow/artifacts/s3/errors_test.go
+++ b/workflow/artifacts/s3/errors_test.go
@@ -1,0 +1,22 @@
+package s3
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransientOSSErr(t *testing.T) {
+	for _, errCode := range s3TransientErrorCodes {
+		err := minio.ErrorResponse{Code: errCode}
+		assert.True(t, isTransientS3Err(err))
+	}
+
+	err := minio.ErrorResponse{Code: "NoSuchBucket"}
+	assert.False(t, isTransientS3Err(err))
+
+	nonOSSErr := errors.New("UnseenError")
+	assert.False(t, isTransientS3Err(nonOSSErr))
+}

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -126,7 +126,7 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 	return err
 }
 
-// loadS3Artifact uploads artifacts to an S3 compliant storage
+// saveS3Artifact uploads artifacts to an S3 compliant storage
 // returns true if the upload is completed or can't be retried (non-transient error)
 // returns false if it can be retried (transient error)
 func saveS3Artifact(s3cli argos3.S3Client, path string, outputArtifact *wfv1.Artifact) (bool, error) {

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -30,7 +30,7 @@ type ArtifactDriver struct {
 	Context     context.Context
 }
 
-// s3TransientErrorCodes is a list of S3 error codes that are transient (retryable))))
+// s3TransientErrorCodes is a list of S3 error codes that are transient (retryable)
 // Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
 var s3TransientErrorCodes = []string{
 	"InternalError",

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -27,6 +28,19 @@ type ArtifactDriver struct {
 	RoleARN     string
 	UseSDKCreds bool
 	Context     context.Context
+}
+
+// s3TransientErrorCodes is a list of S3 error codes that are transient (retryable))))
+// Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
+var s3TransientErrorCodes = []string{
+	"InternalError",
+	"RequestTimeout",
+	"Throttling",
+	"ThrottlingException",
+	"RequestLimitExceeded",
+	"RequestThrottled",
+	"InternalError",
+	"SlowDown",
 }
 
 var _ artifactscommon.ArtifactDriver = &ArtifactDriver{}
@@ -57,21 +71,30 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
 				log.Warnf("Failed to create new S3 client: %v", err)
-				return false, nil
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			origErr := s3cli.GetFile(inputArtifact.S3.Bucket, inputArtifact.S3.Key, path)
 			if origErr == nil {
 				return true, nil
 			}
 			if !argos3.IsS3ErrCode(origErr, "NoSuchKey") {
-				log.Warnf("Failed get file: %v", origErr)
-				return false, nil
+				log.Warnf("Failed to get file: %v", origErr)
+				if isTransientS3Err(origErr) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to get file: %v", origErr)
 			}
 			// If we get here, the error was a NoSuchKey. The key might be a s3 "directory"
 			isDir, err := s3cli.IsDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
 			if err != nil {
-				log.Warnf("Failed to test if %s is a directory: %v", inputArtifact.S3.Bucket, err)
-				return false, nil
+				log.Warnf("Failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
 			}
 			if !isDir {
 				// It's neither a file, nor a directory. Return the original NoSuchKey error
@@ -79,8 +102,11 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			}
 
 			if err = s3cli.GetDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key, path); err != nil {
-				log.Warnf("Failed get directory: %v", err)
-				return false, nil
+				log.Warnf("Failed to get directory: %v", err)
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to get directory: %v", err)
 			}
 			return true, nil
 		})
@@ -99,12 +125,18 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
 				log.Warnf("Failed to create new S3 client: %v", err)
-				return false, nil
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			isDir, err := file.IsDirectory(path)
 			if err != nil {
 				log.Warnf("Failed to test if %s is a directory: %v", path, err)
-				return false, nil
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to test if %s is a directory: %v", path, err)
 			}
 
 			createBucketIfNotPresent := outputArtifact.S3.CreateBucketIfNotPresent
@@ -115,19 +147,29 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 					ObjectLocking: outputArtifact.S3.CreateBucketIfNotPresent.ObjectLocking,
 				})
 				if err != nil {
-					log.Warnf("Failed to create bucket: %v. Error: %v", outputArtifact.S3.Bucket, err)
+					log.Warnf("Failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
+					if isTransientS3Err(err) {
+						return false, nil
+					}
+					return false, fmt.Errorf("failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
 				}
 			}
 
 			if isDir {
 				if err = s3cli.PutDirectory(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
 					log.Warnf("Failed to put directory: %v", err)
-					return false, nil
+					if isTransientS3Err(err) {
+						return false, nil
+					}
+					return false, fmt.Errorf("failed to put directory: %v", err)
 				}
 			} else {
 				if err = s3cli.PutFile(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
 					log.Warnf("Failed to put file: %v", err)
-					return false, nil
+					if isTransientS3Err(err) {
+						return false, nil
+					}
+					return false, fmt.Errorf("failed to put file: %v", err)
 				}
 			}
 			return true, nil
@@ -144,14 +186,33 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 		func() (bool, error) {
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return false, err
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			files, err = s3cli.ListDirectory(artifact.S3.Bucket, artifact.S3.Key)
 			if err != nil {
-				return false, err
+				if isTransientS3Err(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("failed to list directory: %v", err)
 			}
 			return true, nil
 		})
 
 	return files, err
+}
+
+// isTransientS3Err checks if an minio.ErrorResponse error is transient (retryable)
+func isTransientS3Err(err error) bool {
+	if err == nil {
+		return false
+	}
+	for _, transientErrCode := range s3TransientErrorCodes {
+		if argos3.IsS3ErrCode(err, transientErrCode) {
+			return true
+		}
+	}
+	return false
 }

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -70,8 +70,8 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			log.Infof("S3 Load path: %s, key: %s", path, inputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				log.Warnf("Failed to create new S3 client: %v", err)
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to create new S3 client: %v", err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to create new S3 client: %v", err)
@@ -81,8 +81,8 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 				return true, nil
 			}
 			if !argos3.IsS3ErrCode(origErr, "NoSuchKey") {
-				log.Warnf("Failed to get file: %v", origErr)
 				if isTransientS3Err(origErr) {
+					log.Warnf("Failed to get file: %v", origErr)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to get file: %v", origErr)
@@ -90,8 +90,8 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			// If we get here, the error was a NoSuchKey. The key might be a s3 "directory"
 			isDir, err := s3cli.IsDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
 			if err != nil {
-				log.Warnf("Failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
@@ -102,8 +102,8 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			}
 
 			if err = s3cli.GetDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key, path); err != nil {
-				log.Warnf("Failed to get directory: %v", err)
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to get directory: %v", err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to get directory: %v", err)
@@ -124,16 +124,16 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 			log.Infof("S3 Save path: %s, key: %s", path, outputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				log.Warnf("Failed to create new S3 client: %v", err)
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to create new S3 client: %v", err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			isDir, err := file.IsDirectory(path)
 			if err != nil {
-				log.Warnf("Failed to test if %s is a directory: %v", path, err)
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to test if %s is a directory: %v", path, err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to test if %s is a directory: %v", path, err)
@@ -147,8 +147,8 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 					ObjectLocking: outputArtifact.S3.CreateBucketIfNotPresent.ObjectLocking,
 				})
 				if err != nil {
-					log.Warnf("Failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
 					if isTransientS3Err(err) {
+						log.Warnf("Failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
 						return false, nil
 					}
 					return false, fmt.Errorf("failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
@@ -157,16 +157,16 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 
 			if isDir {
 				if err = s3cli.PutDirectory(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
-					log.Warnf("Failed to put directory: %v", err)
 					if isTransientS3Err(err) {
+						log.Warnf("Failed to put directory: %v", err)
 						return false, nil
 					}
 					return false, fmt.Errorf("failed to put directory: %v", err)
 				}
 			} else {
 				if err = s3cli.PutFile(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
-					log.Warnf("Failed to put file: %v", err)
 					if isTransientS3Err(err) {
+						log.Warnf("Failed to put file: %v", err)
 						return false, nil
 					}
 					return false, fmt.Errorf("failed to put file: %v", err)
@@ -187,6 +187,7 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to create new S3 client: %v", err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to create new S3 client: %v", err)
@@ -194,6 +195,7 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 			files, err = s3cli.ListDirectory(artifact.S3.Bucket, artifact.S3.Key)
 			if err != nil {
 				if isTransientS3Err(err) {
+					log.Warnf("Failed to list directory: %v", err)
 					return false, nil
 				}
 				return false, fmt.Errorf("failed to list directory: %v", err)

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -31,19 +31,6 @@ type ArtifactDriver struct {
 	Context     context.Context
 }
 
-// s3TransientErrorCodes is a list of S3 error codes that are transient (retryable)
-// Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
-var s3TransientErrorCodes = []string{
-	"InternalError",
-	"RequestTimeout",
-	"Throttling",
-	"ThrottlingException",
-	"RequestLimitExceeded",
-	"RequestThrottled",
-	"InternalError",
-	"SlowDown",
-}
-
 var (
 	_            artifactscommon.ArtifactDriver = &ArtifactDriver{}
 	defaultRetry                                = wait.Backoff{Duration: time.Second * 2, Factor: 2.0, Steps: 5, Jitter: 0.1}

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -166,16 +166,3 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 
 	return files, err
 }
-
-// isTransientS3Err checks if an minio.ErrorResponse error is transient (retryable)
-func isTransientS3Err(err error) bool {
-	if err == nil {
-		return false
-	}
-	for _, transientErrCode := range s3TransientErrorCodes {
-		if argos3.IsS3ErrCode(err, transientErrCode) {
-			return true
-		}
-	}
-	return false
-}

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -359,17 +358,4 @@ func TestSaveS3Artifact(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestIsTransientOSSErr(t *testing.T) {
-	for _, errCode := range s3TransientErrorCodes {
-		err := minio.ErrorResponse{Code: errCode}
-		assert.True(t, isTransientS3Err(err))
-	}
-
-	err := minio.ErrorResponse{Code: "NoSuchBucket"}
-	assert.False(t, isTransientS3Err(err))
-
-	nonOSSErr := errors.New("UnseenError")
-	assert.False(t, isTransientS3Err(nonOSSErr))
 }

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/minio/minio-go/v7"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -2,11 +2,364 @@ package s3
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	argos3 "github.com/argoproj/pkg/s3"
 	"github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/assert"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
+
+type mockS3Client struct {
+	// files is a map where key is bucket name and value consists of file keys
+	files map[string][]string
+	// mockedErrs is a map where key is the function name and value is the mocked error of that function
+	mockedErrs map[string]error
+}
+
+func newMockS3Client(files map[string][]string, mockedErrs map[string]error) *mockS3Client {
+	return &mockS3Client{
+		files:      files,
+		mockedErrs: mockedErrs,
+	}
+}
+
+func (s *mockS3Client) getMockedErr(funcName string) error {
+	err, ok := s.mockedErrs[funcName]
+	if !ok {
+		return nil
+	}
+	return err
+}
+
+// PutFile puts a single file to a bucket at the specified key
+func (s *mockS3Client) PutFile(bucket, key, path string) error {
+	return s.getMockedErr("PutFile")
+}
+
+// PutDirectory puts a complete directory into a bucket key prefix, with each file in the directory
+// a separate key in the bucket.
+func (s *mockS3Client) PutDirectory(bucket, key, path string) error {
+	return s.getMockedErr("PutDirectory")
+}
+
+// GetFile downloads a file to a local file path
+func (s *mockS3Client) GetFile(bucket, key, path string) error {
+	return s.getMockedErr("GetFile")
+}
+
+// GetDirectory downloads a directory to a local file path
+func (s *mockS3Client) GetDirectory(bucket, key, path string) error {
+	return s.getMockedErr("GetDirectory")
+}
+
+// ListDirectory list the contents of a directory/bucket
+func (s *mockS3Client) ListDirectory(bucket, keyPrefix string) ([]string, error) {
+	dirs := make([]string, 0)
+	err := s.getMockedErr("ListDirectory")
+	if files, ok := s.files[bucket]; ok {
+		for _, file := range files {
+			if strings.HasPrefix(file, keyPrefix) {
+				dirs = append(dirs, file)
+			}
+		}
+	}
+	return dirs, err
+}
+
+// IsDirectory tests if the key is acting like a s3 directory
+func (s *mockS3Client) IsDirectory(bucket, key string) (bool, error) {
+	var isDir bool
+	if !strings.HasSuffix(key, "/") {
+		key += "/"
+	}
+	if files, ok := s.files[bucket]; ok {
+		for _, file := range files {
+			if strings.HasPrefix(file, key) {
+				isDir = true
+				break
+			}
+		}
+	}
+	return isDir, s.getMockedErr("IsDirectory")
+}
+
+// BucketExists returns whether a bucket exists
+func (s *mockS3Client) BucketExists(bucket string) (bool, error) {
+	err := s.getMockedErr("BucketExists")
+	if _, ok := s.files[bucket]; ok {
+		return true, err
+	}
+	return false, err
+}
+
+// MakeBucket creates a bucket with name bucketName and options opts
+func (s *mockS3Client) MakeBucket(bucketName string, opts minio.MakeBucketOptions) error {
+	return s.getMockedErr("MakeBucket")
+}
+
+func TestLoadS3Artifact(t *testing.T) {
+	tests := map[string]struct {
+		s3client  argos3.S3Client
+		bucket    string
+		key       string
+		localPath string
+		done      bool
+		errMsg    string
+	}{
+		"Success": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": []string{
+						"/folder/hello-art.tar.gz",
+					},
+				},
+				map[string]error{}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: "/tmp/hello-art.tar.gz",
+			done:      true,
+			errMsg:    "",
+		},
+		"No such bucket": {
+			s3client: newMockS3Client(
+				map[string][]string{},
+				map[string]error{
+					"GetFile": minio.ErrorResponse{
+						Code: "NoSuchBucket",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: "/tmp/hello-art.tar.gz",
+			done:      true,
+			errMsg:    "failed to get file: The specified bucket does not exist.",
+		},
+		"No such key": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": []string{
+						"/folder/hello-art-2.tar.gz",
+					},
+				},
+				map[string]error{
+					"GetFile": minio.ErrorResponse{
+						Code: "NoSuchKey",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: "/tmp/hello-art.tar.gz",
+			done:      true,
+			errMsg:    "The specified key does not exist.",
+		},
+		"Is Directory": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": []string{
+						"/folder/hello-art-2.tar.gz",
+					},
+				},
+				map[string]error{
+					"GetFile": minio.ErrorResponse{
+						Code: "NoSuchKey",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/",
+			localPath: "/tmp/folder/",
+			done:      true,
+			errMsg:    "",
+		},
+		"Test Directory Failed": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": []string{
+						"/folder/hello-art-2.tar.gz",
+					},
+				},
+				map[string]error{
+					"GetFile": minio.ErrorResponse{
+						Code: "NoSuchKey",
+					},
+					"IsDirectory": minio.ErrorResponse{
+						Code: "InternalError",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/",
+			localPath: "/tmp/folder/",
+			done:      false,
+			errMsg:    "failed to test if /folder/ is a directory: We encountered an internal error, please try again.",
+		},
+		"Get Directory Failed": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": []string{
+						"/folder/hello-art-2.tar.gz",
+					},
+				},
+				map[string]error{
+					"GetFile": minio.ErrorResponse{
+						Code: "NoSuchKey",
+					},
+					"GetDirectory": minio.ErrorResponse{
+						Code: "InternalError",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/",
+			localPath: "/tmp/folder/",
+			done:      false,
+			errMsg:    "failed to get directory: We encountered an internal error, please try again.",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			success, err := loadS3Artifact(tc.s3client, &wfv1.Artifact{
+				ArtifactLocation: wfv1.ArtifactLocation{
+					S3: &wfv1.S3Artifact{
+						S3Bucket: wfv1.S3Bucket{
+							Bucket: tc.bucket,
+						},
+						Key: tc.key,
+					},
+				},
+			}, tc.localPath)
+			assert.Equal(t, tc.done, success)
+			if err != nil {
+				assert.Equal(t, tc.errMsg, err.Error())
+			} else {
+				assert.Equal(t, tc.errMsg, "")
+			}
+		})
+	}
+}
+
+func TestSaveS3Artifact(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "example")
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.RemoveAll(tempDir) // clean up
+
+	tempFile := filepath.Join(tempDir, "tmpfile")
+	if err := ioutil.WriteFile(tempFile, []byte("temporary file's content"), 0666); err != nil {
+		panic(err)
+	}
+
+	tests := map[string]struct {
+		s3client  argos3.S3Client
+		bucket    string
+		key       string
+		localPath string
+		done      bool
+		errMsg    string
+	}{
+		"Success as File": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": {},
+				},
+				map[string]error{}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: tempFile,
+			done:      true,
+			errMsg:    "",
+		},
+		"Success as Directory": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": []string{},
+				},
+				map[string]error{}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: tempDir,
+			done:      true,
+			errMsg:    "",
+		},
+		"Make Bucket Access Denied": {
+			s3client: newMockS3Client(
+				map[string][]string{},
+				map[string]error{
+					"MakeBucket": minio.ErrorResponse{
+						Code: "AccessDenied",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: tempDir,
+			done:      true,
+			errMsg:    "failed to create bucket my-bucket: Access Denied.",
+		},
+		"Save Directory Transient Error": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": {},
+				},
+				map[string]error{
+					"PutDirectory": minio.ErrorResponse{
+						Code: "InternalError",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: tempDir,
+			done:      false,
+			errMsg:    "failed to put directory: We encountered an internal error, please try again.",
+		},
+		"Save File Transient Error": {
+			s3client: newMockS3Client(
+				map[string][]string{
+					"my-bucket": {},
+				},
+				map[string]error{
+					"PutFile": minio.ErrorResponse{
+						Code: "InternalError",
+					},
+				}),
+			bucket:    "my-bucket",
+			key:       "/folder/hello-art.tar.gz",
+			localPath: tempFile,
+			done:      false,
+			errMsg:    "failed to put file: We encountered an internal error, please try again.",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			success, err := saveS3Artifact(
+				tc.s3client,
+				tc.localPath,
+				&wfv1.Artifact{
+					ArtifactLocation: wfv1.ArtifactLocation{
+						S3: &wfv1.S3Artifact{
+							S3Bucket: wfv1.S3Bucket{
+								Bucket:                   tc.bucket,
+								CreateBucketIfNotPresent: &wfv1.CreateS3BucketOptions{},
+							},
+							Key: tc.key,
+						},
+					},
+				})
+			assert.Equal(t, tc.done, success)
+			if err != nil {
+				assert.Equal(t, tc.errMsg, err.Error())
+			} else {
+				assert.Equal(t, tc.errMsg, "")
+			}
+		})
+	}
+}
 
 func TestIsTransientOSSErr(t *testing.T) {
 	for _, errCode := range s3TransientErrorCodes {

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -1,0 +1,23 @@
+package s3
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransientOSSErr(t *testing.T) {
+	for _, errCode := range s3TransientErrorCodes {
+		err := minio.ErrorResponse{Code: errCode}
+		assert.True(t, isTransientS3Err(err))
+	}
+
+	err := minio.ErrorResponse{Code: "NoSuchBucket"}
+	assert.False(t, isTransientS3Err(err))
+
+	nonOSSErr := errors.New("UnseenError")
+	assert.False(t, isTransientS3Err(nonOSSErr))
+}


### PR DESCRIPTION
Closes #5220 

Hi,

This PR fixes the issue of executor retrying non-transient S3 errors.

I took the list of retryable errors from [the minio-go repo](https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102).

As of today, this package doesn't have any unit tests. As the logic is getting more complex it's kind of risky to have no tests. I'll see if I can add some. (Might need some minor refactoring)

Thanks!