### PR TITLE
build: Add containerized make commands. Resolves #6519

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,7 @@ assets
 community
 coverage.out
 dist
-docs
 examples
-manifests
 sdks
 test/e2e
 ui/dist

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ git-ask-pass.sh
 /.brew_home
 /go-diagrams/
 /.run/
+.docker-sync

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,8 @@ scan-%:
 codegen: types swagger docs manifests
 
 .PHONY: codegen-container
-codegen-container: ./hack/makecmd codegen
+codegen-container:
+	./hack/makecmd.sh codegen
 
 .PHONY: types
 types: pkg/apis/workflow/v1alpha1/generated.proto pkg/apis/workflow/v1alpha1/openapi_generated.go pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,9 @@ scan-%:
 .PHONY: codegen
 codegen: types swagger docs manifests
 
+.PHONY: codegen-container
+codegen-container: ./hack/makecmd codegen
+
 .PHONY: types
 types: pkg/apis/workflow/v1alpha1/generated.proto pkg/apis/workflow/v1alpha1/openapi_generated.go pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go
 

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,7 @@
+version: "2"
+syncs:
+  tooling-sync:
+    src: ./
+
+options:
+  compose-file-path: ./hack/docker-compose.tooling.yaml

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -1,6 +1,6 @@
 FROM golang:1.16-alpine
 
-RUN apk add make
+RUN apk add make bash git
 
 WORKDIR /go/src/github.com/argoproj/argo-workflows
 COPY go.mod .

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -1,6 +1,6 @@
 FROM golang:1.16-alpine
 
-RUN apk add make bash git protoc
+RUN apk add make bash git protoc protobuf-dev perl
 
 WORKDIR /go/src/github.com/argoproj/argo-workflows
 COPY go.mod .
@@ -17,3 +17,4 @@ RUN go install -mod=vendor ./vendor/github.com/gogo/protobuf/protoc-gen-gogofast
 RUN go install -mod=vendor ./vendor/golang.org/x/tools/cmd/goimports
 RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+RUN go install -mod=vendor ./vendor/k8s.io/kube-openapi/cmd/openapi-gen

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -8,3 +8,12 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
+
+RUN go mod vendor
+
+RUN go install -mod=vendor ./vendor/k8s.io/code-generator/cmd/go-to-protobuf
+RUN go install -mod=vendor ./vendor/github.com/gogo/protobuf/protoc-gen-gogo
+RUN go install -mod=vendor ./vendor/github.com/gogo/protobuf/protoc-gen-gogofast
+RUN go install -mod=vendor ./vendor/golang.org/x/tools/cmd/goimports
+RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -2,11 +2,14 @@ FROM golang:1.16-alpine
 
 # upgrade grep fixes alpine busybox error
 RUN apk add make bash git protoc protobuf-dev perl curl \
+  gcc musl-dev git mercurial \
     && apk add --no-cache --upgrade grep
 
 # install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 RUN chmod u+x kubectl && mv kubectl /bin/kubectl
+
+ENV CGO_ENABLED=0
 
 # cache mod dependencies
 WORKDIR /go/src/github.com/argoproj/argo-workflows
@@ -27,3 +30,4 @@ RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/proto
 RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 RUN go install -mod=vendor ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
 RUN go install -mod=vendor ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -1,6 +1,8 @@
 FROM golang:1.16-alpine
 
-RUN apk add make bash git protoc protobuf-dev perl curl
+# upgrade grep fixes alpine busybox error
+RUN apk add make bash git protoc protobuf-dev perl curl \
+    && apk add --no-cache --upgrade grep
 
 # install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -1,6 +1,6 @@
 FROM golang:1.16-alpine
 
-RUN apk add make bash git
+RUN apk add make bash git protoc
 
 WORKDIR /go/src/github.com/argoproj/argo-workflows
 COPY go.mod .

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -1,0 +1,10 @@
+FROM golang:1.16-alpine
+
+RUN apk add make
+
+WORKDIR /go/src/github.com/argoproj/argo-workflows
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .

--- a/hack/Dockerfile-tools
+++ b/hack/Dockerfile-tools
@@ -1,7 +1,12 @@
 FROM golang:1.16-alpine
 
-RUN apk add make bash git protoc protobuf-dev perl
+RUN apk add make bash git protoc protobuf-dev perl curl
 
+# install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN chmod u+x kubectl && mv kubectl /bin/kubectl
+
+# cache mod dependencies
 WORKDIR /go/src/github.com/argoproj/argo-workflows
 COPY go.mod .
 COPY go.sum .
