### PR TITLE
fix: out of range in MustUnmarshal

### DIFF
--- a/pkg/apis/workflow/v1alpha1/marshall.go
+++ b/pkg/apis/workflow/v1alpha1/marshall.go
@@ -17,6 +17,9 @@ func MustUnmarshal(text, v interface{}) {
 	case string:
 		MustUnmarshal([]byte(x), v)
 	case []byte:
+		if len(x) == 0 {
+			panic("no text to unmarshal")
+		}
 		if x[0] == '@' {
 			filename := string(x[1:])
 			y, err := ioutil.ReadFile(filepath.Clean(filename))

--- a/pkg/apis/workflow/v1alpha1/marshall_test.go
+++ b/pkg/apis/workflow/v1alpha1/marshall_test.go
@@ -1,0 +1,19 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustUnmarshalClusterWorkflow(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("The code did not panic but should have")
+		} else {
+			assert.Equal(t, r.(string), "no text to unmarshal")
+		}
+	}()
+	_ = MustUnmarshalClusterWorkflow([]byte(""))
+	t.Fatalf("MustUnmarshalClusterWorkflow should have panicked and this part should not have been reached.")
+}


### PR DESCRIPTION
This adds a more readable and easier recoverable message for the case when the input is of length 0. 

This was reported by OSS-fuzz ([issue 43202](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43202)).