### PR TITLE
feat: submit workflow form parameter uses textarea input

### DIFF
--- a/ui/src/app/cluster-workflow-templates/components/cluster-workflow-template-details/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/components/cluster-workflow-template-details/cluster-workflow-template-details.tsx
@@ -123,7 +123,7 @@ export const ClusterWorkflowTemplateDetails = ({history, location, match}: Route
                 )}
             </>
             {template && (
-                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isNarrow={true}>
+                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isMiddle={true}>
                     <SubmitWorkflowPanel
                         kind='ClusterWorkflowTemplate'
                         namespace={namespace}

--- a/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/components/workflow-template-details/workflow-template-details.tsx
@@ -120,7 +120,7 @@ export const WorkflowTemplateDetails = ({history, location, match}: RouteCompone
                 {!template ? <Loading /> : <WorkflowTemplateEditor template={template} onChange={setTemplate} onError={setError} onTabSelected={setTab} selectedTabKey={tab} />}
             </>
             {template && (
-                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isNarrow={sidePanel === 'submit'}>
+                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isMiddle={sidePanel === 'submit'}>
                     {sidePanel === 'submit' && (
                         <SubmitWorkflowPanel
                             kind='WorkflowTemplate'

--- a/ui/src/app/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/submit-workflow-panel.tsx
@@ -147,7 +147,7 @@ export class SubmitWorkflowPanel extends React.Component<Props, State> {
 
     private displayInputFieldForSingleValue(parameter: Parameter) {
         return (
-            <input
+            <textarea
                 className='argo-field'
                 value={this.getValue(parameter)}
                 onChange={event => {

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -69,7 +69,9 @@ interface Props {
 const AttributeRow = (attr: {title: string; value: any}) => (
     <div className='row white-box__details-row' key={attr.title}>
         <div className='columns small-4'>{attr.title}</div>
-        <div className='columns columns--narrower-height small-8'>{attr.value}</div>
+        <div className='columns columns--narrower-height small-8' style={{whiteSpace: 'pre'}}>
+            {attr.value}
+        </div>
     </div>
 );
 const AttributeRows = (props: {attributes: {title: string; value: any}[]}) => (


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

Don't bother creating a PR until you've done this:

* [x] Run `make pre-commit -B` to fix codegen, lint, and commit message problems.

# Motivation

I want to input multiline parameter into Submit Workflow form.

# Features

- ~~Add `inputType: string` field into parameter~~
  - ~~Currently this field accept 'textarea' only. It would be used for `date`, `checkbox`, and so on.~~
  - based on https://github.com/argoproj/argo-workflows/pull/7768#discussion_r800222295, this feature is discarded.
- Change single value parameter form with `textarea`
- Increase submit workflow panel width.

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/915731/152890123-438f6399-a3cd-49cb-9fe2-61952fe917ff.png">

<img width="585" alt="image" src="https://user-images.githubusercontent.com/915731/152890144-7a67b0d4-cdac-4cb7-af7a-ea46b2cc0b9a.png">


close https://github.com/argoproj/argo-workflows/issues/7696
