### PR TITLE
docs: Must use k8sapi to run on GKE Autopilot

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -20,6 +20,9 @@ kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo-workflo
 kubectl create clusterrolebinding YOURNAME-cluster-admin-binding --clusterrole=cluster-admin --user=YOUREMAIL@gmail.com
 ```
 
+!!! note
+    To run Argo on GKE Autopilot, you must use the `k8sapi` executor. Find more information on our [executors doc](workflow-executors.md).
+
 If you are running Argo Workflows locally (e.g. using Minikube or Docker for Desktop), open a port-forward so you can access the namespace:
 
 ```sh

--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -46,6 +46,7 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
 * Reliability:
     * Well-tested
     * Popular
+    * Works on GKE Autopilot
 * Most secure:
     * No `privileged` access
     * Cannot escape the privileges of the pod's service account


### PR DESCRIPTION
Signed-off-by: Simon Behar <simbeh7@gmail.com>

Closes: https://github.com/argoproj/argo-workflows/issues/5434

Closing the loop on #5434: Argo works fine in GKE Autopilot if the `k8sapi` executor is used. I opted to add custom manifests for GKE Autopilot for better user experience, easier automation for creating Argo in Autopilot clusters, and better extensibility if we decide that other configurations are right for Autopilot.

Checklist:

* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
