### PR TITLE
Point to latest stable release

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -33,7 +33,7 @@ This will serve the user interface on https://localhost:2746
 
 If you're using running Argo Workflows on a remote cluster (e.g. on EKS or GKE) then [follow these instructions](argo-server.md#access-the-argo-workflows-ui). 
 
-Next, Download the latest Argo CLI from our [releases page](https://github.com/argoproj/argo-workflows/releases).
+Next, Download the latest Argo CLI from our [releases page](https://github.com/argoproj/argo-workflows/releases/latest).
 
 Finally, submit an example workflow:  
 


### PR DESCRIPTION
Signed-off-by: Kaito Ii <kaitoii1111@gmail.com>

Currently, the release page is filled with Pre-releases. The user needs to scroll through the pages to get to the stable release.
It would be better for the user to be able to access the latest stable release directly from the link.