### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/api/openapi-spec/swagger_test.go
+++ b/api/openapi-spec/swagger_test.go
@@ -2,7 +2,7 @@ package openapi_spec
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +12,7 @@ type obj = map[string]interface{}
 
 func TestSwagger(t *testing.T) {
 	swagger := obj{}
-	data, err := ioutil.ReadFile("swagger.json")
+	data, err := os.ReadFile("swagger.json")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/argo/lint/lint.go
+++ b/cmd/argo/lint/lint.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,7 +106,7 @@ func RunLint(ctx context.Context, client apiclient.Client, kinds []string, outpu
 // Entities of other kinds are ignored.
 func Lint(ctx context.Context, opts *LintOptions) (*LintResults, error) {
 	var fmtr Formatter = defaultFormatter
-	var w io.Writer = ioutil.Discard
+	var w io.Writer = io.Discard
 	if opts.Formatter != nil {
 		fmtr = opts.Formatter
 	}
@@ -147,7 +146,7 @@ func Lint(ctx context.Context, opts *LintOptions) (*LintResults, error) {
 				return nil
 			}
 
-			data, err := ioutil.ReadAll(r)
+			data, err := io.ReadAll(r)
 			if err != nil {
 				return err
 			}

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -3,7 +3,6 @@ package lint
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -66,9 +65,9 @@ spec:
 `)
 
 func TestLintFile(t *testing.T) {
-	file, err := ioutil.TempFile("", "*.yaml")
+	file, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(file.Name(), lintFileData, 0o600)
+	err = os.WriteFile(file.Name(), lintFileData, 0o600)
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -95,9 +94,9 @@ func TestLintFile(t *testing.T) {
 }
 
 func TestLintMultipleKinds(t *testing.T) {
-	file, err := ioutil.TempFile("", "*.yaml")
+	file, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(file.Name(), lintFileData, 0o600)
+	err = os.WriteFile(file.Name(), lintFileData, 0o600)
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -127,9 +126,9 @@ func TestLintMultipleKinds(t *testing.T) {
 }
 
 func TestLintWithOutput(t *testing.T) {
-	file, err := ioutil.TempFile("", "*.yaml")
+	file, err := os.CreateTemp("", "*.yaml")
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(file.Name(), lintFileData, 0o600)
+	err = os.WriteFile(file.Name(), lintFileData, 0o600)
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 
@@ -214,10 +213,10 @@ func TestLintStdin(t *testing.T) {
 }
 
 func TestLintDeviceFile(t *testing.T) {
-	file, err := ioutil.TempFile("", "*.yaml")
+	file, err := os.CreateTemp("", "*.yaml")
 	fd := file.Fd()
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(file.Name(), lintFileData, 0o600)
+	err = os.WriteFile(file.Name(), lintFileData, 0o600)
 	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -40,7 +39,7 @@ func NewEmissaryCommand() *cobra.Command {
 			exitCode := 64
 
 			defer func() {
-				err := ioutil.WriteFile(varRunArgo+"/ctr/"+containerName+"/exitcode", []byte(strconv.Itoa(exitCode)), 0o644)
+				err := os.WriteFile(varRunArgo+"/ctr/"+containerName+"/exitcode", []byte(strconv.Itoa(exitCode)), 0o644)
 				if err != nil {
 					logger.Error(fmt.Errorf("failed to write exit code: %w", err))
 				}
@@ -70,7 +69,7 @@ func NewEmissaryCommand() *cobra.Command {
 				}
 			}()
 
-			data, err := ioutil.ReadFile(varRunArgo + "/template")
+			data, err := os.ReadFile(varRunArgo + "/template")
 			if err != nil {
 				return fmt.Errorf("failed to read template: %w", err)
 			}
@@ -84,7 +83,7 @@ func NewEmissaryCommand() *cobra.Command {
 					for _, y := range x.Dependencies {
 						logger.Infof("waiting for dependency %q", y)
 						for {
-							data, err := ioutil.ReadFile(filepath.Clean(varRunArgo + "/ctr/" + y + "/exitcode"))
+							data, err := os.ReadFile(filepath.Clean(varRunArgo + "/ctr/" + y + "/exitcode"))
 							if os.IsNotExist(err) {
 								time.Sleep(time.Second)
 								continue
@@ -138,7 +137,7 @@ func NewEmissaryCommand() *cobra.Command {
 
 			go func() {
 				for {
-					data, _ := ioutil.ReadFile(filepath.Clean(varRunArgo + "/ctr/" + containerName + "/signal"))
+					data, _ := os.ReadFile(filepath.Clean(varRunArgo + "/ctr/" + containerName + "/signal"))
 					_ = os.Remove(varRunArgo + "/ctr/" + containerName + "/signal")
 					s, _ := strconv.Atoi(string(data))
 					if s > 0 {

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestEmissary(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 
 	varRunArgo = tmp
@@ -26,34 +25,34 @@ func TestEmissary(t *testing.T) {
 
 	x := filepath.Join(wd, "../../../dist/argosay")
 
-	err = ioutil.WriteFile(varRunArgo+"/template", []byte(`{}`), 0o600)
+	err = os.WriteFile(varRunArgo+"/template", []byte(`{}`), 0o600)
 	assert.NoError(t, err)
 
 	t.Run("Exit0", func(t *testing.T) {
 		err := run(x, []string{"exit"})
 		assert.NoError(t, err)
-		data, err := ioutil.ReadFile(varRunArgo + "/ctr/main/exitcode")
+		data, err := os.ReadFile(varRunArgo + "/ctr/main/exitcode")
 		assert.NoError(t, err)
 		assert.Equal(t, "0", string(data))
 	})
 	t.Run("Exit1", func(t *testing.T) {
 		err := run(x, []string{"exit", "1"})
 		assert.Equal(t, 1, err.(*exec.ExitError).ExitCode())
-		data, err := ioutil.ReadFile(varRunArgo + "/ctr/main/exitcode")
+		data, err := os.ReadFile(varRunArgo + "/ctr/main/exitcode")
 		assert.NoError(t, err)
 		assert.Equal(t, "1", string(data))
 	})
 	t.Run("Stdout", func(t *testing.T) {
 		err := run(x, []string{"echo", "hello", "/dev/stdout"})
 		assert.NoError(t, err)
-		data, err := ioutil.ReadFile(varRunArgo + "/ctr/main/stdout")
+		data, err := os.ReadFile(varRunArgo + "/ctr/main/stdout")
 		assert.NoError(t, err)
 		assert.Contains(t, string(data), "hello")
 	})
 	t.Run("Stderr", func(t *testing.T) {
 		err := run(x, []string{"echo", "hello", "/dev/stderr"})
 		assert.NoError(t, err)
-		data, err := ioutil.ReadFile(varRunArgo + "/ctr/main/stderr")
+		data, err := os.ReadFile(varRunArgo + "/ctr/main/stderr")
 		assert.NoError(t, err)
 		assert.Contains(t, string(data), "hello")
 	})
@@ -62,7 +61,7 @@ func TestEmissary(t *testing.T) {
 			syscall.SIGTERM: "terminated",
 			syscall.SIGKILL: "killed",
 		} {
-			err := ioutil.WriteFile(varRunArgo+"/ctr/main/signal", []byte(strconv.Itoa(int(signal))), 0o600)
+			err := os.WriteFile(varRunArgo+"/ctr/main/signal", []byte(strconv.Itoa(int(signal))), 0o600)
 			assert.NoError(t, err)
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -75,7 +74,7 @@ func TestEmissary(t *testing.T) {
 		}
 	})
 	t.Run("Artifact", func(t *testing.T) {
-		err = ioutil.WriteFile(varRunArgo+"/template", []byte(`
+		err = os.WriteFile(varRunArgo+"/template", []byte(`
 {
 	"outputs": {
 		"artifacts": [
@@ -87,12 +86,12 @@ func TestEmissary(t *testing.T) {
 		assert.NoError(t, err)
 		err := run(x, []string{"echo", "hello", "/tmp/artifact"})
 		assert.NoError(t, err)
-		data, err := ioutil.ReadFile(varRunArgo + "/outputs/artifacts/tmp/artifact.tgz")
+		data, err := os.ReadFile(varRunArgo + "/outputs/artifacts/tmp/artifact.tgz")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, string(data)) // data is tgz format
 	})
 	t.Run("ArtifactWithTrailingAndLeadingSlash", func(t *testing.T) {
-		err = ioutil.WriteFile(varRunArgo+"/template", []byte(`
+		err = os.WriteFile(varRunArgo+"/template", []byte(`
 {
 	"outputs": {
 		"artifacts": [
@@ -104,12 +103,12 @@ func TestEmissary(t *testing.T) {
 		assert.NoError(t, err)
 		err := run(x, []string{"echo", "hello", "/tmp/artifact"})
 		assert.NoError(t, err)
-		data, err := ioutil.ReadFile(varRunArgo + "/outputs/artifacts/tmp/artifact.tgz")
+		data, err := os.ReadFile(varRunArgo + "/outputs/artifacts/tmp/artifact.tgz")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, string(data)) // data is tgz format
 	})
 	t.Run("Parameter", func(t *testing.T) {
-		err = ioutil.WriteFile(varRunArgo+"/template", []byte(`
+		err = os.WriteFile(varRunArgo+"/template", []byte(`
 {
 	"outputs": {
 		"parameters": [
@@ -123,7 +122,7 @@ func TestEmissary(t *testing.T) {
 		assert.NoError(t, err)
 		err := run(x, []string{"echo", "hello", "/tmp/parameter"})
 		assert.NoError(t, err)
-		data, err := ioutil.ReadFile(varRunArgo + "/outputs/parameters/tmp/parameter")
+		data, err := os.ReadFile(varRunArgo + "/outputs/parameters/tmp/parameter")
 		assert.NoError(t, err)
 		assert.Contains(t, string(data), "hello")
 	})

--- a/examples/validator.go
+++ b/examples/validator.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -21,7 +20,7 @@ func contains(s []string, e string) bool {
 }
 
 func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[string][]string, error) {
-	schemaBytes, err := ioutil.ReadFile("../api/jsonschema/schema.json")
+	schemaBytes, err := os.ReadFile("../api/jsonschema/schema.json")
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +43,7 @@ func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[s
 		if filepath.Ext(path) != ".yaml" {
 			return nil
 		}
-		yamlBytes, err := ioutil.ReadFile(filepath.Clean(path))
+		yamlBytes, err := os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return err
 		}

--- a/hack/crds.go
+++ b/hack/crds.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"sigs.k8s.io/yaml"
 )
 
 func cleanCRD(filename string) {
-	data, err := ioutil.ReadFile(filepath.Clean(filename))
+	data, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		panic(err)
 	}
@@ -46,14 +46,14 @@ func cleanCRD(filename string) {
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(filename, data, 0o600)
+	err = os.WriteFile(filename, data, 0o600)
 	if err != nil {
 		panic(err)
 	}
 }
 
 func removeCRDValidation(filename string) {
-	data, err := ioutil.ReadFile(filepath.Clean(filename))
+	data, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ func removeCRDValidation(filename string) {
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(filename, data, 0o600)
+	err = os.WriteFile(filename, data, 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/hack/docgen.go
+++ b/hack/docgen.go
@@ -6,7 +6,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -213,7 +212,7 @@ func NewDocGeneratorContext() *DocGeneratorContext {
 }
 
 func (c *DocGeneratorContext) loadFiles() {
-	bytes, err := ioutil.ReadFile("api/openapi-spec/swagger.json")
+	bytes, err := os.ReadFile("api/openapi-spec/swagger.json")
 	if err != nil {
 		panic(err)
 	}
@@ -229,7 +228,7 @@ func (c *DocGeneratorContext) loadFiles() {
 		panic(err)
 	}
 	for _, fileName := range files {
-		bytes, err := ioutil.ReadFile(filepath.Clean(fileName))
+		bytes, err := os.ReadFile(filepath.Clean(fileName))
 		if err != nil {
 			panic(err)
 		}
@@ -346,7 +345,7 @@ func (c *DocGeneratorContext) generate() string {
 func generateDocs() {
 	println("generating docs/fields.md")
 	c := NewDocGeneratorContext()
-	err := ioutil.WriteFile("docs/fields.md", []byte(c.generate()), 0o600)
+	err := os.WriteFile("docs/fields.md", []byte(c.generate()), 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/hack/parse_examples.go
+++ b/hack/parse_examples.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -25,7 +25,7 @@ var (
 )
 
 func parseExamples() {
-	file, err := ioutil.ReadFile("site/fields/index.html")
+	file, err := os.ReadFile("site/fields/index.html")
 	if err != nil {
 		panic(err)
 	}
@@ -35,7 +35,7 @@ func parseExamples() {
 	file = linkRegex.ReplaceAll(file, []byte(newLink))
 	file = detailsRegex.ReplaceAll(file, []byte(newDetails))
 
-	err = ioutil.WriteFile("site/fields/index.html", file, 0o600)
+	err = os.WriteFile("site/fields/index.html", file, 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/hack/swagger/secondaryswaggergen.go
+++ b/hack/swagger/secondaryswaggergen.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -46,12 +45,12 @@ func secondarySwaggerGen() {
 		panic(err)
 	}
 
-	read, err := ioutil.ReadFile("pkg/apiclient/_.secondary.swagger.json")
+	read, err := os.ReadFile("pkg/apiclient/_.secondary.swagger.json")
 	if err != nil {
 		panic(err)
 	}
 	newContents := strings.ReplaceAll(string(read), "argoproj.argo-workflows", "argoproj.argo_workflows")
-	err = ioutil.WriteFile("pkg/apiclient/_.secondary.swagger.json", []byte(newContents), 0o600)
+	err = os.WriteFile("pkg/apiclient/_.secondary.swagger.json", []byte(newContents), 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/apis/workflow/v1alpha1/marshall.go
+++ b/pkg/apis/workflow/v1alpha1/marshall.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"sigs.k8s.io/yaml"
@@ -19,7 +19,7 @@ func MustUnmarshal(text, v interface{}) {
 	case []byte:
 		if x[0] == '@' {
 			filename := string(x[1:])
-			y, err := ioutil.ReadFile(filepath.Clean(filename))
+			y, err := os.ReadFile(filepath.Clean(filename))
 			if err != nil {
 				panic(fmt.Errorf("failed to read file %s: %w", filename, err))
 			}

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -3,7 +3,6 @@ package artifacts
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -183,7 +182,7 @@ func (a *ArtifactServer) returnArtifact(ctx context.Context, w http.ResponseWrit
 	if err != nil {
 		return err
 	}
-	tmp, err := ioutil.TempFile("/tmp", "artifact")
+	tmp, err := os.CreateTemp("/tmp", "artifact")
 	if err != nil {
 		return err
 	}

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -3,9 +3,9 @@ package artifacts
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +41,7 @@ type fakeArtifactDriver struct {
 }
 
 func (a *fakeArtifactDriver) Load(_ *wfv1.Artifact, path string) error {
-	return ioutil.WriteFile(path, a.data, 0o600)
+	return os.WriteFile(path, a.data, 0o600)
 }
 
 func (a *fakeArtifactDriver) Save(_ string, _ *wfv1.Artifact) error {

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -21,7 +21,7 @@ func ClaimSetFor(restConfig *rest.Config) (*types.Claims, error) {
 		bearerToken := restConfig.BearerToken
 		if bearerToken == "" {
 			// should only ever be used for service accounts
-			data, err := ioutil.ReadFile(restConfig.BearerTokenFile)
+			data, err := os.ReadFile(restConfig.BearerTokenFile)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read bearer token file: %w", err)
 			}

--- a/server/auth/serviceaccount/claims_test.go
+++ b/server/auth/serviceaccount/claims_test.go
@@ -1,7 +1,6 @@
 package serviceaccount
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -39,9 +38,9 @@ func TestClaimSetFor(t *testing.T) {
 	})
 
 	// set-up test
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(tmp.Name(), []byte(token), 0o600)
+	err = os.WriteFile(tmp.Name(), []byte(token), 0o600)
 	assert.NoError(t, err)
 	defer func() { _ = os.Remove(tmp.Name()) }()
 

--- a/server/auth/types/claims_test.go
+++ b/server/auth/types/claims_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -217,7 +216,7 @@ func TestGetUserInfoGroups(t *testing.T) {
 	t.Run("UserInfoGroupsReturn", func(t *testing.T) {
 		userInfo := UserInfo{Groups: []string{"Everyone"}}
 		userInfoBytes, _ := json.Marshal(userInfo)
-		body := ioutil.NopCloser(bytes.NewReader(userInfoBytes))
+		body := io.NopCloser(bytes.NewReader(userInfoBytes))
 
 		httpClient = &HttpClientMock{StatusCode: 200, Body: body}
 

--- a/server/auth/webhook/interceptor.go
+++ b/server/auth/webhook/interceptor.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -66,11 +66,11 @@ func addWebhookAuthorization(r *http.Request, kube kubernetes.Interface) error {
 	}
 	// we need to read the request body to check the signature, but we still need it for the GRPC request,
 	// so read it all now, and then reinstate when we are done
-	buf, _ := ioutil.ReadAll(r.Body)
-	defer func() { r.Body = ioutil.NopCloser(bytes.NewBuffer(buf)) }()
+	buf, _ := io.ReadAll(r.Body)
+	defer func() { r.Body = io.NopCloser(bytes.NewBuffer(buf)) }()
 	serviceAccountInterface := kube.CoreV1().ServiceAccounts(namespace)
 	for serviceAccountName, data := range webhookClients.Data {
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
 		client := &webhookClient{}
 		err := yaml.Unmarshal(data, client)
 		if err != nil {

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -7,8 +7,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -125,7 +125,7 @@ func (s *ArgoServerSuite) TestMetricsOK() {
 func (s *ArgoServerSuite) TestSubmitWorkflowTemplateFromGithubWebhook() {
 	s.bearerToken = ""
 
-	data, err := ioutil.ReadFile("testdata/github-webhook-payload.json")
+	data, err := os.ReadFile("testdata/github-webhook-payload.json")
 	assert.NoError(s.T(), err)
 
 	s.Given().

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -734,14 +733,14 @@ func (s *CLISuite) TestWorkflowLint() {
 			})
 	})
 	s.Run("LintDir", func() {
-		tmp, err := ioutil.TempDir("", "")
+		tmp, err := os.MkdirTemp("", "")
 		s.CheckError(err)
 		defer func() { _ = os.RemoveAll(tmp) }()
 		// Read all content of src to data
-		data, err := ioutil.ReadFile("smoke/basic.yaml")
+		data, err := os.ReadFile("smoke/basic.yaml")
 		s.CheckError(err)
 		// Write data to dst
-		err = ioutil.WriteFile(filepath.Join(tmp, "my-workflow.yaml"), data, 0o600)
+		err = os.WriteFile(filepath.Join(tmp, "my-workflow.yaml"), data, 0o600)
 		s.CheckError(err)
 		s.Given().
 			RunCli([]string{"lint", tmp}, func(t *testing.T, output string, err error) {

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -2,7 +2,7 @@ package fixtures
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,7 +56,7 @@ func (g *Given) readResource(text string, v metav1.Object) {
 	if strings.HasPrefix(text, "@") {
 		file = strings.TrimPrefix(text, "@")
 	} else {
-		f, err := ioutil.TempFile("", "argo_e2e")
+		f, err := os.CreateTemp("", "argo_e2e")
 		if err != nil {
 			g.t.Fatal(err)
 		}
@@ -72,7 +72,7 @@ func (g *Given) readResource(text string, v metav1.Object) {
 	}
 
 	{
-		file, err := ioutil.ReadFile(filepath.Clean(file))
+		file, err := os.ReadFile(filepath.Clean(file))
 		if err != nil {
 			g.t.Fatal(err)
 		}

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -3,7 +3,7 @@ package fixtures
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -193,7 +193,7 @@ func (t *Then) ExpectArtifact(nodeName, artifactName string, f func(t *testing.T
 		t.t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.t.Fatal(err)
 	}

--- a/test/e2e/fixtures/util.go
+++ b/test/e2e/fixtures/util.go
@@ -3,7 +3,6 @@ package fixtures
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func LoadObject(text string) (runtime.Object, error) {
 	var yaml string
 	if strings.HasPrefix(text, "@") {
 		file := strings.TrimPrefix(text, "@")
-		f, err := ioutil.ReadFile(filepath.Clean(file))
+		f, err := os.ReadFile(filepath.Clean(file))
 		if err != nil {
 			return nil, err
 		}

--- a/util/file/fileutil.go
+++ b/util/file/fileutil.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/klauspost/pgzip"
@@ -117,5 +116,5 @@ func DecompressContent(content []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to decompress: %w", err)
 	}
 	defer close(gzipReader)
-	return ioutil.ReadAll(gzipReader)
+	return io.ReadAll(gzipReader)
 }

--- a/util/file/fileutil_test.go
+++ b/util/file/fileutil_test.go
@@ -4,7 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -42,7 +42,7 @@ func TestGetGzipReader(t *testing.T) {
 		bufReader := bytes.NewReader(buf)
 		reader, err := file.GetGzipReader(bufReader)
 		assert.NoError(t, err)
-		res, err := ioutil.ReadAll(reader)
+		res, err := io.ReadAll(reader)
 		assert.NoError(t, err)
 		assert.Equal(t, rawContent, string(res))
 		_ = os.Unsetenv(file.GZipImplEnvVarKey)

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -3,7 +3,6 @@ package kubeconfig
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -237,7 +236,7 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 	}
 
 	if len(file) > 0 {
-		fileData, err := ioutil.ReadFile(filepath.Clean(file))
+		fileData, err := os.ReadFile(filepath.Clean(file))
 		if err != nil {
 			return []byte{}, err
 		}

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -1,7 +1,6 @@
 package kubeconfig
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -45,7 +44,7 @@ func Test_BasicAuthString(t *testing.T) {
 			assert.Equal(t, "admin", uname)
 			assert.Equal(t, "admin", pwd)
 		}
-		file, err := ioutil.TempFile("", "config.yaml")
+		file, err := os.CreateTemp("", "config.yaml")
 		assert.NoError(t, err)
 		_, err = file.WriteString(config)
 		assert.NoError(t, err)

--- a/util/template/validate.go
+++ b/util/template/validate.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/valyala/fasttemplate"
 )
@@ -12,7 +11,7 @@ func Validate(s string, validator func(tag string) error) error {
 	if err != nil {
 		return err
 	}
-	_, err = t.ExecuteFunc(ioutil.Discard, func(w io.Writer, tag string) (int, error) {
+	_, err = t.ExecuteFunc(io.Discard, func(w io.Writer, tag string) (int, error) {
 		kind, _ := parseTag(tag)
 		switch kind {
 		case kindExpression:

--- a/util/util.go
+++ b/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -51,7 +50,7 @@ func GetSecrets(ctx context.Context, clientSet kubernetes.Interface, namespace, 
 
 // Write the Terminate message in pod spec
 func WriteTerminateMessage(message string) {
-	err := ioutil.WriteFile("/dev/termination-log", []byte(message), 0o600)
+	err := os.WriteFile("/dev/termination-log", []byte(message), 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -224,7 +223,7 @@ func (g *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact) error 
 // relPath is a given relative path to be inserted in front
 func listFileRelPaths(path string, relPath string) ([]string, error) {
 	results := []string{}
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -3,7 +3,6 @@ package git
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -51,11 +50,11 @@ func (g *ArtifactDriver) auth(sshUser string) (func(), transport.AuthMethod, []s
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		privateKeyFile, err := ioutil.TempFile("", "id_rsa.")
+		privateKeyFile, err := os.CreateTemp("", "id_rsa.")
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		err = ioutil.WriteFile(privateKeyFile.Name(), []byte(g.SSHPrivateKey), 0o600)
+		err = os.WriteFile(privateKeyFile.Name(), []byte(g.SSHPrivateKey), 0o600)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -84,7 +83,7 @@ func (g *ArtifactDriver) auth(sshUser string) (func(), transport.AuthMethod, []s
 		_, err := os.Stat(filename)
 		if os.IsNotExist(err) {
 			//nolint:gosec
-			err := ioutil.WriteFile(filename, []byte(`#!/bin/sh
+			err := os.WriteFile(filename, []byte(`#!/bin/sh
 case "$1" in
 Username*) echo "${GIT_USERNAME}" ;;
 Password*) echo "${GIT_PASSWORD}" ;;

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestGitArtifactDriverLoad_HTTPS(t *testing.T) {
 			t.Skip("not running an GITHUB_TOKEN not set")
 		}
 		_ = os.Remove("git-ask-pass.sh")
-		tmp, err := ioutil.TempDir("", "")
+		tmp, err := os.MkdirTemp("", "")
 		assert.NoError(t, err)
 		driver := &ArtifactDriver{Username: os.Getenv("GITHUB_TOKEN")}
 		assert.NotEmpty(t, driver.Username)
@@ -62,12 +61,12 @@ func TestGitArtifactDriverLoad_SSL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_ = os.Remove("git-ask-pass.sh")
 			key := os.Getenv("HOME") + "/.ssh/id_rsa"
-			data, err := ioutil.ReadFile(key)
+			data, err := os.ReadFile(key)
 			if err != nil && os.IsNotExist(err) {
 				t.Skip(key + " does not exist")
 			}
 			assert.NoError(t, err)
-			tmp, err := ioutil.TempDir("", "")
+			tmp, err := os.MkdirTemp("", "")
 			assert.NoError(t, err)
 			println(tmp)
 			driver := &ArtifactDriver{SSHPrivateKey: string(data)}

--- a/workflow/artifacts/raw/raw_test.go
+++ b/workflow/artifacts/raw/raw_test.go
@@ -2,7 +2,6 @@ package raw_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -19,7 +18,7 @@ const (
 
 func TestLoad(t *testing.T) {
 	content := fmt.Sprintf("time: %v", time.Now().UnixNano())
-	lf, err := ioutil.TempFile("", LoadFileName)
+	lf, err := os.CreateTemp("", LoadFileName)
 	assert.NoError(t, err)
 	defer os.Remove(lf.Name())
 
@@ -31,7 +30,7 @@ func TestLoad(t *testing.T) {
 	err = driver.Load(art, lf.Name())
 	assert.NoError(t, err)
 
-	dat, err := ioutil.ReadFile(lf.Name())
+	dat, err := os.ReadFile(lf.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, content, string(dat))
 }

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,7 +241,7 @@ func TestLoadS3Artifact(t *testing.T) {
 }
 
 func TestSaveS3Artifact(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
+	tempDir, err := os.MkdirTemp("", "example")
 	if err != nil {
 		panic(err)
 	}
@@ -250,7 +249,7 @@ func TestSaveS3Artifact(t *testing.T) {
 	defer os.RemoveAll(tempDir) // clean up
 
 	tempFile := filepath.Join(tempDir, "tmpfile")
-	if err := ioutil.WriteFile(tempFile, []byte("temporary file's content"), 0o600); err != nil {
+	if err := os.WriteFile(tempFile, []byte("temporary file's content"), 0o600); err != nil {
 		panic(err)
 	}
 

--- a/workflow/executor/docker/docker.go
+++ b/workflow/executor/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -170,7 +169,7 @@ func (d *DockerExecutor) GetExitCode(ctx context.Context, containerName string) 
 		return "", errors.InternalWrapError(err, "Could not start command")
 	}
 	defer func() { _ = reader.Close() }()
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return "", errors.InternalWrapError(err, "Could not read from STDOUT")
 	}

--- a/workflow/executor/emissary/emissary.go
+++ b/workflow/executor/emissary/emissary.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,11 +65,11 @@ func (e emissary) writeTemplate(t wfv1.Template) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile("/var/run/argo/template", data, 0o444) // chmod -r--r--r--
+	return os.WriteFile("/var/run/argo/template", data, 0o444) // chmod -r--r--r--
 }
 
 func (e emissary) GetFileContents(_ string, sourcePath string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Clean(filepath.Join("/var/run/argo/outputs/parameters", sourcePath)))
+	data, err := os.ReadFile(filepath.Clean(filepath.Join("/var/run/argo/outputs/parameters", sourcePath)))
 	return string(data), err
 }
 
@@ -148,7 +147,7 @@ func (e emissary) Kill(ctx context.Context, containerNames []string, termination
 	for _, containerName := range containerNames {
 		// allow write-access by other users, because other containers
 		// should delete the signal after receiving it
-		if err := ioutil.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGTERM))), 0o666); err != nil { //nolint:gosec
+		if err := os.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGTERM))), 0o666); err != nil { //nolint:gosec
 			return err
 		}
 	}
@@ -161,7 +160,7 @@ func (e emissary) Kill(ctx context.Context, containerNames []string, termination
 	for _, containerName := range containerNames {
 		// allow write-access by other users, because other containers
 		// should delete the signal after receiving it
-		if err := ioutil.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGKILL))), 0o666); err != nil { //nolint:gosec
+		if err := os.WriteFile("/var/run/argo/ctr/"+containerName+"/signal", []byte(strconv.Itoa(int(syscall.SIGKILL))), 0o666); err != nil { //nolint:gosec
 			return err
 		}
 	}
@@ -170,7 +169,7 @@ func (e emissary) Kill(ctx context.Context, containerNames []string, termination
 
 func (e emissary) ListContainerNames(ctx context.Context) ([]string, error) {
 	var containerNames []string
-	dir, err := ioutil.ReadDir("/var/run/argo/ctr")
+	dir, err := os.ReadDir("/var/run/argo/ctr")
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/executor/emissary/multi_reader_closer_test.go
+++ b/workflow/executor/emissary/multi_reader_closer_test.go
@@ -2,7 +2,7 @@ package emissary
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -10,8 +10,8 @@ import (
 )
 
 func Test_multiReaderCloser(t *testing.T) {
-	a := ioutil.NopCloser(strings.NewReader("a"))
-	b := ioutil.NopCloser(strings.NewReader("b"))
+	a := io.NopCloser(strings.NewReader("a"))
+	b := io.NopCloser(strings.NewReader("b"))
 	c := newMultiReaderCloser(a, b)
 	s := bufio.NewScanner(c)
 	assert.True(t, s.Scan())

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path"
@@ -269,7 +268,7 @@ func (we *WorkflowExecutor) StageFiles() error {
 	default:
 		return nil
 	}
-	err := ioutil.WriteFile(filePath, body, 0o644)
+	err := os.WriteFile(filePath, body, 0o644)
 	if err != nil {
 		return argoerrs.InternalWrapError(err)
 	}
@@ -519,7 +518,7 @@ func (we *WorkflowExecutor) SaveParameters(ctx context.Context) error {
 		} else {
 			log.Infof("Copying %s from volume mount", param.ValueFrom.Path)
 			mountedPath := filepath.Join(common.ExecutorMainFilesystemDir, param.ValueFrom.Path)
-			data, err := ioutil.ReadFile(filepath.Clean(mountedPath))
+			data, err := os.ReadFile(filepath.Clean(mountedPath))
 			if err != nil {
 				// We have a default value to use instead of returning an error
 				if param.ValueFrom.Default != nil {
@@ -567,7 +566,7 @@ func (we *WorkflowExecutor) SaveLogs(ctx context.Context) (*wfv1.Artifact, error
 
 // GetSecret will retrieve the Secrets from VolumeMount
 func (we *WorkflowExecutor) GetSecret(ctx context.Context, accessKeyName string, accessKey string) (string, error) {
-	file, err := ioutil.ReadFile(filepath.Clean(filepath.Join(common.SecretVolMountPath, accessKeyName, accessKey)))
+	file, err := os.ReadFile(filepath.Clean(filepath.Join(common.SecretVolMountPath, accessKeyName, accessKey)))
 	if err != nil {
 		return "", err
 	}
@@ -709,7 +708,7 @@ func (we *WorkflowExecutor) CaptureScriptResult(ctx context.Context) error {
 		return err
 	}
 	defer func() { _ = reader.Close() }()
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return argoerrs.InternalWrapError(err)
 	}
@@ -890,7 +889,7 @@ func unpack(srcPath string, destPath string, decompressor func(string, string) e
 	}
 	// next, decide how we wish to rename the file/dir
 	// to the destination path.
-	files, err := ioutil.ReadDir(tmpDir)
+	files, err := os.ReadDir(tmpDir)
 	if err != nil {
 		return argoerrs.InternalWrapError(err)
 	}
@@ -985,7 +984,7 @@ func (we *WorkflowExecutor) monitorProgress(ctx context.Context, progressFile st
 				log.WithField("progress", we.progress).WithError(err).Warn("failed to patch progress annotation")
 			}
 		case <-fileTicker.C:
-			data, err := ioutil.ReadFile(progressFile)
+			data, err := os.ReadFile(progressFile)
 			if err != nil {
 				if !errors.Is(err, fs.ErrNotExist) {
 					log.WithError(err).WithField("file", progressFile).Info("unable to watch file")

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -306,10 +305,10 @@ func TestChmod(t *testing.T) {
 
 	for _, test := range tests {
 		// Setup directory and file for testing
-		tempDir, err := ioutil.TempDir("testdata", "chmod-dir-test")
+		tempDir, err := os.MkdirTemp("testdata", "chmod-dir-test")
 		assert.NoError(t, err)
 
-		tempFile, err := ioutil.TempFile(tempDir, "chmod-file-test")
+		tempFile, err := os.CreateTemp(tempDir, "chmod-file-test")
 		assert.NoError(t, err)
 
 		// TearDown test by removing directory and file

--- a/workflow/executor/http/http.go
+++ b/workflow/executor/http/http.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -21,7 +21,7 @@ func SendHttpRequest(request *http.Request, timeout *int64) (string, error) {
 	defer out.Body.Close()
 
 	log.WithFields(log.Fields{"url": request.URL, "status": out.Status}).Info("HTTP Request Sent")
-	data, err := ioutil.ReadAll(out.Body)
+	data, err := io.ReadAll(out.Body)
 	if err != nil {
 		return "", err
 	}

--- a/workflow/executor/kubelet/client.go
+++ b/workflow/executor/kubelet/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -54,7 +53,7 @@ func newKubeletClient(namespace, podName string) (*kubeletClient, error) {
 		kubeletPort = 10250
 		log.Infof("Non configured envvar %s, defaulting the kubelet port to %d", common.EnvVarKubeletPort, kubeletPort)
 	}
-	b, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	b, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {
 		return nil, errors.InternalWrapError(err)
 	}
@@ -67,7 +66,7 @@ func newKubeletClient(namespace, podName string) (*kubeletClient, error) {
 		tlsConfig.InsecureSkipVerify = true
 	} else {
 		log.Warningf("Loading service account ca.crt as certificate authority to reach the kubelet api")
-		caCert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+		caCert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 		if err != nil {
 			return nil, errors.InternalWrapError(err)
 		}
@@ -97,7 +96,7 @@ func newKubeletClient(namespace, podName string) (*kubeletClient, error) {
 
 func checkHTTPErr(resp *http.Response) error {
 	if resp.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		return errors.InternalWrapError(fmt.Errorf("unexpected non 200 status code: %d, body: %s", resp.StatusCode, string(b)))
 	}

--- a/workflow/executor/pns/pns.go
+++ b/workflow/executor/pns/pns.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,7 +72,7 @@ func (p *PNSExecutor) GetFileContents(containerName string, sourcePath string) (
 		return "", err
 	}
 	defer func() { _ = p.exitChroot() }()
-	out, err := ioutil.ReadFile(filepath.Clean(sourcePath))
+	out, err := os.ReadFile(filepath.Clean(sourcePath))
 	if err != nil {
 		return "", err
 	}
@@ -296,7 +295,7 @@ func (p *PNSExecutor) getContainerPID(containerName string) int {
 }
 
 func containerNameForPID(pid int) (string, error) {
-	data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
 	if err != nil {
 		return "", err
 	}

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -90,7 +91,7 @@ func inferObjectSelfLink(obj unstructured.Unstructured) string {
 }
 
 func (we *WorkflowExecutor) getKubectlArguments(action string, manifestPath string, flags []string) ([]string, error) {
-	buff, err := ioutil.ReadFile(filepath.Clean(manifestPath))
+	buff, err := os.ReadFile(filepath.Clean(manifestPath))
 	if err != nil {
 		return []string{}, errors.New(errors.CodeBadRequest, err.Error())
 	}
@@ -224,7 +225,7 @@ func (we *WorkflowExecutor) checkResourceState(ctx context.Context, selfLink str
 	}
 
 	defer func() { _ = stream.Close() }()
-	jsonBytes, err := ioutil.ReadAll(stream)
+	jsonBytes, err := io.ReadAll(stream)
 	if err != nil {
 		return false, err
 	}

--- a/workflow/executor/resource_test.go
+++ b/workflow/executor/resource_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -50,7 +49,7 @@ func TestResourceFlags(t *testing.T) {
 	_, err = we.getKubectlArguments("fake", "unknown-location", fakeFlags)
 	assert.EqualError(t, err, "open unknown-location: no such file or directory")
 
-	emptyFile, err := ioutil.TempFile("/tmp", "empty-manifest")
+	emptyFile, err := os.CreateTemp("/tmp", "empty-manifest")
 	assert.NoError(t, err)
 	defer func() { _ = os.Remove(emptyFile.Name()) }()
 	_, err = we.getKubectlArguments("fake", emptyFile.Name(), nil)
@@ -62,7 +61,7 @@ func TestResourceFlags(t *testing.T) {
 func TestResourcePatchFlags(t *testing.T) {
 	fakeClientset := fake.NewSimpleClientset()
 	manifestPath := "../../examples/hello-world.yaml"
-	buff, err := ioutil.ReadFile(manifestPath)
+	buff, err := os.ReadFile(manifestPath)
 	assert.NoError(t, err)
 	fakeFlags := []string{"patch", "--type", "strategic", "-p", string(buff), "-f", manifestPath, "-o", "json"}
 
@@ -93,7 +92,7 @@ func TestResourcePatchFlags(t *testing.T) {
 func TestResourcePatchFlagsJson(t *testing.T) {
 	fakeClientset := fake.NewSimpleClientset()
 	manifestPath := "../../examples/hello-world.yaml"
-	buff, err := ioutil.ReadFile(manifestPath)
+	buff, err := os.ReadFile(manifestPath)
 	assert.NoError(t, err)
 	fakeFlags := []string{"patch", "--type", "json", "-p", string(buff), "-o", "json"}
 

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -288,7 +288,7 @@ func ApplySubmitOpts(wf *wfv1.Workflow, opts *wfv1.SubmitOpts) error {
 					return errors.InternalWrapError(err)
 				}
 			} else {
-				body, err = ioutil.ReadFile(opts.ParameterFile)
+				body, err = os.ReadFile(opts.ParameterFile)
 				if err != nil {
 					return errors.InternalWrapError(err)
 				}
@@ -954,7 +954,7 @@ func SetWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface, hydra
 // Reads from stdin
 func ReadFromStdin() ([]byte, error) {
 	reader := bufio.NewReader(os.Stdin)
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -967,7 +967,7 @@ func ReadFromUrl(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	_ = response.Body.Close()
 	if err != nil {
 		return nil, err
@@ -987,7 +987,7 @@ func ReadFromFilePathsOrUrls(filePathsOrUrls ...string) ([][]byte, error) {
 				return [][]byte{}, err
 			}
 		} else {
-			body, err = ioutil.ReadFile(filepath.Clean(filePathOrUrl))
+			body, err = os.ReadFile(filepath.Clean(filePathOrUrl))
 			if err != nil {
 				return [][]byte{}, err
 			}

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,7 +93,7 @@ func TestReadFromSingleorMultiplePath(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", name)
+			dir, err := os.MkdirTemp("", name)
 			if err != nil {
 				t.Error("Could not create temporary directory")
 			}
@@ -104,7 +103,7 @@ func TestReadFromSingleorMultiplePath(t *testing.T) {
 				content := []byte(tc.contents[i])
 				tmpfn := filepath.Join(dir, tc.fileNames[i])
 				filePaths = append(filePaths, tmpfn)
-				err := ioutil.WriteFile(tmpfn, content, 0o600)
+				err := os.WriteFile(tmpfn, content, 0o600)
 				if err != nil {
 					t.Error("Could not write to temporary file")
 				}
@@ -145,7 +144,7 @@ func TestReadFromSingleorMultiplePathErrorHandling(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", name)
+			dir, err := os.MkdirTemp("", name)
 			if err != nil {
 				t.Error("Could not create temporary directory")
 			}
@@ -156,7 +155,7 @@ func TestReadFromSingleorMultiplePathErrorHandling(t *testing.T) {
 				tmpfn := filepath.Join(dir, tc.fileNames[i])
 				filePaths = append(filePaths, tmpfn)
 				if tc.exists[i] {
-					err := ioutil.WriteFile(tmpfn, content, 0o600)
+					err := os.WriteFile(tmpfn, content, 0o600)
 					if err != nil {
 						t.Error("Could not write to temporary file")
 					}
@@ -599,10 +598,10 @@ func TestApplySubmitOpts(t *testing.T) {
 	})
 	t.Run("ParameterFile", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
-		file, err := ioutil.TempFile("", "")
+		file, err := os.CreateTemp("", "")
 		assert.NoError(t, err)
 		defer func() { _ = os.Remove(file.Name()) }()
-		err = ioutil.WriteFile(file.Name(), []byte(`a: 81861780812`), 0o600)
+		err = os.WriteFile(file.Name(), []byte(`a: 81861780812`), 0o600)
 		assert.NoError(t, err)
 		err = ApplySubmitOpts(wf, &wfv1.SubmitOpts{ParameterFile: file.Name()})
 		assert.NoError(t, err)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since this project has been upgraded to Go 1.17 in #7029, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
