### PR TITLE
feat: add typechecker for CommandLineTool (Part 4/n for CWL transpiler)

### DIFF
--- a/cmd/cwl2argo/transpiler/typechecker_cl.go
+++ b/cmd/cwl2argo/transpiler/typechecker_cl.go
@@ -1,0 +1,203 @@
+package transpiler
+
+import (
+	"errors"
+	"fmt"
+)
+
+func errorNilRequirements(id *string) error {
+	if id != nil {
+		return fmt.Errorf("Requirements cannot be nil in %s", *id)
+	} else {
+		return errors.New("Requiremnets cannot be nil")
+	}
+}
+
+func errorDockerRequirement(id *string) error {
+	if id != nil {
+		return fmt.Errorf("DockerRequirement must be present in all Argo CWL definitions, %s does not satisfy this", *id)
+	} else {
+		return errors.New("DockerRequirement must be present in all Argo CWL definitions")
+	}
+}
+
+func isAllFiles(tys []CommandlineType) bool {
+	for _, ty := range tys {
+		if ty.Kind != CWLFileKind {
+			return false
+		}
+	}
+	return true
+}
+
+func isAllDirectories(tys []CommandlineType) bool {
+	for _, ty := range tys {
+		if ty.Kind != CWLDirectoryKind {
+			return false
+		}
+	}
+	return true
+}
+
+func TypeCheckCommandlineInputs(clins []CommandlineInputParameter) error {
+	for _, clin := range clins {
+
+		allFiles := isAllFiles(clin.Type)
+		allDirectories := isAllDirectories(clin.Type)
+		// type check secondary files
+		if clin.SecondaryFiles != nil && len(clin.SecondaryFiles) > 0 {
+			if !allFiles {
+				return errors.New("File|[]File expected when secondaryFiles is set")
+			}
+		}
+		if clin.Streamable != nil && allFiles != true {
+			return errors.New("streamable only valid when types are of File|[]File")
+		}
+		if clin.Format != nil && allFiles != true {
+			return errors.New("Format only valid when types are of File|[]File")
+		}
+		if clin.LoadContents != nil {
+			return errors.New("LoadContents only valid when types of File|[]File")
+		}
+		if clin.LoadListing != nil && !allDirectories {
+			return errors.New("LoadListing only valid when types of Directory|[]Directory")
+		}
+	}
+	return nil
+}
+
+func TypeCheckCommandlineOutputs(clouts []CommandlineOutputParameter) error {
+	for _, clout := range clouts {
+
+		allFiles := isAllFiles(clout.Type)
+		// type check secondary files
+		if clout.SecondaryFiles != nil && len(clout.SecondaryFiles) > 0 {
+			if !allFiles {
+				return errors.New("File|[]File expected when secondaryFiles is set")
+			}
+		}
+		if clout.Streamable != nil && allFiles != true {
+			return errors.New("streamable only valid when types are of File|[]File")
+		}
+		if clout.Format != nil && allFiles != true {
+			return errors.New("Format only valid when types are of File|[]File")
+		}
+	}
+	return nil
+}
+
+func TypeCheckCommandlineClass(id *string, class string) error {
+	if class == "CommandLineTool" {
+		return nil
+	}
+	if id != nil {
+		return fmt.Errorf("\"CommandLineTool\" required but %s was provided in %s", class, *id)
+	} else {
+		return fmt.Errorf("\"CommandLineTool\" required but %s provided", class)
+	}
+}
+
+func typeCheckDockerRequirement(d *DockerRequirement) error {
+	if d == nil {
+		return errors.New("docker requirement required, nil received")
+	}
+	if d.DockerPull == nil {
+		return errors.New("dockerPull is required")
+	}
+	return nil
+}
+
+func TypeCheckCommandlineRequirements(id *string, clrs []CWLRequirements) error {
+	if clrs == nil {
+		return errorNilRequirements(id)
+	}
+
+	foundDocker := false
+
+	for _, requirement := range clrs {
+		if docker, ok := requirement.(DockerRequirement); ok == true {
+			if err := typeCheckDockerRequirement(&docker); err != nil {
+				return err
+			}
+			foundDocker = true
+		}
+	}
+
+	if foundDocker == false {
+		return errorDockerRequirement(id)
+	}
+	return nil
+}
+
+func TypeCheckCommandlineHints(id *string, hints []interface{}) error {
+
+	return nil
+}
+
+func TypeCheckCLICWLVersion(id *string, cwlVersion *string) error {
+	// allowed to be nil
+	if cwlVersion == nil {
+		return nil
+	}
+	if cwlVersion != nil && *cwlVersion == CWLVersion {
+		return nil
+	}
+	if id != nil {
+		return fmt.Errorf("In %s cwlVerion provided was %s but %s was expected", *id, *cwlVersion, CWLVersion)
+	} else {
+		return fmt.Errorf("cwlVersion provided was %s but %s was expected", *cwlVersion, CWLVersion)
+	}
+}
+
+func TypeCheckBaseCommand(id *string, baseCommand []string, arguments []CommandlineArgument) error {
+
+	if len(baseCommand) > 0 || len(arguments) > 0 {
+		return nil
+	}
+	if id != nil {
+		return fmt.Errorf("In %s len(baseCommand) == 0 and len(arguments) was not > 0", *id)
+	} else {
+		return errors.New("If len(baseCommand) == 0 then len(arguments) must be > 0")
+	}
+}
+
+func TypeCheckCommandlineTool(cl *CommandlineTool, inputs map[string]interface{}) error {
+	var err error
+
+	err = TypeCheckCommandlineInputs(cl.Inputs)
+	if err != nil {
+		return err
+	}
+
+	err = TypeCheckCommandlineOutputs(cl.Outputs)
+	if err != nil {
+		return err
+	}
+
+	err = TypeCheckCommandlineClass(cl.Id, cl.Class)
+	if err != nil {
+		return err
+	}
+
+	err = TypeCheckCommandlineRequirements(cl.Id, cl.Requirements)
+	if err != nil {
+		return err
+	}
+
+	err = TypeCheckCommandlineHints(cl.Id, cl.Hints)
+	if err != nil {
+		return err
+	}
+
+	err = TypeCheckCLICWLVersion(cl.Id, cl.CWLVersion)
+	if err != nil {
+		return nil
+	}
+
+	err = TypeCheckBaseCommand(cl.Id, cl.BaseCommand, cl.Arguments)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cwl2argo/transpiler/typechecker_cl_test.go
+++ b/cmd/cwl2argo/transpiler/typechecker_cl_test.go
@@ -1,0 +1,47 @@
+package transpiler
+
+import "testing"
+
+var (
+	exampleCLI1Id      = "exampleCLI1"
+	dockerPull         = "python:3.7"
+	dockerRequirements = []CWLRequirements{DockerRequirement{DockerPull: &dockerPull}}
+)
+
+var exampleCLI1 = CommandlineTool{
+	Inputs:       make([]CommandlineInputParameter, 0),
+	Outputs:      make([]CommandlineOutputParameter, 0),
+	Class:        "CommandLineTool",
+	Id:           &exampleCLI1Id,
+	Doc:          make([]string, 0),
+	Requirements: make([]CWLRequirements, 0),
+	Hints:        make([]interface{}, 0),
+	CWLVersion:   nil,
+	Intent:       make([]string, 0),
+	BaseCommand:  []string{"echo", "hello world"},
+	Arguments:    make([]CommandlineArgument, 0),
+	Stdin:        nil,
+	Stderr:       nil,
+	Stdout:       nil,
+}
+
+func TestCLIRequirementTypeChecking(t *testing.T) {
+	err := TypeCheckCommandlineTool(&exampleCLI1, make(map[string]interface{}))
+	if err == nil {
+		t.Errorf("Failed to type check: %s", err)
+	}
+	exampleCLI1.Requirements = dockerRequirements
+
+	err = TypeCheckCommandlineTool(&exampleCLI1, map[string]interface{}{})
+	if err != nil {
+		t.Errorf("Failed to type check: %s", err)
+	}
+
+	oldReqs := exampleCLI1.Requirements
+	exampleCLI1.Requirements = nil
+	err = TypeCheckCommandlineTool(&exampleCLI1, make(map[string]interface{}))
+	if err == nil {
+		t.Errorf("Expected <%s> but got nil", errorDockerRequirement(exampleCLI1.Id))
+	}
+	exampleCLI1.Requirements = oldReqs
+}


### PR DESCRIPTION
Signed-off-by: isubasinghe <isitha@pipekit.io>

This PR adds basic type checking for "CommandLineTool" types, it is not complete and only type checks a very limited number of properties for now. This is dependent on #7533 