### PR TITLE
docs: document how to access hyphenated steps in expression templates

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -53,8 +53,8 @@ args: [ "{{ inputs.parameters.message }}" ]
 
 The tag is substituted with the result of evaluating the tag as an expression.
 
-Note that any hyphenated parameter names will cause a parsing error. You can reference them by
-indexing into the parameter map, e.g. `inputs.parameters['my-param']`.
+Note that any hyphenated parameter names or step names will cause a parsing error. You can reference them by
+indexing into the parameter or step map, e.g. `inputs.parameters['my-param']` or `steps['my-step'].outputs.result`.
 
 [Learn about the expression syntax](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
 


### PR DESCRIPTION
Signed-off-by: Michael Crenshaw <michael@crenshaw.dev>

I ran tests to confirm that dot-notation access fails and that string index notation works.
