### PR TITLE
fix: submitting Workflow from WorkflowTemplate will set correct serviceAccount and securityContext. Fixes #7726

### DIFF
--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -125,7 +125,7 @@ func printWorkflowHelper(wf *wfv1.Workflow, getArgs getFlags) string {
 		// also isn't set, we will use the 'default' ServiceAccount in the namespace
 		// the workflow will run in.
 		if wf.Spec.WorkflowTemplateRef != nil {
-			serviceAccount = "unset (will run with referred workflow/cluster template ServiceAccount)"
+			serviceAccount = "unset"
 		} else {
 			serviceAccount = "unset (will run with the default ServiceAccount)"
 		}
@@ -157,9 +157,9 @@ func printWorkflowHelper(wf *wfv1.Workflow, getArgs getFlags) string {
 	if !wf.Status.ResourcesDuration.IsZero() {
 		out += fmt.Sprintf(fmtStr, "ResourcesDuration:", wf.Status.ResourcesDuration)
 	}
-	if len(wf.Spec.Arguments.Parameters) > 0 {
+	if len(wf.GetExecSpec().Arguments.Parameters) > 0 {
 		out += fmt.Sprintf(fmtStr, "Parameters:", "")
-		for _, param := range wf.Spec.Arguments.Parameters {
+		for _, param := range wf.GetExecSpec().Arguments.Parameters {
 			if param.Value == nil {
 				continue
 			}

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -118,13 +118,17 @@ func printWorkflowHelper(wf *wfv1.Workflow, getArgs getFlags) string {
 	out := ""
 	out += fmt.Sprintf(fmtStr, "Name:", wf.ObjectMeta.Name)
 	out += fmt.Sprintf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)
-	serviceAccount := wf.Spec.ServiceAccountName
+	serviceAccount := wf.GetExecSpec().ServiceAccountName
 	if serviceAccount == "" {
 		// if serviceAccountName was not specified in a submitted Workflow, we will
 		// use the serviceAccountName provided in Workflow Defaults (if any). If that
 		// also isn't set, we will use the 'default' ServiceAccount in the namespace
 		// the workflow will run in.
-		serviceAccount = "unset (will run with the default ServiceAccount)"
+		if wf.Spec.WorkflowTemplateRef != nil {
+			serviceAccount = "unset (will run with referred workflow/cluster template ServiceAccount)"
+		} else {
+			serviceAccount = "unset (will run with the default ServiceAccount)"
+		}
 	}
 	out += fmt.Sprintf(fmtStr, "ServiceAccount:", serviceAccount)
 	out += fmt.Sprintf(fmtStr, "Status:", printer.WorkflowStatus(wf))

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -173,6 +173,13 @@ func (w *Workflow) GetTTLStrategy() *TTLStrategy {
 	return ttlStrategy
 }
 
+func (w *Workflow) GetExecSpec() *WorkflowSpec {
+	if w.Status.StoredWorkflowSpec != nil {
+		return w.Status.StoredWorkflowSpec
+	}
+	return &w.Spec
+}
+
 var (
 	WorkflowCreatedAfter = func(t time.Time) WorkflowPredicate {
 		return func(wf Workflow) bool {

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -1132,4 +1132,8 @@ func TestGetExecSpec(t *testing.T) {
 	}
 
 	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "spec-template")
+
+	wf.Status.StoredWorkflowSpec = nil
+
+	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "spec-template")
 }

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -1096,3 +1096,40 @@ func TestStepSpecGetExitHook(t *testing.T) {
 	hooks = step.GetExitHook(step.Arguments)
 	assert.Equal(t, "hook", hooks.Template)
 }
+
+func TestGetExecSpec(t *testing.T) {
+	wf := Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: WorkflowSpec{
+			Templates: []Template{
+				{Name: "spec-template"},
+			},
+		},
+		Status: WorkflowStatus{
+			StoredWorkflowSpec: &WorkflowSpec{
+				Templates: []Template{
+					{Name: "stored-spec-template"},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "stored-spec-template")
+
+	wf = Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: WorkflowSpec{
+			Templates: []Template{
+				{Name: "spec-template"},
+			},
+		},
+	}
+
+	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "spec-template")
+}

--- a/util/printer/workflow-printer.go
+++ b/util/printer/workflow-printer.go
@@ -114,7 +114,7 @@ func printCostOptimizationNudges(wfList []wfv1.Workflow, out io.Writer) {
 
 // PrintSecurityNudges prints security nudges for single workflow
 func PrintSecurityNudges(wf wfv1.Workflow, out io.Writer) {
-	if wf.Spec.SecurityContext == nil {
+	if wf.GetExecSpec().SecurityContext == nil {
 		_, _ = fmt.Fprintln(out, "\nThis workflow does not have security context set. "+
 			"You can run your workflow pods more securely by setting it.")
 		_, _ = fmt.Fprintln(out, "Learn more at https://argoproj.github.io/argo-workflows/workflow-pod-security-context/")


### PR DESCRIPTION
fixes #7726 

Previously if a user started a Workflow from a WorkflowTemplate using the CLI, the serviceAccount and securityContext was not set based upon the StoredWorkflowSpec like is expected. Now, when serviceAccount and securityContext are checked for in `get.go`, `GetExecSpec()` is run to check if `wf.Status.StoredWorkflowSpec` is set or not. If so, it will reference this spec instead as expected.

Example WorkflowTemplate:

```
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: my-workflow-template-test
  namespace: argo
spec:
  entrypoint: main
  securityContext:
    runAsNonRoot: false
  serviceAccountName: argo
  templates:
    - name: main
      metadata:
      container:
        command:
          - bash
          - -c
          - echo 'Hello from WT'; env; sleep 15
        image: ubuntu
        name: main
```

Submitting through CLI:
```
dist/argo submit --from workflowtemplate/my-workflow-template-test --watch
```

Output:
```
Name:                my-workflow-template-test-5ppq9
Namespace:           argo
ServiceAccount:      argo
Status:              Succeeded
Conditions:          
 PodRunning          False
 Completed           True
Created:             Mon Feb 07 15:18:53 -0800 (20 seconds ago)
Started:             Mon Feb 07 15:18:53 -0800 (20 seconds ago)
Finished:            Mon Feb 07 15:19:13 -0800 (now)
Duration:            20 seconds
Progress:            1/1
ResourcesDuration:   32s*(1 cpu),25s*(100Mi memory)

STEP                                TEMPLATE  PODNAME                          DURATION  MESSAGE
 ✔ my-workflow-template-test-5ppq9  main      my-workflow-template-test-5ppq9  19s 
```