### PR TITLE
docs: Use 'depends' instead of 'dependencies' in examples

### DIFF
--- a/examples/buildkit-template.yaml
+++ b/examples/buildkit-template.yaml
@@ -68,8 +68,7 @@ spec:
               parameters:
                 - name: path
                   value: "{{workflow.parameters.path}}"
-            dependencies:
-              - clone
+            depends: "clone"
           - name: image
             template: image
             arguments:
@@ -78,8 +77,7 @@ spec:
                   value: "{{workflow.parameters.path}}"
                 - name: image
                   value: "{{workflow.parameters.image}}"
-            dependencies:
-              - build
+            depends: "build"
     - name: clone
       inputs:
         parameters:

--- a/examples/cluster-workflow-template/cluster-wftmpl-dag.yaml
+++ b/examples/cluster-workflow-template/cluster-wftmpl-dag.yaml
@@ -25,7 +25,7 @@ spec:
           - name: message
             value: A
       - name: B
-        dependencies: [A]
+        depends: "A"
         templateRef:
           name: cluster-workflow-template-whalesay-template
           template: whalesay-template
@@ -35,13 +35,13 @@ spec:
           - name: message
             value: B
       - name: C
-        dependencies: [A]
+        depends: "A"
         templateRef:
           name: cluster-workflow-template-inner-dag
           template: inner-diamond
           clusterScope: true
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         templateRef:
           name: cluster-workflow-template-whalesay-template
           template: whalesay-template

--- a/examples/cluster-workflow-template/clustertemplates.yaml
+++ b/examples/cluster-workflow-template/clustertemplates.yaml
@@ -106,21 +106,21 @@ spec:
           - name: message
             value: inner-A
       - name: inner-B
-        dependencies: [inner-A]
+        depends: "inner-A"
         template: whalesay-template
         arguments:
           parameters:
           - name: message
             value: inner-B
       - name: inner-C
-        dependencies: [inner-A]
+        depends: "inner-A"
         template: whalesay-template
         arguments:
           parameters:
           - name: message
             value: inner-C
       - name: inner-D
-        dependencies: [inner-B, inner-C]
+        depends: "inner-B && inner-C"
         templateRef:
           name: cluster-workflow-template-whalesay-template
           template: whalesay-template

--- a/examples/container-set-template/graph-workflow.yaml
+++ b/examples/container-set-template/graph-workflow.yaml
@@ -21,14 +21,10 @@ spec:
             image: argoproj/argosay:v2
           - name: b
             image: argoproj/argosay:v2
-            dependencies:
-              - a
+            depends: "a"
           - name: c
             image: argoproj/argosay:v2
-            dependencies:
-              - a
+            depends: "a"
           - name: d
             image: argoproj/argosay:v2
-            dependencies:
-              - b
-              - c
+            depends: "b && c"

--- a/examples/container-set-template/outputs-result-workflow.yaml
+++ b/examples/container-set-template/outputs-result-workflow.yaml
@@ -27,8 +27,7 @@ spec:
               parameters:
                 - name: x
                   value: "{{tasks.a.outputs.result}}"
-            dependencies:
-              - a
+            depends: "a"
 
     - name: group
       containerSet:

--- a/examples/container-set-template/sequence-workflow.yaml
+++ b/examples/container-set-template/sequence-workflow.yaml
@@ -21,9 +21,7 @@ spec:
             image: argoproj/argosay:v2
           - name: b
             image: argoproj/argosay:v2
-            dependencies:
-              - a
+            depends: "a"
           - name: c
             image: argoproj/argosay:v2
-            dependencies:
-              - b
+            depends: "b"

--- a/examples/dag-coinflip.yaml
+++ b/examples/dag-coinflip.yaml
@@ -11,13 +11,13 @@ spec:
       - name: A
         template: coinflip
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: coinflip
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: coinflip
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: coinflip
 
   - name: coinflip

--- a/examples/dag-continue-on-fail.yaml
+++ b/examples/dag-continue-on-fail.yaml
@@ -11,24 +11,24 @@ spec:
       - name: A
         template: whalesay
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: intentional-fail
         continueOn:
           failed: true
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: whalesay
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: whalesay
       - name: E
