### PR TITLE
chore: Add .gitattributes to ignore generated Python code for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sdks/python/client/* linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-sdks/python/client/* linguist-generated
+sdks/python/client/** linguist-generated


### PR DESCRIPTION
Python is recognized as the main language of this repo but most of the Python code is auto-generated and shouldn't be included as part of the classification.

Reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code

![image](https://user-images.githubusercontent.com/4269898/140171710-d326aba9-69f9-4712-b26d-9f35ededb7ec.png)
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
