### PR TITLE
fix: Remove need for `get pods` from Emissary

### DIFF
--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -146,7 +146,6 @@ func (s *ArtifactsSuite) TestMainLog() {
 				}
 			})
 	})
-	s.Need(fixtures.None(fixtures.Docker, fixtures.Kubelet))
 	s.Run("ActiveDeadlineSeconds", func() {
 		s.Given().
 			Workflow("@expectedfailures/timeouts-step.yaml").
@@ -156,7 +155,7 @@ func (s *ArtifactsSuite) TestMainLog() {
 			Then().
 			ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 				n := status.Nodes[m.Name]
-				if assert.NotNil(t, n) {
+				if assert.NotNil(t, n.Outputs) {
 					assert.Len(t, n.Outputs.Artifacts, 1)
 				}
 			})

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -146,6 +146,7 @@ func (s *ArtifactsSuite) TestMainLog() {
 				}
 			})
 	})
+	s.Need(fixtures.None(fixtures.Docker, fixtures.Kubelet))
 	s.Run("ActiveDeadlineSeconds", func() {
 		s.Given().
 			Workflow("@expectedfailures/timeouts-step.yaml").
@@ -155,7 +156,7 @@ func (s *ArtifactsSuite) TestMainLog() {
 			Then().
 			ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 				n := status.Nodes[m.Name]
-				if assert.NotNil(t, n.Outputs) {
+				if assert.NotNil(t, n) {
 					assert.Len(t, n.Outputs.Artifacts, 1)
 				}
 			})

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -118,6 +118,8 @@ const (
 	EnvVarContainerName = "ARGO_CONTAINER_NAME"
 	// EnvVarDeadline is the deadline for the pod
 	EnvVarDeadline = "ARGO_DEADLINE"
+	// EnvVarTerminationGracePeriodSeconds is pod.spec.terminationGracePeriodSeconds
+	EnvVarTerminationGracePeriodSeconds = "ARGO_WORKFLOW_NAME"
 	// EnvVarIncludeScriptOutput capture the stdout and stderr
 	EnvVarIncludeScriptOutput = "ARGO_INCLUDE_SCRIPT_OUTPUT"
 	// EnvVarTemplate is the template

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -119,7 +119,7 @@ const (
 	// EnvVarDeadline is the deadline for the pod
 	EnvVarDeadline = "ARGO_DEADLINE"
 	// EnvVarTerminationGracePeriodSeconds is pod.spec.terminationGracePeriodSeconds
-	EnvVarTerminationGracePeriodSeconds = "ARGO_WORKFLOW_NAME"
+	EnvVarTerminationGracePeriodSeconds = "ARGO_TERMINATION_GRACE_PERIOD_SECONDS"
 	// EnvVarIncludeScriptOutput capture the stdout and stderr
 	EnvVarIncludeScriptOutput = "ARGO_INCLUDE_SCRIPT_OUTPUT"
 	// EnvVarTemplate is the template

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -435,7 +435,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			c.Command = append([]string{"/var/run/argo/argoexec", "emissary", "--"}, c.Command...)
 		}
 		c.VolumeMounts = append(c.VolumeMounts, volumeMountVarArgo)
-		if x := pod.Spec.TerminationGracePeriodSeconds; x != nil {
+		if x := pod.Spec.TerminationGracePeriodSeconds; x != nil && c.Name == common.WaitContainerName {
 			c.Env = append(c.Env, apiv1.EnvVar{Name: common.EnvVarTerminationGracePeriodSeconds, Value: fmt.Sprint(*x)})
 		}
 		pod.Spec.Containers[i] = c

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -435,6 +435,9 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			c.Command = append([]string{"/var/run/argo/argoexec", "emissary", "--"}, c.Command...)
 		}
 		c.VolumeMounts = append(c.VolumeMounts, volumeMountVarArgo)
+		if x := pod.Spec.TerminationGracePeriodSeconds; x != nil {
+			c.Env = append(c.Env, apiv1.EnvVar{Name: common.EnvVarTerminationGracePeriodSeconds, Value: fmt.Sprint(*x)})
+		}
 		pod.Spec.Containers[i] = c
 	}
 

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -678,8 +678,7 @@ func (we *WorkflowExecutor) GetSecrets(ctx context.Context, namespace, name, key
 func getTerminationGracePeriodDuration() time.Duration {
 	x, _ := strconv.ParseInt(os.Getenv(common.EnvVarTerminationGracePeriodSeconds), 10, 64)
 	if x > 0 {
-		return time.Duration(x)
-		time.Second
+		return time.Duration(x) * time.Second
 	}
 	return 30 * time.Second
 }

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -17,6 +17,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -107,14 +108,6 @@ type ContainerRuntimeExecutor interface {
 
 	// List all the containers the executor is aware of, including any injected sidecars.
 	ListContainerNames(ctx context.Context) ([]string, error)
-}
-
-func errWithHelp(err error) error {
-	return fmt.Errorf("unable to get pods, you can check https://argoproj.github.io/argo-workflows/faq/: %w", err)
-}
-
-func isErrUnknownGetPods(err error) bool {
-	return strings.Contains(err.Error(), "unknown (get pods)")
 }
 
 // NewExecutor instantiates a new workflow executor
@@ -624,24 +617,6 @@ func (we *WorkflowExecutor) InitDriver(ctx context.Context, art *wfv1.Artifact) 
 	return driver, err
 }
 
-// getPod is a wrapper around the pod interface to get the current pod from kube API server
-func (we *WorkflowExecutor) getPod(ctx context.Context) (*apiv1.Pod, error) {
-	podsIf := we.ClientSet.CoreV1().Pods(we.Namespace)
-	var pod *apiv1.Pod
-	err := waitutil.Backoff(executorretry.ExecutorRetry, func() (bool, error) {
-		var err error
-		pod, err = podsIf.Get(ctx, we.PodName, metav1.GetOptions{})
-		if err != nil && isErrUnknownGetPods(err) {
-			return !errorsutil.IsTransientErr(err), errWithHelp(err)
-		}
-		return !errorsutil.IsTransientErr(err), err
-	})
-	if err != nil {
-		return nil, argoerrs.InternalWrapError(err)
-	}
-	return pod, nil
-}
-
 // GetConfigMapKey retrieves a configmap value and memoizes the result
 func (we *WorkflowExecutor) GetConfigMapKey(ctx context.Context, name, key string) (string, error) {
 	namespace := we.Namespace
@@ -700,13 +675,9 @@ func (we *WorkflowExecutor) GetSecrets(ctx context.Context, namespace, name, key
 }
 
 // GetTerminationGracePeriodDuration returns the terminationGracePeriodSeconds of podSpec in Time.Duration format
-func (we *WorkflowExecutor) GetTerminationGracePeriodDuration(ctx context.Context) (time.Duration, error) {
-	pod, err := we.getPod(ctx)
-	if err != nil || pod.Spec.TerminationGracePeriodSeconds == nil {
-		return time.Duration(0), err
-	}
-	terminationGracePeriodDuration := time.Second * time.Duration(*pod.Spec.TerminationGracePeriodSeconds)
-	return terminationGracePeriodDuration, nil
+func getTerminationGracePeriodDuration() time.Duration {
+	x, _ := strconv.ParseInt(os.Getenv(common.EnvVarTerminationGracePeriodSeconds), 10, 64)
+	return time.Second * time.Duration(x)
 }
 
 // CaptureScriptResult will add the stdout of a script template as output result
@@ -1089,7 +1060,7 @@ func (we *WorkflowExecutor) monitorDeadline(ctx context.Context, containerNames 
 
 func (we *WorkflowExecutor) killContainers(ctx context.Context, containerNames []string) {
 	log.Infof("Killing containers")
-	terminationGracePeriodDuration, _ := we.GetTerminationGracePeriodDuration(ctx)
+	terminationGracePeriodDuration := getTerminationGracePeriodDuration()
 	if err := we.RuntimeExecutor.Kill(ctx, containerNames, terminationGracePeriodDuration); err != nil {
 		log.Warnf("Failed to kill %q: %v", containerNames, err)
 	}
@@ -1111,7 +1082,7 @@ func (we *WorkflowExecutor) KillSidecars(ctx context.Context) error {
 	if len(sidecarNames) == 0 {
 		return nil // exit early as GetTerminationGracePeriodDuration performs `get pod`
 	}
-	terminationGracePeriodDuration, _ := we.GetTerminationGracePeriodDuration(ctx)
+	terminationGracePeriodDuration := getTerminationGracePeriodDuration()
 	return we.RuntimeExecutor.Kill(ctx, sidecarNames, terminationGracePeriodDuration)
 }
 

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -677,7 +677,11 @@ func (we *WorkflowExecutor) GetSecrets(ctx context.Context, namespace, name, key
 // GetTerminationGracePeriodDuration returns the terminationGracePeriodSeconds of podSpec in Time.Duration format
 func getTerminationGracePeriodDuration() time.Duration {
 	x, _ := strconv.ParseInt(os.Getenv(common.EnvVarTerminationGracePeriodSeconds), 10, 64)
-	return time.Second * time.Duration(x)
+	if x > 0 {
+		return time.Duration(x)
+		time.Second
+	}
+	return 30 * time.Second
 }
 
 // CaptureScriptResult will add the stdout of a script template as output result


### PR DESCRIPTION
Signed-off-by: Alex Collins <alex_collins@intuit.com>

This was overlooked and means that certain workflows still need `get pods` permission.

See #4940

Depended on by #8120 
<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --sign-off -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->