### PR TITLE
chore: Improve error message when configmap is not found. Fixes #7356

### DIFF
--- a/workflow/common/configmap.go
+++ b/workflow/common/configmap.go
@@ -29,5 +29,6 @@ func GetConfigMapValue(configMapInformer cache.SharedIndexInformer, namespace, n
 		}
 		return cmValue, nil
 	}
-	return "", fmt.Errorf("ConfigMap '%s' does not exist", name)
+	return "", fmt.Errorf("ConfigMap '%s' does not exist. Please make sure it has the label %s: %s to be detectable by the controller",
+		name, LabelKeyConfigMapType, LabelValueTypeConfigMapParameter)
 }


### PR DESCRIPTION
Fixes #7356. Currently the error message is misleading as the configmap exists in the specified namespace.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
