### PR TITLE
docs: fix continue on failure dag example

### DIFF
--- a/examples/dag-continue-on-fail.yaml
+++ b/examples/dag-continue-on-fail.yaml
@@ -13,13 +13,11 @@ spec:
       - name: B
         depends: "A"
         template: intentional-fail
-        continueOn:
-          failed: true
       - name: C
         depends: "A"
         template: whalesay
       - name: D
-        depends: "B && C"
+        depends: "B.Failed && C"
         template: whalesay
       - name: E
         depends: "A"


### PR DESCRIPTION
Fixed continue on example in the dag template, as `continueOn` and `depends` are not compatible together as documented [here](https://argoproj.github.io/argo-workflows/enhanced-depends-logic/)