### PR TITLE
fix(controller): fix retry on different hosts

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -940,6 +940,13 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 					return
 				}
 			}
+			if node.Type == wfv1.NodeTypePod {
+				if node.HostNodeName != pod.Spec.NodeName {
+					node.HostNodeName = pod.Spec.NodeName
+					woc.wf.Status.Nodes[nodeID] = node
+					woc.updated = true
+				}
+			}
 			if node.Fulfilled() && !node.IsDaemoned() {
 				if pod.GetLabels()[common.LabelKeyCompleted] == "true" {
 					return
@@ -953,13 +960,6 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 			}
 			if node.Succeeded() && match {
 				woc.completedPods[pod.Name] = pod.Status.Phase
-			}
-			if node.Type == wfv1.NodeTypePod {
-				if node.HostNodeName != pod.Spec.NodeName {
-					node.HostNodeName = pod.Spec.NodeName
-					woc.wf.Status.Nodes[nodeID] = node
-					woc.updated = true
-				}
 			}
 		}
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -954,6 +954,13 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 			if node.Succeeded() && match {
 				woc.completedPods[pod.Name] = pod.Status.Phase
 			}
+			if node.Type == wfv1.NodeTypePod {
+				if node.HostNodeName != pod.Spec.NodeName {
+					node.HostNodeName = pod.Spec.NodeName
+					woc.wf.Status.Nodes[nodeID] = node
+					woc.updated = true
+				}
+			}
 		}
 	}
 
@@ -984,7 +991,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 			// node is not a pod, it is already complete, or it can be re-run.
 			continue
 		}
-		if seenPod, ok := seenPods[nodeID]; !ok {
+		if _, ok := seenPods[nodeID]; !ok {
 
 			// grace-period to allow informer sync
 			recentlyStarted := recentlyStarted(node)
@@ -1010,14 +1017,6 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 				woc.updated = true
 			}
 			woc.markNodePhase(node.Name, wfv1.NodeError, "pod deleted")
-		} else {
-			// At this point we are certain that the pod associated with our node is running or has been run;
-			// it is safe to extract the k8s-node information given this knowledge.
-			if node.HostNodeName != seenPod.Spec.NodeName {
-				node.HostNodeName = seenPod.Spec.NodeName
-				woc.wf.Status.Nodes[nodeID] = node
-				woc.updated = true
-			}
 		}
 	}
 	return nil
@@ -1727,11 +1726,6 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 			nodeName = fmt.Sprintf("%s(%d)", retryNodeName, len(retryParentNode.Children))
 			woc.addChildNode(retryNodeName, nodeName)
 			node = nil
-
-			// It has to be one child at least
-			if lastChildNode != nil {
-				RetryOnDifferentHost(woc.wf.NodeID(retryNodeName))(*woc.retryStrategy(processedTmpl), woc.wf.Status.Nodes, processedTmpl)
-			}
 
 			localParams := make(map[string]string)
 			// Change the `pod.name` variable to the new retry node name

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -6160,14 +6160,21 @@ func TestRetryOnDiffHost(t *testing.T) {
 	lastChild.HostNodeName = "test-fail-hostname"
 	woc.wf.Status.Nodes[lastChild.ID] = *lastChild
 
+	pod := &apiv1.Pod{
+		Spec: apiv1.PodSpec{
+			Affinity: &apiv1.Affinity{},
+		},
+	}
+
 	tmpl := &wfv1.Template{}
 	tmpl.RetryStrategy = &retries
-	RetryOnDifferentHost(nodeID)(*woc.retryStrategy(tmpl), woc.wf.Status.Nodes, tmpl)
-	assert.NotNil(t, tmpl.Affinity)
+
+	RetryOnDifferentHost(nodeID)(*woc.retryStrategy(tmpl), woc.wf.Status.Nodes, pod)
+	assert.NotNil(t, pod.Spec.Affinity)
 
 	// Verify if template's Affinity has the right value
 	targetNodeSelectorRequirement :=
-		tmpl.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
 	sourceNodeSelectorRequirement := apiv1.NodeSelectorRequirement{
 		Key:      hostSelector,
 		Operator: apiv1.NodeSelectorOpNotIn,

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/utils/env"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -8,18 +9,31 @@ import (
 )
 
 // RetryTweak is a 2nd order function interface for tweaking the retry
-type RetryTweak = func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, tmpl *wfv1.Template)
+type RetryTweak = func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, pod *apiv1.Pod)
 
-// RetryOnDifferentHost append affinity with fail host to template
+// FindRetryNode locates the closes retry node ancestor to nodeID
+func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
+	boundaryID := nodes[nodeID].BoundaryID
+	boundaryNode := nodes[boundaryID]
+	templateName := boundaryNode.TemplateName
+	for _, node := range nodes {
+		if node.Type == wfv1.NodeTypeRetry && node.TemplateName == templateName {
+			return &node
+		}
+	}
+	return nil
+}
+
+// RetryOnDifferentHost append affinity with fail host to pod
 func RetryOnDifferentHost(retryNodeName string) RetryTweak {
-	return func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, tmpl *wfv1.Template) {
+	return func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, pod *apiv1.Pod) {
 		if retryStrategy.Affinity == nil {
 			return
 		}
 		hostNames := wfretry.GetFailHosts(nodes, retryNodeName)
 		hostLabel := env.GetString("RETRY_HOST_NAME_LABEL_KEY", "kubernetes.io/hostname")
 		if hostLabel != "" && len(hostNames) > 0 {
-			tmpl.Affinity = wfretry.AddHostnamesToAffinity(hostLabel, hostNames, tmpl.Affinity)
+			pod.Spec.Affinity = wfretry.AddHostnamesToAffinity(hostLabel, hostNames, pod.Spec.Affinity)
 		}
 	}
 }

