### PR TITLE
fix: correct task group node's outboundNodes

### DIFF
--- a/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
+++ b/ui/src/app/workflows/components/workflow-dag/workflow-dag.tsx
@@ -254,19 +254,6 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
     }
 
     private getOutboundNodes(nodeID: string): string[] {
-        const node = this.getNode(nodeID);
-        if (node.type === 'Pod' || node.type === 'Skipped') {
-            return [node.id];
-        }
-        let outbound = Array<string>();
-        for (const outboundNodeID of node.outboundNodes || []) {
-            const outNode = this.getNode(outboundNodeID);
-            if (outNode.type === 'Pod') {
-                outbound.push(outboundNodeID);
-            } else {
-                outbound = outbound.concat(this.getOutboundNodes(outboundNodeID));
-            }
-        }
-        return outbound;
+        return this.getNode(nodeID).outboundNodes;
     }
 }

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -318,6 +318,10 @@ func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext,
 		outboundNodeIDs := woc.getOutboundNodes(depNode.ID)
 		outbound = append(outbound, outboundNodeIDs...)
 	}
+	// only overwrite outboundNodes when it has, otherwise it should point to itself
+	if len(outbound) == 0 {
+		return
+	}
 	node := woc.wf.GetNodeByName(nodeName)
 	node.OutboundNodes = outbound
 	woc.wf.Status.Nodes[node.ID] = *node
@@ -493,6 +497,11 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 				groupPhase = node.Phase
 			}
 		}
+		targetTasks := make([]string, 0)
+		for _, t := range expandedTasks {
+			targetTasks = append(targetTasks, t.Name)
+		}
+		woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, taskGroupNode.Name)
 		woc.markNodePhase(taskGroupNode.Name, groupPhase)
 	}
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2130,6 +2130,7 @@ func (woc *wfOperationCtx) initializeNode(nodeName string, nodeType wfv1.NodeTyp
 		Phase:             phase,
 		StartedAt:         metav1.Time{Time: time.Now().UTC()},
 		EstimatedDuration: woc.estimateNodeDuration(nodeName),
+		OutboundNodes:     []string{nodeID},
 	}
 
 	if boundaryNode, ok := woc.wf.Status.Nodes[boundaryID]; ok {
@@ -2405,7 +2406,9 @@ func (woc *wfOperationCtx) getOutboundNodes(nodeID string) []string {
 
 		// If this pod comes from a container set, it should be treated as a container or task group
 		fallthrough
-	case wfv1.NodeTypeContainer, wfv1.NodeTypeTaskGroup:
+	case wfv1.NodeTypeTaskGroup:
+		return node.OutboundNodes
+	case wfv1.NodeTypeContainer:
 		if len(node.Children) == 0 {
 			return []string{node.ID}
 		}


### PR DESCRIPTION
Signed-off-by: book987 <book87987book@gmail.com>

- set node's outboundNodes to itself initially
- update outbound nodes when task group node fullfill
- according to above, return node.OutboundNodes when get task group's outbound node

fix #6834 

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
