### PR TITLE
fix(controller): Only clean-up pod when both main and wait containers have terminated. Fixes #5981

### DIFF
--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -1,0 +1,59 @@
+// +build executor
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
+)
+
+type ResourceTemplateSuite struct {
+	fixtures.E2ESuite
+}
+
+func (s *ResourceTemplateSuite) TestResourceTemplateWithWorkflow() {
+	s.Given().
+		Workflow(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-resource-tmpl-with-wf-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      resource:
+        action: create
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase == Failed
+        manifest: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            generateName: k8s-wf-resource-
+          spec:
+            entrypoint: main
+            templates:
+              - name: main
+                container:
+                  image: argoproj/argosay:v2
+                  command: ["/argosay"]
+`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+		})
+}
+
+func TestResourceTemplateSuite(t *testing.T) {
+	suite.Run(t, new(ResourceTemplateSuite))
+}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1210,7 +1210,7 @@ func getExitCode(pod *apiv1.Pod) *int32 {
 
 func (woc *wfOperationCtx) cleanUpPod(pod *apiv1.Pod) {
 	for _, c := range pod.Status.ContainerStatuses {
-		if c.Name == common.WaitContainerName && c.State.Terminated == nil {
+		if (c.Name == common.WaitContainerName || c.Name == common.MainContainerName) && c.State.Terminated == nil {
 			return // we must not do anything if the wait or main containers are still running
 		}
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1098,7 +1098,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, node *wfv1.NodeStatu
 			newDaemonStatus = pointer.BoolPtr(true)
 			woc.log.Infof("Processing ready daemon pod: %v", pod.ObjectMeta.SelfLink)
 		}
-		woc.cleanUpPod(pod)
+		woc.cleanUpPod(pod, tmpl)
 	default:
 		newPhase = wfv1.NodeError
 		message = fmt.Sprintf("Unexpected pod phase for %s: %s", pod.ObjectMeta.Name, pod.Status.Phase)
@@ -1208,9 +1208,9 @@ func getExitCode(pod *apiv1.Pod) *int32 {
 	return nil
 }
 
-func (woc *wfOperationCtx) cleanUpPod(pod *apiv1.Pod) {
+func (woc *wfOperationCtx) cleanUpPod(pod *apiv1.Pod, tmpl wfv1.Template) {
 	for _, c := range pod.Status.ContainerStatuses {
-		if (c.Name == common.WaitContainerName || c.Name == common.MainContainerName) && c.State.Terminated == nil {
+		if (c.Name == common.WaitContainerName || tmpl.IsMainContainerName(c.Name)) && c.State.Terminated == nil {
 			return // we must not do anything if the wait or main containers are still running
 		}
 	}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5880,6 +5880,75 @@ func TestParamAggregation(t *testing.T) {
 	}
 }
 
+func TestCleanUpPod(t *testing.T) {
+	pod := apiv1.Pod{
+		Status: apiv1.PodStatus{
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{
+					Name:  common.WaitContainerName,
+					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+				},
+				{
+					Name:  common.MainContainerName,
+					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+				},
+			}}}
+	tmpl := wfv1.Template{}
+	assert.True(t, cleanUpPod(&pod, tmpl))
+
+	pod = apiv1.Pod{
+		Status: apiv1.PodStatus{
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{
+					Name:  common.WaitContainerName,
+					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+				},
+				{
+					Name:  common.MainContainerName,
+					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+				},
+			}}}
+	tmpl = wfv1.Template{}
+	assert.False(t, cleanUpPod(&pod, tmpl))
+
+	pod = apiv1.Pod{
+		Status: apiv1.PodStatus{
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{
+					Name:  common.WaitContainerName,
+					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+				},
+				{
+					Name:  common.MainContainerName,
+					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+				},
+			}}}
+	tmpl = wfv1.Template{}
+	assert.False(t, cleanUpPod(&pod, tmpl))
+
+	pod = apiv1.Pod{
+		Status: apiv1.PodStatus{
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{
+					Name:  common.MainContainerName,
+					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+				},
+			}}}
+	tmpl = wfv1.Template{}
+	assert.False(t, cleanUpPod(&pod, tmpl))
+
+	pod = apiv1.Pod{
+		Status: apiv1.PodStatus{
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{
+					Name:  common.MainContainerName,
+					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
+				},
+			}}}
+	tmpl = wfv1.Template{}
+	assert.True(t, cleanUpPod(&pod, tmpl))
+}
+
 func TestRetryOnDiffHost(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5908,7 +5908,6 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 				},
 			}}}
-	tmpl = wfv1.Template{}
 	assert.False(t, cleanUpPod(&pod, tmpl))
 
 	pod = apiv1.Pod{
@@ -5923,7 +5922,6 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
 				},
 			}}}
-	tmpl = wfv1.Template{}
 	assert.False(t, cleanUpPod(&pod, tmpl))
 
 	pod = apiv1.Pod{
@@ -5934,7 +5932,6 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
 				},
 			}}}
-	tmpl = wfv1.Template{}
 	assert.False(t, cleanUpPod(&pod, tmpl))
 
 	pod = apiv1.Pod{
@@ -5945,7 +5942,6 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 				},
 			}}}
-	tmpl = wfv1.Template{}
 	assert.True(t, cleanUpPod(&pod, tmpl))
 }
 

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5880,7 +5880,7 @@ func TestParamAggregation(t *testing.T) {
 	}
 }
 
-func TestCleanUpPod(t *testing.T) {
+func TestPodHasContainerNeedingTermination(t *testing.T) {
 	pod := apiv1.Pod{
 		Status: apiv1.PodStatus{
 			ContainerStatuses: []apiv1.ContainerStatus{
@@ -5894,7 +5894,7 @@ func TestCleanUpPod(t *testing.T) {
 				},
 			}}}
 	tmpl := wfv1.Template{}
-	assert.True(t, cleanUpPod(&pod, tmpl))
+	assert.True(t, podHasContainerNeedingTermination(&pod, tmpl))
 
 	pod = apiv1.Pod{
 		Status: apiv1.PodStatus{
@@ -5908,7 +5908,7 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 				},
 			}}}
-	assert.False(t, cleanUpPod(&pod, tmpl))
+	assert.False(t, podHasContainerNeedingTermination(&pod, tmpl))
 
 	pod = apiv1.Pod{
 		Status: apiv1.PodStatus{
@@ -5922,7 +5922,7 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
 				},
 			}}}
-	assert.False(t, cleanUpPod(&pod, tmpl))
+	assert.False(t, podHasContainerNeedingTermination(&pod, tmpl))
 
 	pod = apiv1.Pod{
 		Status: apiv1.PodStatus{
@@ -5932,7 +5932,7 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
 				},
 			}}}
-	assert.False(t, cleanUpPod(&pod, tmpl))
+	assert.False(t, podHasContainerNeedingTermination(&pod, tmpl))
 
 	pod = apiv1.Pod{
 		Status: apiv1.PodStatus{
@@ -5942,7 +5942,7 @@ func TestCleanUpPod(t *testing.T) {
 					State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}},
 				},
 			}}}
-	assert.True(t, cleanUpPod(&pod, tmpl))
+	assert.True(t, podHasContainerNeedingTermination(&pod, tmpl))
 }
 
 func TestRetryOnDiffHost(t *testing.T) {


### PR DESCRIPTION
Caught a bug while debugging issues with https://github.com/argoproj/argo-workflows/pull/6014. Also fixes #5981. 

For resource templates, main container is used as a wait container. We need to check its termination status before queue the pod for cleanup. Otherwise, when `cleanUpPod` is called during node assessment/reconciliation, the main container would have been killed by clean-up and then wf is marked as failed even though the pod is succeeded (if wf status update happens a little late than pod the cleanup, which explains why builds in https://github.com/argoproj/argo-workflows/pull/6014 only fail occasionally).

Example controller log from PNS test-executor in https://github.com/argoproj/argo-workflows/runs/2676799345:
```
 controller | time="2021-05-26T16:25:15.758Z" level=info msg="Processing workflow" namespace=argo workflow=k8s-resource-tmpl-with-wf-qvl62
 controller | time="2021-05-26T16:25:15.760Z" level=info msg="Get configmaps 200"
 controller | time="2021-05-26T16:25:15.760Z" level=info msg="Updating node k8s-resource-tmpl-with-wf-qvl62 status Pending -> Running" namespace=argo workflow=k8s-resource-tmpl-with-wf-qvl62
 controller | time="2021-05-26T16:25:15.766Z" level=info msg="cleaning up pod" action=terminateContainers key=argo/k8s-resource-tmpl-with-wf-qvl62/terminateContainers
 controller | time="2021-05-26T16:25:15.766Z" level=info msg="https://127.0.0.1:6443/api/v1/namespaces/argo/pods/k8s-resource-tmpl-with-wf-qvl62/exec?command=%2Fbin%2Fsh&command=-c&command=kill+-s15+--+-1&container=main&stderr=true&stdout=true&tty=false"
 controller | time="2021-05-26T16:25:15.770Z" level=info msg="Update workflows 200"
 controller | time="2021-05-26T16:25:15.770Z" level=info msg="Workflow update successful" namespace=argo phase=Running resourceVersion=1092 workflow=k8s-resource-tmpl-with-wf-qvl62
 controller | time="2021-05-26T16:25:15.774Z" level=info msg="Create events 201"
 controller | time="2021-05-26T16:25:15.785Z" level=info msg="Create pods/exec 101"
 controller | time="2021-05-26T16:25:16.772Z" level=info msg="Processing workflow" namespace=argo workflow=k8s-resource-tmpl-with-wf-qvl62
 controller | time="2021-05-26T16:25:16.774Z" level=info msg="Get configmaps 200"
 controller | time="2021-05-26T16:25:16.774Z" level=info msg="Pod failed: Error (exit code 143)" displayName=k8s-resource-tmpl-with-wf-qvl62 namespace=argo pod=k8s-resource-tmpl-with-wf-qvl62 templateName=main workflow=k8s-resource-tmpl-with-wf-qvl62
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
