### PR TITLE
feat(ui): add pagination to workflow-templates.

### DIFF
--- a/ui/src/app/reports/components/reports.tsx
+++ b/ui/src/app/reports/components/reports.tsx
@@ -308,7 +308,12 @@ export class Reports extends BasePage<RouteComponentProps<any>, State> {
                     <div className=' columns small-12 xlarge-12'>
                         <p className='wf-filters-container__title'>Workflow Template</p>
                         <DataLoaderDropdown
-                            load={() => services.workflowTemplate.list(this.state.namespace, []).then(list => list.map(x => x.metadata.name))}
+                            load={() =>
+                                services.workflowTemplate
+                                    .list(this.state.namespace, [])
+                                    .then(list => list.items || [])
+                                    .then(list => list.map(x => x.metadata.name))
+                            }
                             onChange={value => (this.workflowTemplate = value)}
                         />
                     </div>

--- a/ui/src/app/shared/services/workflow-template-service.ts
+++ b/ui/src/app/shared/services/workflow-template-service.ts
@@ -1,4 +1,5 @@
 import * as models from '../../../models';
+import {Pagination} from '../pagination';
 import {Utils} from '../utils';
 import requests from './requests';
 
@@ -10,11 +11,8 @@ export class WorkflowTemplateService {
             .then(res => res.body as models.WorkflowTemplate);
     }
 
-    public list(namespace: string, labels: string[]) {
-        return requests
-            .get(`api/v1/workflow-templates/${namespace}?${Utils.queryParams({labels}).join('&')}`)
-            .then(res => res.body as models.WorkflowTemplateList)
-            .then(list => list.items || []);
+    public list(namespace: string, labels?: string[], pagination?: Pagination) {
+        return requests.get(`api/v1/workflow-templates/${namespace}?${Utils.queryParams({labels, pagination}).join('&')}`).then(res => res.body as models.WorkflowTemplateList);
     }
 
     public get(name: string, namespace: string) {

--- a/ui/src/app/workflows/components/workflow-creator.tsx
+++ b/ui/src/app/workflows/components/workflow-creator.tsx
@@ -24,6 +24,7 @@ export const WorkflowCreator = ({namespace, onCreate}: {namespace: string; onCre
     useEffect(() => {
         services.workflowTemplate
             .list(namespace, [])
+            .then(list => list.items || [])
             .then(setWorkflowTemplates)
             .catch(setError);
     }, [namespace]);

--- a/ui/src/app/workflows/components/workflow-filters/workflow-filters.tsx
+++ b/ui/src/app/workflows/components/workflow-filters/workflow-filters.tsx
@@ -58,7 +58,12 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                     <div className='columns small-2 xlarge-12'>
                         <p className='wf-filters-container__title'>Workflow Template</p>
                         <DataLoaderDropdown
-                            load={() => services.workflowTemplate.list(this.props.namespace, []).then(list => list.map(x => x.metadata.name))}
+                            load={() =>
+                                services.workflowTemplate
+                                    .list(this.props.namespace, [])
+                                    .then(list => list.items || [])
+                                    .then(list => list.map(x => x.metadata.name))
+                            }
                             onChange={value => (this.workflowTemplate = value)}
                         />
                     </div>


### PR DESCRIPTION
Co-authored-by: Adrian Wawrzak <wawrzak.adrian@ericsson.com>

In case of higher number of templates, especially over slow internet connection there is no reasonable time the request can be completed giving us nothing in return. Workflow templates pagination is meant mainly to help with that. If you see drawbacks of having it implemented only in UI component, please consider another enhancement to this implementation. We would appreciate if it could get in any form into some upcoming release (although it is NOT critically urgent).

![argo-wf-pagination](https://user-images.githubusercontent.com/30836983/140307662-6d92aaf2-963c-4564-8755-bd3b32efa8b2.png)

