### PR TITLE
docs: Fix workflow name in suspend outputs example

### DIFF
--- a/examples/suspend-template-outputs.yaml
+++ b/examples/suspend-template-outputs.yaml
@@ -9,7 +9,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: suspend-outputs
+  name: suspend-outputs
 spec:
   entrypoint: suspend
   templates:


### PR DESCRIPTION
The comments above uses `argo node set suspend-outputs` so we need a fixed workflow name. 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
