### PR TITLE
fix(docs): fix data transformation example

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2185,6 +2185,8 @@ Outputs hold parameters, artifacts, and results from a step
 
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/dag-conditional-parameters.yaml)
 
+- [`data-transformations.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/data-transformations.yaml)
+
 - [`exit-handler-with-artifacts.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/exit-handler-with-artifacts.yaml)
 
 - [`exit-handler-with-param.yaml`](https://github.com/argoproj/argo-workflows/blob/master/examples/exit-handler-with-param.yaml)

--- a/examples/data-transformations.yaml
+++ b/examples/data-transformations.yaml
@@ -42,6 +42,10 @@ spec:
 
         transformation:
           - expression: "filter(data, {# endsWith \"main.log\"})"
+      outputs:
+        artifacts:
+          - name: file
+            path: /file
 
     - name: process-logs
       inputs:


### PR DESCRIPTION
This PR fixes the data transformation example https://github.com/argoproj/argo-workflows/blob/master/examples/data-transformations.yaml by adding a target artifact.

Without this the workflow crashes with:

```
Error (exit code 64): unable to process data template: unable to process data source: unable to source artifact paths: template artifact location not set
```

Closes https://github.com/argoproj/argo-workflows/issues/6900 . 
