### PR TITLE
docs: Fix typo mentees -> mentors

### DIFF
--- a/docs/mentoring.md
+++ b/docs/mentoring.md
@@ -21,7 +21,7 @@ We'll find the right mentor for you.
 
 Create a pull request which changes this page to add you to this list:
 
-Mentees:
+Mentors:
 
 * @alexec (Alex)
 * @simster7 (Simon)


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
