### PR TITLE
chore: Revert "chore(deps): bump peaceiris/actions-gh-pages from 2.5.0 to 3.8.0 (#7642)"

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: pip install mkdocs==1.0.4 mkdocs_material==4.1.1
       - run: mkdocs build
       - run: make parse-examples
-      - uses: peaceiris/actions-gh-pages@v3.8.0
+      - uses: peaceiris/actions-gh-pages@v2.5.0
         env:
           PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
           PUBLISH_BRANCH: gh-pages


### PR DESCRIPTION
This reverts commit 17342bacc991c1eb9cce5639c857936d3ab8c5c9 as it breaks the pages deployment: https://github.com/argoproj/argo-workflows/runs/4954762195?check_suite_focus=true

The error is ` Error: Action failed with "not found deploy key or tokens"`, which needs to be looked into separately. My guess is the existing way that configured the personal token is not compatible with the new version.
