### PR TITLE
fix: allow wf templates without parameter values (Fixes #6044)

### DIFF
--- a/server/clusterworkflowtemplate/cluster_workflow_template_server.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server.go
@@ -32,7 +32,7 @@ func (cwts *ClusterWorkflowTemplateServer) CreateClusterWorkflowTemplate(ctx con
 	cwts.instanceIDService.Label(req.Template)
 	creator.Label(ctx, req.Template)
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template)
+	_, err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (cwts *ClusterWorkflowTemplateServer) LintClusterWorkflowTemplate(ctx conte
 	wfClient := auth.GetWfClient(ctx)
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template)
+	_, err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (cwts *ClusterWorkflowTemplateServer) UpdateClusterWorkflowTemplate(ctx con
 	wfClient := auth.GetWfClient(ctx)
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err = validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template)
+	_, err = validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
@@ -154,18 +154,33 @@ func getClusterWorkflowTemplateServer() (clusterwftmplpkg.ClusterWorkflowTemplat
 
 func TestWorkflowTemplateServer_CreateClusterWorkflowTemplate(t *testing.T) {
 	server, ctx := getClusterWorkflowTemplateServer()
-	cwftReq := clusterwftmplpkg.ClusterWorkflowTemplateCreateRequest{
-		Template: unlabelled.DeepCopy(),
-	}
-	cwftReq.Template.Name = "foo"
-	assert.NotContains(t, cwftReq.Template.Labels, common.LabelKeyControllerInstanceID)
-	cwftRsp, err := server.CreateClusterWorkflowTemplate(ctx, &cwftReq)
-	if assert.NoError(t, err) {
-		assert.NotNil(t, cwftRsp)
-		// ensure the label is added
-		assert.Contains(t, cwftRsp.Labels, common.LabelKeyControllerInstanceID)
-		assert.Contains(t, cwftRsp.Labels, common.LabelKeyCreator)
-	}
+	t.Run("Without parameter values", func(t *testing.T) {
+		tmpl := unlabelled.DeepCopy()
+		tmpl.Name = "foo-without-param-values"
+		tmpl.Spec.Arguments.Parameters[0].Value = nil
+		req := clusterwftmplpkg.ClusterWorkflowTemplateCreateRequest{
+			Template: tmpl,
+		}
+		resp, err := server.CreateClusterWorkflowTemplate(ctx, &req)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "message", resp.Spec.Arguments.Parameters[0].Name)
+			assert.Nil(t, resp.Spec.Arguments.Parameters[0].Value)
+		}
+	})
+	t.Run("With parameter values", func(t *testing.T) {
+		cwftReq := clusterwftmplpkg.ClusterWorkflowTemplateCreateRequest{
+			Template: unlabelled.DeepCopy(),
+		}
+		cwftReq.Template.Name = "foo-with-param-values"
+		assert.NotContains(t, cwftReq.Template.Labels, common.LabelKeyControllerInstanceID)
+		cwftRsp, err := server.CreateClusterWorkflowTemplate(ctx, &cwftReq)
+		if assert.NoError(t, err) {
+			assert.NotNil(t, cwftRsp)
+			// ensure the label is added
+			assert.Contains(t, cwftRsp.Labels, common.LabelKeyControllerInstanceID)
+			assert.Contains(t, cwftRsp.Labels, common.LabelKeyCreator)
+		}
+	})
 }
 
 func TestWorkflowTemplateServer_GetClusterWorkflowTemplate(t *testing.T) {
@@ -226,6 +241,20 @@ func TestWorkflowTemplateServer_LintClusterWorkflowTemplate(t *testing.T) {
 		if assert.NoError(t, err) {
 			assert.Contains(t, resp.Labels, common.LabelKeyControllerInstanceID)
 			assert.Contains(t, resp.Labels, common.LabelKeyCreator)
+		}
+	})
+
+	t.Run("Without param values", func(t *testing.T) {
+		tmpl := unlabelled.DeepCopy()
+		tmpl.Name = "foo-without-param-values"
+		tmpl.Spec.Arguments.Parameters[0].Value = nil
+		req := clusterwftmplpkg.ClusterWorkflowTemplateLintRequest{
+			Template: tmpl,
+		}
+		resp, err := server.LintClusterWorkflowTemplate(ctx, &req)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "message", resp.Spec.Arguments.Parameters[0].Name)
+			assert.Nil(t, resp.Spec.Arguments.Parameters[0].Value)
 		}
 	})
 }

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -609,7 +609,7 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{})
+	_, err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{Submit: true})
 	if err != nil {
 		return nil, err
 	}

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -447,8 +447,7 @@ const workflowtmpl = `
     "arguments": {
       "parameters": [
         {
-          "name": "message",
-          "value": "hello world"
+          "name": "message"
         }
       ]
     },
@@ -880,11 +879,25 @@ func TestPodLogs(t *testing.T) {
 
 func TestSubmitWorkflowFromResource(t *testing.T) {
 	server, ctx := getWorkflowServer()
-	t.Run("SubmitFromWorkflowTemplate", func(t *testing.T) {
-		wf, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
+	t.Run("SubmitFromWorkflowTemplate fails if missing parameters", func(t *testing.T) {
+		_, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
 			Namespace:    "workflows",
 			ResourceKind: "workflowtemplate",
 			ResourceName: "workflow-template-whalesay-template",
+		})
+		assert.EqualError(t, err, "spec.arguments.message.value is required")
+	})
+	t.Run("SubmitFromWorkflowTemplate", func(t *testing.T) {
+		opts := v1alpha1.SubmitOpts{
+			Parameters: []string{
+				"message=hello",
+			},
+		}
+		wf, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
+			Namespace:     "workflows",
+			ResourceKind:  "workflowtemplate",
+			ResourceName:  "workflow-template-whalesay-template",
+			SubmitOptions: &opts,
 		})
 		if assert.NoError(t, err) {
 			assert.NotNil(t, wf)

--- a/server/workflowtemplate/workflow_template_server.go
+++ b/server/workflowtemplate/workflow_template_server.go
@@ -33,7 +33,7 @@ func (wts *WorkflowTemplateServer) CreateWorkflowTemplate(ctx context.Context, r
 	creator.Label(ctx, req.Template)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template)
+	_, err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (wts *WorkflowTemplateServer) LintWorkflowTemplate(ctx context.Context, req
 	creator.Label(ctx, req.Template)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template)
+	_, err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (wts *WorkflowTemplateServer) UpdateWorkflowTemplate(ctx context.Context, r
 	wfClient := auth.GetWfClient(ctx)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err = validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template)
+	_, err = validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/workflowtemplate/workflow_template_server_test.go
+++ b/server/workflowtemplate/workflow_template_server_test.go
@@ -172,6 +172,18 @@ func getWorkflowTemplateServer() (workflowtemplatepkg.WorkflowTemplateServiceSer
 
 func TestWorkflowTemplateServer_CreateWorkflowTemplate(t *testing.T) {
 	server, ctx := getWorkflowTemplateServer()
+	t.Run("Without parameter values", func(t *testing.T) {
+		var wftReq workflowtemplatepkg.WorkflowTemplateCreateRequest
+		v1alpha1.MustUnmarshal(wftStr1, &wftReq)
+		wftReq.Template.Name = "foo-without-param-values"
+		wftReq.Template.Spec.Arguments.Parameters[0].Value = nil
+		wftRsp, err := server.CreateWorkflowTemplate(ctx, &wftReq)
+		if assert.NoError(t, err) {
+			assert.NotNil(t, wftRsp)
+			assert.Equal(t, "message", wftRsp.Spec.Arguments.Parameters[0].Name)
+			assert.Nil(t, wftRsp.Spec.Arguments.Parameters[0].Value)
+		}
+	})
 	t.Run("Labelled", func(t *testing.T) {
 		var wftReq workflowtemplatepkg.WorkflowTemplateCreateRequest
 		v1alpha1.MustUnmarshal(wftStr1, &wftReq)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -169,7 +169,7 @@ func IsWorkflowCompleted(wf *wfv1.Workflow) bool {
 	return false
 }
 
-// SubmitWorkflow validates and submit a single workflow and override some of the fields of the workflow
+// SubmitWorkflow validates and submits a single workflow and overrides some of the fields of the workflow
 func SubmitWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, wfClientset wfclientset.Interface, namespace string, wf *wfv1.Workflow, opts *wfv1.SubmitOpts) (*wfv1.Workflow, error) {
 	err := ApplySubmitOpts(wf, opts)
 	if err != nil {
@@ -178,7 +178,7 @@ func SubmitWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, wfClie
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{})
+	_, err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{Submit: true})
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -45,9 +45,9 @@ func validateWithOptions(yamlStr string, opts ValidateOpts) (*wfv1.Conditions, e
 
 // validateWorkflowTemplate is a test helper to accept WorkflowTemplate YAML as a string and return
 // its validation result.
-func validateWorkflowTemplate(yamlStr string) error {
+func validateWorkflowTemplate(yamlStr string, opts ValidateOpts) error {
 	wftmpl := unmarshalWftmpl(yamlStr)
-	_, err := ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl)
+	_, err := ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, opts)
 	return err
 }
 
@@ -1671,7 +1671,7 @@ spec:
 `
 
 func TestWorkflowTemplate(t *testing.T) {
-	err := validateWorkflowTemplate(templateRefTarget)
+	err := validateWorkflowTemplate(templateRefTarget, ValidateOpts{})
 	assert.NoError(t, err)
 }
 
