### PR TITLE
 fix(executor): change script file permissions to 0o644 and add test for non-root user creating a script

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -793,6 +793,34 @@ func (s *FunctionalSuite) TestDataTransformation() {
 		})
 }
 
+func (s *FunctionalSuite) TestScriptAsNonRoot() {
+	s.Given().
+		Workflow(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: script-nonroot-
+spec:
+  entrypoint: whalesay
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+  templates:
+    - name: whalesay
+      script:
+        image: argoproj/argosay:v2
+        command: ["bash"]
+        source: |
+          ls -l /argo/staging
+          cat /argo/stahing/script
+          sleep 10s
+`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded)
+}
+
 func TestFunctionalSuite(t *testing.T) {
 	suite.Run(t, new(FunctionalSuite))
 }

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -251,7 +251,7 @@ func (we *WorkflowExecutor) StageFiles() error {
 	default:
 		return nil
 	}
-	err := ioutil.WriteFile(filePath, body, 0o600)
+	err := ioutil.WriteFile(filePath, body, 0o644)
 	if err != nil {
 		return errors.InternalWrapError(err)
 	}


### PR DESCRIPTION
Fixes #6643

This change adds a test to catch the case where the WorkflowExecutor.StageFiles() method creates a script file that is not readable by group/other, so execution of the script by the main container fails when there is a securityContext that specifies runAsNonRoot.

I'm pushing this first to make sure that the E2E test fails as expected before I push the fix, which is to revert a change in StageFiles() that changed the file permissions to 600 from 644.

