### PR TITLE
fix: Reset started time for each node to current when retrying workflow

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -754,6 +754,7 @@ func retryWorkflow(ctx context.Context, kubeClient kubernetes.Interface, hydrato
 				newNode := node.DeepCopy()
 				newNode.Phase = wfv1.NodeRunning
 				newNode.Message = ""
+				newNode.StartedAt = metav1.Time{Time: time.Now().UTC()}
 				newNode.FinishedAt = metav1.Time{}
 				newWF.Status.Nodes[newNode.ID] = *newNode
 				continue
@@ -775,6 +776,7 @@ func retryWorkflow(ctx context.Context, kubeClient kubernetes.Interface, hydrato
 			newNode := node.DeepCopy()
 			newNode.Phase = wfv1.NodeRunning
 			newNode.Message = ""
+			newNode.StartedAt = metav1.Time{Time: time.Now().UTC()}
 			newNode.FinishedAt = metav1.Time{}
 			newWF.Status.Nodes[newNode.ID] = *newNode
 			continue

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -731,12 +732,21 @@ func TestDeepDeleteNodes(t *testing.T) {
 func TestRetryWorkflow(t *testing.T) {
 	kubeClient := kubefake.NewSimpleClientset()
 	wfClient := argofake.NewSimpleClientset().ArgoprojV1alpha1().Workflows("my-ns")
+	createdTime := metav1.Time{Time: time.Now().UTC()}
+	finishedTime := metav1.Time{Time: createdTime.Add(time.Second * 2)}
 	wf := &wfv1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 			common.LabelKeyCompleted:               "true",
 			common.LabelKeyWorkflowArchivingStatus: "Pending",
 		}},
-		Status: wfv1.WorkflowStatus{Phase: wfv1.WorkflowFailed},
+		Status: wfv1.WorkflowStatus{
+			Phase:      wfv1.WorkflowFailed,
+			StartedAt:  createdTime,
+			FinishedAt: finishedTime,
+			Nodes: map[string]wfv1.NodeStatus{
+				"failed-node":    {Name: "failed-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: wfv1.NodeFailed, Message: "failed"},
+				"succeeded-node": {Name: "succeeded-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: wfv1.NodeSucceeded, Message: "succeeded"}},
+		},
 	}
 
 	ctx := context.Background()
@@ -745,8 +755,24 @@ func TestRetryWorkflow(t *testing.T) {
 	wf, err = RetryWorkflow(ctx, kubeClient, hydratorfake.Always, wfClient, wf.Name, false, "")
 	if assert.NoError(t, err) {
 		assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
+		assert.Equal(t, metav1.Time{}, wf.Status.FinishedAt)
+		assert.True(t, wf.Status.StartedAt.After(createdTime.Time))
 		assert.NotContains(t, wf.Labels, common.LabelKeyCompleted)
 		assert.NotContains(t, wf.Labels, common.LabelKeyWorkflowArchivingStatus)
+		for _, node := range wf.Status.Nodes {
+			switch node.Phase {
+			case wfv1.NodeSucceeded:
+				assert.Equal(t, "succeeded", node.Message)
+				assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
+				assert.Equal(t, createdTime, node.StartedAt)
+				assert.Equal(t, finishedTime, node.FinishedAt)
+			case wfv1.NodeFailed:
+				assert.Equal(t, "", node.Message)
+				assert.Equal(t, wfv1.NodeRunning, node.Phase)
+				assert.Equal(t, metav1.Time{}, node.FinishedAt)
+				assert.True(t, node.StartedAt.After(createdTime.Time))
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Previous PR #5798 fixed the case for workflow-level `activeDeadlineSeconds` but template-level `Timeout` still does not work as expected when retrying the workflow since the `StartedAt` for each node has not been reset to current time. Failed nodes would get error `Template xxx exceeded its deadline` instantly when getting retried if they previously exceeded the timeout. 

Related issue https://github.com/argoproj/argo-workflows/issues/5796.



Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
