### PR TITLE
feat: support gcs deletion capability #3102

### DIFF
--- a/workflow/artifacts/artifactory/artifactory.go
+++ b/workflow/artifacts/artifactory/artifactory.go
@@ -80,3 +80,7 @@ func (a *ArtifactDriver) Save(path string, artifact *wfv1.Artifact) error {
 func (a *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, error) {
 	return nil, fmt.Errorf("ListObjects is currently not supported for this artifact type, but it will be in a future version")
 }
+
+func (a *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	return fmt.Errorf("Delete is not currently supported for this artifact type but it will be in a future version")
+}

--- a/workflow/artifacts/common/common.go
+++ b/workflow/artifacts/common/common.go
@@ -10,5 +10,7 @@ type ArtifactDriver interface {
 	// Save uploads the path to artifact destination
 	Save(path string, outputArtifact *v1alpha1.Artifact) error
 
+	Delete(artifact *v1alpha1.Artifact) error
+
 	ListObjects(artifact *v1alpha1.Artifact) ([]string, error)
 }

--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -208,6 +208,9 @@ func deleteObjects(client *storage.Client, bucket, key string) error {
 	}
 	for _, objName := range objNames {
 		err = deleteObject(client, bucket, objName)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -220,3 +220,7 @@ func (g *ArtifactDriver) error(err error, cmd *exec.Cmd) error {
 func (g *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, error) {
 	return nil, fmt.Errorf("ListObjects is currently not supported for this artifact type, but it will be in a future version")
 }
+
+func (g *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	return fmt.Errorf("Delete is currently not supported for this artifact type, but it will be in a future version")
+}

--- a/workflow/artifacts/hdfs/hdfs.go
+++ b/workflow/artifacts/hdfs/hdfs.go
@@ -231,3 +231,7 @@ func (driver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact) e
 func (driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, error) {
 	return nil, fmt.Errorf("ListObjects is currently not supported for this artifact type, but it will be in a future version")
 }
+
+func (driver *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	return fmt.Errorf("Delete is not currently supported for this artifact type but will be in a future version")
+}

--- a/workflow/artifacts/http/http.go
+++ b/workflow/artifacts/http/http.go
@@ -51,3 +51,7 @@ func (h *ArtifactDriver) Save(string, *wfv1.Artifact) error {
 func (h *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, error) {
 	return nil, fmt.Errorf("ListObjects is currently not supported for this artifact type, but it will be in a future version")
 }
+
+func (h *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	return fmt.Errorf("Delete is currently not supported for this artifact type, but will be in a future version")
+}

--- a/workflow/artifacts/oss/oss.go
+++ b/workflow/artifacts/oss/oss.go
@@ -179,6 +179,10 @@ func (ossDriver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string,
 	return files, err
 }
 
+func (ossDriver *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	return fmt.Errorf("Delete is currently not supported for this artifact type, but will be in a future version")
+}
+
 func setBucketLogging(client *oss.Client, bucketName string) error {
 	if os.Getenv(wfcommon.EnvVarArgoTrace) == "1" {
 		err := client.SetBucketLogging(bucketName, bucketName, bucketLogFilePrefix, true)

--- a/workflow/artifacts/raw/raw.go
+++ b/workflow/artifacts/raw/raw.go
@@ -35,3 +35,8 @@ func (g *ArtifactDriver) Save(string, *wfv1.Artifact) error {
 func (a *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, error) {
 	return nil, fmt.Errorf("ListObjects is currently not supported for this artifact type, but it will be in a future version")
 }
+
+func (a *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	// it is impossible to delete this resource
+	return nil
+}

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -173,3 +173,7 @@ func (s3Driver *ArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, 
 
 	return files, err
 }
+
+func (s3Driver *ArtifactDriver) Delete(artifact *wfv1.Artifact) error {
+	return fmt.Errorf("Delete is not currently supported for this artifact type but it will be in a future version")
+}


### PR DESCRIPTION
Signed-off-by: Isitha Subasinghe <isitha@pipekit.io>

Adds support for deletion of GCS objects. Addresses #3102. Will add deletion capability to other drivers in later PRs. 
Tested with https://github.com/fsouza/fake-gcs-server but tests were removed prior to PR creation since this test would mean a dependency on "fake-gcs-server"
