### PR TITLE
fix: Ensure that user cannot override reserved labels

### DIFF
--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v3"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
 // NewVersionCmd returns a new `version` command to be used as a sub-command to root
@@ -87,6 +88,12 @@ func ParseLabels(labelSpec interface{}) (map[string]string, error) {
 		if len(labelSpec[0]) == 0 {
 			return nil, fmt.Errorf("unexpected empty label key")
 		}
+
+		if _, reserved := common.ReservedWorkflowLabelKeys[labelSpec[0]]; reserved {
+			log.Warnf("Ignoring label with key '%s' as it is reserved", labelSpec[0])
+			continue
+		}
+
 		labels[labelSpec[0]] = labelSpec[1]
 	}
 	return labels, nil

--- a/util/cmd/cmd_test.go
+++ b/util/cmd/cmd_test.go
@@ -81,22 +81,6 @@ func TestMakeParseLabels(t *testing.T) {
 			t.Errorf("labels %s expect error, reason: %s, got nil", test.labels, test.name)
 		}
 	}
-
-	warnCases := []struct {
-		name   string
-		labels interface{}
-	}{
-		{
-			name:   "reserved",
-			labels: common.LabelKeyCreatorEmail,
-		},
-	}
-	for _, test := range warnCases {
-		_, err := ParseLabels(test.labels)
-		if err == nil {
-			t.Errorf("labels %s expect error, reason: %s, got nil", test.labels, test.name)
-		}
-	}
 }
 
 func TestReservedLabel(t *testing.T) {

--- a/util/cmd/cmd_test.go
+++ b/util/cmd/cmd_test.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
 func TestMakeParseLabels(t *testing.T) {
@@ -75,5 +80,31 @@ func TestMakeParseLabels(t *testing.T) {
 		if err == nil {
 			t.Errorf("labels %s expect error, reason: %s, got nil", test.labels, test.name)
 		}
+	}
+
+	warnCases := []struct {
+		name   string
+		labels interface{}
+	}{
+		{
+			name:   "reserved",
+			labels: common.LabelKeyCreatorEmail,
+		},
+	}
+	for _, test := range warnCases {
+		_, err := ParseLabels(test.labels)
+		if err == nil {
+			t.Errorf("labels %s expect error, reason: %s, got nil", test.labels, test.name)
+		}
+	}
+}
+
+func TestReservedLabel(t *testing.T) {
+	reservedLabel := fmt.Sprintf("%s=abc@xyz.com", common.LabelKeyCreatorEmail)
+	labels, err := ParseLabels(reservedLabel)
+
+	if assert.NoError(t, err) {
+		// Label doesn't get parsed because it is reserved
+		assert.Len(t, labels, 0)
 	}
 }

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -73,7 +73,7 @@ const (
 	LabelKeyWorkflowTemplate = workflow.WorkflowFullName + "/workflow-template"
 	// LabelKeyWorkflowEventBinding is a label applied to Workflows that are submitted from a WorkflowEventBinding
 	LabelKeyWorkflowEventBinding = workflow.WorkflowFullName + "/workflow-event-binding"
-	// LabelKeyWorkflowTemplate is a label applied to Workflows that are submitted from ClusterWorkflowtemplate
+	// LabelKeyClusterWorkflowTemplate is a label applied to Workflows that are submitted from ClusterWorkflowtemplate
 	LabelKeyClusterWorkflowTemplate = workflow.WorkflowFullName + "/cluster-workflow-template"
 	// LabelKeyOnExit is a label applied to Pods that are run from onExit nodes, so that they are not shut down when stopping a Workflow
 	LabelKeyOnExit = workflow.WorkflowFullName + "/on-exit"
@@ -202,8 +202,27 @@ const (
 // AnnotationKeyKillCmd specifies the command to use to kill to container, useful for injected sidecars
 var AnnotationKeyKillCmd = func(containerName string) string { return workflow.WorkflowFullName + "/kill-cmd-" + containerName }
 
-// GlobalVarWorkflowRootTags is a list of root tags in workflow which could be used for variable reference
+// GlobalVarValidWorkflowVariablePrefix is a list of root tags in workflow which could be used for variable reference
 var GlobalVarValidWorkflowVariablePrefix = []string{"item.", "steps.", "inputs.", "outputs.", "pod.", "workflow.", "tasks."}
+
+// ReservedWorkflowLabelKeys keeps track of workflow label keys that are managed by Argo Workflows, so they cannot be
+// overridden using the CLI. Note that users can still edit these keys directly with K8s... to prevent that appropriate
+// RBAC permissions should be set.
+var ReservedWorkflowLabelKeys = map[string]bool{
+	LabelKeyControllerInstanceID:    true,
+	LabelKeyCreator:                 true,
+	LabelKeyCreatorEmail:            true,
+	LabelKeyCompleted:               true,
+	LabelKeyWorkflowArchivingStatus: true,
+	LabelKeyWorkflow:                true,
+	LabelKeyPhase:                   true,
+	LabelKeyPreviousWorkflowName:    true,
+	LabelKeyCronWorkflow:            true,
+	LabelKeyWorkflowTemplate:        true,
+	LabelKeyWorkflowEventBinding:    true,
+	LabelKeyClusterWorkflowTemplate: true,
+	LabelKeyOnExit:                  true,
+}
 
 func UnstructuredHasCompletedLabel(obj interface{}) bool {
 	if wf, ok := obj.(*unstructured.Unstructured); ok {


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/7215, which could be a potential security vulnerability with users overriding labels set by Argo. 

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
