### PR TITLE
fix(executor): Fix compatibility issue when selfLink is no longer populated for k8s>=1.21. Fixes #6045

### DIFF
--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -79,9 +79,9 @@ spec:
           spec:
             serviceAccountName: argo
             containers:
-            - name: pi
-              image: perl
-              command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+            - name: argosay-container
+              image: argoproj/argosay:v2
+              command: ["/argosay"]
             restartPolicy: Never
 `).
 		When().

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -59,10 +60,26 @@ func (we *WorkflowExecutor) ExecResource(action string, manifestPath string, fla
 	if resourceName == "" || resourceKind == "" {
 		return "", "", "", errors.New(errors.CodeBadRequest, "Kind and name are both required but at least one of them is missing from the manifest")
 	}
-	resourceFullName := fmt.Sprintf("%s.%s/%s", resourceKind, resourceGroup, resourceName)
-	selfLink := obj.GetSelfLink()
+	resourceFullName := fmt.Sprintf("%s.%s/%s", strings.ToLower(resourceKind), resourceGroup, resourceName)
+	selfLink := inferObjectSelfLink(obj)
 	log.Infof("Resource: %s/%s. SelfLink: %s", obj.GetNamespace(), resourceFullName, selfLink)
 	return obj.GetNamespace(), resourceFullName, selfLink, nil
+}
+
+func inferObjectSelfLink(obj unstructured.Unstructured) string {
+	gvk := obj.GroupVersionKind()
+	// This is the best guess we can do here and is what `kubectl` uses under the hood. Hopefully future versions of the
+	// REST client would remove the need to infer the plural name.
+	pluralGVR, _ := meta.UnsafeGuessKindToResource(gvk)
+	var selfLinkPrefix string
+	if gvk.Group == "" {
+		selfLinkPrefix = "api"
+	} else {
+		selfLinkPrefix = "apis"
+	}
+	// We cannot use `obj.GetSelfLink()` directly since it is deprecated and will be removed after Kubernetes 1.21: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1164-remove-selflink
+	return fmt.Sprintf("%s/%s/namespaces/%s/%s/%s",
+		selfLinkPrefix, obj.GetAPIVersion(), obj.GetNamespace(), pluralGVR.Resource, obj.GetName())
 }
 
 func (we *WorkflowExecutor) getKubectlArguments(action string, manifestPath string, flags []string) ([]string, error) {

--- a/workflow/executor/resource_test.go
+++ b/workflow/executor/resource_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -149,4 +151,31 @@ func TestResourceConditionsMatching(t *testing.T) {
 	finished, err = matchConditions(jsonBytes, successReqs, failReqs)
 	assert.Error(t, err, "Neither success condition nor the failure condition has been matched. Retrying...")
 	assert.True(t, finished)
+}
+
+// TestInferSelfLink tests whether the inferred self link for k8s objects are correct.
+func TestInferSelfLink(t *testing.T) {
+	obj := unstructured.Unstructured{}
+	obj.SetNamespace("test-namespace")
+	obj.SetName("test-name")
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	})
+	assert.Equal(t, "api/v1/namespaces/test-namespace/pods/test-name", inferObjectSelfLink(obj))
+
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "TestKind",
+	})
+	assert.Equal(t, "apis/test.group/v1/namespaces/test-namespace/testkinds/test-name", inferObjectSelfLink(obj))
+
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.group",
+		Version: "v1",
+		Kind:    "Duty",
+	})
+	assert.Equal(t, "apis/test.group/v1/namespaces/test-namespace/duties/test-name", inferObjectSelfLink(obj))
 }


### PR DESCRIPTION
See context in https://github.com/argoproj/argo-workflows/issues/6008. Also Fixes #6045. 

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
