### PR TITLE
fix: manifests/quick-start/sso for running locally PROFILE=sso

### DIFF
--- a/manifests/quick-start/sso/dex/dex-cm.yaml
+++ b/manifests/quick-start/sso/dex/dex-cm.yaml
@@ -15,7 +15,7 @@ data:
     staticClients:
       - id: argo-server
         redirectURIs:
-          - http://localhost:2746/oauth2/callback
+          - http://localhost:8080/oauth2/callback
         name: Argo Server
         secret: ZXhhbXBsZS1hcHAtc2VjcmV0
     connectors:

--- a/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
+++ b/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
@@ -8,7 +8,7 @@ data:
     clientSecret:
       name: argo-server-sso
       key: clientSecret
-    redirectUrl: http://localhost:2746/oauth2/callback
+    redirectUrl: http://localhost:8080/oauth2/callback
     scopes:
     - groups
     - email


### PR DESCRIPTION
Signed-off-by: Tetsuya Shiota <tetsuya.shiota.1231@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.

I noticed that `make start PROFILE=sso` didn't work well.
That is caused by the UI server launched by the command listens on :8080 but the redirect URI for dex configured to `http://localhost:2746/oauth2/callback`.
This PR fixed it.
https://github.com/argoproj/argo-workflows/blob/a3fd704a1715900f2144c0362e562f75f1524126/docs/running-locally.md