### PR TITLE
feat(controller): Add config for potential CPU hogs

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -12,9 +12,11 @@ Note that these environment variables may be removed at any time.
 | `ALWAYS_OFFLOAD_NODE_STATUS` | `bool` | Whether to always offload the node status. |
 | `ARCHIVED_WORKFLOW_GC_PERIOD` | `time.Duration` | The periodicity for GC of archived workflows. |
 | `ARGO_TRACE` | `bool` | Whether to enable tracing statements in Argo components. |
+| `CRON_SYNC_PERIOD` | `time.Duration` | How ofen to sync cron workflows. Default `10s` |
 | `DEFAULT_REQUEUE_TIME` | `time.Duration` | The requeue time for the rate limiter of the workflow queue. |
 | `EXPRESSION_TEMPLATES` | `bool` | Escape hatch to disable expression templates. Default `true`. |
 | `GZIP_IMPLEMENTATION` | `string` | The implementation of compression/decompression. Currently only "PGZip" and "GZip" are supported. Defaults to "PGZip". |
+| `INDEX_WORKFLOW_SEMAPHORE_KEYS` | `bool` | Whether or not to index semaphores. Defaults to `true`. |
 | `LEADER_ELECTION_IDENTITY` | `string` | The ID used for workflow controllers to elect a leader. |
 | `LEADER_ELECTION_DISABLE` | `bool` | Whether leader election should be disabled. |
 | `LEADER_ELECTION_LEASE_DURATION` | `time.Duration` | The duration that non-leader candidates will wait to force acquire leadership. |

--- a/workflow/controller/indexes/workflow_index.go
+++ b/workflow/controller/indexes/workflow_index.go
@@ -1,13 +1,23 @@
 package indexes
 
 import (
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
+	"os"
 
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
+
+var (
+	indexWorkflowSemaphoreKeys = os.Getenv("INDEX_WORKFLOW_SEMAPHORE_KEYS") != "false"
+)
+
+func init() {
+	log.WithField("indexWorkflowSemaphoreKeys", indexWorkflowSemaphoreKeys).Info("index config")
+}
 
 func MetaWorkflowIndexFunc(obj interface{}) ([]string, error) {
 	m, err := meta.Accessor(obj)
@@ -26,6 +36,11 @@ func WorkflowIndexValue(namespace, name string) string {
 }
 
 func WorkflowSemaphoreKeysIndexFunc() cache.IndexFunc {
+	if !indexWorkflowSemaphoreKeys {
+		return func(obj interface{}) ([]string, error) {
+			return nil, nil
+		}
+	}
 	return func(obj interface{}) ([]string, error) {
 		un, ok := obj.(*unstructured.Unstructured)
 		if !ok {

--- a/workflow/controller/indexes/workflow_index.go
+++ b/workflow/controller/indexes/workflow_index.go
@@ -1,11 +1,12 @@
 package indexes
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
-	"os"
 
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -3,9 +3,10 @@ package cron
 import (
 	"context"
 	"fmt"
-	"github.com/argoproj/argo-workflows/v3/util/env"
 	"reflect"
 	"time"
+
+	"github.com/argoproj/argo-workflows/v3/util/env"
 
 	"github.com/argoproj/pkg/sync"
 	log "github.com/sirupsen/logrus"

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"fmt"
+	"github.com/argoproj/argo-workflows/v3/util/env"
 	"reflect"
 	"time"
 
@@ -53,12 +54,17 @@ const (
 	cronWorkflowWorkers      = 8
 )
 
+var (
+	cronSyncPeriod = env.LookupEnvDurationOr("CRON_SYNC_PERIOD", 10*time.Second)
+)
+
 func init() {
 	// this make sure we support timezones
 	_, err := time.Parse(time.RFC822, "17 Oct 07 14:03 PST")
 	if err != nil {
 		log.Fatal(err)
 	}
+	log.WithField("cronSyncPeriod", cronSyncPeriod).Info("cron config")
 }
 
 func NewCronController(wfclientset versioned.Interface, dynamicInterface dynamic.Interface, wfInformer cache.SharedIndexInformer, namespace string, managedNamespace string, instanceId string, metrics *metrics.Metrics, eventRecorderManager events.EventRecorderManager) *Controller {
@@ -96,7 +102,8 @@ func (cc *Controller) Run(ctx context.Context) {
 	defer cc.cron.Stop()
 
 	go cc.cronWfInformer.Informer().Run(ctx.Done())
-	go wait.UntilWithContext(ctx, cc.syncAll, 10*time.Second)
+
+	go wait.UntilWithContext(ctx, cc.syncAll, cronSyncPeriod)
 
 	for i := 0; i < cronWorkflowWorkers; i++ {
 		go wait.Until(cc.runCronWorker, time.Second, ctx.Done())


### PR DESCRIPTION
@sarabala1979 further analysis confirmed what I thought:

* `util.FromUnstructured` is expensive, especially when called in a loop.
* 7x CPU increase was only on one of the 7 clusters. 
* Other clusters did increase, but by only about 1.2x
* v2.12 introduced `syncAll` which call `FromUnstructured` in a loop every 10s. I hope we can change the 10s to 60s. @simster7 ?
* `WorkflowSemaphoreKeysIndexFunc` did increase CPU usage on two clusters. We can disable it on one cluster to test to see if it is a cause.