### PR TITLE
fix(controller): Fix getPodByNode, TestGetPodByNode. Fixes #6458

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2190,7 +2190,8 @@ func (woc *wfOperationCtx) getPodByNode(node *wfv1.NodeStatus) (*apiv1.Pod, erro
 	if node.Type != wfv1.NodeTypePod {
 		return nil, fmt.Errorf("Expected node type %s, got %s", wfv1.NodeTypePod, node.Type)
 	}
-	return woc.controller.getPod(woc.wf.GetNamespace(), node.ID)
+	podName := wfutil.PodName(woc.wf.Name, node.Name, node.TemplateName, node.ID)
+	return woc.controller.getPod(woc.wf.GetNamespace(), podName)
 }
 
 func (woc *wfOperationCtx) recordNodePhaseEvent(node *wfv1.NodeStatus) {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3519,7 +3519,6 @@ func getEvents(controller *WorkflowController, num int) []string {
 }
 
 func TestGetPodByNode(t *testing.T) {
-	os.Setenv("POD_NAMES", "v1")
 	workflowText := `
 metadata:
   name: dag-events


### PR DESCRIPTION
Signed-off-by: Micah Beeman <micah.beeman@workiva.com>

getPodByNode was broken by the changes in https://github.com/argoproj/argo-workflows/pull/6712
Fixed by using the `PodName` util to obtain the pod name to pass to `getPod`
Added sleep after pods are created to fix flakiness in TestGetPodByNode

Fixes https://github.com/argoproj/argo-workflows/issues/6458