### PR TITLE
feat(server): Allow redirect_uri to be automatically resolved when using sso

### DIFF
--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -293,9 +293,9 @@ data:
     clientSecret:
       name: client-secret-secret
       key: client-secret-key
-    # This is the redirect URL supplied to the provider (required). It must
+    # This is the redirect URL supplied to the provider (optional). It must
     # be in the form <argo-server-root-url>/oauth2/callback. It must be
-    # browser-accessible.
+    # browser-accessible. If omitted, will be automatically generated.
     redirectUrl: https://argo-server/oauth2/callback
     # Additional scopes to request. Typically needed for SSO RBAC. >= v2.12
     scopes:


### PR DESCRIPTION
We currently need to front Argo behind two endpoints with unique URLs and this currently causes issues as you have to configure the redirect URL when setting up SSO.

Many other tools we use like JupyterHub and MLFlow will use the Host header to "guess" the redirect URL when you have not explicitly set it, this has the benefit of not needing to configure the redirect URL and in our case enables us to serve Argo behind two endpoints without issue.

I saw no existing tests around this code path in the sso module, I am happy to write some if requested but for now I have tested the changed in our environment and verified that existing behavior still works when the redirect URL is set.

Checklist:

* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.