### PR TITLE
fix(ui): Fix the UI crashing issue

### DIFF
--- a/ui/src/app/archived-workflows/components/archived-workflow-list/archived-workflow-list.tsx
+++ b/ui/src/app/archived-workflows/components/archived-workflow-list/archived-workflow-list.tsx
@@ -125,12 +125,16 @@ export class ArchivedWorkflowList extends BasePage<RouteComponentProps<any>, Sta
 
     private get filterParams() {
         const params = new URLSearchParams();
-        this.state.selectedPhases.forEach(phase => {
-            params.append('phase', phase);
-        });
-        this.state.selectedLabels.forEach(label => {
-            params.append('label', label);
-        });
+        if (this.state.selectedPhases) {
+            this.state.selectedPhases.forEach(phase => {
+                params.append('phase', phase);
+            });
+        }
+        if (this.state.selectedLabels) {
+            this.state.selectedLabels.forEach(label => {
+                params.append('label', label);
+            });
+        }
         params.append('minStartedAt', this.state.minStartedAt.toISOString());
         params.append('maxStartedAt', this.state.maxStartedAt.toISOString());
         if (this.state.pagination.offset) {

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -65,12 +65,16 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
 
     private get filterParams() {
         const params = new URLSearchParams();
-        this.state.selectedPhases.forEach(phase => {
-            params.append('phase', phase);
-        });
-        this.state.selectedLabels.forEach(label => {
-            params.append('label', label);
-        });
+        if (this.state.selectedPhases) {
+            this.state.selectedPhases.forEach(phase => {
+                params.append('phase', phase);
+            });
+        }
+        if (this.state.selectedLabels) {
+            this.state.selectedLabels.forEach(label => {
+                params.append('label', label);
+            });
+        }
         if (this.state.pagination.offset) {
             params.append('offset', this.state.pagination.offset);
         }


### PR DESCRIPTION
#5498 Fixed the labels not being remembered issue. However, when the user switched from an earlier version of Argo to the latest, the UI crashes because `selectedLabels` was not previously stored in the localStroage.

To reproduce:
1. Clear localStorage
1. Checkout a version before #5498 4eb351cbaf82bbee5903b91b4ef094190e1e0134 (e.g. dfe6ceb430d2bd7c13987624105450a0994e08fc)
1. Play Argo UI for a bit, then switch back to the latest master commit
1. UI crashes now

This will give an unpleasant user experience when they upgrade Argo version. This PR fixes the crashing issue by simply adding some checks.

![Untitled](https://user-images.githubusercontent.com/1311594/115971813-a9b5e380-a518-11eb-95bb-5a148c7482cd.png)

/cc @simster7 