### PR TITLE
fix: nil-pointer in ApplySubmitOpts

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -227,6 +227,9 @@ func PopulateSubmitOpts(command *cobra.Command, submitOpts *wfv1.SubmitOpts, inc
 
 // Apply the Submit options into workflow object
 func ApplySubmitOpts(wf *wfv1.Workflow, opts *wfv1.SubmitOpts) error {
+	if wf == nil {
+		return fmt.Errorf("workflow cannot be nil")
+	}
 	if opts == nil {
 		opts = &wfv1.SubmitOpts{}
 	}


### PR DESCRIPTION
* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

An issue was found by a fuzzer whereby `nil` can be passed to `ApplySubmitOpts` and a nil-dereference would occur on [this line](https://github.com/argoproj/argo-workflows/blob/26c1224b0d8b0786ef1a75a58e49914810d3e115/workflow/util/util.go#L243):

`wfLabels := wf.GetLabels()`

This PR fixes that.
