### PR TITLE
fix: Report container, plugin and HTTP  progress. Fixes #7918

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ git-ask-pass.sh
 /go-diagrams/
 /.run/
 sdks/python/client/dist/*
+/cmd/argoexec/commands/test.txt

--- a/pkg/apis/workflow/v1alpha1/progress.go
+++ b/pkg/apis/workflow/v1alpha1/progress.go
@@ -9,6 +9,12 @@ import (
 // Progress in N/M format. N is number of task complete. M is number of tasks.
 type Progress string
 
+const (
+	ProgressUndefined = Progress("")
+	ProgressZero      = Progress("0/0") // zero value (not the same as "no progress)
+	ProgressDefault   = Progress("0/1")
+)
+
 func NewProgress(n, m int64) (Progress, bool) {
 	return ParseProgress(fmt.Sprintf("%v/%v", n, m))
 }

--- a/workflow/progress/updater.go
+++ b/workflow/progress/updater.go
@@ -10,7 +10,7 @@ import (
 // PodProgress reads the progress annotation of a pod and ensures it's valid and synced
 // with the node status.
 func PodProgress(pod *apiv1.Pod, node *wfv1.NodeStatus) wfv1.Progress {
-	progress := wfv1.Progress("0/1")
+	progress := wfv1.ProgressDefault
 	if node.Progress.IsValid() {
 		progress = node.Progress
 	}
@@ -21,37 +21,66 @@ func PodProgress(pod *apiv1.Pod, node *wfv1.NodeStatus) wfv1.Progress {
 			progress = v
 		}
 	}
-	if node.Fulfilled() {
-		progress = progress.Complete()
-	}
 	return progress
 }
 
 // UpdateProgress ensures the workflow's progress is updated with the individual node progress.
+// This func can perform any repair work needed
 func UpdateProgress(wf *wfv1.Workflow) {
-	wf.Status.Progress = "0/0"
-	for _, node := range wf.Status.Nodes {
-		if node.Type != wfv1.NodeTypePod && node.Type != wfv1.NodeTypeHTTP {
+	wf.Status.Progress = wfv1.ProgressZero
+	// We loop over all executable nodes first, otherwise sum will be wrong.
+	for nodeID, node := range wf.Status.Nodes {
+		if !executable(node.Type) {
 			continue
 		}
-		if node.Progress.IsValid() {
-			wf.Status.Progress = wf.Status.Progress.Add(node.Progress)
+		// all executable nodes should have progress defined, if not, we just set it to the default value.
+		if node.Progress == wfv1.ProgressUndefined {
+			node.Progress = wfv1.ProgressDefault
+			wf.Status.Nodes[nodeID] = node
 		}
+		// it could be possible for corruption to result in invalid progress, we just ignore invalid progress
+		if !node.Progress.IsValid() {
+			continue
+		}
+		// if the node has finished successfully, then we can just set progress complete
+		switch node.Phase {
+		case wfv1.NodeSucceeded, wfv1.NodeSkipped, wfv1.NodeOmitted:
+			node.Progress = node.Progress.Complete()
+			wf.Status.Nodes[nodeID] = node
+		}
+		// the total should only contain node that are valid
+		wf.Status.Progress = wf.Status.Progress.Add(node.Progress)
 	}
+	// For non-executable nodes, we sum up the children.
+	// It is quite possible for a succeeded node to contain failed children (e.g. continues-on failed flag is set)
+	// so it is possible for the sum progress to be "1/2" (for example)
 	for nodeID, node := range wf.Status.Nodes {
-		if node.Type == wfv1.NodeTypePod {
+		if executable(node.Type) {
 			continue
 		}
 		progress := sumProgress(wf, node, make(map[string]bool))
-		if progress.IsValid() && node.Progress != progress {
+		if progress.IsValid() {
 			node.Progress = progress
 			wf.Status.Nodes[nodeID] = node
 		}
 	}
+	// we could check an invariant here, wf.Status.Nodes[wf.Name].Progress == wf.Status.Progress, but I think there's
+	// always the chance that the nodes get corrupted, so I think we leave it
+}
+
+// executable states that the progress of this node type is updated by other code. It should not be summed.
+// It maybe that this type of node never gets progress.
+func executable(nodeType wfv1.NodeType) bool {
+	switch nodeType {
+	case wfv1.NodeTypePod, wfv1.NodeTypeHTTP, wfv1.NodeTypePlugin, wfv1.NodeTypeContainer, wfv1.NodeTypeSuspend:
+		return true
+	default:
+		return false
+	}
 }
 
 func sumProgress(wf *wfv1.Workflow, node wfv1.NodeStatus, visited map[string]bool) wfv1.Progress {
-	progress := wfv1.Progress("0/0")
+	progress := wfv1.ProgressZero
 	for _, childNodeID := range node.Children {
 		if visited[childNodeID] {
 			continue
@@ -60,7 +89,7 @@ func sumProgress(wf *wfv1.Workflow, node wfv1.NodeStatus, visited map[string]boo
 		// this will tolerate missing child (will be "") and therefore ignored
 		child := wf.Status.Nodes[childNodeID]
 		progress = progress.Add(sumProgress(wf, child, visited))
-		if child.Type == wfv1.NodeTypePod || child.Type == wfv1.NodeTypeHTTP {
+		if executable(child.Type) {
 			v := child.Progress
 			if v.IsValid() {
 				progress = progress.Add(v)


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>

Fixes #7918
Fixes #7925 

This PR also include what I think is a correction to behaviour. Previously failed/error nodes were considered complete. That seems incorrect to me. I think only succeded nodes should count.

<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->