### PR TITLE
fix(executor): Retry kubectl on internal transient error

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -38,7 +38,7 @@ func matchTransientErrPattern(err error) bool {
 	if pattern == "" {
 		return false
 	}
-	match, _ := regexp.MatchString(pattern, err.Error())
+	match, _ := regexp.MatchString(pattern, generateErrorString(err))
 	return match
 }
 
@@ -63,10 +63,7 @@ func isTransientNetworkErr(err error) bool {
 		}
 	}
 
-	errorString := err.Error()
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		errorString = fmt.Sprintf("%s %s", errorString, exitErr.Stderr)
-	}
+	errorString := generateErrorString(err)
 	if strings.Contains(errorString, "net/http: TLS handshake timeout") {
 		// If error is - tlsHandshakeTimeoutError, retry.
 		return true
@@ -79,4 +76,12 @@ func isTransientNetworkErr(err error) bool {
 	}
 
 	return false
+}
+
+func generateErrorString(err error) string {
+	errorString := err.Error()
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		errorString = fmt.Sprintf("%s %s", errorString, exitErr.Stderr)
+	}
+	return errorString
 }

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,10 @@ var (
 	ioTimeoutErr           net.Error = netError("i/o timeout")
 	connectionTimedout     net.Error = netError("connection timed out")
 	transientErr           net.Error = netError("this error is transient")
+	transientExitErr                 = exec.ExitError{
+		ProcessState: &os.ProcessState{},
+		Stderr: []byte("this error is transient"),
+	}
 )
 
 const transientEnvVarKey = "TRANSIENT_ERROR_PATTERN"
@@ -67,9 +72,11 @@ func TestIsTransientErr(t *testing.T) {
 	t.Run("TransientErrorPattern", func(t *testing.T) {
 		_ = os.Setenv(transientEnvVarKey, "this error is transient")
 		assert.True(t, IsTransientErr(transientErr))
+		assert.True(t, IsTransientErr(&transientExitErr))
 
 		_ = os.Setenv(transientEnvVarKey, "this error is not transient")
 		assert.False(t, IsTransientErr(transientErr))
+		assert.False(t, IsTransientErr(&transientExitErr))
 
 		_ = os.Setenv(transientEnvVarKey, "")
 		assert.False(t, IsTransientErr(transientErr))

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -26,7 +26,7 @@ var (
 	transientErr           net.Error = netError("this error is transient")
 	transientExitErr                 = exec.ExitError{
 		ProcessState: &os.ProcessState{},
-		Stderr: []byte("this error is transient"),
+		Stderr:       []byte("this error is transient"),
 	}
 )
 


### PR DESCRIPTION
fix(executor): Retry kubectl on internal transient error
Signed-off-by: wujayway <wujayway@gmail.com>

Fixes fix(executor): Retry kubectl on internal transient error

This PR(https://github.com/argoproj/argo-workflows/pull/6472, https://github.com/argoproj/argo-workflows/issues/6467) only fix retry kubectl on k8s api error.
We also need to retry kubectl on internal transient error.
<!--

* Run `make pre-commit -B` to fix codegen, lint, and commit message problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.
* Set your PR as a draft initially.
* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Your PR needs to pass the required checks before it can be approved. If the check is not required (e.g. E2E tests) it
  does not need to pass.
* Once required tests have passed, mark your PR "Ready for review".
* Say how you tested your changes. If you changed the UI, attach screenshots.

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->