### PR TITLE
fix(controller): TestPodExists unit test

### DIFF
--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1637,7 +1637,7 @@ func TestPodExists(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 
-	existingPod, doesExist, err := woc.podExists(pod.Name)
+	existingPod, doesExist, err := woc.podExists(pod.ObjectMeta.Name)
 	assert.NoError(t, err)
 	assert.NotNil(t, existingPod)
 	assert.True(t, doesExist)


### PR DESCRIPTION
Recent PR #6712 Added TestPodExists

the code is fine, runs well in local machine but somehow in github ci, it fails very often
#6753 https://github.com/argoproj/argo-workflows/runs/3632323865?check_suite_focus=true
#6749 https://github.com/argoproj/argo-workflows/runs/3627112929?check_suite_focus=true

I tested using
```
	assert.Equal(t, "hello-world", pod.Name)
	assert.Equal(t, "hello-world", pod.ObjectMeta.Name)
	assert.Equal(t, pod.Name, pod.ObjectMeta.Name)
```

They indeed show the same value in github CI

but using `woc.podExists(pod.Name)` just fails

changing to `woc.podExists(pod.ObjectMeta.Name)` seems to solve the issue


Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
