### PR TITLE
fix: Use v1 pod name if no template name or ref. Fixes #7595 and #7749

### DIFF
--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,4 +1,4 @@
-import {Inputs, MemoizationStatus, NODE_PHASE, NodePhase, NodeStatus, NodeType, Outputs, RetryStrategy} from '../../models';
+import {Inputs, MemoizationStatus, NodePhase, NodeStatus, NodeType, Outputs, RetryStrategy} from '../../models';
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
 describe('pod names', () => {

--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,4 +1,4 @@
-import {NODE_PHASE, NodeStatus, NodeType} from '../../models';
+import {NODE_PHASE, NodePhase, NodeStatus, NodeType} from '../../models';
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
 describe('pod names', () => {
@@ -40,6 +40,7 @@ describe('pod names', () => {
         // case: no template ref or template name
         // expect fallback to empty string
         const nodeType: NodeType = 'Pod';
+        const nodePhase: NodePhase = NODE_PHASE.SUCCEEDED;
 
         const node: NodeStatus = {
             id: 'patch-processing-pipeline-ksp78-1623891970',
@@ -47,7 +48,7 @@ describe('pod names', () => {
             displayName: 'retriable-map-authoring-initializer',
             type: nodeType,
             templateScope: 'local/',
-            phase: NODE_PHASE.SUCCEEDED
+            phase: nodePhase
         };
 
         expect(getTemplateNameFromNode(node)).toEqual('');

--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,4 +1,4 @@
-import {NODE_PHASE, NodeStatus} from '../../models';
+import {NODE_PHASE, NodeStatus, NodeType} from '../../models';
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
 describe('pod names', () => {
@@ -39,11 +39,13 @@ describe('pod names', () => {
     test('getTemplateNameFromNode', () => {
         // case: no template ref or template name
         // expect fallback to empty string
+        const nodeType: NodeType = 'Pod';
+
         const node: NodeStatus = {
             id: 'patch-processing-pipeline-ksp78-1623891970',
             name: 'patch-processing-pipeline-ksp78.retriable-map-authoring-initializer',
             displayName: 'retriable-map-authoring-initializer',
-            type: 'Pod',
+            type: nodeType,
             templateScope: 'local/',
             phase: NODE_PHASE.SUCCEEDED
         };

--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,4 +1,4 @@
-import {NODE_PHASE, NodePhase, NodeStatus, NodeType} from '../../models';
+import {Inputs, MemoizationStatus, NODE_PHASE, NodePhase, NodeStatus, NodeType, Outputs, RetryStrategy} from '../../models';
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
 describe('pod names', () => {
@@ -40,7 +40,15 @@ describe('pod names', () => {
         // case: no template ref or template name
         // expect fallback to empty string
         const nodeType: NodeType = 'Pod';
-        const nodePhase: NodePhase = NODE_PHASE.SUCCEEDED;
+        const nodePhase: NodePhase = 'Succeeded';
+        const retryStrategy: RetryStrategy = {};
+        const outputs: Outputs = {};
+        const inputs: Inputs = {};
+        const memoizationStatus: MemoizationStatus = {
+            hit: false,
+            key: 'key',
+            cacheName: 'cache'
+        };
 
         const node: NodeStatus = {
             id: 'patch-processing-pipeline-ksp78-1623891970',
@@ -48,7 +56,21 @@ describe('pod names', () => {
             displayName: 'retriable-map-authoring-initializer',
             type: nodeType,
             templateScope: 'local/',
-            phase: nodePhase
+            phase: nodePhase,
+            boundaryID: '',
+            message: '',
+            startedAt: '',
+            finishedAt: '',
+            podIP: '',
+            daemoned: false,
+            retryStrategy,
+            outputs,
+            children: [],
+            outboundNodes: [],
+            templateName: '',
+            inputs,
+            hostNodeName: '',
+            memoizationStatus
         };
 
         expect(getTemplateNameFromNode(node)).toEqual('');

--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,4 +1,4 @@
-import {NODE_PHASE, NodeStatus, NodeType} from '../../models';
+import {NODE_PHASE, NodeStatus} from '../../models';
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
 describe('pod names', () => {

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -6,9 +6,12 @@ export const POD_NAME_V2 = 'v2';
 export const maxK8sResourceNameLength = 253;
 export const k8sNamingHashLength = 10;
 
-// getPodName returns a deterministic pod name
+// getPodName returns a deterministic pod name. It returns a combination of the
+// workflow name, template name, and a hash if the POD_NAME_V2 annotation is
+// set. If the templateName or templateRef is not defined on a given node, it
+// falls back to POD_NAME_V1
 export const getPodName = (workflowName: string, nodeName: string, templateName: string, nodeID: string, version: string): string => {
-    if (version === POD_NAME_V2) {
+    if (version === POD_NAME_V2 && templateName !== '') {
         if (workflowName === nodeName) {
             return workflowName;
         }
@@ -49,6 +52,11 @@ export const createFNVHash = (input: string): number => {
 export const getTemplateNameFromNode = (node: NodeStatus): string => {
     if (node.templateName && node.templateName !== '') {
         return node.templateName;
+    }
+
+    // fall back to v1 pod names if no templateName or templateRef defined
+    if (!node.templateRef) {
+        return '';
     }
 
     return node.templateRef.template;


### PR DESCRIPTION
Signed-off-by: J.P. Zivalich <jp@pipekit.io>

This PR:
- Falls back to the v1 pod names in the UI if no templateName or templateRef is set on a given node - my hypothesis is that certain virtual nodes might not have a a templateName or templateRef set as seen here: https://github.com/argoproj/argo-workflows/issues/7595#issuecomment-1017776672
- Fixes #7595 

@liuzqt Could you run one of your workflows locally using this PR branch to test if it is working? I want to validate that I don't have to make an additional change to the workflow controller
