### PR TITLE
fixed ARGOCD_SERVER environment variable

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,10 +23,10 @@ argo --help
 
 You'll need to configure your commands to use the Argo Server if you have [offloaded node status](offloading-large-workflows.md) or are trying to access your [workflow archive](workflow-archive.md). 
 
-To do so, set the `ARGO_SERVER` environment variable, e.g.:
+To do so, set the `ARGOCD_SERVER` environment variable, e.g.:
 
 ```
-export ARGO_SERVER=localhost:2746
+export ARGOCD_SERVER=localhost:2746
 ```
 
 See [TLS](tls.md).


### PR DESCRIPTION
Testing on v2.1.7+a408e29 only `ARGOCD_SERVER` works, not `ARGO_SERVER`.

This is also shown as `ARGOCD_SERVER` here:

https://argo-cd.readthedocs.io/en/stable/user-guide/ci_automation/#synchronize-the-app-optional
