### PR TITLE
fix: resolve resourcesDuration

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -260,10 +260,8 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	}
 
 	if woc.execWf.Spec.Metrics != nil {
-		realTimeScope := map[string]func() float64{common.GlobalVarWorkflowDuration: func() float64 {
-			return time.Since(woc.wf.Status.StartedAt.Time).Seconds()
-		}}
-		woc.computeMetrics(woc.execWf.Spec.Metrics.Prometheus, woc.globalParams, realTimeScope, true)
+		localScope, realTimeScope := woc.prepareMetricScope(nil)
+		woc.computeMetrics(woc.execWf.Spec.Metrics.Prometheus, localScope, realTimeScope, true)
 	}
 
 	if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
@@ -467,11 +465,9 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	}
 
 	if woc.execWf.Spec.Metrics != nil {
-		realTimeScope := map[string]func() float64{common.GlobalVarWorkflowDuration: func() float64 {
-			return node.FinishedAt.Sub(node.StartedAt.Time).Seconds()
-		}}
 		woc.globalParams[common.GlobalVarWorkflowStatus] = string(workflowStatus)
-		woc.computeMetrics(woc.execWf.Spec.Metrics.Prometheus, woc.globalParams, realTimeScope, false)
+		localScope, realTimeScope := woc.prepareMetricScope(node)
+		woc.computeMetrics(woc.execWf.Spec.Metrics.Prometheus, localScope, realTimeScope, false)
 	}
 
 	err = woc.deletePVCs(ctx)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -260,7 +260,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	}
 
 	if woc.execWf.Spec.Metrics != nil {
-		localScope, realTimeScope := woc.prepareMetricScope(nil)
+		localScope, realTimeScope := woc.prepareDefaultMetricScope()
 		woc.computeMetrics(woc.execWf.Spec.Metrics.Prometheus, localScope, realTimeScope, true)
 	}
 

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Knetic/govaluate"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -493,6 +494,26 @@ func (woc *wfOperationCtx) expandStep(step wfv1.WorkflowStep) ([]wfv1.WorkflowSt
 func (woc *wfOperationCtx) prepareMetricScope(node *wfv1.NodeStatus) (map[string]string, map[string]func() float64) {
 	realTimeScope := make(map[string]func() float64)
 	localScope := woc.globalParams.DeepCopy()
+
+	if node == nil {
+		durationCPU := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceCPU)
+		durationMem := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceMemory)
+
+		localScope[common.LocalVarDuration] = "0"
+		localScope[common.LocalVarStatus] = string(wfv1.NodePending)
+		localScope[durationCPU] = "0"
+		localScope[durationMem] = "0"
+
+		realTimeScope = map[string]func() float64{
+			common.GlobalVarWorkflowDuration: func() float64 {
+				return time.Since(woc.wf.Status.StartedAt.Time).Seconds()
+			},
+			common.LocalVarDuration: func() float64 { return 0.0 },
+			durationCPU:             func() float64 { return 0.0 },
+			durationMem:             func() float64 { return 0.0 },
+		}
+		return localScope, realTimeScope
+	}
 
 	if node.Fulfilled() {
 		localScope[common.LocalVarDuration] = fmt.Sprintf("%f", node.FinishedAt.Sub(node.StartedAt.Time).Seconds())

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -491,29 +491,28 @@ func (woc *wfOperationCtx) expandStep(step wfv1.WorkflowStep) ([]wfv1.WorkflowSt
 	return expandedStep, nil
 }
 
+func (woc *wfOperationCtx) prepareDefaultMetricScope() (map[string]string, map[string]func() float64) {
+	durationCPU := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceCPU)
+	durationMem := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceMemory)
+
+	localScope := woc.globalParams.DeepCopy()
+	localScope[common.LocalVarDuration] = "0"
+	localScope[common.LocalVarStatus] = string(wfv1.NodePending)
+	localScope[durationCPU] = "0"
+	localScope[durationMem] = "0"
+
+	var realTimeScope = map[string]func() float64{
+		common.GlobalVarWorkflowDuration: func() float64 {
+			return time.Since(woc.wf.Status.StartedAt.Time).Seconds()
+		},
+	}
+
+	return localScope, realTimeScope
+}
+
 func (woc *wfOperationCtx) prepareMetricScope(node *wfv1.NodeStatus) (map[string]string, map[string]func() float64) {
 	realTimeScope := make(map[string]func() float64)
 	localScope := woc.globalParams.DeepCopy()
-
-	if node == nil {
-		durationCPU := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceCPU)
-		durationMem := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceMemory)
-
-		localScope[common.LocalVarDuration] = "0"
-		localScope[common.LocalVarStatus] = string(wfv1.NodePending)
-		localScope[durationCPU] = "0"
-		localScope[durationMem] = "0"
-
-		realTimeScope = map[string]func() float64{
-			common.GlobalVarWorkflowDuration: func() float64 {
-				return time.Since(woc.wf.Status.StartedAt.Time).Seconds()
-			},
-			common.LocalVarDuration: func() float64 { return 0.0 },
-			durationCPU:             func() float64 { return 0.0 },
-			durationMem:             func() float64 { return 0.0 },
-		}
-		return localScope, realTimeScope
-	}
 
 	if node.Fulfilled() {
 		localScope[common.LocalVarDuration] = fmt.Sprintf("%f", node.FinishedAt.Sub(node.StartedAt.Time).Seconds())

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -171,23 +171,20 @@ func TestResourceDurationMetric(t *testing.T) {
 	assert.Equal(t, "0", localScope["exitCode"])
 }
 
-func TestResourceDurationMetricUninitializedNode(t *testing.T) {
+func TestResourceDurationMetricDefaultMetricScope(t *testing.T) {
 	wf := wfv1.Workflow{Status: wfv1.WorkflowStatus{StartedAt: metav1.NewTime(time.Now())}}
 	woc := wfOperationCtx{
 		globalParams: make(common.Parameters),
 		wf:           &wf,
 	}
 
-	localScope, realTimeScope := woc.prepareMetricScope(nil)
+	localScope, realTimeScope := woc.prepareDefaultMetricScope()
 
 	assert.Equal(t, "0", localScope["resourcesDuration.cpu"])
 	assert.Equal(t, "0", localScope["resourcesDuration.memory"])
 	assert.Equal(t, "0", localScope["duration"])
 	assert.Equal(t, "Pending", localScope["status"])
 	assert.Less(t, realTimeScope["workflow.duration"](), 1.0)
-	assert.Equal(t, 0.0, realTimeScope["duration"]())
-	assert.Equal(t, 0.0, realTimeScope["resourcesDuration.cpu"]())
-	assert.Equal(t, 0.0, realTimeScope["resourcesDuration.memory"]())
 }
 
 var optionalArgumentAndParameter = `

--- a/workflow/metrics/util.go
+++ b/workflow/metrics/util.go
@@ -222,17 +222,22 @@ func IsValidMetricName(name string) bool {
 	return model.IsValidMetricName(model.LabelValue(name))
 }
 
-func ValidateMetricGauge(gauge *wfv1.Gauge) error {
-	if gauge == nil {
-		return errors.New("gauge is nil")
-	}
-	if gauge.Value == "" {
-		return errors.New("missing gauge.value")
-	}
-	if gauge.Realtime != nil && *gauge.Realtime {
-		if strings.Contains(gauge.Value, "resourcesDuration.") {
-			return errors.New("'resourcesDuration.*' metrics cannot be used in real-time")
+func ValidateMetricValues(metric *wfv1.Prometheus) error {
+	if metric.Gauge != nil {
+		if metric.Gauge.Value == "" {
+			return errors.New("missing gauge.value")
 		}
+		if metric.Gauge.Realtime != nil && *metric.Gauge.Realtime {
+			if strings.Contains(metric.Gauge.Value, "resourcesDuration.") {
+				return errors.New("'resourcesDuration.*' metrics cannot be used in real-time")
+			}
+		}
+	}
+	if metric.Counter != nil && metric.Counter.Value == "" {
+		return errors.New("missing counter.value")
+	}
+	if metric.Histogram != nil && metric.Histogram.Value == "" {
+		return errors.New("missing histogram.value")
 	}
 	return nil
 }

--- a/workflow/metrics/util.go
+++ b/workflow/metrics/util.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -219,6 +220,21 @@ func getWorkersBusy(name string) prometheus.Gauge {
 
 func IsValidMetricName(name string) bool {
 	return model.IsValidMetricName(model.LabelValue(name))
+}
+
+func ValidateMetricGauge(gauge *wfv1.Gauge) error {
+	if gauge == nil {
+		return errors.New("gauge is nil")
+	}
+	if gauge.Value == "" {
+		return errors.New("missing gauge.value")
+	}
+	if gauge.Realtime != nil && *gauge.Realtime {
+		if strings.Contains(gauge.Value, "resourcesDuration.") {
+			return errors.New("'resourcesDuration.*' metrics cannot be used in real-time")
+		}
+	}
+	return nil
 }
 
 func ValidateMetricLabels(metrics map[string]string) error {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -413,8 +413,8 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 			if metric.Help == "" {
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s metric '%s' must contain a help string under 'help: ' field", tmpl.Name, metric.Name)
 			}
-			if err := metrics.ValidateMetricGauge(metric.Gauge); err != nil {
-				return errors.Errorf(errors.CodeBadRequest, "templates.%s metric '%s' gauge error: %s", tmpl.Name, metric.Name, err)
+			if err := metrics.ValidateMetricValues(metric); err != nil {
+				return errors.Errorf(errors.CodeBadRequest, "templates.%s metric '%s' error: %s", tmpl.Name, metric.Name, err)
 			}
 		}
 	}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -413,6 +413,9 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 			if metric.Help == "" {
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s metric '%s' must contain a help string under 'help: ' field", tmpl.Name, metric.Name)
 			}
+			if err := metrics.ValidateMetricGauge(metric.Gauge); err != nil {
+				return errors.Errorf(errors.CodeBadRequest, "templates.%s metric '%s' gauge error: %s", tmpl.Name, metric.Name, err)
+			}
 		}
 	}
 	return nil

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2256,30 +2256,7 @@ spec:
 
 func TestInvalidMetricGauge(t *testing.T) {
 	_, err := validate(invalidRealtimeMetricGauge)
-	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' gauge error: 'resourcesDuration.*' metrics cannot be used in real-time")
-}
-
-var invalidNilMetricGauge = `
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: hello-world-
-spec:
-  entrypoint: whalesay
-  templates:
-  - name: whalesay
-    metrics:
-      prometheus:
-        - name: metric_name
-          help: please
-          gauge:
-    container:
-      image: docker/whalesay:latest
-`
-
-func TestInvalidNilMetricGauge(t *testing.T) {
-	_, err := validate(invalidNilMetricGauge)
-	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' gauge error: gauge is nil")
+	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' error: 'resourcesDuration.*' metrics cannot be used in real-time")
 }
 
 var invalidNoValueMetricGauge = `
@@ -2303,7 +2280,7 @@ spec:
 
 func TestInvalidNoValueMetricGauge(t *testing.T) {
 	_, err := validate(invalidNoValueMetricGauge)
-	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' gauge error: missing gauge.value")
+	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' error: missing gauge.value")
 }
 
 var validMetricGauges = `


### PR DESCRIPTION
- Fixes #6053 

### Testing
I submitted this workflow:
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: whale-my-resources-
spec:
  metrics:
      prometheus:
        - name: duration
          help: duration
          gauge:
            realtime: false
            value: "{{resourcesDuration.cpu}}"
  entrypoint: whalesay
  templates:
  - name: whalesay
    script:
      image: alpine:3
      command: [/bin/sh]
      source: |
        sleep 20
```

The metrics were logged without error.

I then changed the workflow to use `realtime: true` and submitted again, with the same result.