### PR TITLE
ci: Auto-cancel redundant builds

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - "master"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Unit Tests

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     if: github.repository == 'argoproj/argo-workflows'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
       - master
       - dev-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/hack/git/hooks/commit-msg
+++ b/hack/git/hooks/commit-msg
@@ -6,7 +6,7 @@ grep -q 'Signed-off-by: ' "$1" || {
   exit 1
 }
 
-grep -qE '^(?:feat|fix|docs|style|refactor|perf|test|chore)\(?(?:\w+|\s|\-|_)?\)?!?:\s\w+' "$1" || grep -q 'Merge' "$1" || {
+grep -qE '^(?:build|feat|fix|docs|style|refactor|perf|test|ci|chore|revert)\(?(?:\w+|\s|\-|_)?\)?!?:\s\w+' "$1" || grep -q 'Merge' "$1" || {
   echo >&2 'Commit message must be semantic: https://github.com/zeke/semantic-pull-requests'
   exit 1
 }


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>

This frees up Github runners for other builds, reducing delay in CI feedback.

<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->