### PR TITLE
docs: Add FAQs in memoization doc and add link in the err message

### DIFF
--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -38,4 +38,11 @@ spec:
 ...
 ```
 
+## FAQs
 
+1. If you see errors like `"error creating cache entry: ConfigMap \"reuse-task\" is invalid: []: Too long: must have at most 1048576 characters"`,
+   this is due to [the 1MB limit placed on the size of `ConfigMap`](https://github.com/kubernetes/kubernetes/issues/19781).
+   Here are a couple of ways that might help resolve this:
+    * Delete the existing `ConfigMap` cache or switch to use a different cache.
+    * Reduce the size of the output parameters for the nodes that are being memoized.
+    * Split your cache into different memoization keys and cache names so that each cache entry is small.

--- a/workflow/controller/cache/configmap_cache.go
+++ b/workflow/controller/cache/configmap_cache.go
@@ -139,7 +139,7 @@ func (c *configMapCache) Save(ctx context.Context, key string, nodeId string, va
 	_, err = c.kubeClient.CoreV1().ConfigMaps(c.namespace).Update(ctx, cache, metav1.UpdateOptions{})
 	if err != nil {
 		c.logError(err, log.Fields{"key": key, "nodeId": nodeId}, "Kubernetes error creating new cache entry")
-		return fmt.Errorf("error creating cache entry: %w", err)
+		return fmt.Errorf("error creating cache entry: %w. Please check out this page for help: https://argoproj.github.io/argo-workflows/memoization/#faqs", err)
 	}
 	return nil
 }

--- a/workflow/controller/cache/configmap_cache.go
+++ b/workflow/controller/cache/configmap_cache.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -135,7 +137,16 @@ func (c *configMapCache) Save(ctx context.Context, key string, nodeId string, va
 		cache.Data = make(map[string]string)
 	}
 	cache.Data[key] = string(entryJSON)
-
+	totalCacheSize := 0
+	for _, v := range cache.Data {
+		totalCacheSize += len(v)
+	}
+	if totalCacheSize > apiv1.MaxSecretSize {
+		err = field.TooLong(field.NewPath("data"), "", apiv1.MaxSecretSize)
+		c.logError(err, log.Fields{"key": key, "nodeId": nodeId},
+			fmt.Sprintf("Cannot save cache entry %s with size %d since the total cache size %d would exceed the limit %d", key, len(entryJSON), totalCacheSize, apiv1.MaxSecretSize))
+		return err
+	}
 	_, err = c.kubeClient.CoreV1().ConfigMaps(c.namespace).Update(ctx, cache, metav1.UpdateOptions{})
 	if err != nil {
 		c.logError(err, log.Fields{"key": key, "nodeId": nodeId}, "Kubernetes error creating new cache entry")

--- a/workflow/controller/cache_test.go
+++ b/workflow/controller/cache_test.go
@@ -2,8 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,26 +97,4 @@ func TestConfigMapCacheSave(t *testing.T) {
 	var entry cache.Entry
 	wfv1.MustUnmarshal([]byte(cm.Data["hi-there-world"]), &entry)
 	assert.Equal(t, entry.LastHitTimestamp.Time, entry.CreationTimestamp.Time)
-}
-
-func TestConfigMapCacheTooLarge(t *testing.T) {
-	var MockParamValue = strings.Repeat("a", apiv1.MaxSecretSize+1)
-	MockParam := wfv1.Parameter{
-		Name:  "hello",
-		Value: wfv1.AnyStringPtr(MockParamValue),
-	}
-	cancel, controller := newController()
-	defer cancel()
-	c := cache.NewConfigMapCache("default", controller.kubeclientset, "whalesay-cache")
-
-	ctx := context.Background()
-	outputs := wfv1.Outputs{}
-	outputs.Parameters = append(outputs.Parameters, MockParam)
-	err := c.Save(ctx, "hi-there-world", "", &outputs)
-	assert.EqualError(t, err, fmt.Sprintf("data: Too long: must have at most %d bytes", apiv1.MaxSecretSize))
-
-	cm, err := controller.kubeclientset.CoreV1().ConfigMaps("default").Get(ctx, "whalesay-cache", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.NotNil(t, cm)
-	assert.Equal(t, "", cm.Data["hi-there-world"])
 }


### PR DESCRIPTION
Currently the error look like the following if the size exceeds etcd limit:

```
time="2021-05-06T09:07:55Z" level=error msg="Failed to save node outputs to cache" error="error creating cache entry: ConfigMap \"reuse-task\" is invalid: []: Too long: must have at most 1048576 characters" namespace=argo nodeID=xxx workflow=xxx
```

With this PR, the error is now more informative so users know what to do and we can save update API calls (imagine if many nodes are using the same cache, they'll make that many API calls that turn out to fail, which would increase load of k8s apiserver).

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

<!--

Please leave your PR in draft if you don't need a review yet. 

To fix failing `CI / Codegen`, run `make codegen`. 

-->
