### PR TITLE
docs: Propose to mark k8sapi as somewhat popular

### DIFF
--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -45,7 +45,7 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
 
 * Reliability:
     * Well-tested
-    * Popular
+    * Somewhat Popular
 * Most secure:
     * No `privileged` access
     * Cannot escape the privileges of the pod's service account


### PR DESCRIPTION
After reading this doc I originally went with k8sapi since it seemed the most kubernetes native, secure and was considered popular. But this seems to not be the case. 
Reference.
https://github.com/argoproj/argo-workflows/issues/5770#issuecomment-828607599

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
