### PR TITLE
fix(emissary): strip trailing slash from artifact src before creating…

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -192,7 +193,7 @@ func saveArtifact(srcPath string) error {
 		logger.WithError(err).Errorf("cannot save artifact %s", srcPath)
 		return nil
 	}
-	dstPath := varRunArgo + "/outputs/artifacts/" + srcPath + ".tgz"
+	dstPath := filepath.Join(varRunArgo, "/outputs/artifacts/", strings.TrimSuffix(srcPath, "/")+".tgz")
 	logger.Infof("%s -> %s", srcPath, dstPath)
 	z := filepath.Dir(dstPath)
 	if err := os.MkdirAll(z, 0o755); err != nil { // chmod rwxr-xr-x

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -91,6 +91,23 @@ func TestEmissary(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, string(data)) // data is tgz format
 	})
+	t.Run("ArtifactWithTrailingAndLeadingSlash", func(t *testing.T) {
+		err = ioutil.WriteFile(varRunArgo+"/template", []byte(`
+{
+	"outputs": {
+		"artifacts": [
+			{"path": "/tmp/artifact/"}
+		]
+	}
+}
+`), 0o600)
+		assert.NoError(t, err)
+		err := run(x, []string{"echo", "hello", "/tmp/artifact"})
+		assert.NoError(t, err)
+		data, err := ioutil.ReadFile(varRunArgo + "/outputs/artifacts/tmp/artifact.tgz")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, string(data)) // data is tgz format
+	})
 	t.Run("Parameter", func(t *testing.T) {
 		err = ioutil.WriteFile(varRunArgo+"/template", []byte(`
 {

--- a/workflow/executor/emissary/emissary.go
+++ b/workflow/executor/emissary/emissary.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -78,7 +79,7 @@ func (e emissary) CopyFile(_ string, sourcePath string, destPath string, _ int) 
 	// this implementation is very different, because we expect the emissary binary has already compressed the file
 	// so no compression can or needs to be implemented here
 	// TODO - warn the user we ignored compression?
-	sourceFile := filepath.Join("/var/run/argo/outputs/artifacts", sourcePath+".tgz")
+	sourceFile := filepath.Join("/var/run/argo/outputs/artifacts", strings.TrimSuffix(sourcePath, "/")+".tgz")
 	log.Infof("%s -> %s", sourceFile, destPath)
 	src, err := os.Open(filepath.Clean(sourceFile))
 	if err != nil {


### PR DESCRIPTION
Hi,

At the moment when running workflows with Emissary executor and saving output artifacts, trailing and leading slashes in `srcPath` are not being taken into consideration before creating the destination file. When compressing a full directory, `srcPath` could either be, for instance:

* `/tmp`
* `/tmp/`

For now, [paths are only being concatenated](https://github.com/argoproj/argo-workflows/blob/master/cmd/argoexec/commands/emissary.go#L195), leading in our second example to output paths looking like `/var/run/argo/outputs/artifacts//tmp/.tgz`. I believe this should probably be `var/run/argo/outputs/artifacts/tmp.tgz`

My proposal consists of using :
* `filepath.Join` for concatenation, which would take care of potential specific characters (`.`, `..` and `/` basically)
* `strings.TrimSuffix` for getting rid of the trailing slashes

I've also added a unit test case for validating the behaviour.

As it's my first time opening a pull request on Argo, I have no idea whether or not those changes might break any other parts of the codebase. Also please let me know if anything looks wrong regarding the implementation details.

As far as I know this PR does not address any open issues so please just let me know if this contribution does not make any sense to you folks.

Thanks in advance for taking the time to consider this change.

Signed-off-by: Elliot Maincourt <e.maincourt@gmail.com>
