### PR TITLE
fix(executor): Allow PNS to `runAsNonRoot` with injected sidecar. Fixes #6030

### DIFF
--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -77,7 +77,14 @@ func NewRootCommand() *cobra.Command {
 func initExecutor() *executor.WorkflowExecutor {
 	version := argo.GetVersion()
 	executorType := os.Getenv(common.EnvVarContainerRuntimeExecutor)
-	log.WithFields(log.Fields{"version": version.Version, "executorType": executorType}).Info("Starting Workflow Executor")
+	groups, _ := os.Getgroups()
+	log.WithField("version", version.Version).
+		WithField("executorType", executorType).
+		WithField("groups", groups).
+		WithField("gid", os.Getgid()).
+		WithField("uid", os.Getuid()).
+		WithField("pid", os.Getpid()).
+		Info("Starting Workflow Executor")
 	config, err := clientConfig.ClientConfig()
 	checkErr(err)
 	config = restclient.AddUserAgent(config, fmt.Sprintf("argo-workflows/%s argo-executor/%s", version.Version, executorType))

--- a/test/e2e/run_as_not_root_test.go
+++ b/test/e2e/run_as_not_root_test.go
@@ -23,6 +23,15 @@ func (s *RunAsNonRootSuite) TestRunAsNonRootWorkflow() {
 		WaitForWorkflow(fixtures.ToBeSucceeded)
 }
 
+func (s *RunAsNonRootSuite) TestRunAsNonRootSidecarInjectedWorkflow() {
+	s.Need(fixtures.None(fixtures.Docker))
+	s.Given().
+		Workflow("@testdata/runasnonroot-sidecar-injected-workflow.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded)
+}
+
 func (s *RunAsNonRootSuite) TestRunAsNonRootWithOutputParams() {
 	s.Need(fixtures.None(fixtures.Docker, fixtures.K8SAPI, fixtures.Kubelet))
 	s.Given().

--- a/test/e2e/testdata/runasnonroot-sidecar-injected-workflow.yaml
+++ b/test/e2e/testdata/runasnonroot-sidecar-injected-workflow.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: runasnonroot-sidecar-injected-
+spec:
+  entrypoint: main
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 8737
+  podSpecPatch: |
+    terminationGracePeriodSeconds: 3
+    containers:
+      - name: wait
+      - name: main
+      - name: sidecar
+        image: argoproj/argosay:v1
+        command:
+         - sh
+         - -c
+        args:
+          - "sleep 999"
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v1

--- a/test/e2e/testdata/sidecar-injected-workflow.yaml
+++ b/test/e2e/testdata/sidecar-injected-workflow.yaml
@@ -4,9 +4,6 @@ metadata:
   generateName: sidecar-injected-
 spec:
   entrypoint: main
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 8737
   podSpecPatch: |
     terminationGracePeriodSeconds: 3
     containers:

--- a/test/e2e/testdata/sidecar-injected-workflow.yaml
+++ b/test/e2e/testdata/sidecar-injected-workflow.yaml
@@ -4,6 +4,9 @@ metadata:
   generateName: sidecar-injected-
 spec:
   entrypoint: main
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 8737
   podSpecPatch: |
     terminationGracePeriodSeconds: 3
     containers:


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>Checklist:
