### PR TITLE
docs: Revert "docs: Update link to the new CNCF Slack channel (#5681)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![slack](https://img.shields.io/badge/slack-argo_workflows-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01QW9QSSSK)
+[![slack](https://img.shields.io/badge/slack-argoproj-brightgreen.svg?logo=slack)](https://argoproj.github.io/community/join-slack)
 [![CI](https://github.com/argoproj/argo-workflows/workflows/CI/badge.svg)](https://github.com/argoproj/argo-workflows/actions?query=event%3Apush+branch%3Amaster)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3830/badge)](https://bestpractices.coreinfrastructure.org/projects/3830)
 [![Twitter Follow](https://img.shields.io/twitter/follow/argoproj?style=social)](https://twitter.com/argoproj)


### PR DESCRIPTION
I discussed with @alexmt and he's going to reuse the existing link with instructions to join the CNCF workspace and channels. See https://github.com/argoproj/argo-cd/pull/6044#discussion_r614325390 for more context. Reverting previous change.

This reverts commit eab122bba07b8907ee4ab6b1d8d72dcf0adc17fa.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
