### PR TITLE
Fixes# specify the cmd of influxdb

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1300,6 +1300,7 @@ spec:
       limit: 10                         # retry container if it fails
     container:
       image: influxdb:1.2
+      command: ["influxd"]
       readinessProbe:                   # wait for readinessProbe to succeed
         httpGet:
           path: /ping

--- a/examples/daemon-step.yaml
+++ b/examples/daemon-step.yaml
@@ -47,6 +47,7 @@ spec:
     daemon: true
     container:
       image: influxdb:1.2
+      command: ["influxd"]
       readinessProbe:
         httpGet:
           path: /ping


### PR DESCRIPTION
Fixes #example/daemon-step.yaml init problem
>   Warning  WorkflowNodeError    9m51s  workflow-controller  Error node daemon-step-zn9tk[0].influx(0): container "main" in template "influxdb", does not have the command specified: when using the emissary executor you must either explicitly specify the command, or list the image's command in the index: https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary

to fix this problem, I add the init cmd in template


<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->