### PR TITLE
fix: Only save memoization cache when node succeeded

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -874,11 +874,13 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 				woc.wf.Status.Nodes[nodeID] = *newState
 				woc.addOutputsToGlobalScope(node.Outputs)
 				if node.MemoizationStatus != nil {
-					c := woc.controller.cacheFactory.GetCache(controllercache.ConfigMapCache, node.MemoizationStatus.CacheName)
-					err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
-					if err != nil {
-						woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
-						node.Phase = wfv1.NodeError
+					if node.Succeeded() {
+						c := woc.controller.cacheFactory.GetCache(controllercache.ConfigMapCache, node.MemoizationStatus.CacheName)
+						err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
+						if err != nil {
+							woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
+							node.Phase = wfv1.NodeError
+						}
 					}
 				}
 				if node.Phase == wfv1.NodeRunning {


### PR DESCRIPTION
I am not sure if this is the intended behavior but currently cache is saved regardless of node's status, which is not useful and counter-intuitive to our users. 

For example, a failed node may have no output like `{"nodeID":"memoized-simple-workflow-fzvkz","outputs":null,"creationTimestamp":"2021-04-19T13:17:28Z"}` and then if a new template retrieves the cache, it will become successful and subsequent steps would fail due to the lack of outputs from the previous step.

Let me know if this currently behavior is indeed desired. Then we probably need to introduce a toggle for this. We have no use case to save cache for unsuccessful nodes.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
