### PR TITLE
docs: Fix typo on examples page, add link to GH directory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Argo is an open source project that provides container-native workflows for Kube
 
 Argo is implemented as a Kubernetes CRD (Custom Resource Definition). As a result, Argo workflows can be managed using `kubectl` and natively integrates with other Kubernetes services such as volumes, secrets, and RBAC. The new Argo software is light-weight and installs in under a minute, and provides complete workflow features including parameter substitution, artifacts, fixtures, loops and recursive workflows.
 
-Many of the Argo examples used in this walkthrough are available in the [`/examples` directory](https://github.com/argoproj/argo-workflows/tree/master/examples) on Github. If you like this project, please give us a star!
+Many of the Argo examples used in this walkthrough are available in the [`/examples` directory](https://github.com/argoproj/argo-workflows/tree/master/examples) on GitHub. If you like this project, please give us a star!
 
 For a complete description of the Argo workflow spec, please refer to [our spec definitions](https://github.com/argoproj/argo-workflows/blob/master/pkg/apis/workflow/v1alpha1/workflow_types.go).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ Argo is an open source project that provides container-native workflows for Kube
 
 Argo is implemented as a Kubernetes CRD (Custom Resource Definition). As a result, Argo workflows can be managed using `kubectl` and natively integrates with other Kubernetes services such as volumes, secrets, and RBAC. The new Argo software is light-weight and installs in under a minute, and provides complete workflow features including parameter substitution, artifacts, fixtures, loops and recursive workflows.
 
-Many of the Argo examples used in this walkthrough are available at in this directory. If you like this project, please give us a star!
+Many of the Argo examples used in this walkthrough are available in the [`/examples` directory](https://github.com/argoproj/argo-workflows/tree/master/examples) on Github. If you like this project, please give us a star!
 
 For a complete description of the Argo workflow spec, please refer to [our spec definitions](https://github.com/argoproj/argo-workflows/blob/master/pkg/apis/workflow/v1alpha1/workflow_types.go).
 


### PR DESCRIPTION
This is a very small typo fix to the "Documentation by Example" README and a suggestion to link to the Github directory holding the YAML files for all of the examples on this docs page. 

Tested on my fork.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
