### PR TITLE
docs: PROFILE=SSO to PROFILE=sso for case-sensitive filesystem

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -67,7 +67,7 @@ For testing SSO integration, you can start a Argo with sso profile which will de
 a pre-configured dex instance in argo namespace
 
 ```sh
-make start PROFILE=SSO
+make start PROFILE=sso
 ```
 
 ## Troubleshooting Notes


### PR DESCRIPTION
Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.

`make start PROFILE=SSO` didn't work in my environment.
But `make start PROFILE=sso` work in my environment.
```
 % cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.2 LTS"
```
I guess that is caused by whether the filesystem is case-sensitive or not.
```
 % make start PROFILE=SSO

GIT_COMMIT=080538f76e5b7162323fa70339bf6030ace68a51 GIT_BRANCH=fix-docs-running-locally GIT_TAG=untagged GIT_TREE_STATE=clean RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-mycluster DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false
RUN_MODE=local PROFILE=SSO AUTH_MODE=hybrid SECURE=false STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl get ns argo || kubectl create ns argo
NAME   STATUS   AGE
argo   Active   25m
kubectl config set-context --current --namespace=argo
Context "k3d-mycluster" modified.
installing PROFILE=SSO, E2E_EXECUTOR=pns
dist/kustomize build --load_restrictor=none test/e2e/manifests/SSO | sed 's/argoproj\//argoproj\//' | sed 's/containerRuntimeExecutor: docker/containerRuntimeExecutor: pns/' | kubectl -n argo apply --prune -l app.kubernetes.io/part-of=argo -f -
Error: error creating new loader with git: url lacks host: test/e2e/manifests/SSO, dir: evalsymlink failure on 'test/e2e/manifests/SSO' : lstat /home/shiota/go/src/github.com/shioshiota/argo-workflows/test/e2e/manifests/SSO: no such file or directory, get: invalid source string: test/e2e/manifests/SSO
error: no objects passed to apply
make: *** [Makefile:409: install] Error 1
```