### PR TITLE
fix: transient errors for s3 artifacts: Fixes #7349

### DIFF
--- a/util/wait/backoff.go
+++ b/util/wait/backoff.go
@@ -3,7 +3,6 @@ package wait
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 

--- a/util/wait/backoff.go
+++ b/util/wait/backoff.go
@@ -3,6 +3,7 @@ package wait
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 

--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -1,6 +1,10 @@
 package s3
 
-import argos3 "github.com/argoproj/pkg/s3"
+import (
+	argos3 "github.com/argoproj/pkg/s3"
+
+	"github.com/argoproj/argo-workflows/v3/util/errors"
+)
 
 // s3TransientErrorCodes is a list of S3 error codes that are transient (retryable)
 // Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
@@ -25,5 +29,5 @@ func isTransientS3Err(err error) bool {
 			return true
 		}
 	}
-	return false
+	return errors.IsTransientErr(err)
 }

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -15,7 +15,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	envutil "github.com/argoproj/argo-workflows/v3/util/env"
-	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 	artifactscommon "github.com/argoproj/argo-workflows/v3/workflow/artifacts/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
@@ -79,7 +78,7 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			log.Infof("S3 Load path: %s, key: %s", path, inputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create new S3 client: %v", err)
+				return !isTransientS3Err(err), fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			return loadS3Artifact(s3cli, inputArtifact, path)
 		})
@@ -96,12 +95,12 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 		return true, nil
 	}
 	if !argos3.IsS3ErrCode(origErr, "NoSuchKey") {
-		return !(isTransientS3Err(origErr) || errorsutil.IsTransientErr(origErr)), fmt.Errorf("failed to get file: %v", origErr)
+		return !isTransientS3Err(origErr), fmt.Errorf("failed to get file: %v", origErr)
 	}
 	// If we get here, the error was a NoSuchKey. The key might be a s3 "directory"
 	isDir, err := s3cli.IsDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
 	if err != nil {
-		return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
+		return !isTransientS3Err(err), fmt.Errorf("failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
 	}
 	if !isDir {
 		// It's neither a file, nor a directory. Return the original NoSuchKey error
@@ -109,7 +108,7 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 	}
 
 	if err = s3cli.GetDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key, path); err != nil {
-		return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to get directory: %v", err)
+		return !isTransientS3Err(err), fmt.Errorf("failed to get directory: %v", err)
 	}
 	return true, nil
 }
@@ -124,7 +123,7 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 			log.Infof("S3 Save path: %s, key: %s", path, outputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create new S3 client: %v", err)
+				return !isTransientS3Err(err), fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			return saveS3Artifact(s3cli, path, outputArtifact)
 		})
@@ -148,17 +147,17 @@ func saveS3Artifact(s3cli argos3.S3Client, path string, outputArtifact *wfv1.Art
 			ObjectLocking: outputArtifact.S3.CreateBucketIfNotPresent.ObjectLocking,
 		})
 		if err != nil {
-			return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
+			return !isTransientS3Err(err), fmt.Errorf("failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
 		}
 	}
 
 	if isDir {
 		if err = s3cli.PutDirectory(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
-			return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to put directory: %v", err)
+			return !isTransientS3Err(err), fmt.Errorf("failed to put directory: %v", err)
 		}
 	} else {
 		if err = s3cli.PutFile(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
-			return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to put file: %v", err)
+			return !isTransientS3Err(err), fmt.Errorf("failed to put file: %v", err)
 		}
 	}
 	return true, nil
@@ -173,11 +172,11 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 		func() (bool, error) {
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create new S3 client: %v", err)
+				return !isTransientS3Err(err), fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			files, err = s3cli.ListDirectory(artifact.S3.Bucket, artifact.S3.Key)
 			if err != nil {
-				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to list directory: %v", err)
+				return !isTransientS3Err(err), fmt.Errorf("failed to list directory: %v", err)
 			}
 			return true, nil
 		})

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 	artifactscommon "github.com/argoproj/argo-workflows/v3/workflow/artifacts/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
@@ -72,7 +73,7 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 			log.Infof("S3 Load path: %s, key: %s", path, inputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return !isTransientS3Err(err), fmt.Errorf("failed to create new S3 client: %v", err)
+				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			return loadS3Artifact(s3cli, inputArtifact, path)
 		})
