### PR TITLE
fix: only add security context config for controller plugins

### DIFF
--- a/cmd/argo/commands/plugin/plugin.go
+++ b/cmd/argo/commands/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -64,10 +65,13 @@ func loadPlugin(pluginDir string) (*loadResult, error) {
 	}
 	plug.Spec.Container.Args = []string{string(code)}
 
-	// Match default security settings for easier patch.
-	runAsNonRoot := true
-	runAsUser := int64(1000)
-	plug.Spec.Container.SecurityContext = &apiv1.SecurityContext{RunAsNonRoot: &runAsNonRoot, RunAsUser: &runAsUser}
+	if strings.Contains(pluginDir, "controller") {
+		// Match default security settings for easier patch.
+		runAsNonRoot := true
+		runAsUser := int64(1000)
+		plug.Spec.Container.SecurityContext = &apiv1.SecurityContext{RunAsNonRoot: &runAsNonRoot, RunAsUser: &runAsUser}
+	}
+
 	cm := &apiv1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",

--- a/examples/plugins/executor/hello/hello-executor-plugin-configmap.yaml
+++ b/examples/plugins/executor/hello/hello-executor-plugin-configmap.yaml
@@ -43,9 +43,6 @@ data:
     image: python:alpine3.6
     name: hello-executor-plugin
     resources: {}
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1000
 kind: ConfigMap
 metadata:
   annotations:

--- a/examples/plugins/executor/python/python-executor-plugin-configmap.yaml
+++ b/examples/plugins/executor/python/python-executor-plugin-configmap.yaml
@@ -49,9 +49,6 @@ data:
     image: python:alpine3.6
     name: python-executor-plugin
     resources: {}
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1000
 kind: ConfigMap
 metadata:
   annotations:

--- a/examples/plugins/executor/slack/slack-executor-plugin-configmap.yaml
+++ b/examples/plugins/executor/slack/slack-executor-plugin-configmap.yaml
@@ -56,9 +56,6 @@ data:
     image: python:alpine3.6
     name: slack-executor-plugin
     resources: {}
-    securityContext:
-      runAsNonRoot: true
-      runAsUser: 1000
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
That config isn't relevant to executor plugins. It's important for controller plugins, because the controller runs in a no-root pod by default.