### PR TITLE
feat: Annotate pod events with workflow name and UID

### DIFF
--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -341,6 +341,20 @@ func (w *When) CreateConfigMap(name string, data map[string]string) *When {
 	return w
 }
 
+func (w *When) UpdateConfigMap(name string, data map[string]string) *When {
+	w.t.Helper()
+
+	ctx := context.Background()
+	_, err := w.kubeClient.CoreV1().ConfigMaps(Namespace).Update(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{Label: "true"}},
+		Data:       data,
+	}, metav1.UpdateOptions{})
+	if err != nil {
+		w.t.Fatal(err)
+	}
+	return w
+}
+
 func (w *When) DeleteConfigMap(name string) *When {
 	w.t.Helper()
 	ctx := context.Background()

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -30,10 +30,10 @@ const (
 	// was scheduled to run by CronWorkflow.
 	AnnotationKeyCronWfScheduledTime = workflow.WorkflowFullName + "/scheduled-time"
 
-  // AnnotationKeyWorkflowName is the name of the workflow
+	// AnnotationKeyWorkflowName is the name of the workflow
 	AnnotationKeyWorkflowName = workflow.WorkflowFullName + "/workflow-name"
-  // AnnotationKeyWorkflowUID is the uid of the workflow
-	AnnotationKeyWorkflowUID  = workflow.WorkflowFullName + "/workflow-uid"
+	// AnnotationKeyWorkflowUID is the uid of the workflow
+	AnnotationKeyWorkflowUID = workflow.WorkflowFullName + "/workflow-uid"
 
 	// LabelKeyControllerInstanceID is the label the controller will carry forward to workflows/pod labels
 	// for the purposes of workflow segregation

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -30,6 +30,9 @@ const (
 	// was scheduled to run by CronWorkflow.
 	AnnotationKeyCronWfScheduledTime = workflow.WorkflowFullName + "/scheduled-time"
 
+	AnnotationKeyWorkflowName = workflow.WorkflowFullName + "/workflow-name"
+	AnnotationKeyWorkflowUID  = workflow.WorkflowFullName + "/workflow-uid"
+
 	// LabelKeyControllerInstanceID is the label the controller will carry forward to workflows/pod labels
 	// for the purposes of workflow segregation
 	LabelKeyControllerInstanceID = workflow.WorkflowFullName + "/controller-instanceid"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -30,7 +30,9 @@ const (
 	// was scheduled to run by CronWorkflow.
 	AnnotationKeyCronWfScheduledTime = workflow.WorkflowFullName + "/scheduled-time"
 
+  // AnnotationKeyWorkflowName is the name of the workflow
 	AnnotationKeyWorkflowName = workflow.WorkflowFullName + "/workflow-name"
+  // AnnotationKeyWorkflowUID is the uid of the workflow
 	AnnotationKeyWorkflowUID  = workflow.WorkflowFullName + "/workflow-uid"
 
 	// LabelKeyControllerInstanceID is the label the controller will carry forward to workflows/pod labels

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2183,6 +2183,10 @@ func (woc *wfOperationCtx) recordNodePhaseEvent(node *wfv1.NodeStatus) {
 		eventType = apiv1.EventTypeNormal
 	}
 	eventConfig := woc.controller.Config.NodeEvents
+	annotations := map[string]string{
+		common.AnnotationKeyNodeType: string(node.Type),
+		common.AnnotationKeyNodeName: node.Name,
+	}
 	var involvedObject runtime.Object = woc.wf
 	if eventConfig.SendAsPod {
 		pod, err := woc.getPodByNode(node)
@@ -2191,14 +2195,13 @@ func (woc *wfOperationCtx) recordNodePhaseEvent(node *wfv1.NodeStatus) {
 		}
 		if pod != nil {
 			involvedObject = pod
+			annotations[common.AnnotationKeyWorkflowName] = woc.wf.Name
+			annotations[common.AnnotationKeyWorkflowUID] = string(woc.wf.GetUID())
 		}
 	}
 	woc.eventRecorder.AnnotatedEventf(
 		involvedObject,
-		map[string]string{
-			common.AnnotationKeyNodeType: string(node.Type),
-			common.AnnotationKeyNodeName: node.Name,
-		},
+		annotations,
 		eventType,
 		fmt.Sprintf("WorkflowNode%s", node.Phase),
 		message,


### PR DESCRIPTION
### Story
With the ability to configure node events to be sent with the involved
object set to the pod, it would be handy if annotations were provided
in the event that would allow the pod/node to understand which workflow
it belongs to.

### Testing

* Run the server locally
* Submit a workflow
* Print out the events and their annotations

### Test results

✅ confirmed that pod events included workflow annotations. Here is an example:

<img width="560" alt="Screen Shot 2021-07-29 at 4 40 00 PM" src="https://user-images.githubusercontent.com/5930159/127569452-4abc8af7-6923-4bbf-8c66-29e528e1cbd6.png">

✅ confirmed that events for the workflow did not contain these annotations (e.g. the `WorkflowRunning` event)
✅ confirmed that non-pod events did not contain these annotations (e.g. `WorkflowNodeRunning` events for a DAG node type):
<img width="433" alt="Screen Shot 2021-07-29 at 4 43 03 PM" src="https://user-images.githubusercontent.com/5930159/127569709-e17b4e69-ccf0-454c-b09c-52ad575d712c.png">


### Notes

I couldn't find a good way to assert that events had certain annotations in the unit tests. I attempted to use If anyone has a good idea on how to do that, I'm open to hearing it. I attempted to do something like:
```golang
controller.kubeclientset.CoreV1().Events(woc.wf.GetNamespace()).List(ctx, metav1.ListOptions{})
```

But that would always return an empty list


Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
