### PR TITLE
fix:  locally running argo workflow quick start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -26,7 +26,7 @@ kubectl create clusterrolebinding YOURNAME-cluster-admin-binding --clusterrole=c
 !!! note
     To run Argo on GKE Autopilot, you must use the `emissary` executor or the `k8sapi` executor. Find more information on our [executors doc](workflow-executors.md).
 
-If you are running Argo Workflows locally (e.g. using Minikube or Docker for Desktop), open a port-forward so you can access the namespace:
+If you are running Argo Workflows locally (e.g. using Minikube or Docker for Desktop), you will need to add `--secure=false` to `argo-server` deployment, then open a port-forward so you can access the namespace:
 
 ```sh
 kubectl -n argo port-forward deployment/argo-server 2746:2746


### PR DESCRIPTION
* Update quick-start.md with instructions to get started locally
