### PR TITLE
fix(server): Fix nil pointer error when getting artifacts from a step without artifacts

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2482,6 +2482,9 @@ type SuspendTemplate struct {
 
 // GetArtifactByName returns an input artifact by its name
 func (in *Inputs) GetArtifactByName(name string) *Artifact {
+	if in == nil {
+		return nil
+	}
 	return in.Artifacts.GetArtifactByName(name)
 }
 

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -417,6 +417,16 @@ func TestNodes_Map(t *testing.T) {
 	})
 }
 
+// TestInputs_NoArtifacts makes sure that the code doesn't panic when trying to get artifacts from a node status
+// without any artifacts
+func TestInputs_NoArtifacts(t *testing.T) {
+	s := NodeStatus{ID: "node_1", Inputs: nil, Outputs: nil}
+	inArt := s.Inputs.GetArtifactByName("test-artifact")
+	assert.Nil(t, inArt)
+	outArt := s.Outputs.GetArtifactByName("test-artifact")
+	assert.Nil(t, outArt)
+}
+
 func TestResourcesDuration_String(t *testing.T) {
 	assert.Empty(t, ResourcesDuration{}.String(), "empty")
 	assert.Equal(t, "1s*(100Mi memory)", ResourcesDuration{corev1.ResourceMemory: NewResourceDuration(1 * time.Second)}.String(), "memory")

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -109,6 +109,8 @@ func newServer() *ArtifactServer {
 						},
 					},
 				},
+				// a node without input/output artifacts
+				"my-node-no-artifacts": wfv1.NodeStatus{},
 			},
 		},
 	}
@@ -196,6 +198,20 @@ func TestArtifactServer_GetInputArtifact(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestArtifactServer_NodeWithoutArtifact makes sure that the server doesn't panic due to a nil-pointer error
+// when trying to get an artifact from a node result without any artifacts
+func TestArtifactServer_NodeWithoutArtifact(t *testing.T) {
+	s := newServer()
+	r := &http.Request{}
+	r.URL = mustParse(fmt.Sprintf("/input-artifacts/my-ns/my-wf/my-node-no-artifacts/%s", "my-artifact"))
+	w := &testhttp.TestResponseWriter{}
+	s.GetInputArtifact(w, r)
+	// make sure there is no nil pointer panic
+	assert.Equal(t, 500, w.StatusCode)
+	s.GetOutputArtifact(w, r)
+	assert.Equal(t, 500, w.StatusCode)
 }
 
 func TestArtifactServer_GetOutputArtifactWithoutInstanceID(t *testing.T) {


### PR DESCRIPTION
Fixes #6024.

Hi, sorry for this late PR. Been busy with work lately.

This simply adds a nil pointer check for input artifacts, similar to what had been done to the output artifacts.

https://github.com/argoproj/argo-workflows/blob/eb6503cb106b3660437f9f1f703db69330a99a87/pkg/apis/workflow/v1alpha1/workflow_types.go#L2529-L2534

This is to prevent a nil point panic when the user tries to get input artifacts from a step without any input artifacts specified.

To reproduce the issue, submit a workflow without any input artifacts, and try to get an input artifact from one of the steps.

Thanks!