### PR TITLE
test: 3m faster and more robust e2e

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -115,8 +115,8 @@ jobs:
           echo '127.0.0.1 minio'    | sudo tee -a /etc/hosts
           echo '127.0.0.1 postgres' | sudo tee -a /etc/hosts
           echo '127.0.0.1 mysql'    | sudo tee -a /etc/hosts
-      - run: make install install controller cli $(go env GOPATH)/bin/goreman PROFILE=${{matrix.profile}} E2E_EXECUTOR=${{matrix.containerRuntimeExecutor}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info
-      - run: make start PROFILE=${{matrix.profile}} E2E_EXECUTOR=${{matrix.containerRuntimeExecutor}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info 2>&1 > /tmp/log/argo-e2e/argo.log &
+      - run: make install controller cli $(go env GOPATH)/bin/goreman PROFILE=${{matrix.profile}} E2E_EXECUTOR=${{matrix.containerRuntimeExecutor}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info
+      - run: make start PROFILE=${{matrix.profile}} E2E_EXECUTOR=${{matrix.containerRuntimeExecutor}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info UI=false 2>&1 > /tmp/log/argo-e2e/argo.log &
         timeout-minutes: 4
       - name: make/pull argoexec-image
         run: |
@@ -128,15 +128,9 @@ jobs:
       - run: make wait
         timeout-minutes: 4
       - run: make ${{matrix.test}} E2E_TIMEOUT=1m STATIC_FILES=false
-      - name: Get wait container logs
+      - name: cat argo.log
         if: ${{ failure() }}
-        run: kubectl get pod -o name | xargs -L 1 kubectl logs -c wait
-      - name: Upload logs
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{matrix.test}}-${{matrix.containerRuntimeExecutor}}
-          path: /tmp/log/argo-e2e
+        run: cat /tmp/log/argo-e2e/argo.log
 
   codegen:
     name: Codegen

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ else
 STATIC_FILES          ?= $(shell [ $(DEV_BRANCH) = true ] && echo false || echo true)
 endif
 
-START_UI              ?= $(shell [ "$(CI)" != "" ] && echo true || echo false)
+UI                    ?= true
 GOTEST                ?= go test -v
 PROFILE               ?= minimal
 # by keeping this short we speed up the tests
@@ -457,7 +457,7 @@ endif
 	grep '127.0.0.1[[:blank:]]*mysql' /etc/hosts
 	./hack/port-forward.sh
 ifeq ($(RUN_MODE),local)
-	env DEFAULT_REQUEUE_TIME=$(DEFAULT_REQUEUE_TIME) SECURE=$(SECURE) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) LOG_LEVEL=$(LOG_LEVEL) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) IMAGE_NAMESPACE=$(IMAGE_NAMESPACE) VERSION=$(VERSION) AUTH_MODE=$(AUTH_MODE) NAMESPACED=$(NAMESPACED) NAMESPACE=$(KUBE_NAMESPACE) $(GOPATH)/bin/goreman -set-ports=false -logtime=false start $(shell if [ -z $GREP_LOGS ]; then echo; else echo "| grep \"$(GREP_LOGS)\""; fi)
+	env DEFAULT_REQUEUE_TIME=$(DEFAULT_REQUEUE_TIME) SECURE=$(SECURE) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) LOG_LEVEL=$(LOG_LEVEL) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) IMAGE_NAMESPACE=$(IMAGE_NAMESPACE) VERSION=$(VERSION) AUTH_MODE=$(AUTH_MODE) NAMESPACED=$(NAMESPACED) NAMESPACE=$(KUBE_NAMESPACE) UI=$(UI) $(GOPATH)/bin/goreman -set-ports=false -logtime=false start $(shell if [ -z $GREP_LOGS ]; then echo; else echo "| grep \"$(GREP_LOGS)\""; fi)
 endif
 
 $(GOPATH)/bin/stern:
@@ -466,14 +466,6 @@ $(GOPATH)/bin/stern:
 .PHONY: logs
 logs: $(GOPATH)/bin/stern
 	stern -l workflows.argoproj.io/workflow 2>&1
