### PR TITLE
feat(controller): opt-in to sending pod node events as pod

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -125,11 +125,12 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Tulip](https://tulip.com/)
 1. [UFirstGroup](https://www.ufirstgroup.com)
 1. [Vispera](https://www.vispera.co)
+1. [VMware](https://www.vmware.com/)
 1. [Wavefront](https://www.wavefront.com/)
 1. [Wellcome Trust](https://wellcome.ac.uk/)
-1. [VMware](https://www.vmware.com/)
 1. [WooliesX](https://wooliesx.com.au/)
 1. [Woolworths Group](https://www.woolworthsgroup.com.au/)
+1. [Workiva](https://www.workiva.com/)
 1. [Zhihu](https://www.zhihu.com/)
 
 ### Projects Using Argo

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type ResourceRateLimit struct {
 // Config contain the configuration settings for the workflow controller
 type Config struct {
 
-	// NodeEvents configures how node events are omitted
+	// NodeEvents configures how node events are emitted
 	NodeEvents NodeEvents `json:"nodeEvents,omitempty"`
 
 	// ExecutorImage is the image name of the executor to use when running pods

--- a/config/node_events.go
+++ b/config/node_events.go
@@ -2,7 +2,7 @@ package config
 
 type NodeEvents struct {
 	Enabled   *bool `json:"enabled,omitempty"`
-	SendAsPod *bool `json:"sendAsPod,omitempty"`
+	SendAsPod bool  `json:"sendAsPod,omitempty"`
 }
 
 func (e NodeEvents) IsEnabled() bool {

--- a/config/node_events.go
+++ b/config/node_events.go
@@ -1,7 +1,8 @@
 package config
 
 type NodeEvents struct {
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled   *bool `json:"enabled,omitempty"`
+	SendAsPod *bool `json:"sendAsPod,omitempty"`
 }
 
 func (e NodeEvents) IsEnabled() bool {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2112,17 +2112,7 @@ func (woc *wfOperationCtx) getPodByNode(node *wfv1.NodeStatus) (*apiv1.Pod, erro
 	if node.Type != wfv1.NodeTypePod {
 		return nil, fmt.Errorf("Expected node type %s, got %s", wfv1.NodeTypePod, node.Type)
 	}
-	podList, err := woc.getAllWorkflowPods()
-	if err != nil {
-		return nil, err
-	}
-	for _, pod := range podList {
-		nodeNameForPod := pod.Annotations[common.AnnotationKeyNodeName]
-		if node.Name == nodeNameForPod {
-			return pod, nil
-		}
-	}
-	return nil, fmt.Errorf("No pod could be found for node %s", node.Name)
+	return woc.controller.getPod(woc.wf.GetNamespace(), node.ID)
 }
 
 func (woc *wfOperationCtx) recordNodePhaseEvent(node *wfv1.NodeStatus) {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3395,8 +3395,6 @@ spec:
 			"Normal WorkflowRunning Workflow Running",
 			"Normal WorkflowNodeRunning Running node dag-events",
 			"Normal WorkflowNodeRunning Running node dag-events.a",
-			"Normal WorkflowNodeRunning Running node dag-events.a",
-			"Normal WorkflowNodeSucceeded Succeeded node dag-events.a",
 			"Normal WorkflowNodeSucceeded Succeeded node dag-events.a",
 			"Normal WorkflowNodeSucceeded Succeeded node dag-events",
 			"Normal WorkflowSucceeded Workflow completed",
@@ -3420,8 +3418,6 @@ spec:
 			"Normal WorkflowNodeRunning Running node steps-events",
 			"Normal WorkflowNodeRunning Running node steps-events[0]",
 			"Normal WorkflowNodeRunning Running node steps-events[0].a",
-			"Normal WorkflowNodeRunning Running node steps-events[0].a",
-			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
 			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
 			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0]",
 			"Normal WorkflowNodeSucceeded Succeeded node steps-events",
@@ -3442,8 +3438,6 @@ spec:
 `: {
 			"Normal WorkflowRunning Workflow Running",
 			"Normal WorkflowNodeRunning Running node no-dag-or-steps",
-			"Normal WorkflowNodeRunning Running node no-dag-or-steps",
-			"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
 			"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
 			"Normal WorkflowSucceeded Workflow completed",
 		},
@@ -3453,8 +3447,7 @@ spec:
 		t.Run(wf.Name, func(t *testing.T) {
 			cancel, controller := newController(wf)
 			defer cancel()
-			sendAsPod := true
-			controller.Config.NodeEvents = config.NodeEvents{SendAsPod: &sendAsPod}
+			controller.Config.NodeEvents = config.NodeEvents{SendAsPod: true}
 			woc := newWorkflowOperationCtx(wf, controller)
 			createRunningPods(ctx, woc)
 			woc.operate(ctx)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3363,6 +3363,109 @@ spec:
 	}
 }
 
+func TestEventNodeEventsAsPod(t *testing.T) {
+	for manifest, want := range map[string][]string{
+		// Invalid spec
+		`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: invalid-spec
+spec:
+  entrypoint: 123
+`: {
+			"Warning WorkflowFailed invalid spec: template name '123' undefined",
+		},
+		// DAG
+		`
+metadata:
+  name: dag-events
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: a
+            template: whalesay
+    - name: whalesay
+      container:
+        image: docker/whalesay:latest
+`: {
+			"Normal WorkflowRunning Workflow Running",
+			"Normal WorkflowNodeRunning Running node dag-events",
+			"Normal WorkflowNodeRunning Running node dag-events.a",
+			"Normal WorkflowNodeRunning Running node dag-events.a",
+			"Normal WorkflowNodeSucceeded Succeeded node dag-events.a",
+			"Normal WorkflowNodeSucceeded Succeeded node dag-events.a",
+			"Normal WorkflowNodeSucceeded Succeeded node dag-events",
+			"Normal WorkflowSucceeded Workflow completed",
+		},
+		// steps
+		`
+metadata:
+  name: steps-events
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: a
+            template: whalesay
+    - name: whalesay
+      container:
+        image: docker/whalesay:latest
+`: {
+			"Normal WorkflowRunning Workflow Running",
+			"Normal WorkflowNodeRunning Running node steps-events",
+			"Normal WorkflowNodeRunning Running node steps-events[0]",
+			"Normal WorkflowNodeRunning Running node steps-events[0].a",
+			"Normal WorkflowNodeRunning Running node steps-events[0].a",
+			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
+			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0].a",
+			"Normal WorkflowNodeSucceeded Succeeded node steps-events[0]",
+			"Normal WorkflowNodeSucceeded Succeeded node steps-events",
+			"Normal WorkflowSucceeded Workflow completed",
+		},
+		// no DAG or steps
+		`
+metadata:
+  name: no-dag-or-steps
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+`: {
+			"Normal WorkflowRunning Workflow Running",
+			"Normal WorkflowNodeRunning Running node no-dag-or-steps",
+			"Normal WorkflowNodeRunning Running node no-dag-or-steps",
+			"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
+			"Normal WorkflowNodeSucceeded Succeeded node no-dag-or-steps",
+			"Normal WorkflowSucceeded Workflow completed",
+		},
+	} {
+		wf := wfv1.MustUnmarshalWorkflow(manifest)
+		ctx := context.Background()
+		t.Run(wf.Name, func(t *testing.T) {
+			cancel, controller := newController(wf)
+			defer cancel()
+			sendAsPod := true
+			controller.Config.NodeEvents = config.NodeEvents{SendAsPod: &sendAsPod}
+			woc := newWorkflowOperationCtx(wf, controller)
+			createRunningPods(ctx, woc)
+			woc.operate(ctx)
+			makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+			woc = newWorkflowOperationCtx(woc.wf, controller)
+			woc.operate(ctx)
+			assert.ElementsMatch(t, want, getEvents(controller, len(want)))
+		})
+	}
+}
+
 func getEvents(controller *WorkflowController, num int) []string {
 	c := controller.eventRecorderManager.(*testEventRecorderManager).eventRecorder.Events
 	events := make([]string, num)
@@ -3370,6 +3473,46 @@ func getEvents(controller *WorkflowController, num int) []string {
 		events[i] = <-c
 	}
 	return events
+}
+
+func TestGetPodByNode(t *testing.T) {
+	workflowText := `
+metadata:
+  name: dag-events
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: a
+            template: whalesay
+    - name: whalesay
+      container:
+        image: docker/whalesay:latest
+`
+	wf := wfv1.MustUnmarshalWorkflow(workflowText)
+	ctx := context.Background()
+	cancel, controller := newController(wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(wf, controller)
+	createRunningPods(ctx, woc)
+	woc.operate(ctx)
+	// Parent dag node has no pod
+	parentNode := woc.wf.GetNodeByName("dag-events")
+	pod, err := woc.getPodByNode(parentNode)
+	assert.Nil(t, pod)
+	assert.Error(t, err, "Expected node type Pod, got DAG")
+	// Pod node should return a pod
+	podNode := woc.wf.GetNodeByName("dag-events.a")
+	pod, err = woc.getPodByNode(podNode)
+	assert.NotNil(t, pod)
+	assert.Nil(t, err)
+	// Invalid node should not return a pod
+	invalidNode := wfv1.NodeStatus{Type: wfv1.NodeTypePod, Name: "doesnt-exist"}
+	pod, err = woc.getPodByNode(&invalidNode)
+	assert.Nil(t, pod)
+	assert.Error(t, err, "No pod could be found for node doesnt-exist")
 }
 
 var pdbwf = `

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3492,6 +3492,7 @@ spec:
         image: docker/whalesay:latest
 `
 	wf := wfv1.MustUnmarshalWorkflow(workflowText)
+	wf.Namespace = "argo"
 	ctx := context.Background()
 	cancel, controller := newController(wf)
 	defer cancel()
@@ -3512,7 +3513,7 @@ spec:
 	invalidNode := wfv1.NodeStatus{Type: wfv1.NodeTypePod, Name: "doesnt-exist"}
 	pod, err = woc.getPodByNode(&invalidNode)
 	assert.Nil(t, pod)
-	assert.Error(t, err, "No pod could be found for node doesnt-exist")
+	assert.Nil(t, err)
 }
 
 var pdbwf = `


### PR DESCRIPTION
## Summary

Because of how kubernetes aggregates events and how Argo sends both
workflow and node events with the same involved object (the workflow),
some workflow and node events can get merged into a single event, without
specifying which nodes are merged into one. This makes it challenging to
respond to phase changes for nodes that have a particular annotation
because kubernetes ignores annotations when checking if an event is
similar.

Creating an opt-in feature to send node events for nodes of type "Pod"
with the involved object set to the associated pod will force kubernetes
to send an event for each pod instead of aggregated several events into
a single event and thus make it possible build a system solely that
responds to node phase changes using Argo Workflows and Argo Events.

An alternative solution to this would be creating a `WorkflowNode`
custom resource and sending events with the workflow node itself as the
involved object, but that seemed like a bigger change than necessary.

This should provide a means to solve the problem raised in
https://github.com/argoproj/argo-workflows/issues/4136

## Testing
I tested my changes by running argo locally: `make start PROFILE=postgres` and kicking off the [hello-world](https://github.com/argoproj/argo-workflows/blob/master/examples/hello-world.yaml) workflow.
I confirmed that the expected events were sent (without sending events for the pod resource)
I then modified my code to configure the controller's `NodeEvents.SendAsPod`, and set it to true. I then re-ran `make start PROFILE=postgres` and kicked off the hello-world workflow. This time, I confirmed that node events were being sent for both the workflow and the pod.

The unit tests describe and verify this scenario well.

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
