### PR TITLE
feat(ui): use dl tag instead of p tag in user-info ui

### DIFF
--- a/ui/src/app/userinfo/components/user-info.tsx
+++ b/ui/src/app/userinfo/components/user-info.tsx
@@ -37,12 +37,30 @@ export class UserInfo extends BasePage<RouteComponentProps<any>, State> {
                     </h3>
                     {this.state.userInfo && (
                         <>
-                            <p>Issuer: {this.state.userInfo.issuer || '-'}</p>
-                            <p>Subject: {this.state.userInfo.subject || '-'}</p>
-                            <p>Groups: {(this.state.userInfo.groups && this.state.userInfo.groups.length > 0 && this.state.userInfo.groups.join(', ')) || '-'}</p>
-                            <p>Email: {this.state.userInfo.email || '-'}</p>
-                            <p>Email Verified: {this.state.userInfo.emailVerified || '-'}</p>
-                            <p>Service Account: {this.state.userInfo.serviceAccountName || '-'}</p>
+                            <dl>
+                                <dt>Issuer:</dt>
+                                <dd>{this.state.userInfo.issuer || '-'}</dd>
+                            </dl>
+                            <dl>
+                                <dt>Subject:</dt>
+                                <dd>{this.state.userInfo.subject || '-'}</dd>
+                            </dl>
+                            <dl>
+                                <dt>Groups:</dt>
+                                <dd>{(this.state.userInfo.groups && this.state.userInfo.groups.length > 0 && this.state.userInfo.groups.join(', ')) || '-'}</dd>
+                            </dl>
+                            <dl>
+                                <dt>Email:</dt>
+                                <dd>{this.state.userInfo.email || '-'}</dd>
+                            </dl>
+                            <dl>
+                                <dt>Email Verified:</dt>
+                                <dd>{this.state.userInfo.emailVerified || '-'}</dd>
+                            </dl>
+                            <dl>
+                                <dt>Service Account:</dt>
+                                <dd>{this.state.userInfo.serviceAccountName || '-'}</dd>
+                            </dl>
                         </>
                     )}
                     <a className='argo-button argo-button--base-o' href={uiUrl('login')}>


### PR DESCRIPTION
Signed-off-by: Tetsuya Shiota <tetsuya.shiota.1231@gmail.com>

Checklist:

* [x] My organization is added to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).

Tips:

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.

`<dl>` is a more appropriate tag than `<p>` to display user detail info. 
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p

Before:
![image](https://user-images.githubusercontent.com/2749804/128612195-9ca389e9-e69e-49eb-a61d-e163511e4d21.png)


After:
![image](https://user-images.githubusercontent.com/2749804/128612114-3ac58566-49bb-47d1-8763-07b9969a6999.png)
