### PR TITLE
chore: Bump Go version to 1.17.8

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.8"
       - uses: actions/cache@v3
         with:
           path: |
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.8"
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -329,7 +329,7 @@ jobs:
           node-version: "16"
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.8"
       - uses: actions/cache@v3
         with:
           path: ui/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG DOCKER_VERSION=20.10.12
 ARG KUBECTL_VERSION=1.22.3
 ARG JQ_VERSION=1.6
 
-FROM golang:1.17 as builder
+FROM golang:1.17.8 as builder
 
 RUN apt-get update && apt-get --no-install-recommends install -y \
     git \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -8,7 +8,7 @@ ARG IMAGE_OS_VERSION=1809
 
 # had issues with official golange image for windows so I'm using plain servercore
 FROM mcr.microsoft.com/windows/servercore:${IMAGE_OS_VERSION} as builder
-ENV GOLANG_VERSION=1.17
+ENV GOLANG_VERSION=1.17.8
 SHELL ["powershell", "-Command"]
 
 # install chocolatey package manager


### PR DESCRIPTION
Upgrading Go to 1.17.8 would resolve the following CVEs:

https://github.com/advisories/GHSA-8c83-vp4v-h7fq | critical |   | go | 1.17.6 | fixed in 1.17.7, 1.16.14 | 11-Feb-2022 00:00 | 21-Mar-2022 13:11
https://github.com/advisories/GHSA-6685-ffxp-xm6f | high |   | go | 1.17.6 | fixed in 1.17.8, 1.16.15 | 03-Mar-2022 00:00 | 21-Mar-2022 13:11
https://github.com/advisories/GHSA-52j8-p7r3-733m | high |   | go | 1.17.6 | fixed in 1.17.7, 1.16.14 | 18-Nov-2019 00:00 | 21-Mar-2022 13:11
https://github.com/advisories/GHSA-q99m-p7hq-5v4f | high |   | go | 1.17.6 | fixed in 1.17.7, 1.16.14 | 19-Jan-2022 00:00 | 21-Mar-2022 13:11

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
