### PR TITLE
fix(executor/pns): panic of pidFileHandles concurrent writes

### DIFF
--- a/workflow/executor/pns/pns.go
+++ b/workflow/executor/pns/pns.go
@@ -34,6 +34,9 @@ type PNSExecutor struct {
 	// mu for `containerNameToPID``
 	mu sync.RWMutex
 
+	// mu for `pidFileHandles``
+	pmu sync.RWMutex
+
 	containerNameToPID map[string]int
 
 	// pidFileHandles holds file handles to all root containers
@@ -57,6 +60,7 @@ func NewPNSExecutor(clientset *kubernetes.Clientset, podName, namespace string) 
 		podName:            podName,
 		namespace:          namespace,
 		mu:                 sync.RWMutex{},
+		pmu:                sync.RWMutex{},
 		containerNameToPID: make(map[string]int),
 		pidFileHandles:     make(map[int]*os.File),
 		thisPID:            thisPID,
@@ -82,6 +86,8 @@ func (p *PNSExecutor) enterChroot(containerName string) error {
 	if pid == 0 {
 		return fmt.Errorf("cannot enter chroot for container named %q: no PID known - maybe short running container", containerName)
 	}
+	p.pmu.RLock()
+	defer p.pmu.RUnlock()
 	if err := p.pidFileHandles[pid].Chdir(); err != nil {
 		return errors.InternalWrapErrorf(err, "failed to chdir to main filesystem: %v", err)
 	}
@@ -320,6 +326,8 @@ func (p *PNSExecutor) secureRootFiles() error {
 				return err
 			}
 
+			p.pmu.Lock()
+			defer p.pmu.Unlock()
 			if p.pidFileHandles[pid] != fs {
 				// the main container may have switched (e.g. gone from busybox to the user's container)
 				if prevInfo, ok := p.pidFileHandles[pid]; ok {


### PR DESCRIPTION
In PNS executor, there is a panic `concurrent map writes` on `p.pidFileHandles`. When error occurs, the `Wait` method will be re-invoked, and starts a new goroutine, the `p.pidFileHandles` will be concurrently assigned. This fix adds a lock to protect it.

panic log:
```
time="2021-08-19T04:02:13.596Z" level=info msg="Starting Workflow Executor" executorType=pns version=v3.1.6-patch
time="2021-08-19T04:02:13.600Z" level=info msg="Creating PNS executor (namespace: test, pod: sparkly-bear-m6bxb, pid: 36)"
time="2021-08-19T04:02:13.600Z" level=info msg="Creating a K8sAPI executor"
time="2021-08-19T04:02:13.600Z" level=info msg="Executor initialized" includeScriptOutput=false namespace=test podName=sparkly-bear-m6bxb template="{\"name\":\"argosay\",\"inputs\":{\"parameters\":[{\"name\":\"message\",\"value\":\"hello argo\"}]},\"outputs\":{},\"metadata\":{},\"container\":{\"name\":\"main\",\"image\":\"argoproj/argosay:v2\",\"command\":[\"/argosay\"],\"args\":[\"echo\",\"hello argo\"],\"resources\":{}},\"archiveLocation\":{\"archiveLogs\":true,\"s3\":{\"endpoint\":\"minio-service.kubeflow:9000\",\"bucket\":\"mlpipeline\",\"insecure\":true,\"accessKeySecret\":{\"name\":\"mlpipeline-minio-artifact\",\"key\":\"accesskey\"},\"secretKeySecret\":{\"name\":\"mlpipeline-minio-artifact\",\"key\":\"secretkey\"},\"key\":\"artifacts/sparkly-bear-m6bxb/2021/08/19/sparkly-bear-m6bxb\"}}}" version="&Version{Version:v3.1.6-patch,BuildDate:2021-08-18T12:50:41Z,GitCommit:9c47963b66061143735843db27977dbf9b4cbbf4,GitTag:v3.1.6-patch,GitTreeState:clean,GoVersion:go1.15.7,Compiler:gc,Platform:linux/amd64,}"
time="2021-08-19T04:02:13.600Z" level=info msg="Starting annotations monitor"
time="2021-08-19T04:02:13.600Z" level=info msg="Starting deadline monitor"
time="2021-08-19T04:02:13.702Z" level=info msg="secured root for pid 62 root: runc:[2:INIT] (\"/proc/62/root\")"
time="2021-08-19T04:02:13.702Z" level=info msg="mapped container name \"pid/62\" to pid 62"
time="2021-08-19T04:02:13.752Z" level=info msg="secured root for pid 62 root: runc:[2:INIT] (\"/proc/62/root\")"
time="2021-08-19T04:02:13.803Z" level=info msg="secured root for pid 62 root: runc:[2:INIT] (\"/proc/62/root\")"
time="2021-08-19T04:02:13.853Z" level=info msg="secured root for pid 62 root: runc:[2:INIT] (\"/proc/62/root\")"
time="2021-08-19T04:02:13.904Z" level=info msg="secured root for pid 62 root: runc:[2:INIT] (\"/proc/62/root\")"
time="2021-08-19T04:02:13.954Z" level=warning msg="failed to secure root file handle for 62" error="open /proc/62/root: no such file or directory"
time="2021-08-19T04:02:16.300Z" level=info msg="secured root for pid 70 root: runc:[2:INIT] (\"/proc/70/root\")"
time="2021-08-19T04:02:16.300Z" level=info msg="mapped container name \"pid/70\" to pid 70"
time="2021-08-19T04:02:16.350Z" level=info msg="secured root for pid 70 root: runc:[2:INIT] (\"/proc/70/root\")"
time="2021-08-19T04:02:16.401Z" level=info msg="secured root for pid 70 root: runc:[2:INIT] (\"/proc/70/root\")"
time="2021-08-19T04:02:16.451Z" level=info msg="secured root for pid 70 root: runc:[2:INIT] (\"/proc/70/root\")"
time="2021-08-19T04:02:16.502Z" level=info msg="secured root for pid 70 root: pilot-agent (\"/proc/70/root\")"
time="2021-08-19T04:02:16.553Z" level=info msg="secured root for pid 70 root: pilot-agent (\"/proc/70/root\")"
...
time="2021-08-19T04:02:39.642Z" level=info msg="secured root for pid 70 root: pilot-agent (\"/proc/70/root\")"
fatal error: concurrent map writes

goroutine 69 [running]:
runtime.throw(0x21aef3e, 0x15)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc000e17d68 sp=0xc000e17d38 pc=0x4362f2
runtime.mapassign_fast64(0x1ec7ae0, 0xc000485500, 0x46, 0xc00047dd00)
	/usr/local/go/src/runtime/map_fast64.go:101 +0x33e fp=0xc000e17da8 sp=0xc000e17d68 pc=0x412c5e
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).secureRootFiles.func1(0xc000e17f20, 0xc00061b020, 0x0, 0x0)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:327 +0x448 fp=0xc000e17ec8 sp=0xc000e17da8 pc=0x1cf9f88
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).secureRootFiles(0xc00061b020, 0xc000e42060, 0x0)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:342 +0x99 fp=0xc000e17f50 sp=0xc000e17ec8 pc=0x1cf96f9
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).pollRootProcesses(0xc00061b020, 0x24e8fc0, 0xc000d67020, 0xc000623570, 0x1, 0x1)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:176 +0xc5 fp=0xc000e17fb0 sp=0xc000e17f50 pc=0x1cf8005
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc000e17fb8 sp=0xc000e17fb0 pc=0x46bd21
created by github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).Wait
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:133 +0x7e

goroutine 1 [sleep]:
time.Sleep(0x3b9aca00)
	/usr/local/go/src/runtime/time.go:188 +0xbf
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).Wait(0xc00061b020, 0x24e8f80, 0xc0001aa010, 0xc000623570, 0x1, 0x1, 0x44090a, 0xc00005c000)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:157 +0x15b
github.com/argoproj/argo-workflows/v3/workflow/executor.(*WorkflowExecutor).Wait.func1(0xc000682d80, 0x300000002, 0xc000682d80)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:923 +0x66
github.com/argoproj/argo-workflows/v3/util/wait.Backoff.func1(0xc000ebfa00, 0x468c5f, 0x22909a0)
	/go/src/github.com/argoproj/argo-workflows/util/wait/backoff.go:15 +0x2f
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0xc000ebfa90, 0xcb4a3000, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:211 +0x69
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff(0xf4240000, 0x3ff999999999999a, 0x3fe0000000000000, 0x2, 0x0, 0xc000ebfa90, 0xc0001aa010, 0xc00061b0e0)
	/go/pkg/mod/k8s.io/apimachinery@v0.19.6/pkg/util/wait/wait.go:399 +0x55
github.com/argoproj/argo-workflows/v3/util/wait.Backoff(0x3b9aca00, 0x3ff999999999999a, 0x3fe0000000000000, 0x5, 0x0, 0xc000927b48, 0x1, 0x1)
	/go/src/github.com/argoproj/argo-workflows/util/wait/backoff.go:13 +0x9d
github.com/argoproj/argo-workflows/v3/workflow/executor.(*WorkflowExecutor).Wait(0xc0002be2c0, 0x24e8f80, 0xc0001aa010, 0xc000927c70, 0xa49e66)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:922 +0x1a9
github.com/argoproj/argo-workflows/v3/cmd/argoexec/commands.waitContainer(0x24e8f80, 0xc0001aa010, 0x0, 0x0)
	/go/src/github.com/argoproj/argo-workflows/cmd/argoexec/commands/wait.go:42 +0x132
github.com/argoproj/argo-workflows/v3/cmd/argoexec/commands.NewWaitCommand.func1(0xc0001e7340, 0xc0004e39a0, 0x0, 0x2)
	/go/src/github.com/argoproj/argo-workflows/cmd/argoexec/commands/wait.go:18 +0x3d
github.com/spf13/cobra.(*Command).execute(0xc0001e7340, 0xc0004e3980, 0x2, 0x2, 0xc0001e7340, 0xc0004e3980)
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001e6580, 0x228d1e8, 0xc0001af1a8, 0xc000927f48)
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
	/go/src/github.com/argoproj/argo-workflows/cmd/argoexec/main.go:15 +0x2b

goroutine 18 [chan receive]:
k8s.io/klog/v2.(*loggingT).flushDaemon(0x328d560)
	/go/pkg/mod/k8s.io/klog/v2@v2.5.0/klog.go:1169 +0x8b
created by k8s.io/klog/v2.init.0
	/go/pkg/mod/k8s.io/klog/v2@v2.5.0/klog.go:417 +0xdf

goroutine 98 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc00012ec30)
	/go/pkg/mod/go.opencensus.io@v0.22.3/stats/view/worker.go:154 +0x105
created by go.opencensus.io/stats/view.init.0
	/go/pkg/mod/go.opencensus.io@v0.22.3/stats/view/worker.go:32 +0x57

goroutine 68 [runnable]:
github.com/sirupsen/logrus.(*TextFormatter).Format(0xc000280de0, 0xc000216310, 0x477725, 0x1, 0x0, 0x468edb, 0xc000b11b70)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/text_formatter.go:132 +0xf5
github.com/sirupsen/logrus.(*Entry).write(0xc000216310)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:275 +0x7f
github.com/sirupsen/logrus.Entry.log(0xc000256fc0, 0xc000558690, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:251 +0x1c9
github.com/sirupsen/logrus.(*Entry).Log(0xc0004fe150, 0x4, 0xc000b11d38, 0x1, 0x1)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:287 +0xf0
github.com/sirupsen/logrus.(*Entry).Logf(0xc0004fe150, 0xc000000004, 0x21d35df, 0x25, 0xc000b11e78, 0x3, 0x3)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:333 +0xe5
github.com/sirupsen/logrus.(*Logger).Logf(0xc000256fc0, 0x4, 0x21d35df, 0x25, 0xc000b11e78, 0x3, 0x3)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:146 +0x95
github.com/sirupsen/logrus.(*Logger).Infof(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:160
github.com/sirupsen/logrus.Infof(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/exported.go:154
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).secureRootFiles.func1(0xc000b11f20, 0xc00061b020, 0x0, 0x0)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:328 +0x5c5
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).secureRootFiles(0xc00061b020, 0xc000e420c0, 0x0)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:342 +0x99
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).pollRootProcesses(0xc00061b020, 0x24e8fc0, 0xc00061bd40, 0xc000623570, 0x1, 0x1)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:176 +0xc5
created by github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).Wait
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:133 +0x7e

goroutine 129 [chan receive]:
github.com/argoproj/pkg/stats.StartStatsTicker.func1(0xc000516f00)
	/go/pkg/mod/github.com/argoproj/pkg@v0.10.1/stats/stats_linux.go:19 +0x37
created by github.com/argoproj/pkg/stats.StartStatsTicker
	/go/pkg/mod/github.com/argoproj/pkg@v0.10.1/stats/stats_linux.go:17 +0x4d

goroutine 131 [syscall]:
os/signal.signal_recv(0x0)
	/usr/local/go/src/runtime/sigqueue.go:147 +0x9d
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:23 +0x25
created by os/signal.Notify.func1.1
	/usr/local/go/src/os/signal/signal.go:150 +0x45

goroutine 132 [sleep]:
time.Sleep(0x2540be400)
	/usr/local/go/src/runtime/time.go:188 +0xbf
github.com/argoproj/argo-workflows/v3/workflow/executor.watchFileChanges.func1(0xc000195080, 0x24e8f80, 0xc0001aa010, 0x21be8b4, 0x1d, 0x2540be400)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:958 +0x7d
created by github.com/argoproj/argo-workflows/v3/workflow/executor.watchFileChanges
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:935 +0x8e

goroutine 133 [select]:
github.com/argoproj/argo-workflows/v3/workflow/executor.(*WorkflowExecutor).monitorAnnotations.func1(0x24e8f80, 0xc0001aa010, 0xc00061b0e0, 0xc000194c60, 0xc0002be2c0, 0xc000195080)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:986 +0xef
created by github.com/argoproj/argo-workflows/v3/workflow/executor.(*WorkflowExecutor).monitorAnnotations
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:984 +0x21b

goroutine 134 [sleep]:
time.Sleep(0x3b9aca00)
	/usr/local/go/src/runtime/time.go:188 +0xbf
github.com/argoproj/argo-workflows/v3/workflow/executor.(*WorkflowExecutor).monitorDeadline(0xc0002be2c0, 0x24e8f80, 0xc0001aa010, 0xc000623570, 0x1, 0x1, 0xc000194c60)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:1072 +0x17b
created by github.com/argoproj/argo-workflows/v3/workflow/executor.(*WorkflowExecutor).Wait
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/executor.go:921 +0xf6

goroutine 135 [sleep]:
time.Sleep(0x2faf080)
	/usr/local/go/src/runtime/time.go:188 +0xbf
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).pollRootProcesses(0xc00061b020, 0x24e8fc0, 0xc00061b260, 0xc000623570, 0x1, 0x1)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:182 +0x8b
created by github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).Wait
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:133 +0x7e

goroutine 101 [IO wait]:
internal/poll.runtime_pollWait(0x7f187160ccc8, 0x72, 0x249ac40)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc00062a698, 0x72, 0x249ac00, 0x31d5730, 0x0)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00062a680, 0xc000320e00, 0x6fd, 0x6fd, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:159 +0x1a5
net.(*netFD).Read(0xc00062a680, 0xc000320e00, 0x6fd, 0x6fd, 0x203000, 0x65147b, 0xc000d9dd60)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc00061e660, 0xc000320e00, 0x6fd, 0x6fd, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:182 +0x8e
crypto/tls.(*atLeastReader).Read(0xc0004e31e0, 0xc000320e00, 0x6fd, 0x6fd, 0x212, 0x6f8, 0xc000903668)
	/usr/local/go/src/crypto/tls/conn.go:779 +0x62
bytes.(*Buffer).ReadFrom(0xc000d9de80, 0x2494dc0, 0xc0004e31e0, 0x40b4a5, 0x1f06be0, 0x21107a0)
	/usr/local/go/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc000d9dc00, 0x2498c40, 0xc00061e660, 0x5, 0xc00061e660, 0x201)
	/usr/local/go/src/crypto/tls/conn.go:801 +0xf3
crypto/tls.(*Conn).readRecordOrCCS(0xc000d9dc00, 0x0, 0x0, 0x0)
	/usr/local/go/src/crypto/tls/conn.go:608 +0x115
crypto/tls.(*Conn).readRecord(...)
	/usr/local/go/src/crypto/tls/conn.go:576
crypto/tls.(*Conn).Read(0xc000d9dc00, 0xc0008b2000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/crypto/tls/conn.go:1252 +0x15f
net/http.(*persistConn).Read(0xc000552360, 0xc0008b2000, 0x1000, 0x1000, 0xc000e42000, 0xc000903c58, 0x405835)
	/usr/local/go/src/net/http/transport.go:1887 +0x77
bufio.(*Reader).fill(0xc000463020)
	/usr/local/go/src/bufio/bufio.go:101 +0x105
bufio.(*Reader).Peek(0xc000463020, 0x1, 0x0, 0x0, 0x1, 0x0, 0xc0001945a0)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc000552360)
	/usr/local/go/src/net/http/transport.go:2040 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1708 +0xcb7

goroutine 102 [select]:
net/http.(*persistConn).writeLoop(0xc000552360)
	/usr/local/go/src/net/http/transport.go:2340 +0x11c
created by net/http.(*Transport).dialConn
	/usr/local/go/src/net/http/transport.go:1709 +0xcdc

goroutine 161 [semacquire]:
sync.runtime_SemacquireMutex(0xc000256ff4, 0x611dd700, 0x1)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc000256ff0)
	/usr/local/go/src/sync/mutex.go:138 +0x105
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:81
github.com/sirupsen/logrus.(*MutexWrap).Lock(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:53
github.com/sirupsen/logrus.Entry.log(0xc000256fc0, 0xc00036f770, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:238 +0x296
github.com/sirupsen/logrus.(*Entry).Log(0xc000324070, 0x4, 0xc000a93d38, 0x1, 0x1)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:287 +0xf0
github.com/sirupsen/logrus.(*Entry).Logf(0xc000324070, 0xc000000004, 0x21d35df, 0x25, 0xc000a93e78, 0x3, 0x3)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/entry.go:333 +0xe5
github.com/sirupsen/logrus.(*Logger).Logf(0xc000256fc0, 0x4, 0x21d35df, 0x25, 0xc000a93e78, 0x3, 0x3)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:146 +0x95
github.com/sirupsen/logrus.(*Logger).Infof(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/logger.go:160
github.com/sirupsen/logrus.Infof(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.6.0/exported.go:154
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).secureRootFiles.func1(0xc000a93f20, 0xc00061b020, 0x0, 0x0)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:328 +0x5c5
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).secureRootFiles(0xc00061b020, 0xc0001941e0, 0x0)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:342 +0x99
github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).pollRootProcesses(0xc00061b020, 0x24e8fc0, 0xc0004625a0, 0xc000623570, 0x1, 0x1)
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:176 +0xc5
created by github.com/argoproj/argo-workflows/v3/workflow/executor/pns.(*PNSExecutor).Wait
	/go/src/github.com/argoproj/argo-workflows/workflow/executor/pns/pns.go:133 +0x7e
```