### PR TITLE
fix: Unreachable code in util/tls/tls.go. Fixes #6950

### DIFF
--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -22,7 +22,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 	case *ecdsa.PrivateKey:
 		b, err := x509.MarshalECPrivateKey(k)
 		if err != nil {
-			log.Fatal(err)
+			log.Print(err)
 			os.Exit(2)
 		}
 		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}


### PR DESCRIPTION
Signed-off-by: chavacava <salvadorcavadini+github@gmail.com>

Hi @alexec, I did not push a PR because it is not clear to me how to replace the `log.Fatal`
In the base code I've found  `fmt.Println(err)`, `log.Print(err)`, `println(err)` just before `os.Exit`. 
In this PR I've opt for `log.Print(err)` because is ≃ to `log.Fatal` without exiting.

Fixes #6950