### PR TITLE
fix: show invalid cron schedule error on cron status ui

### DIFF
--- a/ui/src/app/cron-workflows/components/pretty-schedule.tsx
+++ b/ui/src/app/cron-workflows/components/pretty-schedule.tsx
@@ -1,4 +1,5 @@
 import React = require('react');
+import {WarningIcon} from '../../shared/components/fa-icons';
 
 const x = require('cronstrue');
 
@@ -13,9 +14,16 @@ const x = require('cronstrue');
 
 export const PrettySchedule = ({schedule}: {schedule: string}) => {
     try {
+        if (schedule.split(' ').length >= 6) {
+            throw new Error('cron schedules must consist of 5 values only');
+        }
         const pretty = x.toString(schedule);
         return <span title={pretty}>{pretty}</span>;
     } catch (e) {
-        return <>{e.toString()}</>;
+        return (
+            <span>
+                <WarningIcon /> {e.toString()}
+            </span>
+        );
     }
 };

--- a/ui/src/app/cron-workflows/components/schedule-validator.tsx
+++ b/ui/src/app/cron-workflows/components/schedule-validator.tsx
@@ -5,8 +5,8 @@ const x = require('cronstrue');
 
 export const ScheduleValidator = ({schedule}: {schedule: string}) => {
     try {
-        if (schedule.split(' ').length === 6) {
-            throw new Error('seconds are not supported');
+        if (schedule.split(' ').length >= 6) {
+            throw new Error('cron schedules must consist of 5 values only');
         }
         return (
             <span>


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

## Problem

argo-workflows doen't support cron `second`, but it is possible to create from yaml. At that time cron workflow ui doesn't show error.

<img width="769" alt="Pasted_Image_2021_12_18_17_50" src="https://user-images.githubusercontent.com/915731/146635385-cb3b0cec-7875-470b-8c1f-8471cd4ab833.png">

```yaml
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: my-cronworkflow-template-1
spec:
  schedule: "*/2 * * * * *"
  workflowSpec:
    entrypoint: whalesay-template
    workflowTemplateRef:
      name: my-workflow-template-1
    arguments:
      parameters:
        - name: message1
          value: hello from cron
```

## How to solve?

Copy schedule validator from cron editor has schedule validator into pretty-schedule.

https://github.com/argoproj/argo-workflows/blob/d7a1e16514e30a197c53296b270748647c615bbb/ui/src/app/cron-workflows/components/schedule-validator.tsx#L8-L20

![image](https://user-images.githubusercontent.com/915731/146635439-2237f0d1-c1fe-415f-b4ac-cfa94f73d5ab.png)
