### PR TITLE
feat: add overridable default input artifacts #2026 

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -158,12 +158,10 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.ArgumentsProvider, globalParams,
 	// Performs substitutions of input artifacts
 	artifacts := newTmpl.Inputs.Artifacts
 	for i, inArt := range artifacts {
-		// if artifact has hard-wired location, we prefer that
-		if inArt.HasLocationOrKey() {
-			continue
-		}
+
 		argArt := args.GetArtifactByName(inArt.Name)
-		if !inArt.Optional {
+
+		if !inArt.Optional && !inArt.HasLocationOrKey() {
 			// artifact must be supplied
 			if argArt == nil {
 				return nil, errors.Errorf(errors.CodeBadRequest, "inputs.artifacts.%s was not supplied", inArt.Name)

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -161,3 +161,39 @@ func TestIsDone(t *testing.T) {
 		},
 	}}))
 }
+
+func TestOverridableDefaultInputArts(t *testing.T) {
+	tmpl := wfv1.Template{}
+	tmpl.Name = "artifact-printing"
+
+	art := wfv1.Artifact{}
+	art.Name = "overridable-art"
+	rawArt := wfv1.RawArtifact{}
+	rawArt.Data = "default contents"
+	art.Raw = &rawArt
+	tmpl.Inputs.Artifacts = []wfv1.Artifact{art}
+
+	inputs := wfv1.Inputs{}
+
+	inputArt := wfv1.Artifact{}
+	inputArt.Name = art.Name
+	inputRawArt := wfv1.RawArtifact{}
+	inputRawArt.Data = "replacement contents"
+	inputArt.Raw = &inputRawArt
+
+	inputs.Artifacts = []wfv1.Artifact{}
+
+	globalParams := make(map[string]string)
+	localParams := make(map[string]string)
+
+	newTmpl, err := ProcessArgs(&tmpl, &inputs, globalParams, localParams, false, "", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, newTmpl)
+	assert.Equal(t, newTmpl.Inputs.Artifacts[0].Raw.Data, rawArt.Data)
+
+	inputs.Artifacts = []wfv1.Artifact{inputArt}
+	newTmpl, err = ProcessArgs(&tmpl, &inputs, globalParams, localParams, false, "", nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, newTmpl)
+	assert.Equal(t, newTmpl.Inputs.Artifacts[0].Raw.Data, inputRawArt.Data)
+}


### PR DESCRIPTION
This adds support for overridable default input artifacts as described in  #2026. An earlier PR was opened in #7341 but it was not showing the diff accurately due to https://stackoverflow.com/questions/16306012/github-pull-request-showing-commits-that-are-already-in-target-branch hence this was opened. 

