### PR TITLE
fix: Disable SDK release from master branch

### DIFF
--- a/.github/workflows/sdks.yaml
+++ b/.github/workflows/sdks.yaml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - master
 jobs:
   sdk:
     if: github.repository == 'argoproj/argo-workflows'


### PR DESCRIPTION
Currently this is also running on master branch, which would fail the CI. Example: https://github.com/argoproj/argo-workflows/runs/4534564425?check_suite_focus=true

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