@@ -2298,7 +2298,7 @@ spec:
 `
 
 func TestWorkflowTemplateWithEntrypoint(t *testing.T) {
-	err := validateWorkflowTemplate(wfTemplateWithEntrypoint)
+	err := validateWorkflowTemplate(wfTemplateWithEntrypoint, ValidateOpts{})
 	assert.NoError(t, err)
 }
 
@@ -2567,7 +2567,7 @@ spec:
 `
 
 func TestWorkflowTemplateLabels(t *testing.T) {
-	err := validateWorkflowTemplate(testWorkflowTemplateLabels)
+	err := validateWorkflowTemplate(testWorkflowTemplateLabels, ValidateOpts{})
 	assert.NoError(t, err)
 }
 
@@ -2733,17 +2733,29 @@ spec:
 `
 
 func TestWorkflowTemplateWithEnumValue(t *testing.T) {
-	err := validateWorkflowTemplate(workflowTeamplateWithEnumValues)
+	err := validateWorkflowTemplate(workflowTeamplateWithEnumValues, ValidateOpts{})
+	assert.NoError(t, err)
+	err = validateWorkflowTemplate(workflowTeamplateWithEnumValues, ValidateOpts{Lint: true})
+	assert.NoError(t, err)
+	err = validateWorkflowTemplate(workflowTeamplateWithEnumValues, ValidateOpts{Submit: true})
 	assert.NoError(t, err)
 }
 
 func TestWorkflowTemplateWithEmptyEnumList(t *testing.T) {
-	err := validateWorkflowTemplate(workflowTemplateWithEmptyEnumList)
+	err := validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{})
+	assert.NoError(t, err)
+	err = validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{Lint: true})
+	assert.NoError(t, err)
+	err = validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{Submit: true})
 	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 }
 
 func TestWorkflowTemplateWithArgumentValueNotFromEnumList(t *testing.T) {
-	err := validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList)
+	err := validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{})
+	assert.NoError(t, err)
+	err = validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Lint: true})
+	assert.NoError(t, err)
+	err = validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Submit: true})
 	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 }
 
@@ -2787,7 +2799,7 @@ spec:
 `
 
 func TestValidActiveDeadlineSecondsArgoVariable(t *testing.T) {
-	err := validateWorkflowTemplate(validActiveDeadlineSecondsArgoVariable)
+	err := validateWorkflowTemplate(validActiveDeadlineSecondsArgoVariable, ValidateOpts{})
 	assert.NoError(t, err)
 }
 
