### PR TITLE
Build Docker manifest only when all dependencies are ready

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,55 +190,11 @@ jobs:
             docker push quay.io/$image_name
           done
 
-  push-linux-amd64-images:
-    name: Push manifest with linux/amd64
-    if: github.repository == 'argoproj/argo-workflows'
-    runs-on: ubuntu-20.04
-    needs: [ build-linux-amd64 ]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Docker Login
-        uses: Azure/docker-login@v1
-        with:
-          username: ${{ secrets.DOCKERIO_USERNAME }}
-          password: ${{ secrets.DOCKERIO_PASSWORD }}
-
-      - name: Login to Quay
-        uses: Azure/docker-login@v1
-        with:
-          login-server: quay.io
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_PASSWORD }}
-
-      - name: Push Multiarch Image
-        env:
-          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
-        run: |
-          echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
-
-          docker_org=$DOCKERIO_ORG
-
-          tag=$(basename $GITHUB_REF)
-          if [ $tag = "master" ]; then
-            tag="latest"
-          fi
-
-          targets="workflow-controller argoexec argocli"
-          for target in $targets; do
-            image_name="${docker_org}/${target}:${tag}"
-
-            docker manifest create $image_name ${image_name}-linux-amd64
-            docker manifest create quay.io/$image_name quay.io/${image_name}-linux-amd64
-
-            docker manifest push $image_name
-            docker manifest push quay.io/$image_name
-          done
-
   push-images:
     name: Push manifest with all images
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-20.04
-    needs: [ build-linux-arm64, build-windows, push-linux-amd64-images ]
+    needs: [ build-linux-amd64, build-linux-arm64, build-windows ]
     steps:
       - uses: actions/checkout@v2
       - name: Docker Login
@@ -282,6 +238,7 @@ jobs:
             docker manifest push $image_name
             docker manifest push quay.io/$image_name
           done
+
   test-images-linux-amd64:
     name: Try pulling linux/amd64
     if: github.repository == 'argoproj/argo-workflows'


### PR DESCRIPTION
Fixes #6541. The `push-linux-amd64-images` step is the same as the `push-images` step but only used the `linux/amd64` platform.