### PR TITLE
fix(ui): Fix link for archived logs

### DIFF
--- a/ui/src/app/shared/services/workflow-service.test.ts
+++ b/ui/src/app/shared/services/workflow-service.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import {Workflow} from '../../../models';
+import {WorkflowsService} from './workflows-service';
+
+const workflow = (name: string, namespace: string, uid: string): Workflow => {
+    return {
+        metadata: {
+            name,
+            namespace,
+            uid
+        },
+        spec: {}
+    };
+};
+
+describe('workflow service', () => {
+    const service = new WorkflowsService();
+    test('getArtifactLogsUrl', () => {
+        expect(service.getArtifactLogsUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-container', false)).toBe(
+            'artifacts/argo/hello-world/test-node/test-container-logs'
+        );
+        expect(service.getArtifactLogsUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-container', true)).toBe(
+            'artifacts-by-uid/test-uid/test-node/test-container-logs'
+        );
+    });
+
+    test('getArtifactDownloadUrl', () => {
+        expect(service.getArtifactDownloadUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-artifact', false, false)).toBe(
+            'artifacts/argo/hello-world/test-node/test-artifact'
+        );
+        expect(service.getArtifactDownloadUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-artifact', true, false)).toBe(
+            'artifacts-by-uid/test-uid/test-node/test-artifact'
+        );
+        expect(service.getArtifactDownloadUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-artifact', false, true)).toBe(
+            'input-artifacts/argo/hello-world/test-node/test-artifact'
+        );
+        expect(service.getArtifactDownloadUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-artifact', true, true)).toBe(
+            'input-artifacts-by-uid/test-uid/test-node/test-artifact'
+        );
+    });
+});

--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -198,7 +198,7 @@ export class WorkflowsService {
     }
 
     public getArtifactLogsUrl(workflow: Workflow, nodeId: string, container: string, archived: boolean) {
-        return this.getArtifactDownloadUrl(workflow, nodeId, container + '-logs', archived, true);
+        return this.getArtifactDownloadUrl(workflow, nodeId, container + '-logs', archived, false);
     }
 
     public getArtifactDownloadUrl(workflow: Workflow, nodeId: string, artifactName: string, archived: boolean, isInput: boolean) {


### PR DESCRIPTION
Fixes #5983 
Fixes #6015 

Hi,

This is a UI fix for the log issue.

The issue is that the UI tries to retrieve the logs from `input-artifacts` by mistake.