### PR TITLE
docs: add workaround note for conditionals with quoted params

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -804,8 +804,8 @@ spec:
 ```
 
 !!! note
-    If the parameter value contains quotes, it may invalidate the govaluate expression. To handle parameters with quote,
-    embed an [expr](https://github.com/antonmedv/expr) expression in the conditional. For example:
+    If the parameter value contains quotes, it may invalidate the govaluate expression. To handle parameters with 
+    quotes, embed an [expr](https://github.com/antonmedv/expr) expression in the conditional. For example:
 
     ```yaml
     when: "{{=inputs.parameters['may-contain-quotes'] == 'example'}}"


### PR DESCRIPTION
Conditionals [fail when params contain quotes](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1641838749082900). I've added a note to docs with a workaround.

The workaround works because the expr expression gets evaluated first, producing `true` or `false`. Then govaluate evaluates the boolean expression and returns the same value.

I don't see a make target for testing docs, so I'm not sure whether my formatting is correct.