### PR TITLE
fix: replace docker.io with quay.io to avoid the image pull limit

### DIFF
--- a/manifests/base/argo-server/argo-server-deployment.yaml
+++ b/manifests/base/argo-server/argo-server-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: argo-server
       containers:
         - name: argo-server
-          image: docker.io/argoproj/argocli:latest
+          image: quay.io/argoproj/argocli:latest
           securityContext:
             capabilities:
               drop:

--- a/manifests/base/workflow-controller/workflow-controller-deployment.yaml
+++ b/manifests/base/workflow-controller/workflow-controller-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: argo
       containers:
         - name: workflow-controller
-          image: docker.io/argoproj/workflow-controller:latest
+          image: quay.io/argoproj/workflow-controller:latest
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
@@ -28,7 +28,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:latest
+            - quay.io/argoproj/argoexec:latest
           env:
             - name: LEADER_ELECTION_IDENTITY
               valueFrom:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -603,7 +603,7 @@ spec:
       containers:
       - args:
         - server
-        image: docker.io/argoproj/argocli:latest
+        image: quay.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -649,7 +649,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:latest
+        - quay.io/argoproj/argoexec:latest
         command:
         - workflow-controller
         env:
@@ -658,7 +658,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: docker.io/argoproj/workflow-controller:latest
+        image: quay.io/argoproj/workflow-controller:latest
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifests/namespace-install.yaml
+++ b/manifests/namespace-install.yaml
@@ -495,7 +495,7 @@ spec:
       - args:
         - server
         - --namespaced
-        image: docker.io/argoproj/argocli:latest
+        image: quay.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -541,7 +541,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:latest
+        - quay.io/argoproj/argoexec:latest
         - --namespaced
         command:
         - workflow-controller
@@ -551,7 +551,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: docker.io/argoproj/workflow-controller:latest
+        image: quay.io/argoproj/workflow-controller:latest
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -831,7 +831,7 @@ spec:
         - server
         - --auth-mode
         - client
-        image: docker.io/argoproj/argocli:latest
+        image: quay.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -926,7 +926,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:latest
+        - quay.io/argoproj/argoexec:latest
         - --namespaced
         command:
         - workflow-controller
@@ -936,7 +936,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: docker.io/argoproj/workflow-controller:latest
+        image: quay.io/argoproj/workflow-controller:latest
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -875,7 +875,7 @@ spec:
         - server
         - --auth-mode
         - client
-        image: docker.io/argoproj/argocli:latest
+        image: quay.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -1015,7 +1015,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:latest
+        - quay.io/argoproj/argoexec:latest
         - --namespaced
         command:
         - workflow-controller
@@ -1025,7 +1025,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: docker.io/argoproj/workflow-controller:latest
+        image: quay.io/argoproj/workflow-controller:latest
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -875,7 +875,7 @@ spec:
         - server
         - --auth-mode
         - client
-        image: docker.io/argoproj/argocli:latest
+        image: quay.io/argoproj/argocli:latest
         name: argo-server
         ports:
         - containerPort: 2746
@@ -1007,7 +1007,7 @@ spec:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/argoexec:latest
+        - quay.io/argoproj/argoexec:latest
         - --namespaced
         command:
         - workflow-controller
@@ -1017,7 +1017,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: docker.io/argoproj/workflow-controller:latest
+        image: quay.io/argoproj/workflow-controller:latest
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
closes #6539 

Signed-off-by: Hong Wang <wanghong230@gmail.com>

Tests:

Faked the tag locally with v9.9.9, and run make manifests, inspected the manifests

% cat dist/manifests/quick-start-postgres.yaml |grep v9.9.9
    docker/whalesay:v9.9.9:
        image: quay.io/argoproj/argocli:v9.9.9
        - quay.io/argoproj/argoexec:v9.9.9
        image: quay.io/argoproj/workflow-controller:v9.9.9
        
Generate the manifest with latest tag, installed the manifest successfully, the hello world workflow worked
