### PR TITLE
fix: Page workflow event bindings basehref

### DIFF
--- a/ui/src/app/shared/base.ts
+++ b/ui/src/app/shared/base.ts
@@ -1,6 +1,6 @@
-function baseUrl(): string {
+export function baseUrl(): string {
     const base = document.querySelector('base');
-    return base ? base.getAttribute('href') : '/';
+    return base && base.getAttribute('href') ? base.getAttribute('href') : '/';
 }
 
 export function uiUrl(uiPath: string): string {

--- a/ui/src/app/userinfo/components/cli-help.tsx
+++ b/ui/src/app/userinfo/components/cli-help.tsx
@@ -1,13 +1,11 @@
 import * as React from 'react';
 import {createRef, useState} from 'react';
+import {baseUrl} from '../../shared/base';
 import {Notice} from '../../shared/components/notice';
 
 export const CliHelp = () => {
     const argoSecure = document.location.protocol === 'https:';
-    const argoBaseHref = document
-        .getElementsByTagName('base')[0]
-        .href.toString()
-        .replace(document.location.protocol + '//' + document.location.host + '/', '');
+    const argoBaseHref = baseUrl();
     const argoToken = (
         decodeURIComponent(document.cookie)
             .split(';')

--- a/ui/src/app/workflow-event-bindings/components/workflow-event-bindings/workflow-event-bindings.tsx
+++ b/ui/src/app/workflow-event-bindings/components/workflow-event-bindings/workflow-event-bindings.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {WorkflowEventBinding} from '../../../../models';
-import {uiUrl} from '../../../shared/base';
+import {apiUrl, uiUrl} from '../../../shared/base';
 import {ErrorNotice} from '../../../shared/components/error-notice';
 import {InfoIcon} from '../../../shared/components/fa-icons';
 import {GraphPanel} from '../../../shared/components/graph/graph-panel';
@@ -106,8 +106,8 @@ export const WorkflowEventBindings = ({match, location, history}: RouteComponent
                     </p>
                     <p>
                         <code>
-                            curl '{document.location.protocol}//{document.location.host}/api/v1/events/{namespace}/-' -H 'Content-Type: application/json' -H 'Authorization:
-                            $ARGO_TOKEN' -d '&#123;&#125;'
+                            curl '{document.location.protocol}//{document.location.host}
+                            {apiUrl(`api/v1/events/${namespace}/-`)}' -H 'Content-Type: application/json' -H 'Authorization: $ARGO_TOKEN' -d '&#123;&#125;'
                         </code>
                     </p>
                     <p>


### PR DESCRIPTION
Fixes #7416 

- Page workflow event bindings curl example support basehref.
- Enhance the robustness of the code.
  - export shared/base baseUrl 
  - base.getAttribute('href') may return null (`<base target="_blank">`)
  -  userinfo/components/cli-help.tsx argoBaseHref may report undefined error