### PR TITLE
chore: ArgoSever mistype

### DIFF
--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -54,7 +54,7 @@ func NewServerCommand() *cobra.Command {
 		Use:   "server",
 		Short: "start the Argo Server",
 		Example: fmt.Sprintf(`
-See %s`, help.ArgoSever),
+See %s`, help.ArgoServer),
 		RunE: func(c *cobra.Command, args []string) error {
 			cmd.SetLogFormatter(logFormat)
 			stats.RegisterStackDumper()

--- a/util/help/topics.go
+++ b/util/help/topics.go
@@ -1,9 +1,9 @@
 package help
 
 const (
-	root      = "https://argoproj.github.io/argo-workflows"
-	ArgoSever = root + "/argo-server.md"
-	CLI       = root + "/cli.md"
+	root       = "https://argoproj.github.io/argo-workflows"
+	ArgoServer = root + "/argo-server.md"
+	CLI        = root + "/cli.md"
 
 	WorkflowTemplates                          = root + "/workflow-templates.md"
 	WorkflowTemplatesReferencingOtherTemplates = WorkflowTemplates + "#referencing-other-workflowtemplates"


### PR DESCRIPTION
Quick Fix - I believe `ArgoSever` is meant to be `ArgoServer` 🙃 