### PR TITLE
fix: Set empty start time for nodes in retrying workflows as they have not started yet

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -788,7 +788,7 @@ func retryWorkflow(ctx context.Context, kubeClient kubernetes.Interface, hydrato
 				newNode := node.DeepCopy()
 				newNode.Phase = wfv1.NodeRunning
 				newNode.Message = ""
-				newNode.StartedAt = metav1.Time{Time: time.Now().UTC()}
+				newNode.StartedAt = metav1.Time{}
 				newNode.FinishedAt = metav1.Time{}
 				newWF.Status.Nodes[newNode.ID] = *newNode
 				continue
@@ -810,7 +810,7 @@ func retryWorkflow(ctx context.Context, kubeClient kubernetes.Interface, hydrato
 			newNode := node.DeepCopy()
 			newNode.Phase = wfv1.NodeRunning
 			newNode.Message = ""
-			newNode.StartedAt = metav1.Time{Time: time.Now().UTC()}
+			newNode.StartedAt = metav1.Time{}
 			newNode.FinishedAt = metav1.Time{}
 			newWF.Status.Nodes[newNode.ID] = *newNode
 			continue

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -770,13 +770,13 @@ func TestRetryWorkflow(t *testing.T) {
 			case wfv1.NodeSucceeded:
 				assert.Equal(t, "succeeded", node.Message)
 				assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-				assert.Equal(t, createdTime, node.StartedAt)
+				assert.Equal(t, metav1.Time{}, node.StartedAt)
 				assert.Equal(t, finishedTime, node.FinishedAt)
 			case wfv1.NodeFailed:
 				assert.Equal(t, "", node.Message)
 				assert.Equal(t, wfv1.NodeRunning, node.Phase)
 				assert.Equal(t, metav1.Time{}, node.FinishedAt)
-				assert.True(t, node.StartedAt.After(createdTime.Time))
+				assert.Equal(t, metav1.Time{}, node.StartedAt)
 			}
 		}
 	}


### PR DESCRIPTION
This was overlooked in https://github.com/argoproj/argo-workflows/pull/5801. The start time should be empty instead of current time since the nodes have not started yet. Otherwise it's problematic for all nodes to start at the same time.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
