### PR TITLE
docs: typo in example for Workflow Restrictions

### DIFF
--- a/docs/workflow-restrictions.md
+++ b/docs/workflow-restrictions.md
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap
-data: |
-  workflowRestrictions:
+data:
+  workflowRestrictions: |
     templateReferencing: Secure
 ```


### PR DESCRIPTION
Fix a typo in the example config for workflow-restrictions, so the example will match the [reference file](https://argoproj.github.io/argo-workflows/workflow-controller-configmap.yaml).

Using the current example configuration would result in the following error:
```
invalid type for io.k8s.api.core.v1.ConfigMap.data: got "string", expected "map"
```

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --sign-off -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->