### PR TITLE
docs: Add `terrytangyuan` to list of approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ owners:
 - alexec
 
 reviewers:
-- terrytangyuan
 - xianlubird
 
 approvers:
@@ -13,3 +12,4 @@ approvers:
 - jessesuen
 - sarabala1979
 - simster7
+- terrytangyuan


### PR DESCRIPTION
This PR moves myself to the list of approvers as defined [here](https://github.com/argoproj/argoproj/blob/master/community/membership.md#approver).

- [x] Reviewer for at least 3 months
* Been reviewer for 7 months (reference: https://github.com/argoproj/argo-workflows/pull/5191)
- [x] Reviewer for or author of at least 10 substantial PRs to the codebase, with the definition of substantial subject to the lead's discretion (e.g. refactors, enhancements rather than grammar correction or one-line pulls).
* Authored 160 PRs: https://github.com/argoproj/argo-workflows/pulls?q=is%3Apr+author%3Aterrytangyuan+
* Reviewed PRs: https://github.com/argoproj/argo-workflows/pulls?q=is%3Apr+reviewed-by%3Aterrytangyuan+is%3Aclosed
* Involved issue discussions: https://github.com/argoproj/argo-workflows/issues?q=is%3Aissue+involves%3Aterrytangyuan
- [x] Sponsored by a subproject lead
* Initial sponsor is @alexec and other maintainers who approve this PR will be seen as additional sponsors.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>