### PR TITLE
chore: enabled `rowserrcheck` and `sqlclosecheck` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,9 +32,8 @@ linters:
     - govet
     - ineffassign
     - misspell
-    # TODO https://github.com/argoproj/argo-workflows/issues/6838
-    # - rowserrcheck
-    # - sqlclosecheck
+    - rowserrcheck
+    - sqlclosecheck
     - staticcheck
     - structcheck
     - typecheck

--- a/persist/sqldb/backfill_nodes.go
+++ b/persist/sqldb/backfill_nodes.go
@@ -19,7 +19,7 @@ func (s backfillNodes) String() string {
 	return fmt.Sprintf("backfillNodes{%s}", s.tableName)
 }
 
-func (s backfillNodes) apply(session sqlbuilder.Database) error {
+func (s backfillNodes) apply(session sqlbuilder.Database) (err error) {
 	log.Info("Backfill node status")
 	rs, err := session.SelectFrom(s.tableName).
 		Columns("workflow").
@@ -28,6 +28,14 @@ func (s backfillNodes) apply(session sqlbuilder.Database) error {
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		tmpErr := rs.Close()
+		if err == nil {
+			err = tmpErr
+		}
+	}()
+
 	for rs.Next() {
 		workflow := ""
 		err := rs.Scan(&workflow)


### PR DESCRIPTION
Updated code to defer closing sql.Rows recommended by linters

resolves #6838 

The `sqlclosecheck` linter says to use defer but not sure if this is the best way to handle returning the error. I am also not sure if its possible to hit a scenario where the code gets an error on `rs.Scan` and `rs.Close` as an example. Currently the code only sets the error in the defer func if there were no errors previously. 