### PR TITLE
fix: TLS problem in UI. Fixes #7632

### DIFF
--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -122,8 +122,9 @@ func GenerateX509KeyPairTLSConfig(tlsMinVersion uint16) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		Certificates: []tls.Certificate{*cer},
-		MinVersion:   uint16(tlsMinVersion),
+		Certificates:       []tls.Certificate{*cer},
+		MinVersion:         uint16(tlsMinVersion),
+		InsecureSkipVerify: true,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #7632

**PLEASE NOTE**:
- [InsecureSkipVerify](https://pkg.go.dev/crypto/tls#:~:text=InsecureSkipVerify%20bool) is not relevant in the context of a server, as it is for client config so "crypto/tls accepts any certificate presented by the server and any host name in that certificate". In short, this line shouldn't be here
- As far as I can see, it seemed to be needed because it (as a part of `tls.Config` is passed into `apiserver.ArgoServerOpts` (seen [here](https://github.com/argoproj/argo-workflows/blob/master/cmd/argo/commands/server.go#L161))
- In turn, I think this `InsecureSkipVerify: true` is used in other areas ([here](https://github.com/argoproj/argo-workflows/blob/1df69afb6fa57598862edc083c6c0b968e728035/server/auth/sso/sso.go#L131) for instance)
- The correct way, would be that a flag was passed in here instead that simply allows the user to decide whether the clients elsewhere in the application should be able to skip verification. This would always need to be `true` in the case of self signed certs, unless some way could be determined that would allow the self signed certs to be trusted.

I believe it likely that this is the case, but cannot guarantee it without further testing. However, merging this pull request does put it in a better situation than before #7621 was merged.