### PR TITLE
fix(ui): Fix workflow summary page unscrollable issue

### DIFF
--- a/ui/src/app/archived-workflows/components/archived-workflow-details/archived-workflow-details.tsx
+++ b/ui/src/app/archived-workflows/components/archived-workflow-details/archived-workflow-details.tsx
@@ -157,18 +157,20 @@ export class ArchivedWorkflowDetails extends BasePage<RouteComponentProps<any>, 
         return (
             <>
                 {this.tab === 'summary' ? (
-                    <div className='argo-container'>
-                        <div className='workflow-details__content'>
-                            <WorkflowSummaryPanel workflow={this.state.workflow} />
-                            {execSpec(this.state.workflow).arguments && execSpec(this.state.workflow).arguments.parameters && (
-                                <React.Fragment>
-                                    <h6>Parameters</h6>
-                                    <WorkflowParametersPanel parameters={execSpec(this.state.workflow).arguments.parameters} />
-                                </React.Fragment>
-                            )}
-                            <h6>Artifacts</h6>
-                            <WorkflowArtifacts workflow={this.state.workflow} archived={true} />
-                            <WorkflowResourcePanel workflow={this.state.workflow} />
+                    <div className='workflow-details__container'>
+                        <div className='argo-container'>
+                            <div className='workflow-details__content'>
+                                <WorkflowSummaryPanel workflow={this.state.workflow} />
+                                {execSpec(this.state.workflow).arguments && execSpec(this.state.workflow).arguments.parameters && (
+                                    <React.Fragment>
+                                        <h6>Parameters</h6>
+                                        <WorkflowParametersPanel parameters={execSpec(this.state.workflow).arguments.parameters} />
+                                    </React.Fragment>
+                                )}
+                                <h6>Artifacts</h6>
+                                <WorkflowArtifacts workflow={this.state.workflow} archived={true} />
+                                <WorkflowResourcePanel workflow={this.state.workflow} />
+                            </div>
                         </div>
                     </div>
                 ) : (

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.scss
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.scss
@@ -37,6 +37,12 @@
     }
   }
 
+  &__container {
+    height: calc(100vh - 2 * #{$top-bar-height});
+    max-width: 100%;
+    overflow: auto;
+  }
+
   &__graph-container {
     position: relative;
     height: calc(100vh - 2 * #{$top-bar-height});

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -163,20 +163,22 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
                 {!workflow ? (
                     <Loading />
                 ) : (
-                    <div className='argo-container'>
-                        <div className='workflow-details__content'>
-                            <WorkflowSummaryPanel workflow={workflow} />
-                            {renderSecurityNudge()}
-                            {renderCostOptimisations()}
-                            {workflow.spec.arguments && workflow.spec.arguments.parameters && (
-                                <React.Fragment>
-                                    <h6>Parameters</h6>
-                                    <WorkflowParametersPanel parameters={workflow.spec.arguments.parameters} />
-                                </React.Fragment>
-                            )}
-                            <h5>Artifacts</h5>
-                            <WorkflowArtifacts workflow={workflow} archived={false} />
-                            <WorkflowResourcePanel workflow={workflow} />
+                    <div className='workflow-details__container'>
+                        <div className='argo-container'>
+                            <div className='workflow-details__content'>
+                                <WorkflowSummaryPanel workflow={workflow} />
+                                {renderSecurityNudge()}
+                                {renderCostOptimisations()}
+                                {workflow.spec.arguments && workflow.spec.arguments.parameters && (
+                                    <React.Fragment>
+                                        <h6>Parameters</h6>
+                                        <WorkflowParametersPanel parameters={workflow.spec.arguments.parameters} />
+                                    </React.Fragment>
+                                )}
+                                <h5>Artifacts</h5>
+                                <WorkflowArtifacts workflow={workflow} archived={false} />
+                                <WorkflowResourcePanel workflow={workflow} />
+                            </div>
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
I noticed that the workflow summary page is not scrollable. There is no way to scroll down and view the whole workflow manifest. This PR fixes it by wrapping the `argo-container` with a scrollable container.

| Before                                                                                                                                         	| After                                                                                                                 	|
|------------------------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------	|
| ![Screen Shot 2021-04-22 at 11 34 20 PM](https://user-images.githubusercontent.com/1311594/115814604-ebde0880-a3e4-11eb-8bb5-5773d1cb5458.png) 	| ![scroll-after](https://user-images.githubusercontent.com/1311594/115814419-fedfe100-a3c2-11eb-8d96-a7f5db833f37.gif) 	|