--- a/workflow/controller/retry_tweak_test.go
+++ b/workflow/controller/retry_tweak_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+)
+
+func TestFindRetryNode(t *testing.T) {
+	allNodes := wfv1.Nodes{
+		"A1": wfv1.NodeStatus{
+			ID:           "A1",
+			Type:         wfv1.NodeTypeSteps,
+			Phase:        wfv1.NodeRunning,
+			BoundaryID:   "",
+			Children:     []string{"B1", "B2"},
+			TemplateName: "tmpl1",
+		},
+		"B1": wfv1.NodeStatus{
+			ID:           "B1",
+			Type:         wfv1.NodeTypeSkipped,
+			Phase:        wfv1.NodeSkipped,
+			BoundaryID:   "",
+			Children:     []string{},
+			TemplateName: "tmpl2",
+		},
+		// retry node
+		"B2": wfv1.NodeStatus{
+			ID:           "B2",
+			Type:         wfv1.NodeTypeRetry,
+			Phase:        wfv1.NodeRunning,
+			BoundaryID:   "",
+			Children:     []string{"C1"},
+			TemplateName: "tmpl1",
+		},
+		"C1": wfv1.NodeStatus{
+			ID:           "C1",
+			Type:         wfv1.NodeTypeSteps,
+			Phase:        wfv1.NodeRunning,
+			BoundaryID:   "",
+			Children:     []string{"D1", "D2"},
+			TemplateName: "tmpl2",
+		},
+		"D1": wfv1.NodeStatus{
+			ID:           "D1",
+			Type:         wfv1.NodeTypeSkipped,
+			Phase:        wfv1.NodeSkipped,
+			BoundaryID:   "A1",
+			Children:     []string{},
+			TemplateName: "tmpl2",
+		},
+		"D2": wfv1.NodeStatus{
+			ID:           "D2",
+			Type:         wfv1.NodeTypePod,
+			Phase:        wfv1.NodeRunning,
+			BoundaryID:   "A1",
+			Children:     []string{},
+			TemplateName: "tmpl2",
+		},
+	}
+	t.Run("Expect to find retry node", func(t *testing.T) {
+		node := allNodes["B2"]
+		assert.Equal(t, FindRetryNode(allNodes, "D2"), &node)
+	})
+	t.Run("Expect to get nil", func(t *testing.T) {
+		a := FindRetryNode(allNodes, "A1")
+		assert.Nil(t, a)
+	})
+}

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -108,6 +108,28 @@ func (woc *wfOperationCtx) hasPodSpecPatch(tmpl *wfv1.Template) bool {
 	return woc.execWf.Spec.HasPodSpecPatch() || tmpl.HasPodSpecPatch()
 }
 
+// scheduleOnDifferentHost adds affinity to prevent retry on the same host when
+// retryStrategy.affinity.nodeAntiAffinity{} is specified
+func (woc *wfOperationCtx) scheduleOnDifferentHost(node *wfv1.NodeStatus, pod *apiv1.Pod) error {
+	if node != nil && pod != nil {
+		if retryNode := FindRetryNode(woc.wf.Status.Nodes, node.ID); retryNode != nil {
+			// recover template for the retry node
+			tmplCtx, err := woc.createTemplateContext(retryNode.GetTemplateScope())
+			if err != nil {
+				return err
+			}
+			_, retryTmpl, _, err := tmplCtx.ResolveTemplate(retryNode)
+			if err != nil {
+				return err
+			}
+			if retryStrategy := woc.retryStrategy(retryTmpl); retryStrategy != nil {
+				RetryOnDifferentHost(retryNode.ID)(*retryStrategy, woc.wf.Status.Nodes, pod)
+			}
+		}
+	}
+	return nil
+}
+
 type createWorkflowPodOpts struct {
 	includeScriptOutput bool
 	onExitPod           bool
@@ -386,6 +408,10 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	node := woc.wf.GetNodeByName(nodeName)
 	templateDeadline, err := woc.checkTemplateTimeout(tmpl, node)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := woc.scheduleOnDifferentHost(node, pod); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Ref
Fixes https://github.com/argoproj/argo-workflows/issues/6248
Fixes https://github.com/argoproj/argo-workflows/issues/5830

## Fixes
This PR fixes the following issues:
- assign `HostNodeName` earlier before the next pod is retried
- collect hostnames from errored /failure nodes in complex workflow by iterating over the tree
- `FAIL HOSTS` in UI
- inject `affinity` with failed host before the pod is scheduled

Additionally, the fix allows merging affinity from `spec` and `podSpecPatch`.

## Test
I've tested in a few ways:
- local K3D cluster
- in a private cluster with prod application
- unit tests

All tests were run from simple to more complex workflows.
[example-workflow.txt](https://github.com/argoproj/argo-workflows/files/6880350/template-pod-spec-patch.txt)


![image](https://user-images.githubusercontent.com/10375055/127038028-5a2a0f62-b24a-49ee-a57f-31b8127b4769.png)
