### PR TITLE
fix: OAuth2 callback with self-signed Root CA. Fixes #6793

### DIFF
--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -2,7 +2,6 @@ package sso
 
 import (
 	"context"
-	"crypto/tls"
 	"testing"
 	"time"
 
@@ -29,7 +28,7 @@ func (fakeOidcProvider) Verifier(config *oidc.Config) *oidc.IDTokenVerifier {
 	return nil
 }
 
-func fakeOidcFactory(ctx context.Context, issuer string, tlsConfig *tls.Config) (providerInterface, error) {
+func fakeOidcFactory(ctx context.Context, issuer string) (providerInterface, error) {
 	return fakeOidcProvider{ctx, issuer}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Niclas Schnickmann <niclas.schnickmann@nextstep-services.de>

Looks like #6961 did not fix #6793 completely as I missed to add an http.Client to the oauth Exchange call.

This one was tested on my staging cluster and works fine with Keycloak (internal CA/self-signed).