### PR TITLE
fix: Fix ANSI color sequences escaping

### DIFF
--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -40,7 +40,12 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
             .getContainerLogs(workflow, podName, nodeId, selectedContainer, grep, archived)
             .map(e => (!podName ? e.podName + ': ' : '') + e.content + '\n')
             // this next line highlights the search term in bold with a yellow background, white text
-            .map(x => x.replace(new RegExp(grep, 'g'), y => '\u001b[1m\u001b[43;1m\u001b[37m' + y + '\u001b[0m'))
+            .map(x => {
+                if (grep !== '') {
+                    return x.replace(new RegExp(grep, 'g'), y => '\u001b[1m\u001b[43;1m\u001b[37m' + y + '\u001b[0m');
+                }
+                return x;
+            })
             .publishReplay()
             .refCount();
         const subscription = source.subscribe(


### PR DESCRIPTION
This fixes a bug where an empty regex applied to all log lines would prefix every characters with `\u001b[1m\u001b[43;1m\u001b[37m\u001b[0m` (normally used to wrapped RegExp matches for highlighting). This bug removes any formatting made using ANSI color sequences.

Before:
![image](https://user-images.githubusercontent.com/648780/141483779-afc5950a-27e1-41d4-af24-daa737007b63.png)

After:
![image](https://user-images.githubusercontent.com/648780/141483628-f84748ac-ae8d-4ea3-92b2-45fbfa6e0a36.png)

Fixes https://github.com/argoproj/argo-workflows/issues/7189

Signed-off-by: Guillaume Fillon <guillaume.fillon@auth0.com>
