### PR TITLE
feat: Add template node to pod name. Fixes #1319

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -32,6 +32,7 @@ Note that these environment variables may be removed at any time.
 | `RETRY_BACKOFF_STEPS` | `int` | `5` | The retry backoff steps when retrying API calls. |
 | `RETRY_HOST_NAME_LABEL_KEY` | `string` | `kubernetes.io/hostname` | The label key for host name used when retrying templates. |
 | `TRANSIENT_ERROR_PATTERN` | `string` | `""` | The regular expression that represents additional patterns for transient errors. |
+| `USE_LEGACY_POD_NAMES` | `bool` | `false` | Whether to have pod names contain the template name (false) or be the node id (true). |
 | `WF_DEL_PROPAGATION_POLICY` | `string` | `""` | The deletion propagation policy for workflows. |
 | `WORKFLOW_GC_PERIOD` | `time.Duration` | `5m` | The periodicity for GC of workflows. |
 | `BUBBLE_ENTRY_TEMPLATE_ERR` | `bool` | `true` | Whether to bubble up template errors to workflow. |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -26,13 +26,13 @@ Note that these environment variables may be removed at any time.
 | `LEADER_ELECTION_RETRY_PERIOD` | `time.Duration` | `5s` | The duration that the leader election clients should wait between tries of actions. |
 | `MAX_OPERATION_TIME` | `time.Duration` | `30s` | The maximum time a workflow operation is allowed to run for before requeuing the workflow onto the work queue. |
 | `OFFLOAD_NODE_STATUS_TTL` | `time.Duration` | `5m` | The TTL to delete the offloaded node status. Currently only used for testing. |
+| `POD_NAMES` | `string` | `v2` | Whether to have pod names contain the template name (v2) or be the node id (v1). |
 | `RECENTLY_STARTED_POD_DURATION` | `time.Duration` | `10s` | The duration of a pod before the pod is considered to be recently started. |
 | `RETRY_BACKOFF_DURATION` | `time.Duration` | `10ms` | The retry backoff duration when retrying API calls. |
 | `RETRY_BACKOFF_FACTOR` | `float` | `2.0` | The retry backoff factor when retrying API calls. |
 | `RETRY_BACKOFF_STEPS` | `int` | `5` | The retry backoff steps when retrying API calls. |
 | `RETRY_HOST_NAME_LABEL_KEY` | `string` | `kubernetes.io/hostname` | The label key for host name used when retrying templates. |
 | `TRANSIENT_ERROR_PATTERN` | `string` | `""` | The regular expression that represents additional patterns for transient errors. |
