### PR TITLE
feat: Workflow/WorkflowTemplate/CronWorkflow write operation audit log

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-workflows/v3/server/auth"
 	argoutil "github.com/argoproj/argo-workflows/v3/util"
+	"github.com/argoproj/argo-workflows/v3/util/audit"
 	"github.com/argoproj/argo-workflows/v3/util/fields"
 	"github.com/argoproj/argo-workflows/v3/util/instanceid"
 	"github.com/argoproj/argo-workflows/v3/util/logs"
@@ -86,6 +87,7 @@ func (s *workflowServer) CreateWorkflow(ctx context.Context, req *workflowpkg.Wo
 		return nil, err
 	}
 
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditCreate)
 	return wf, nil
 }
 
@@ -302,6 +304,7 @@ func (s *workflowServer) DeleteWorkflow(ctx context.Context, req *workflowpkg.Wo
 	if err != nil {
 		return nil, err
 	}
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditDelete)
 	return &workflowpkg.WorkflowDeleteResponse{}, nil
 }
 
@@ -323,6 +326,8 @@ func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.Wor
 	if err != nil {
 		return nil, err
 	}
+
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditRetry)
 	return wf, nil
 }
 
@@ -347,6 +352,8 @@ func (s *workflowServer) ResubmitWorkflow(ctx context.Context, req *workflowpkg.
 	if err != nil {
 		return nil, err
 	}
+
+	audit.LogWorkflowAudit(ctx, created, audit.WorkflowAuditResubmit)
 	return created, nil
 }
 
@@ -373,6 +380,7 @@ func (s *workflowServer) ResumeWorkflow(ctx context.Context, req *workflowpkg.Wo
 		return nil, err
 	}
 
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditResume)
 	return wf, nil
 }
 
@@ -399,6 +407,7 @@ func (s *workflowServer) SuspendWorkflow(ctx context.Context, req *workflowpkg.W
 		return nil, err
 	}
 
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditSuspend)
 	return wf, nil
 }
 
@@ -424,6 +433,8 @@ func (s *workflowServer) TerminateWorkflow(ctx context.Context, req *workflowpkg
 	if err != nil {
 		return nil, err
 	}
+
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditTerminate)
 	return wf, nil
 }
 
@@ -446,6 +457,8 @@ func (s *workflowServer) StopWorkflow(ctx context.Context, req *workflowpkg.Work
 	if err != nil {
 		return nil, err
 	}
+
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditStop)
 	return wf, nil
 }
 
@@ -491,6 +504,8 @@ func (s *workflowServer) SetWorkflow(ctx context.Context, req *workflowpkg.Workf
 	if err != nil {
 		return nil, err
 	}
+
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditSet)
 	return wf, nil
 }
 
@@ -613,5 +628,11 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 	if err != nil {
 		return nil, err
 	}
-	return wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+
+	if wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{}); err != nil {
+		return nil, err
+	}
+
+	audit.LogWorkflowAudit(ctx, wf, audit.WorkflowAuditSubmit)
+	return wf, nil
 }

--- a/util/audit/audit.go
+++ b/util/audit/audit.go
@@ -1,0 +1,75 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
+	"github.com/argoproj/argo-workflows/v3/workflow/creator"
+)
+
+type WorkflowAudit string
+
+const (
+	WorkflowAuditCreate    WorkflowAudit = "Create"
+	WorkflowAuditDelete    WorkflowAudit = "Delete"
+	WorkflowAuditRetry     WorkflowAudit = "Retry"
+	WorkflowAuditResubmit  WorkflowAudit = "Resubmit"
+	WorkflowAuditResume    WorkflowAudit = "Resume"
+	WorkflowAuditSuspend   WorkflowAudit = "Suspend"
+	WorkflowAuditTerminate WorkflowAudit = "Terminate"
+	WorkflowAuditStop      WorkflowAudit = "Stop"
+	WorkflowAuditSet       WorkflowAudit = "Set"
+	WorkflowAuditSubmit    WorkflowAudit = "Submit"
+)
+
+func LogWorkflowAudit(ctx context.Context, wf *wfv1.Workflow, wa WorkflowAudit) {
+	fields := log.Fields{
+		"name":             wf.Name,
+		"namespace":        wf.Namespace,
+		"phase":            wf.Labels[common.LabelKeyPhase],
+		"workflowTemplate": wf.Labels[common.LabelKeyWorkflowTemplate],
+		"cronWorkflow":     wf.Labels[common.LabelKeyCronWorkflow],
+	}
+	creator.LogFields(ctx, fields)
+	log.WithFields(fields).Info(fmt.Sprintf("Workflow %s", wa))
+}
+
+type WorkflowTemplateAudit string
+
+const (
+	WorkflowTemplateAuditCreate WorkflowTemplateAudit = "Create"
+	WorkflowTemplateAuditDelete WorkflowTemplateAudit = "Delete"
+	WorkflowTemplateAuditUpdate WorkflowTemplateAudit = "Update"
+)
+
+func LogWorkflowTemplateAudit(ctx context.Context, wfTmpl *wfv1.WorkflowTemplate, wta WorkflowTemplateAudit) {
+	fields := log.Fields{
+		"name":      wfTmpl.Name,
+		"namespace": wfTmpl.Namespace,
+	}
+	creator.LogFields(ctx, fields)
+	log.WithFields(fields).Info(fmt.Sprintf("WorkflowTemplate %s", wta))
+}
+
+type CronWorkflowAudit string
+
+const (
+	CronWorkflowAuditCreate  CronWorkflowAudit = "Create"
+	CronWorkflowAuditDelete  CronWorkflowAudit = "Delete"
+	CronWorkflowAuditUpdate  CronWorkflowAudit = "Update"
+	CronWorkflowAuditResume  CronWorkflowAudit = "Resume"
+	CronWorkflowAuditSuspend CronWorkflowAudit = "Suspend"
+)
+
+func LogCronWorkflowAudit(ctx context.Context, cwf *wfv1.CronWorkflow, cwa CronWorkflowAudit) {
+	fields := log.Fields{
+		"name":      cwf.Name,
+		"namespace": cwf.Namespace,
+	}
+	creator.LogFields(ctx, fields)
+	log.WithFields(fields).Info(fmt.Sprintf("CronWorkflow %s", cwa))
+}

