### PR TITLE
fix: Shutdown workqueues to avoid goroutine leaks

### DIFF
--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -129,6 +129,8 @@ func TestWorkflowQueueMetrics(t *testing.T) {
 	m := New(config, config)
 	workqueue.SetProvider(m)
 	wfQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "workflow_queue")
+	defer wfQueue.ShutDown()
+
 	assert.NotNil(t, m.workqueueMetrics["workflow_queue-depth"])
 	assert.NotNil(t, m.workqueueMetrics["workflow_queue-adds"])
 	assert.NotNil(t, m.workqueueMetrics["workflow_queue-latency"])

--- a/workflow/metrics/work_queue_test.go
+++ b/workflow/metrics/work_queue_test.go
@@ -25,6 +25,8 @@ func TestMetricsWorkQueue(t *testing.T) {
 	assert.Len(t, m.workersBusy, 1)
 
 	queue := m.RateLimiterWithBusyWorkers(workqueue.DefaultControllerRateLimiter(), "test")
+	defer queue.ShutDown()
+
 	queue.Add("A")
 	assert.Equal(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value)
 


### PR DESCRIPTION
# Motivation

The workqueues created in `TestWorkflowQueueMetrics` and `TestMetricsWorkQueue` will leak goroutines if we  don't shutdown them in the end of tests:

```
leaks.go:82: found unexpected goroutines:
    [Goroutine 36 in state chan receive, with k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop on top of the stack:
    goroutine 36 [chan receive]:
    k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop(0xc000364f60)
            /home/yuanting/work/dev/goprojects/argo-workflows/vendor/k8s.io/client-go/util/workqueue/queue.go:204 +0xa7
    created by k8s.io/client-go/util/workqueue.newQueue
            /home/yuanting/work/dev/goprojects/argo-workflows/vendor/k8s.io/client-go/util/workqueue/queue.go:62 +0x1af

    ]
```
