### PR TITLE
docs: remove memoization beta and add install note

### DIFF
--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -1,7 +1,5 @@
 # Step Level Memoization
 
-![beta](assets/beta.svg)
-
 > v2.10 and after
 
 ## Introduction
@@ -37,6 +35,9 @@ spec:
 
 ...
 ```
+
+!!! Note 
+    In order to use memoization it is necessary to add the verbs `create` and `update` to the `configmaps` resource for the appropriate (cluster) roles. In the case of a cluster install the `argo-cluster-role` cluster role should be updated, whilst for a namespace install the `argo-role` role should be updated.
 
 ## FAQs
 


### PR DESCRIPTION
Signed-off-by: roofurmston <thomas.furmston@deliveroo.co.uk>

This PR aims to improve the documentation for the memoization page in the following ways:

- It removes the beta tag on the page. (From discussion in the Argo Workflow slack channel it was indicated that this feature is no longer in beta.)
- Adds a note on changes required to the default installation in order to use step memoization. 

Rationale, there have been several issues in Github in which people have had difficulty implementing the simple memoization example. One cause was people having difficulty with the required permissions. For example, [https://github.com/argoproj/argo-workflows/issues/6942](https://github.com/argoproj/argo-workflows/issues/6942).

Also, as a tangential point, currently memoization has consistent behaviour with regard permissions. See [https://github.com/argoproj/argo-workflows/issues/7381](https://github.com/argoproj/argo-workflows/issues/7381) . This current behaviour makes it hard to understand the permission error when it occurs.


Don't bother creating a PR until you've done this:

* [ ] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, you can make it "Ready for review".
* Say how how you tested your changes. If you changed the UI, attach screenshots.

Tips:

* If changes were requested, and you've made them, then dismiss the review to get it looked at again.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* You can ask for help!
