### PR TITLE
fix: Add nil-check in LintWorkflow

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -495,6 +495,9 @@ func (s *workflowServer) SetWorkflow(ctx context.Context, req *workflowpkg.Workf
 }
 
 func (s *workflowServer) LintWorkflow(ctx context.Context, req *workflowpkg.WorkflowLintRequest) (*wfv1.Workflow, error) {
+	if req.Workflow == nil {
+		return nil, fmt.Errorf("unable to get a workflow")
+	}
 	wfClient := auth.GetWfClient(ctx)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43808&q=argo&can=1

The crash occurs because `req.Workflow` is `nil`:
https://github.com/argoproj/argo-workflows/blob/0e80356f06bf3e2d29b1c12bd1ed2412bc9ee211/server/workflow/workflow_server.go#L497-L501

`nil` is passed to:

https://github.com/argoproj/argo-workflows/blob/0e80356f06bf3e2d29b1c12bd1ed2412bc9ee211/util/instanceid/service.go#L31-L37

... where it is then passed to:

https://github.com/argoproj/argo-workflows/blob/0e80356f06bf3e2d29b1c12bd1ed2412bc9ee211/util/labels/labeler.go#L8-L13

... where it fails when `obj.GetLabels()` is called.

This PR adds an early check for `req.Workflow`.