### PR TITLE
fix(executor): emissary - make /var/run/argo files readable from non-root users. Fixes #6238

### DIFF
--- a/workflow/executor/emissary/emissary.go
+++ b/workflow/executor/emissary/emissary.go
@@ -62,7 +62,7 @@ func (e emissary) writeTemplate(t wfv1.Template) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile("/var/run/argo/template", data, 0o400) // chmod -r--------
+	return ioutil.WriteFile("/var/run/argo/template", data, 0o444) // chmod -r--r--r--
 }
 
 func (e emissary) GetFileContents(_ string, sourcePath string) (string, error) {
@@ -137,7 +137,7 @@ func (e emissary) isComplete(containerNames []string) bool {
 
 func (e emissary) Kill(ctx context.Context, containerNames []string, terminationGracePeriodDuration time.Duration) error {
 	for _, containerName := range containerNames {
-		if err := ioutil.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGTERM))), 0o600); err != nil {
+		if err := ioutil.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGTERM))), 0o644); err != nil {
 			return err
 		}
 	}
@@ -148,7 +148,7 @@ func (e emissary) Kill(ctx context.Context, containerNames []string, termination
 		return err
 	}
 	for _, containerName := range containerNames {
-		if err := ioutil.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGKILL))), 0o600); err != nil {
+		if err := ioutil.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGKILL))), 0o644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #6238 

In this PR, I verified a real workflow works end to end with non-root users.

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: hello-world-
spec:
  entrypoint: hw
  templates:
  - name: hw
    container:
      image: curlimages/curl:latest
      command: [sh, -c, "echo hello"]
```

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
