### PR TITLE
feat: Adds timezone to argo cron list output (#7557)

### DIFF
--- a/cmd/argo/commands/cron/list.go
+++ b/cmd/argo/commands/cron/list.go
@@ -66,7 +66,7 @@ func printTable(wfList []wfv1.CronWorkflow, listArgs *listFlags) {
 	if listArgs.allNamespaces {
 		_, _ = fmt.Fprint(w, "NAMESPACE\t")
 	}
-	_, _ = fmt.Fprint(w, "NAME\tAGE\tLAST RUN\tNEXT RUN\tSCHEDULE\tSUSPENDED")
+	_, _ = fmt.Fprint(w, "NAME\tAGE\tLAST RUN\tNEXT RUN\tSCHEDULE\tTIMEZONE\tSUSPENDED")
 	_, _ = fmt.Fprint(w, "\n")
 	for _, cwf := range wfList {
 		if listArgs.allNamespaces {
@@ -84,7 +84,7 @@ func printTable(wfList []wfv1.CronWorkflow, listArgs *listFlags) {
 		} else {
 			cleanNextScheduledTime = "N/A"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t", cwf.ObjectMeta.Name, humanize.RelativeDurationShort(cwf.ObjectMeta.CreationTimestamp.Time, time.Now()), cleanLastScheduledTime, cleanNextScheduledTime, cwf.Spec.Schedule, cwf.Spec.Suspend)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%t", cwf.ObjectMeta.Name, humanize.RelativeDurationShort(cwf.ObjectMeta.CreationTimestamp.Time, time.Now()), cleanLastScheduledTime, cleanNextScheduledTime, cwf.Spec.Schedule, cwf.Spec.Timezone, cwf.Spec.Suspend)
 		_, _ = fmt.Fprintf(w, "\n")
 	}
 	_ = w.Flush()


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

Don't bother creating a PR until you've done this:

* [X] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

Create your PR as a draft.

Added the timezone to the output of argo cron list):

```
NAME                         AGE   LAST RUN   NEXT RUN   SCHEDULE                           TIMEZONE     SUSPENDED
my-cron-workflow-c90cadee    20h   2h         14h        45 12,13,14,15,16,17,18,19 * * *                false
my-cron-workflow2-f4f27c90   20h   20h        26s        * * * * *                          US/Central   true
```

Note that the timezone field is empty when there is no timezone specified in the CronWorkflow object.  Since the cron server appears to default to UTC when no timezone is specified (at least as I understand that time.Now() returns the local time in UTC), would it make sense to print UTC when the timezone is null?

There do not appear to be any tests for this code.
