### PR TITLE
docs: Document version requirements for newer retry features.

### DIFF
--- a/docs/retries.md
+++ b/docs/retries.md
@@ -29,7 +29,7 @@ Use `retryPolicy` to choose which failures to retry:
 - Always: Retry all failed steps
 - OnFailure: Retry steps whose main container is marked as failed in Kubernetes
 - OnError: Retry steps that encounter Argo controller errors, or whose init or wait containers fail
-- OnTransientError: Retry steps that encounter errors [defined as transient](https://github.com/argoproj/argo-workflows/blob/master/util/errors/errors.go), or errors matching the TRANSIENT_ERROR_PATTERN [environment variable](https://argoproj.github.io/argo-workflows/environment-variables/).
+- OnTransientError: Retry steps that encounter errors [defined as transient](https://github.com/argoproj/argo-workflows/blob/master/util/errors/errors.go), or errors matching the TRANSIENT_ERROR_PATTERN [environment variable](https://argoproj.github.io/argo-workflows/environment-variables/). Available in version 3.0 and later.
 
 For example:
 
@@ -52,7 +52,9 @@ spec:
       args: ["import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)"]
 ```
 
-## Retry expressions
+## Conditional retries
+
+> v3.2 and after
 
 You can also use `expression` to control retries. The `expression` field
 accepts an [expr](https://github.com/antonmedv/expr) expression and has


### PR DESCRIPTION
I didn't realize that kubeflow pipelines was using an argo version too old to get certain retry features, so thought I'd add version requirements to the docs.

cc @jli

Signed-off-by: Josh Carp <jm.carp@gmail.com>

Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
