### PR TITLE
fix: Use default value for empty env vars

### DIFF
--- a/util/env/env.go
+++ b/util/env/env.go
@@ -10,7 +10,7 @@ import (
 
 func LookupEnvDurationOr(key string, o time.Duration) time.Duration {
 	v, found := os.LookupEnv(key)
-	if found {
+	if found && v != "" {
 		d, err := time.ParseDuration(v)
 		if err != nil {
 			log.WithField(key, v).WithError(err).Panic("failed to parse")
@@ -23,7 +23,7 @@ func LookupEnvDurationOr(key string, o time.Duration) time.Duration {
 
 func LookupEnvIntOr(key string, o int) int {
 	v, found := os.LookupEnv(key)
-	if found {
+	if found && v != "" {
 		d, err := strconv.Atoi(v)
 		if err != nil {
 			log.WithField(key, v).WithError(err).Panic("failed to convert to int")
@@ -36,7 +36,7 @@ func LookupEnvIntOr(key string, o int) int {
 
 func LookupEnvFloatOr(key string, o float64) float64 {
 	v, found := os.LookupEnv(key)
-	if found {
+	if found && v != "" {
 		d, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			log.WithField(key, v).WithError(err).Panic("failed to convert to float")

--- a/util/env/env_test.go
+++ b/util/env/env_test.go
@@ -15,6 +15,8 @@ func TestLookupEnvDurationOr(t *testing.T) {
 	assert.Panics(t, func() { LookupEnvDurationOr("FOO", time.Second) }, "bad value")
 	_ = os.Setenv("FOO", "1h")
 	assert.Equal(t, time.Hour, LookupEnvDurationOr("FOO", time.Second), "env var value")
+	_ = os.Setenv("FOO", "")
+	assert.Equal(t, time.Second, LookupEnvDurationOr("FOO", time.Second), "empty var value; default value")
 }
 
 func TestLookupEnvIntOr(t *testing.T) {
@@ -24,6 +26,8 @@ func TestLookupEnvIntOr(t *testing.T) {
 	assert.Panics(t, func() { LookupEnvIntOr("FOO", 1) }, "bad value")
 	_ = os.Setenv("FOO", "2")
 	assert.Equal(t, 2, LookupEnvIntOr("FOO", 1), "env var value")
+	_ = os.Setenv("FOO", "")
+	assert.Equal(t, 1, LookupEnvIntOr("FOO", 1), "empty var value; default value")
 }
 
 func TestLookupEnvFloatOr(t *testing.T) {
@@ -33,4 +37,6 @@ func TestLookupEnvFloatOr(t *testing.T) {
 	assert.Panics(t, func() { LookupEnvFloatOr("FOO", 1.) }, "bad value")
 	_ = os.Setenv("FOO", "2.0")
 	assert.Equal(t, 2., LookupEnvFloatOr("FOO", 1.), "env var value")
+	_ = os.Setenv("FOO", "")
+	assert.Equal(t, 1., LookupEnvFloatOr("FOO", 1.), "empty var value; default value")
 }


### PR DESCRIPTION
Set but empty env vars should use the default value instead of panic-ing

Signed-off-by: Simon Behar <simbeh7@gmail.com>

Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
