### PR TITLE
feat(controller): Allow configurable host name label key when retrying different hosts

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -29,6 +29,7 @@ Note that these environment variables may be removed at any time.
 | `RETRY_BACKOFF_DURATION` | `time.Duration` | `10ms` | The retry backoff duration when retrying API calls. |
 | `RETRY_BACKOFF_FACTOR` | `float` | `2.0` | The retry backoff factor when retrying API calls. |
 | `RETRY_BACKOFF_STEPS` | `int` | `5` | The retry backoff steps when retrying API calls. |
+| `RETRY_HOST_NAME_LABEL_KEY` | `string` | `kubernetes.io/hostname` | The label key for host name used when retrying templates. |
 | `TRANSIENT_ERROR_PATTERN` | `string` | `""` | The regular expression that represents additional patterns for transient errors. |
 | `WF_DEL_PROPAGATION_POLICY` | `string` | `""` | The deletion propagation policy for workflows. |
 | `WORKFLOW_GC_PERIOD` | `time.Duration` | `5m` | The periodicity for GC of workflows. |

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"k8s.io/utils/env"
+
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	wfretry "github.com/argoproj/argo-workflows/v3/workflow/util/retry"
 )
@@ -15,7 +17,7 @@ func RetryOnDifferentHost(retryNodeName string) RetryTweak {
 			return
 		}
 		hostNames := wfretry.GetFailHosts(nodes, retryNodeName)
-		hostLabel := "kubernetes.io/hostname"
+		hostLabel := env.GetString("RETRY_HOST_NAME_LABEL_KEY", "kubernetes.io/hostname")
 		if hostLabel != "" && len(hostNames) > 0 {
 			tmpl.Affinity = wfretry.AddHostnamesToAffinity(hostLabel, hostNames, tmpl.Affinity)
 		}


### PR DESCRIPTION
Currently this has been hard-coded to `"kubernetes.io/hostname"` and will not be reliable on different environments (`k3s` or some internal k8s distributions). For example, `k3s` uses `k3s.io/hostname` so we won't be able to test `RetryOnDifferentHost` if it's hard-coded.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
