### PR TITLE
fix: workflow-node-info long attribute message cannot be wrapped in the ui

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -69,7 +69,7 @@ interface Props {
 const AttributeRow = (attr: {title: string; value: any}) => (
     <div className='row white-box__details-row' key={attr.title}>
         <div className='columns small-4'>{attr.title}</div>
-        <div className='columns columns--narrower-height small-8' style={{whiteSpace: 'pre'}}>
+        <div className='columns columns--narrower-height small-8' style={{whiteSpace: 'pre-wrap'}}>
             {attr.value}
         </div>
     </div>


### PR DESCRIPTION
Signed-off-by: krrrr38 <k.kaizu38@gmail.com>

Fixes https://github.com/argoproj/argo-workflows/pull/7768/files#r805380145

https://github.com/argoproj/argo-workflows/pull/7768/files#r805380145 breaks long message ui. If message or input are too long, it should be wrapped.

- before: `pre`
  - <img width="1094" alt="image" src="https://user-images.githubusercontent.com/915731/153775764-225a57cc-dc92-4947-b02c-e517b1191b4a.png">
- after: `pre-wrap`
  - <img width="878" alt="image" src="https://user-images.githubusercontent.com/915731/153775771-607ad0b3-79dc-4036-9fd6-5b00f0d18dce.png">


