### PR TITLE
docs: Fixing the missing -parameter word in workflow-templates docs

### DIFF
--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -155,7 +155,7 @@ spec:
   entrypoint: whalesay
   arguments:
     parameters:
-      - name: global
+      - name: global-parameter
         value: hello
   templates:
     - name: whalesay


### PR DESCRIPTION
I think there is a problem in [workflow-templates.md](https://github.com/argoproj/argo-workflows/blob/master/docs/workflow-templates.md?plain=1#L158)

The problem is:
In WorkflowTemplate
args: ["{{workflow.parameters.global-parameter}}"] is `global-parameter` here.

But in Workflow,
It is referred as `global`
![fail-message](https://user-images.githubusercontent.com/26150511/147964769-bb66233b-0684-4f16-8a74-43ffa9353fff.png)
