### PR TITLE
docs: Add lifecyclehook doc to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           - estimated-duration.md
           - workflow-pod-security-context.md
           - progress.md
+          - lifecyclehook.md
           - workflow-creator.md
           - synchronization.md
           - workflow-of-workflows.md


### PR DESCRIPTION
Signed-off-by: caelan-io <45773958+caelan-io@users.noreply.github.com>

Adds lifecyclehook doc to mkdocs.yml to appear in the online documentation.

Thanks @alexec for reminder.