### PR TITLE
fix: unit test TestNewOperation. Fixes #7063

### DIFF
--- a/server/event/dispatch/operation_test.go
+++ b/server/event/dispatch/operation_test.go
@@ -3,6 +3,7 @@ package dispatch
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,18 +154,22 @@ func TestNewOperation(t *testing.T) {
 
 	expectedParamValues := []string{
 		"bar",
-		`{"bar":"baz"}`,
 		"bar",
+		`{"bar":"baz"}`,
 	}
+	var paramValues []string
 	// assert
 	list, err := client.ArgoprojV1alpha1().Workflows("my-ns").List(ctx, metav1.ListOptions{})
 	if assert.NoError(t, err) && assert.Len(t, list.Items, 3) {
-		for i, wf := range list.Items {
+		for _, wf := range list.Items {
 			assert.Equal(t, "my-instanceid", wf.Labels[common.LabelKeyControllerInstanceID])
 			assert.Equal(t, "my-sub", wf.Labels[common.LabelKeyCreator])
 			assert.Contains(t, wf.Labels, common.LabelKeyWorkflowEventBinding)
-			assert.Equal(t, []wfv1.Parameter{{Name: "my-param", Value: wfv1.AnyStringPtr(expectedParamValues[i])}}, wf.Spec.Arguments.Parameters)
+			assert.Contains(t, "my-param", wf.Spec.Arguments.Parameters[0].Name)
+			paramValues = append(paramValues, string(*wf.Spec.Arguments.Parameters[0].Value))
 		}
+		sort.Strings(paramValues)
+		assert.Equal(t, expectedParamValues, paramValues)
 	}
 	assert.Equal(t, "Warning WorkflowEventBindingError failed to dispatch event: failed to evaluate workflow template expression: unexpected token EOF (1:1)", <-recorder.Events)
 	assert.Equal(t, "Warning WorkflowEventBindingError failed to dispatch event: failed to get workflow template: workflowtemplates.argoproj.io \"not-found\" not found", <-recorder.Events)


### PR DESCRIPTION
Fixes #7063

tested with `go test -count=100 -run=TestNewOperation ./server/event/dispatch`

order of pipeline execution (list) may be different from the order of submission due to network delays

Tips:

* Maybe add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it does not need to pass
* Sign-off your commits to pass the DCO check: `git commit --signoff`.
* Run `make pre-commit -B` to fix codegen or lint problems.
* Say how how you tested your changes. If you changed the UI, attach screenshots.
* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* You can ask for help! 
