### PR TITLE
build: fix codegen failure on master branch

### DIFF
--- a/pkg/apis/workflow/v1alpha1/generated.pb.go
+++ b/pkg/apis/workflow/v1alpha1/generated.pb.go
@@ -22213,10 +22213,7 @@ func (m *OSSBucket) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthGenerated
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthGenerated
 			}
 			if (iNdEx + skippy) > l {


### PR DESCRIPTION
CI on master branch is failing.

The reason is that #5780 upgraded the protobuf version and #5731 needs protobuf regenerated.