### PR TITLE
feat: allow passing in user-defined context to Argo client

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -116,6 +116,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Sidecar Technologies](https://hello.getsidecar.com/)
 1. [Softonic](https://hello.softonic.com/)
 1. [Sohu](https://www.sohu.com/)
+1. [Spell](https://www.spell.ml/)
 1. [Stillwater Supercomputing, Inc](http://www.stillwater-sc.com/)
 1. [strongDM](https://www.strongdm.com/)
 1. [Styra](https://www.styra.com/)

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -62,7 +62,7 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 	if opts.ArgoServerOpts.HTTP1 {
 		return newHTTP1Client(opts.ArgoServerOpts.GetURL(), opts.AuthSupplier(), opts.ArgoServerOpts.InsecureSkipVerify, opts.Context)
 	} else if opts.ArgoServerOpts.URL != "" {
-		return newArgoServerClient(opts.ArgoServerOpts, opts.AuthSupplier())
+		return newArgoServerClient(opts.ArgoServerOpts, opts.AuthSupplier(), opts.Context)
 	} else {
 		if opts.ClientConfigSupplier != nil {
 			opts.ClientConfig = opts.ClientConfigSupplier()

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -27,6 +27,7 @@ type Client interface {
 
 type Opts struct {
 	ArgoServerOpts ArgoServerOpts
+	Context *context.Context
 	InstanceID     string
 	AuthSupplier   func() string
 	// DEPRECATED: use `ClientConfigSupplier`
@@ -59,7 +60,7 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 		return nil, nil, fmt.Errorf("cannot use instance ID with Argo Server")
 	}
 	if opts.ArgoServerOpts.HTTP1 {
-		return newHTTP1Client(opts.ArgoServerOpts.GetURL(), opts.AuthSupplier(), opts.ArgoServerOpts.InsecureSkipVerify)
+		return newHTTP1Client(opts.ArgoServerOpts.GetURL(), opts.AuthSupplier(), opts.ArgoServerOpts.InsecureSkipVerify, opts.Context)
 	} else if opts.ArgoServerOpts.URL != "" {
 		return newArgoServerClient(opts.ArgoServerOpts, opts.AuthSupplier())
 	} else {
@@ -67,7 +68,7 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 			opts.ClientConfig = opts.ClientConfigSupplier()
 		}
 
-		ctx, client, err := newArgoKubeClient(opts.ClientConfig, instanceid.NewService(opts.InstanceID))
+		ctx, client, err := newArgoKubeClient(opts.ClientConfig, instanceid.NewService(opts.InstanceID), opts.Context)
 		return ctx, client, err
 	}
 }

--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -38,7 +38,7 @@ type argoKubeClient struct {
 
 var _ Client = &argoKubeClient{}
 
-func newArgoKubeClient(clientConfig clientcmd.ClientConfig, instanceIDService instanceid.Service) (context.Context, Client, error) {
+func newArgoKubeClient(clientConfig clientcmd.ClientConfig, instanceIDService instanceid.Service, baseContext *context.Context) (context.Context, Client, error) {
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, err
@@ -64,7 +64,11 @@ func newArgoKubeClient(clientConfig clientcmd.ClientConfig, instanceIDService in
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err := gatekeeper.Context(context.Background())
+	ctx := context.Background()
+	if baseContext != nil {
+		ctx = *baseContext
+	}
+	ctx, err = gatekeeper.Context(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/apiclient/argo-server-client.go
+++ b/pkg/apiclient/argo-server-client.go
@@ -71,9 +71,13 @@ func newClientConn(opts ArgoServerOpts) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func newContext(auth string) context.Context {
-	if auth == "" {
-		return context.Background()
+func newContext(auth string, baseContext *context.Context) context.Context {
+	ctx := context.Background()
+	if baseContext != nil {
+		ctx = *baseContext
 	}
-	return metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", auth))
+	if auth == "" {
+		return ctx
+	}
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", auth))
 }

--- a/pkg/apiclient/argo-server-client.go
+++ b/pkg/apiclient/argo-server-client.go
@@ -27,12 +27,12 @@ type argoServerClient struct {
 
 var _ Client = &argoServerClient{}
 
-func newArgoServerClient(opts ArgoServerOpts, auth string) (context.Context, Client, error) {
+func newArgoServerClient(opts ArgoServerOpts, auth string, baseContext *context.Context) (context.Context, Client, error) {
 	conn, err := newClientConn(opts)
 	if err != nil {
 		return nil, nil, err
 	}
-	return newContext(auth), &argoServerClient{conn}, nil
+	return newContext(auth, baseContext), &argoServerClient{conn}, nil
 }
 
 func (a *argoServerClient) NewWorkflowServiceClient() workflowpkg.WorkflowServiceClient {

--- a/pkg/apiclient/http1-client.go
+++ b/pkg/apiclient/http1-client.go
@@ -40,6 +40,10 @@ func (h httpClient) NewInfoServiceClient() (infopkg.InfoServiceClient, error) {
 	return http1.InfoServiceClient(h), nil
 }
 
-func newHTTP1Client(baseUrl string, auth string, insecureSkipVerify bool) (context.Context, Client, error) {
-	return context.Background(), httpClient(http1.NewFacade(baseUrl, auth, insecureSkipVerify)), nil
+func newHTTP1Client(baseUrl string, auth string, insecureSkipVerify bool, baseContext *context.Context) (context.Context, Client, error) {
+	ctx := context.Background()
+	if baseContext != nil {
+		ctx = *baseContext
+	}
+	return ctx, httpClient(http1.NewFacade(baseUrl, auth, insecureSkipVerify)), nil
 }


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Hello, this PR adds a `Context` field to the Argo Client opts so a user-defined context can be used in place of `context.Background()`. Basically go programs using the API Client might want the argo client to respect ex. context cancellation on a parent context.

I tested by running `make cli` and editing the CLI to use a custom context.

With thanks to the reviewers :)