### PR TITLE
fix: make sure to get the hostNodeName at every pod change

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1052,6 +1052,9 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, node *wfv1.NodeStatu
 	var newDaemonStatus *bool
 	var message string
 	updated := false
+	if node.HostNodeName != pod.Spec.NodeName {
+		node.HostNodeName = pod.Spec.NodeName
+	}
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		newPhase = wfv1.NodePending


### PR DESCRIPTION
RFC: potentially fixes #5054

it also fixes that the hostNodeName is also available for short-lived (failing) pods, as otherwise the hostNodeName is only fetched during some reconsoliation loop

@goock  @alexec  please comment
