### PR TITLE
fix: Match cli display pod names with k8s. Fixes #7646

### DIFF
--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -539,7 +539,6 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix str
 	duration := humanize.RelativeDurationShort(node.StartedAt.Time, node.FinishedAt.Time)
 	if node.Type == wfv1.NodeTypePod {
 		podName := util.PodName(wfName, nodeName, templateName, node.ID)
-		fmt.Println("GOT POD NAME ======>", podName)
 		args = []interface{}{nodePrefix, nodeName, templateName, podName, duration, node.Message, ""}
 	} else {
 		args = []interface{}{nodePrefix, nodeName, templateName, "", "", node.Message, ""}

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -524,7 +524,7 @@ func renderChild(w *tabwriter.Writer, wf *wfv1.Workflow, nInfo renderNode, depth
 }
 
 // Main method to print information of node in get
-func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, nodePrefix string, getArgs getFlags) {
+func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix string, getArgs getFlags) {
 	nodeName := fmt.Sprintf("%s %s", jobStatusIconMap[node.Phase], node.DisplayName)
 	if node.IsActiveSuspendNode() {
 		nodeName = fmt.Sprintf("%s %s", nodeTypeIconMap[node.Type], node.DisplayName)
@@ -538,7 +538,9 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, nodePrefix string, get
 	var args []interface{}
 	duration := humanize.RelativeDurationShort(node.StartedAt.Time, node.FinishedAt.Time)
 	if node.Type == wfv1.NodeTypePod {
-		args = []interface{}{nodePrefix, nodeName, templateName, node.ID, duration, node.Message, ""}
+		podName := util.PodName(wfName, nodeName, templateName, node.ID)
+		fmt.Println("GOT POD NAME ======>", podName)
+		args = []interface{}{nodePrefix, nodeName, templateName, podName, duration, node.Message, ""}
 	} else {
 		args = []interface{}{nodePrefix, nodeName, templateName, "", "", node.Message, ""}
 	}
@@ -566,7 +568,7 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, nodePrefix string, get
 func (nodeInfo *boundaryNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow, depth int, nodePrefix string, childPrefix string, getArgs getFlags) {
 	filtered, childIndent := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
-		printNode(w, nodeInfo.getNodeStatus(wf), nodePrefix, getArgs)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs)
 	}
 
 	for i, nInfo := range nodeInfo.boundaryContained {
@@ -579,7 +581,7 @@ func (nodeInfo *boundaryNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow
 func (nodeInfo *nonBoundaryParentNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow, depth int, nodePrefix string, childPrefix string, getArgs getFlags) {
 	filtered, childIndent := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
-		printNode(w, nodeInfo.getNodeStatus(wf), nodePrefix, getArgs)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs)
 	}
 
 	for i, nInfo := range nodeInfo.children {
@@ -592,7 +594,7 @@ func (nodeInfo *nonBoundaryParentNode) renderNodes(w *tabwriter.Writer, wf *wfv1
 func (nodeInfo *executionNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow, _ int, nodePrefix string, _ string, getArgs getFlags) {
 	filtered, _ := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
-		printNode(w, nodeInfo.getNodeStatus(wf), nodePrefix, getArgs)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs)
 	}
 }
 

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -524,7 +524,7 @@ func renderChild(w *tabwriter.Writer, wf *wfv1.Workflow, nInfo renderNode, depth
 }
 
 // Main method to print information of node in get
-func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix string, getArgs getFlags) {
+func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix string, getArgs getFlags, podNameVersion util.PodNameVersion) {
 	nodeName := fmt.Sprintf("%s %s", jobStatusIconMap[node.Phase], node.DisplayName)
 	if node.IsActiveSuspendNode() {
 		nodeName = fmt.Sprintf("%s %s", nodeTypeIconMap[node.Type], node.DisplayName)
@@ -538,7 +538,7 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix str
 	var args []interface{}
 	duration := humanize.RelativeDurationShort(node.StartedAt.Time, node.FinishedAt.Time)
 	if node.Type == wfv1.NodeTypePod {
-		podName := util.PodName(wfName, nodeName, templateName, node.ID)
+		podName := util.PodName(wfName, nodeName, templateName, node.ID, podNameVersion)
 		args = []interface{}{nodePrefix, nodeName, templateName, podName, duration, node.Message, ""}
 	} else {
 		args = []interface{}{nodePrefix, nodeName, templateName, "", "", node.Message, ""}
@@ -567,7 +567,8 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix str
 func (nodeInfo *boundaryNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow, depth int, nodePrefix string, childPrefix string, getArgs getFlags) {
 	filtered, childIndent := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
-		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs)
+		version := util.GetWorkflowPodNameVersion(wf)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs, version)
 	}
 
 	for i, nInfo := range nodeInfo.boundaryContained {
@@ -580,7 +581,8 @@ func (nodeInfo *boundaryNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow
 func (nodeInfo *nonBoundaryParentNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow, depth int, nodePrefix string, childPrefix string, getArgs getFlags) {
 	filtered, childIndent := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
-		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs)
+		version := util.GetWorkflowPodNameVersion(wf)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs, version)
 	}
 
 	for i, nInfo := range nodeInfo.children {
@@ -593,7 +595,8 @@ func (nodeInfo *nonBoundaryParentNode) renderNodes(w *tabwriter.Writer, wf *wfv1
 func (nodeInfo *executionNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow, _ int, nodePrefix string, _ string, getArgs getFlags) {
 	filtered, _ := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
-		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs)
+		version := util.GetWorkflowPodNameVersion(wf)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs, version)
 	}
 }
 

--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
 
 func testPrintNodeImpl(t *testing.T, expected string, node wfv1.NodeStatus, getArgs getFlags) {
@@ -19,7 +20,7 @@ func testPrintNodeImpl(t *testing.T, expected string, node wfv1.NodeStatus, getA
 	w := tabwriter.NewWriter(&result, 0, 8, 1, '\t', 0)
 	filtered, _ := filterNode(node, getArgs)
 	if !filtered {
-		printNode(w, node, "testWf", "", getArgs)
+		printNode(w, node, "testWf", "", getArgs, util.PodNameV1)
 	}
 	err := w.Flush()
 	assert.NoError(t, err)

--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -19,7 +19,7 @@ func testPrintNodeImpl(t *testing.T, expected string, node wfv1.NodeStatus, getA
 	w := tabwriter.NewWriter(&result, 0, 8, 1, '\t', 0)
 	filtered, _ := filterNode(node, getArgs)
 	if !filtered {
-		printNode(w, node, "", getArgs)
+		printNode(w, node, "testWf", "", getArgs)
 	}
 	err := w.Flush()
 	assert.NoError(t, err)

--- a/cmd/argo/commands/get_test.go
+++ b/cmd/argo/commands/get_test.go
@@ -20,7 +20,7 @@ func testPrintNodeImpl(t *testing.T, expected string, node wfv1.NodeStatus, getA
 	w := tabwriter.NewWriter(&result, 0, 8, 1, '\t', 0)
 	filtered, _ := filterNode(node, getArgs)
 	if !filtered {
-		printNode(w, node, "testWf", "", getArgs, util.PodNameV1)
+		printNode(w, node, "testWf", "", getArgs, util.GetPodNameVersion())
 	}
 	err := w.Flush()
 	assert.NoError(t, err)

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -17,7 +17,6 @@ import (
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
-	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
@@ -87,11 +86,10 @@ func (t *Then) ExpectWorkflowNode(selector func(status wfv1.NodeStatus) bool, f 
 		if n != nil {
 			_, _ = fmt.Println("Found node", "id="+n.ID, "type="+n.Type)
 			if n.Type == wfv1.NodeTypePod {
-				version := util.PodNameV1
-				annotations := metadata.GetAnnotations()
-				if annotations[common.AnnotationKeyPodNameVersion] == util.PodNameV2.String() {
-					version = util.PodNameV2
+				wf := &wfv1.Workflow{
+					ObjectMeta: *metadata,
 				}
+				version := util.GetWorkflowPodNameVersion(wf)
 				podName := util.PodName(t.wf.Name, n.Name, n.TemplateName, n.ID, version)
 
 				var err error

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1623,7 +1623,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	// Inject the pod name. If the pod has a retry strategy, the pod name will be changed and will be injected when it
 	// is determined
 	if resolvedTmpl.IsPodType() && woc.retryStrategy(resolvedTmpl) == nil {
-		localParams[common.LocalVarPodName] = wfutil.PodName(woc.wf.Name, nodeName, resolvedTmpl.Name, woc.wf.NodeID(nodeName))
+		localParams[common.LocalVarPodName] = woc.getPodName(nodeName, resolvedTmpl.Name)
 	}
 
 	// Merge Template defaults to template
@@ -1814,7 +1814,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 			localParams := make(map[string]string)
 			// Change the `pod.name` variable to the new retry node name
 			if processedTmpl.IsPodType() {
-				localParams[common.LocalVarPodName] = wfutil.PodName(woc.wf.Name, nodeName, processedTmpl.Name, woc.wf.NodeID(nodeName))
+				localParams[common.LocalVarPodName] = woc.getPodName(nodeName, processedTmpl.Name)
 			}
 			// Inject the retryAttempt number
 			localParams[common.LocalVarRetries] = strconv.Itoa(len(retryParentNode.Children))
@@ -2218,7 +2218,8 @@ func (woc *wfOperationCtx) getPodByNode(node *wfv1.NodeStatus) (*apiv1.Pod, erro
 	if node.Type != wfv1.NodeTypePod {
 		return nil, fmt.Errorf("Expected node type %s, got %s", wfv1.NodeTypePod, node.Type)
 	}
-	podName := wfutil.PodName(woc.wf.Name, node.Name, node.TemplateName, node.ID)
+
+	podName := woc.getPodName(node.Name, node.TemplateName)
 	return woc.controller.getPod(woc.wf.GetNamespace(), podName)
 }
 
@@ -3550,6 +3551,12 @@ func (woc *wfOperationCtx) substituteGlobalVariables() error {
 		return err
 	}
 	return nil
+}
+
+// getPodName gets the appropriate pod name for a workflow based on the
+// POD_NAMES environment variable
+func (woc *wfOperationCtx) getPodName(nodeName, templateName string) string {
+	return wfutil.PodName(woc.wf.Name, nodeName, templateName, woc.wf.NodeID(nodeName), wfutil.GetPodNameVersion())
 }
 
 // setWfPodNamesAnnotation sets an annotation on a workflow with the pod naming

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -204,7 +204,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.PodName(woc.wf.Name, nodeName, tmpl.Name, nodeID),
+			Name:      util.PodName(woc.wf.Name, nodeName, tmpl.Name, nodeID, util.GetPodNameVersion()),
 			Namespace: woc.wf.ObjectMeta.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow

--- a/workflow/util/pod_name.go
+++ b/workflow/util/pod_name.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
+
+	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
 const (
@@ -42,8 +45,8 @@ func GetPodNameVersion() PodNameVersion {
 }
 
 // PodName return a deterministic pod name
-func PodName(workflowName, nodeName, templateName, nodeID string) string {
-	if GetPodNameVersion() == PodNameV1 {
+func PodName(workflowName, nodeName, templateName, nodeID string, version PodNameVersion) string {
+	if version == PodNameV1 {
 		return nodeID
 	}
 
@@ -67,4 +70,17 @@ func ensurePodNamePrefixLength(prefix string) string {
 	}
 
 	return prefix
+}
+
+// GetWorkflowPodNameVersion gets the pod name version from the annotation of a
+// given workflow
+func GetWorkflowPodNameVersion(wf *v1alpha1.Workflow) PodNameVersion {
+	annotations := wf.GetAnnotations()
+	version := annotations[common.AnnotationKeyPodNameVersion]
+
+	if version == PodNameV2.String() {
+		return PodNameV2
+	}
+
+	return PodNameV1
 }

--- a/workflow/util/pod_name_test.go
+++ b/workflow/util/pod_name_test.go
@@ -19,7 +19,7 @@ func TestPodName(t *testing.T) {
 	actual := ensurePodNamePrefixLength(expected)
 	assert.Equal(t, expected, actual)
 
-	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID, PodNameV1)
+	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID, GetPodNameVersion())
 	assert.Equal(t, nodeID, name)
 
 	// long case
@@ -34,6 +34,6 @@ func TestPodName(t *testing.T) {
 
 	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
 
-	name = PodName(longWfName, nodeName, longTemplateName, nodeID, PodNameV1)
+	name = PodName(longWfName, nodeName, longTemplateName, nodeID, GetPodNameVersion())
 	assert.Equal(t, nodeID, name)
 }

--- a/workflow/util/pod_name_test.go
+++ b/workflow/util/pod_name_test.go
@@ -19,7 +19,7 @@ func TestPodName(t *testing.T) {
 	actual := ensurePodNamePrefixLength(expected)
 	assert.Equal(t, expected, actual)
 
-	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID)
+	name := PodName(shortWfName, nodeName, shortTemplateName, nodeID, PodNameV1)
 	assert.Equal(t, nodeID, name)
 
 	// long case
@@ -34,6 +34,6 @@ func TestPodName(t *testing.T) {
 
 	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
 
-	name = PodName(longWfName, nodeName, longTemplateName, nodeID)
+	name = PodName(longWfName, nodeName, longTemplateName, nodeID, PodNameV1)
 	assert.Equal(t, nodeID, name)
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -822,7 +822,8 @@ func retryWorkflow(ctx context.Context, kubeClient kubernetes.Interface, hydrato
 		}
 		if node.Type == wfv1.NodeTypePod {
 			templateName := getTemplateFromNode(node)
-			podName := PodName(wf.Name, node.Name, templateName, node.ID)
+			version := GetWorkflowPodNameVersion(wf)
+			podName := PodName(wf.Name, node.Name, templateName, node.ID, version)
 			log.Infof("Deleting pod: %s", podName)
 			err := podIf.Delete(ctx, podName, metav1.DeleteOptions{})
 			if err != nil && !apierr.IsNotFound(err) {


### PR DESCRIPTION
This PR:
- Invokes the workflow utils PodNames function in the cmd printNode function to add the updated pod name to the printout
- Modifies the PodNames function to take the version as a parameter, allowing it to be invoked in the cli when the `POD_NAMES` environment variable isn't present
- Fixes #7646 


```
Name:                dag-diamond-xtpd7
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Succeeded
Conditions:
 PodRunning          False
 Completed           True
Created:             Wed Jan 26 16:32:00 -0500 (13 seconds ago)
Started:             Wed Jan 26 16:32:00 -0500 (13 seconds ago)
Finished:            Wed Jan 26 16:32:13 -0500 (now)
Duration:            13 seconds
Progress:            4/4
ResourcesDuration:   8s*(1 cpu),0s*(100Mi memory)

STEP                  TEMPLATE  PODNAME                            DURATION  MESSAGE
 ✔ dag-diamond-xtpd7  diamond
 ├─✔ A                echo      dag-diamond-xtpd7-echo-3871903043  3s
 ├─✔ B                echo      dag-diamond-xtpd7-echo-3888680662  3s
 ├─✔ C                echo      dag-diamond-xtpd7-echo-3905458281  3s
 └─✔ D                echo      dag-diamond-xtpd7-echo-3922235900  3s
```

Signed-off-by: J.P. Zivalich <jp@pipekit.io>

