### PR TITLE
build: Specify Dockerfile version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+#syntax=docker/dockerfile:1.2
 
 ARG DOCKER_CHANNEL=stable
 ARG DOCKER_VERSION=18.09.1


### PR DESCRIPTION
Needed for the `mount` option on some build system (e.g. ours).