### PR TITLE
docs: Remove whitespace at argo-server-sso.md

### DIFF
--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -143,7 +143,7 @@ sso:
   userInfoPath: /oauth2/v1/userinfo
 ```
 
- #### Example expr
+#### Example expr
 
 ```shell
 # assuming customClaimGroupName: argo_groups


### PR DESCRIPTION
This whitespace makes a weird title at the webpage with the # instead of creating a new H4 as we can see at https://argoproj.github.io/argo-workflows/argo-server-sso/#custom-claims

Signed-off-by: Francisco Barón baronizquierdo@gmail.com