### PR TITLE
docs: Remove RBAC for SSO from Roadmap (Already implemented)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,10 +33,6 @@ Improve the handling of artifacts loaded from AWS, GCS, Artifactory et al.  For 
 
 Make it easier to understand how long and how much resource workflows use by supporting [automatic duration prediction](https://github.com/argoproj/argo-workflows/issues/2717) for newly started workflows and [historical workflow reports](https://github.com/argoproj/argo-workflows/issues/3557).
 
-## RBAC for SSO
-
-The #1 community voted feature is [RBAC for SSO](https://github.com/argoproj/argo-workflows/issues/3525). This will allow users to provide different access to different users within the GUI.
-
 ## Scaling, Reliability, Performance
 
 Continue to improve support for large numbers (10,000+) of massive (2,000+ node) workflows.


### PR DESCRIPTION
It looks like RBAC for SSO is already implemented by https://github.com/argoproj/argo-workflows/pull/4198 so hopefully it can be removed from the roadmap as it is also documented? https://argoproj.github.io/argo-workflows/argo-server-sso/#sso-rbac

Checklist:

* [n/a] ~~My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).~~ I am researching Argo, and have not adopted it yet.

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
