### PR TITLE
fix: Fix type assertion bug

### DIFF
--- a/util/unstructured/workflow/conditions.go
+++ b/util/unstructured/workflow/conditions.go
@@ -19,6 +19,14 @@ func GetConditions(un *unstructured.Unstructured) wfv1.Conditions {
 		if !ok {
 			return nil
 		}
+		_, ok = m["type"].(string)
+		if !ok {
+			return nil
+		}
+		_, ok = m["status"].(string)
+		if !ok {
+			return nil
+		}
 		x = append(x, wfv1.Condition{
 			Type:   wfv1.ConditionType(m["type"].(string)),
 			Status: metav1.ConditionStatus(m["status"].(string)),


### PR DESCRIPTION
Fixes a crash found by [the operator fuzzer](https://github.com/cncf/cncf-fuzzing/blob/main/projects/argo/operator_fuzzer.go) where the type assertion of `m["type"]` and `m["status"]` would crash Argo because either was `nil`.

@terrytangyuan @hblixt @jannfis

OSS-fuzz issue: https://oss-fuzz.com/testcase-detail/4663831211671552