### PR TITLE
fix: Fix inconsistent ordering of workflows with the list command. 

### DIFF
--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -38,7 +38,8 @@ type listFlags struct {
 }
 
 var (
-	nameFields    = "metadata,items.metadata.name"
+	// finishedAt and creationTimestamp must be included to have a consistent display order of workflows
+	nameFields    = "metadata,items.metadata.name,items.metadata.creationTimestamp,items.status.finishedAt"
 	defaultFields = "metadata,items.metadata,items.spec,items.status.phase,items.status.message,items.status.finishedAt,items.status.startedAt,items.status.estimatedDuration,items.status.progress"
 )
 

--- a/cmd/argo/commands/list_test.go
+++ b/cmd/argo/commands/list_test.go
@@ -76,11 +76,21 @@ func Test_listWorkflows(t *testing.T) {
 			assert.Len(t, workflows, 1)
 		}
 	})
+	t.Run("Names", func(t *testing.T) {
+		workflows, err := list(&metav1.ListOptions{FieldSelector: nameFields}, listFlags{fields: nameFields})
+		if assert.NoError(t, err) {
+			assert.Len(t, workflows, 3)
+			// most recent workflow will be shown first
+			assert.Equal(t, "bar-", workflows[0].Name)
+			assert.Equal(t, "baz-", workflows[1].Name)
+			assert.Equal(t, "foo-", workflows[2].Name)
+		}
+	})
 }
 
 func list(listOptions *metav1.ListOptions, flags listFlags) (wfv1.Workflows, error) {
 	c := &workflowmocks.WorkflowServiceClient{}
-	c.On("ListWorkflows", mock.Anything, &workflow.WorkflowListRequest{ListOptions: listOptions, Fields: defaultFields}).Return(&wfv1.WorkflowList{Items: wfv1.Workflows{
+	c.On("ListWorkflows", mock.Anything, &workflow.WorkflowListRequest{ListOptions: listOptions, Fields: flags.displayFields()}).Return(&wfv1.WorkflowList{Items: wfv1.Workflows{
 		{ObjectMeta: metav1.ObjectMeta{Name: "foo-", CreationTimestamp: metav1.Time{Time: time.Now().Add(-2 * time.Hour)}}, Status: wfv1.WorkflowStatus{FinishedAt: metav1.Time{Time: time.Now().Add(-2 * time.Hour)}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "bar-", CreationTimestamp: metav1.Time{Time: time.Now()}}},
 		{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #7581

Hi, this PR fixes an issue where `argo list -o name` has inconsistent display order than `argo list`. The root cause is that we sort workflows based on `CreationTimestamp` and `FinishedAt`:

https://github.com/argoproj/argo-workflows/blob/f1fe3bee498ac7eb895af6f89a0eba5095410467/pkg/apis/workflow/v1alpha1/workflow_types.go#L130-L145

So we need to make sure these two fields are included in the name-only field selectors as well, in order to have a consistent sort.

### Before
Workflows have inconsistent display order with / without `-o name`
![Screenshot from 2022-01-19 23-39-28](https://user-images.githubusercontent.com/1311594/150274645-8078118a-1aab-46d7-b306-ebe02c8c74c0.png)

### After
Workflows have consistent display order now
![Screenshot from 2022-01-19 23-40-00](https://user-images.githubusercontent.com/1311594/150274646-93efc06d-901d-4eca-b9f8-7e2c2efd72ad.png)

Thanks!

Signed-off-by: Peixuan Ding <dingpeixuan911@gmail.com>