### PR TITLE
feat!: Remove deprecated config flags. Fixes #7971

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,20 +25,8 @@ type Config struct {
 	// NodeEvents configures how node events are emitted
 	NodeEvents NodeEvents `json:"nodeEvents,omitempty"`
 
-	// ExecutorImage is the image name of the executor to use when running pods
-	// DEPRECATED: use --executor-image flag to workflow-controller instead
-	ExecutorImage string `json:"executorImage,omitempty"`
-
-	// ExecutorImagePullPolicy is the imagePullPolicy of the executor to use when running pods
-	// DEPRECATED: use `executor.imagePullPolicy` in configmap instead
-	ExecutorImagePullPolicy string `json:"executorImagePullPolicy,omitempty"`
-
 	// Executor holds container customizations for the executor to use when running pods
 	Executor *apiv1.Container `json:"executor,omitempty"`
-
-	// ExecutorResources specifies the resource requirements that will be used for the executor sidecar
-	// DEPRECATED: use `executor.resources` in configmap instead
-	ExecutorResources *apiv1.ResourceRequirements `json:"executorResources,omitempty"`
 
 	// MainContainer holds container customization for the main container
 	MainContainer *apiv1.Container `json:"mainContainer,omitempty"`
@@ -59,10 +47,6 @@ type Config struct {
 
 	// ArtifactRepository contains the default location of an artifact repository for container artifacts
 	ArtifactRepository wfv1.ArtifactRepository `json:"artifactRepository,omitempty"`
-
-	// Namespace is a label selector filter to limit the controller's watch to a specific namespace
-	// DEPRECATED: support will be remove in a future release
-	Namespace string `json:"namespace,omitempty"`
 
 	// InstanceID is a label selector to limit the controller's watch to a specific instance. It
 	// contains an arbitrary value that is carried forward into its pod labels, under the key
@@ -158,6 +142,13 @@ func (c Config) GetPodGCDeleteDelayDuration() time.Duration {
 	}
 
 	return c.PodGCDeleteDelayDuration.Duration
+}
+
+func (c Config) GetExecutor() *apiv1.Container {
+	if c.Executor != nil {
+		return c.Executor
+	}
+	return &apiv1.Container{}
 }
 
 // PodSpecLogStrategy contains the configuration for logging the pod spec in controller log for debugging purpose

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,6 +6,15 @@ the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summar
 
 ## Upgrading to v3.3
 
+### feat!: Remove deprecated config flags
+
+This PR removes the following options -
+
+- executorImage (use --executor-image flag to workflow-controller instead)
+- executorImagePullPolicy (use executor.imagePullPolicy in configmap instead)
+- executorResources (use executor.resources in configmap instead)
+- namespace
+
 ### [fce82d572](https://github.com/argoproj/argo-workflows/commit/fce82d5727b89cfe49e8e3568fff40725bd43734) feat: Remove pod workers (#7837)
 
 This PR removes pod workers from the code, the pod informer directly writes into the workflow queue. As a result the `--pod-workers` flag has been removed. 

--- a/workflow/controller/config_test.go
+++ b/workflow/controller/config_test.go
@@ -11,7 +11,7 @@ import (
 func TestUpdateConfig(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
-	err := controller.updateConfig(&config.Config{ExecutorImage: "argoexec:latest"})
+	err := controller.updateConfig(&config.Config{})
 	assert.NoError(t, err)
 	assert.NotNil(t, controller.Config)
 	assert.NotNil(t, controller.archiveLabelSelector)

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1115,7 +1115,7 @@ func (wfc *WorkflowController) GetManagedNamespace() string {
 	if wfc.managedNamespace != "" {
 		return wfc.managedNamespace
 	}
-	return wfc.Config.Namespace
+	return wfc.managedNamespace
 }
 
 func (wfc *WorkflowController) GetContainerRuntimeExecutor(labels labels.Labels) string {

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -140,7 +140,6 @@ func newController(options ...interface{}) (context.CancelFunc, *WorkflowControl
 	kube := fake.NewSimpleClientset()
 	wfc := &WorkflowController{
 		Config: config.Config{
-			ExecutorImage: "executor:latest",
 			Images: map[string]config.Image{
 				"my-image": {
 					Command: []string{"my-cmd"},

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -690,17 +690,8 @@ func (woc *wfOperationCtx) newExecContainer(name string, tmpl *wfv1.Template) *a
 		Image:           woc.controller.executorImage(),
 		ImagePullPolicy: woc.controller.executorImagePullPolicy(),
 		Env:             woc.createEnvVars(),
-	}
-	if woc.controller.Config.Executor != nil {
-		exec.Args = woc.controller.Config.Executor.Args
-		if woc.controller.Config.Executor.SecurityContext != nil {
-			exec.SecurityContext = woc.controller.Config.Executor.SecurityContext.DeepCopy()
-		}
-	}
-	if isResourcesSpecified(woc.controller.Config.Executor) {
-		exec.Resources = *woc.controller.Config.Executor.Resources.DeepCopy()
-	} else if woc.controller.Config.ExecutorResources != nil {
-		exec.Resources = *woc.controller.Config.ExecutorResources.DeepCopy()
+		Resources: woc.controller.Config.GetExecutor().Resources,
+		SecurityContext: woc.controller.Config.GetExecutor().SecurityContext,
 	}
 	if woc.controller.Config.KubeConfig != nil {
 		path := woc.controller.Config.KubeConfig.MountPath


### PR DESCRIPTION
Fixes #7971

This PR removes the following options -

- executorImage (use --executor-image flag to workflow-controller instead)
- executorImagePullPolicy (use executor.imagePullPolicy in configmap instead)
- executorResources (use executor.resources in configmap instead)
- namespace
<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->