### PR TITLE
fix(executor): handle hdfs optional artifact at retriving hdfs file stat. Fixes #6598

### DIFF
--- a/workflow/artifacts/hdfs/hdfs.go
+++ b/workflow/artifacts/hdfs/hdfs.go
@@ -144,6 +144,9 @@ func (driver *ArtifactDriver) Load(_ *wfv1.Artifact, path string) error {
 
 	srcStat, err := hdfscli.Stat(driver.Path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New(errors.CodeNotFound, err.Error())
+		}
 		return err
 	}
 	if srcStat.IsDir() {


### PR DESCRIPTION
fixes #6598

reference code:
https://github.com/colinmarc/hdfs/blob/v1.1.3/stat.go#L21
https://github.com/colinmarc/hdfs/blob/e2c734b8518275eeb74661de28966a00b9b6c212/exceptions.go#L10

hdfs.Stat returns:
os.ErrNotExist
ErrPermission
default error wrap in os.pathError

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
