### PR TITLE
fix(executor): Disambiguate PNS executor initialization log

### DIFF
--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -107,6 +107,7 @@ func initExecutor() *executor.WorkflowExecutor {
 	checkErr(err)
 
 	var cre executor.ContainerRuntimeExecutor
+	log.Infof("Creating a %s executor", executorType)
 	switch executorType {
 	case common.ContainerRuntimeExecutorK8sAPI:
 		cre = k8sapi.NewK8sAPIExecutor(clientset, config, podName, namespace)

--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -41,7 +41,6 @@ type ctr struct {
 }
 
 func NewDockerExecutor(namespace, podName string) (*DockerExecutor, error) {
-	log.Infof("Creating a docker executor")
 	return &DockerExecutor{namespace, podName, make(map[string]ctr)}, nil
 }
 

--- a/workflow/executor/k8sapi/k8sapi.go
+++ b/workflow/executor/k8sapi/k8sapi.go
@@ -19,7 +19,6 @@ type K8sAPIExecutor struct {
 }
 
 func NewK8sAPIExecutor(clientset kubernetes.Interface, config *restclient.Config, podName, namespace string) *K8sAPIExecutor {
-	log.Infof("Creating a K8sAPI executor")
 	client := newK8sAPIClient(clientset, config, podName, namespace)
 	return &K8sAPIExecutor{
 		client: client,

--- a/workflow/executor/kubelet/kubelet.go
+++ b/workflow/executor/kubelet/kubelet.go
@@ -15,7 +15,6 @@ type KubeletExecutor struct {
 }
 
 func NewKubeletExecutor(namespace, podName string) (*KubeletExecutor, error) {
-	log.Infof("Creating a kubelet executor")
 	cli, err := newKubeletClient(namespace, podName)
 	if err != nil {
 		return nil, errors.InternalWrapError(err)

--- a/workflow/executor/pns/pns.go
+++ b/workflow/executor/pns/pns.go
@@ -50,7 +50,7 @@ type PNSExecutor struct {
 
 func NewPNSExecutor(clientset *kubernetes.Clientset, podName, namespace string) (*PNSExecutor, error) {
 	thisPID := os.Getpid()
-	log.Infof("Creating PNS executor (namespace: %s, pod: %s, pid: %d)", namespace, podName, thisPID)
+	log.Infof("Initialized PNS executor (namespace: %s, pod: %s, pid: %d)", namespace, podName, thisPID)
 	if thisPID == 1 {
 		return nil, errors.New(errors.CodeBadRequest, "process namespace sharing is not enabled on pod")
 	}


### PR DESCRIPTION
When using the PNS executor, we are currently observing the following log:

```
time="2021-08-21T02:08:59.598Z" level=info msg="Creating PNS executor (namespace: argo, pod: memoized-simple-workflow-with-cache-gc-wfnjj, pid: 7)"
time="2021-08-21T02:08:59.598Z" level=info msg="Creating a K8sAPI executor"
```

This is confusing and caused by `NewPNSExecutor` that uses `NewK8sAPIExecutor` as a delegate with "k8sapi" in the log. This PR disambiguates this and moves the log to the root.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
