### PR TITLE
feat(ui): submit workflow make button disable after clicking

### DIFF
--- a/ui/src/app/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/submit-workflow-panel.tsx
@@ -24,6 +24,7 @@ interface State {
     templates: Template[];
     labels: string[];
     error?: Error;
+    isSubmitting: boolean;
 }
 
 const workflowEntrypoint = '<default>';
@@ -43,7 +44,8 @@ export class SubmitWorkflowPanel extends React.Component<Props, State> {
             selectedTemplate: defaultTemplate,
             parameters: this.props.workflowParameters || [],
             templates: [defaultTemplate].concat(this.props.templates),
-            labels: ['submit-from-ui=true']
+            labels: ['submit-from-ui=true'],
+            isSubmitting: false
         };
         this.state = state;
     }
@@ -98,8 +100,8 @@ export class SubmitWorkflowPanel extends React.Component<Props, State> {
                         <TagsInput tags={this.state.labels} onChange={labels => this.setState({labels})} />
                     </div>
                     <div key='submit'>
-                        <button onClick={() => this.submit()} className='argo-button argo-button--base'>
-                            <i className='fa fa-plus' /> Submit
+                        <button onClick={() => this.submit()} className='argo-button argo-button--base' disabled={this.state.isSubmitting}>
+                            <i className='fa fa-plus' /> {this.state.isSubmitting ? 'Loading...' : 'Submit'}
                         </button>
                     </div>
                 </div>
@@ -165,6 +167,7 @@ export class SubmitWorkflowPanel extends React.Component<Props, State> {
     }
 
     private submit() {
+        this.setState({isSubmitting: true});
         services.workflows
             .submit(this.props.kind, this.props.name, this.props.namespace, {
                 entryPoint: this.state.entrypoint === workflowEntrypoint ? null : this.state.entrypoint,
@@ -172,6 +175,6 @@ export class SubmitWorkflowPanel extends React.Component<Props, State> {
                 labels: this.state.labels.join(',')
             })
             .then((submitted: Workflow) => (document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`)))
-            .catch(error => this.setState({error}));
+            .catch(error => this.setState({error, isSubmitting: false}));
     }
 }


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

## Motivation

When we have large workflows, it has some delays to submit workflow in workflow template ui. At that time, UI has no feedback.

## Solution

After clicking submit button, the button shows `Loading...`.

## Checks

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Say how how you tested your changes. If you changed the UI, attach screenshots.

https://user-images.githubusercontent.com/915731/144739056-a42f8242-f858-4f46-b6db-134a25fe7366.mov


