### PR TITLE
refactor(server): surface error when no workflow event binding is matched

### DIFF
--- a/server/event/dispatch/operation.go
+++ b/server/event/dispatch/operation.go
@@ -37,7 +37,7 @@ type Operation struct {
 }
 
 func NewOperation(ctx context.Context, instanceIDService instanceid.Service, eventRecorder record.EventRecorder, events []wfv1.WorkflowEventBinding, namespace, discriminator string, payload *wfv1.Item) (*Operation, error) {
-	env, err := expressionEnvironment(ctx, namespace, discriminator, payload)
+	env, err := ExpressionEnvironment(ctx, namespace, discriminator, payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow template expression environment: %w", err)
 	}
@@ -187,7 +187,7 @@ func (o *Operation) evaluateStringExpression(statement string, errorInfo string)
 	return v, nil
 }
 
-func expressionEnvironment(ctx context.Context, namespace, discriminator string, payload *wfv1.Item) (map[string]interface{}, error) {
+func ExpressionEnvironment(ctx context.Context, namespace, discriminator string, payload *wfv1.Item) (map[string]interface{}, error) {
 	src := map[string]interface{}{
 		"namespace":     namespace,
 		"discriminator": discriminator,

--- a/server/event/dispatch/operation_test.go
+++ b/server/event/dispatch/operation_test.go
@@ -359,7 +359,7 @@ func Test_populateWorkflowMetadata(t *testing.T) {
 }
 
 func Test_expressionEnvironment(t *testing.T) {
-	env, err := expressionEnvironment(context.TODO(), "my-ns", "my-d", &wfv1.Item{Value: []byte(`{"foo":"bar"}`)})
+	env, err := ExpressionEnvironment(context.TODO(), "my-ns", "my-d", &wfv1.Item{Value: []byte(`{"foo":"bar"}`)})
 	if assert.NoError(t, err) {
 		assert.Equal(t, "my-ns", env["namespace"])
 		assert.Equal(t, "my-d", env["discriminator"])

--- a/server/event/event_server_test.go
+++ b/server/event/event_server_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,16 +17,42 @@ import (
 )
 
 func TestController(t *testing.T) {
-	clientset := fake.NewSimpleClientset()
+	wfeb := wfv1.WorkflowEventBinding{}
+	wfebYAML := `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowEventBinding
+metadata:
+  name: event-consumer-5
+  namespace: my-ns
+  labels:
+    "workflows.argoproj.io/controller-instanceid": "my-instanceid"
+spec:
+  event:
+    selector: payload.discriminator == "test-discriminator"
+  submit:
+    workflowTemplateRef:
+      name: hello-argoo
+`
+	wfv1.MustUnmarshal(wfebYAML, &wfeb)
+	wfebList := &wfv1.WorkflowEventBindingList{
+		Items: []wfv1.WorkflowEventBinding{wfeb},
+	}
+
+	clientset := fake.NewSimpleClientset(wfebList)
+
 	s := NewController(instanceid.NewService("my-instanceid"), events.NewEventRecorderManager(fakekube.NewSimpleClientset()), 1, 1)
 
+	payload := `{"discriminator": "test-discriminator"}`
+	item, err := wfv1.ParseItem(payload)
+	assert.NoError(t, err)
+
 	ctx := context.WithValue(context.TODO(), auth.WfKey, clientset)
-	_, err := s.ReceiveEvent(ctx, &eventpkg.EventRequest{Namespace: "my-ns", Payload: &wfv1.Item{}})
+	_, err = s.ReceiveEvent(ctx, &eventpkg.EventRequest{Namespace: "my-ns", Payload: &item})
 	assert.NoError(t, err)
 
 	assert.Len(t, s.operationQueue, 1, "one event to be processed")
 
-	_, err = s.ReceiveEvent(ctx, &eventpkg.EventRequest{})
+	_, err = s.ReceiveEvent(ctx, &eventpkg.EventRequest{Namespace: "my-ns", Payload: &item})
 	assert.EqualError(t, err, "operation queue full", "backpressure when queue is full")
 
 	stopCh := make(chan struct{}, 1)
@@ -33,4 +60,79 @@ func TestController(t *testing.T) {
 	s.Run(stopCh)
 
 	assert.Len(t, s.operationQueue, 0, "all events were processed")
+}
+
+func TestControllerNoWorkflowEventBinding(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+
+	s := NewController(instanceid.NewService("my-instanceid"), events.NewEventRecorderManager(fakekube.NewSimpleClientset()), 1, 1)
+
+	ctx := context.WithValue(context.TODO(), auth.WfKey, clientset)
+	_, err := s.ReceiveEvent(ctx, &eventpkg.EventRequest{Namespace: "my-ns"})
+	assert.Errorf(t, err, "failed to match any workflow event binding")
+	assert.Len(t, s.operationQueue, 0)
+}
+
+func TestControllerWrongSelector(t *testing.T) {
+	wfeb := wfv1.WorkflowEventBinding{}
+	wfebYAML := `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowEventBinding
+metadata:
+  name: event-consumer-5
+  namespace: my-ns
+  labels:
+    "workflows.argoproj.io/controller-instanceid": "my-instanceid"
+spec:
+  submit:
+    workflowTemplateRef:
+      name: hello-argoo
+`
+	tests := map[string]struct {
+		selector    string
+		payload     string
+		expectedErr error
+	}{
+		"Wrong Discriminator": {
+			selector:    `payload.discriminator == "wrong-discriminator-2"`,
+			payload:     `{"discriminator": "test-discriminator"}`,
+			expectedErr: fmt.Errorf("failed to match any workflow event binding"),
+		},
+		"Selector doesn't evaluate to bool": {
+			selector:    `1 + 2 + 3`,
+			payload:     `{}`,
+			expectedErr: fmt.Errorf("failed to match any workflow event binding"),
+		},
+		"Selector wrong selector": {
+			selector:    `(@)#*!@&(^@%@^*`,
+			payload:     `{}`,
+			expectedErr: fmt.Errorf("failed to match any workflow event binding"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			wfv1.MustUnmarshal(wfebYAML, &wfeb)
+			wfeb.Spec.Event.Selector = tc.selector
+			wfebList := &wfv1.WorkflowEventBindingList{
+				Items: []wfv1.WorkflowEventBinding{wfeb},
+			}
+			clientset := fake.NewSimpleClientset(wfebList)
+
+			s := NewController(instanceid.NewService("my-instanceid"), events.NewEventRecorderManager(fakekube.NewSimpleClientset()), 1, 1)
+			payload := tc.payload
+			item, err := wfv1.ParseItem(payload)
+			assert.NoError(t, err)
+
+			ctx := context.WithValue(context.TODO(), auth.WfKey, clientset)
+			_, err = s.ReceiveEvent(ctx, &eventpkg.EventRequest{Namespace: "my-ns", Payload: &item})
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+				assert.Len(t, s.operationQueue, 1)
+			} else {
+				assert.Errorf(t, err, tc.expectedErr.Error())
+				assert.Len(t, s.operationQueue, 0)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Argo server currently doesn't return any error when there is no WorkflowEventBinding matched the request, which confuses developers: see #5800

This PR fixes it:

![Screen Shot 2021-05-05 at 2 53 21 AM](https://user-images.githubusercontent.com/1311594/117105976-10bf6d80-ad4d-11eb-8181-274e0b1862c1.png)

Please let me know if you guys think this makes sense. Thanks!

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
