### PR TITLE
feat(controller): Delay pod GC deletion by a configurable amount (default 5s)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"time"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,11 +107,15 @@ type Config struct {
 	// PodSpecLogStrategy enables the logging of podspec on controller log.
 	PodSpecLogStrategy PodSpecLogStrategy `json:"podSpecLogStrategy,omitempty"`
 
-	// PodGCGracePeriodSeconds specifies the duration in seconds before the pods in the GC queue get deleted.
-	// Value must be non-negative integer. A zero value indicates that the pods will be deleted immediately
-	// as soon as they arrived in the pod GC queue.
-	// Defaults to 30 seconds.
+	// PodGCGracePeriodSeconds specifies the duration in seconds before a terminating pod is forcefully killed.
+	// Value must be non-negative integer. A zero value indicates that the pod will be forcefully terminated immediately.
+	// Defaults to the Kubernetes default of 30 seconds.
 	PodGCGracePeriodSeconds *int64 `json:"podGCGracePeriodSeconds,omitempty"`
+
+	// PodGCDeleteDelayDuration specifies the duration in seconds before the pods in the GC queue get deleted.
+	// Value must be non-negative integer. A zero value indicates that the pods will be deleted immediately.
+	// Defaults to 5 seconds.
+	PodGCDeleteDelayDuration *metav1.Duration `json:"podGCDeleteDelayDuration,omitempty"`
 
 	// WorkflowRestrictions restricts the controller to executing Workflows that meet certain restrictions
 	WorkflowRestrictions *WorkflowRestrictions `json:"workflowRestrictions,omitempty"`
@@ -142,6 +147,14 @@ func (c Config) GetResourceRateLimit() ResourceRateLimit {
 		Limit: math.MaxFloat32,
 		Burst: math.MaxInt32,
 	}
+}
+
+func (c Config) GetPodGCDeleteDelayDuration() time.Duration {
+	if c.PodGCDeleteDelayDuration == nil {
+		return 5 * time.Second
+	}
+
+	return c.PodGCDeleteDelayDuration.Duration
 }
 
 // PodSpecLogStrategy contains the configuration for logging the pod spec in controller log for debugging purpose

--- a/test/e2e/pod_cleanup_test.go
+++ b/test/e2e/pod_cleanup_test.go
@@ -21,7 +21,7 @@ type PodCleanupSuite struct {
 	fixtures.E2ESuite
 }
 
-const enoughTimeForPodCleanup = 3 * time.Second
+const enoughTimeForPodCleanup = 10 * time.Second
 
 func (s *PodCleanupSuite) TestNone() {
 	s.Given().

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -768,7 +768,8 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		}
 		if doPodGC {
 			for podName := range woc.completedPods {
-				woc.controller.queuePodForCleanup(woc.wf.Namespace, podName, deletePod)
+				delay := woc.controller.Config.GetPodGCDeleteDelayDuration()
+				woc.controller.queuePodForCleanupAfter(woc.wf.Namespace, podName, deletePod, delay)
 			}
 		}
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -596,10 +596,12 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 			switch woc.execWf.Spec.PodGC.Strategy {
 			case wfv1.PodGCOnPodSuccess:
 				if podPhase == apiv1.PodSucceeded {
-					woc.controller.queuePodForCleanup(woc.wf.Namespace, podName, deletePod)
+					delay := woc.controller.Config.GetPodGCDeleteDelayDuration()
+					woc.controller.queuePodForCleanupAfter(woc.wf.Namespace, podName, deletePod, delay)
 				}
 			case wfv1.PodGCOnPodCompletion:
-				woc.controller.queuePodForCleanup(woc.wf.Namespace, podName, deletePod)
+				delay := woc.controller.Config.GetPodGCDeleteDelayDuration()
+				woc.controller.queuePodForCleanupAfter(woc.wf.Namespace, podName, deletePod, delay)
 			}
 		} else {
 			// label pods which will not be deleted


### PR DESCRIPTION
The PR https://github.com/argoproj/argo-workflows/pull/5033 was meant to fix the issue of delaying pod deletion for some period so things like logging scrapers can do their thing before the pod goes away.

Based on my comments https://github.com/argoproj/argo-workflows/pull/5033#discussion_r581354568 this won't actually work as intended and another solution is needed.

My fix in this PR aims to delay the actual deletion by some configurable value and the deletion logic will then either delete immediately or queue the deletion for after this period.

@terrytangyuan tagging you as you did the original PR and tagging @alexec as you were the reviewer, as you might have more insight here. I have written an initial test here but am happy to expand coverage if desired.

One area I am not sure about is what other docs need to be updated for an API change and if that is a manual process or if there is some automation around that, it was not clear to me as I could not find any documentation explaining how to make contributions that add to the spec and this is my first time so just let me know what else I need to do.

Checklist:

* [X] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
