### PR TITLE
docs: fix typo in container-set-template.md

### DIFF
--- a/docs/container-set-template.md
+++ b/docs/container-set-template.md
@@ -87,7 +87,7 @@ Then you know you need only a maximum of 2Gi. You could set as follows:
 
 The total is 2Gi, which is enough for `b`. We're all good.
 
-Example B: Diamond DAG e.g. a diamond `a -> b -> d and  a -> b -> d`, i.e. `b` and `c` run at the same time.
+Example B: Diamond DAG e.g. a diamond `a -> b -> d and  a -> c -> d`, i.e. `b` and `c` run at the same time.
 
 * `a` needs 1000 cpu
 * `b` needs 2000 cpu


### PR DESCRIPTION
Diamond DAG e.g. a diamond `a -> b -> d` and  `a -> b-> d`, i.e. `b` and `c` run at the same time.  
Maybe replace  `a -> c-> d` with `a -> b-> d`