--- a/workflow/creator/creator.go
+++ b/workflow/creator/creator.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/server/auth"
@@ -21,6 +22,19 @@ func Label(ctx context.Context, obj metav1.Object) {
 		}
 		if claims.PreferredUsername != "" {
 			labels.Label(obj, common.LabelKeyCreatorPreferredUsername, dnsFriendly(claims.PreferredUsername))
+		}
+	}
+}
+
+func LogFields(ctx context.Context, fields log.Fields) {
+	claims := auth.GetClaims(ctx)
+	if claims != nil {
+		fields["creator"] = claims.Subject
+		if claims.Email != "" {
+			fields["creatorEmail"] = claims.Email
+		}
+		if claims.PreferredUsername != "" {
+			fields["creatorPreferredUsername"] = claims.PreferredUsername
 		}
 	}
 }

--- a/workflow/creator/creator_test.go
+++ b/workflow/creator/creator_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/square/go-jose.v2/jwt"
 
@@ -50,6 +51,24 @@ func TestLabel(t *testing.T) {
 		Label(context.WithValue(context.TODO(), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: sub}}), wf)
 		if assert.NotEmpty(t, wf.Labels) {
 			assert.Equal(t, strings.Repeat("x", 20), wf.Labels[common.LabelKeyCreator])
+		}
+	})
+}
+
+func TestLogFields(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		fields := log.Fields{}
+		LogFields(context.TODO(), fields)
+		assert.Empty(t, fields)
+	})
+	t.Run("NotEmpty", func(t *testing.T) {
+		fields := log.Fields{}
+		claims := &types.Claims{Claims: jwt.Claims{Subject: strings.Repeat("x", 63) + "y"}, Email: "my@email", PreferredUsername: "username"}
+		LogFields(context.WithValue(context.TODO(), auth.ClaimsKey, claims), fields)
+		if assert.NotEmpty(t, fields) {
+			assert.Equal(t, strings.Repeat("x", 63)+"y", fields["creator"])
+			assert.Equal(t, "my@email", fields["creatorEmail"])
+			assert.Equal(t, "username", fields["creatorPreferredUsername"])
 		}
 	})
 }


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

ref https://github.com/argoproj/argo-workflows/issues/4271

- Add util/audit package which support audit logger
- Implement WRITE operation server audit info log for Workflow/WorkflowTemplate/CronWorkflow which includes who do it.

example info logs like followings.

```sh
argo-server | time="2022-01-30T20:40:07.267Z" level=info msg="CronWorkflow Resume" name=my-cronworkflow-template-1 namespace=argo
argo-server | time="2022-01-30T20:40:07.866Z" level=info msg="CronWorkflow Suspend" name=my-cronworkflow-template-1 namespace=argo
argo-server | time="2022-01-30T20:40:19.198Z" level=info msg="Workflow Submit" cronWorkflow= name=jsonlog-wcgdk namespace=argo phase= workflowTemplate=jsonlog
argo-server | time="2022-01-30T20:40:22.413Z" level=info msg="Workflow Terminate" cronWorkflow= name=jsonlog-wcgdk namespace=argo phase=Running workflowTemplate=jsonlog
```
