### PR TITLE
fix: Fix supplied global workflow parameters, fixes 

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -527,15 +527,13 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 		if param.Value == nil && param.ValueFrom == nil {
 			return fmt.Errorf("either value or valueFrom must be specified in order to set global parameter %s", param.Name)
 		}
-		if param.ValueFrom != nil {
-			if param.ValueFrom.ConfigMapKeyRef != nil {
-				cmValue, err := common.GetConfigMapValue(woc.controller.configMapInformer, woc.wf.ObjectMeta.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
-				if err != nil {
-					return fmt.Errorf("failed to set global parameter %s from configmap with name %s and key %s: %w",
-						param.Name, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key, err)
-				}
-				woc.globalParams["workflow.parameters."+param.Name] = cmValue
+		if param.ValueFrom != nil && param.ValueFrom.ConfigMapKeyRef != nil {
+			cmValue, err := common.GetConfigMapValue(woc.controller.configMapInformer, woc.wf.ObjectMeta.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
+			if err != nil {
+				return fmt.Errorf("failed to set global parameter %s from configmap with name %s and key %s: %w",
+					param.Name, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key, err)
 			}
+			woc.globalParams["workflow.parameters."+param.Name] = cmValue
 		} else {
 			woc.globalParams["workflow.parameters."+param.Name] = param.Value.String()
 		}


### PR DESCRIPTION
Signed-off-by: Peixuan Ding <dingpeixuan911@gmail.com>

Hi, this PR fixes an issue where `supplied` workflow parameters are not correctly set in the global parameters. See #7563 for more details.

For example, in the following workflow template, the parameter `name` is supplied by UI or CLI. However, it will not be set in the global parameters because both `valueFrom` and `value` exist at the runtime. The workflow controller only looks for `configMapKeyRef` when `valueFrom` is set.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: workflow-template-whalesay-template
spec:
  arguments:
    parameters:
      - name: name
        valueFrom:
          supplied: {}
  entrypoint: whalesay-template
  templates:
  - name: whalesay-template
    container:
      image: docker/whalesay
      command: [cowsay]
      args: ["{{workflow.parameters.name}}"
```

Fixes #7563, also relates to #7476

Thanks!
