### PR TITLE
feat: add archive retry command to argo CLI. Fixes #7907

### DIFF
--- a/cmd/argo/commands/archive/resubmit.go
+++ b/cmd/argo/commands/archive/resubmit.go
@@ -45,27 +45,27 @@ func NewResubmitCommand() *cobra.Command {
 
 # Resubmit multiple workflows:
 
-  argo resubmit uid another-uid
+  argo archive resubmit uid another-uid
 
 # Resubmit multiple workflows by label selector:
 
-  argo resubmit -l workflows.argoproj.io/test=true
+  argo archive resubmit -l workflows.argoproj.io/test=true
 
 # Resubmit multiple workflows by field selector:
 
-  argo resubmit --field-selector metadata.namespace=argo
+  argo archive resubmit --field-selector metadata.namespace=argo
 
 # Resubmit and wait for completion:
 
-  argo resubmit --wait uid
+  argo archive resubmit --wait uid
 
 # Resubmit and watch until completion:
 
-  argo resubmit --watch uid
+  argo archive resubmit --watch uid
 
 # Resubmit and tail logs until completion:
 
-  argo resubmit --log uid
+  argo archive resubmit --log uid
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmd.Flag("priority").Changed {

--- a/cmd/argo/commands/archive/retry.go
+++ b/cmd/argo/commands/archive/retry.go
@@ -1,0 +1,150 @@
+package archive
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/argoproj/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+
+	client "github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
+	workflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow"
+	workflowarchivepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowarchive"
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+)
+
+type retryOps struct {
+	nodeFieldSelector string // --node-field-selector
+	restartSuccessful bool   // --restart-successful
+	namespace         string // --namespace
+	labelSelector     string // --selector
+	fieldSelector     string // --field-selector
+}
+
+// hasSelector returns true if the CLI arguments selects multiple workflows
+func (o *retryOps) hasSelector() bool {
+	if o.labelSelector != "" || o.fieldSelector != "" {
+		return true
+	}
+	return false
+}
+
+func NewRetryCommand() *cobra.Command {
+	var (
+		cliSubmitOpts common.CliSubmitOpts
+		retryOpts     retryOps
+	)
+	command := &cobra.Command{
+		Use:   "retry [WORKFLOW...]",
+		Short: "retry zero or more workflows",
+		Example: `# Retry a workflow:
+
+  argo archive retry uid
+
+# Retry multiple workflows:
+
+  argo archive retry uid another-uid
+
+# Retry multiple workflows by label selector:
+
+  argo archive retry -l workflows.argoproj.io/test=true
+
+# Retry multiple workflows by field selector:
+
+  argo archive retry --field-selector metadata.namespace=argo
+
+# Retry and wait for completion:
+
+  argo archive retry --wait uid
+
+# Retry and watch until completion:
+
+  argo archive retry --watch uid
+		
+# Retry and tail logs until completion:
+
+  argo archive retry --log uid
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 && !retryOpts.hasSelector() {
+				cmd.HelpFunc()(cmd, args)
+				os.Exit(1)
+			}
+
+			ctx, apiClient := client.NewAPIClient(cmd.Context())
+			serviceClient := apiClient.NewWorkflowServiceClient()
+			archiveServiceClient, err := apiClient.NewArchivedWorkflowServiceClient()
+			errors.CheckError(err)
+			retryOpts.namespace = client.Namespace()
+
+			err = retryArchivedWorkflows(ctx, archiveServiceClient, serviceClient, retryOpts, cliSubmitOpts, args)
+			errors.CheckError(err)
+		},
+	}
+
+	command.Flags().StringVarP(&cliSubmitOpts.Output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().BoolVarP(&cliSubmitOpts.Wait, "wait", "w", false, "wait for the workflow to complete, only works when a single workflow is retried")
+	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is retried")
+	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")
+	command.Flags().BoolVar(&retryOpts.restartSuccessful, "restart-successful", false, "indicates to restart successful nodes matching the --node-field-selector")
+	command.Flags().StringVar(&retryOpts.nodeFieldSelector, "node-field-selector", "", "selector of nodes to reset, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVarP(&retryOpts.labelSelector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	command.Flags().StringVar(&retryOpts.fieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
+	return command
+}
+
+// retryWorkflows retries workflows by given retryArgs or workflow names
+func retryArchivedWorkflows(ctx context.Context, archiveServiceClient workflowarchivepkg.ArchivedWorkflowServiceClient, serviceClient workflowpkg.WorkflowServiceClient, retryOpts retryOps, cliSubmitOpts common.CliSubmitOpts, args []string) error {
+	selector, err := fields.ParseSelector(retryOpts.nodeFieldSelector)
+	if err != nil {
+		return fmt.Errorf("unable to parse node field selector '%s': %s", retryOpts.nodeFieldSelector, err)
+	}
+	var wfs wfv1.Workflows
+	if retryOpts.hasSelector() {
+		wfs, err = listArchivedWorkflows(ctx, archiveServiceClient, retryOpts.fieldSelector, retryOpts.labelSelector, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, uid := range args {
+		wfs = append(wfs, wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:       types.UID(uid),
+				Namespace: retryOpts.namespace,
+			},
+		})
+	}
+
+	var lastRetried *wfv1.Workflow
+	retriedUids := make(map[string]bool)
+	for _, wf := range wfs {
+		if _, ok := retriedUids[string(wf.UID)]; ok {
+			// de-duplication in case there is an overlap between the selector and given workflow names
+			continue
+		}
+		retriedUids[string(wf.UID)] = true
+
+		lastRetried, err = archiveServiceClient.RetryArchivedWorkflow(ctx, &workflowarchivepkg.RetryArchivedWorkflowRequest{
+			Uid:               string(wf.UID),
+			Namespace:         wf.Namespace,
+			Name:              wf.Name,
+			RestartSuccessful: retryOpts.restartSuccessful,
+			NodeFieldSelector: selector.String(),
+		})
+		if err != nil {
+			return err
+		}
+		printWorkflow(lastRetried, cliSubmitOpts.Output)
+	}
+	if len(retriedUids) == 1 {
+		// watch or wait when there is only one workflow retried
+		common.WaitWatchOrLog(ctx, serviceClient, lastRetried.Namespace, []string{lastRetried.Name}, cliSubmitOpts)
+	}
+	return nil
+}

--- a/cmd/argo/commands/archive/root.go
+++ b/cmd/argo/commands/archive/root.go
@@ -19,5 +19,6 @@ func NewArchiveCommand() *cobra.Command {
 	command.AddCommand(NewListLabelKeyCommand())
 	command.AddCommand(NewListLabelValueCommand())
 	command.AddCommand(NewResubmitCommand())
+	command.AddCommand(NewRetryCommand())
 	return command
 }

--- a/docs/cli/argo_archive_resubmit.md
+++ b/docs/cli/argo_archive_resubmit.md
@@ -15,27 +15,27 @@ argo archive resubmit [WORKFLOW...] [flags]
 
 # Resubmit multiple workflows:
 
-  argo resubmit uid another-uid
+  argo archive resubmit uid another-uid
 
 # Resubmit multiple workflows by label selector:
 
-  argo resubmit -l workflows.argoproj.io/test=true
+  argo archive resubmit -l workflows.argoproj.io/test=true
 
 # Resubmit multiple workflows by field selector:
 
-  argo resubmit --field-selector metadata.namespace=argo
+  argo archive resubmit --field-selector metadata.namespace=argo
 
 # Resubmit and wait for completion:
 
-  argo resubmit --wait uid
+  argo archive resubmit --wait uid
 
 # Resubmit and watch until completion:
 
-  argo resubmit --watch uid
+  argo archive resubmit --watch uid
 
 # Resubmit and tail logs until completion:
 
-  argo resubmit --log uid
+  argo archive resubmit --log uid
 
 ```
 

--- a/docs/cli/argo_archive_retry.md
+++ b/docs/cli/argo_archive_retry.md
@@ -1,15 +1,56 @@
-## argo archive
+## argo archive retry
 
-manage the workflow archive
+retry zero or more workflows
 
 ```
-argo archive [flags]
+argo archive retry [WORKFLOW...] [flags]
+```
+
+### Examples
+
+```
+# Retry a workflow:
+
+  argo archive retry uid
+
+# Retry multiple workflows:
+
+  argo archive retry uid another-uid
+
+# Retry multiple workflows by label selector:
+
+  argo archive retry -l workflows.argoproj.io/test=true
+
+# Retry multiple workflows by field selector:
+
+  argo archive retry --field-selector metadata.namespace=argo
+
+# Retry and wait for completion:
+
+  argo archive retry --wait uid
+
+# Retry and watch until completion:
+
+  argo archive retry --watch uid
+		
+# Retry and tail logs until completion:
+
+  argo archive retry --log uid
+
 ```
 
 ### Options
 
 ```
-  -h, --help   help for archive
+      --field-selector string        Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
+  -h, --help                         help for retry
+      --log                          log the workflow until it completes
+      --node-field-selector string   selector of nodes to reset, eg: --node-field-selector inputs.paramaters.myparam.value=abc
+  -o, --output string                Output format. One of: name|json|yaml|wide
+      --restart-successful           indicates to restart successful nodes matching the --node-field-selector
+  -l, --selector string              Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+  -w, --wait                         wait for the workflow to complete, only works when a single workflow is retried
+      --watch                        watch the workflow until it completes, only works when a single workflow is retried
 ```
 
 ### Options inherited from parent commands
@@ -47,12 +88,5 @@ argo archive [flags]
 
 ### SEE ALSO
 
-* [argo](argo.md)	 - argo is the command line interface to Argo
-* [argo archive delete](argo_archive_delete.md)	 - delete a workflow in the archive
-* [argo archive get](argo_archive_get.md)	 - get a workflow in the archive
-* [argo archive list](argo_archive_list.md)	 - list workflows in the archive
-* [argo archive list-label-keys](argo_archive_list-label-keys.md)	 - list workflows label keys in the archive
-* [argo archive list-label-values](argo_archive_list-label-values.md)	 - get workflow label values in the archive
-* [argo archive resubmit](argo_archive_resubmit.md)	 - resubmit one or more workflows
-* [argo archive retry](argo_archive_retry.md)	 - retry zero or more workflows
+* [argo archive](argo_archive.md)	 - manage the workflow archive
 

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -234,14 +234,15 @@ func (w *archivedWorkflowServer) RetryArchivedWorkflow(ctx context.Context, req 
 		}
 	}
 
-	wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Update(ctx, wf, metav1.UpdateOptions{})
-	if apierr.IsNotFound(err) {
+	result, err := wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Update(ctx, wf, metav1.UpdateOptions{})
+	if err != nil {
 		wf.ObjectMeta.ResourceVersion = ""
-		wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		wf.ObjectMeta.UID = ""
+		result, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return wf, nil
+	return result, nil
 }

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -221,28 +221,35 @@ func (w *archivedWorkflowServer) RetryArchivedWorkflow(ctx context.Context, req 
 		return nil, err
 	}
 
-	wf, podsToDelete, err := util.FormulateRetryWorkflow(ctx, wf, req.RestartSuccessful, req.NodeFieldSelector)
-	if err != nil {
-		return nil, err
-	}
+	_, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})
+	if apierr.IsNotFound(err) {
 
-	for _, podName := range podsToDelete {
-		log.WithFields(log.Fields{"podDeleted": podName}).Info("Deleting pod")
-		err := kubeClient.CoreV1().Pods(wf.Namespace).Delete(ctx, podName, metav1.DeleteOptions{})
-		if err != nil && !apierr.IsNotFound(err) {
-			return nil, err
-		}
-	}
-
-	result, err := wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Update(ctx, wf, metav1.UpdateOptions{})
-	if err != nil {
-		wf.ObjectMeta.ResourceVersion = ""
-		wf.ObjectMeta.UID = ""
-		result, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		wf, podsToDelete, err := util.FormulateRetryWorkflow(ctx, wf, req.RestartSuccessful, req.NodeFieldSelector)
 		if err != nil {
 			return nil, err
 		}
+
+		for _, podName := range podsToDelete {
+			log.WithFields(log.Fields{"podDeleted": podName}).Info("Deleting pod")
+			err := kubeClient.CoreV1().Pods(wf.Namespace).Delete(ctx, podName, metav1.DeleteOptions{})
+			if err != nil && !apierr.IsNotFound(err) {
+				return nil, err
+			}
+		}
+
+		wf.ObjectMeta.ResourceVersion = ""
+		wf.ObjectMeta.UID = ""
+		result, err := wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		return result, nil
 	}
 
-	return result, nil
+	if err == nil {
+		return nil, status.Error(codes.AlreadyExists, "Workflow already exists on cluster, use argo retry {name} instead")
+	}
+
+	return nil, err
 }

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -185,9 +185,8 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		assert.Len(t, resp.Items, 2)
 	})
 	t.Run("RetryArchivedWorkflow", func(t *testing.T) {
-		wf, err := w.RetryArchivedWorkflow(ctx, &workflowarchivepkg.RetryArchivedWorkflowRequest{Uid: "failed-uid"})
-		assert.NoError(t, err)
-		assert.NotNil(t, wf)
+		_, err := w.RetryArchivedWorkflow(ctx, &workflowarchivepkg.RetryArchivedWorkflowRequest{Uid: "failed-uid"})
+		assert.Equal(t, err, status.Error(codes.AlreadyExists, "Workflow already exists on cluster, use argo retry {name} instead"))
 	})
 	t.Run("ResubmitArchivedWorkflow", func(t *testing.T) {
 		wf, err := w.ResubmitArchivedWorkflow(ctx, &workflowarchivepkg.ResubmitArchivedWorkflowRequest{Uid: "resubmit-uid", Memoized: false})


### PR DESCRIPTION
Fixes #7907 

It is currently only possible for an archived workflow to be retried through the CLI by using `kubectl create` then `argo retry`. This feature removes the need to do this set of operations by retrying workflows directly from the archive with the argo CLI: `argo archive retry {uid}`. This cli command supports the wait, watch or log flags as `argo retry`.