### PR TITLE
fix(controller): Increase readiness timeout from 1s to 30s

### DIFF
--- a/manifests/base/workflow-controller/workflow-controller-deployment.yaml
+++ b/manifests/base/workflow-controller/workflow-controller-deployment.yaml
@@ -47,6 +47,7 @@ spec:
             failureThreshold: 3
             initialDelaySeconds: 90
             periodSeconds: 60
+            timeoutSeconds: 30
       securityContext:
         runAsNonRoot: true
       nodeSelector:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -613,6 +613,7 @@ spec:
             port: 6060
           initialDelaySeconds: 90
           periodSeconds: 60
+          timeoutSeconds: 30
         name: workflow-controller
         ports:
         - containerPort: 9090

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -508,6 +508,7 @@ spec:
             port: 6060
           initialDelaySeconds: 90
           periodSeconds: 60
+          timeoutSeconds: 30
         name: workflow-controller
         ports:
         - containerPort: 9090

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -881,6 +881,7 @@ spec:
             port: 6060
           initialDelaySeconds: 90
           periodSeconds: 60
+          timeoutSeconds: 30
         name: workflow-controller
         ports:
         - containerPort: 9090

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -970,6 +970,7 @@ spec:
             port: 6060
           initialDelaySeconds: 90
           periodSeconds: 60
+          timeoutSeconds: 30
         name: workflow-controller
         ports:
         - containerPort: 9090

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -962,6 +962,7 @@ spec:
             port: 6060
           initialDelaySeconds: 90
           periodSeconds: 60
+          timeoutSeconds: 30
         name: workflow-controller
         ports:
         - containerPort: 9090


### PR DESCRIPTION
1s is too short under stress. I want to be cautious about restarting, hence 30s rather than a shorter time like 10s.