### PR TITLE
chore: Add a note on when to provide diagnostics for workflow pods

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,6 +35,8 @@ What executor are you running? Docker/K8SAPI/Kubelet/PNS/Emissary
 # Logs from the workflow controller:
 kubectl logs -n argo deploy/workflow-controller | grep ${workflow}
 
+# If the workflow's pods have not been created, you can skip the rest of the diagnostics.
+
 # The workflow's pods that are problematic:
 kubectl get pod -o yaml -l workflows.argoproj.io/workflow=${workflow},workflow.argoproj.io/phase!=Succeeded
 

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -27,6 +27,8 @@ What executor are you running? Docker/K8SAPI/Kubelet/PNS/Emissary
 # Logs from the workflow controller:
 kubectl logs -n argo deploy/workflow-controller | grep ${workflow}
 
+# If the workflow's pods have not been created, you can skip the rest of the diagnostics.
+
 # The workflow's pods that are problematic:
 kubectl get pod -o yaml -l workflows.argoproj.io/workflow=${workflow},workflow.argoproj.io/phase!=Succeeded
 


### PR DESCRIPTION
The rest of the diagnostics are only necessary when workflow pods have been created.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
