### PR TITLE
fix: improve feedback to user when submitting a workflow from the CLI w/o a serviceaccount specified

### DIFF
--- a/cmd/argo/commands/archive/get.go
+++ b/cmd/argo/commands/archive/get.go
@@ -51,7 +51,11 @@ func NewGetCommand() *cobra.Command {
 				fmt.Printf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)
 				serviceAccount := wf.Spec.ServiceAccountName
 				if serviceAccount == "" {
-					serviceAccount = "default"
+					// if serviceAccountName was not specified in a submitted Workflow, we will
+					// use the serviceAccountName provided in Workflow Defaults (if any). If that
+					// also isn't set, we will use the 'default' ServiceAccount in the namespace
+					// the workflow will run in.
+					serviceAccount = "unset (will run with the default ServiceAccount)"
 				}
 				fmt.Printf(fmtStr, "ServiceAccount:", serviceAccount)
 				fmt.Printf(fmtStr, "Status:", wf.Status.Phase)

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -120,7 +120,11 @@ func printWorkflowHelper(wf *wfv1.Workflow, getArgs getFlags) string {
 	out += fmt.Sprintf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)
 	serviceAccount := wf.Spec.ServiceAccountName
 	if serviceAccount == "" {
-		serviceAccount = "default"
+		// if serviceAccountName was not specified in a submitted Workflow, we will
+		// use the serviceAccountName provided in Workflow Defaults (if any). If that
+		// also isn't set, we will use the 'default' ServiceAccount in the namespace
+		// the workflow will run in.
+		serviceAccount = "unset (will run with the default ServiceAccount)"
 	}
 	out += fmt.Sprintf(fmtStr, "ServiceAccount:", serviceAccount)
 	out += fmt.Sprintf(fmtStr, "Status:", printer.WorkflowStatus(wf))


### PR DESCRIPTION
**What was the issue?**
When submitting a workflow using `argo submit somefile.yaml`, if the workflow does not explicitly specify a `spec.serviceAccountName`, the output of the command would look like this: 

```
❯ argo submit workflow-artifact-repo-ref-test.yaml
Name:                artifactory-repository-ref-vp472
Namespace:           argo
ServiceAccount:      default
Status:              Pending
Created:             Thu Nov 18 15:24:57 +0100 (now)
Progress:
```

The important bit here is the `ServiceAccount: default` bit. In my case, I have configured a default ServiceAccount in the `workflowDefaults` section of the workflow-controller configmap. This means that my workflow will not run with `ServiceAccount: default`, but with the ServiceAccount I specified there. See the command below:

```
❯ argo get @latest
Name:                artifactory-repository-ref-vp472
Namespace:           argo
ServiceAccount:      argo-default-workflow
Status:              Succeeded
Conditions:
 PodRunning          False
 Completed           True
```

**What did I change?**
I changed the string that is returned as the value for `serviceaccount` when no serviceaccount is set. Instead of suggesting the workflow is using the `default` serviceaccount, it now specifies that no serviceaccount has been set, and we're using a default ServiceAccount instead.

**Further context**
This PR is the result of a Slack discussion between myself and @crenshaw-dev on this particular issue. 