### PR TITLE
docs: updating documentation on how to setup IRSA on AWS

### DIFF
--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -115,6 +115,9 @@ data:
         key: secretKey
       # If this is set to true, argo workflows will use AWS SDK default credentials provider chain. This will allow things like
       # IRSA and any of the authentication methods that the golang SDK uses in it's default chain.
+      # If you are using IRSA on AWS, and set this option to true, you will also need to modify Argo-Server Deployment with
+      # `spec.template.spec.securityContext.fsGroup: 65534` configuration. This is required for IRSA to be able to access 
+      # `/var/run/secrets/eks.amazonaws.com/serviceaccount/token` file, and authenticate with AWS.
       useSDKCreds: false
 
   # Specifies the container runtime interface to use (default: docker)


### PR DESCRIPTION
I tried configuring my Argo-Server to use s3 as an artifact repository, and then archive all logs automatically, and it worked fine. But then when I wanted to load those logs in the Argo-Server UI using the link `https://<arg_server_host>/artifacts/argo/<workflow_name>/<pod_name>/main-logs` I got the following error:

```
failed to create new S3 client: WebIdentityErr: failed fetching WebIdentity token: 
caused by: WebIdentityErr: unable to read file at /var/run/secrets/eks.amazonaws.com/serviceaccount/token
caused by: open /var/run/secrets/eks.amazonaws.com/serviceaccount/token: permission denied
```

Reading through similar issues here: https://github.com/kubernetes-sigs/external-dns/pull/1185 I found out that IRSA requires this setting on the Deployment:
`spec.template.spec.securityContext.fsGroup: 65534` to fix the above issue. 

I thought it would be helpful to others to find information how to deal with it here, rather than search for the answers if they hit this problem.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
