### PR TITLE
feat: add emit capability for transpiler (Part 5/n) for transpiler implementation 

### DIFF
--- a/cmd/cwl2argo/transpiler/ast_cl.go
+++ b/cmd/cwl2argo/transpiler/ast_cl.go
@@ -1,0 +1,303 @@
+package transpiler
+
+// interface due to large number of child types
+type CWLRequirements interface {
+	isCWLRequirement()
+}
+
+type DockerRequirement struct {
+	Class                 string  `yaml:"class"`
+	DockerPull            *string `yaml:"dockerPull"`
+	DockerLoad            *string `yaml:"dockerLoad"`
+	DockerFile            *string `yaml:"dockerFile"`
+	DockerImport          *string `yaml:"dockerImport"`
+	DockerImageId         *string `yaml:"dockerImageId"`
+	DockerOutputDirectory *string `yaml:"dockerOutputDirectory"`
+}
+
+type SoftwarePackage struct {
+	Package string  `yaml:"package"`
+	Version Strings `yaml:"version"`
+	Specs   Strings `yaml:"specs"`
+}
+
+type SoftwareRequirement struct {
+	Class    string            `yaml:"class"` // constant SoftwareRequirement
+	Packages []SoftwarePackage `yaml:"packages"`
+}
+
+type LoadListingRequirement struct {
+	Class       string           `yaml:"class"` // constant LoadListingRequirement
+	LoadListing *LoadListingEnum `yaml:"loadListing"`
+}
+
+type Dirent struct {
+	entry     CWLExpression  `yaml:"entry"`
+	entryName *CWLExpression `yaml:"entryName"`
+	writeable *bool          `yaml:"writeable"`
+}
+
+type InitialWorkDirRequirementListing interface {
+	isInitialWorkDirRequirementListing()
+}
+
+type InitialWorkDirRequirement struct {
+	Class   string                           `yaml:"class"` // constant InitialWorkDirRequirement
+	Listing InitialWorkDirRequirementListing `yaml:"listing"`
+}
+
+type InlineJavascriptRequirement struct {
+	Class         string  `yaml:"class"` // constant InlineJavascriptRequirement
+	ExpressionLib Strings `yaml:"expressionLib"`
+}
+
+type SchemaDefRequirementType interface {
+	isSchemaDefRequirementType()
+}
+
+type SchemaDefRequirement struct {
+	Class string                     `yaml:"class"` // constant SchemaDefRequirement
+	Types []SchemaDefRequirementType `yaml:"types"`
+}
+
+type EnvironmentDef struct {
+	EnvName  string        `yaml:"envName"`
+	EnvValue CWLExpression `yaml:"envValue"`
+}
+
+type EnvVarRequirement struct {
+	Class  string           `yaml:"class"` // constant EnvVarRequirement
+	EnvDef []EnvironmentDef `yaml:"envDef"`
+}
+
+type ShellCommandRequirement struct {
+	Class string `yaml:"class"` // constant ShellCommandRequirement
+}
+
+type WorkReuse struct {
+	Class       string        `yaml:"class"` // constant WorkReuse
+	EnableReuse CWLExpression `yaml:"enableReuse"`
+}
+
+type NetworkAccess struct {
+	Class         string // constant NetworkAccess
+	NetworkAccess CWLExpression
+}
+
+type InplaceUpdateRequirement struct {
+	Class         string `yaml:"class"` // constant InplaceUpdateRequirement
+	InplaceUpdate Bool   `yaml:"inplaceUpdate"`
+}
+
+type ToolTimeLimit struct {
+	Class     string        `yaml:"class"` // constant ToolTimeLimit
+	TimeLimit CWLExpression `yaml:"timeLimit"`
+}
+
+type ResourceRequirement struct {
+	Class     string         `yaml:"class"` // constand ResourceRequirement
+	CoresMin  *CWLExpression `yaml:"coresMin"`
+	CoresMax  *CWLExpression `yaml:"coresMax"`
+	RamMin    *CWLExpression `yaml:"ramMin"`
+	RamMax    *CWLExpression `yaml:"ramMax"`
+	TmpdirMin *CWLExpression `yaml:"tmpdirMin"`
+	TmpdirMax *CWLExpression `yaml:"tmpdirMin"`
+	OutdirMin *CWLExpression `yaml:"outdirMin"`
+	OutdirMax *CWLExpression `yaml:"outdirMax"`
+}
+
+func (_ InlineJavascriptRequirement) isCWLRequirement() {}
+func (_ SchemaDefRequirement) isCWLRequirement()        {}
+func (_ LoadListingRequirement) isCWLRequirement()      {}
+func (_ DockerRequirement) isCWLRequirement()           {}
+func (_ SoftwareRequirement) isCWLRequirement()         {}
+func (_ InitialWorkDirRequirement) isCWLRequirement()   {}
+func (_ EnvVarRequirement) isCWLRequirement()           {}
+func (_ ShellCommandRequirement) isCWLRequirement()     {}
+func (_ WorkReuse) isCWLRequirement()                   {}
+func (_ NetworkAccess) isCWLRequirement()               {}
+func (_ InplaceUpdateRequirement) isCWLRequirement()    {}
+func (_ ToolTimeLimit) isCWLRequirement()               {}
+
+func (_ CommandlineInputRecordSchema) isSchemaDefRequirementType() {}
+func (_ CommandlineInputEnumSchema) isSchemaDefRequirementType()   {}
+func (_ CommandlineInputArraySchema) isSchemaDefRequirementType()  {}
+func (_ DockerRequirement) isSchemaDefRequirementType()            {}
+func (_ SoftwareRequirement) isSchemaDefRequirementType()          {}
+func (_ InitialWorkDirRequirement) isSchemaDefRequirementType()    {}
+
+type CommandlineInputRecordField struct {
+	Name           string              `yaml:"name"`
+	Type           CommandlineTypes    `yaml:"type"` // len(1) represents scalar len > 1 represents array
+	Doc            Strings             `yaml:"doc"`
+	Label          *string             `yaml:"label"`
+	SecondaryFiles SecondaryFiles      `yaml:"secondaryFiles"`
+	Streamable     *bool               `yaml:"streamable"`
+	Format         CWLFormat           `yaml:"format"`
+	LoadContents   *bool               `yaml:"loadContents"`
+	LoadListing    LoadListingEnum     `yaml:"loadListing"`
+	InputBinding   *CommandlineBinding `yaml:"inputBinding"`
+}
+
+type CommandlineInputArraySchema struct {
+	Items        CommandlineTypes    `yaml:"items"`
+	Type         string              `yaml:"type"` // MUST be array
+	Label        *string             `yaml:"label"`
+	Doc          Strings             `yaml:"doc"`
+	Name         *string             `yaml:"name"`
+	InputBinding *CommandlineBinding `yaml:"inputBinding"`
+}
+
+type CommandlineInputEnumSchema struct {
+	Symbols      Strings `yaml:"symbols"`
+	Type         string  `yaml:"type"` // MUST BE enum, only a placeholder for type verification purposes
+	Label        *string `yaml:"label"`
+	Doc          Strings `yaml:"doc"`
+	Name         *string `yaml:"name"`
+	InputBinding *CommandlineBinding
+}
+
+type CommandlineInputRecordSchema struct {
+	Type         string                         `yaml:"type"` // MUST BE "record"
+	Fields       *[]CommandlineInputRecordField `yaml:"fields"`
+	Label        *string                        `yaml:"label"`
+	Doc          *Strings                       `yaml:"doc"`
+	Name         *string                        `yaml:"name"`
+	inputBinding *CommandlineBinding            `yaml:"inputBinding"`
+}
+
+func (_ CWLNull) isFlat()                    {}
+func (_ CWLBool) isFlat()                    {}
+func (_ CWLInt) isFlat()                     {}
+func (_ CWLLong) isFlat()                    {}
+func (_ CWLFloat) isFlat()                   {}
+func (_ CWLDouble) isFlat()                  {}
+func (_ CWLFile) isFlat()                    {}
+func (_ CWLDirectory) isFlat()               {}
+func (_ CWLStdin) isFlat()                   {}
+func (_ String) isFlat()                     {}
+func (_ CommandlineInputEnumSchema) isFlat() {}
+
+type Type int32
+
+const (
+	CWLNullKind Type = iota
+	CWLBoolKind
+	CWLIntKind
+	CWLLongKind
+	CWLFloatKind
+	CWLDoubleKind
+	CWLFileKind
+	CWLDirectoryKind
+	CWLStdinKind
+	CWLStringKind
+	CWLRecordKind
+	CWLRecordFieldKind
+	CWLEnumKind
+	CWLArrayKind
+)
+
+type CommandlineType struct {
+	Kind   Type
+	Record *CommandlineInputRecordSchema
+	Enum   *CommandlineInputEnumSchema
+	Array  *CommandlineInputArraySchema
+}
+
+type CommandlineTypes []CommandlineType
+
+type CommandlineBinding struct {
+	LoadContents  *bool         `yaml:"loadContents"`
+	Position      *int          `yaml:"position"`
+	Prefix        *string       `yaml:"prefix"`
+	Seperate      *bool         `yaml:"seperate"`
+	ItemSeperator *string       `yaml:"itemSeperator"`
+	ValueFrom     CWLExpression `yaml:"valueFrom"`
+	ShellQuote    *bool         `yaml:"bool"`
+}
+
+type CommandlineInputParameter struct {
+	Type           CommandlineTypes    `yaml:"type"` // len(1) == scalar while len > 1 == array
+	Label          *string             `yaml:"label"`
+	SecondaryFiles SecondaryFiles      `yaml:"secondaryFiles"` // len(1) == scalar while len > 1 == array
+	Streamable     *bool               `yaml:"streamable"`
+	Doc            Strings             `yaml:"doc"`
+	Id             *string             `yaml:"id"`
+	Format         *CWLFormat          `yaml:"format"`
+	LoadContents   *bool               `yaml:"loadContents"`
+	LoadListing    *LoadListingEnum    `yaml:"loadListing"`
+	Default        interface{}         `yaml:"default"`
+	InputBinding   *CommandlineBinding `yaml:"inputBinding"`
+}
+
+type OutputBindingGlobKind int32
+
+const (
+	GlobStringKind OutputBindingGlobKind = iota
+	GlobStringsKind
+	GlobExpressionKind
+)
+
+type CommandlineOutputBindingGlob struct {
+	Kind       OutputBindingGlobKind
+	String     String
+	Strings    Strings
+	Expression CWLExpression
+}
+
+type CommandlineOutputBinding struct {
+	LoadContents *bool                        `yaml:"loadContents"`
+	LoadListing  LoadListingEnum              `yaml:"loadListing"`
+	Glob         CommandlineOutputBindingGlob `yaml:"glob"`
+	OutputEval   CWLExpression                `yaml:"outputEval"`
+}
+
+type CommandlineOutputParameter struct {
+	Type           CommandlineTypes          `yaml:"type"`
+	Label          *string                   `yaml:"label"`
+	SecondaryFiles SecondaryFiles            `yaml:"secondaryFiles"`
+	Streamable     *bool                     `yaml:"streamable"`
+	Doc            Strings                   `yaml:"doc"`
+	Id             *string                   `yaml:"id"`
+	Format         *CWLFormat                `yaml:"format"`
+	OutputBinding  *CommandlineOutputBinding `yaml:"outputBinding"`
+}
+
+type CommandlineArgumentKind int32
+
+const (
+	ArgumentStringKind CommandlineArgumentKind = iota
+	ArgumentExpressionKind
+	ArgumentCLIBindingKind
+)
+
+type CommandlineArgument struct {
+	Kind               CommandlineArgumentKind
+	String             String
+	Expression         CWLExpression
+	CommandlineBinding CommandlineBinding
+}
+
+type Inputs []CommandlineInputParameter
+type Outputs []CommandlineOutputParameter
+type Requirements []CWLRequirements
+type Hints []interface{}
+type Arguments []CommandlineArgument
+
+type CommandlineTool struct {
+	Inputs       Inputs         `yaml:"inputs"`
+	Outputs      Outputs        `yaml:"outputs"`
+	Class        string         `yaml:"class"` // Must be "CommandLineTool"
+	Id           *string        `yaml:"id"`
+	Label        *string        `yaml:"label"`
+	Doc          Strings        `yaml:"doc"`
+	Requirements Requirements   `yaml:"requirements"`
+	Hints        Hints          `yaml:"hints"`
+	CWLVersion   *string        `yaml:"cwlVersion"`
+	Intent       Strings        `yaml:"intent"`
+	BaseCommand  Strings        `yaml:"baseCommand"`
+	Arguments    Arguments      `yaml:"arguments"`
+	Stdin        *CWLExpression `yaml:"stdin"`
+	Stderr       *CWLExpression `yaml:"stderr"`
+	Stdout       *CWLExpression `yaml:"stdout"`
+}

