### PR TITLE
docs: Minor improvement to the Cron schedule on day light saving time

### DIFF
--- a/docs/cron-workflows.md
+++ b/docs/cron-workflows.md
@@ -66,33 +66,38 @@ This setting can also be configured in tandem with `concurrencyPolicy` to achiev
 Daylight Saving (DST) is taking into account when using timezone. This guarantees argo only schedule workflow once when the clock moves forward or back.
 
 For example, with timezone set at `America/Los_Angeles`, we have daylight saving 
-- +1 hour (DST start) 2020-03-08 02:00:00
 
-| cron       | sequence | workflow execution time       |
-|------------|----------|-------------------------------|
-| 59 1 * * * | 1        | 2020-03-08 01:59:00 -0800 PST |
-|            | 2        | 2020-03-09 01:59:00 -0700 PDT |
-|            | 3        | 2020-03-10 01:59:00 -0700 PDT |
-| 0 2 * * *  | 1        | 2020-03-09 02:00:00 -0700 PDT |
-|            | 2        | 2020-03-10 02:00:00 -0700 PDT |
-|            | 3        | 2020-03-11 02:00:00 -0700 PDT |
-| 1 2 * * *  | 1        | 2020-03-09 02:01:00 -0700 PDT |
-|            | 2        | 2020-03-10 02:01:00 -0700 PDT |
-|            | 3        | 2020-03-11 02:01:00 -0700 PDT |
+- +1 hour (DST start) at 2020-03-08 02:00:00:
 
-- -1 hour (DST end) 2020-11-01 02:00:00
+    **Note:** The schedules between 02:00 a.m. to 02:59 a.m. were skipped on Mar 8th due to the clock being moved forward:
 
-| cron       | sequence | workflow execution time       |
-|------------|----------|-------------------------------|
-| 59 1 * * * | 1        | 2020-11-01 01:59:00 -0700 PDT |
-|            | 2        | 2020-11-01 01:59:00 -0800 PST |
-|            | 3        | 2020-11-02 01:59:00 -0800 PST |
-| 0 2 * * *  | 1        | 2020-11-01 02:00:00 -0800 PST |
-|            | 2        | 2020-11-02 02:00:00 -0800 PST |
-|            | 3        | 2020-11-03 02:00:00 -0800 PST |
-| 1 2 * * *  | 1        | 2020-11-01 02:01:00 -0800 PST |
-|            | 2        | 2020-11-02 02:01:00 -0800 PST |
-|            | 3        | 2020-11-03 02:01:00 -0800 PST |
+    | cron       | sequence | workflow execution time       |
+    |------------|----------|-------------------------------|
+    | 59 1 * * * | 1        | 2020-03-08 01:59:00 -0800 PST |
+    |            | 2        | 2020-03-09 01:59:00 -0700 PDT |
+    |            | 3        | 2020-03-10 01:59:00 -0700 PDT |
+    | 0 2 * * *  | 1        | 2020-03-09 02:00:00 -0700 PDT |
+    |            | 2        | 2020-03-10 02:00:00 -0700 PDT |
+    |            | 3        | 2020-03-11 02:00:00 -0700 PDT |
+    | 1 2 * * *  | 1        | 2020-03-09 02:01:00 -0700 PDT |
+    |            | 2        | 2020-03-10 02:01:00 -0700 PDT |
+    |            | 3        | 2020-03-11 02:01:00 -0700 PDT |
+
+- -1 hour (DST end) at 2020-11-01 02:00:00:
+
+    **Note:** the schedules between 01:00 a.m. to 01:59 a.m. were triggered twice on Nov 1st due to the clock being set back:
+
+    | cron       | sequence | workflow execution time       |
+    |------------|----------|-------------------------------|
+    | 59 1 * * * | 1        | 2020-11-01 01:59:00 -0700 PDT |
+    |            | 2        | 2020-11-01 01:59:00 -0800 PST |
+    |            | 3        | 2020-11-02 01:59:00 -0800 PST |
+    | 0 2 * * *  | 1        | 2020-11-01 02:00:00 -0800 PST |
+    |            | 2        | 2020-11-02 02:00:00 -0800 PST |
+    |            | 3        | 2020-11-03 02:00:00 -0800 PST |
+    | 1 2 * * *  | 1        | 2020-11-01 02:01:00 -0800 PST |
+    |            | 2        | 2020-11-02 02:01:00 -0800 PST |
+    |            | 3        | 2020-11-03 02:01:00 -0800 PST |
 
 ## Managing `CronWorkflow`
 


### PR DESCRIPTION
Fixes #8137

Minor clarification and format improvement. See #8137 for more details:

| Before                                                                                                                                                                                                                     	| After                                                                                                                                                                   	|
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
| Note the minor format issue with the bullet-point: <img width="774" alt="Screen Shot 2022-03-13 at 1 41 23 PM" src="https://user-images.githubusercontent.com/1311594/158072147-9574676a-33d1-4fa5-8210-e4a3177cecfa.png"> 	| <img width="744" alt="Screen Shot 2022-03-13 at 1 47 19 PM" src="https://user-images.githubusercontent.com/1311594/158072363-6b69e0a2-88bd-4537-bfac-84d9204815e0.png"> 	|
| <img width="746" alt="Screen Shot 2022-03-13 at 1 41 39 PM" src="https://user-images.githubusercontent.com/1311594/158072145-cd3a9ce8-ead6-4998-a759-590d311657ba.png">                                                    	| <img width="764" alt="Screen Shot 2022-03-13 at 1 47 25 PM" src="https://user-images.githubusercontent.com/1311594/158072370-74a5da65-8d42-4d50-82e1-874fc737ae47.png"> 	|

Thanks!