### PR TITLE
build: Pin jinja2==3.0.0 to fix pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.17'
-      - run: pip install mkdocs==1.2.3 mkdocs_material==8.1.9
+      - run: pip install jinja2==3.0.0 mkdocs==1.2.3 mkdocs_material==8.1.9
       - run: mkdocs build
       - run: make parse-examples
       - uses: peaceiris/actions-gh-pages@v2.9.0


### PR DESCRIPTION
Fixes the issue when building docs page:
AttributeError: module 'jinja2' has no attribute 'contextfilter'

See https://github.com/mkdocs/mkdocs/issues/2799.


<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --sign-off -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->