### PR TITLE
fix(ui): Changed placing of chat/get help button. Fixes #5817

### DIFF
--- a/ui/src/app/shared/components/chat-button.tsx
+++ b/ui/src/app/shared/components/chat-button.tsx
@@ -21,7 +21,7 @@ export const ChatButton = () => {
     }
 
     return (
-        <div style={{position: 'fixed', right: 25, bottom: 55}}>
+        <div style={{position: 'fixed', right: 10, bottom: 10}}>
             <a href={link.url} className='argo-button argo-button--special'>
                 <i className='fas fa-comment-alt' /> {link.name}
             </a>

--- a/ui/src/app/shared/components/chat-button.tsx
+++ b/ui/src/app/shared/components/chat-button.tsx
@@ -21,7 +21,7 @@ export const ChatButton = () => {
     }
 
     return (
-        <div style={{position: 'fixed', right: 10, bottom: 10}}>
+        <div style={{position: 'fixed', right: 25, bottom: 55}}>
             <a href={link.url} className='argo-button argo-button--special'>
                 <i className='fas fa-comment-alt' /> {link.name}
             </a>

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -2,11 +2,13 @@ import * as React from 'react';
 import {Pagination, parseLimit} from '../pagination';
 import {WarningIcon} from './fa-icons';
 
+require('./pagination-panel-p.scss');
+
+
 export class PaginationPanel extends React.Component<{pagination: Pagination; onChange: (pagination: Pagination) => void; numRecords: number}> {
     public render() {
-        const styles: React.CSSProperties = {padding-bottom: '45px'}
         return (
-            <p style={styles}>
+            <p style={{paddingBottom: '45px'}}>
                 <button
                     disabled={!this.props.pagination.offset}
                     className='argo-button argo-button--base-o'

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -4,8 +4,9 @@ import {WarningIcon} from './fa-icons';
 
 export class PaginationPanel extends React.Component<{pagination: Pagination; onChange: (pagination: Pagination) => void; numRecords: number}> {
     public render() {
+        const styles: React.CSSProperties = {padding-bottom: '45px'}
         return (
-            <p style="padding-bottom: 45px;">
+            <p style={styles}>
                 <button
                     disabled={!this.props.pagination.offset}
                     className='argo-button argo-button--base-o'

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import {Pagination, parseLimit} from '../pagination';
 import {WarningIcon} from './fa-icons';
 
-require('./pagination-panel-p.scss');
-
 
 export class PaginationPanel extends React.Component<{pagination: Pagination; onChange: (pagination: Pagination) => void; numRecords: number}> {
     public render() {

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {Pagination, parseLimit} from '../pagination';
 import {WarningIcon} from './fa-icons';
 
-
 export class PaginationPanel extends React.Component<{pagination: Pagination; onChange: (pagination: Pagination) => void; numRecords: number}> {
     public render() {
         return (

--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -5,7 +5,7 @@ import {WarningIcon} from './fa-icons';
 export class PaginationPanel extends React.Component<{pagination: Pagination; onChange: (pagination: Pagination) => void; numRecords: number}> {
     public render() {
         return (
-            <p>
+            <p style="padding-bottom: 45px;">
                 <button
                     disabled={!this.props.pagination.offset}
                     className='argo-button argo-button--base-o'


### PR DESCRIPTION
Changed placing of chat/"get help" button.  Fix #5817

Signed-off-by: Kasper Aaquist Johansen <kasperaaquist@gmail.com>
Before: https://www.dropbox.com/s/0u3f6sjzjjneygj/before.png?dl=0
After: https://www.dropbox.com/s/ymxsq97b1ckgmbf/after.png?dl=0

I have tried to align it such it is placed top middle of the drop down menu. 