### PR TITLE
fix: ci sleep command syntax for macOS 12

### DIFF
--- a/hack/port-forward.sh
+++ b/hack/port-forward.sh
@@ -9,7 +9,7 @@ pf() {
   ./hack/free-port.sh $port
   echo "port-forward $resource $port"
   kubectl -n argo port-forward "svc/$resource" "$port:$dest_port" > /dev/null &
-	until lsof -i ":$port" > /dev/null ; do sleep 1s ; done
+	until lsof -i ":$port" > /dev/null ; do sleep 1 ; done
 }
 
 wait-for() {


### PR DESCRIPTION
This is a very simple change that changes the `sleep` bash command syntax to a format that should work everywhere.

For some unknown reason, the new macOS 12 ships with a `sleep` command which has to be called like `sleep 1` rather than `sleep 1s`.