@@ -89,12 +90,12 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 		return true, nil
 	}
 	if !argos3.IsS3ErrCode(origErr, "NoSuchKey") {
-		return !isTransientS3Err(origErr), fmt.Errorf("failed to get file: %v", origErr)
+		return !errorsutil.IsTransientErr(origErr) || !isTransientS3Err(origErr), fmt.Errorf("failed to get file: %v", origErr)
 	}
 	// If we get here, the error was a NoSuchKey. The key might be a s3 "directory"
 	isDir, err := s3cli.IsDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
 	if err != nil {
-		return !isTransientS3Err(err), fmt.Errorf("failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
+		return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to test if %s is a directory: %v", inputArtifact.S3.Key, err)
 	}
 	if !isDir {
 		// It's neither a file, nor a directory. Return the original NoSuchKey error
@@ -102,7 +103,7 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 	}
 
 	if err = s3cli.GetDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key, path); err != nil {
-		return !isTransientS3Err(err), fmt.Errorf("failed to get directory: %v", err)
+		return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to get directory: %v", err)
 	}
 	return true, nil
 }
@@ -117,7 +118,7 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 			log.Infof("S3 Save path: %s, key: %s", path, outputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return !isTransientS3Err(err), fmt.Errorf("failed to create new S3 client: %v", err)
+				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			return saveS3Artifact(s3cli, path, outputArtifact)
 		})
@@ -141,17 +142,17 @@ func saveS3Artifact(s3cli argos3.S3Client, path string, outputArtifact *wfv1.Art
 			ObjectLocking: outputArtifact.S3.CreateBucketIfNotPresent.ObjectLocking,
 		})
 		if err != nil {
-			return !isTransientS3Err(err), fmt.Errorf("failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
+			return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create bucket %s: %v", outputArtifact.S3.Bucket, err)
 		}
 	}
 
 	if isDir {
 		if err = s3cli.PutDirectory(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
-			return !isTransientS3Err(err), fmt.Errorf("failed to put directory: %v", err)
+			return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to put directory: %v", err)
 		}
 	} else {
 		if err = s3cli.PutFile(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
-			return !isTransientS3Err(err), fmt.Errorf("failed to put file: %v", err)
+			return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to put file: %v", err)
 		}
 	}
 	return true, nil
@@ -166,11 +167,11 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 		func() (bool, error) {
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {
-				return !isTransientS3Err(err), fmt.Errorf("failed to create new S3 client: %v", err)
+				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to create new S3 client: %v", err)
 			}
 			files, err = s3cli.ListDirectory(artifact.S3.Bucket, artifact.S3.Key)
 			if err != nil {
-				return !isTransientS3Err(err), fmt.Errorf("failed to list directory: %v", err)
+				return !(isTransientS3Err(err) || errorsutil.IsTransientErr(err)), fmt.Errorf("failed to list directory: %v", err)
 			}
 			return true, nil
 		})

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 	"fmt"
-	envutil "github.com/argoproj/argo-workflows/v3/util/env"
 	"os"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	envutil "github.com/argoproj/argo-workflows/v3/util/env"
 	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 	artifactscommon "github.com/argoproj/argo-workflows/v3/workflow/artifacts/common"

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -4,20 +4,18 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/argoproj/pkg/file"
 	argos3 "github.com/argoproj/pkg/s3"
 	"github.com/minio/minio-go/v7"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	envutil "github.com/argoproj/argo-workflows/v3/util/env"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 	artifactscommon "github.com/argoproj/argo-workflows/v3/workflow/artifacts/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
+	executorretry "github.com/argoproj/argo-workflows/v3/workflow/executor/retry"
 )
 
 // ArtifactDriver is a driver for AWS S3
@@ -36,15 +34,7 @@ type ArtifactDriver struct {
 	ServerSideCustomerKey string
 }
 
