### PR TITLE
fix: git artifact checked out even if local file matches name of working branch. Fixes #8282

### DIFF
--- a/workflow/artifacts/git/git.go
+++ b/workflow/artifacts/git/git.go
@@ -177,7 +177,7 @@ func (g *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) error {
 		// way of resolving revisions (e.g. mybranch, HEAD^, v1.2.3)
 		rev := getRevisionForCheckout(inputArtifact.Git.Revision)
 		log.Info("Checking out revision ", rev)
-		cmd := exec.Command("git", "checkout", rev)
+		cmd := exec.Command("git", "checkout", rev, "--")
 		cmd.Dir = path
 		cmd.Env = env
 		output, err := cmd.Output()


### PR DESCRIPTION
Signed-off-by: Dillen Padhiar <dpadhiar99@gmail.com>

Fixes #8282 

Argo workflows could not checkout a git artifact if the branch name matched a local file in the repo. This is amended by using `git checkout rev --`. The double-hyphen denotes that everything before it is a branch and after is a path.

Example workflow: 

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: input-artifact-git-
spec:
  entrypoint: git-clone
  templates:
  - name: git-clone
    inputs:
      artifacts:
      - name: argo-source
        path: /src
        git:
          repo: https://github.com/dpadhiar/argo-cd-tokens.git
          revision: "demo"
    container:
      image: golang:1.10
      command: [sh, -c]
      args: ["git status && ls && cat VERSION"]
      workingDir: /src
```

Workflow controller logs:
```
logs | input-artifact-git-hkkgr init time="2022-04-01T16:00:30.547Z" level=info msg="`[git checkout demo --]` stdout:\nBranch 'demo' set up to track remote branch 'demo' from 'origin'.\n"
logs | input-artifact-git-hkkgr init time="2022-04-01T16:00:30.658Z" level=info msg="`[git checkout demo --]` stdout:\n"
logs | input-artifact-git-hkkgr init time="2022-04-01T16:00:30.659Z" level=info msg="Detecting if /argo/inputs/artifacts/argo-source.tmp is a tarball"
logs | input-artifact-git-hkkgr init time="2022-04-01T16:00:30.666Z" level=info msg="Successfully download file: /argo/inputs/artifacts/argo-source"
logs | input-artifact-git-hkkgr init time="2022-04-01T16:00:30.670Z" level=info msg="Alloc=94632 TotalAlloc=487451 Sys=221851 NumGC=17 Goroutines=4"
```