### PR TITLE
docs: Fix template-defaults duplicated in docs and add missing whitespace in h1

### DIFF
--- a/docs/template-defaults.md
+++ b/docs/template-defaults.md
@@ -1,4 +1,4 @@
-#Template Defaults
+# Template Defaults
 > v3.1 and after
 
 ## Introduction

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,7 +136,6 @@ nav:
           - workflow-executors.md
           - sidecar-injection.md
           - default-workflow-specs.md
-          - template-defaults.md
           - offloading-large-workflows.md
           - workflow-archive.md
           - metrics.md


### PR DESCRIPTION
### Problem:
Under `User Guide/Intermediate` is the page `docs/template-defaults.md` linked but is shown as `None`

<img width="347" alt="Bildschirmfoto 2021-08-25 um 17 15 47" src="https://user-images.githubusercontent.com/24293821/130817573-7a29a35a-91e8-4c65-8c35-b8de197c2b4e.png">

It seems the page is also referenced twice in `mkdocs` :
- https://github.com/argoproj/argo-workflows/blob/master/mkdocs.yml#L45
- https://github.com/argoproj/argo-workflows/blob/master/mkdocs.yml#L139

### Fixes:
- add missing whitespace in https://github.com/argoproj/argo-workflows/blob/master/docs/template-defaults.md#L1
- remove `template-defaults.md` from Configuration (https://github.com/argoproj/argo-workflows/blob/master/mkdocs.yml#L139)

### Test:

Executed mkdocs locally and checked the result: 
<img width="1092" alt="Bildschirmfoto 2021-08-25 um 17 47 23" src="https://user-images.githubusercontent.com/24293821/130822689-9457a654-8a6f-4205-99ad-596fcc53e37e.png">
