### PR TITLE
fix: `argo node set` panic: index out of range and correct docs

### DIFF
--- a/cmd/argo/commands/node.go
+++ b/cmd/argo/commands/node.go
@@ -38,7 +38,7 @@ func NewNodeCommand() *cobra.Command {
   argo node set my-wf --message "We did it!"" --node-field-selector displayName=approve
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) < 1 {
+			if len(args) < 2 {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}

--- a/examples/suspend-template-outputs.yaml
+++ b/examples/suspend-template-outputs.yaml
@@ -1,16 +1,15 @@
 # This example uses a suspend template that expects outputs to be provided to it. These outputs may be provided by the CLI
-# with the 'argo set' command, the API with the '/set' endpoint, or directly via K8s.
+# with the 'argo node set' command, the API with the '/set' endpoint, or directly via K8s.
 #
 # Example:
-#   argo set outputs my-wf '{"message": "Hello, world!"}' --node-field-selector displayName=approve
-#   argo set message my-wf 'Test message' --node-field-selector displayName=approve
-#   argo resume my-wf
+#   argo node set suspend-outputs -p message="Hello, world!" --node-field-selector displayName=approve
+#   argo node set suspend-outputs --message="Test message" --node-field-selector displayName=approve
+#   argo resume suspend-outputs
 
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  name: simon
-  #generateName: suspend-template-
+  generateName: suspend-outputs
 spec:
   entrypoint: suspend
   templates:


### PR DESCRIPTION
Example is incorrect and also fixes a panic when not enough arguments were supplied.

Signed-off-by: Jesse Suen <jessesuen@gmail.com>

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
