### PR TITLE
docs: link to examples with relative link instead of symlink

### DIFF
--- a/docs/conditional-artifacts-parameters.md
+++ b/docs/conditional-artifacts-parameters.md
@@ -28,8 +28,8 @@ under step/DAG level output parameter. Both use the
 
 ```
 
-* [Steps artifacts example](examples/conditional-artifacts.yaml)
-* [DAG artifacts example](examples/dag-conditional-artifacts.yaml)
+* [Steps artifacts example](../examples/conditional-artifacts.yaml)
+* [DAG artifacts example](../examples/dag-conditional-artifacts.yaml)
 
 ## Conditional Parameters
 
@@ -51,8 +51,8 @@ under step/DAG level output parameter. Both use the
               expression: "steps.flipcoin.outputs.result == 'heads' ? steps.heads.outputs.result : steps.tails.outputs.result"
 ```
 
-* [Steps parameter example](examples/conditional-parameters.yaml)
-* [DAG parameter example](examples/dag-conditional-parameters.yaml)
+* [Steps parameter example](../examples/conditional-parameters.yaml)
+* [DAG parameter example](../examples/dag-conditional-parameters.yaml)
 
 ## Build-In Functions
 
@@ -65,7 +65,7 @@ Convenient functions added to support more use cases:
    e.g: `jsonpath('{"employee":{"name":"sonoo","salary":56000,"married":true}}", "$.employee.name" )` )
 5. [Sprig](http://masterminds.github.io/sprig/) - Support all `sprig` functions
 
-* [Advanced example: fibonacci Sequence](examples/fibonacci-seq-conditional-param.yaml)
+* [Advanced example: fibonacci Sequence](../examples/fibonacci-seq-conditional-param.yaml)
 
 !!! NOTE 
     Expressions will decode the `-` as operator if template name has `-`, it will fail the expression. So here solution

--- a/docs/cron-backfill.md
+++ b/docs/cron-backfill.md
@@ -2,7 +2,7 @@
 
 ## Use Case
 
-* You are using cron workflows to run daily jobs, you may need to re-run for a date, or run some historical days. 
+* You are using cron workflows to run daily jobs, you may need to re-run for a date, or run some historical days.
 
 ## Solution
 
@@ -10,7 +10,7 @@
 2. Create your cron workflow to run daily and invoke that template.
 3. Create a backfill workflow that uses `withSequence` to run the job for each date.
 
-This [full example](examples/cron-backfill.yaml) contains:
+This [full example](../examples/cron-backfill.yaml) contains:
 
 * A workflow template named `job`.
 * A cron workflow named `daily-job`.

--- a/docs/template-defaults.md
+++ b/docs/template-defaults.md
@@ -24,7 +24,7 @@ spec:
     container:
       image: docker/whalesay:latest
 ```
-[template defaults example](examples/template-defaults.yaml)
+[template defaults example](../examples/template-defaults.yaml)
 
 ## Configuring `templateDefaults` in Controller Level
 Operator can configure the `templateDefaults` in [workflowDefaults](default-workflow-specs.md). This `templateDefault` will be applied to all the workflow which runs on the controller.

--- a/docs/tolerating-pod-deletion.md
+++ b/docs/tolerating-pod-deletion.md
@@ -6,7 +6,7 @@ In Kubernetes, pods are cattle and can be deleted at any time. Deletion could be
 
 This can be very inconvenient, your workflow will error, but for reasons outside of your control.
  
-A [pod disruption budget](examples/default-pdb-support.yaml) can reduce the likelihood of this happening. But, it cannot entirely prevent it.   
+A [pod disruption budget](../examples/default-pdb-support.yaml) can reduce the likelihood of this happening. But, it cannot entirely prevent it.   
 
 To retry pods that were deleted, set `retryStrategy.retryPolicy: OnError`.
 

--- a/docs/work-avoidance.md
+++ b/docs/work-avoidance.md
@@ -30,7 +30,7 @@ touch /work/markers/$(date +%Y-%m-%d)-echo-{{inputs.parameters.num}}
  
 You need to store the marker files between workflows and this can be achieved using [a PVC](fields.md#persistentvolumeclaim) and [optional input artifact](fields.md#artifact). 
 
-[This complete work avoidance example](examples/work-avoidance.yaml) has the following:
+[This complete work avoidance example](../examples/work-avoidance.yaml) has the following:
 
 * A PVC to store the markers on.
 * A `load-markers` step that loads the marker files from artifact storage.

--- a/docs/workflow-concepts.md
+++ b/docs/workflow-concepts.md
@@ -108,7 +108,7 @@ These templates are used to invoke/call other templates and provide execution co
 
 ##### [Steps](fields.md#workflowstep)
 
-A steps template allows you to define your tasks in a series of steps. The structure of the template is a "list of lists". Outer lists will run sequentially and inner lists will run in parallel. You can set a wide array of options to control execution, such as [`when:` clauses to conditionally execute a step](examples/coinflip.yaml).
+A steps template allows you to define your tasks in a series of steps. The structure of the template is a "list of lists". Outer lists will run sequentially and inner lists will run in parallel. You can set a wide array of options to control execution, such as [`when:` clauses to conditionally execute a step](../examples/coinflip.yaml).
     
 In this example `step1` runs first. Once it is completed, `step2a` and `step2b` will run in parallel:
 ```yaml

--- a/docs/workflow-notifications.md
+++ b/docs/workflow-notifications.md
@@ -8,6 +8,6 @@ There are a number of use cases where you may wish to notify an external system 
 
 You have options:
 
-1. For individual workflows, can add an exit handler to your workflow, [for example](examples/exit-handlers.yaml).
+1. For individual workflows, can add an exit handler to your workflow, [for example](../examples/exit-handlers.yaml).
 1. If you want the same for every workflow, you can add an exit handler to [the default workflow spec](default-workflow-specs.md).
 1. Use a service (e.g. [Heptio Labs EventRouter](https://github.com/heptiolabs/eventrouter)) to the [Workflow events](workflow-events.md) we emit.


### PR DESCRIPTION
/docs/examples is a symlink to /examples, but links that use the symlink
don't work on Github. For instance, the link to the exit-handlers.yaml
example (first link in the doc) is broken:
https://github.com/argoproj/argo-workflows/blob/67a38e33ed1a4d33085c9f566bf64b8b15c8199e/docs/workflow-notifications.md

Sorry, I don't have a go toolchain set up, so I didn't run the pre-commit locally. But I tested that the new links work on Github in my fork:
https://github.com/jli/argo-workflows/blob/1790a2887074c0b895df8e484c9d51395fa25763/docs/workflow-notifications.md