### PR TITLE
docs: Correct the use of _check_return_type in Python SDK examples

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -46,7 +46,8 @@ api_client = argo_workflows.ApiClient(configuration)
 api_instance = workflow_service_api.WorkflowServiceApi(api_client)
 api_response = api_instance.create_workflow(
     namespace="argo",
-    body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest, _check_return_type=False, _check_type=False))
+    body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest, _check_type=False),
+    _check_return_type=False)
 pprint(api_response)
 
 ```
@@ -89,7 +90,8 @@ api_instance = workflow_service_api.WorkflowServiceApi(api_client)
 if __name__ == '__main__':
     api_response = api_instance.create_workflow(
         namespace='argo',
-        body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest, _check_return_type=False))
+        body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest),
+        _check_return_type=False)
     pprint(api_response)
 
 ```

--- a/sdks/python/examples/hello-world-from-object.py
+++ b/sdks/python/examples/hello-world-from-object.py
@@ -28,5 +28,6 @@ api_client = argo_workflows.ApiClient(configuration)
 api_instance = workflow_service_api.WorkflowServiceApi(api_client=api_client)
 api_response = api_instance.create_workflow(
     namespace='argo',
-    body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest, _check_return_type=False))
+    body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest),
+    _check_return_type=False)
 pprint(api_response)

--- a/sdks/python/examples/hello-world-from-raw-yaml.py
+++ b/sdks/python/examples/hello-world-from-raw-yaml.py
@@ -17,5 +17,6 @@ api_client = argo_workflows.ApiClient(configuration)
 api_instance = workflow_service_api.WorkflowServiceApi(api_client)
 api_response = api_instance.create_workflow(
     namespace='argo',
-    body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest, _check_return_type=False, _check_type=False))
+    body=IoArgoprojWorkflowV1alpha1WorkflowCreateRequest(workflow=manifest, _check_type=False),
+    _check_return_type=False)
 pprint(api_response)


### PR DESCRIPTION
See https://github.com/argoproj/argo-workflows/issues/7293#issuecomment-1024731592. 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
