### PR TITLE
Add custom health check for ingress

### DIFF
--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -155,6 +155,20 @@ spec:
             path: /argo(/|$)(.*)
 ```
 
+If ingress doesn't work fine because of UNHEALTHY state in backend service, this is caused by fail in health check. To fix this, you have to apply custom health check with BackendConfig like this:
+
+```
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: argo-backend-config
+spec:
+  healthCheck:
+    port: 2746
+    type: HTTPS
+    requestPath: /argo/
+```
+
 [Learn more](https://github.com/argoproj/argo-workflows/issues/3080)
 
 


### PR DESCRIPTION
Ingress sometimes fails to start up because of fail in health check.
To avoid this, we have to add custom health check to service.

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
