### PR TITLE
fix(fields): handle nexted fields when excluding

### DIFF
--- a/util/fields/fields.go
+++ b/util/fields/fields.go
@@ -60,7 +60,7 @@ func (f Cleaner) WillExclude(x string) bool {
 
 func (f Cleaner) matches(x string) bool {
 	for y := range f.fields {
-		if strings.HasPrefix(x, y) {
+		if strings.HasPrefix(x, y) || strings.HasPrefix(y, x) {
 			return true
 		}
 	}

--- a/util/fields/fields_test.go
+++ b/util/fields/fields_test.go
@@ -28,6 +28,8 @@ func TestCleaner_WillExclude(t *testing.T) {
 		assert.False(t, NewCleaner("foo").WillExclude("foo"))
 		assert.False(t, NewCleaner("foo").WillExclude("foo.bar"))
 		assert.True(t, NewCleaner("foo").WillExclude("bar"))
+		assert.False(t, NewCleaner("foo.bar.baz").WillExclude("foo.bar"))
+
 	})
 	t.Run("Exclude", func(t *testing.T) {
 		assert.True(t, NewCleaner("-foo").WillExclude("foo"))


### PR DESCRIPTION
# Checklist
* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

# Fix
This PR resolves #6284 by ensuring that a list request to a nested field does not cause parent fields to be ignored. I added a small unit test to the existing test suite to ensure the fix works as expected and doesn't contradict previous features.