### PR TITLE
fix(executor/docker): fix random errors with message "No such container:path". Fixes #6352

### DIFF
--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -208,11 +208,14 @@ func (d *DockerExecutor) Wait(ctx context.Context, containerNames []string) erro
 				if err != nil {
 					return err
 				}
-				_, waitErr := common.RunCommand("docker", append([]string{"wait"}, containerIDs...)...)
-				if waitErr != nil && strings.Contains(waitErr.Error(), "No such container") {
+				_, err = common.RunCommand("docker", append([]string{"wait"}, containerIDs...)...)
+				if err != nil && strings.Contains(err.Error(), "No such container") {
 					// e.g. reason could be ContainerCannotRun
-					log.WithError(waitErr).Info("ignoring error as container may have been re-created and therefore container ID may have changed")
+					log.WithError(err).Info("ignoring error as container may have been re-created and therefore container ID may have changed")
 					continue
+				}
+				if err != nil {
+					return err
 				}
 				// After docker wait, sometimes the container can still be in "Created" state.
 				// https://github.com/argoproj/argo-workflows/issues/6352
@@ -236,7 +239,7 @@ func (d *DockerExecutor) Wait(ctx context.Context, containerNames []string) erro
 				if foundUnfinished {
 					continue
 				}
-				return waitErr
+				return nil
 			}
 			time.Sleep(time.Second)
 		}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/6352

## Root Cause
After `docker wait` exits 0, there is a chance the container is still in "Created" state.
I'm not sure why that happens, but it now happens stably on GKE per my observation.

## Fix
the fix is a workaround to check container status after `docker wait` and do `docker wait` again if we found some containers haven't finished yet.

## Verification
I reproduced the issue in #6352 stably as explained in https://github.com/argoproj/argo-workflows/issues/6352#issuecomment-892523099.
Then I verified with this PR, the issue never shows up again.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
