### PR TITLE
fix: Fix argo lint panic when missing param value in DAG task. Fixes #7701

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -1326,6 +1326,9 @@ func validateDAGTaskArgumentDependency(arguments wfv1.Arguments, ancestry []stri
 	}
 
 	for _, param := range arguments.Parameters {
+		if param.Value == nil {
+			return errors.Errorf(errors.CodeBadRequest, "missing value for parameter '%s'", param.Name)
+		}
 		if strings.HasPrefix(param.Value.String(), "{{tasks.") {
 			// All parameter values should have been validated, so
 			// index 1 should exist.

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -1033,3 +1033,42 @@ func TestDAGOutputsResolveTaskAggregatedOutputs(t *testing.T) {
 	_, err := validate(dagOutputsResolveTaskAggregatedOutputs)
 	assert.NoError(t, err)
 }
+
+var dagMissingParamValueInTask = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+spec:
+  entrypoint: root
+  templates:
+    - name: template
+      inputs:
+        parameters:
+          - name: data
+      container:
+        name: main
+        image: alpine
+    - name: root
+      inputs:
+        parameters:
+          - name: anything_param
+      dag:
+        tasks:
+          - name: task
+            template: template
+            arguments:
+              parameters:
+                - name: data
+                  valueFrom:
+                    parameter: "{{inputs.parameters.anything_param}}"
+  arguments:
+    parameters:
+      - name: anything_param
+        value: anything_param
+`
+
+func TestDAGMissingParamValueInTask(t *testing.T) {
+	_, err := validate(dagMissingParamValueInTask)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "templates.root.tasks.task missing value for parameter 'data'")
+	}
+}


### PR DESCRIPTION
Fixes #7701.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
