### PR TITLE
fix: Allow TLS secret configuration to be specified on the command line. Fixes #5582

### DIFF
--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -218,6 +218,7 @@ See %s`, help.ArgoServer),
 	command.Flags().StringVar(&baseHRef, "basehref", defaultBaseHRef, "Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. Defaults to the environment variable BASE_HREF.")
 	// "-e" for encrypt, like zip
 	command.Flags().BoolVarP(&secure, "secure", "e", true, "Whether or not we should listen on TLS.")
+	command.Flags().StringVar(&tlsCertificateSecretName, "tls-certificate-secret-name", "", "The name of a Kubernetes secret that contains the server certificates")
 	command.Flags().BoolVar(&htst, "hsts", true, "Whether or not we should add a HTTP Secure Transport Security header. This only has effect if secure is enabled.")
 	command.Flags().StringArrayVar(&authModes, "auth-mode", []string{"client"}, "API server authentication mode. Any 1 or more length permutation of: client,server,sso")
 	command.Flags().StringVar(&configMap, "configmap", "workflow-controller-configmap", "Name of K8s configmap to retrieve workflow controller configuration")

--- a/docs/cli/argo_server.md
+++ b/docs/cli/argo_server.md
@@ -31,6 +31,7 @@ See https://argoproj.github.io/argo-workflows/argo-server/
       --namespaced                           run as namespaced mode
   -p, --port int                             Port to listen on (default 2746)
       --sso-namespace string                 namespace that will be used for SSO RBAC. Defaults to installation namespace. Used only in namespaced mode
+      --tls-certificate-secret-name string   The name of a Kubernetes secret that contains the server certificates
       --x-frame-options string               Set X-Frame-Options header in HTTP responses. (default "DENY")
 ```
 

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/argoproj/argo-workflows/v3/util"

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -142,18 +142,20 @@ func GetServerTLSConfigFromSecret(ctx context.Context, kubectlConfig kubernetes.
 		return nil, err
 	}
 
+	// Join certpem and keypem into an X509KeyPair
 	cert, err := tls.X509KeyPair(certpem, keypem)
 	if err != nil {
 		return nil, err
 	}
 
+	// Pull the ca.crt from the Kubernetes secret
 	capem, err := util.GetSecrets(ctx, kubectlConfig, namespace, tlsKubernetesSecretName, tlsCaSecretKey)
 	if err != nil {
 		return nil, err
 	}
 
 	rootCAs, err := x509.SystemCertPool()
-	if rootCAs != nil {
+	if err != nil {
 		log.Warnf("failed to get system certificate pool: %v, continuing with empty certificate trust", err)
 		rootCAs = x509.NewCertPool()
 	}


### PR DESCRIPTION
Fixes #5582 

Additionally, secrets (particularly those from cert-manager) contain a `ca.crt` which is now added to the certificate trusts, meaning that the issue in #7632 should also be fixed properly, allowing privately signed certificates to be used by argo server.

<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->

I tested these changes by running `argo server` locally and confirming that when `ca.crt` is added to the TLSConfig as a trusted cert, the grpc-gateway endpoint `/api/v1/info` returns a valid response. The UI appears functional, etc.