### PR TITLE
docs: Making metadata header lowercase to match selector

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -76,7 +76,8 @@ metadata:
   name: event-consumer
 spec:
   event:
-    selector: payload.message != "" && metadata["X-Argo-E2E"] == ["true"] && discriminator == "my-discriminator"
+    # Metadata header must be lowercase to match selector.  Incoming headers are converted to lowercase.  See "Metadata" section below for details.
+    selector: payload.message != "" && metadata["x-argo-e2e"] == ["true"] && discriminator == "my-discriminator"
   submit:
     workflowTemplateRef:
       name: my-wf-tmple


### PR DESCRIPTION
The name of the header in the metadata object inside the selector must be lowercase to match properly.  See the "Metadata" section below.  Trying with this example it was not matching, and thus not running the workflow.  Once I made the header name lowercase in the selector the selector matched and the workflow ran as expected.

Checklist:

* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