-        dependencies: [A]
+        depends: "A"
         template: intentional-fail
       - name: F
-        dependencies: [A]
+        depends: "A"
         template: whalesay
       - name: G
-        dependencies: [E, F]
+        depends: "E && F"
         template: whalesay
 
   - name: whalesay

--- a/examples/dag-daemon-task.yaml
+++ b/examples/dag-daemon-task.yaml
@@ -16,7 +16,7 @@ spec:
 
       - name: init-database
         template: influxdb-client
-        dependencies: [influx]
+        depends: "influx"
         arguments:
           parameters:
           - name: cmd
@@ -24,21 +24,21 @@ spec:
 
       - name: producer-1
         template: influxdb-client
-        dependencies: [init-database]
+        depends: "init-database"
         arguments:
           parameters:
           - name: cmd
             value: for i in $(seq 1 20); do curl -XPOST 'http://{{tasks.influx.ip}}:8086/write?db=mydb' -d "cpu,host=server01,region=uswest load=$i" ; sleep .5 ; done
       - name: producer-2
         template: influxdb-client
-        dependencies: [init-database]
+        depends: "init-database"
         arguments:
           parameters:
           - name: cmd
             value: for i in $(seq 1 20); do curl -XPOST 'http://{{tasks.influx.ip}}:8086/write?db=mydb' -d "cpu,host=server02,region=uswest load=$((RANDOM % 100))" ; sleep .5 ; done
       - name: producer-3
         template: influxdb-client
-        dependencies: [init-database]
+        depends: "init-database"
         arguments:
           parameters:
           - name: cmd
@@ -46,7 +46,7 @@ spec:
 
       - name: consumer
         template: influxdb-client
-        dependencies: [producer-1, producer-2, producer-3]
+        depends: "producer-1 && producer-2 && producer-3"
         arguments:
           parameters:
           - name: cmd

--- a/examples/dag-diamond-steps.yaml
+++ b/examples/dag-diamond-steps.yaml
@@ -53,17 +53,17 @@ spec:
         arguments:
           parameters: [{name: message, value: A}]
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: echo-thrice
         arguments:
           parameters: [{name: message, value: B}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: echo-thrice
         arguments:
           parameters: [{name: message, value: C}]
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: echo-thrice
         arguments:
           parameters: [{name: message, value: D}]

--- a/examples/dag-diamond.yaml
+++ b/examples/dag-diamond.yaml
@@ -20,17 +20,17 @@ spec:
         arguments:
           parameters: [{name: message, value: A}]
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: B}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: C}]
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: echo
         arguments:
           parameters: [{name: message, value: D}]

--- a/examples/dag-disable-failFast.yaml
+++ b/examples/dag-disable-failFast.yaml
@@ -36,14 +36,14 @@ spec:
       - name: A
         template: a
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: b
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: c
       - name: D
-        dependencies: [B]
+        depends: "B"
         template: d
       - name: E
-        dependencies: [D]
+        depends: "D"
         template: d

--- a/examples/dag-multiroot.yaml
+++ b/examples/dag-multiroot.yaml
@@ -25,17 +25,16 @@ spec:
         arguments:
           parameters: [{name: message, value: A}]
       - name: B
-        dependencies: []
         template: echo
         arguments:
           parameters: [{name: message, value: B}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: C}]
       - name: D
-        dependencies: [A, B]
+        depends: "A && B"
         template: echo
         arguments:
           parameters: [{name: message, value: D}]

--- a/examples/dag-nested.yaml
+++ b/examples/dag-nested.yaml
@@ -20,17 +20,17 @@ spec:
         arguments:
           parameters: [{name: message, value: A}]
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: nested-diamond
         arguments:
           parameters: [{name: message, value: B}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: nested-diamond
         arguments:
           parameters: [{name: message, value: C}]
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: nested-diamond
         arguments:
           parameters: [{name: message, value: D}]
@@ -45,17 +45,17 @@ spec:
         arguments:
           parameters: [{name: message, value: "{{inputs.parameters.message}}A"}]
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: "{{inputs.parameters.message}}B"}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: "{{inputs.parameters.message}}C"}]
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: echo
         arguments:
           parameters: [{name: message, value: "{{inputs.parameters.message}}D"}]

