### PR TITLE
fix: Argo events generate workflow name using epoch time cause duplicate name.

### DIFF
--- a/server/event/dispatch/operation.go
+++ b/server/event/dispatch/operation.go
@@ -106,11 +106,6 @@ func (o *Operation) dispatch(ctx context.Context, wfeb wfv1.WorkflowEventBinding
 			return nil, err
 		}
 
-		if wf.Name == "" {
-			// make sure we have a predicable name, so re-creation doesn't create two workflows
-			wf.SetName(wf.GetGenerateName() + nameSuffix)
-		}
-
 		// users will always want to know why a workflow was submitted,
 		// so we label with creator (which is a standard) and the name of the triggering event
 		creator.Label(o.ctx, wf)


### PR DESCRIPTION
Fixes #6732

This code remove wf.name and leave wf.generateName do it.

Signed-off-by: Thisadee Preeyawongsakul <thisadee_pre@truecorp.co.th>

