### PR TITLE
feat: Add env vars config for argo-server and workflow-controller

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/argoproj/pkg/cli"
@@ -13,6 +14,8 @@ import (
 	"github.com/argoproj/pkg/stats"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 
@@ -135,6 +138,20 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().Float32Var(&qps, "qps", 20.0, "Queries per second")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run workflow-controller as namespaced mode")
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", "", "namespace that workflow-controller watches, default to the installation namespace")
+
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("ARGO")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	if err := viper.BindPFlags(command.Flags()); err != nil {
+		log.Fatal(err)
+	}
+	command.Flags().VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && viper.IsSet(f.Name) {
+			val := viper.Get(f.Name)
+			command.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+		}
+	})
+
 	return &command
 }
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -37,7 +37,19 @@ Note that these environment variables may be removed at any time.
 | `WORKFLOW_GC_PERIOD` | `time.Duration` | `5m` | The periodicity for GC of workflows. |
 | `BUBBLE_ENTRY_TEMPLATE_ERR` | `bool` | `true` | Whether to bubble up template errors to workflow. |
 | `INFORMER_WRITE_BACK` | `bool` | `true` | Whether to write back to informer instead of catching up. |
-| `GRPC_MESSAGE_SIZE` | `string` | Use different GRPC Max message size for Argo server deployment (supporting huge workflows) |
+| `GRPC_MESSAGE_SIZE` | `string` | Use different GRPC Max message size for Argo server deployment (supporting huge workflows). |
+
+CLI parameters of the `argo-server` and `workflow-controller` can be specified as environment variables with the `ARGO_` prefix. For example:
+
+```
+workflow-controller --managed-namespace=argo
+```
+
+Can be expressed as:
+
+```
+ARGO_MANAGED_NAMESPACE=argo workflow-controller
+```
 
 You can set environment variable for the argo-server deployment, for example:
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,8 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.7.5
 	github.com/valyala/fasthttp v1.22.0 // indirect


### PR DESCRIPTION
This is a proposal for https://github.com/argoproj/argo-workflows/issues/5914. It uses https://github.com/spf13/viper to parse environment variables from the flag names.

I tested this like this:
![image](https://user-images.githubusercontent.com/3706527/133956849-4c3039d0-afa0-447f-9027-4103feefa3c8.png)
![image](https://user-images.githubusercontent.com/3706527/133956881-d82d5921-f4ba-48aa-9248-b35d7a5b66be.png)
