### PR TITLE
feat(controller): Added new workflow and Prometheus metric state. Fixes #7036

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_phase.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_phase.go
@@ -4,17 +4,18 @@ package v1alpha1
 type WorkflowPhase string
 
 const (
-	WorkflowUnknown   WorkflowPhase = ""
-	WorkflowPending   WorkflowPhase = "Pending" // pending some set-up - rarely used
-	WorkflowRunning   WorkflowPhase = "Running" // any node has started; pods might not be running yet, the workflow maybe suspended too
-	WorkflowSucceeded WorkflowPhase = "Succeeded"
-	WorkflowFailed    WorkflowPhase = "Failed" // it maybe that the the workflow was terminated
-	WorkflowError     WorkflowPhase = "Error"
+	WorkflowUnknown    WorkflowPhase = ""
+	WorkflowPending    WorkflowPhase = "Pending" // pending some set-up - rarely used
+	WorkflowRunning    WorkflowPhase = "Running" // any node has started; pods might not be running yet, the workflow maybe suspended too
+	WorkflowSucceeded  WorkflowPhase = "Succeeded"
+	WorkflowFailed     WorkflowPhase = "Failed"     // it maybe that the the workflow was terminated
+	WorkflowTerminated WorkflowPhase = "Terminated" // it maybe that the the workflow was terminated by human
+	WorkflowError      WorkflowPhase = "Error"
 )
 
 func (p WorkflowPhase) Completed() bool {
 	switch p {
-	case WorkflowSucceeded, WorkflowFailed, WorkflowError:
+	case WorkflowSucceeded, WorkflowFailed, WorkflowTerminated, WorkflowError:
 		return true
 	default:
 		return false

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -53,6 +53,8 @@ const (
 	NodeSkipped NodePhase = "Skipped"
 	// Node or child of node exited with non-0 code
 	NodeFailed NodePhase = "Failed"
+	// Node or child was terminated by human interaction
+	NodeTerminated NodePhase = "Terminated"
 	// Node had an error other than a non 0 exit code
 	NodeError NodePhase = "Error"
 	// Node was omitted because its `depends` condition was not met (only relevant in DAGs)

--- a/test/e2e/fixtures/print.go
+++ b/test/e2e/fixtures/print.go
@@ -12,12 +12,13 @@ import (
 )
 
 var workflowPhaseIcon = map[wfv1.WorkflowPhase]string{
-	"":                     color.Ize(color.Gray, "?"),
-	wfv1.WorkflowPending:   color.Ize(color.Yellow, "◷"),
-	wfv1.WorkflowRunning:   color.Ize(color.Blue, "●"),
-	wfv1.WorkflowSucceeded: color.Ize(color.Green, "✔"),
-	wfv1.WorkflowFailed:    color.Ize(color.Red, "✖"),
-	wfv1.WorkflowError:     color.Ize(color.Red, "⚠"),
+	"":                      color.Ize(color.Gray, "?"),
+	wfv1.WorkflowPending:    color.Ize(color.Yellow, "◷"),
+	wfv1.WorkflowRunning:    color.Ize(color.Blue, "●"),
+	wfv1.WorkflowSucceeded:  color.Ize(color.Green, "✔"),
+	wfv1.WorkflowFailed:     color.Ize(color.Red, "✖"),
+	wfv1.WorkflowTerminated: color.Ize(color.Yellow, "#"),
+	wfv1.WorkflowError:      color.Ize(color.Red, "⚠"),
 }
 
 var nodePhaseIcon = map[wfv1.NodePhase]string{

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1177,7 +1177,7 @@ func (wfc *WorkflowController) isArchivable(wf *wfv1.Workflow) bool {
 func (wfc *WorkflowController) syncWorkflowPhaseMetrics() {
 	defer runtimeutil.HandleCrash(runtimeutil.PanicHandlers...)
 
-	for _, phase := range []wfv1.NodePhase{wfv1.NodePending, wfv1.NodeRunning, wfv1.NodeSucceeded, wfv1.NodeFailed, wfv1.NodeError} {
+	for _, phase := range []wfv1.NodePhase{wfv1.NodePending, wfv1.NodeRunning, wfv1.NodeSucceeded, wfv1.NodeFailed, wfv1.NodeTerminated, wfv1.NodeError} {
 		keys, err := wfc.wfInformer.GetIndexer().IndexKeys(indexes.WorkflowPhaseIndex, string(phase))
 		errors.CheckError(err)
 		wfc.metrics.SetWorkflowPhaseGauge(phase, len(keys))


### PR DESCRIPTION
# Summary

This PR adds a new workflow & Prometheus metric state 'Terminated' for terminated workflows (as req. in #7036).
When terminating a workflow in argo-workflows this should be correctly represented within the Prometheus metrics. In the current state this will not be handled as a dedicated state. IMHO a user terminated workflow should not be treated as a failed one. Therefore, a new gauge for Prometheus should be integrated to provide this.

# Use Cases

The current overview of human terminated workflows can be misleading. It should be directly visible that a workflow was terminated manually by a human interaction and it was expected that this workflow could not terminate in a successful way. This will be more important when It comes to monitoring and alerting with Prometheus/Grafana setups where terminated workflows should not raise any alerts.

# Tests
This has been tested on release/3.2 in a test setup with a modified Grafana dashboard where it was possible to see terminated Workflows. These ones will not more be displayed as failed ones.
