### PR TITLE
feat: add claims.Email into gatekeeper audit log entry

### DIFF
--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -310,7 +310,7 @@ func (s *gatekeeper) rbacAuthorization(claims *types.Claims, req interface{}) (*
 		}
 	}
 	// important! write an audit entry (i.e. log entry) so we know which user performed an operation
-	log.WithFields(log.Fields{"serviceAccount": delegatedAccount.Name, "loginServiceAccount": loginAccount.Name, "subject": claims.Subject, "ssoDelegationAllowed": ssoDelegationAllowed, "ssoDelegated": ssoDelegated}).Info("selected SSO RBAC service account for user")
+	log.WithFields(log.Fields{"serviceAccount": delegatedAccount.Name, "loginServiceAccount": loginAccount.Name, "subject": claims.Subject, "email": claims.Email, "ssoDelegationAllowed": ssoDelegationAllowed, "ssoDelegated": ssoDelegated}).Info("selected SSO RBAC service account for user")
 	return s.getClientsForServiceAccount(claims, delegatedAccount)
 }
 


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

# Motivation

ref https://github.com/argoproj/argo-workflows/issues/4271

I want to know who call api. 

Currently gatekeeper SSO log has audit feature, but there is no `Email` information. If not, it is difficult to figure out who call api.

In this PR, I add `claims.Email` into gatekeeper audit log like a following.

```
argo-server | time="2022-02-04T22:44:08.800Z" level=info msg="selected SSO RBAC service account for user" email=kilgore@kilgore.trout loginServiceAccount=argo-server serviceAccount=argo-server ssoDelegated=false ssoDelegationAllowed=false subject=Cg0wLTM4NS0yODA4OS0wEgRtb2Nr
```