### PR TITLE
chore: Surface parse duration error in operator

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2798,7 +2798,7 @@ func parseStringToDuration(durationString string) (time.Duration, error) {
 	} else if duration, err := time.ParseDuration(durationString); err == nil {
 		suspendDuration = duration
 	} else {
-		return 0, fmt.Errorf("unable to parse %s as a duration", durationString)
+		return 0, fmt.Errorf("unable to parse %s as a duration: %w", durationString, err)
 	}
 	return suspendDuration, nil
 }


### PR DESCRIPTION
Before: `unable to parse 3ss as a duration`
After: `unable to parse 3ss as a duration time: unknown unit "ss" in duration "3ss"`

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