--- a/examples/dag-targets.yaml
+++ b/examples/dag-targets.yaml
@@ -38,22 +38,22 @@ spec:
         arguments:
           parameters: [{name: message, value: A}]
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: B}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: message, value: C}]
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         template: echo
         arguments:
           parameters: [{name: message, value: D}]
       - name: E
-        dependencies: [C]
+        depends: "C"
         template: echo
         arguments:
           parameters: [{name: message, value: E}]

--- a/examples/dag-task-level-timeout.yaml
+++ b/examples/dag-task-level-timeout.yaml
@@ -14,12 +14,12 @@ spec:
         arguments:
           parameters: [{name: timeout, value: "20s"}]
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: timeout, value: "10s"}]
       - name: C
-        dependencies: [A]
+        depends: "A"
         template: echo
         arguments:
           parameters: [{name: timeout, value: "20s"}]

--- a/examples/exit-handler-dag-level.yaml
+++ b/examples/exit-handler-dag-level.yaml
@@ -16,19 +16,19 @@ spec:
             arguments:
               parameters: [{name: message, value: A}]
           - name: B
-            dependencies: [A]
+            depends: "A"
             onExit: exit
             template: echo
             arguments:
               parameters: [{name: message, value: B}]
           - name: C
-            dependencies: [A]
+            depends: "A"
             onExit: exit
             template: echo
             arguments:
               parameters: [{name: message, value: C}]
           - name: D
-            dependencies: [B, C]
+            depends: "B && C"
             onExit: exit
             template: echo
             arguments:

--- a/examples/key-only-artifact.yaml
+++ b/examples/key-only-artifact.yaml
@@ -14,8 +14,7 @@ spec:
             template: generate
           - name: consume
             template: consume
-            dependencies:
-              - generate
+            depends: "generate"
     - name: generate
       container:
         image: argoproj/argosay:v2

--- a/examples/loops-dag.yaml
+++ b/examples/loops-dag.yaml
@@ -15,7 +15,7 @@ spec:
           parameters:
           - {name: message, value: A}
       - name: B
-        dependencies: [A]
+        depends: "A"
         template: whalesay
         arguments:
           parameters:
@@ -25,7 +25,7 @@ spec:
         - bar
         - baz
       - name: C
-        dependencies: [B]
+        depends: "B"
         template: whalesay
         arguments:
           parameters:

--- a/examples/map-reduce.yaml
+++ b/examples/map-reduce.yaml
@@ -35,13 +35,11 @@ spec:
                 - name: part
                   s3:
                     key: "{{workflow.name}}/parts/{{item}}.json"
-            dependencies:
-              - split
+            depends: "split"
             withParam: '{{tasks.split.outputs.result}}'
           - name: reduce
             template: reduce
-            dependencies:
-              - map
+            depends: "map"
     # The `split` task creates a number of "parts". Each part has a unique ID (index).
     # This task writes one "part file" for each of pieces of processing that needs doing, into to single directory
     # which is then saved as an output artifact.

--- a/examples/parallelism-nested-dag.yaml
+++ b/examples/parallelism-nested-dag.yaml
@@ -23,28 +23,28 @@ spec:
             value: "1"
       - name: b2
         template: B
-        dependencies: [b1]
+        depends: "b1"
         arguments:
           parameters:
           - name: msg
             value: "2"
       - name: b3
         template: B
-        dependencies: [b1]
+        depends: "b1"
         arguments:
           parameters:
           - name: msg
             value: "3"
       - name: b4
         template: B
-        dependencies: [b1]
+        depends: "b1"
         arguments:
           parameters:
           - name: msg
             value: "4"
       - name: b5
         template: B
-        dependencies: [b2, b3, b4]
+        depends: "b2 && b3 && b4"
         arguments:
           parameters:
           - name: msg
@@ -64,14 +64,14 @@ spec:
             value: "{{inputs.parameters.msg}} c1"
       - name: c2
         template: one-job
