### PR TITLE
fix(controller): allow initial duration to be 0 instead of current_time-0

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -235,7 +235,11 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	}
 
 	// Update workflow duration variable
-	woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", time.Since(woc.wf.Status.StartedAt.Time).Seconds())
+	if woc.wf.Status.StartedAt.IsZero() {
+		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", time.Duration(0).Seconds())
+	} else {
+		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", time.Since(woc.wf.Status.StartedAt.Time).Seconds())
+	}
 
 	// Populate the phase of all the nodes prior to execution
 	for _, node := range woc.wf.Status.Nodes {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -148,6 +148,37 @@ spec:
 	}), "zero node durations empty")
 }
 
+func TestGlobalParamDuration(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf
+  namespace: my-ns
+spec:
+  entrypoint: main
+  templates:
+   - name: main
+     dag:
+       tasks:
+       - name: pod
+         template: pod
+   - name: pod
+     container: 
+       image: my-image
+`)
+	cancel, controller := newController(wf)
+	defer cancel()
+
+	ctx := context.Background()
+	woc := newWorkflowOperationCtx(wf, controller)
+	woc.operate(ctx)
+  assert.Equal(t, woc.globalParams[common.GlobalVarWorkflowDuration], "0.000000")
+
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+	woc = newWorkflowOperationCtx(woc.wf, controller)
+	woc.operate(ctx)
+	assert.Greater(t, woc.globalParams[common.GlobalVarWorkflowDuration], "0.000000")
+}
+
 func TestEstimatedDuration(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(`
 metadata:

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -171,7 +171,7 @@ spec:
 	ctx := context.Background()
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-  assert.Equal(t, woc.globalParams[common.GlobalVarWorkflowDuration], "0.000000")
+	assert.Equal(t, woc.globalParams[common.GlobalVarWorkflowDuration], "0.000000")
 
 	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
 	woc = newWorkflowOperationCtx(woc.wf, controller)


### PR DESCRIPTION
a workflow like below will result in
- first pod produce duration ~= 9223372036.123456
- second pod produce duration ~= 15.123456

This PR fixes this, making first pod produce duration = 0

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: exit-handlers-
spec:
  entrypoint: run
  templates:
  - name: run
    steps:
    - - name: run1
        template: duration
    - - name: run2
        template: duration
  - name: duration
    container:
      image: alpine:latest
      command: [sh, -c]
      args: ["echo {{workflow.duration}}; sleep 15;"]
```

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