@@ -2797,11 +2809,11 @@ func TestMaxLengthName(t *testing.T) {
 	assert.EqualError(t, err, "workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	wftmpl := &wfv1.WorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	_, err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl)
+	_, err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, ValidateOpts{})
 	assert.EqualError(t, err, "workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwftmpl := &wfv1.ClusterWorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	_, err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl)
+	_, err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl, ValidateOpts{})
 	assert.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 60)}}
@@ -2904,7 +2916,7 @@ spec:
 		invalidContainerSetTemplateWithOutputParams,
 	}
 	for _, manifest := range invalidManifests {
-		err := validateWorkflowTemplate(manifest)
+		err := validateWorkflowTemplate(manifest, ValidateOpts{})
 		if assert.NotNil(t, err) {
 			assert.Contains(t, err.Error(), "containerSet.containers must have a container named \"main\" for input or output")
 		}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2743,18 +2743,18 @@ func TestWorkflowTemplateWithEnumValue(t *testing.T) {
 
 func TestWorkflowTemplateWithEmptyEnumList(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{})
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 	err = validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{Lint: true})
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 	err = validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{Submit: true})
 	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 }
 
 func TestWorkflowTemplateWithArgumentValueNotFromEnumList(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{})
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 	err = validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Lint: true})
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 	err = validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Submit: true})
 	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 }


### PR DESCRIPTION
This change allows linting and creation of workflow templates without requiring parameter values. As best as I can determine, this fixes a regression of previous behavior.

------

### Testing
Unit tests were added to prove the behavior shown below.

Using this workflow example from the issue, I can lint and create a template without specified parameter values.
```a.yaml
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: hello-world-parameters
spec:
  entrypoint: whalesay
  arguments:
    parameters:
      - name: message
  templates:
    - name: whalesay
      container:
        image: docker/whalesay
        command: [ cowsay ]
        args: [ "{{workflow.parameters.message}}" ] 
```

Lint:
```
$ ~/git/argo-workflows/dist/argo lint ./a.yaml 
✔ no linting errors found!
```

Create:
```
$ ~/git/argo-workflows/dist/argo template create ./a.yaml 
Name:                hello-world-parameters
Namespace:           argo
Created:             Mon Nov 01 19:47:28 -0500 (now)
```

Submitting without providing parameters does not work (as expected):
```
$ ~/git/argo-workflows/dist/argo submit --from workflowtemplate/hello-world-parameters
FATA[2021-11-01T19:48:55.857Z] Failed to submit workflow: spec.arguments.message.value is required 
```

If parameters are provided, it succeeds:
```
$ ~/git/argo-workflows/dist/argo submit --from workflowtemplate/hello-world-parameters -p 'message=hi'
Name:                hello-world-parameters-xqhhm
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Mon Nov 01 19:49:33 -0500 (now)
Progress:            
Parameters:          
  message:           hi
```

Signed-off-by: Kenny Trytek <kenneth.g.trytek@gmail.com>