### PR TITLE
fix(executor): Fix compatibility issue with k8s>=1.21 when selfLink is no longer populated

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -60,8 +60,11 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, fla
 		return "", "", "", errors.New(errors.CodeBadRequest, "Kind and name are both required but at least one of them is missing from the manifest")
 	}
 	resourceFullName := fmt.Sprintf("%s.%s/%s", resourceKind, resourceGroup, resourceName)
-	selfLink := obj.GetSelfLink()
-	log.Infof("Resource: %s/%s. SelfLink: %s", obj.GetNamespace(), resourceFullName, selfLink)
+	resourceNamespace := obj.GetNamespace()
+	// We cannot use `obj.GetSelfLink()` directly since it is deprecated and will be removed after Kubernetes 1.21: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1164-remove-selflink
+	selfLink := fmt.Sprintf("apis/%s/namespaces/%s/%s/%s",
+		obj.GetAPIVersion(), resourceNamespace, resourceKind, resourceName)
+	log.Infof("Resource: %s/%s. SelfLink: %s", resourceNamespace, resourceFullName, selfLink)
 	return obj.GetNamespace(), resourceFullName, selfLink, nil
 }
 


### PR DESCRIPTION
We cannot use `obj.GetSelfLink()` directly since it is deprecated and will be removed after Kubernetes 1.21: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1164-remove-selflink

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
