### PR TITLE
fix: update old buildkit version in buildkit-template.yaml

### DIFF
--- a/examples/buildkit-template.yaml
+++ b/examples/buildkit-template.yaml
@@ -134,7 +134,7 @@ spec:
           secret:
             secretName: docker-config
       container:
-        image: moby/buildkit:v0.7.2-rootless
+        image: moby/buildkit:v0.9.3-rootless
         volumeMounts:
           - name: work
             mountPath: /work


### PR DESCRIPTION
I spent a few hours trying to figure out why the example in buildkit-template.yaml was not working with a private insecure docker registry.
The problem was a bug in the moby/buildkit version used in this example: moby/moby#40814. I updated the version so other people waste time like I did.