### PR TITLE
fix: support archive.none for OSS directory artifacts

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -129,6 +129,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [VMware](https://www.vmware.com/)
 1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
 1. [Zhihu](https://www.zhihu.com/)
+1. [Galixir](https://www.galixir.com/)
 
 ### Projects Using Argo
 

--- a/USERS.md
+++ b/USERS.md
@@ -54,6 +54,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [FOLIO](http://corp.folio-sec.com/)
 1. [FreeWheel](https://freewheel.com/)
 1. [Fynd Trak](https://trak.fynd.com/)
+1. [Galixir](https://www.galixir.com/)
 1. [Gardener](https://gardener.cloud/)
 1. [GitHub](https://github.com/)
 1. [Gladly](https://gladly.com/)
@@ -129,7 +130,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [VMware](https://www.vmware.com/)
 1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
 1. [Zhihu](https://www.zhihu.com/)
-1. [Galixir](https://www.galixir.com/)
+
 
 ### Projects Using Argo
 


### PR DESCRIPTION
to fix problem: #6293 
I have used the following workflow to test, and the result is correct.
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  name: test-archive-none
spec:
  entrypoint: oss-getter-and-uploader
  templates:
  - name: oss-getter-and-uploader
    inputs:
      artifacts:
      - name: oss-none-empty-dir
        path: "/mnt/input/none-empty"
        oss:
          key: "some/none-empty"
        archive:
          none: {}
      - name: oss-empty-dir
        path: "/mnt/input/empty-dir"
        oss:
          key: "some/emptydir"
        archive:
          none: {}
      - name: oss-file
        path: "/mnt/input/file"
        oss:
          key: "some/file"
        archive:
          none: {}
      - name: oss-3level
        path: "/mnt/input/3level"
        oss:
          key: "some/3level-dir"
        archive:
          none: {}
    container:
      image: 'alpine:latest'
      command: ['/bin/sh', '-c']
      args: ["cp -rf /mnt/input /mnt/output"]
      volumeMounts:
        - name: out
          mountPath: /mnt
    volumes:
      - name: out
        emptyDir: { }
    outputs:
      artifacts:
      - name: oss-none-empty-dir
        path: "/mnt/output/none-empty"
        oss:
          key: "some2/none-empty"
        archive:
          none: {}
      - name: oss-empty-dir
        path: "/mnt/output/empty-dir"
        oss:
          key: "some2/emptydir"
        archive:
          none: {}
      - name: oss-file
        path: "/mnt/output/file"
        oss:
          key: "some2/file"
        archive:
          none: {}
      - name: oss-3level
        path: "/mnt/output/3level"
        oss:
          key: "some2/3level-dir"
        archive:
          none: {}
```

Thanks to @terrytangyuan  a lot.  He helped me to rectify some code, but I failed to commit the PR because my mistake. So, I open this one and commits again.
