### PR TITLE
fix(ui): Fix greediness in regex for auth token replacement

### DIFF
--- a/ui/src/app/userinfo/components/cli-help.tsx
+++ b/ui/src/app/userinfo/components/cli-help.tsx
@@ -13,7 +13,7 @@ export const CliHelp = () => {
             .split(';')
             .map(x => x.trim())
             .find(x => x.startsWith('authorization=')) || ''
-    ).replace(/^authorization="?(.*)"?$/, '$1');
+    ).replace(/^authorization="?(.*?)"?$/, '$1');
 
     const text = `export ARGO_SERVER='${document.location.hostname}:${document.location.port || (argoSecure ? 443 : 80)}' 
 export ARGO_HTTP1=true  


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Unfortunately my last PR #5677 still has a little bug in the regular expression. The auth token we get from the cookie is sometimes wrapped by quotes (`"`) and sometimes it is not. Therefore the regex wraps the matched token with optional quotes (`"?(.*)"?`). This regex matches`"token"` such as `token`. The problem is the first case (`"token"`). In this case the captured bit inside the parentheses would also match the second quote (`token"`) because the part inside the parentheses (`(.*)`) matches all characters greedily. This can be fixed by matching lazily (`.*?`) as proposed in the Merge request.

Sorry for this - I guess the screenshot testing was not successful. Nevertheless here's more screenshots of the running system before and after my fix:

before:
![Screenshot 2021-04-23 at 16 13 27](https://user-images.githubusercontent.com/695307/115884399-27adb800-a44f-11eb-86a9-7297d0ad9fd9.png)

after:
![Screenshot 2021-04-23 at 16 13 42](https://user-images.githubusercontent.com/695307/115884411-2b413f00-a44f-11eb-9b22-e6268ea40009.png)


<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
