### PR TITLE
perf: Update k8sapi list call to pass in ResourceVersion

### DIFF
--- a/workflow/executor/k8sapi/client.go
+++ b/workflow/executor/k8sapi/client.go
@@ -114,7 +114,10 @@ func (c *k8sAPIClient) until(ctx context.Context, f func(pod *corev1.Pod) bool) 
 	podInterface := c.clientset.CoreV1().Pods(c.namespace)
 	for {
 		done, err := func() (bool, error) {
-			w, err := podInterface.Watch(ctx, metav1.ListOptions{FieldSelector: "metadata.name=" + c.podName})
+			w, err := podInterface.Watch(ctx, metav1.ListOptions{
+				FieldSelector:   "metadata.name=" + c.podName,
+				ResourceVersion: "0",
+			})
 			if err != nil {
 				return true, fmt.Errorf("failed to establish pod watch: %w", err)
 			}


### PR DESCRIPTION
This PR adds the `ResourceVersion` as a parameter to Kubernetes API watch requests. We have found that this call becomes very costly since it requires an ETCD range request rather than using the cache. It looks like this is something Argo already does for some of its CLI commands, such as [watch](https://github.com/argoproj/argo-workflows/blob/4e450e250168e6b4d51a126b784e90b11a0162bc/cmd/argo/commands/watch.go#L55-L58).  

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
