### PR TITLE
ci: Add links to commit hashes in auto-generated changelog

### DIFF
--- a/hack/changelog.sh
+++ b/hack/changelog.sh
@@ -9,7 +9,7 @@ git tag -l 'v*' | sort -rd | while read last; do
   if [ "$tag" != "" ]; then
     echo "## $tag ($(git log $tag -n1 --format=%as))"
     echo
-	  git --no-pager log --format=' * %h %s' $last..$tag
+	  git --no-pager log --format=' * [%h](https://github.com/argoproj/argo-workflows/commit/%H) %s' $last..$tag
 	  echo
 	  echo "### Contributors"
 	  echo


### PR DESCRIPTION
This is to make it easier to inspect changes in each commit in the auto-generated markdown file.

Example outputs:

```
 * [0368c2ea](https://github.com/argoproj/argo-workflows/commit/0368c2eadfe34a979973e0b40b6cb4c288e55f38) Allow use of public repos without prior registration (#36)
 * [e7e3c509](https://github.com/argoproj/argo-workflows/commit/e7e3c5095c0a1b4312993a234aceb0b90d69f90e) Support -f/--file flag in `argocd app add` (#35)
 * [d256256d](https://github.com/argoproj/argo-workflows/commit/d256256defbf6dcc733424df9374a2dc32069875) Update CONTRIBUTING.md (#32)
```


Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:


* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
