### PR TITLE
docs: Change `http` to `https` for argo-server. Fixes #5866

### DIFF
--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -4,6 +4,9 @@
 
 > v2.5 and after
 
+!!! Warning "HTTP vs HTTPS"
+    Since v3.0 the Argo Server listens for HTTPS requests, rather than HTTP.
+
 The Argo Server is a server that exposes an API and UI for workflows. You'll need to use this if you want to [offload large workflows](offloading-large-workflows.md) or the [workflow archive](workflow-archive.md).
 
 You can run this in either "hosted" or "local" mode.
@@ -32,7 +35,8 @@ To run locally:
 argo server
 ```
 
-This will start a server on port 2746 which you can view at [http://localhost:2746](http://localhost:2746).
+This will start a server on port 2746 which you can view at [https://localhost:2746](https://localhost:2746).
+
 
 ## Options
 
@@ -71,7 +75,7 @@ following:
 kubectl -n argo port-forward svc/argo-server 2746:2746
 ```
 
-Then visit: http://127.0.0.1:2746
+Then visit: https://127.0.0.1:2746
 
 
 ### Expose a `LoadBalancer`

--- a/docs/async-pattern.md
+++ b/docs/async-pattern.md
@@ -64,7 +64,7 @@ You may need  an [access token](access-token.md).
 
 ```
 curl --request PUT \
-  --url http://localhost:2746/api/v1/workflows/<NAMESPACE>/<WORKFLOWNAME>/resume
+  --url https://localhost:2746/api/v1/workflows/<NAMESPACE>/<WORKFLOWNAME>/resume
   --header 'content-type: application/json' \
   --header "Authorization: Bearer $ARGO_TOKEN" \
   --data '{
@@ -78,7 +78,7 @@ or stop if unsuccessful:
 
 ```
 curl --request PUT \
-  --url http://localhost:2746/api/v1/workflows/<NAMESPACE>/<WORKFLOWNAME>/stop
+  --url https://localhost:2746/api/v1/workflows/<NAMESPACE>/<WORKFLOWNAME>/stop
   --header 'content-type: application/json' \
   --header "Authorization: Bearer $ARGO_TOKEN" \
   --data '{

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -12,7 +12,7 @@ The server can be configured with or without client auth (`server --auth-mode cl
 
 ```
 ARGO_TOKEN=$(argo auth token)
-curl -H "Authorization: $ARGO_TOKEN" http://localhost:2746/api/v1/workflows/argo
+curl -H "Authorization: $ARGO_TOKEN" https://localhost:2746/api/v1/workflows/argo
 ```
 
 * Learn more on [how to generate an access token](access-token.md).
@@ -20,5 +20,5 @@ curl -H "Authorization: $ARGO_TOKEN" http://localhost:2746/api/v1/workflows/argo
 API reference docs :
  
 * [Latest docs](swagger.md) (maybe incorrect)
-* Interactively in the [Argo Server UI](http://localhost:2746/apidocs). (>= v2.10)
+* Interactively in the [Argo Server UI](https://localhost:2746/apidocs). (>= v2.10)
 

--- a/docs/rest-examples.md
+++ b/docs/rest-examples.md
@@ -14,7 +14,7 @@ Assuming
 
 ```
 curl --request POST \
-  --url http://localhost:2746/api/v1/workflows/argo \
+  --url https://localhost:2746/api/v1/workflows/argo \
   --header 'content-type: application/json' \
   --data '{
   "namespace": "argo",
@@ -59,19 +59,19 @@ curl --request POST \
 
 ```
 curl --request GET \
-  --url http://localhost:2746/api/v1/workflows/argo
+  --url https://localhost:2746/api/v1/workflows/argo
 ```
 
 ## Getting single workflow for namespace argo
 
 ```
 curl --request GET \
-  --url http://localhost:2746/api/v1/workflows/argo/abc-dthgt
+  --url https://localhost:2746/api/v1/workflows/argo/abc-dthgt
 ```
 
 ## Deleting single workflow for namespace argo
 
 ```
 curl --request DELETE \
-  --url http://localhost:2746/api/v1/workflows/argo/abc-dthgt
+  --url https://localhost:2746/api/v1/workflows/argo/abc-dthgt
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,7 +73,7 @@ Argo Workflows requires various levels of network access depending on configurat
 
 ### Argo Server
 
-The argo server is commonly exposed to end-users to provide users with a user interface for visualizing and managing their workflows. It must also be exposed if leveraging [webhooks](webhooks.md) to trigger workflows. Both of these use cases require that the argo-server Service to be exposed for ingress traffic (e.g. with an Ingress object or load balancer). Note that the Argo UI is also available to be accessed by running the server locally (i.e. `argo server`) using local kubeconfig credentials, and visiting the UI over http://localhost:2746.
+The argo server is commonly exposed to end-users to provide users with a user interface for visualizing and managing their workflows. It must also be exposed if leveraging [webhooks](webhooks.md) to trigger workflows. Both of these use cases require that the argo-server Service to be exposed for ingress traffic (e.g. with an Ingress object or load balancer). Note that the Argo UI is also available to be accessed by running the server locally (i.e. `argo server`) using local kubeconfig credentials, and visiting the UI over https://localhost:2746.
 
 The argo server additionally has a feature to allow downloading of artifacts through the user interface. This feature requires that the argo-server be given egress access to the underlying artifact provider (e.g. S3, GCS, MinIO, Arfactory) in order to download and stream the artifact.
 

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -14,7 +14,7 @@ Run `make start PROFILE=stress IMAGE_NAMESPACE=alexcollinsintuit DOCKER_PUSH=tru
 
 If this fails, just try running it again.
 
-Open http://localhost:2746 and check you can run a workflow.
+Open https://localhost:2746 and check you can run a workflow.
 
 Open `test/stress/main.go` and run it with a small number (e.g. 10) workflows and make sure they complete.
 

--- a/docs/workflow-submitting-workflow.md
+++ b/docs/workflow-submitting-workflow.md
@@ -24,7 +24,7 @@ spec:
         command:
           - sh
         source: >
-          curl http://argo-server:2746/api/v1/workflows/argo/submit \
+          curl https://argo-server:2746/api/v1/workflows/argo/submit \
             -fs \
             -H "Authorization: Bearer eyJhbGci..." \
             -d '{"resourceKind": "WorkflowTemplate", "resourceName": "wait", "submitOptions": {"labels": "workflows.argoproj.io/workflow-template=wait"}}'


### PR DESCRIPTION
Goal:

* Cheaply reduce the number of users asking about this.

Method:

* Correct docs.

Screenshot:

![image](https://user-images.githubusercontent.com/1142830/118183708-45879080-b3ef-11eb-9f81-16499e6abdb2.png)

Fixes #5866