### PR TITLE
feat: Add Python SDK versioning script

### DIFF
--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -1,5 +1,7 @@
-# SDK version
 VERSION := $(shell ./sdk_version.py)
+ifndef VERSION
+  $(error "Failed to obtain a valid version for the SDK")
+endif
 
 # work dir
 WD := $(shell echo "`pwd`/client")
@@ -7,10 +9,7 @@ WD := $(shell echo "`pwd`/client")
 DOCKER = docker run --rm -v $(WD):/wd --workdir /wd
 CHOWN = chown -R $(shell id -u):$(shell id -g)
 
-verify_version:
-	@if [ ${VERSION} == "FAILED" ]; then echo "Failed to obtain a valid version from the SDK versioning script! Version: ${VERSION}"; exit 1; fi
-
-publish: verify_version generate
+publish: generate
 	pip install setuptools twine build
 	python -m build --sdist --wheel --outdir client/dist/ client
 	twine check client/dist/*

--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -1,13 +1,8 @@
-GIT_TAG               := $(shell git describe --exact-match --tags --abbrev=0 2> /dev/null || echo untagged)
-ifeq ($(GIT_TAG),untagged)
-VERSION               := 0.0.0-latest
-else
-# remove the "v" prefix, not allowed
-VERSION               := $(subst v,,$(GIT_TAG))
-endif
+# SDK version
+VERSION := $(shell ./sdk_version.py)
 
 # work dir
-WD                    := $(shell echo "`pwd`/client")
+WD := $(shell echo "`pwd`/client")
 
 DOCKER = docker run --rm -v $(WD):/wd --workdir /wd
 CHOWN = chown -R $(shell id -u):$(shell id -g)

--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -7,7 +7,10 @@ WD := $(shell echo "`pwd`/client")
 DOCKER = docker run --rm -v $(WD):/wd --workdir /wd
 CHOWN = chown -R $(shell id -u):$(shell id -g)
 
-publish: generate
+verify_version:
+	@if [ ${VERSION} == "FAILED" ]; then echo "Failed to obtain a valid version from the SDK versioning script! Version: ${VERSION}"; exit 1; fi
+
+publish: verify_version generate
 	pip install setuptools twine build
 	python -m build --sdist --wheel --outdir client/dist/ client
 	twine check client/dist/*

--- a/sdks/python/sdk_version.py
+++ b/sdks/python/sdk_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 When the Python SDK was migrated to the Argo Workflows repository, we kept the `argo-workflows` name for the Python
@@ -15,36 +15,21 @@ VERSION_PREFIX = 'v'
 VERSION_INCREMENT = 3
 MAJOR_VERSION_INDEX = 0
 UNTAGGED = 'untagged'
+
 FAILED = 'FAILED'  # indicator captured by the makefile to know when something failed
 UNTAGGED_VERSION = '0.0.0-latest'
-
 git_tag_cmd = 'git describe --exact-match --tags --abbrev=0 2> /dev/null || echo untagged'
-
-git_tag = None
 try:
     git_tag = os.popen(git_tag_cmd).read().strip()
-except ValueError:
-    print(FAILED)
-    exit(1)
+    if git_tag == UNTAGGED:
+        print(UNTAGGED_VERSION)  # this goes to sys.stdout, so it's captured by the Makefile
+        exit(0)
 
-if git_tag == UNTAGGED:
-    print(UNTAGGED_VERSION)  # this goes to sys.stdout, so it's captured by the Makefile
-    exit(1)
-
-version_digits = None
-try:
     version_digits = [int(i) for i in git_tag.replace(VERSION_PREFIX, '').split('.')]
-except ValueError:
-    print(FAILED)
-    exit(1)
+    version_digits[MAJOR_VERSION_INDEX] += VERSION_INCREMENT
 
-version_digits[MAJOR_VERSION_INDEX] += VERSION_INCREMENT
-
-version = None
-try:
     version = '.'.join([str(i) for i in version_digits])
-except ValueError:
-    print(FAILED)
-    exit(1)
-
-print(version)
+    print(version)
+    exit(0)
+except Exception as e:
+    raise e

--- a/sdks/python/sdk_version.py
+++ b/sdks/python/sdk_version.py
@@ -10,22 +10,41 @@ takes the major version, adds 3 to it, and prints to stdout the new version, whi
 """
 
 import os
-import sys
 
 VERSION_PREFIX = 'v'
 VERSION_INCREMENT = 3
 MAJOR_VERSION_INDEX = 0
 UNTAGGED = 'untagged'
+FAILED = 'FAILED'  # indicator captured by the makefile to know when something failed
 UNTAGGED_VERSION = '0.0.0-latest'
 
 git_tag_cmd = 'git describe --exact-match --tags --abbrev=0 2> /dev/null || echo untagged'
-git_tag = os.popen(git_tag_cmd).read().strip()
+
+git_tag = None
+try:
+    git_tag = os.popen(git_tag_cmd).read().strip()
+except ValueError:
+    print(FAILED)
+    exit(1)
+
 if git_tag == UNTAGGED:
     print(UNTAGGED_VERSION)  # this goes to sys.stdout, so it's captured by the Makefile
-    sys.exit(0)
+    exit(1)
 
-version_digits = [int(i) for i in git_tag.replace(VERSION_PREFIX, '').split('.')]
+version_digits = None
+try:
+    version_digits = [int(i) for i in git_tag.replace(VERSION_PREFIX, '').split('.')]
+except ValueError:
+    print(FAILED)
+    exit(1)
+
 version_digits[MAJOR_VERSION_INDEX] += VERSION_INCREMENT
 
-version = '.'.join([str(i) for i in version_digits])
+version = None
+try:
+    version = '.'.join([str(i) for i in version_digits])
+except ValueError:
+    print(FAILED)
+    exit(1)
+
 print(version)

--- a/sdks/python/sdk_version.py
+++ b/sdks/python/sdk_version.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+"""
+When the Python SDK was migrated to the Argo Workflows repository, we kept the `argo-workflows` name for the Python
+package as we wanted to publish it to the same PyPi project on the public index. However, the existing `argo-workflows`
+package was on version 5.0.0 already, while Argo Workflows was on 3.x.x. We wanted to publish the SDK as version 6.0.0
+to indicate backwards incompatibility. So, this script takes the Argo Workflows tag, when a new release is created,
+takes the major version, adds 3 to it, and prints to stdout the new version, which is:
+- ARGO_MAJOR+3.ARGO_MINOR.ARGO_PATCH
+"""
+
+import os
+import sys
+
+VERSION_PREFIX = 'v'
+VERSION_INCREMENT = 3
+MAJOR_VERSION_INDEX = 0
+UNTAGGED = 'untagged'
+UNTAGGED_VERSION = '0.0.0-latest'
+
+git_tag_cmd = 'git describe --exact-match --tags --abbrev=0 2> /dev/null || echo untagged'
+git_tag = os.popen(git_tag_cmd).read().strip()
+if git_tag == UNTAGGED:
+    print(UNTAGGED_VERSION)  # this goes to sys.stdout, so it's captured by the Makefile
+    sys.exit(0)
+
+version_digits = [int(i) for i in git_tag.replace(VERSION_PREFIX, '').split('.')]
+version_digits[MAJOR_VERSION_INDEX] += VERSION_INCREMENT
+
+version = '.'.join([str(i) for i in version_digits])
+print(version)


### PR DESCRIPTION
When the Python SDK was migrated to the Argo Workflows repository, we kept the `argo-workflows` name for the Python
package as we wanted to publish it to the same PyPi project on the public index. However, the existing `argo-workflows`
package was on version 5.0.0 already, while Argo Workflows was on 3.x.x. We wanted to publish the SDK as version 6.0.0
to indicate backwards incompatibility. So, this script takes the Argo Workflows tag, when a new release is created,
takes the major version, adds 3 to it, and prints to stdout the new version, which is:
- ARGO_MAJOR+3.ARGO_MINOR.ARGO_PATCH

Fixes: #7423 

Functional testing:
```
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ ./sdk_version.py                                                                                                                                                             
untagged
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ git tag -a v7.0.0 -m "tag 7 test"                                                                                                                                           
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ ./sdk_version.py                                                                                                                                                              
10.0.0
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ git tag -a v7.1.0 -m "tag 7 test"                                                                                                                                             
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ ./sdk_version.py                                                                                                                                                              
10.1.0
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ git tag -a v7.1.3 -m "tag 7 test"                                                                                                                                             
((python) ) ➜  python git:(fv/py-sdk-versioning) ✗ ./sdk_version.py                                                                                                                                                              
10.1.3
```

CC: @terrytangyuan 