### PR TITLE
build: Reorder CI checks so required checks run first

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -58,12 +58,15 @@ jobs:
             containerRuntimeExecutor: emissary
             profile: minimal
           - test: test-executor
-            containerRuntimeExecutor: docker
+            containerRuntimeExecutor: emissary
             profile: minimal
-          - test: test-examples
+          - test: test-functional
             containerRuntimeExecutor: emissary
             profile: minimal
           - test: test-executor
+            containerRuntimeExecutor: docker
+            profile: minimal
+          - test: test-examples
             containerRuntimeExecutor: emissary
             profile: minimal
           - test: test-executor
@@ -74,9 +77,6 @@ jobs:
             profile: minimal
           - test: test-executor
             containerRuntimeExecutor: pns
-            profile: minimal
-          - test: test-functional
-            containerRuntimeExecutor: emissary
             profile: minimal
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actions runs CI checks in order. Sometimes they get throttled, so required checks only run after non-required checks finish. If a required check if flakey, it will be useful to know if it fails as soon as possible, so the run can be cancelled and CI re-run.

Example from this PR:
<img width="816" alt="image" src="https://user-images.githubusercontent.com/614838/140088716-f27d6ed9-b24d-4e74-bcfb-3ebb485c75be.png">

Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
