### PR TITLE
fix(executor): fix GCS artifact retry

### DIFF
--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -1,0 +1,38 @@
+package gcs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+type tlsHandshakeTimeoutError struct{}
+
+func (tlsHandshakeTimeoutError) Temporary() bool { return true }
+func (tlsHandshakeTimeoutError) Error() string   { return "net/http: TLS handshake timeout" }
+
+func TestIsTransientGCSErr(t *testing.T) {
+	for _, test := range []struct {
+		err         error
+		shouldretry bool
+	}{
+		{&googleapi.Error{Code: 0}, false},
+		{&googleapi.Error{Code: 429}, true},
+		{&googleapi.Error{Code: 518}, true},
+		{&googleapi.Error{Code: 599}, true},
+		{&url.Error{Op: "blah", URL: "blah", Err: errors.New("connection refused")}, true},
+		{io.ErrUnexpectedEOF, true},
+		{&tlsHandshakeTimeoutError{}, true},
+		{fmt.Errorf("Test unwrapping of a temporary error: %w", &googleapi.Error{Code: 500}), true},
+		{fmt.Errorf("Test unwrapping of a non-retriable error: %w", &googleapi.Error{Code: 400}), false},
+	} {
+		got := isTransientGCSErr(test.err)
+		if got != test.shouldretry {
+			t.Errorf("%+v: got %v, want %v", test, got, test.shouldretry)
+		}
+	}
+}


### PR DESCRIPTION
The current gcs artifact exponentialbackoff is not working.
- fix retry
- added only retry on transient error

