### PR TITLE
fix(controller): TestPodExists test, add delay. Fixes #6458

### DIFF
--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1637,6 +1637,8 @@ func TestPodExists(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 
+	// Sleep 1 second to wait for informer getting pod info
+	time.Sleep(time.Second)
 	existingPod, doesExist, err := woc.podExists(pod.ObjectMeta.Name)
 	assert.NoError(t, err)
 	assert.NotNil(t, existingPod)


### PR DESCRIPTION
Fixes #6458

There's a slight delay between creating pod and informer getting this event,
which result in flaky test

Tested using

`go test -count=100 -run=TestPodExists ./workflow/controller`

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
