### PR TITLE
fix: Upgrade prismjs to v1.26 to fix security scan. Fixes #7599

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -86,7 +86,7 @@
     },
     "resolutions": {
         "lodash": "4.17.21",
-        "prismjs": "1.24.0",
+        "prismjs": "1.26.0",
         "@types/react": "16.8.5"
     }
 }


### PR DESCRIPTION
Fixes #7599.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>