### PR TITLE
fix(controller): Force main container name to be "main" as per v3.0. Fixes #6405

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -142,7 +142,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	wfSpec := woc.execWf.Spec.DeepCopy()
 
 	for i, c := range mainCtrs {
-		if c.Name == "" {
+		if c.Name == "" || tmpl.GetType() != wfv1.TemplateTypeContainerSet {
 			c.Name = common.MainContainerName
 		}
 		// Allow customization of main container resources.

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -553,6 +553,13 @@ func Test_createWorkflowPod_rateLimited(t *testing.T) {
 	}
 }
 
+func Test_createWorkflowPod_containerName(t *testing.T) {
+	woc := newWoc()
+	pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Name: "invalid"}}, &wfv1.Template{}, &createWorkflowPodOpts{})
+	assert.NoError(t, err)
+	assert.Equal(t, common.MainContainerName, pod.Spec.Containers[1].Name)
+}
+
 func Test_createWorkflowPod_emissary(t *testing.T) {
 	t.Run("NoCommand", func(t *testing.T) {
 		woc := newWoc()


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>
Fixes #6405 