### PR TITLE
fix: do not panic when termination-log is not writeable. Fixes #8220

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -53,7 +53,7 @@ func GetSecrets(ctx context.Context, clientSet kubernetes.Interface, namespace, 
 func WriteTerminateMessage(message string) {
 	err := ioutil.WriteFile("/dev/termination-log", []byte(message), 0o600)
 	if err != nil {
-		panic(err)
+		println("unable to write termination log: " + err.Error())
 	}
 }
 


### PR DESCRIPTION
Fixes #8220
