### PR TITLE
feat: made workflow.labels and workflow.annotations exposable as JSON string

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -179,7 +179,6 @@ const (
 	GlobalVarWorkflowLabels = "workflow.labels"
 	// GlobalVarWorkflowAnnotations is a JSON string containing all workflow annotations
 	GlobalVarWorkflowAnnotations = "workflow.annotations"
-
 	// GlobalVarWorkflowCronScheduleTime is the scheduled timestamp of a Workflow started by a CronWorkflow
 	GlobalVarWorkflowCronScheduleTime = "workflow.scheduledTime"
 

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -175,6 +175,11 @@ const (
 	GlobalVarWorkflowDuration = "workflow.duration"
 	// GlobalVarWorkflowParameters is a JSON string containing all workflow parameters
 	GlobalVarWorkflowParameters = "workflow.parameters"
+	// GlobalVarWorkflowLabels is a JSON string containing all workflow labels
+	GlobalVarWorkflowLabels = "workflow.labels"
+	// GlobalVarWorkflowAnnotations is a JSON string containing all workflow annotations
+	GlobalVarWorkflowAnnotations = "workflow.annotations"
+
 	// GlobalVarWorkflowCronScheduleTime is the scheduled timestamp of a Workflow started by a CronWorkflow
 	GlobalVarWorkflowCronScheduleTime = "workflow.scheduledTime"
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -539,8 +539,16 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 			return fmt.Errorf("either value or valueFrom must be specified in order to set global parameter %s", param.Name)
 		}
 	}
+
+	if workflowLabels, err := json.Marshal(woc.wf.ObjectMeta.Labels); err == nil {
+		woc.globalParams[common.GlobalVarWorkflowLabels] = string(workflowLabels)
+	}
 	for k, v := range woc.wf.ObjectMeta.Annotations {
 		woc.globalParams["workflow.annotations."+k] = v
+	}
+
+	if workflowAnnotations, err := json.Marshal(woc.wf.ObjectMeta.Annotations); err == nil {
+		woc.globalParams[common.GlobalVarWorkflowAnnotations] = string(workflowAnnotations)
 	}
 	for k, v := range woc.wf.ObjectMeta.Labels {
 		woc.globalParams["workflow.labels."+k] = v

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -366,6 +366,8 @@ func TestGlobalParams(t *testing.T) {
 	assert.Contains(t, woc.globalParams, "workflow.name")
 	assert.Contains(t, woc.globalParams, "workflow.namespace")
 	assert.Contains(t, woc.globalParams, "workflow.parameters")
+	assert.Contains(t, woc.globalParams, "workflow.labels")
+	assert.Contains(t, woc.globalParams, "workflow.annotations")
 	assert.Contains(t, woc.globalParams, "workflow.serviceAccountName")
 	assert.Contains(t, woc.globalParams, "workflow.uid")
 

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -177,9 +177,12 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 		}
 	}
 
+	ctx.globalParams[common.GlobalVarWorkflowAnnotations] = placeholderGenerator.NextPlaceholder()
 	for k := range wf.ObjectMeta.Annotations {
 		ctx.globalParams["workflow.annotations."+k] = placeholderGenerator.NextPlaceholder()
 	}
+
+	ctx.globalParams[common.GlobalVarWorkflowLabels] = placeholderGenerator.NextPlaceholder()
 	for k := range wf.ObjectMeta.Labels {
 		ctx.globalParams["workflow.labels."+k] = placeholderGenerator.NextPlaceholder()
 	}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -3138,3 +3138,31 @@ func TestStepsOutputParametersForContainerSet(t *testing.T) {
 	_, err := validate(stepsOutputParametersForContainerSet)
 	assert.NoError(t, err)
 }
+
+var globalAnnotationsAndLabels = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+  labels:
+    testLabel: foobar
+  annotations:
+    workflows.argoproj.io/description: |
+      This is a simple hello world example.
+spec:
+  entrypoint: whalesay1
+  arguments:
+    parameters:
+    - name: message
+      value: hello world
+
+  templates:
+  - name: whalesay1
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["{{workflow.annotations}},  {{workflow.labels}}"]`
+
+func TestResolveAnnotationsAndLabelsJSson(t *testing.T) {
+	_, err := validate(globalAnnotationsAndLabels)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
#7289 

This feature allows for the `workflow.labels` and `workflow.annotations` to be exposed as JSON string the same way currently a user could do this for `workflow.parameters`.
