### PR TITLE
fix(controller): fix retry on transient errors when validating workflow spec

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
@@ -3254,7 +3253,7 @@ func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) error {
 
 		// Validate the execution wfSpec
 		var wfConditions *wfv1.Conditions
-		err := wait.ExponentialBackoff(retry.DefaultRetry,
+		err := waitutil.Backoff(retry.DefaultRetry,
 			func() (bool, error) {
 				var validationErr error
 				wfConditions, validationErr = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, woc.wf, validateOpts)


### PR DESCRIPTION
The original code isn't retrying due returning non-nil error on ExponentialBackoff

fixes: https://github.com/argoproj/argo-workflows/pull/6178 #6163

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
