### PR TITLE
fix: added check for initContainer name in workflow template

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -310,6 +310,15 @@ func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamesp
 	return nil
 }
 
+func (ctx *templateValidationCtx) validateInitContainers(containers []wfv1.UserContainer) error {
+	for _, container := range containers {
+		if len(container.Container.Name) == 0 {
+			return errors.Errorf(errors.CodeBadRequest, "initContainer does not have a name")
+		}
+	}
+	return nil
+}
+
 func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx *templateresolution.Context, args wfv1.ArgumentsProvider) error {
 	if err := validateTemplateType(tmpl); err != nil {
 		return err
@@ -318,6 +327,12 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 	scope, err := validateInputs(tmpl)
 	if err != nil {
 		return err
+	}
+
+	if len(tmpl.InitContainers) > 0 {
+		if err := ctx.validateInitContainers(tmpl.InitContainers); err != nil {
+			return err
+		}
 	}
 
 	localParams := make(map[string]string)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -329,10 +329,8 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 		return err
 	}
 
-	if len(tmpl.InitContainers) > 0 {
-		if err := ctx.validateInitContainers(tmpl.InitContainers); err != nil {
-			return err
-		}
+	if err := ctx.validateInitContainers(tmpl.InitContainers); err != nil {
+		return err
 	}
 
 	localParams := make(map[string]string)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -313,7 +313,7 @@ func ValidateCronWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamesp
 func (ctx *templateValidationCtx) validateInitContainers(containers []wfv1.UserContainer) error {
 	for _, container := range containers {
 		if len(container.Container.Name) == 0 {
-			return errors.Errorf(errors.CodeBadRequest, "initContainer does not have a name")
+			return errors.Errorf(errors.CodeBadRequest, "initContainers must all have container name")
 		}
 	}
 	return nil

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -3138,3 +3138,40 @@ func TestStepsOutputParametersForContainerSet(t *testing.T) {
 	_, err := validate(stepsOutputParametersForContainerSet)
 	assert.NoError(t, err)
 }
+
+var testInitContainerHasName = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: spurious-
+spec:
+  entrypoint: main
+
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: spurious
+        template: spurious
+
+  - name: spurious
+    retryStrategy:
+      retryPolicy: Always
+    initContainers:
+    - image: alpine:latest
+      # name: sleep
+      command:
+      - sleep
+      - "15"
+    container:
+      image: alpine:latest
+      command:
+      - echo
+      - "i am running"
+`
+
+func TestInitContainerHasName(t *testing.T) {
+
+	_, err := validate(testInitContainerHasName)
+	assert.EqualError(t, err, "templates.main.tasks.spurious initContainers must all have container name")
+}


### PR DESCRIPTION
#7383

If an `initContainer` omits the `name` key, the workflow will immediately fail now.

Example workflow from original issue:

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: spurious-
spec:
  entrypoint: main

  templates:
  - name: main
    dag:
      tasks:
      - name: spurious
        template: spurious

  - name: spurious
    retryStrategy:
      retryPolicy: Always
    initContainers:
    - image: alpine:latest
      # name: sleep
      command:
      - sleep
      - "15"
    container:
      image: alpine:latest
      command:
      - echo
      - "i am running"
```

Output:

```
FATA[2021-12-14T11:11:46.032Z] Failed to submit workflow: templates.main.tasks.spurious initContainers must all have container name
```
