### PR TITLE
fix(cli): Overridding name/generateName when creating CronWorkflows if specified

### DIFF
--- a/cmd/argo/commands/cron/create.go
+++ b/cmd/argo/commands/cron/create.go
@@ -81,6 +81,14 @@ func CreateCronWorkflows(filePaths []string, cliOpts *cliCreateOpts, submitOpts 
 			log.Fatal(err)
 		}
 		cronWf.Spec.WorkflowSpec = newWf.Spec
+		if generateName := newWf.ObjectMeta.GenerateName; generateName != "" {
+			cronWf.ObjectMeta.GenerateName = generateName
+			cronWf.ObjectMeta.Name = ""
+		}
+		if name := newWf.ObjectMeta.Name; name != "" {
+			cronWf.ObjectMeta.Name = name
+			cronWf.ObjectMeta.GenerateName = ""
+		}
 		if cronWf.Namespace == "" {
 			cronWf.Namespace = client.Namespace()
 		}

--- a/cmd/argo/commands/cron/create.go
+++ b/cmd/argo/commands/cron/create.go
@@ -81,6 +81,9 @@ func CreateCronWorkflows(filePaths []string, cliOpts *cliCreateOpts, submitOpts 
 			log.Fatal(err)
 		}
 		cronWf.Spec.WorkflowSpec = newWf.Spec
+		// We have only copied the workflow spec to the cron workflow but not the metadata
+		// that includes name and generateName. Here we copy the metadata to the cron
+		// workflow's metadata and remove the unnecessary and mutually exclusive part.
 		if generateName := newWf.ObjectMeta.GenerateName; generateName != "" {
 			cronWf.ObjectMeta.GenerateName = generateName
 			cronWf.ObjectMeta.Name = ""

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1165,6 +1165,22 @@ func (s *CLISuite) TestCron() {
 		})
 	})
 
+	s.Run("Create Name Override", func() {
+		s.Given().RunCli([]string{"cron", "create", "cron/basic.yaml", "--name", "basic-cron-wf-overridden-name", "-l", "workflows.argoproj.io/test=true"}, func(t *testing.T, output string, err error) {
+			if assert.NoError(t, err) {
+				assert.Contains(t, strings.Replace(output, " ", "", -1), "Name:basic-cron-wf-overridden-name")
+			}
+		})
+	})
+
+	s.Run("Create GenerateName Override", func() {
+		s.Given().RunCli([]string{"cron", "create", "cron/basic.yaml", "--generate-name", "basic-cron-wf-overridden-generate-name-", "-l", "workflows.argoproj.io/test=true"}, func(t *testing.T, output string, err error) {
+			if assert.NoError(t, err) {
+				assert.Contains(t, strings.Replace(output, " ", "", -1), "Name:basic-cron-wf-overridden-generate-name-")
+			}
+		})
+	})
+
 	s.Run("List", func() {
 		s.Given().RunCli([]string{"cron", "list"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err) {


### PR DESCRIPTION
Currently we only copy the workflow spec after we applied the submit options but generateName/name cannot be overridden. This PR fixes this issue.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
