### PR TITLE
fix: Pod "START TIME"/ "END TIME" tooltip shows time in UTC and local…

### DIFF
--- a/ui/src/app/shared/components/timestamp.tsx
+++ b/ui/src/app/shared/components/timestamp.tsx
@@ -3,12 +3,15 @@ import * as React from 'react';
 import {ago} from '../duration';
 
 export const Timestamp = ({date}: {date: Date | string | number}) => {
+    const tooltip = (utc: Date | string | number) => {
+        return utc.toString() + '\n' + new Date(utc.toString()).toLocaleString();
+    };
     return (
         <span>
             {date === null || date === undefined ? (
                 '-'
             ) : (
-                <span title={date.toString()}>
+                <span title={tooltip(date)}>
                     <Ticker intervalMs={1000}>{() => ago(new Date(date))}</Ticker>
                 </span>
             )}


### PR DESCRIPTION
… timezone Fixes #7488

Signed-off-by: Tino Schroeter <tino.schroeter@gmail.com>

This will close [#7488](https://github.com/argoproj/argo-workflows/issues/7488)

> Tooltip will now show both, utc and local timezone...

[x] Run make pre-commit -B to fix codegen, lint, and commit message problems.

```diff
diff /ui/src/app/shared/components/timestamp.tsx
 export const Timestamp = ({date}: {date: Date | string | number}) => {
+    const tooltip = (utc: Date | string | number) => {
+        return utc.toString() + '\n' + new Date(utc.toString()).toLocaleString();
+    };
     return (
         <span>
             {date === null || date === undefined ? (
                 '-'
             ) : (
-                <span title={date.toString()}>
+                <span title={tooltip(date)}>
                     <Ticker intervalMs={1000}>{() => ago(new Date(date))}</Ticker>
                 </span>
             )}
```

## UI Example: 

timezone: Germany
![argoWorkflowDe](https://user-images.githubusercontent.com/2047016/151676650-1bc6d633-31a9-487d-aefc-5263e20ea642.png)

timezone: US 
![argoWorkflowUs](https://user-images.githubusercontent.com/2047016/151676659-0425bfde-0297-4f0e-b937-b82ac0a1df00.png)


old version
![oldVersion](https://user-images.githubusercontent.com/2837437/147958693-4e480149-930c-4647-81eb-5ccfe745298e.png)