### PR TITLE
docs(executor): document k8s executor behaviour with program warnings

### DIFF
--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -38,6 +38,8 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
     * Operations performed against the local Kubelet
 * Artifacts:
     * Output artifacts must be saved on volumes (e.g. [emptyDir](empty-dir.md)) and not the base image layer (e.g. `/tmp`)
+* Step/Task result:
+    * Warnings that normally goes to stderr will get captured in a step or a dag task's `outputs.result`. May require changes if your pipeline is condition on `steps/tasks.name.outputs.result`
 * Configuration:
     * Additional Kubelet configuration maybe needed
 
@@ -55,6 +57,8 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
     * Log retrieval and container operations performed against the remote Kubernetes API
 * Artifacts:
     * Output artifacts must be saved on volumes (e.g. [emptyDir](empty-dir.md)) and not the base image layer (e.g. `/tmp`)
+* Step/Task result:
+    * Warnings that normally goes to stderr will get captured in a step or a dag task's `outputs.result`. May require changes if your pipeline is condition on `steps/tasks.name.outputs.result`
 * Configuration:
     * No additional configuration needed.
 

--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -39,7 +39,7 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
 * Artifacts:
     * Output artifacts must be saved on volumes (e.g. [emptyDir](empty-dir.md)) and not the base image layer (e.g. `/tmp`)
 * Step/Task result:
-    * Warnings that normally goes to stderr will get captured in a step or a dag task's `outputs.result`. May require changes if your pipeline is condition on `steps/tasks.name.outputs.result`
+    * Warnings that normally goes to stderr will get captured in a step or a dag task's `outputs.result`. May require changes if your pipeline is conditioned on `steps/tasks.name.outputs.result`
 * Configuration:
     * Additional Kubelet configuration maybe needed
 
@@ -58,7 +58,7 @@ The executor to be used in your workflows can be changed in [the configmap](./wo
 * Artifacts:
     * Output artifacts must be saved on volumes (e.g. [emptyDir](empty-dir.md)) and not the base image layer (e.g. `/tmp`)
 * Step/Task result:
-    * Warnings that normally goes to stderr will get captured in a step or a dag task's `outputs.result`. May require changes if your pipeline is condition on `steps/tasks.name.outputs.result`
+    * Warnings that normally goes to stderr will get captured in a step or a dag task's `outputs.result`. May require changes if your pipeline is conditioned on `steps/tasks.name.outputs.result`
 * Configuration:
     * No additional configuration needed.
 


### PR DESCRIPTION
When switching from docker executor to k8sapi/kubelet executor, the behaviour on what gets captured in `steps/tasks.outputs.result` is a little different.

In an error-free run, argo docker executor will only store the stdout in step/task's result. However, when using k8sapi/kubelet executor, due to k8s logs unable to differentiate between stdout and stderr, k8sapi/kubelet will also store the warning messages. This may cause issues if downstream depends on the `outputs.result` (e.g. withParam)

https://github.com/kubernetes/kubernetes/issues/28167


Signed-off-by: Tianchu Zhao <evantczhao@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
