### PR TITLE
feat(ui): let workflow dag and node info scroll independently

### DIFF
--- a/ui/src/app/shared/components/graph/graph-panel.scss
+++ b/ui/src/app/shared/components/graph/graph-panel.scss
@@ -53,6 +53,7 @@
 .graph {
   overflow: scroll;
   text-align: center;
+  max-height: calc(100vh - 2 * #{$top-bar-height});
 
   .group {
     rect {

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.scss
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.scss
@@ -2,7 +2,7 @@
 
 .workflow-details {
 
-  overflow-y: scroll;
+  overflow-y: hidden;
 
   &, & > .row {
     height: calc(100vh - 2 * #{$top-bar-height});

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.scss
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.scss
@@ -2,6 +2,9 @@
 
 .workflow-node-info {
 
+    max-height: calc(100vh - 2 * #{$top-bar-height});
+    overflow-y: auto;
+
     .tabs {
         a {
             padding-right: 0;


### PR DESCRIPTION
let workflow dag and node info scroll independently
so that users don't need to scroll back and forth when trying to view details from different template



before:
![before](https://user-images.githubusercontent.com/20961507/113739380-140e0c00-9743-11eb-8ddc-f874f7c7d548.PNG)

after:
![after](https://user-images.githubusercontent.com/20961507/113739394-1708fc80-9743-11eb-8f0d-a24cc3b0612d.PNG)


Signed-off-by: Tianchu Zhao <evantczhao@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
