### PR TITLE
feat: Pass include script output as an environment variable

### DIFF
--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -100,6 +100,8 @@ func initExecutor() *executor.WorkflowExecutor {
 	tmpl, err := executor.LoadTemplate(podAnnotationsPath)
 	checkErr(err)
 
+	includeScriptOutput := os.Getenv(common.EnvVarIncludeScriptOutput) == "true"
+
 	var cre executor.ContainerRuntimeExecutor
 	switch executorType {
 	case common.ContainerRuntimeExecutorK8sAPI:
@@ -115,9 +117,15 @@ func initExecutor() *executor.WorkflowExecutor {
 	}
 	checkErr(err)
 
-	wfExecutor := executor.NewExecutor(clientset, restClient, podName, namespace, podAnnotationsPath, cre, *tmpl)
+	wfExecutor := executor.NewExecutor(clientset, restClient, podName, namespace, podAnnotationsPath, cre, *tmpl, includeScriptOutput)
 	yamlBytes, _ := json.Marshal(&wfExecutor.Template)
-	log.Infof("Executor (version: %s, build_date: %s) initialized (pod: %s/%s) with template:\n%s", version.Version, version.BuildDate, namespace, podName, string(yamlBytes))
+	log.
+		WithField("version", version.String()).
+		WithField("namespace", namespace).
+		WithField("podName", podName).
+		WithField("template", string(yamlBytes)).
+		WithField("includeScriptOutput", includeScriptOutput).
+		Info("Executor initialized")
 	return &wfExecutor
 }
 

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -189,8 +189,6 @@ type ExecutionControl struct {
 	// It is used to signal the executor to terminate a daemoned container. In the future it will be
 	// used to support workflow or steps/dag level timeouts.
 	Deadline *time.Time `json:"deadline,omitempty"`
-	// IncludeScriptOutput is containing flag to include script output
-	IncludeScriptOutput bool `json:"includeScriptOutput,omitempty"`
 }
 
 func UnstructuredHasCompletedLabel(obj interface{}) bool {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5665,10 +5665,12 @@ func TestWFWithRetryAndWithParam(t *testing.T) {
 		pods, err := listPods(woc)
 		assert.NoError(t, err)
 		assert.True(t, len(pods.Items) > 0)
-		for _, pod := range pods.Items {
-			podbyte, err := json.Marshal(pod)
-			assert.NoError(t, err)
-			assert.Contains(t, string(podbyte), "includeScriptOutput")
+		if assert.Len(t, pods.Items, 3) {
+			ctrs := pods.Items[0].Spec.Containers
+			assert.Len(t, ctrs, 2)
+			envs := ctrs[1].Env
+			assert.Len(t, envs, 2)
+			assert.Equal(t, apiv1.EnvVar{Name: "ARGO_INCLUDE_SCRIPT_OUTPUT", Value: "true"}, envs[1])
 		}
 	})
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -320,11 +320,19 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 		}
 	}
 
+	// Add standard environment variables, making pod spec larger
+	envVars := []apiv1.EnvVar{
+		{Name: common.EnvVarIncludeScriptOutput, Value: strconv.FormatBool(opts.includeScriptOutput)},
+	}
+
+	for i, c := range pod.Spec.InitContainers {
+		c.Env = append(c.Env, apiv1.EnvVar{Name: common.EnvVarContainerName, Value: c.Name})
+		c.Env = append(c.Env, envVars...)
+		pod.Spec.InitContainers[i] = c
+	}
 	for i, c := range pod.Spec.Containers {
-		c.Env = append(c.Env,
-			apiv1.EnvVar{Name: common.EnvVarContainerName, Value: c.Name},
-			apiv1.EnvVar{Name: common.EnvVarIncludeScriptOutput, Value: strconv.FormatBool(c.Name == common.MainContainerName && opts.includeScriptOutput)},
-		)
+		c.Env = append(c.Env, apiv1.EnvVar{Name: common.EnvVarContainerName, Value: c.Name})
+		c.Env = append(c.Env, envVars...)
 		pod.Spec.Containers[i] = c
 	}
 
@@ -679,9 +687,7 @@ func (woc *wfOperationCtx) addMetadata(pod *apiv1.Pod, tmpl *wfv1.Template, opts
 		pod.ObjectMeta.Labels[k] = v
 	}
 
-	execCtl := common.ExecutionControl{
-		IncludeScriptOutput: opts.includeScriptOutput,
-	}
+	execCtl := common.ExecutionControl{}
 
 	if woc.workflowDeadline != nil {
 		execCtl.Deadline = woc.workflowDeadline
@@ -693,7 +699,7 @@ func (woc *wfOperationCtx) addMetadata(pod *apiv1.Pod, tmpl *wfv1.Template, opts
 		execCtl.Deadline = &opts.executionDeadline
 	}
 
-	if execCtl.Deadline != nil || opts.includeScriptOutput {
+	if execCtl.Deadline != nil {
 		execCtlBytes, err := json.Marshal(execCtl)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
As discussed in PR #5946, this is the first step in getting rid of reading the pod annotations in the executor.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
