### PR TITLE
docs: Add a note on version for HTTP template successCondition

### DIFF
--- a/docs/http-template.md
+++ b/docs/http-template.md
@@ -40,7 +40,7 @@ spec:
         #  response.statusCode: int, the response status code
         #  response.body: string, the response body
         #  response.headers: map[string][]string, the response headers
-        successCondition: "response.body contains \"google\""
+        successCondition: "response.body contains \"google\"" # available since v3.3
         body: "test body" # Change request body
 ```
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -163,6 +163,8 @@ returns `0`. Please review the Sprig documentation to understand which functions
 
 ### HTTP Templates
 
+> Since v3.3
+
 Only available for `successCondition`
 
 | Variable | Description|

--- a/examples/http-success-condition.yaml
+++ b/examples/http-success-condition.yaml
@@ -6,7 +6,7 @@ metadata:
     workflows.argoproj.io/test: "true"
   annotations:
     workflows.argoproj.io/description: |
-      Exemplifies usage of successCondition in HTTP template
+      Exemplifies usage of successCondition in HTTP template (available since v3.3)
 spec:
   entrypoint: main
   templates:


### PR DESCRIPTION
See discussion in https://github.com/argoproj/argo-workflows/discussions/7376#discussioncomment-1820675. It's better to add a version in the doc. v3.3 is kind of predicted. If there's a better practice, please let me know.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
