### PR TITLE
feat: Provide context to NewAPIClient

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -32,6 +32,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Botkeeper](https://www.botkeeper.com/)
 1. [ByteDance](https://www.bytedance.com/en/)
 1. [Canva](https://www.canva.com/)
+1. [Capact](https://capact.io/)
 1. [Capital One](https://www.capitalone.com/tech/)
 1. [Carrefour](https://www.carrefour.com/)
 1. [CarTrack](https://www.cartrack.com/)

--- a/cmd/argo/commands/archive/delete.go
+++ b/cmd/argo/commands/archive/delete.go
@@ -15,7 +15,7 @@ func NewDeleteCommand() *cobra.Command {
 		Use:   "delete UID...",
 		Short: "delete a workflow in the archive",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewArchivedWorkflowServiceClient()
 			errors.CheckError(err)
 			for _, uid := range args {

--- a/cmd/argo/commands/archive/get.go
+++ b/cmd/argo/commands/archive/get.go
@@ -27,7 +27,7 @@ func NewGetCommand() *cobra.Command {
 			}
 			uid := args[0]
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewArchivedWorkflowServiceClient()
 			errors.CheckError(err)
 			wf, err := serviceClient.GetArchivedWorkflow(ctx, &workflowarchivepkg.GetArchivedWorkflowRequest{Uid: uid})

--- a/cmd/argo/commands/archive/list.go
+++ b/cmd/argo/commands/archive/list.go
@@ -25,7 +25,7 @@ func NewListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list workflows in the archive",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewArchivedWorkflowServiceClient()
 			errors.CheckError(err)
 			namespace := client.Namespace()

--- a/cmd/argo/commands/client/conn.go
+++ b/cmd/argo/commands/client/conn.go
@@ -54,7 +54,6 @@ func AddAPIClientFlagsToCmd(cmd *cobra.Command) {
 
 func NewAPIClient(ctx context.Context) (context.Context, apiclient.Client) {
 	ctx, client, err := apiclient.NewClientFromOpts(
-		ctx,
 		apiclient.Opts{
 			ArgoServerOpts: argoServerOpts,
 			InstanceID:     instanceID,
@@ -63,6 +62,7 @@ func NewAPIClient(ctx context.Context) (context.Context, apiclient.Client) {
 			},
 			ClientConfigSupplier: func() clientcmd.ClientConfig { return GetConfig() },
 			Offline:              Offline,
+			Context:              ctx,
 		})
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/client/conn.go
+++ b/cmd/argo/commands/client/conn.go
@@ -52,8 +52,9 @@ func AddAPIClientFlagsToCmd(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&argoServerOpts.InsecureSkipVerify, "insecure-skip-verify", "k", os.Getenv("ARGO_INSECURE_SKIP_VERIFY") == "true", "If true, the Argo Server's certificate will not be checked for validity. This will make your HTTPS connections insecure. Defaults to the ARGO_INSECURE_SKIP_VERIFY environment variable.")
 }
 
-func NewAPIClient() (context.Context, apiclient.Client) {
+func NewAPIClient(ctx context.Context) (context.Context, apiclient.Client) {
 	ctx, client, err := apiclient.NewClientFromOpts(
+		ctx,
 		apiclient.Opts{
 			ArgoServerOpts: argoServerOpts,
 			InstanceID:     instanceID,

--- a/cmd/argo/commands/clustertemplate/create.go
+++ b/cmd/argo/commands/clustertemplate/create.go
@@ -31,7 +31,7 @@ func NewCreateCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			createClusterWorkflowTemplates(args, &cliCreateOpts)
+			createClusterWorkflowTemplates(cmd.Context(), args, &cliCreateOpts)
 		},
 	}
 	command.Flags().StringVarP(&cliCreateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
@@ -39,11 +39,11 @@ func NewCreateCommand() *cobra.Command {
 	return command
 }
 
-func createClusterWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
+func createClusterWorkflowTemplates(ctx context.Context, filePaths []string, cliOpts *cliCreateOpts) {
 	if cliOpts == nil {
 		cliOpts = &cliCreateOpts{}
 	}
-	ctx, apiClient := client.NewAPIClient(context.Background())
+	ctx, apiClient := client.NewAPIClient(ctx)
 	serviceClient, err := apiClient.NewClusterWorkflowTemplateServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/clustertemplate/create.go
+++ b/cmd/argo/commands/clustertemplate/create.go
@@ -1,6 +1,7 @@
 package clustertemplate
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -42,7 +43,7 @@ func createClusterWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) 
 	if cliOpts == nil {
 		cliOpts = &cliCreateOpts{}
 	}
-	ctx, apiClient := client.NewAPIClient()
+	ctx, apiClient := client.NewAPIClient(context.Background())
 	serviceClient, err := apiClient.NewClusterWorkflowTemplateServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/clustertemplate/delete.go
+++ b/cmd/argo/commands/clustertemplate/delete.go
@@ -1,6 +1,7 @@
 package clustertemplate
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/argoproj/pkg/errors"
@@ -27,7 +28,7 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func apiServerDeleteClusterWorkflowTemplates(allWFs bool, wfTmplNames []string) {
-	ctx, apiClient := client.NewAPIClient()
+	ctx, apiClient := client.NewAPIClient(context.Background())
 	serviceClient, err := apiClient.NewClusterWorkflowTemplateServiceClient()
 	errors.CheckError(err)
 

--- a/cmd/argo/commands/clustertemplate/delete.go
+++ b/cmd/argo/commands/clustertemplate/delete.go
@@ -19,7 +19,7 @@ func NewDeleteCommand() *cobra.Command {
 		Use:   "delete WORKFLOW_TEMPLATE",
 		Short: "delete a cluster workflow template",
 		Run: func(cmd *cobra.Command, args []string) {
-			apiServerDeleteClusterWorkflowTemplates(all, args)
+			apiServerDeleteClusterWorkflowTemplates(cmd.Context(), all, args)
 		},
 	}
 
@@ -27,8 +27,8 @@ func NewDeleteCommand() *cobra.Command {
 	return command
 }
 
-func apiServerDeleteClusterWorkflowTemplates(allWFs bool, wfTmplNames []string) {
-	ctx, apiClient := client.NewAPIClient(context.Background())
+func apiServerDeleteClusterWorkflowTemplates(ctx context.Context, allWFs bool, wfTmplNames []string) {
+	ctx, apiClient := client.NewAPIClient(ctx)
 	serviceClient, err := apiClient.NewClusterWorkflowTemplateServiceClient()
 	errors.CheckError(err)
 

--- a/cmd/argo/commands/clustertemplate/get.go
+++ b/cmd/argo/commands/clustertemplate/get.go
@@ -21,7 +21,7 @@ func NewGetCommand() *cobra.Command {
 		Use:   "get CLUSTER WORKFLOW_TEMPLATE...",
 		Short: "display details about a cluster workflow template",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewClusterWorkflowTemplateServiceClient()
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/argo/commands/clustertemplate/lint.go
+++ b/cmd/argo/commands/clustertemplate/lint.go
@@ -25,7 +25,7 @@ func NewLintCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			opts := lint.LintOptions{
 				Files:            args,
 				DefaultNamespace: client.Namespace(),

--- a/cmd/argo/commands/clustertemplate/list.go
+++ b/cmd/argo/commands/clustertemplate/list.go
@@ -23,7 +23,7 @@ func NewListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list cluster workflow templates",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewClusterWorkflowTemplateServiceClient()
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/argo/commands/cron/create.go
+++ b/cmd/argo/commands/cron/create.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -47,7 +48,7 @@ func NewCreateCommand() *cobra.Command {
 }
 
 func CreateCronWorkflows(filePaths []string, cliOpts *cliCreateOpts, submitOpts *wfv1.SubmitOpts) {
-	ctx, apiClient := client.NewAPIClient()
+	ctx, apiClient := client.NewAPIClient(context.Background())
 	serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/cron/create.go
+++ b/cmd/argo/commands/cron/create.go
@@ -36,7 +36,7 @@ func NewCreateCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			CreateCronWorkflows(args, &cliCreateOpts, &submitOpts)
+			CreateCronWorkflows(cmd.Context(), args, &cliCreateOpts, &submitOpts)
 		},
 	}
 
@@ -47,8 +47,8 @@ func NewCreateCommand() *cobra.Command {
 	return command
 }
 
-func CreateCronWorkflows(filePaths []string, cliOpts *cliCreateOpts, submitOpts *wfv1.SubmitOpts) {
-	ctx, apiClient := client.NewAPIClient(context.Background())
+func CreateCronWorkflows(ctx context.Context, filePaths []string, cliOpts *cliCreateOpts, submitOpts *wfv1.SubmitOpts) {
+	ctx, apiClient := client.NewAPIClient(ctx)
 	serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/cron/delete.go
+++ b/cmd/argo/commands/cron/delete.go
@@ -16,7 +16,7 @@ func NewDeleteCommand() *cobra.Command {
 		Use:   "delete [CRON_WORKFLOW... | --all]",
 		Short: "delete a cron workflow",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 			errors.CheckError(err)
 			if all {

--- a/cmd/argo/commands/cron/get.go
+++ b/cmd/argo/commands/cron/get.go
@@ -29,7 +29,7 @@ func NewGetCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 			errors.CheckError(err)
 			namespace := client.Namespace()

--- a/cmd/argo/commands/cron/lint.go
+++ b/cmd/argo/commands/cron/lint.go
@@ -24,7 +24,7 @@ func NewLintCommand() *cobra.Command {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			opts := lint.LintOptions{
 				Files:            args,
 				Strict:           strict,

--- a/cmd/argo/commands/cron/list.go
+++ b/cmd/argo/commands/cron/list.go
@@ -29,7 +29,7 @@ func NewListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list cron workflows",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 			errors.CheckError(err)
 			namespace := client.Namespace()

--- a/cmd/argo/commands/cron/resume.go
+++ b/cmd/argo/commands/cron/resume.go
@@ -16,7 +16,7 @@ func NewResumeCommand() *cobra.Command {
 		Use:   "resume [CRON_WORKFLOW...]",
 		Short: "resume zero or more cron workflows",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 			errors.CheckError(err)
 			namespace := client.Namespace()

--- a/cmd/argo/commands/cron/suspend.go
+++ b/cmd/argo/commands/cron/suspend.go
@@ -16,7 +16,7 @@ func NewSuspendCommand() *cobra.Command {
 		Use:   "suspend CRON_WORKFLOW...",
 		Short: "suspend zero or more cron workflows",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewCronWorkflowServiceClient()
 			errors.CheckError(err)
 			namespace := client.Namespace()

--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -40,7 +40,7 @@ func NewDeleteCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			var workflows wfv1.Workflows
 			if !allNamespaces {

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -70,7 +70,7 @@ func NewGetCommand() *cobra.Command {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 			for _, name := range args {

--- a/cmd/argo/commands/lint.go
+++ b/cmd/argo/commands/lint.go
@@ -35,7 +35,7 @@ func NewLintCommand() *cobra.Command {
   cat manifests.yaml | argo lint --kinds=workflows,cronworkflows -`,
 		Run: func(cmd *cobra.Command, args []string) {
 			client.Offline = offline
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			if len(args) == 0 {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -62,7 +62,7 @@ func NewListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list workflows",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			if !allNamespaces {
 				listArgs.namespace = client.Namespace()

--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -88,7 +88,7 @@ func NewLogsCommand() *cobra.Command {
 			}
 
 			// set-up
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 

--- a/cmd/argo/commands/node.go
+++ b/cmd/argo/commands/node.go
@@ -68,7 +68,7 @@ func NewNodeCommand() *cobra.Command {
 				outputParameters = string(res)
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 

--- a/cmd/argo/commands/resubmit.go
+++ b/cmd/argo/commands/resubmit.go
@@ -74,7 +74,7 @@ func NewResubmitCommand() *cobra.Command {
 				cliSubmitOpts.priority = &resubmitOpts.priority
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			resubmitOpts.namespace = client.Namespace()
 			err := resubmitWorkflows(ctx, serviceClient, resubmitOpts, cliSubmitOpts, args)

--- a/cmd/argo/commands/resume.go
+++ b/cmd/argo/commands/resume.go
@@ -29,7 +29,7 @@ func NewResumeCommand() *cobra.Command {
   argo resume @latest
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 

--- a/cmd/argo/commands/retry.go
+++ b/cmd/argo/commands/retry.go
@@ -77,7 +77,7 @@ func NewRetryCommand() *cobra.Command {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			retryOpts.namespace = client.Namespace()
 

--- a/cmd/argo/commands/stop.go
+++ b/cmd/argo/commands/stop.go
@@ -59,7 +59,7 @@ func NewStopCommand() *cobra.Command {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			stopArgs.namespace = client.Namespace()
 

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -73,7 +73,7 @@ func NewSubmitCommand() *cobra.Command {
 				log.Warn("--status should only be used with --watch")
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 			if from != "" {

--- a/cmd/argo/commands/suspend.go
+++ b/cmd/argo/commands/suspend.go
@@ -22,7 +22,7 @@ func NewSuspendCommand() *cobra.Command {
   argo suspend @latest
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 			for _, wfName := range args {

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -31,7 +31,7 @@ func NewCreateCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			CreateWorkflowTemplates(args, &cliCreateOpts)
+			CreateWorkflowTemplates(cmd.Context(), args, &cliCreateOpts)
 		},
 	}
 	command.Flags().StringVarP(&cliCreateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
@@ -39,11 +39,11 @@ func NewCreateCommand() *cobra.Command {
 	return command
 }
 
-func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
+func CreateWorkflowTemplates(ctx context.Context, filePaths []string, cliOpts *cliCreateOpts) {
 	if cliOpts == nil {
 		cliOpts = &cliCreateOpts{}
 	}
-	ctx, apiClient := client.NewAPIClient(context.Background())
+	ctx, apiClient := client.NewAPIClient(ctx)
 	serviceClient, err := apiClient.NewWorkflowTemplateServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -42,7 +43,7 @@ func CreateWorkflowTemplates(filePaths []string, cliOpts *cliCreateOpts) {
 	if cliOpts == nil {
 		cliOpts = &cliCreateOpts{}
 	}
-	ctx, apiClient := client.NewAPIClient()
+	ctx, apiClient := client.NewAPIClient(context.Background())
 	serviceClient, err := apiClient.NewWorkflowTemplateServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/template/delete.go
+++ b/cmd/argo/commands/template/delete.go
@@ -29,7 +29,7 @@ func NewDeleteCommand() *cobra.Command {
 }
 
 func apiServerDeleteWorkflowTemplates(allWFs bool, wfTmplNames []string) {
-	ctx, apiClient := client.NewAPIClient()
+	ctx, apiClient := client.NewAPIClient(context.Background())
 	serviceClient, err := apiClient.NewWorkflowTemplateServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/template/delete.go
+++ b/cmd/argo/commands/template/delete.go
@@ -20,7 +20,7 @@ func NewDeleteCommand() *cobra.Command {
 		Use:   "delete WORKFLOW_TEMPLATE",
 		Short: "delete a workflow template",
 		Run: func(cmd *cobra.Command, args []string) {
-			apiServerDeleteWorkflowTemplates(all, args)
+			apiServerDeleteWorkflowTemplates(cmd.Context(), all, args)
 		},
 	}
 
@@ -28,8 +28,8 @@ func NewDeleteCommand() *cobra.Command {
 	return command
 }
 
-func apiServerDeleteWorkflowTemplates(allWFs bool, wfTmplNames []string) {
-	ctx, apiClient := client.NewAPIClient(context.Background())
+func apiServerDeleteWorkflowTemplates(ctx context.Context, allWFs bool, wfTmplNames []string) {
+	ctx, apiClient := client.NewAPIClient(ctx)
 	serviceClient, err := apiClient.NewWorkflowTemplateServiceClient()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/argo/commands/template/get.go
+++ b/cmd/argo/commands/template/get.go
@@ -21,7 +21,7 @@ func NewGetCommand() *cobra.Command {
 		Use:   "get WORKFLOW_TEMPLATE...",
 		Short: "display details about a workflow template",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewWorkflowTemplateServiceClient()
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/argo/commands/template/lint.go
+++ b/cmd/argo/commands/template/lint.go
@@ -24,7 +24,7 @@ func NewLintCommand() *cobra.Command {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			opts := lint.LintOptions{
 				Files:            args,
 				Strict:           strict,

--- a/cmd/argo/commands/template/list.go
+++ b/cmd/argo/commands/template/list.go
@@ -25,7 +25,7 @@ func NewListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "list workflow templates",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient, err := apiClient.NewWorkflowTemplateServiceClient()
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/argo/commands/terminate.go
+++ b/cmd/argo/commands/terminate.go
@@ -68,7 +68,7 @@ func NewTerminateCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			t.namespace = client.Namespace()
 

--- a/cmd/argo/commands/version.go
+++ b/cmd/argo/commands/version.go
@@ -21,7 +21,7 @@ func NewVersionCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.PrintVersion(CLIName, argo.GetVersion(), short)
 			if _, ok := os.LookupEnv("ARGO_SERVER"); ok {
-				ctx, apiClient := client.NewAPIClient()
+				ctx, apiClient := client.NewAPIClient(cmd.Context())
 				serviceClient, err := apiClient.NewInfoServiceClient()
 				errors.CheckError(err)
 				serverVersion, err := serviceClient.GetVersion(ctx, &infopkg.GetVersionRequest{})

--- a/cmd/argo/commands/wait.go
+++ b/cmd/argo/commands/wait.go
@@ -34,7 +34,7 @@ func NewWaitCommand() *cobra.Command {
   argo wait @latest
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 			waitWorkflows(ctx, serviceClient, namespace, args, ignoreNotFound, false)

--- a/cmd/argo/commands/watch.go
+++ b/cmd/argo/commands/watch.go
@@ -38,7 +38,7 @@ func NewWatchCommand() *cobra.Command {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
-			ctx, apiClient := client.NewAPIClient()
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
 			serviceClient := apiClient.NewWorkflowServiceClient()
 			namespace := client.Namespace()
 			watchWorkflow(ctx, serviceClient, namespace, args[0], getArgs)

--- a/cmd/argo/commands/watch.go
+++ b/cmd/argo/commands/watch.go
@@ -90,6 +90,9 @@ func watchWorkflow(ctx context.Context, serviceClient workflowpkg.WorkflowServic
 			wf = newWf
 		case <-ticker.C:
 			// If we don't, refresh the workflow screen every second
+		case <-ctx.Done():
+			// When the context gets canceled
+			return
 		}
 
 		printWorkflowStatus(wf, getArgs)

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -40,6 +40,14 @@ func (o Opts) String() string {
 	return fmt.Sprintf("(argoServerOpts=%v,instanceID=%v)", o.ArgoServerOpts, o.InstanceID)
 }
 
+func (o *Opts) GetContext() context.Context {
+	if o.Context == nil {
+		o.Context = context.Background()
+	}
+
+	return o.Context
+}
+
 // DEPRECATED: use NewClientFromOpts
 func NewClient(argoServer string, authSupplier func() string, clientConfig clientcmd.ClientConfig) (context.Context, Client, error) {
 	return NewClientFromOpts(Opts{
@@ -69,11 +77,7 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 			opts.ClientConfig = opts.ClientConfigSupplier()
 		}
 
-		if opts.Context == nil {
-			opts.Context = context.Background()
-		}
-
-		ctx, client, err := newArgoKubeClient(opts.Context, opts.ClientConfig, instanceid.NewService(opts.InstanceID))
+		ctx, client, err := newArgoKubeClient(opts.GetContext(), opts.ClientConfig, instanceid.NewService(opts.InstanceID))
 		return ctx, client, err
 	}
 }

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -41,7 +41,7 @@ func (o Opts) String() string {
 
 // DEPRECATED: use NewClientFromOpts
 func NewClient(argoServer string, authSupplier func() string, clientConfig clientcmd.ClientConfig) (context.Context, Client, error) {
-	return NewClientFromOpts(Opts{
+	return NewClientFromOpts(context.Background(), Opts{
 		ArgoServerOpts: ArgoServerOpts{URL: argoServer},
 		AuthSupplier:   authSupplier,
 		ClientConfigSupplier: func() clientcmd.ClientConfig {
@@ -50,7 +50,7 @@ func NewClient(argoServer string, authSupplier func() string, clientConfig clien
 	})
 }
 
-func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
+func NewClientFromOpts(ctx context.Context, opts Opts) (context.Context, Client, error) {
 	log.WithField("opts", opts).Debug("Client options")
 	if opts.Offline {
 		return newOfflineClient()
@@ -67,7 +67,7 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 			opts.ClientConfig = opts.ClientConfigSupplier()
 		}
 
-		ctx, client, err := newArgoKubeClient(opts.ClientConfig, instanceid.NewService(opts.InstanceID))
+		ctx, client, err := newArgoKubeClient(ctx, opts.ClientConfig, instanceid.NewService(opts.InstanceID))
 		return ctx, client, err
 	}
 }

--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -39,7 +39,7 @@ type argoKubeClient struct {
 
 var _ Client = &argoKubeClient{}
 
-func newArgoKubeClient(clientConfig clientcmd.ClientConfig, instanceIDService instanceid.Service) (context.Context, Client, error) {
+func newArgoKubeClient(ctx context.Context, clientConfig clientcmd.ClientConfig, instanceIDService instanceid.Service) (context.Context, Client, error) {
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, nil, err
@@ -75,7 +75,7 @@ func newArgoKubeClient(clientConfig clientcmd.ClientConfig, instanceIDService in
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx, err := gatekeeper.Context(context.Background())
+	ctx, err = gatekeeper.Context(ctx)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR allows to provide an existing context.Context to the NewAPIClient function. It also improves the context handling in `argo watch`.

Currently the NewAPIClient function return a new context.Context.
It can be sometimes useful to provide an existing context (e.g. a global Cobra context). For now, Golang does not have a built-in option to merge two different contexts into a single one (see https://github.com/golang/go/issues/36503), which could be another way to handle this.

We embed in [Capact](https://github.com/capactio/capact) the `argo watch` command in our CLI. As we run Cobra using `ExecuteContext`, sending SIGINT and cancelling the Cobra context does not stop the context in the APIClient, thus it gets blocked, and we have to kill the process to stop watching an Argo workflow.

https://github.com/capactio/capact/blob/6973b7bf72a308a47765ee0fc739f8dcc77f54ba/cmd/cli/main.go#L17.

I tested this by compiling the `argo` binary and verifying that `argo watch` behaves the same. I also built our `capact` binary using this branch and confirmed, that this change allows Argo watch to get cancelled on SIGINT.