### PR TITLE
fix(emissary): throw argo error on file not exist

### DIFF
--- a/workflow/executor/emissary/emissary.go
+++ b/workflow/executor/emissary/emissary.go
@@ -11,8 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/argoproj/argo-workflows/v3/errors"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-workflows/v3/errors"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/workflow/executor"


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

re #6391 

I took the liberty of not adding tests because it's a 1 line change and there are currently no tests for the emissary executor :stuck_out_tongue: 
