### PR TITLE
chore: Remove unnecessary message in commit-msg git hook

### DIFF
--- a/hack/git/hooks/commit-msg
+++ b/hack/git/hooks/commit-msg
@@ -11,4 +11,3 @@ grep -qE '^(?:feat|fix|docs|style|refactor|perf|test|chore)\(?(?:\w+|\s|\-|_)?\)
   exit 1
 }
 
-echo 'Your commit message is acceptable'


### PR DESCRIPTION
This doesn't seem necessary if the message looks good.

```
$ git commit -m "chore: Remove unnecessary message in commit-msg git hook"
Your commit message is acceptable
[master 0a22ec1d] chore: Remove unnecessary message in commit-msg git hook
 1 file changed, 1 deletion(-)

```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
