### PR TITLE
fix(controller): Wrong validate order when validate DAG task's argument

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -1242,13 +1242,13 @@ func (ctx *templateValidationCtx) validateDAG(scope map[string]interface{}, tmpl
 		if err != nil {
 			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s %s", tmpl.Name, task.Name, err.Error())
 		}
-		err = validateDAGTaskArgumentDependency(task.Arguments, ancestry)
-		if err != nil {
-			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s %s", tmpl.Name, task.Name, err.Error())
-		}
 		err = validateArguments(fmt.Sprintf("templates.%s.tasks.%s.arguments.", tmpl.Name, task.Name), task.Arguments)
 		if err != nil {
 			return err
+		}
+		err = validateDAGTaskArgumentDependency(task.Arguments, ancestry)
+		if err != nil {
+			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s %s", tmpl.Name, task.Name, err.Error())
 		}
 		// Validate the template again with actual arguments.
 		_, err = ctx.validateTemplateHolder(&task, tmplCtx, &task.Arguments)


### PR DESCRIPTION
fix #6189 

before:
![Screenshot 2021-06-22 at 3 16 29 PM](https://user-images.githubusercontent.com/17219814/122880781-f4af7400-d36c-11eb-99e9-a84ff3948949.png)

after:
![Screenshot 2021-06-22 at 3 16 36 PM](https://user-images.githubusercontent.com/17219814/122880819-0264f980-d36d-11eb-9c9c-065910009179.png)

Signed-off-by: BOOK <book78987book@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
