### PR TITLE
fix: use golangci-lint v1.37.0 to support apple M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ dist/manifests/%: manifests/%
 # lint/test/etc
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.36.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.37.0
 
 .PHONY: lint
 lint: server/static/files.go $(GOPATH)/bin/golangci-lint


### PR DESCRIPTION
Signed-off-by: Hong Wang <wanghong230@gmail.com>

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 



Before:
% make lint
GIT_COMMIT=37395d6818ba151213a1bb8338356cf553c2404a GIT_BRANCH=master GIT_TAG=untagged GIT_TREE_STATE=clean RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.36.0
golangci/golangci-lint info checking GitHub for tag 'v1.36.0'
golangci/golangci-lint info found version: 1.36.0 for v1.36.0/darwin/arm64
make: *** [/Users/hong/go/bin/golangci-lint] Error 1

After:
% make lint
GIT_COMMIT=37395d6818ba151213a1bb8338356cf553c2404a GIT_BRANCH=master GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.37.0
golangci/golangci-lint info checking GitHub for tag 'v1.37.0'
golangci/golangci-lint info found version: 1.37.0 for v1.37.0/darwin/arm64
golangci/golangci-lint info installed /Users/hong/go/bin/golangci-lint
rm -Rf v3 vendor
.....
filename_unadjuster: 6.666µs, max_same_issues: 667ns, uniq_by_line: 292ns, max_from_linter: 250ns, path_shortener: 250ns, exclude: 209ns, diff: 209ns, sort_results: 125ns, source_code: 124ns, max_per_file_from_linter: 124ns, path_prefixer: 84ns, severity-rules: 83ns
INFO [runner] linters took 155.896417ms with stages: goanalysis_metalinter: 144.766709ms, unused: 7.408375ms
INFO fixer took 0s with no stages
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 18 samples, avg is 83.5MB, max is 140.3MB
INFO Execution took 1.660852542s

