### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestEmissary(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
+	tmp := t.TempDir()
 
 	varRunArgo = tmp
 	includeScriptOutput = true

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -28,11 +28,10 @@ func TestGitArtifactDriverLoad_HTTPS(t *testing.T) {
 			t.Skip("not running an GITHUB_TOKEN not set")
 		}
 		_ = os.Remove("git-ask-pass.sh")
-		tmp, err := ioutil.TempDir("", "")
-		assert.NoError(t, err)
+		tmp := t.TempDir()
 		driver := &ArtifactDriver{Username: os.Getenv("GITHUB_TOKEN")}
 		assert.NotEmpty(t, driver.Username)
-		err = driver.Load(&wfv1.Artifact{
+		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{
 				Git: &wfv1.GitArtifact{
 					Repo:     tt.url,
@@ -67,8 +66,7 @@ func TestGitArtifactDriverLoad_SSL(t *testing.T) {
 				t.Skip(key + " does not exist")
 			}
 			assert.NoError(t, err)
-			tmp, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
+			tmp := t.TempDir()
 			println(tmp)
 			driver := &ArtifactDriver{SSHPrivateKey: string(data)}
 			err = driver.Load(&wfv1.Artifact{

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -264,12 +264,7 @@ func TestLoadS3Artifact(t *testing.T) {
 }
 
 func TestSaveS3Artifact(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		panic(err)
-	}
-
-	defer os.RemoveAll(tempDir) // clean up
+	tempDir := t.TempDir()
 
 	tempFile := filepath.Join(tempDir, "tmpfile")
 	if err := ioutil.WriteFile(tempFile, []byte("temporary file's content"), 0o600); err != nil {

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -306,14 +306,10 @@ func TestChmod(t *testing.T) {
 
 	for _, test := range tests {
 		// Setup directory and file for testing
-		tempDir, err := ioutil.TempDir("testdata", "chmod-dir-test")
-		assert.NoError(t, err)
+		tempDir := t.TempDir()
 
 		tempFile, err := ioutil.TempFile(tempDir, "chmod-file-test")
 		assert.NoError(t, err)
-
-		// TearDown test by removing directory and file
-		defer os.RemoveAll(tempDir)
 
 		// Run chmod function
 		err = chmod(tempDir, test.mode, test.recurse)

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -94,11 +94,7 @@ func TestReadFromSingleorMultiplePath(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", name)
-			if err != nil {
-				t.Error("Could not create temporary directory")
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 			var filePaths []string
 			for i := range tc.fileNames {
 				content := []byte(tc.contents[i])
@@ -145,11 +141,7 @@ func TestReadFromSingleorMultiplePathErrorHandling(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", name)
-			if err != nil {
-				t.Error("Could not create temporary directory")
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 			var filePaths []string
 			for i := range tc.fileNames {
 				content := []byte(tc.contents[i])


### PR DESCRIPTION
A small enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->