-
-.PHONY: watch-pods
-watch-pods:
-	# NODE_ID:.metadata.name
-	# EXECUTION_CONTROL:.metadata.annotations.workflows\.argoproj\.io/execution
-	kubectl get pod \
-	  -o=custom-columns='WORKFLOW:.metadata.labels.workflows\.argoproj\.io/workflow,NODE_NAME:.metadata.annotations.workflows\.argoproj\.io/node-name,STATUS:.status.phase,MESSAGE:.metadata.annotations.workflows\.argoproj\.io/node-message,CTRS:.status.containerStatuses[*].name,CTR STATUS:.status.containerStatuses[*].state.terminated.reason,EXIT CODES:.status.containerStatuses[*].state.terminated.exitCode' \
-	  -w
 
 .PHONY: wait
 wait:

--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,4 @@
-executor-image : make argoexec-image
 controller: ./hack/free-port.sh 9090 && PNS_PRIVILEGED=true DEFAULT_REQUEUE_TIME=${DEFAULT_REQUEUE_TIME} LEADER_ELECTION_IDENTITY=local ALWAYS_OFFLOAD_NODE_STATUS=${ALWAYS_OFFLOAD_NODE_STATUS} OFFLOAD_NODE_STATUS_TTL=30s WORKFLOW_GC_PERIOD=30s UPPERIO_DB_DEBUG=${UPPERIO_DB_DEBUG} ARCHIVED_WORKFLOW_GC_PERIOD=30s ./dist/workflow-controller --executor-image ${IMAGE_NAMESPACE}/argoexec:${VERSION} --namespaced=${NAMESPACED} --namespace ${NAMESPACE} --loglevel ${LOG_LEVEL}
 argo-server: ./hack/free-port.sh 2746 && UPPERIO_DB_DEBUG=${UPPERIO_DB_DEBUG} ./dist/argo --loglevel ${LOG_LEVEL} server --namespaced=${NAMESPACED} --namespace ${NAMESPACE} --auth-mode ${AUTH_MODE} --secure=$SECURE --x-frame-options=SAMEORIGIN
-ui: ./hack/free-port.sh 8080 && yarn --cwd ui install && yarn --cwd ui start
+ui: [ "$UI" = "true" ] && ./hack/free-port.sh 8080 && yarn --cwd ui install && yarn --cwd ui start
 logs: make logs
-watch-pods: make watch-pods

--- a/hack/free-port.sh
+++ b/hack/free-port.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
-set -eux
+set -eu
 
 port=$1
 
-lsof -s TCP:LISTEN -i ":$port" | grep -v PID | awk '{print $2}' | xargs kill || true
-
-
+lsof -s TCP:LISTEN -i ":$port" | grep -v PID | awk '{print $2}' | xargs -L 1 kill || true

--- a/hack/port-forward.sh
+++ b/hack/port-forward.sh
@@ -20,7 +20,7 @@ info() {
 
 if [[ "$(kubectl -n argo get pod -l app=minio -o name)" != "" ]]; then
   pf MinIO deploy/minio 9000
-  fi
+fi
 
 dex=$(kubectl -n argo get pod -l app=dex -o name)
 if [[ "$dex" != "" ]]; then

--- a/hack/port-forward.sh
+++ b/hack/port-forward.sh
@@ -18,12 +18,9 @@ info() {
     echo '[INFO] ' "$@"
 }
 
-killall kubectl || true
-
-
 if [[ "$(kubectl -n argo get pod -l app=minio -o name)" != "" ]]; then
   pf MinIO deploy/minio 9000
-fi
+  fi
 
 dex=$(kubectl -n argo get pod -l app=dex -o name)
 if [[ "$dex" != "" ]]; then


### PR DESCRIPTION
The pattern of job failures suggests to me it fails if you start using `PROFILE=mysql`. This PR simplifies that.

* Stop running the UI on CI (this saves 3m).
* Fix a bug in `free-port.sh` that means it exits early.