### PR TITLE
docs: Add `x-kubernetes-group-version-kind` attribute to JSON schema

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -4427,7 +4427,14 @@
         "metadata",
         "spec"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "argoproj.io",
+          "kind": "ClusterWorkflowTemplate",
+          "version": "v1alpha1"
+        }
+      ]
     },
     "io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateCreateRequest": {
       "properties": {
@@ -4742,7 +4749,14 @@
         "metadata",
         "spec"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "argoproj.io",
+          "kind": "CronWorkflow",
+          "version": "v1alpha1"
+        }
+      ]
     },
     "io.argoproj.workflow.v1alpha1.CronWorkflowDeletedResponse": {
       "type": "object"
@@ -7036,7 +7050,14 @@
         "metadata",
         "spec"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "argoproj.io",
+          "kind": "Workflow",
+          "version": "v1alpha1"
+        }
+      ]
     },
     "io.argoproj.workflow.v1alpha1.WorkflowCreateRequest": {
       "properties": {
@@ -7086,7 +7107,14 @@
         "metadata",
         "spec"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "argoproj.io",
+          "kind": "WorkflowEventBinding",
+          "version": "v1alpha1"
+        }
+      ]
     },
     "io.argoproj.workflow.v1alpha1.WorkflowEventBindingList": {
       "description": "WorkflowEventBindingList is list of event resources",
@@ -7648,7 +7676,14 @@
         "metadata",
         "spec"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "argoproj.io",
+          "kind": "WorkflowTaskSet",
+          "version": "v1alpha1"
+        }
+      ]
     },
     "io.argoproj.workflow.v1alpha1.WorkflowTaskSetSpec": {
       "properties": {
@@ -7696,7 +7731,14 @@
         "metadata",
         "spec"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "argoproj.io",
+          "kind": "WorkflowTemplate",
+          "version": "v1alpha1"
+        }
+      ]
     },
     "io.argoproj.workflow.v1alpha1.WorkflowTemplateCreateRequest": {
       "properties": {

--- a/hack/jsonschema/main.go
+++ b/hack/jsonschema/main.go
@@ -27,9 +27,17 @@ func main() {
 			"WorkflowTemplate",
 			"WorkflowTaskSet",
 		} {
-			v := definitions.(obj)["io.argoproj.workflow.v1alpha1."+kind].(obj)["properties"].(obj)
-			v["apiVersion"].(obj)["const"] = "argoproj.io/v1alpha1"
-			v["kind"].(obj)["const"] = kind
+			v := definitions.(obj)["io.argoproj.workflow.v1alpha1."+kind].(obj)
+			v["x-kubernetes-group-version-kind"] = []map[string]string{
+				{
+					"group":   "argoproj.io",
+					"kind":    kind,
+					"version": "v1alpha1",
+				},
+			}
+			props := v["properties"].(obj)
+			props["apiVersion"].(obj)["const"] = "argoproj.io/v1alpha1"
+			props["kind"].(obj)["const"] = kind
 		}
 		schema := obj{
 			"$id":     "http://workflows.argoproj.io/workflows.json", // don't really know what this should be


### PR DESCRIPTION
If definitions are associated to Kubernetes resources, they may have this attribute to identify this:
https://github.com/kubernetes/kubernetes/blob/master/api/openapi-spec/README.md#x-kubernetes-group-version-kind. For object definitions, it is a list (as I did here in the PR): https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/explain/test-swagger.json#L34-L40

Context:
We generate a [library](https://jsonnet-libs.github.io/argo-workflows-libsonnet/) from the json schema and we use this attribute to determine which objects are actual Kubernetes resources