### PR TITLE
fix: SSO to handle multiple authorization cookies such as from wildca…

### DIFF
--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -171,6 +171,10 @@ func getAuthHeaders(md metadata.MD) []string {
 func (s gatekeeper) getClients(ctx context.Context, req interface{}) (*servertypes.Clients, *types.Claims, error) {
 	md, _ := metadata.FromIncomingContext(ctx)
 	authorizations := getAuthHeaders(md)
+	// Required for GetMode() with Server auth when no auth header specified
+	if len(authorizations) == 0 {
+		authorizations = append(authorizations, "")
+	}
 	valid := false
 	var mode Mode
 	var authorization string

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -358,6 +358,19 @@ func (s *ArgoServerSuite) TestCookieAuth() {
 		Status(200)
 }
 
+// You could have multiple authorization headers, set by wildcard domain cookies in the case of some SSO implementations
+func (s *ArgoServerSuite) TestMultiCookieAuth() {
+	token := s.bearerToken
+	defer func() { s.bearerToken = token }()
+	s.bearerToken = ""
+	s.e().GET("/api/v1/workflows/argo").
+		WithCookie("authorization", "invalid1").
+		WithCookie("authorization", "Bearer "+token).
+		WithCookie("authorization", "invalid2").
+		Expect().
+		Status(200)
+}
+
 func (s *ArgoServerSuite) TestPermission() {
 	nsName := fixtures.Namespace
 	// Create good serviceaccount


### PR DESCRIPTION
…rd domains. Fixes #7592

Signed-off-by: Ken Hyer <khyer123@gmail.com>

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

This PR addresses a situation where Argo Workflow is hosted on a subdomain, and our organization has an org-wide cookie issued by our SSO provider with name 'authorization'. Meanwhile, Argo Server's UI authentication issues its own authorization cookie for both SSO and client authorization. Modern browsers will send both cookies, and Argo Server was only picking one to attempt to authenticate on. As a result, Argo Server would throw a "token not valid for running mode" error. This isn't necessarily Argo's fault, browsers don't send many details with cookies. But it's a real-world situation that we've run into in our organization. 

I replicated issue in my dev environment, showing an authorization cookie set on parent example.com domain, and Argo's bearer token set on the subdomain:
![before_cookies](https://user-images.githubusercontent.com/9206546/150843288-e97b72d8-8ef6-49ef-b8b0-353584b41d70.png)

Resulting error:
![before_auth_attempt](https://user-images.githubusercontent.com/9206546/150843487-1c3d81a5-1c5c-46f0-b7aa-4c67e866a88f.png)

The PR modifies the gateway so that it will now fetch any available authorization cookies, and attempt to validate them to find one that is valid for its running mode(s) instead of just dying on the first one it finds. 

After the modification is applied, we still have the two cookies:

![after_cookies](https://user-images.githubusercontent.com/9206546/150843797-dc298f39-b7e2-4a3b-85fc-963fedc64270.png)

But now calls to the server are successfully authenticated: 

![after_api_result](https://user-images.githubusercontent.com/9206546/150843843-fc40a95a-ce23-493c-b542-5fbd375eb145.png)

A unit test replicating this situation (authentication with multiple cookies with the same name) is also written. 