gcs bucket accepts about 1000 write request initially, then autoscales up. [link](https://cloud.google.com/storage/docs/request-rate#auto-scaling)
When having over 1000 write request in a burst from stale, we will see some errors.

Tested with below workflows/config on gke:1.18.17-gke.1901 with
- argo-workflow 3.1.1 + gcloud bucket1
- argo-workflow 3.1.1 + gcloud bucket2 + this PR

<details>
  <summary>Workflows</summary>

  ```
  apiVersion: argoproj.io/v1alpha1
  kind: Workflow
  metadata:
    generateName: stress-test-
    labels:
      workflows.argoproj.io/container-runtime-executor: emissary
  spec:
    entrypoint: loops-dag
    podGC:
      strategy: OnWorkflowSuccess
    templates:
    - name: loops-dag
      dag:
        tasks:
        - name: A
          template: gen-process-indices
        - name: B
          dependencies: [A]
          template: whalesay
          arguments:
            parameters:
            - {name: message, value: "{{item}}"}
          withParam: "{{tasks.A.outputs.result}}"
        - name: C
          dependencies: [B]
          template: whalesay
          arguments:
            parameters:
            - {name: message, value: C}
    - name: whalesay
      inputs:
        parameters:
        - name: message
      container:
        image: docker/whalesay:latest
        command: [cowsay]
        args: ["{{inputs.parameters.message}}"]
    - name: gen-process-indices
      script:
        image: python:alpine3.6
        command: [python]
        source: |
          import json
          import sys
          json.dump([i for i in range(0, 2000)], sys.stdout)
  ---
  apiVersion: argoproj.io/v1alpha1
  kind: Workflow
  metadata:
    generateName: artifact-passing-
  spec:
    entrypoint: artifact-example
    templates:
    - name: artifact-example
      steps:
      - - name: generate-artifact
          template: whalesay
      - - name: consume-artifact
          template: print-message
          arguments:
            artifacts:
            # bind message to the hello-art artifact
            # generated by the generate-artifact step
            - name: message
              from: "{{steps.generate-artifact.outputs.artifacts.hello-art}}"
  
    - name: whalesay
      container:
        image: docker/whalesay:latest
        command: [sh, -c]
        args: ["cowsay hello world | tee /tmp/hello_world.txt"]
      outputs:
        artifacts:
        # generate hello-art artifact from /tmp/hello_world.txt
        # artifacts can be directories as well as files
        - name: hello-art
          path: /tmp/hello_world.txt
  
    - name: print-message
      inputs:
        artifacts:
        # unpack the message input artifact
        # and put it at /tmp/message
        - name: message
          path: /tmp/message
      container:
        image: alpine:latest
        command: [sh, -c]
        args: ["cat /tmp/message"]
  ```
</details>

<details>
  <summary>Config</summary>

```
    artifactRepository:
      archiveLogs: true
      gcs:
        bucket: bucket1
        keyFormat: "pipeline/log/{{workflow.name}}/{{pod.name}}"
        serviceAccountKeySecret:
          name: service-ac-key
          key: service-ac-key.json
```
```
    artifactRepository:
      archiveLogs: true
      gcs:
        bucket: bucket2
        keyFormat: "pipeline/log/{{workflow.name}}/{{pod.name}}"
        serviceAccountKeySecret:
          name: service-ac-key
          key: service-ac-key.json
```
</details>

---

**argo-workflow 3.1.1 + gcloud bucket1**

produce following error on wait container
<details>
  <summary>wait container log</summary>

```
time="2021-07-15T15:27:29.299Z" level=info msg="Starting annotations monitor"
time="2021-07-15T15:27:29.299Z" level=info msg="Starting deadline monitor"
time="2021-07-15T15:28:53.315Z" level=info msg="Main container completed"
time="2021-07-15T15:28:53.315Z" level=info msg="No Script output reference in workflow. Capturing script output ignored"
time="2021-07-15T15:28:53.315Z" level=info msg="Saving logs"
time="2021-07-15T15:28:53.336Z" level=info msg="GCS Save path: /tmp/argo/outputs/logs/main.log, key: pipeline/log/stress-test-2ztc4/stress-test-2ztc4-3
865573343/main.log"
time="2021-07-15T15:29:03.425Z" level=error msg="executor error: upload /tmp/argo/outputs/logs/main.log: writer close: Post \"https://storage.googleapi
s.com/upload/storage/v1/b/bucket1/o?alt=json&name=pipeline%2Flog%2Fstress-test-2ztc4%2Fstress-test-2ztc4-3865573343%2Fmain.log&prettyPrint
=false&projection=full&uploadType=multipart\": oauth2: cannot fetch token: Post \"https://oauth2.googleapis.com/token\": net/http: TLS handshake timeou
t"
time="2021-07-15T15:29:03.425Z" level=info msg="No output parameters"
time="2021-07-15T15:29:03.425Z" level=info msg="No output artifacts"
time="2021-07-15T15:29:03.425Z" level=info msg="Killing sidecars []"
time="2021-07-15T15:29:03.426Z" level=info msg="Alloc=24648 TotalAlloc=29651 Sys=73553 NumGC=4 Goroutines=9"
time="2021-07-15T15:29:03.455Z" level=fatal msg="upload /tmp/argo/outputs/logs/main.log: writer close: Post \"https://storage.googleapis.com/upload/sto
rage/v1/b/bucket1/o?alt=json&name=pipeline%2Flog%2Fstress-test-2ztc4%2Fstress-test-2ztc4-3865573343%2Fmain.log&prettyPrint=false&projectio
n=full&uploadType=multipart\": oauth2: cannot fetch token: Post \"https://oauth2.googleapis.com/token\": net/http: TLS handshake timeout"
```
</details>

**argo-workflow 3.1.1 + gcloud bucket2 + this PR**

workflow successfully finish
we can see that there's retry from the log

<details>
  <summary>wait container log</summary>

  ```
  time="2021-07-17T13:19:59.647Z" level=info msg="Starting Workflow Executor" executorType=emissary version=v3.1.1+a245fe6.dirty
  time="2021-07-17T13:19:59.664Z" level=info msg="Executor initialized" includeScriptOutput=false namespace=default podName=stress-test-f65vd-1802293675 template="{\"name\":\"whalesay\",\"inputs\":{\"parameters\":[{\"name\":\"message\",\"value\":\"1857\"}]},\"outputs\":{},\"metadata\":{},\"container\":{\"name\":\"\",\"image\":\"docker/whalesay:latest\",\"command\":[\"cowsay\"],\"args\":[\"1857\"],\"resources\":{}},\"archiveLocation\":{\"archiveLogs\":true,\"gcs\":{\"bucket\":\"wx-lty-mmm-super-dev\",\"serviceAccountKeySecret\":{\"name\":\"service-ac-key\",\"key\":\"service-ac-key.json\"},\"key\":\"pipeline/log/stress-test-f65vd/stress-test-f65vd-1802293675\"}}}" version="&Version{Version:v3.1.1+a245fe6.dirty,BuildDate:2021-07-17T13:11:50Z,GitCommit:a245fe67db56d2808fb78c6079d08404cbee91aa,GitTag:v3.1.1,GitTreeState:dirty,GoVersion:go1.15.7,Compiler:gc,Platform:linux/amd64,}"
  time="2021-07-17T13:19:59.664Z" level=info msg="Starting annotations monitor"
  time="2021-07-17T13:19:59.666Z" level=info msg="Starting deadline monitor"
  time="2021-07-17T13:20:19.669Z" level=info msg="Main container completed"
  time="2021-07-17T13:20:19.669Z" level=info msg="No Script output reference in workflow. Capturing script output ignored"
  time="2021-07-17T13:20:19.669Z" level=info msg="Saving logs"
  time="2021-07-17T13:20:19.749Z" level=info msg="GCS Save path: /tmp/argo/outputs/logs/main.log, key: pipeline/log/stress-test-f65vd/stress-test-f65vd-1802293675/main.log"
  time="2021-07-17T13:20:31.870Z" level=info msg="GCS Save path: /tmp/argo/outputs/logs/main.log, key: pipeline/log/stress-test-f65vd/stress-test-f65vd-1802293675/main.log"
  time="2021-07-17T13:20:32.032Z" level=info msg="not deleting local artifact" localArtPath=/tmp/argo/outputs/logs/main.log
  time="2021-07-17T13:20:32.032Z" level=info msg="Successfully saved file: /tmp/argo/outputs/logs/main.log"
  time="2021-07-17T13:20:32.032Z" level=info msg="No output parameters"
  time="2021-07-17T13:20:32.032Z" level=info msg="No output artifacts"
  time="2021-07-17T13:20:32.032Z" level=info msg="Annotating pod with output"
  time="2021-07-17T13:20:32.053Z" level=info msg="Patch pods 200"
  time="2021-07-17T13:20:32.063Z" level=info msg="Killing sidecars []"
  time="2021-07-17T13:20:32.063Z" level=info msg="Alloc=23466 TotalAlloc=50845 Sys=73297 NumGC=5 Goroutines=11"
  ```
</details>

---

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
