### PR TITLE
fix!: Enable authentication by default on Argo Server `/metrics` endpoint. Fixes #6592

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"time"
+
+	"google.golang.org/grpc/metadata"
 
 	"github.com/gorilla/handlers"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -323,7 +326,19 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 	mux.HandleFunc("/input-artifacts-by-uid/", artifactServer.GetInputArtifactByUID)
 	mux.Handle("/oauth2/redirect", handlers.ProxyHeaders(http.HandlerFunc(as.oAuth2Service.HandleRedirect)))
 	mux.Handle("/oauth2/callback", handlers.ProxyHeaders(http.HandlerFunc(as.oAuth2Service.HandleCallback)))
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		if os.Getenv("ARGO_SERVER_METRICS_AUTH") != "false" {
+			header := metadata.New(map[string]string{"authorization": r.Header.Get("Authorization")})
+			ctx := metadata.NewIncomingContext(context.Background(), header)
+			if _, err := as.gatekeeper.Context(ctx); err != nil {
+				log.WithError(err).Error("failed to authenticate /metrics endpoint")
+				w.WriteHeader(403)
+				return
+			}
+		}
+		promhttp.Handler().ServeHTTP(w, r)
+
+	})
 	// we only enable HTST if we are secure mode, otherwise you would never be able access the UI
 	mux.HandleFunc("/", static.NewFilesServer(as.baseHRef, as.tlsConfig != nil && as.hsts, as.xframeOptions, as.accessControlAllowOrigin).ServerFiles)
 	return &httpServer

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -154,9 +154,6 @@ func (s gatekeeper) getClients(ctx context.Context) (*servertypes.Clients, *type
 	md, _ := metadata.FromIncomingContext(ctx)
 	authorization := getAuthHeader(md)
 	mode, valid := s.Modes.GetMode(authorization)
-	println("md", md)
-	println("authorization", authorization)
-	println("mode", mode)
 	if !valid {
 		return nil, nil, status.Error(codes.Unauthenticated, "token not valid for running mode")
 	}

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -154,6 +154,9 @@ func (s gatekeeper) getClients(ctx context.Context) (*servertypes.Clients, *type
 	md, _ := metadata.FromIncomingContext(ctx)
 	authorization := getAuthHeader(md)
 	mode, valid := s.Modes.GetMode(authorization)
+	println("md", md)
+	println("authorization", authorization)
+	println("mode", mode)
 	if !valid {
 		return nil, nil, status.Error(codes.Unauthenticated, "token not valid for running mode")
 	}

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -95,9 +95,17 @@ func (s *ArgoServerSuite) TestVersion() {
 	})
 }
 
-func (s *ArgoServerSuite) TestMetrics() {
-	s.Need(fixtures.CI)
-	s.e().GET("/metrics").
+func (s *ArgoServerSuite) TestMetricsForbidden() {
+	s.bearerToken = ""
+	s.e().
+		GET("/metrics").
+		Expect().
+		Status(403)
+}
+
+func (s *ArgoServerSuite) TestMetricsOK() {
+	s.e().
+		GET("/metrics").
 		Expect().
 		Status(200).
 		Body().


### PR DESCRIPTION
 Fixes #6592

Signed-off-by: Alex Collins <alex_collins@intuit.com>