### PR TITLE
examples: fixing missing namespace

### DIFF
--- a/examples/configmaps/simple-parameters-configmap.yaml
+++ b/examples/configmaps/simple-parameters-configmap.yaml
@@ -5,5 +5,6 @@ metadata:
   labels:
     # Note that this label is required for the informer to detect this ConfigMap.
     workflows.argoproj.io/configmap-type: Parameter
+  namespace: argo
 data:
   msg: 'hello world'

--- a/examples/configmaps/simple-parameters-configmap.yaml
+++ b/examples/configmaps/simple-parameters-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     # Note that this label is required for the informer to detect this ConfigMap.
     workflows.argoproj.io/configmap-type: Parameter
+  # Note that the ConfigMap should reside in where workflow-controller is installed.
   namespace: argo
 data:
   msg: 'hello world'


### PR DESCRIPTION
If we don't specify namespace while creating a ConfigMap to read keys from it, we can get errors like:
![Issue-1](https://user-images.githubusercontent.com/26150511/150769513-27592363-beb7-4450-90b1-96f1a7e3e8e8.png)

- So, we can define what should be done and where to as a side note in example for user experience as in commit history.