@@ -11,6 +16,7 @@ COPY . .
 
 RUN go mod vendor
 
+# install go binaries in dockerfile - faster than at runtime
 RUN go install -mod=vendor ./vendor/k8s.io/code-generator/cmd/go-to-protobuf
 RUN go install -mod=vendor ./vendor/github.com/gogo/protobuf/protoc-gen-gogo
 RUN go install -mod=vendor ./vendor/github.com/gogo/protobuf/protoc-gen-gogofast
@@ -18,3 +24,4 @@ RUN go install -mod=vendor ./vendor/golang.org/x/tools/cmd/goimports
 RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 RUN go install -mod=vendor ./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 RUN go install -mod=vendor ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
+RUN go install -mod=vendor ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/hack/docker-compose.tooling.yaml
+++ b/hack/docker-compose.tooling.yaml
@@ -1,0 +1,5 @@
+version: '3'
+services:
+  tooling:
+    image: argo-wf-tools
+    command: make codegen

--- a/hack/makecmd.sh
+++ b/hack/makecmd.sh
@@ -26,7 +26,7 @@ do
     tools-image)
       build_tools_image
     ;;
-    run-cmd)
+    codegen)
       build_tools_image
       run_mounted_command make codegen
       prune_docker_containers

--- a/hack/makecmd.sh
+++ b/hack/makecmd.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+build_tools_image() {
+  docker build -t argo-wf-tools -f ./hack/Dockerfile-tools .
+}
+
+run_mounted_command() {
+  docker run \
+    -it \
+    --mount type=bind,source="$(pwd)",target=/go/src/github.com/argoproj/argo-workflows \
+    argo-wf-tools \
+    "$@"
+}
+
+prune_docker_images() {
+  docker image prune -f
+}
+
+prune_docker_containers() {
+  docker container prune -f
+}
+
+for arg in "$@"
+do
+  case $arg in
+    tools-image)
+      build_tools_image
+    ;;
+    run-cmd)
+      build_tools_image
+      run_mounted_command make codegen
+      prune_docker_containers
+      prune_docker_images
+    ;;
+    prune)
+      prune_docker_containers
+      prune_docker_images
+    ;;
+  esac
+done

--- a/hack/makecmd.sh
+++ b/hack/makecmd.sh
@@ -20,6 +20,10 @@ prune_docker_containers() {
   docker container prune -f
 }
 
+ensure_vendor() {
+  go mod vendor
+}
+
 for arg in "$@"
 do
   case $arg in
@@ -27,6 +31,7 @@ do
       build_tools_image
     ;;
     codegen)
+      ensure_vendor
       build_tools_image
       run_mounted_command make codegen
       prune_docker_containers

--- a/hack/makecmd.sh
+++ b/hack/makecmd.sh
@@ -28,12 +28,20 @@ for arg in "$@"
 do
   case $arg in
     tools-image)
+      ensure_vendor
       build_tools_image
     ;;
     codegen)
       ensure_vendor
       build_tools_image
       run_mounted_command make codegen
+      prune_docker_containers
+      prune_docker_images
+    ;;
+    lint)
+      ensure_vendor
+      build_tools_image
+      run_mounted_command make lint
       prune_docker_containers
       prune_docker_images
     ;;

--- a/hack/makecmd.sh
+++ b/hack/makecmd.sh
@@ -4,12 +4,16 @@ build_tools_image() {
   docker build -t argo-wf-tools -f ./hack/Dockerfile-tools .
 }
 
-run_mounted_command() {
-  docker run \
-    -it \
-    --mount type=bind,source="$(pwd)",target=/go/src/github.com/argoproj/argo-workflows \
-    argo-wf-tools \
-    "$@"
+start_sync() {
+  docker-sync start
+}
+
+start_sync_stack() {
+  docker-sync-stack start
+}
+
+stop_sync() {
+  docker-sync stop
 }
 
 prune_docker_images() {
@@ -34,14 +38,9 @@ do
     codegen)
       ensure_vendor
       build_tools_image
-      run_mounted_command make codegen
-      prune_docker_containers
-      prune_docker_images
-    ;;
-    lint)
-      ensure_vendor
-      build_tools_image
-      run_mounted_command make lint
+      start_sync
+      start_sync_stack
+      stop_sync
       prune_docker_containers
       prune_docker_images
     ;;


### PR DESCRIPTION
This PR:
- Adds containerized versions of make commands that are commonly run while developing


It works by spinning up a container that holds tooling dependencies and volume mounting it on the user's filesystem.
The goal is to allow for development without having to spend as much time configuring your host machine.