-        dependencies: [c1]
+        depends: "c1"
         arguments:
           parameters:
           - name: msg
             value: "{{inputs.parameters.msg}} c2"
       - name: c3
         template: one-job
-        dependencies: [c1]
+        depends: "c1"
         arguments:
           parameters:
           - name: msg

--- a/examples/parameter-aggregation-dag.yaml
+++ b/examples/parameter-aggregation-dag.yaml
@@ -20,14 +20,14 @@ spec:
         withItems: [1, 2, 3, 4]
       - name: print-nums
         template: whalesay
-        dependencies: [odd-or-even]
+        depends: "odd-or-even"
         arguments:
           parameters:
           - name: message
             value: "{{tasks.odd-or-even.outputs.parameters.num}}"
       - name: print-evenness
         template: whalesay
-        dependencies: [odd-or-even]
+        depends: "odd-or-even"
         arguments:
           parameters:
           - name: message
@@ -35,7 +35,7 @@ spec:
       # Next, for each even number, divide it by two (using a script template).
       # Skip odd numbers using a `when` clause.
       - name: divide-by-2
-        dependencies: [odd-or-even]
+        depends: "odd-or-even"
         template: divide-by-2
         arguments:
           parameters:
@@ -45,7 +45,7 @@ spec:
         when: "{{item.evenness}} == even"
       # Finally, print all numbers processed in the previous step
       - name: print
-        dependencies: [divide-by-2]
+        depends: "divide-by-2"
         template: whalesay
         arguments:
           parameters:

--- a/examples/pod-spec-from-previous-step.yaml
+++ b/examples/pod-spec-from-previous-step.yaml
@@ -11,7 +11,7 @@ spec:
       - name: parse-resources
         template: parse-resources-tmpl
       - name: setup-resources
-        dependencies: [parse-resources]
+        depends: "parse-resources"
         template: setup-resources-tmpl
         arguments:
           parameters:

--- a/examples/resubmit.yaml
+++ b/examples/resubmit.yaml
@@ -17,10 +17,10 @@ spec:
       - name: B
         template: rand-fail-steps
       - name: C
-        dependencies: [B]
+        depends: "B"
         template: random-fail
       - name: D
-        dependencies: [A, B]
+        depends: "A && B"
         template: random-fail
 
   - name: rand-fail-steps

--- a/examples/workflow-template/dag.yaml
+++ b/examples/workflow-template/dag.yaml
@@ -24,7 +24,7 @@ spec:
           - name: message
             value: A
       - name: B
-        dependencies: [A]
+        depends: "A"
         templateRef:
           name: workflow-template-whalesay-template
           template: whalesay-template
@@ -33,12 +33,12 @@ spec:
           - name: message
             value: B
       - name: C
-        dependencies: [A]
+        depends: "A"
         templateRef:
           name: workflow-template-inner-dag
           template: inner-diamond
       - name: D
-        dependencies: [B, C]
+        depends: "B && C"
         templateRef:
           name: workflow-template-whalesay-template
           template: whalesay-template

--- a/examples/workflow-template/templates.yaml
+++ b/examples/workflow-template/templates.yaml
@@ -101,21 +101,21 @@ spec:
           - name: message
             value: inner-A
       - name: inner-B
-        dependencies: [inner-A]
+        depends: "inner-A"
         template: whalesay-template
         arguments:
           parameters:
           - name: message
             value: inner-B
       - name: inner-C
-        dependencies: [inner-A]
+        depends: "inner-A"
         template: whalesay-template
         arguments:
           parameters:
           - name: message
             value: inner-C
       - name: inner-D
-        dependencies: [inner-B, inner-C]
+        depends: "inner-B && inner-C"
         templateRef:
           name: workflow-template-whalesay-template
           template: whalesay-template


### PR DESCRIPTION
This probably should have been done some time ago. `depends` was released in v2.9 and is the preferred way to specify DAG dependencies. However, the examples don't reflect that and many users will not be aware of the existence of `depends` unless they search the docs. I propose we feature `depends` in the examples instead.

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
