### PR TITLE
fix: submitting cluster workflow template on namespaced install returns error

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3350,6 +3350,10 @@ func (woc *wfOperationCtx) fetchWorkflowSpec() (wfv1.WorkflowSpecHolder, error) 
 	var err error
 	// Logic for workflow refers Workflow template
 	if woc.wf.Spec.WorkflowTemplateRef.ClusterScope {
+		if woc.controller.cwftmplInformer == nil {
+			woc.log.Errorf("clusterWorkflowTemplate RBAC is missing")
+			return nil, fmt.Errorf("cannot get resource clusterWorkflowTemplate at cluster scope")
+		}
 		specHolder, err = woc.controller.cwftmplInformer.Lister().Get(woc.wf.Spec.WorkflowTemplateRef.Name)
 	} else {
 		specHolder, err = woc.controller.wftmplInformer.Lister().WorkflowTemplates(woc.wf.Namespace).Get(woc.wf.Spec.WorkflowTemplateRef.Name)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3351,7 +3351,7 @@ func (woc *wfOperationCtx) fetchWorkflowSpec() (wfv1.WorkflowSpecHolder, error) 
 	// Logic for workflow refers Workflow template
 	if woc.wf.Spec.WorkflowTemplateRef.ClusterScope {
 		if woc.controller.cwftmplInformer == nil {
-			woc.log.WithError(err).Errorf("clusterWorkflowTemplate RBAC is missing")
+			woc.log.WithError(err).Error("clusterWorkflowTemplate RBAC is missing")
 			return nil, fmt.Errorf("cannot get resource clusterWorkflowTemplate at cluster scope")
 		}
 		specHolder, err = woc.controller.cwftmplInformer.Lister().Get(woc.wf.Spec.WorkflowTemplateRef.Name)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3351,7 +3351,7 @@ func (woc *wfOperationCtx) fetchWorkflowSpec() (wfv1.WorkflowSpecHolder, error) 
 	// Logic for workflow refers Workflow template
 	if woc.wf.Spec.WorkflowTemplateRef.ClusterScope {
 		if woc.controller.cwftmplInformer == nil {
-			woc.log.Errorf("clusterWorkflowTemplate RBAC is missing")
+			woc.log.WithError(err).Errorf("clusterWorkflowTemplate RBAC is missing")
 			return nil, fmt.Errorf("cannot get resource clusterWorkflowTemplate at cluster scope")
 		}
 		specHolder, err = woc.controller.cwftmplInformer.Lister().Get(woc.wf.Spec.WorkflowTemplateRef.Name)


### PR DESCRIPTION

fixes #7266 

Example output: 
 ```
Name:                cluster-workflow-template-hello-world-lk5vb
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Error
Message:             cannot get resource clusterWorkflowTemplate at cluster scope
Conditions:          
 Completed           True
Created:             Fri Dec 17 09:20:15 -0800 (1 minute ago)
Started:             Fri Dec 17 09:21:19 -0800 (1 second ago)
Finished:            Fri Dec 17 09:21:19 -0800 (1 second ago)
Duration:            0 seconds
Progress:            0/0

This workflow does not have security context set. You can run your workflow pods more securely by setting it.
Learn more at https://argoproj.github.io/argo-workflows/workflow-pod-security-context/
```