### PR TITLE
feat: Make DownwardAPI optional

### DIFF
--- a/cmd/argoexec/commands/data.go
+++ b/cmd/argoexec/commands/data.go
@@ -12,7 +12,7 @@ func NewDataCommand() *cobra.Command {
 		Short: "Process data",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			wfExecutor := initExecutor()
+			wfExecutor := initExecutor(ctx)
 			return wfExecutor.Data(ctx)
 		},
 	}

--- a/cmd/argoexec/commands/init.go
+++ b/cmd/argoexec/commands/init.go
@@ -24,7 +24,7 @@ func NewInitCommand() *cobra.Command {
 }
 
 func loadArtifacts(ctx context.Context) error {
-	wfExecutor := initExecutor()
+	wfExecutor := initExecutor(ctx)
 	defer wfExecutor.HandleError(ctx)
 	defer stats.LogStats()
 

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -32,7 +32,7 @@ func NewResourceCommand() *cobra.Command {
 }
 
 func execResource(ctx context.Context, action string) error {
-	wfExecutor := initExecutor()
+	wfExecutor := initExecutor(ctx)
 	defer wfExecutor.HandleError(ctx)
 	err := wfExecutor.StageFiles()
 	if err != nil {

--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -25,7 +25,7 @@ func NewWaitCommand() *cobra.Command {
 }
 
 func waitContainer(ctx context.Context) error {
-	wfExecutor := initExecutor()
+	wfExecutor := initExecutor(ctx)
 	defer wfExecutor.HandleError(ctx) // Must be placed at the bottom of defers stack.
 	defer stats.LogStats()
 	stats.StartStatsTicker(5 * time.Minute)

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,9 @@ type Config struct {
 	// KubeletInsecure disable the TLS verification of the kubelet containerRuntimeExecutor, default to false
 	KubeletInsecure bool `json:"kubeletInsecure,omitempty"`
 
+	// DownwardAPIUnvailable disables mounting a DownwardAPI volume at the executor and using it for getting pod annotations, default to false
+	DownwardAPIUnavailable bool `json:"downwardAPIUnavailable,omitempty"`
+
 	// ArtifactRepository contains the default location of an artifact repository for container artifacts
 	ArtifactRepository ArtifactRepository `json:"artifactRepository,omitempty"`
 

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -135,6 +135,9 @@ data:
   # disable the TLS verification of the kubelet executor (default: false)
   kubeletInsecure: false
 
+  # disable mounting a DownwardAPI volume at the executor and using it for getting pod annotations
+  downwardAPIUnavailable: false
+
   # The command/args for each image, needed when the command is not specified and the emissary executor is used.
   # https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
   images: |

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -117,6 +117,8 @@ const (
 	EnvVarKubeletPort = "ARGO_KUBELET_PORT"
 	// EnvVarKubeletInsecure is used to disable the TLS verification
 	EnvVarKubeletInsecure = "ARGO_KUBELET_INSECURE"
+	// EnvVarDownwardAPIUnavailable is used to disable the use of the DownwardAPI volume for getting pod annotations
+	EnvVarDownwardAPIUnavailable = "ARGO_DOWNWARD_API_UNAVAILABLE"
 	// EnvVarArgoTrace is used enable tracing statements in Argo components
 	EnvVarArgoTrace = "ARGO_TRACE"
 


### PR DESCRIPTION
Currently, the controller mounts a DownwardAPI volume at each executor instance. The later uses it to read pod annotations and get updates on the main container's execution status. As mentioned in #4616, DownwardAPI volumes are not available outside of Kubernetes (i.e., in serverless environments).

This patch adds a `downwardAPIUnavailable` flag to the controller (can be set in the ConfigMap). By default, the value is `false`. When set to `true`, the controller does not mount the DownwardAPI volumes and sets the `ARGO_DOWNWARD_API_UNAVAILABLE` environmental variable for the executor, so it will use the Kubernetes API instead to get updates (the executor will poll the main container's status, as there is no file to monitor at the filesystem level any more).

The patch has been tested by submitting various workflows with and without the configuration. No changes have been done to the UI.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
