### PR TITLE
docs(installation): add compatible kubernetes version doc

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,8 @@ You can choose one of three common installations:
 
 Choose [a manifests from the list](https://github.com/argoproj/argo-workflows/tree/stable/manifests).
 
+Use the [correct Argo workflow version for your Kubernetes](https://argoproj.github.io/argo-workflows/releases/#supported-kubernetes-version).
+
 E.g.
 
 ```sh

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,7 +22,7 @@ The compatible Argo workflow and Kubernetes versions are as below.
 See [Kubernete version skew policy](https://kubernetes.io/releases/version-skew-policy/) for more deail.
 
 |Argo workflow version|Kubernetes version|
-|-|-|-|
+|-|-|
 |3.1|1.18-1.20|
 |3.0|1.18-1.20|
 |2.12|1.17-1.19|

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -15,6 +15,18 @@ If a release contains breaking changes, or CVE fixes, this will documented in th
 
 Both the `argo-server` and `argocli` should be the same version as the controller.
 
+## Supported Kubernetes Version
+
+The compatible Argo workflow and Kubernetes versions are as below.
+
+See [Kubernete version skew policy](https://kubernetes.io/releases/version-skew-policy/) for more deail.
+
+|Argo workflow version|Kubernetes version|
+|-|-|-|
+|3.1|1.18-1.20|
+|3.0|1.18-1.20|
+|2.12|1.17-1.19|
+
 # Release Cycle
 
 For **unstable**, we build and tag `latest` images for every commit to master.


### PR DESCRIPTION
We had an issue where argo-workflow loops failed to monitor/update workflow yaml status on mismatched argo version and gke cluster

upgrading argo to make sure a matching kubectl and kubernetes helps to resolve the issue.

Adding kubernetes version doc may help other users

---

Signed-off-by: Tianchu Zhao <evantczhao@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
