### PR TITLE
feat(controller): Log expression context for conditional retries.

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -791,6 +791,7 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 	if retryStrategy.Expression != "" && len(node.Children) > 0 {
 		localScope := buildRetryStrategyLocalScope(node, woc.wf.Status.Nodes)
 		scope := env.GetFuncMap(localScope)
+		woc.log.WithField("node", node.Name).Infof("evaluating retry conditional with scope %s", localScope)
 		res, err := expr.Eval(retryStrategy.Expression, scope)
 		if err != nil {
 			return nil, false, err


### PR DESCRIPTION
I was debugging an issue with conditional retries, and it took a while to figure out that a certain failure mode was associated with an exit code of `-1`. Logging the expression context would help with this kind of task in the future. Let me know if there's a better place to put this than the operator logs!

cc @jli

Signed-off-by: Josh Carp <jm.carp@gmail.com>

Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
