### PR TITLE
fix(ui): Fix workflow list table column width mismatch

### DIFF
--- a/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
@@ -48,8 +48,8 @@ export class WorkflowsRow extends React.Component<WorkflowsRowProps, WorkflowRow
                         <PhaseIcon value={wf.status.phase} />
                     </div>
                     <Link to={uiUrl(`workflows/${wf.metadata.namespace}/${wf.metadata.name}`)} className='small-11 row'>
-                        <div className='columns small-2'>{wf.metadata.name}</div>
-                        <div className='columns small-2'>{wf.metadata.namespace}</div>
+                        <div className='columns small-3'>{wf.metadata.name}</div>
+                        <div className='columns small-1'>{wf.metadata.namespace}</div>
                         <div className='columns small-1'>
                             <Timestamp date={wf.status.startedAt} />
                         </div>


### PR DESCRIPTION
The table header and content don't seem to be aligned. #5678 changed the header width but not the content width.

| Before                                                                                                                                        	| After                                                                                                                                         	|
|-----------------------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Screen Shot 2021-04-21 at 8 22 01 PM](https://user-images.githubusercontent.com/1311594/115638026-8ce29b80-a2df-11eb-8021-45f7791ba2b8.png) 	| ![Screen Shot 2021-04-21 at 8 22 21 PM](https://user-images.githubusercontent.com/1311594/115638027-8ce29b80-a2df-11eb-89a4-6f2dc4f77b98.png) 	|