### PR TITLE
test: skip `TestDoNotCreatePodsUnderStopBehavior` for `docker` executor. Fixes #7040

### DIFF
--- a/test/e2e/signals_test.go
+++ b/test/e2e/signals_test.go
@@ -86,6 +86,7 @@ func (s *SignalsSuite) TestTerminateBehavior() {
 
 // Tests that new pods are never created once a stop shutdown strategy has been added
 func (s *SignalsSuite) TestDoNotCreatePodsUnderStopBehavior() {
+	s.Need(fixtures.None(fixtures.Docker))
 	s.Given().
 		Workflow("@functional/stop-terminate-2.yaml").
 		When().


### PR DESCRIPTION
We no longer wish to invest in the Docker executor. Rather than try and figure out why this flakey test is failing, let's skip it.

…cutor. Fixes #7040
