### PR TITLE
feat(ui): Support log viewing for user supplied init containers

### DIFF
--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -81,7 +81,7 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
 
     const containers = ['init', 'wait'].concat(
         templates
-            .map(t => ((t.containerSet && t.containerSet.containers) || [{name: 'main'}]).concat(t.sidecars || []))
+            .map(t => ((t.containerSet && t.containerSet.containers) || [{name: 'main'}]).concat(t.sidecars || []).concat(t.initContainers || []))
             .reduce((a, v) => a.concat(v), [])
             .map(c => c.name)
     );

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -281,8 +281,8 @@ const WorkflowNodeExitCode = ({exitCode}: {exitCode: number}) =>
         <div className='columns 6 text-center'>No exit code</div>
     );
 
-function hasEnv(container: models.kubernetes.Container | models.Sidecar | models.Script): container is models.kubernetes.Container | models.Sidecar {
-    return (container as models.kubernetes.Container | models.Sidecar).env !== undefined;
+function hasEnv(container: models.kubernetes.Container | models.UserContainer | models.Script): container is models.kubernetes.Container | models.UserContainer {
+    return (container as models.kubernetes.Container | models.UserContainer).env !== undefined;
 }
 
 const EnvVar = (props: {env: models.kubernetes.EnvVar}) => {
@@ -308,7 +308,7 @@ const EnvVar = (props: {env: models.kubernetes.EnvVar}) => {
 
 const WorkflowNodeContainer = (props: {
     nodeId: string;
-    container: models.kubernetes.Container | models.Sidecar | models.Script;
+    container: models.kubernetes.Container | models.UserContainer | models.Script;
     onShowContainerLogs: (nodeId: string, container: string) => any;
     onShowEvents: () => void;
 }) => {

--- a/ui/src/models/workflows.ts
+++ b/ui/src/models/workflows.ts
@@ -157,9 +157,9 @@ export interface Script {
 }
 
 /**
- * Sidecar is a container which runs alongside the main container
+ * UserContainer is is a container specified by a user.
  */
-export interface Sidecar {
+export interface UserContainer {
     /**
      * Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
      * Variable references $(VAR_NAME) are expanded using the container's environment.
@@ -353,7 +353,11 @@ export interface Template {
     /**
      * Sidecars is a list of containers which run alongside the main container Sidecars are automatically killed when the main container completes
      */
-    sidecars?: Sidecar[];
+    sidecars?: UserContainer[];
+    /**
+     * InitContainers is a list of containers which run before the main container.
+     */
+    initContainers?: UserContainer[];
     /**
      * Steps define a series of sequential/parallel workflow steps
      */


### PR DESCRIPTION
For [this example](https://github.com/argoproj/argo-workflows/blob/master/examples/init-container.yaml), we cannot view user supplied init container logs in the UI. The log is available via `kubectl logs` though.

The custom init container name `hello` should show up in the selections.

Before the change:
![image (1)](https://user-images.githubusercontent.com/4269898/141531818-69ba965f-9a38-4296-9f64-a16dca218143.png)


After the change:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/4269898/141536468-3bef65d4-98cf-42d0-aa37-ef2e6ac003d0.png">

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
