### PR TITLE
fix: Fix broken Windows build

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -36,7 +36,7 @@ RUN mkdir C:\app && \
     curl -L -o C:\app\kubectl.exe "https://storage.googleapis.com/kubernetes-release/release/v%KUBECTL_VERSION%/bin/windows/amd64/kubectl.exe" && \
     curl -L -o C:\app\jq.exe "https://github.com/stedolan/jq/releases/download/jq-%JQ_VERSION%/jq-win64.exe"
 
-COPY --from=builder C:/ProgramData/chocolatey/lib/docker-cli/tools/docker.exe C:/app/docker.exe
+COPY --from=builder C:/ProgramData/chocolatey/lib/docker-cli/tools/docker/docker.exe C:/app/docker.exe
 COPY --from=builder C:/tools/git C:/app/git
 COPY --from=builder C:/ProgramData/chocolatey/lib/7zip.portable/tools/7z-extra/x64/7za.exe C:/app/7za.exe
 


### PR DESCRIPTION
Fixes #7931 

The newest chocolatey package for docker-cli v20.10.12 places the binary in a `docker` subdirectory.

<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->