### PR TITLE
fix(ui): Fix an UI dropdown flickering issue

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.scss
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.scss
@@ -2,7 +2,7 @@
 
 .workflow-node-info {
 
-    max-height: calc(100vh - 2 * #{$top-bar-height});
+    height: calc(100vh - 2 * #{$top-bar-height});
     overflow-y: auto;
 
     .tabs {


### PR DESCRIPTION
The UI currently has a strange flickering issue on Chrome 90.0.4430.93

## Diagnose

The issue is introduced because the container `workflow-node-info` is not long enough. Whenever the dropdown is triggered, it overflows the container, having scroll bar to appear. The scroll bar then squeezes the width of the container.

I propose a simple fix to set the height of `workflow-node-info` to full screen, so that dropdown won't overflow the container anymore.

![Screen Shot 2021-04-28 at 11 52 09 PM](https://user-images.githubusercontent.com/1311594/116501269-617f2400-a87e-11eb-8e2d-4fda62fd2465.png)

Before & after:

| Before                                                                                                                             	| After                                                                                                                             	|
|------------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------------------	|
| ![dropdown-flicering-before](https://user-images.githubusercontent.com/1311594/116500351-64791500-a87c-11eb-9936-e4190858e413.gif) 	| ![dropdown-flicering-after](https://user-images.githubusercontent.com/1311594/116500389-78bd1200-a87c-11eb-8eba-4721d1307ac3.gif) 	|


<details><summary>Also tested on very long node info page and scrolling still works</summary>
<p>

![dropdown-flicering-after2](https://user-images.githubusercontent.com/1311594/116501495-e407e380-a87e-11eb-8f15-82e0a2d83b4d.gif)

</p>
</details>