### PR TITLE
fix(executor): Correctly surface error when resource is deleted during status checking

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -213,7 +213,7 @@ func (we *WorkflowExecutor) checkResourceState(ctx context.Context, selfLink str
 	if err != nil {
 		err = errors.Cause(err)
 		if apierr.IsNotFound(err) {
-			err = errors.Errorf(errors.CodeNotFound, "The resource has been deleted while its status was still being checked. Will not be retried: %v", err)
+			return false, errors.Errorf(errors.CodeNotFound, "The resource has been deleted while its status was still being checked. Will not be retried: %v", err)
 		}
 		return false, err
 	}

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -210,6 +211,10 @@ func (we *WorkflowExecutor) checkResourceState(ctx context.Context, selfLink str
 		return true, errors.Errorf(errors.CodeNotFound, "The error is detected to be transient: %v. Retrying...", err)
 	}
 	if err != nil {
+		err = errors.Cause(err)
+		if apierr.IsNotFound(err) {
+			err = errors.Errorf(errors.CodeNotFound, "The resource has been deleted while its status was still being checked. Will not be retried: %v", err)
+		}
 		return false, err
 	}
 
@@ -220,10 +225,6 @@ func (we *WorkflowExecutor) checkResourceState(ctx context.Context, selfLink str
 	}
 	jsonString := string(jsonBytes)
 	log.Info(jsonString)
-
-	if strings.Contains(jsonString, "NotFound") {
-		return false, errors.Errorf(errors.CodeNotFound, "The resource has been deleted. Will not be retried.")
-	}
 	if !gjson.Valid(jsonString) {
 		return false, errors.Errorf(errors.CodeNotFound, "Encountered invalid JSON response when checking resource status. Will not be retried: %q", jsonString)
 	}


### PR DESCRIPTION
In the current implementation, `strings.Contains(jsonString, "NotFound")` block would never be reached since the error would be returned immediately if it's not transient. Also switched to use `apierr.IsNotFound(err)` which is more robust than string matching.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