-var (
-	_            artifactscommon.ArtifactDriver = &ArtifactDriver{}
-	defaultRetry                                = wait.Backoff{
-		Steps:    envutil.LookupEnvIntOr("RETRY_BACKOFF_STEPS", 5),
-		Duration: envutil.LookupEnvDurationOr("RETRY_BACKOFF_DURATION", time.Second*2),
-		Factor:   envutil.LookupEnvFloatOr("RETRY_BACKOFF_FACTOR", 2.0),
-		Jitter:   0.1,
-	}
-)
+var _ artifactscommon.ArtifactDriver = &ArtifactDriver{}
 
 // newMinioClient instantiates a new minio client object.
 func (s3Driver *ArtifactDriver) newS3Client(ctx context.Context) (argos3.S3Client, error) {
@@ -73,7 +63,7 @@ func (s3Driver *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := waitutil.Backoff(defaultRetry,
+	err := waitutil.Backoff(executorretry.ExecutorRetry,
 		func() (bool, error) {
 			log.Infof("S3 Load path: %s, key: %s", path, inputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
@@ -118,7 +108,7 @@ func (s3Driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := waitutil.Backoff(defaultRetry,
+	err := waitutil.Backoff(executorretry.ExecutorRetry,
 		func() (bool, error) {
 			log.Infof("S3 Save path: %s, key: %s", path, outputArtifact.S3.Key)
 			s3cli, err := s3Driver.newS3Client(ctx)
@@ -168,7 +158,7 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 	defer cancel()
 
 	var files []string
-	err := waitutil.Backoff(defaultRetry,
+	err := waitutil.Backoff(executorretry.ExecutorRetry,
 		func() (bool, error) {
 			s3cli, err := s3Driver.newS3Client(ctx)
 			if err != nil {

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -239,7 +239,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		},
 	}
 
-	t.Setenv(transientEnvVarKey, "this error is transient")
+	_ = os.Setenv(transientEnvVarKey, "this error is transient")
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			success, err := loadS3Artifact(tc.s3client, &wfv1.Artifact{
@@ -260,6 +260,7 @@ func TestLoadS3Artifact(t *testing.T) {
 			}
 		})
 	}
+	_ = os.Unsetenv(transientEnvVarKey)
 }
 
 func TestSaveS3Artifact(t *testing.T) {
@@ -372,7 +373,7 @@ func TestSaveS3Artifact(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		t.Setenv(transientEnvVarKey, "this error is transient")
+		_ = os.Setenv(transientEnvVarKey, "this error is transient")
 		t.Run(name, func(t *testing.T) {
 			success, err := saveS3Artifact(
 				tc.s3client,
@@ -398,5 +399,6 @@ func TestSaveS3Artifact(t *testing.T) {
 				assert.Equal(t, tc.errMsg, "")
 			}
 		})
+		_ = os.Unsetenv(transientEnvVarKey)
 	}
 }

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -110,6 +110,7 @@ func isErrUnknownGetPods(err error) bool {
 
 // NewExecutor instantiates a new workflow executor
 func NewExecutor(clientset kubernetes.Interface, restClient rest.Interface, podName, namespace string, cre ContainerRuntimeExecutor, template wfv1.Template, includeScriptOutput bool, deadline time.Time, annotationPatchTickDuration, readProgressFileTickDuration time.Duration) WorkflowExecutor {
+	log.WithFields(log.Fields{"Steps": executorretry.Steps, "Duration": executorretry.Duration, "Factor": executorretry.Factor, "Jitter": executorretry.Jitter}).Info("Using executor retry strategy")
 	return WorkflowExecutor{
 		PodName:                      podName,
 		ClientSet:                    clientset,

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -25,7 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -33,28 +32,14 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/util"
 	"github.com/argoproj/argo-workflows/v3/util/archive"
-	envutil "github.com/argoproj/argo-workflows/v3/util/env"
 	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
 	"github.com/argoproj/argo-workflows/v3/util/retry"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 	artifact "github.com/argoproj/argo-workflows/v3/workflow/artifacts"
 	artifactcommon "github.com/argoproj/argo-workflows/v3/workflow/artifacts/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
+	executorretry "github.com/argoproj/argo-workflows/v3/workflow/executor/retry"
 )
-
-// ExecutorRetry is a retry backoff settings for WorkflowExecutor
-// Run	Seconds
-// 0	0.000
-// 1	1.000
-// 2	2.600
-// 3	5.160
-// 4	9.256
-var ExecutorRetry = wait.Backoff{
-	Steps:    envutil.LookupEnvIntOr("EXECUTOR_RETRY_BACKOFF_STEPS", 5),
-	Duration: envutil.LookupEnvDurationOr("EXECUTOR_RETRY_BACKOFF_DURATION", 1*time.Second),
-	Factor:   envutil.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_FACTOR", 1.6),
-	Jitter:   envutil.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_JITTER", 0.5),
-}
 
 const (
 	// This directory temporarily stores the tarballs of the artifacts before uploading
@@ -612,7 +597,7 @@ func (we *WorkflowExecutor) InitDriver(ctx context.Context, art *wfv1.Artifact) 
 func (we *WorkflowExecutor) getPod(ctx context.Context) (*apiv1.Pod, error) {
 	podsIf := we.ClientSet.CoreV1().Pods(we.Namespace)
 	var pod *apiv1.Pod
-	err := waitutil.Backoff(ExecutorRetry, func() (bool, error) {
+	err := waitutil.Backoff(executorretry.ExecutorRetry, func() (bool, error) {
 		var err error
 		pod, err = podsIf.Get(ctx, we.PodName, metav1.GetOptions{})
 		if err != nil && isErrUnknownGetPods(err) {
@@ -765,7 +750,7 @@ func (we *WorkflowExecutor) HasError() error {
 
 // AddAnnotation adds an annotation to the workflow pod
 func (we *WorkflowExecutor) AddAnnotation(ctx context.Context, key, value string) error {
-	return common.AddPodAnnotation(ctx, we.ClientSet, we.PodName, we.Namespace, key, value, ExecutorRetry)
+	return common.AddPodAnnotation(ctx, we.ClientSet, we.PodName, we.Namespace, key, value, executorretry.ExecutorRetry)
 }
 
 // isTarball returns whether or not the file is a tarball
@@ -948,7 +933,7 @@ func (we *WorkflowExecutor) Wait(ctx context.Context) error {
 	}
 
 	go we.monitorDeadline(ctx, containerNames)
-	err := waitutil.Backoff(ExecutorRetry, func() (bool, error) {
+	err := waitutil.Backoff(executorretry.ExecutorRetry, func() (bool, error) {
 		err := we.RuntimeExecutor.Wait(ctx, containerNames)
 		return err == nil, err
 	})

--- a/workflow/executor/retry/retry.go
+++ b/workflow/executor/retry/retry.go
@@ -3,7 +3,6 @@ package retry
 import (
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/argoproj/argo-workflows/v3/util/env"
@@ -17,13 +16,9 @@ import (
 // 3	5.160
 // 4	9.256
 var (
-	steps         = env.LookupEnvIntOr("EXECUTOR_RETRY_BACKOFF_STEPS", 5)
-	duration      = env.LookupEnvDurationOr("EXECUTOR_RETRY_BACKOFF_DURATION", 1*time.Second)
-	factor        = env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_FACTOR", 1.6)
-	jitter        = env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_JITTER", 0.5)
-	ExecutorRetry = wait.Backoff{Steps: steps, Duration: duration, Factor: factor, Jitter: jitter}
+	Steps         = env.LookupEnvIntOr("EXECUTOR_RETRY_BACKOFF_STEPS", 5)
+	Duration      = env.LookupEnvDurationOr("EXECUTOR_RETRY_BACKOFF_DURATION", 1*time.Second)
+	Factor        = env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_FACTOR", 1.6)
+	Jitter        = env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_JITTER", 0.5)
+	ExecutorRetry = wait.Backoff{Steps: Steps, Duration: Duration, Factor: Factor, Jitter: Jitter}
 )
-
-func init() {
-	log.WithFields(log.Fields{"steps": steps, "duration": duration, "factor": factor, "jitter": jitter}).Info("Executor retry set")
-}

--- a/workflow/executor/retry/retry.go
+++ b/workflow/executor/retry/retry.go
@@ -1,0 +1,29 @@
+package retry
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/argoproj/argo-workflows/v3/util/env"
+)
+
+// ExecutorRetry is a retry backoff settings for WorkflowExecutor
+// Run	Seconds
+// 0	0.000
+// 1	1.000
+// 2	2.600
+// 3	5.160
+// 4	9.256
+var (
+	steps         = env.LookupEnvIntOr("EXECUTOR_RETRY_BACKOFF_STEPS", 5)
+	duration      = env.LookupEnvDurationOr("EXECUTOR_RETRY_BACKOFF_DURATION", 1*time.Second)
+	factor        = env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_FACTOR", 1.6)
+	jitter        = env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_JITTER", 0.5)
+	ExecutorRetry = wait.Backoff{Steps: steps, Duration: duration, Factor: factor, Jitter: jitter}
+)
+
+func init() {
+	log.WithFields(log.Fields{"steps": steps, "duration": duration, "factor": factor, "jitter": jitter}).Info("Executor retry set")
+}


### PR DESCRIPTION
When connection problems occur while loading artifacts, the workflow init step exits and the workflow fails. This is a regression.
We propose a fix in this PR for issue: #7349.
Fixes #7349

In this PR we add an extra check for Transient errors every time the S3 Transient errors are checked.

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
