### PR TITLE
fix: Return error when YAML submission is invalid

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -204,6 +204,15 @@ func (s *CLISuite) TestSubmitDryRun() {
 		})
 }
 
+func (s *CLISuite) TestSubmitInvalidWf() {
+	s.Given().
+		RunCli([]string{"submit", "smoke/basic-invalid.yaml", "-l", "workflows.argoproj.io/test=true"}, func(t *testing.T, output string, err error) {
+			if assert.Error(t, err) {
+				assert.Contains(t, output, "yaml file at index 0 is not valid:")
+			}
+		})
+}
+
 func (s *CLISuite) TestSubmitServerDryRun() {
 	s.Given().
 		RunCli([]string{"submit", "smoke/basic.yaml", "--server-dry-run", "-o", "yaml", "-l", "workflows.argoproj.io/test=true"}, func(t *testing.T, output string, err error) {

--- a/test/e2e/smoke/basic-invalid.yaml
+++ b/test/e2e/smoke/basic-invalid.yaml
@@ -1,0 +1,11 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: basic-
+spec:
+  entrypoint: run-workflow
+  templates:
+    - name: run-workflow
+      container:
+        image: argoproj/argosay:v2
+        args: [echo, ":( no hello because:"]-this-is-invalid-yaml


### PR DESCRIPTION
When submitting a file with invalid YAML the CLI output is not helpful:

```
$ argo submit invalid.yaml
INFO[2021-11-02T12:25:12.398Z] No Workflow found in given files
```

This PR prints the relevant YAML parsing error

```
$ argo submit invalid.yaml
ERRO[2021-11-02T12:25:12.397Z] yaml file at index 0 is not valid: error converting YAML to JSON: yaml: line 12: did not find expected key
INFO[2021-11-02T12:25:12.398Z] No Workflow found in given files
```

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
