### PR TITLE
fix: Fix unit test with missing createRunningPods()

### DIFF
--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -281,9 +281,7 @@ func withAnnotation(key, val string) with {
 
 // createRunningPods creates the pods that are marked as running in a given test so that they can be accessed by the
 // pod assessor
-// This function is called `createRunningPods`, but since it is currently not used and should not be removed it has been
-// renamed to `_` until a use is found.
-func _(ctx context.Context, woc *wfOperationCtx) {
+func createRunningPods(ctx context.Context, woc *wfOperationCtx) {
 	podcs := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace())
 	for _, node := range woc.wf.Status.Nodes {
 		if node.Type == wfv1.NodeTypePod && node.Phase == wfv1.NodeRunning {


### PR DESCRIPTION
This has been removed in https://github.com/argoproj/argo-workflows/pull/6297 but it's actually being used in unit tests: 

```
workflow/controller/operator_test.go:3483:4: undefined: createRunningPods
workflow/controller/operator_test.go:3525:2: undefined: createRunningPods

```
See failed build on master branch: https://github.com/argoproj/argo-workflows/runs/3392422636

This PR adds it back and moves it closer to where it's being used.

cc @simster7 


Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