--- a/cmd/cwl2argo/transpiler/emit_cl.go
+++ b/cmd/cwl2argo/transpiler/emit_cl.go
@@ -1,0 +1,309 @@
+package transpiler
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"sort"
+
+	v1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+const (
+	ArgoType    = "Workflow"
+	ArgoVersion = "argoproj.io/v1alpha1"
+)
+
+func emitDockerRequirement(container *apiv1.Container, d *DockerRequirement) error {
+	tmpContainer := container.DeepCopy()
+
+	if d.DockerPull == nil {
+		return errors.New("dockerPull is a required field")
+	}
+
+	tmpContainer.Image = *d.DockerPull
+
+	if d.DockerFile != nil {
+		return errors.New("")
+	}
+
+	if d.DockerImageId != nil {
+		return errors.New("")
+	}
+
+	if d.DockerImport != nil {
+		return errors.New("")
+	}
+
+	*container = *tmpContainer
+	return nil
+}
+
+func convertAndAdd(inputs *v1.Inputs, input CommandlineInputParameter, addIndexString bool) error {
+	// for now we don't care about the other fields
+	for i, ty := range input.Type {
+		if ty.Kind != CWLStringKind {
+			return errors.New("string is the only supported type at the moment")
+		}
+		name := *input.Id
+		if addIndexString {
+			name = fmt.Sprintf("%s_%d", name, i)
+		}
+		param := v1.Parameter{Name: name}
+		inputs.Parameters = append(inputs.Parameters, param)
+	}
+	return nil
+}
+
+func emitInputParam(input CommandlineInputParameter) (*v1.Inputs, error) {
+	params := make([]v1.Parameter, 0)
+	artifacts := make([]v1.Artifact, 0)
+	mappedInput := v1.Inputs{Parameters: params, Artifacts: artifacts}
+
+	if len(input.Type) <= 0 {
+		return &mappedInput, nil
+	}
+
+	if len(input.Type) == 1 {
+		convertAndAdd(&mappedInput, input, false)
+	} else {
+		convertAndAdd(&mappedInput, input, true)
+	}
+	return &mappedInput, nil
+}
+
+func dockerNotPresent() error { return errors.New("DockerRequirement was not found") }
+
+func findDockerRequirement(clTool *CommandlineTool) (*DockerRequirement, error) {
+	var docker *DockerRequirement
+	docker = nil
+	for _, req := range clTool.Requirements {
+		d, ok := req.(DockerRequirement)
+		if ok {
+			log.Info("Found DockerRequirement")
+			docker = &d
+		}
+	}
+
+	if docker != nil {
+		return docker, nil
+	} else {
+		return nil, dockerNotPresent()
+	}
+}
+
+func emitInputParams(template *v1.Template, inputs []CommandlineInputParameter) error {
+	params := make([]v1.Parameter, 0)
+	artifacts := make([]v1.Artifact, 0)
+
+	for _, input := range inputs {
+		newInput, err := emitInputParam(input)
+		if err != nil {
+			return err
+		}
+		params = append(params, newInput.Parameters...)
+		artifacts = append(artifacts, newInput.Artifacts...)
+	}
+	mappedInput := v1.Inputs{Parameters: params, Artifacts: artifacts}
+
+	template.Inputs = mappedInput
+	return nil
+}
+
+// dummy function to evaluate CommandlineTool
+// until proper eval functionality is added
+func evalArgument(arg CommandlineArgument) (*string, error) {
+	switch arg.Kind {
+	case ArgumentStringKind:
+		return (*string)(&arg.String), nil
+	default:
+		return nil, errors.New("only string is accepted at the moment")
+	}
+}
+
+type bindingTuple struct {
+	commandlineBinding CommandlineBinding
+	Kind               Type
+	Key                string
+	value              string
+}
+
+type inputBindingRetriever interface {
+	GetInputBindings(inputs map[string]interface{}) ([]bindingTuple, error)
+}
+
+func (inputParameter CommandlineInputParameter) GetInputBindings(inputs map[string]interface{}) ([]bindingTuple, error) {
+	bindings := make([]bindingTuple, 0)
+	for _, ty := range inputParameter.Type {
+		if inputParameter.Id == nil {
+			return nil, errors.New("input parameter is nil")
+		}
+
+		inputi, ok := inputs[*inputParameter.Id]
+		if !ok {
+			return nil, fmt.Errorf("%s was not present in input", *inputParameter.Id)
+		}
+
+		switch ty.Kind {
+		case CWLStringKind:
+			value, ok := inputi.(string)
+			if !ok {
+				return nil, errors.New("Invalid type")
+			}
+			pair := bindingTuple{*inputParameter.InputBinding, CWLStringKind, *inputParameter.Id, value}
+			bindings = append(bindings, pair)
+		default:
+			return nil, fmt.Errorf("Invalid type %T", inputi)
+		}
+
+	}
+	return bindings, nil
+}
+
+func sortInputBindingPairsByPosition(boundingPairs []bindingTuple) {
+	sort.Slice(boundingPairs, func(i, j int) bool {
+		left := boundingPairs[i]
+		right := boundingPairs[j]
+		if left.commandlineBinding.Position == nil {
+			return true
+		}
+		if right.commandlineBinding.Position == nil {
+			return false
+		}
+		return *left.commandlineBinding.Position < *right.commandlineBinding.Position
+	})
+}
+
+func emitArgumentParams(container *apiv1.Container,
+	inputBindings Inputs,
+	baseCommand Strings,
+	arguments Arguments,
+	inputs map[string]interface{}) ([]bindingTuple, error,
+) {
+	cmds := make([]string, 0)
+	skip := false
+
+	if len(baseCommand) == 0 {
+		if len(arguments) == 0 {
+			return nil, errors.New("len(baseCommand)==0 && len(arguments)==0")
+		}
+		cmd, err := evalArgument(arguments[0])
+		if err != nil {
+			return nil, err
+		}
+		cmds = append(cmds, *cmd)
+		skip = false
+	}
+
+	for _, cmd := range baseCommand {
+		cmds = append(cmds, cmd)
+	}
+
+	for i, arg := range arguments {
+		if i == 0 && skip {
+			continue
+		}
+		cmd, err := evalArgument(arg)
+		if err != nil {
+			return nil, err
+		}
+		cmds = append(cmds, *cmd)
+	}
+
+	bindings := make([]bindingTuple, 0)
+
+	for _, inputBinding := range inputBindings {
+		newBindings, err := inputBinding.GetInputBindings(inputs)
+		if err != nil {
+			return nil, err
+		}
+		bindings = append(bindings, newBindings...)
+	}
+	sortInputBindingPairsByPosition(bindings)
+
+	args := make([]string, 0)
+	for _, pair := range bindings {
+		arg := fmt.Sprintf("{{inputs.parameters.%s}}", pair.Key)
+		args = append(args, arg)
+	}
+
+	container.Command = cmds
+	container.Args = args
+
+	return bindings, nil
+}
+
+func getInputBindingInputs(inputs Inputs) Inputs {
+	newInputs := make(Inputs, 0)
+
+	for _, input := range inputs {
+		if input.InputBinding != nil {
+			newInputs = append(newInputs, input)
+		}
+	}
+	return newInputs
+}
+
+func emitArguments(spec *v1.WorkflowSpec, bindings []bindingTuple) error {
+	params := make([]v1.Parameter, 0)
+	arts := make([]v1.Artifact, 0)
+
+	for _, tup := range bindings {
+		switch tup.Kind {
+		case CWLStringKind:
+			params = append(params, v1.Parameter{Name: tup.Key, Value: (*v1.AnyString)(&tup.value)})
+		default:
+			return fmt.Errorf("%T is not supported", tup.Kind)
+		}
+	}
+	args := v1.Arguments{Parameters: params, Artifacts: arts}
+	spec.Arguments = args
+	return nil
+}
+
+func EmitCommandlineTool(clTool *CommandlineTool, inputs map[string]interface{}) (*v1.Workflow, error) {
+	var wf v1.Workflow
+	var err error
+
+	wf.Name = *clTool.Id
+	spec := v1.WorkflowSpec{}
+	wf.APIVersion = ArgoVersion
+	wf.Kind = ArgoType
+
+	container := apiv1.Container{}
+
+	dockerRequirement, err := findDockerRequirement(clTool)
+	if err != nil {
+		return nil, err
+	}
+
+	err = emitDockerRequirement(&container, dockerRequirement)
+	if err != nil {
+		return nil, err
+	}
+
+	template := v1.Template{}
+	template.Container = &container
+	template.Name = *clTool.Id
+
+	err = emitInputParams(&template, clTool.Inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	inputBindings := getInputBindingInputs(clTool.Inputs)
+	bindings, err := emitArgumentParams(&container, inputBindings, clTool.BaseCommand, clTool.Arguments, inputs)
+	if err != nil {
+		return nil, nil
+	}
+
+	emitArguments(&spec, bindings)
+
+	spec.Templates = []v1.Template{template}
+	spec.Entrypoint = template.Name
+
+	wf.Spec = spec
+	return &wf, nil
+}

--- a/cmd/cwl2argo/transpiler/emit_cl_test.go
+++ b/cmd/cwl2argo/transpiler/emit_cl_test.go
@@ -1,0 +1,39 @@
+package transpiler
+
+import (
+	"testing"
+)
+
+func TestSortInputBindingsByPosition(t *testing.T) {
+	position4 := 4
+	position1 := 1
+	position5 := 5
+	position3 := 3
+	position2 := 2
+	bindings := []bindingTuple{
+		{CommandlineBinding{}, CWLStringKind, "one", "1"},
+		{CommandlineBinding{}, CWLStringKind, "two", "2"},
+		{CommandlineBinding{Position: &position1}, CWLStringKind, "three", "3"},
+		{CommandlineBinding{}, CWLStringKind, "four", "4"},
+		{CommandlineBinding{Position: &position2}, CWLStringKind, "five", "5"},
+		{CommandlineBinding{}, CWLStringKind, "six", "6"},
+		{CommandlineBinding{Position: &position3}, CWLStringKind, "seven", "7"},
+		{CommandlineBinding{Position: &position4}, CWLStringKind, "eight", "8"},
+		{CommandlineBinding{Position: &position5}, CWLStringKind, "nine", "9"},
+		{CommandlineBinding{}, CWLStringKind, "ten", "10"}}
+	sortInputBindingPairsByPosition(bindings)
+
+	var last *int
+	last = nil
+
+	for _, pair := range bindings {
+		if last == nil {
+			last = pair.commandlineBinding.Position
+			continue
+		}
+		if *last+1 != *pair.commandlineBinding.Position {
+			t.Errorf("Sorting not correct, expected monotonic sequence [%d,%d] is not monotonic", *last, *pair.commandlineBinding.Position)
+		}
+		last = pair.commandlineBinding.Position
+	}
+}

--- a/cmd/cwl2argo/transpiler/transpiler.go
+++ b/cmd/cwl2argo/transpiler/transpiler.go
@@ -1,0 +1,81 @@
+package transpiler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	CWLVersion = "v1.2"
+)
+
+func TranspileCommandlineTool(cl CommandlineTool, inputs map[string]interface{}, outputFile string) error {
+	wf, err := EmitCommandlineTool(&cl, inputs)
+	if err != nil {
+		return err
+	}
+	// HACK: yaml Marshalling doesn't marshal correctly
+	// therefore we turn the Workflow to map[string]interface and marshal that
+	data, err := json.Marshal(wf)
+	if err != nil {
+		return err
+	}
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(data, &m)
+	if err != nil {
+		return err
+	}
+	data, err = yaml.Marshal(m)
+	return os.WriteFile(outputFile, data, 0644)
+}
+
+func TranspileFile(inputFile string, inputsFile string, outputFile string) error {
+
+	log.Warn("Currently the transpiler expects preprocessed CWL input, sbpack is the recommended way of preprocessing, use cwlpack from here https://github.com/rabix/sbpack/tree/84bd7867a0630a826280a702db715377aa879f6a")
+	var cwl map[string]interface{}
+	var inputs map[string]interface{}
+
+	def, err := os.ReadFile(inputFile)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(def, &cwl)
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(inputsFile)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(data, &inputs)
+	if err != nil {
+		return err
+	}
+
+	class, ok := cwl["class"]
+	if !ok {
+		return errors.New("<class> expected")
+	}
+
+	if class == "CommandLineTool" {
+		var cliTool CommandlineTool
+		err := yaml.Unmarshal(def, &cliTool)
+		if err != nil {
+			return err
+		}
+
+		return TranspileCommandlineTool(cliTool, inputs, outputFile)
+	} else {
+		return fmt.Errorf("%s is not supported as of yet", class)
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: isubasinghe <isitha@pipekit.io>
This is the code for emitting Argo YAML for a very simple CWL CommandLineTool. It only support strings inputs. outputs are not yet supported. These will be added later onwords. CWL Workflow types are not supported as well. This is a tiny subset of the CWL specification but the aim of the PR is to keep the ball moving with regards to transpilation from CWL. 

This is dependent on #7538