### PR TITLE
docs: Add note on additional required permission for createBucketIfNotPresent for OSS driver

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -202,6 +202,8 @@ artifacts:
         key: secretKey
 ```
 
+You can also set `createBucketIfNotPresent` to `true` to tell the artifact driver to automatically create the OSS bucket if it doesn't exist yet when saving artifacts. Note that you'll need to set additional permission for your OSS account to create new buckets.
+
 # Configure the Default Artifact Repository
 
 In order for Argo to use your artifact repository, you can configure it as the


### PR DESCRIPTION
It's worth adding this since our users encounter this issue very often.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