-| `USE_LEGACY_POD_NAMES` | `bool` | `false` | Whether to have pod names contain the template name (false) or be the node id (true). |
 | `WF_DEL_PROPAGATION_POLICY` | `string` | `""` | The deletion propagation policy for workflows. |
 | `WORKFLOW_GC_PERIOD` | `time.Duration` | `5m` | The periodicity for GC of workflows. |
 | `BUBBLE_ENTRY_TEMPLATE_ERR` | `bool` | `true` | Whether to bubble up template errors to workflow. |

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -17,8 +17,8 @@ import (
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
-	"github.com/argoproj/argo-workflows/v3/workflow/controller"
 	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
+	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
 
 type Then struct {
@@ -88,7 +88,7 @@ func (t *Then) ExpectWorkflowNode(selector func(status wfv1.NodeStatus) bool, f 
 			if n.Type == wfv1.NodeTypePod {
 				var err error
 				ctx := context.Background()
-				podName := controller.PodName(t.wf.Name, n.Name, n.TemplateName)
+				podName := util.PodName(t.wf.Name, n.Name, n.TemplateName)
 				p, err = t.kubeClient.CoreV1().Pods(t.wf.Namespace).Get(ctx, podName, metav1.GetOptions{})
 				if err != nil {
 					if !apierr.IsNotFound(err) {

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -88,7 +88,7 @@ func (t *Then) ExpectWorkflowNode(selector func(status wfv1.NodeStatus) bool, f 
 			if n.Type == wfv1.NodeTypePod {
 				var err error
 				ctx := context.Background()
-				podName := util.PodName(t.wf.Name, n.Name, n.TemplateName)
+				podName := util.PodName(t.wf.Name, n.Name, n.TemplateName, n.ID)
 				p, err = t.kubeClient.CoreV1().Pods(t.wf.Namespace).Get(ctx, podName, metav1.GetOptions{})
 				if err != nil {
 					if !apierr.IsNotFound(err) {

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -17,6 +17,7 @@ import (
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/controller"
 	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
 )
 
@@ -87,7 +88,8 @@ func (t *Then) ExpectWorkflowNode(selector func(status wfv1.NodeStatus) bool, f 
 			if n.Type == wfv1.NodeTypePod {
 				var err error
 				ctx := context.Background()
-				p, err = t.kubeClient.CoreV1().Pods(t.wf.Namespace).Get(ctx, n.ID, metav1.GetOptions{})
+				podName := controller.PodName(t.wf.Name, n.Name, n.TemplateName)
+				p, err = t.kubeClient.CoreV1().Pods(t.wf.Namespace).Get(ctx, podName, metav1.GetOptions{})
 				if err != nil {
 					if !apierr.IsNotFound(err) {
 						t.t.Error(err)

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -15,6 +15,10 @@ const (
 	// DockerSockVolumeName is the volume name for the /var/run/docker.sock host path volume
 	DockerSockVolumeName = "docker-sock"
 
+	// AnnotationKeyNodeID is the ID of the node.
+	// Historically, the pod name was the same as the node ID.
+	// Therefore, if it does not exist, then the node ID is the pod name.
+	AnnotationKeyNodeID = workflow.WorkflowFullName + "/node-id"
 	// AnnotationKeyNodeName is the pod metadata annotation key containing the workflow node name
 	AnnotationKeyNodeName = workflow.WorkflowFullName + "/node-name"
 	// AnnotationKeyNodeName is the node's type

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1029,6 +1029,7 @@ func (wfc *WorkflowController) newPodInformer(ctx context.Context) cache.SharedI
 	source := wfc.newWorkflowPodWatch(ctx)
 	informer := cache.NewSharedIndexInformer(source, &apiv1.Pod{}, podResyncPeriod, cache.Indexers{
 		indexes.WorkflowIndex: indexes.MetaWorkflowIndexFunc,
+		indexes.NodeIDIndex:   indexes.MetaNodeIDIndexFunc,
 		indexes.PodPhaseIndex: indexes.PodPhaseIndexFunc,
 	})
 	informer.AddEventHandler(

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -34,7 +34,7 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				if err == nil {
 					wfNodesLock.Lock()
-					node := woc.wf.Status.Nodes[pod.Name]
+					node := woc.wf.Status.Nodes[woc.nodeID(pod)]
 					wfNodesLock.Unlock()
 					woc.markNodePhase(node.Name, wfv1.NodeFailed, fmt.Sprintf("workflow shutdown with strategy:  %s", woc.GetShutdownStrategy()))
 					return
@@ -53,7 +53,7 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				if err == nil {
 					wfNodesLock.Lock()
-					node := woc.wf.Status.Nodes[pod.Name]
+					node := woc.wf.Status.Nodes[woc.nodeID(pod)]
 					wfNodesLock.Unlock()
 					woc.markNodePhase(node.Name, wfv1.NodeFailed, "Step exceeded its deadline")
 					return

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -19,6 +19,9 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 	if pod == nil {
 		return
 	}
+
+	nodeID := woc.nodeID(pod)
+
 	switch pod.Status.Phase {
 	case apiv1.PodSucceeded, apiv1.PodFailed:
 		// Skip any pod which are already completed
@@ -34,7 +37,7 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				if err == nil {
 					wfNodesLock.Lock()
-					node := woc.wf.Status.Nodes[woc.nodeID(pod)]
+					node := woc.wf.Status.Nodes[nodeID]
 					wfNodesLock.Unlock()
 					woc.markNodePhase(node.Name, wfv1.NodeFailed, fmt.Sprintf("workflow shutdown with strategy:  %s", woc.GetShutdownStrategy()))
 					return
@@ -53,7 +56,7 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				if err == nil {
 					wfNodesLock.Lock()
-					node := woc.wf.Status.Nodes[woc.nodeID(pod)]
+					node := woc.wf.Status.Nodes[nodeID]
 					wfNodesLock.Unlock()
 					woc.markNodePhase(node.Name, wfv1.NodeFailed, "Step exceeded its deadline")
 					return

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -36,10 +36,8 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 				woc.log.Infof("Deleting Pending pod %s/%s as part of workflow shutdown with strategy: %s", pod.Namespace, pod.Name, woc.GetShutdownStrategy())
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				if err == nil {
-					wfNodesLock.Lock()
-					node := woc.wf.Status.Nodes[nodeID]
-					wfNodesLock.Unlock()
-					woc.markNodePhase(node.Name, wfv1.NodeFailed, fmt.Sprintf("workflow shutdown with strategy:  %s", woc.GetShutdownStrategy()))
+					msg := fmt.Sprintf("workflow shutdown with strategy:  %s", woc.GetShutdownStrategy())
+					woc.handleExecutionControlError(nodeID, wfNodesLock, msg)
 					return
 				}
 				// If we fail to delete the pod, fall back to setting the annotation
@@ -55,10 +53,7 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 				woc.log.Infof("Deleting Pending pod %s/%s which has exceeded workflow deadline %s", pod.Namespace, pod.Name, woc.workflowDeadline)
 				err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 				if err == nil {
-					wfNodesLock.Lock()
-					node := woc.wf.Status.Nodes[nodeID]
-					wfNodesLock.Unlock()
-					woc.markNodePhase(node.Name, wfv1.NodeFailed, "Step exceeded its deadline")
+					woc.handleExecutionControlError(nodeID, wfNodesLock, "Step exceeded its deadline")
 					return
 				}
 				// If we fail to delete the pod, fall back to setting the annotation
@@ -72,6 +67,14 @@ func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1
 			woc.controller.queuePodForCleanup(woc.wf.Namespace, pod.Name, shutdownPod)
 		}
 	}
+}
+
+// handleExecutionControlError marks a node as failed with an error message
+func (woc *wfOperationCtx) handleExecutionControlError(nodeID string, wfNodesLock *sync.RWMutex, errorMsg string) {
+	wfNodesLock.Lock()
+	node := woc.wf.Status.Nodes[nodeID]
+	wfNodesLock.Unlock()
+	woc.markNodePhase(node.Name, wfv1.NodeFailed, errorMsg)
 }
 
 // killDaemonedChildren kill any daemoned pods of a steps or DAG template node.

--- a/workflow/controller/indexes/indexes.go
+++ b/workflow/controller/indexes/indexes.go
@@ -9,6 +9,7 @@ package indexes
 const (
 	ClusterWorkflowTemplateIndex = "clusterworkflowtemplate"
 	CronWorkflowIndex            = "cronworkflow"
+	NodeIDIndex                  = "nodeID"
 	WorkflowIndex                = "workflow"
 	WorkflowTemplateIndex        = "workflowtemplate"
 	WorkflowPhaseIndex           = "workflow.phase"

--- a/workflow/controller/indexes/workflow_index.go
+++ b/workflow/controller/indexes/workflow_index.go
@@ -32,6 +32,17 @@ func MetaWorkflowIndexFunc(obj interface{}) ([]string, error) {
 	return []string{WorkflowIndexValue(m.GetNamespace(), name)}, nil
 }
 
+func MetaNodeIDIndexFunc(obj interface{}) ([]string, error) { // TODO test
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, nil
+	}
+	if nodeID, ok := m.GetAnnotations()[common.AnnotationKeyNodeID]; ok {
+		return []string{m.GetNamespace() + "/" + nodeID}, nil
+	}
+	return []string{m.GetNamespace() + "/" + m.GetName()}, nil
+}
+
 func WorkflowIndexValue(namespace, name string) string {
 	return namespace + "/" + name
 }

--- a/workflow/controller/indexes/workflow_index.go
+++ b/workflow/controller/indexes/workflow_index.go
@@ -32,14 +32,18 @@ func MetaWorkflowIndexFunc(obj interface{}) ([]string, error) {
 	return []string{WorkflowIndexValue(m.GetNamespace(), name)}, nil
 }
 
-func MetaNodeIDIndexFunc(obj interface{}) ([]string, error) { // TODO test
+// MetaNodeIDIndexFunc takes a kubernetes object and returns either the
+// namespace and its node id or the namespace and its name
+func MetaNodeIDIndexFunc(obj interface{}) ([]string, error) {
 	m, err := meta.Accessor(obj)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
+
 	if nodeID, ok := m.GetAnnotations()[common.AnnotationKeyNodeID]; ok {
 		return []string{m.GetNamespace() + "/" + nodeID}, nil
 	}
+
 	return []string{m.GetNamespace() + "/" + m.GetName()}, nil
 }
 

--- a/workflow/controller/indexes/workflow_index_test.go
+++ b/workflow/controller/indexes/workflow_index_test.go
@@ -25,6 +25,43 @@ metadata:
 	}
 }
 
+func TestMetaNodeIDIndexFunc(t *testing.T) {
+	withNodeID := `
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: my-ns
+  name: retry-test-p7jzr-whalesay-2308805457
+  labels:
+    workflows.argoproj.io/workflow: my-wf
+  annotations:
+    workflows.argoproj.io/node-id: retry-test-p7jzr-2308805457
+    workflows.argoproj.io/node-name: 'retry-test-p7jzr[0].steps-outer-step1'
+`
+	withoutNodeID := `
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: my-ns
+  name: retry-test-p7jzr-whalesay-2308805457
+  labels:
+    workflows.argoproj.io/workflow: my-wf
+  annotations:
+    workflows.argoproj.io/node-name: 'retry-test-p7jzr[0].steps-outer-step1'
+`
+	obj := &unstructured.Unstructured{}
+	wfv1.MustUnmarshal(withNodeID, obj)
+	v, err := MetaNodeIDIndexFunc(obj)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"my-ns/retry-test-p7jzr-2308805457"}, v)
+
+	obj = &unstructured.Unstructured{}
+	wfv1.MustUnmarshal(withoutNodeID, obj)
+	v, err = MetaNodeIDIndexFunc(obj)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"my-ns/retry-test-p7jzr-whalesay-2308805457"}, v)
+}
+
 func TestWorkflowIndexValue(t *testing.T) {
 	assert.Equal(t, "my-ns/my-wf", WorkflowIndexValue("my-ns", "my-wf"))
 }

--- a/workflow/controller/node_counters.go
+++ b/workflow/controller/node_counters.go
@@ -53,7 +53,7 @@ func (woc *wfOperationCtx) getUnsuccessfulChildren(boundaryID string) int64 {
 }
 
 func (woc *wfOperationCtx) nodePodExist(node wfv1.NodeStatus) bool {
-	_, podExist, _ := woc.podExists(node.ID) // TODO - test
+	_, podExist, _ := woc.podExists(node.ID)
 	return podExist
 }
 

--- a/workflow/controller/node_counters.go
+++ b/workflow/controller/node_counters.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"fmt"
-
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
@@ -55,7 +53,7 @@ func (woc *wfOperationCtx) getUnsuccessfulChildren(boundaryID string) int64 {
 }
 
 func (woc *wfOperationCtx) nodePodExist(node wfv1.NodeStatus) bool {
-	_, podExist, _ := woc.controller.podInformer.GetIndexer().GetByKey(fmt.Sprintf("%s/%s", woc.wf.Namespace, node.ID))
+	_, podExist, _ := woc.podExists(node.ID) // TODO - test
 	return podExist
 }
 

--- a/workflow/controller/node_counters_test.go
+++ b/workflow/controller/node_counters_test.go
@@ -147,4 +147,17 @@ func TestCounters(t *testing.T) {
 	assert.Equal(t, int64(2), woc.getActivePods("2"))
 	assert.Equal(t, int64(2), woc.getActiveChildren("2"))
 	assert.Equal(t, int64(2), woc.getUnsuccessfulChildren("2"))
+
+	testNodePodExists(t, woc)
+}
+
+func testNodePodExists(t *testing.T, woc *wfOperationCtx) {
+	for _, node := range woc.wf.Status.Nodes {
+		if node.ID == "" {
+			continue
+		}
+
+		doesPodExist := woc.nodePodExist(node)
+		assert.True(t, doesPodExist)
+	}
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -939,9 +939,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 			woc.updateAgentPodStatus(ctx, pod)
 			return
 		}
-		nodeNameForPod := pod.Annotations[common.AnnotationKeyNodeName]
-
-		nodeID := woc.wf.NodeID(nodeNameForPod)
+		nodeID := woc.nodeID(pod)
 		seenPodLock.Lock()
 		seenPods[nodeID] = pod
 		seenPodLock.Unlock()
@@ -967,7 +965,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 				}
 				woc.updated = true
 			}
-			node := woc.wf.Status.Nodes[pod.ObjectMeta.Name]
+			node := woc.wf.Status.Nodes[nodeID]
 			match := true
 			if woc.execWf.Spec.PodGC.GetLabelSelector() != nil {
 				var podLabels labels.Set = pod.GetLabels()
@@ -1032,7 +1030,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 
 			// grace-period to allow informer sync
 			recentlyStarted := recentlyStarted(node)
-			woc.log.WithFields(log.Fields{"podName": node.Name, "nodePhase": node.Phase, "recentlyStarted": recentlyStarted}).Info("Workflow pod is missing")
+			woc.log.WithFields(log.Fields{"nodeName": node.Name, "nodePhase": node.Phase, "recentlyStarted": recentlyStarted}).Info("Workflow pod is missing")
 			metrics.PodMissingMetric.WithLabelValues(strconv.FormatBool(recentlyStarted), string(node.Phase)).Inc()
 
 			// If the node is pending and the pod does not exist, it could be the case that we want to try to submit it
@@ -1057,6 +1055,14 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (woc *wfOperationCtx) nodeID(pod *apiv1.Pod) string {
+	nodeID, ok := pod.Annotations[common.AnnotationKeyNodeID]
+	if !ok {
+		nodeID = woc.wf.NodeID(pod.Annotations[common.AnnotationKeyNodeName])
+	}
+	return nodeID
 }
 
 func recentlyStarted(node wfv1.NodeStatus) bool {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1549,36 +1549,25 @@ spec:
 
 // TestWorkflowParallelismLimit verifies parallelism at a workflow level is honored.
 func TestWorkflowParallelismLimit(t *testing.T) {
-	cancel, controller := newController()
+	ctx := context.Background()
+	wf := wfv1.MustUnmarshalWorkflow(workflowParallelismLimit)
+	cancel, controller := newController(wf)
 	defer cancel()
 
-	ctx := context.Background()
-	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("default")
-	wf := wfv1.MustUnmarshalWorkflow(workflowParallelismLimit)
-	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
-	assert.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
 	pods, err := listPods(woc)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(pods.Items))
-	// operate again and make sure we don't schedule any more pods
+	assert.Len(t, pods.Items, 2)
+
 	makePodsPhase(ctx, woc, apiv1.PodRunning)
 
-	syncPodsInformer(ctx, woc)
-
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
-	assert.NoError(t, err)
-	// wfBytes, _ := json.MarshalIndent(wf, "", "  ")
-	// log.Printf("%s", wfBytes)
-	woc = newWorkflowOperationCtx(wf, controller)
+	// operate again and make sure we don't schedule any more pods
+	woc = newWorkflowOperationCtx(woc.wf, controller)
 	woc.operate(ctx)
 	pods, err = listPods(woc)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(pods.Items))
+	assert.Len(t, pods.Items, 2)
 }
 
 var stepsTemplateParallelismLimit = `

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -214,7 +214,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			},
 			Annotations: map[string]string{
 				common.AnnotationKeyNodeName: nodeName,
-				common.AnnotationKeyNodeID:   nodeID, // TODO - test annotation is applied
+				common.AnnotationKeyNodeID:   nodeID,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(woc.wf, wfv1.SchemeGroupVersion.WithKind(workflow.WorkflowKind)),

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -233,7 +233,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	}
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName(woc.wf.Name, nodeName, tmpl.Name), // TODO - test
+			Name:      podName(woc.wf.Name, nodeName, tmpl.Name),
 			Namespace: woc.wf.ObjectMeta.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow
@@ -489,15 +489,21 @@ func (woc *wfOperationCtx) podExists(nodeID string) (existing *apiv1.Pod, exists
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get pod from informer store: %w", err)
 	}
-	switch len(objs) {
-	case 0:
-	case 1:
-		if existing, ok := objs[0].(*apiv1.Pod); ok {
-			return existing, true, nil
-		}
-	default:
+
+	objectCount := len(objs)
+
+	if objectCount == 0 {
+		return nil, false, nil
+	}
+
+	if objectCount > 1 {
 		return nil, false, fmt.Errorf("expected < 2 pods, got %d - this is a bug", len(objs))
 	}
+
+	if existing, ok := objs[0].(*apiv1.Pod); ok {
+		return existing, true, nil
+	}
+
 	return nil, false, nil
 }
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -173,9 +173,12 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	// we must check to see if the pod exists rather than just optimistically creating the pod and see if we get
 	// an `AlreadyExists` error because we won't get that error if there is not enough resources.
 	// Performance enhancement: Code later in this func is expensive to execute, so return quickly if we can.
-	if existing, exists, err := woc.podExists(nodeID); err != nil {
+	existing, exists, err := woc.podExists(nodeID)
+	if err != nil {
 		return nil, err
-	} else if exists {
+	}
+
+	if exists {
 		woc.log.WithField("podPhase", existing.Status.Phase).Debugf("Skipped pod %s (%s) creation: already exists", nodeName, nodeID)
 		return existing, nil
 	}

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -144,7 +144,7 @@ type createWorkflowPodOpts struct {
 }
 
 // podName return a deterministic pod name
-func podName(workflowName, nodeName, templateName string) string { // TODO - tests
+func podName(workflowName, nodeName, templateName string) string {
 	if workflowName == nodeName {
 		return workflowName
 	}

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -206,7 +206,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	}
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.PodName(woc.wf.Name, nodeName, tmpl.Name),
+			Name:      util.PodName(woc.wf.Name, nodeName, tmpl.Name, nodeID),
 			Namespace: woc.wf.ObjectMeta.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -143,8 +143,8 @@ type createWorkflowPodOpts struct {
 	executionDeadline   time.Time
 }
 
-// podName return a deterministic pod name
-func podName(workflowName, nodeName, templateName string) string {
+// PodName return a deterministic pod name
+func PodName(workflowName, nodeName, templateName string) string {
 	if workflowName == nodeName {
 		return workflowName
 	}
@@ -236,7 +236,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	}
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName(woc.wf.Name, nodeName, tmpl.Name),
+			Name:      PodName(woc.wf.Name, nodeName, tmpl.Name),
 			Namespace: woc.wf.ObjectMeta.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1581,7 +1581,7 @@ func TestPodName(t *testing.T) {
 	actual := ensurePodNamePrefixLength(expected)
 	assert.Equal(t, expected, actual)
 
-	name := podName(shortWfName, nodeName, shortTemplateName)
+	name := PodName(shortWfName, nodeName, shortTemplateName)
 	assert.Equal(t, "wfname-templatename-1454367246", name)
 
 	// long case
@@ -1596,7 +1596,7 @@ func TestPodName(t *testing.T) {
 
 	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
 
-	name = podName(longWfName, nodeName, longTemplateName)
+	name = PodName(longWfName, nodeName, longTemplateName)
 	assert.Equal(t, maxK8sResourceNameLength, len(name))
 }
 

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1570,11 +1570,19 @@ func TestPodMetadataWithWorkflowDefaults(t *testing.T) {
 	cancel()
 }
 
-func TestEnsurePodNamePrefixLength(t *testing.T) {
+func TestPodName(t *testing.T) {
+	nodeName := "nodename"
+
 	// short case
-	expected := fmt.Sprintf("%s-%s", "wfname", "templatename")
+	shortWfName := "wfname"
+	shortTemplateName := "templatename"
+
+	expected := fmt.Sprintf("%s-%s", shortWfName, shortTemplateName)
 	actual := ensurePodNamePrefixLength(expected)
 	assert.Equal(t, expected, actual)
+
+	name := podName(shortWfName, nodeName, shortTemplateName)
+	assert.Equal(t, "wfname-templatename-1454367246", name)
 
 	// long case
 	longWfName := "alongworkflownamethatincludeslotsofdetailsandisessentiallyalargerunonsentencewithpoorstyleandnopunctuationtobehadwhatsoever"
@@ -1587,4 +1595,7 @@ func TestEnsurePodNamePrefixLength(t *testing.T) {
 	actual = ensurePodNamePrefixLength(expected)
 
 	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
+
+	name = podName(longWfName, nodeName, longTemplateName)
+	assert.Equal(t, maxK8sResourceNameLength, len(name))
 }

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1569,3 +1569,22 @@ func TestPodMetadataWithWorkflowDefaults(t *testing.T) {
 	assert.Equal(t, "label-value", pod.ObjectMeta.Labels["controller-level-pod-label"])
 	cancel()
 }
+
+func TestEnsurePodNamePrefixLength(t *testing.T) {
+	// short case
+	expected := fmt.Sprintf("%s-%s", "wfname", "templatename")
+	actual := ensurePodNamePrefixLength(expected)
+	assert.Equal(t, expected, actual)
+
+	// long case
+	longWfName := "alongworkflownamethatincludeslotsofdetailsandisessentiallyalargerunonsentencewithpoorstyleandnopunctuationtobehadwhatsoever"
+	longTemplateName := "alongtemplatenamethatincludessliightlymoredetailsandiscertainlyalargerunonstnencewithevenworsestylisticconcernsandpreposterouslyeliminatespunctuation"
+
+	sum := len(longWfName) + len(longTemplateName)
+	assert.Greater(t, sum, maxK8sResourceNameLength-k8sNamingHashLength)
+
+	expected = fmt.Sprintf("%s-%s", longWfName, longTemplateName)
+	actual = ensurePodNamePrefixLength(expected)
+
+	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
+}

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1570,36 +1570,6 @@ func TestPodMetadataWithWorkflowDefaults(t *testing.T) {
 	cancel()
 }
 
-func TestPodName(t *testing.T) {
-	nodeName := "nodename"
-
-	// short case
-	shortWfName := "wfname"
-	shortTemplateName := "templatename"
-
-	expected := fmt.Sprintf("%s-%s", shortWfName, shortTemplateName)
-	actual := ensurePodNamePrefixLength(expected)
-	assert.Equal(t, expected, actual)
-
-	name := PodName(shortWfName, nodeName, shortTemplateName)
-	assert.Equal(t, "wfname-templatename-1454367246", name)
-
-	// long case
-	longWfName := "alongworkflownamethatincludeslotsofdetailsandisessentiallyalargerunonsentencewithpoorstyleandnopunctuationtobehadwhatsoever"
-	longTemplateName := "alongtemplatenamethatincludessliightlymoredetailsandiscertainlyalargerunonstnencewithevenworsestylisticconcernsandpreposterouslyeliminatespunctuation"
-
-	sum := len(longWfName) + len(longTemplateName)
-	assert.Greater(t, sum, maxK8sResourceNameLength-k8sNamingHashLength)
-
-	expected = fmt.Sprintf("%s-%s", longWfName, longTemplateName)
-	actual = ensurePodNamePrefixLength(expected)
-
-	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
-
-	name = PodName(longWfName, nodeName, longTemplateName)
-	assert.Equal(t, maxK8sResourceNameLength, len(name))
-}
-
 func TestPodExists(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()

--- a/workflow/util/pod_name.go
+++ b/workflow/util/pod_name.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"fmt"
+	"hash/fnv"
+	"os"
+)
+
+const (
+	maxK8sResourceNameLength = 253
+	k8sNamingHashLength      = 10
+)
+
+// PodName return a deterministic pod name
+func PodName(workflowName, nodeName, templateName, nodeID string) string {
+	if os.Getenv("POD_NAMES") == "v1" {
+		return nodeID
+	}
+
+	if workflowName == nodeName {
+		return workflowName
+	}
+
+	prefix := fmt.Sprintf("%s-%s", workflowName, templateName)
+	prefix = ensurePodNamePrefixLength(prefix)
+
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(nodeName))
+	return fmt.Sprintf("%s-%v", prefix, h.Sum32())
+}
+
+func ensurePodNamePrefixLength(prefix string) string {
+	maxPrefixLength := maxK8sResourceNameLength - k8sNamingHashLength
+
+	if len(prefix) > maxPrefixLength-1 {
+		return prefix[0 : maxPrefixLength-1]
+	}
+
+	return prefix
+}

--- a/workflow/util/pod_name_test.go
+++ b/workflow/util/pod_name_test.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPodName(t *testing.T) {
+	nodeName := "nodename"
+	nodeID := "1"
+
+	// short case
+	shortWfName := "wfname"
+	shortTemplateName := "templatename"
+
+	expected := fmt.Sprintf("%s-%s", shortWfName, shortTemplateName)
+	actual := ensurePodNamePrefixLength(expected)
+	assert.Equal(t, expected, actual)
+
+	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID)
+	assert.Equal(t, "wfname-templatename-1454367246", name)
+
+	// long case
+	longWfName := "alongworkflownamethatincludeslotsofdetailsandisessentiallyalargerunonsentencewithpoorstyleandnopunctuationtobehadwhatsoever"
+	longTemplateName := "alongtemplatenamethatincludessliightlymoredetailsandiscertainlyalargerunonstnencewithevenworsestylisticconcernsandpreposterouslyeliminatespunctuation"
+
+	sum := len(longWfName) + len(longTemplateName)
+	assert.Greater(t, sum, maxK8sResourceNameLength-k8sNamingHashLength)
+
+	expected = fmt.Sprintf("%s-%s", longWfName, longTemplateName)
+	actual = ensurePodNamePrefixLength(expected)
+
+	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
+
+	name = PodName(longWfName, nodeName, longTemplateName, nodeID)
+	assert.Equal(t, maxK8sResourceNameLength, len(name))
+}

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -51,11 +50,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/packer"
 	"github.com/argoproj/argo-workflows/v3/workflow/templateresolution"
 	"github.com/argoproj/argo-workflows/v3/workflow/validate"
-)
-
-const (
-	maxK8sResourceNameLength = 253
-	k8sNamingHashLength      = 10
 )
 
 // NewWorkflowInformer returns the workflow informer used by the controller. This is actually
@@ -1060,32 +1054,4 @@ func GetNodeType(tmpl *wfv1.Template) wfv1.NodeType {
 		return wfv1.NodeTypeSuspend
 	}
 	return ""
-}
-
-// PodName return a deterministic pod name
-func PodName(workflowName, nodeName, templateName, nodeID string) string {
-	if os.Getenv("USE_LEGACY_POD_NAMES") == "true" {
-		return nodeID
-	}
-
-	if workflowName == nodeName {
-		return workflowName
-	}
-
-	prefix := fmt.Sprintf("%s-%s", workflowName, templateName)
-	prefix = ensurePodNamePrefixLength(prefix)
-
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(nodeName))
-	return fmt.Sprintf("%s-%v", prefix, h.Sum32())
-}
-
-func ensurePodNamePrefixLength(prefix string) string {
-	maxPrefixLength := maxK8sResourceNameLength - k8sNamingHashLength
-
-	if len(prefix) > maxPrefixLength-1 {
-		return prefix[0 : maxPrefixLength-1]
-	}
-
-	return prefix
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -810,7 +810,7 @@ func retryWorkflow(ctx context.Context, kubeClient kubernetes.Interface, hydrato
 		}
 		if node.Type == wfv1.NodeTypePod {
 			log.Infof("Deleting pod: %s", node.ID)
-			podName := PodName(wf.Name, node.Name, node.TemplateName)
+			podName := PodName(wf.Name, node.Name, node.TemplateName, node.ID)
 			err := podIf.Delete(ctx, podName, metav1.DeleteOptions{})
 			if err != nil && !apierr.IsNotFound(err) {
 				return nil, errors.InternalWrapError(err)
@@ -1063,7 +1063,11 @@ func GetNodeType(tmpl *wfv1.Template) wfv1.NodeType {
 }
 
 // PodName return a deterministic pod name
-func PodName(workflowName, nodeName, templateName string) string {
+func PodName(workflowName, nodeName, templateName, nodeID string) string {
+	if os.Getenv("USE_LEGACY_POD_NAMES") == "true" {
+		return nodeID
+	}
+
 	if workflowName == nodeName {
 		return workflowName
 	}

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -843,6 +843,7 @@ func TestToUnstructured(t *testing.T) {
 
 func TestPodName(t *testing.T) {
 	nodeName := "nodename"
+	nodeID := "1"
 
 	// short case
 	shortWfName := "wfname"
@@ -852,7 +853,7 @@ func TestPodName(t *testing.T) {
 	actual := ensurePodNamePrefixLength(expected)
 	assert.Equal(t, expected, actual)
 
-	name := PodName(shortWfName, nodeName, shortTemplateName)
+	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID)
 	assert.Equal(t, "wfname-templatename-1454367246", name)
 
 	// long case
@@ -867,6 +868,6 @@ func TestPodName(t *testing.T) {
 
 	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
 
-	name = PodName(longWfName, nodeName, longTemplateName)
+	name = PodName(longWfName, nodeName, longTemplateName, nodeID)
 	assert.Equal(t, maxK8sResourceNameLength, len(name))
 }

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -839,35 +838,4 @@ func TestToUnstructured(t *testing.T) {
 		assert.Equal(t, workflow.Group, gv.Group)
 		assert.Equal(t, workflow.Version, gv.Version)
 	}
-}
-
-func TestPodName(t *testing.T) {
-	nodeName := "nodename"
-	nodeID := "1"
-
-	// short case
-	shortWfName := "wfname"
-	shortTemplateName := "templatename"
-
-	expected := fmt.Sprintf("%s-%s", shortWfName, shortTemplateName)
-	actual := ensurePodNamePrefixLength(expected)
-	assert.Equal(t, expected, actual)
-
-	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID)
-	assert.Equal(t, "wfname-templatename-1454367246", name)
-
-	// long case
-	longWfName := "alongworkflownamethatincludeslotsofdetailsandisessentiallyalargerunonsentencewithpoorstyleandnopunctuationtobehadwhatsoever"
-	longTemplateName := "alongtemplatenamethatincludessliightlymoredetailsandiscertainlyalargerunonstnencewithevenworsestylisticconcernsandpreposterouslyeliminatespunctuation"
-
-	sum := len(longWfName) + len(longTemplateName)
-	assert.Greater(t, sum, maxK8sResourceNameLength-k8sNamingHashLength)
-
-	expected = fmt.Sprintf("%s-%s", longWfName, longTemplateName)
-	actual = ensurePodNamePrefixLength(expected)
-
-	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
-
-	name = PodName(longWfName, nodeName, longTemplateName, nodeID)
-	assert.Equal(t, maxK8sResourceNameLength, len(name))
 }


### PR DESCRIPTION
This PR is a continuation of Alex's PoC  #6647 that fixes #1319. It:
- Sets pod names to a concatenation of the wf name, template name, and hash
- Allows for an override of the pod name to the node id if the env `USE_LEGACY_POD_NAMES` is set to true
- Stores the node id as an annotation on the pod

Sample terminal output:
```
$ kubectl get pods -n argo
NAME                                   READY   STATUS      RESTARTS   AGE
minio-786d5cbc44-c9ppg                 1/1     Running     7          19h
retry-test-p7jzr-whalesay-2308805457   0/2     Completed   0          13h
retry-test-p7jzr-whalesay-2378053249   0/2     Completed   0          13h
```