### PR TITLE
feat: DAG/TASK Custom Metrics Example

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -82,6 +82,8 @@ Workflow is the definition of a workflow resource
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
 
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
+
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
 - [`dag-diamond-steps.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-diamond-steps.yaml)
@@ -460,6 +462,8 @@ WorkflowSpec is the specification of a Workflow.
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
@@ -859,6 +863,8 @@ CronWorkflowSpec is the specification of a CronWorkflow
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
 
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
+
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
 - [`dag-diamond-steps.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-diamond-steps.yaml)
@@ -1213,6 +1219,8 @@ WorkflowTemplateSpec is a spec of WorkflowTemplate.
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
@@ -2555,6 +2563,8 @@ DAGTemplate is a template subtype for directed acyclic graph templates
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
 
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
+
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
 - [`dag-diamond-steps.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-diamond-steps.yaml)
@@ -3760,6 +3770,8 @@ DAGTask represents a node in the graph during DAG execution
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -3989,6 +3989,8 @@ Item expands a single workflow step into multiple parallel steps The value of It
 
 - [`ci.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/ci.yaml)
 
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
+
 - [`dag-diamond-steps.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-diamond-steps.yaml)
 
 - [`loops-dag.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/loops-dag.yaml)
@@ -4267,6 +4269,8 @@ ObjectMeta is metadata that all persisted resources must have, which includes al
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
@@ -4851,6 +4855,8 @@ A single application container that you want to run within a pod.
 - [`dag-coinflip.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-coinflip.yaml)
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
@@ -5512,6 +5518,8 @@ PersistentVolumeClaimSpec describes the common attributes of storage devices and
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
 - [`dag-continue-on-fail.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-continue-on-fail.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1554,6 +1554,8 @@ Arguments to a template
 
 - [`daemon-step.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/daemon-step.yaml)
 
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
+
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
 - [`dag-diamond-steps.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-diamond-steps.yaml)
@@ -1739,6 +1741,8 @@ Metrics are a list of metrics emitted from a Workflow/Template
 <br>
 
 - [`custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/custom-metrics.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 </details>
 
 ### Fields
@@ -2266,6 +2270,8 @@ Parameter indicate a passed string parameter to a service template with an optio
 
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
+
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
 - [`dag-diamond-steps.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-diamond-steps.yaml)
@@ -2414,6 +2420,8 @@ Prometheus is a prometheus metric to be emitted
 <br>
 
 - [`custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/custom-metrics.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 </details>
 
 ### Fields
@@ -2721,6 +2729,8 @@ Inputs are the mechanism for passing parameters, artifacts, volumes from one tem
 - [`daemon-nginx.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/daemon-nginx.yaml)
 
 - [`daemon-step.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/daemon-step.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`dag-daemon-task.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-daemon-task.yaml)
 
@@ -3583,6 +3593,8 @@ Counter is a Counter prometheus metric
 <br>
 
 - [`custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/custom-metrics.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 </details>
 
 ### Fields
@@ -3599,6 +3611,8 @@ Gauge is a Gauge prometheus metric
 <br>
 
 - [`custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/custom-metrics.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 </details>
 
 ### Fields
@@ -3653,6 +3667,8 @@ MetricLabel is a single label for a prometheus metric
 - [`dag-conditional-artifacts.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-artifacts.yaml)
 
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
+
+- [`dag-custom-metrics.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-custom-metrics.yaml)
 
 - [`data-transformations.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/data-transformations.yaml)
 

--- a/examples/dag-custom-metrics.yaml
+++ b/examples/dag-custom-metrics.yaml
@@ -23,7 +23,7 @@ metadata:
   generateName: dag-task-
 spec:
   entrypoint: dag-task
-  metrics:   # Custom metric workflow level
+  metrics: # Custom metric workflow level
     prometheus:
       - name: playground_workflow_duration
         help: "Duration gauge by workflow level"
@@ -77,7 +77,7 @@ spec:
       parameters:
       - name: message
       - name: tag
-    metrics:   # Custom metric template level
+    metrics: # Custom metric template level
       prometheus:
         - name: playground_workflow_duration_task_seconds
           help: "Duration gauge by task name in seconds - task level"

--- a/examples/dag-custom-metrics.yaml
+++ b/examples/dag-custom-metrics.yaml
@@ -1,0 +1,103 @@
+# The following workflow executes the tasks in parallel and emit the data for each task
+#                       DAG                       <-- The custom metric will emit the status and duration for entire workflow
+#                    /       \
+#                   /         \
+#                  /           \
+#                 /             \
+#                /               \
+#               /                 \
+#              /                   \
+#             /                     \
+#            /                       \
+#           /                         \
+#       TEST-TWO                   TEST-ONE
+#        /     \                     /   \    
+#       /       \                   /     \
+#      /         \                 /       \
+#     /           \               /         \
+# TEST-TWO-B   TEST-TWO-A    TEST-ONE-B  TEST-ONE-B  <-- The custom metric will emit the status and duration for each task in parallel
+
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-task-
+spec:
+  entrypoint: dag-task
+  metrics:   # Custom metric workflow level
+    prometheus:
+      - name: playground_workflow_duration
+        help: "Duration gauge by workflow level"
+        labels:
+          - key: "playground_id_workflow"
+            value: "test"
+          - key: status
+            value: "{{workflow.status}}"
+        gauge:
+          realtime: false
+          value: "{{workflow.duration}}"
+      - name: playground_workflow_result_counter
+        help: "Count of workflow execution by result status  - workflow level"
+        labels:
+          - key: "playground_id_workflow_counter"
+            value: "test"
+          - key: status
+            value: "{{workflow.status}}"
+        counter:
+          value: "1"
+  templates:
+  - name: dag-task
+    dag:
+      tasks:
+      - name: TEST-ONE
+        template: echo
+        arguments:
+          parameters: 
+            - name: message
+              value: "console output-->TEST-{{item.command}}"
+            - name: tag
+              value: "{{item.tag}}"
+        withItems:
+          - { tag: TEST-ONE-A, command: ONE-A }
+          - { tag: TEST-ONE-B, command: ONE-B }
+
+      - name: TEST-TWO
+        template: echo
+        arguments:
+          parameters: 
+            - name: message
+              value: "console output-->TEST-{{item.command}}"
+            - name: tag
+              value: "{{item.tag}}"
+        withItems:
+          - { tag: TEST-TWO-A, command: TWO-A }
+          - { tag: TEST-TWO-B, command: TWO-B }
+
+  - name: echo
+    inputs:
+      parameters:
+      - name: message
+      - name: tag
+    metrics:   # Custom metric template level
+      prometheus:
+        - name: playground_workflow_duration_task_seconds
+          help: "Duration gauge by task name in seconds - task level"
+          labels:
+            - key: "playground_task_name"
+              value: "{{inputs.parameters.tag}}"
+            - key: status
+              value: "{{status}}"
+          gauge:
+            realtime: false
+            value: "{{duration}}"
+        - name: playground_workflow_result_task_counter
+          help: "Count of task execution by result status  - task level"
+          labels:
+            - key: "playground_task_name_counter"
+              value: "{{inputs.parameters.tag}}"
+            - key: status
+              value: "{{status}}"
+          counter:
+            value: "1"
+    container:
+      image: alpine:3.7
+      command: [echo, "{{inputs.parameters.message}}"]


### PR DESCRIPTION
DAG/TASK custom metrics example.
1. Emit custom metrics per each tasks using `withItems`.
2. Emit custom metric per task workflow.

### Results
```bash
# HELP argo_workflows_playground_workflow_duration_task_seconds Duration gauge by name in seconds - task level
# TYPE argo_workflows_playground_workflow_duration_task_seconds gauge
argo_workflows_playground_workflow_duration_task_seconds{playground_id_workflow="TEST-A",status="Succeeded"} 7
argo_workflows_playground_workflow_duration_task_seconds{playground_id_workflow="TEST-B",status="Succeeded"} 7
argo_workflows_playground_workflow_duration_task_seconds{playground_id_workflow="TEST-ONE-A",status="Succeeded"} 7
argo_workflows_playground_workflow_duration_task_seconds{playground_id_workflow="TEST-ONE-B",status="Succeeded"} 6
argo_workflows_playground_workflow_duration_task_seconds{playground_id_workflow="TEST-TWO-A",status="Succeeded"} 6
argo_workflows_playground_workflow_duration_task_seconds{playground_id_workflow="TEST-TWO-B",status="Succeeded"} 6
```

```bash
# HELP argo_workflows_playground_workflow_result_task_counter Count of workflow execution by result status  - task level
# TYPE argo_workflows_playground_workflow_result_task_counter counter
argo_workflows_playground_workflow_result_task_counter{playground_task_name_counter="TEST-ONE-A",status="Succeeded"} 1
argo_workflows_playground_workflow_result_task_counter{playground_task_name_counter="TEST-ONE-B",status="Succeeded"} 1
argo_workflows_playground_workflow_result_task_counter{playground_task_name_counter="TEST-TWO-A",status="Succeeded"} 1
argo_workflows_playground_workflow_result_task_counter{playground_task_name_counter="TEST-TWO-B",status="Succeeded"} 1
```
Signed-off-by: Everton <58737540+everton-nasc@users.noreply.github.com>

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).