### PR TITLE
fix(controller): dehydrate workflow before deleting offloaded node status

### DIFF
--- a/persist/sqldb/explosive_offload_node_status_repo.go
+++ b/persist/sqldb/explosive_offload_node_status_repo.go
@@ -33,6 +33,6 @@ func (n *explosiveOffloadNodeStatusRepo) Delete(string, string) error {
 	return OffloadNotSupportedError
 }
 
-func (n *explosiveOffloadNodeStatusRepo) ListOldOffloads(string) ([]UUIDVersion, error) {
+func (n *explosiveOffloadNodeStatusRepo) ListOldOffloads(string) (map[string][]string, error) {
 	return nil, OffloadNotSupportedError
 }

--- a/persist/sqldb/mocks/OffloadNodeStatusRepo.go
+++ b/persist/sqldb/mocks/OffloadNodeStatusRepo.go
@@ -89,15 +89,15 @@ func (_m *OffloadNodeStatusRepo) List(namespace string) (map[sqldb.UUIDVersion]v
 }
 
 // ListOldOffloads provides a mock function with given fields: namespace
-func (_m *OffloadNodeStatusRepo) ListOldOffloads(namespace string) ([]sqldb.UUIDVersion, error) {
+func (_m *OffloadNodeStatusRepo) ListOldOffloads(namespace string) (map[string][]string, error) {
 	ret := _m.Called(namespace)
 
-	var r0 []sqldb.UUIDVersion
-	if rf, ok := ret.Get(0).(func(string) []sqldb.UUIDVersion); ok {
+	var r0 map[string][]string
+	if rf, ok := ret.Get(0).(func(string) map[string][]string); ok {
 		r0 = rf(namespace)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]sqldb.UUIDVersion)
+			r0 = ret.Get(0).(map[string][]string)
 		}
 	}
 

--- a/persist/sqldb/offload_node_status_repo.go
+++ b/persist/sqldb/offload_node_status_repo.go
@@ -26,7 +26,7 @@ type OffloadNodeStatusRepo interface {
 	Save(uid, namespace string, nodes wfv1.Nodes) (string, error)
 	Get(uid, version string) (wfv1.Nodes, error)
 	List(namespace string) (map[UUIDVersion]wfv1.Nodes, error)
-	ListOldOffloads(namespace string) ([]UUIDVersion, error)
+	ListOldOffloads(namespace string) (map[string][]string, error)
 	Delete(uid, version string) error
 	IsEnabled() bool
 }
@@ -178,7 +178,7 @@ func (wdc *nodeOffloadRepo) List(namespace string) (map[UUIDVersion]wfv1.Nodes, 
 	return res, nil
 }
 
-func (wdc *nodeOffloadRepo) ListOldOffloads(namespace string) ([]UUIDVersion, error) {
+func (wdc *nodeOffloadRepo) ListOldOffloads(namespace string) (map[string][]string, error) {
 	log.WithFields(log.Fields{"namespace": namespace}).Debug("Listing old offloaded nodes")
 	var records []UUIDVersion
 	err := wdc.session.
@@ -191,7 +191,11 @@ func (wdc *nodeOffloadRepo) ListOldOffloads(namespace string) ([]UUIDVersion, er
 	if err != nil {
 		return nil, err
 	}
-	return records, nil
+	x := make(map[string][]string)
+	for _, r := range records {
+		x[r.UID] = append(x[r.UID], r.Version)
+	}
+	return x, nil
 }
 
 func (wdc *nodeOffloadRepo) Delete(uid, version string) error {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -187,6 +187,7 @@ var indexers = cache.Indexers{
 	indexes.SemaphoreConfigIndexName:     indexes.WorkflowSemaphoreKeysIndexFunc(),
 	indexes.WorkflowPhaseIndex:           indexes.MetaWorkflowPhaseIndexFunc(),
 	indexes.ConditionsIndex:              indexes.ConditionsIndexFunc,
+	indexes.UIDIndex:                     indexes.MetaUIDFunc,
 }
 
 // Run starts an Workflow resource controller
@@ -553,35 +554,57 @@ func (wfc *WorkflowController) workflowGarbageCollector(stopCh <-chan struct{}) 
 					log.WithField("err", err).Error("Failed to list old offloaded nodes")
 					continue
 				}
-				if len(oldRecords) == 0 {
-					log.Info("Zero old offloads, nothing to do")
-					continue
-				}
-				// get every lives workflow (1000s) into a map
-				liveOffloadNodeStatusVersions := make(map[types.UID]string)
-				workflows, err := util.NewWorkflowLister(wfc.wfInformer).List()
-				if err != nil {
-					log.WithField("err", err).Error("Failed to list incomplete workflows")
-					continue
-				}
-				for _, wf := range workflows {
-					// this could be the empty string - as it is no longer offloaded
-					liveOffloadNodeStatusVersions[wf.UID] = wf.Status.OffloadNodeStatusVersion
-				}
-				log.WithFields(log.Fields{"len_wfs": len(liveOffloadNodeStatusVersions), "len_old_offloads": len(oldRecords)}).Info("Deleting old offloads that are not live")
-				for _, record := range oldRecords {
-					// this could be empty string
-					nodeStatusVersion, ok := liveOffloadNodeStatusVersions[types.UID(record.UID)]
-					if !ok || nodeStatusVersion != record.Version {
-						err := wfc.offloadNodeStatusRepo.Delete(record.UID, record.Version)
-						if err != nil {
-							log.WithField("err", err).Error("Failed to delete offloaded nodes")
-						}
+				log.WithField("len_wfs", len(oldRecords)).Info("Deleting old offloads that are not live")
+				for uid, versions := range oldRecords {
+					if err := wfc.deleteOffloadedNodesForWorkflow(uid, versions); err != nil {
+						log.WithError(err).WithField("uid", uid).Error("Failed to delete old offloaded nodes")
 					}
 				}
+				log.Info("Workflow GC finished")
 			}
 		}
 	}
+}
+
+func (wfc *WorkflowController) deleteOffloadedNodesForWorkflow(uid string, versions []string) error {
+	workflows, err := wfc.wfInformer.GetIndexer().ByIndex(indexes.UIDIndex, uid)
+	if err != nil {
+		return err
+	}
+	var wf *wfv1.Workflow
+	switch l := len(workflows); l {
+	case 0:
+		log.WithField("uid", uid).Info("Workflow missing, probably deleted")
+	case 1:
+		un := workflows[0].(*unstructured.Unstructured)
+		wf, err = util.FromUnstructured(un)
+		if err != nil {
+			return err
+		}
+		key := wf.ObjectMeta.Namespace + "/" + wf.ObjectMeta.Name
+		wfc.workflowKeyLock.Lock(key)
+		defer wfc.workflowKeyLock.Unlock(key)
+		// workflow might still be hydrated
+		if wfc.hydrator.IsHydrated(wf) {
+			log.WithField("uid", wf.UID).Info("Hydrated workflow encountered")
+			err = wfc.hydrator.Dehydrate(wf)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("expected no more than 1 workflow, got %d", l)
+	}
+	for _, version := range versions {
+		// skip delete if offload is live
+		if wf != nil && wf.Status.OffloadNodeStatusVersion == version {
+			continue
+		}
+		if err := wfc.offloadNodeStatusRepo.Delete(uid, version); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (wfc *WorkflowController) archivedWorkflowGarbageCollector(stopCh <-chan struct{}) {

--- a/workflow/controller/indexes/indexes.go
+++ b/workflow/controller/indexes/indexes.go
@@ -15,4 +15,5 @@ const (
 	PodPhaseIndex                = "pod.phase"
 	ConditionsIndex              = "status.conditions"
 	SemaphoreConfigIndexName     = "bySemaphoreConfigMap"
+	UIDIndex                     = "uid"
 )

--- a/workflow/controller/indexes/uid_index.go
+++ b/workflow/controller/indexes/uid_index.go
@@ -1,0 +1,14 @@
+package indexes
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+)
+
+var MetaUIDFunc cache.IndexFunc = func(obj interface{}) ([]string, error) {
+	v, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, nil
+	}
+	return []string{string(v.GetUID())}, nil
+}


### PR DESCRIPTION
Offloaded nodes are periodically garbage collected. The garbage collector first compiles a map of node status versions to keep (based on available k8s resources) and assumes that all other node statuses can be deleted. For workflows without a value for 'OffloadNodeStatusVersion' it is assumed that the nodes are not (or no longer) being offloaded. 

Unfortunately this is not always correct: we observed (quite regularly) that node status information was deleted prematurely, destroying active workflows and/or making it impossible to review workflow results afterwards.

While investigating the issue we discovered that the workflows provided by the workflow lister are sometimes hydrated and because of that do not yet have a value for 'OffloadNodeStatusVersion'. However this doesn't necessarily mean that the nodes of that particular workflow are not actually offloaded and can be disregarded safely.

In order to resolve this issue we experimented with an Argo build where the garbage collector ensures workflow dehydration before deleting anything. We thoroughly tested this version and we couldn't reproduce the problem anymore. It looks like we did indeed find the culprit.

This PR suggests to implement this particular change in order to prevent losing any offloaded node information. We do not know however if this is actually the right approach. It could be that there is a root cause to be fixed somewhere else in the workflow controller. Because of the seemingly random nature of the problem it could perhaps be caused by some race condition?

Signed-off-by: Reijer Copier <reijer.copier@kadaster.nl>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).