### PR TITLE
fix(executor/docker): fix failed to wait for main container to complete: timed out waiting for the condition: container does not exist

### DIFF
--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -256,7 +256,7 @@ func (d *DockerExecutor) validateCompleted(ctx context.Context, containerNames [
 			// docker inspect $(docker run -d --entrypoint invalid argoproj/argosay:v2) | less
 			// In this case, we can distinguish the container by
 			// checking its exit code.
-			code, err := d.GetExitCode(ctx, container.containerID)
+			code, err := d.GetExitCode(ctx, name)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
This is a follow up fix of https://github.com/argoproj/argo-workflows/pull/6508.

I start to observe "container does not exist" errors after deploying argo v3.1.6 to KFP test clusters.

After some investigations, I found out this bug, `d.GetExitCode` expects a container name, not a container ID, so it always fail with "container not found" here.

https://github.com/argoproj/argo-workflows/blob/e0103ccd6ff7cb7b1eb4f369c5829fc8560d94ce/workflow/executor/docker/docker.go#L159

## Why did the bug slip in?

The original issue https://github.com/argoproj/argo-workflows/issues/6352 happens when the main container starts slower than the wait container and main container stays in "Created" state for a while (e.g. when one node is assigned too many Pods).

Before the fix in https://github.com/argoproj/argo-workflows/pull/6508, upon first call to executor.Wait, the docker executor falsely think main container has stopped, so it exits early and fail to extract outputs from main container (main container is still running).

After the first fix, the first call to executor.Wait will fail with "container does not exist", but we have a backoff configured in https://github.com/argoproj/argo-workflows/blob/386abb4d4242bd960a4c77557820ab9b9a72a92d/workflow/executor/executor.go#L917-L932. As long as main container starts running within 10s (4 retries) after it turns into "created" state, the docker executor will be able to wait properly for main container to finish.

Therefore, the first PR did improve toleration in this case to 10 seconds, so it passed my initial testing. With this PR, the toleration is increased to step active deadline seconds, so it's even better compared to before. When main container is stuck in "Created" state, it should check the main container's status every 1 second and wait for it to start running.

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
