### PR TITLE
docs: Add notes to params from configmap examples to reduce user errors

### DIFF
--- a/examples/arguments-parameters-from-configmap.yaml
+++ b/examples/arguments-parameters-from-configmap.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     workflows.argoproj.io/description: |
       This example demonstrates loading parameter values from configmap.
+      Note that the "simple-parameters" ConfigMap (defined in examples/configmaps/simple-parameters-configmap.yaml)
+      needs to be created first before submitting this workflow.
     workflows.argoproj.io/verify.py: |
       assert status["phase"] == "Succeeded"
 spec:

--- a/examples/configmaps/simple-parameters-configmap.yaml
+++ b/examples/configmaps/simple-parameters-configmap.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: simple-parameters
-  namespace: argo
   labels:
+    # Note that this label is required for the informer to detect this ConfigMap.
     workflows.argoproj.io/configmap-type: Parameter
 data:
   msg: 'hello world'

--- a/examples/global-parameters-from-configmap.yaml
+++ b/examples/global-parameters-from-configmap.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     workflows.argoproj.io/description: |
       This example demonstrates loading global parameter values from configmap.
+      Note that the "simple-parameters" ConfigMap (defined in examples/configmaps/simple-parameters-configmap.yaml)
+      needs to be created first before submitting this workflow.
     workflows.argoproj.io/verify.py: |
       assert status["phase"] == "Succeeded"
 spec:

--- a/hack/test-examples.sh
+++ b/hack/test-examples.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 ./dist/argo delete -l workflows.argoproj.io/test
 
 # Load the configmaps that contains the parameter values used for certain examples.
-kubectl apply -f examples/configmaps/simple-parameters-configmap.yaml
+kubectl create -n argo -f examples/configmaps/simple-parameters-configmap.yaml
 
 grep -lR 'workflows.argoproj.io/test' examples/* | while read f ; do
   ./dist/argo submit --watch --verify $f


### PR DESCRIPTION
These changes would reduce user errors:
1. Created ConfigMap in a different namespace
2. Required ConfigMap is not created before submitting the workflow
3. Required label in ConfigMap is missing.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems. 
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismis the review to get it looked at again.
* You can ask for help! 
