### PR TITLE
docs: Fix bad callout render in quick-start docs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,7 +9,7 @@ Firstly, you'll need a Kubernetes cluster and `kubectl` set-up
 To get started quickly, you can use the quick start manifest which will install Argo Workflow as well as some commonly used components:
 
 !!! note
-These manifests are intended to help you get started quickly. They are not suitable in production, on test environments, or any environment containing any real data. They contain hard-coded passwords that are publicly available.
+    These manifests are intended to help you get started quickly. They are not suitable in production, on test environments, or any environment containing any real data. They contain hard-coded passwords that are publicly available.
 
 ```sh
 kubectl create ns argo

--- a/examples/README.md
+++ b/examples/README.md
@@ -235,12 +235,12 @@ spec:
           parameters:
           - name: message
             value: "hello2a"
-      - name: hello2b           # single dash => run in parallel with previous step
-        template: whalesay
-        arguments:
-          parameters:
-          - name: message
-            value: "hello2b"
+    - name: hello2b           # single dash => run in parallel with previous step
+      template: whalesay
+      arguments:
+        parameters:
+        - name: message
+          value: "hello2b"
 
   # This is the same template as from the previous example
   - name: whalesay


### PR DESCRIPTION
Very minor fix to the "!!! note" not rendering in quick-start.md (https://argoproj.github.io/argo-workflows/quick-start/).

While I was at it, I combined the consecutive GKE "notes" into one, with the shell snippet.

Here are the rendered changes, for your consideration ![new-quick-start](https://user-images.githubusercontent.com/2049051/133863533-7762dbfb-4dae-43fe-81b1-d821dc4ebd2b.jpg)
