### PR TITLE
fix(gcs): backoff bool should be false if error is transient

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -105,13 +105,13 @@ func (g *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) error {
 			gcsClient, err := g.newGCSClient()
 			if err != nil {
 				log.Warnf("Failed to create new GCS client: %v", err)
-				return isTransientGCSErr(err), err
+				return !isTransientGCSErr(err), err
 			}
 			defer gcsClient.Close()
 			err = downloadObjects(gcsClient, inputArtifact.GCS.Bucket, inputArtifact.GCS.Key, path)
 			if err != nil {
 				log.Warnf("Failed to download objects from GCS: %v", err)
-				return isTransientGCSErr(err), err
+				return !isTransientGCSErr(err), err
 			}
 			return true, nil
 		})
@@ -207,12 +207,12 @@ func (g *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact) error 
 			log.Infof("GCS Save path: %s, key: %s", path, outputArtifact.GCS.Key)
 			client, err := g.newGCSClient()
 			if err != nil {
-				return isTransientGCSErr(err), err
+				return !isTransientGCSErr(err), err
 			}
 			defer client.Close()
 			err = uploadObjects(client, outputArtifact.GCS.Bucket, outputArtifact.GCS.Key, path)
 			if err != nil {
-				return isTransientGCSErr(err), err
+				return !isTransientGCSErr(err), err
 			}
 			return true, nil
 		})
@@ -309,12 +309,12 @@ func (g *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, error) 
 			client, err := g.newGCSClient()
 			if err != nil {
 				log.Warnf("Failed to create new GCS client: %v", err)
-				return isTransientGCSErr(err), err
+				return !isTransientGCSErr(err), err
 			}
 			defer client.Close()
 			files, err = listByPrefix(client, artifact.GCS.Bucket, artifact.GCS.Key, "")
 			if err != nil {
-				return isTransientGCSErr(err), err
+				return !isTransientGCSErr(err), err
 			}
 			return true, nil
 		})

--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"testing"
 
+	argoErrors "github.com/argoproj/argo-workflows/v3/errors"
 	"google.golang.org/api/googleapi"
 )
 
@@ -21,6 +22,7 @@ func TestIsTransientGCSErr(t *testing.T) {
 		shouldretry bool
 	}{
 		{&googleapi.Error{Code: 0}, false},
+		{argoErrors.New(argoErrors.CodeNotFound, "no results for key: foo/bar"), false},
 		{&googleapi.Error{Code: 429}, true},
 		{&googleapi.Error{Code: 518}, true},
 		{&googleapi.Error{Code: 599}, true},

--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -7,8 +7,9 @@ import (
 	"net/url"
 	"testing"
 
-	argoErrors "github.com/argoproj/argo-workflows/v3/errors"
 	"google.golang.org/api/googleapi"
+
+	argoErrors "github.com/argoproj/argo-workflows/v3/errors"
 )
 
 type tlsHandshakeTimeoutError struct{}


### PR DESCRIPTION
Fixes #6576

I'm not really sure how to write proper `e2e` or `unit` tests for this fix as it involves stubbing the GCS API... I am deploying this fix to our staging cluster and testing it just now. I'll comment here with the tests carried out and the outcomes.