### PR TITLE
docs: Additional details added to workflow archive doc pages

### DIFF
--- a/docs/workflow-archive.md
+++ b/docs/workflow-archive.md
@@ -11,3 +11,17 @@ To enable this feature, configure a Postgres or MySQL (>= 5.7.8) database under 
 Be aware that this feature will only archive the statuses of the workflows (which pods have been executed, what was the result, ...)
 
 However, the logs of each pod will NOT be archived. If you need to access the logs of the pods, you need to setup [an artifact repository](artifact-repository-ref.md) thanks to [this doc](configure-artifact-repository.md).
+
+In addition the table specified in the configmap above, the following tables are created when enabling archiving:
+
+* argo_archived_workflows
+* argo_archived_workflows_labels
+* schema_history
+
+The database migration will only occur successfully if none of the tables exist. If a partial set of the tables exist, the database migration may fail and the Argo workflow-controller pod may fail to start. If this occurs delete all of the tables and try restarting the deployment.
+
+## Required database permissions
+
+### Postgres
+The database user/role needs to have `CREATE` and `USAGE` permissions on the `public` schema of the database so that the necessary table can be generted during the migration.
+

--- a/docs/workflow-archive.md
+++ b/docs/workflow-archive.md
@@ -24,4 +24,3 @@ The database migration will only occur successfully if none of the tables exist.
 
 ### Postgres
 The database user/role needs to have `CREATE` and `USAGE` permissions on the `public` schema of the database so that the necessary table can be generted during the migration.
-


### PR DESCRIPTION
A few minor additional details have been added to the Workflow Archive doc pages. 

* Tables generated during the database migration have been listed
* Details about workflow-controller  startup failures with an incomplete set of tables have been added
* Required database permissions for postgres has been explicitly stated. 

I ran into some issues trying to utilize a different postgres schema and strict role permissions and thought these additional details may help others.

Signed-off-by: Anthony Scott <anthony@canthonyscott.com>

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
