### PR TITLE
docs: minor tab indentation

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -78,14 +78,14 @@ make argoexec-image
 2. Find an e2e test that you want to run in `test/e2e`
 3. Determine which profile the e2e test is using by inspecting the go build flag at the top of the file and referring to [ci-build.yaml](https://github.com/argoproj/argo-workflows/blob/master/.github/workflows/ci-build.yaml)
 
-For example `TestArchiveStrategies` in `test/e2e/functional_test.go` has the following build flags
+    For example `TestArchiveStrategies` in `test/e2e/functional_test.go` has the following build flags
 
-```go
-//go:build functional
-// +build functional
-```
+    ```go
+    //go:build functional
+    // +build functional
+    ```
 
-In [ci-build.yaml](https://github.com/argoproj/argo-workflows/blob/master/.github/workflows/ci-build.yaml) the functional test suite is using the `minimal` profile
+    In [ci-build.yaml](https://github.com/argoproj/argo-workflows/blob/master/.github/workflows/ci-build.yaml) the functional test suite is using the `minimal` profile
 
 4. Run the profile in a terminal window
 


### PR DESCRIPTION
Fixes e2e test docs steps indentation. 

Earlier : 
<img src="https://user-images.githubusercontent.com/33422449/159053796-d20b3806-807d-4db6-af7b-07093a8cb701.png" height="300" width="500" />

Now:
<img src="https://user-images.githubusercontent.com/33422449/159053818-5d4156bf-badd-4466-8907-fee4a94afa11.png" height="300" width ="500"/>

