### PR TITLE
fix: reduce number of workflows displayed in UI by default. Fixes #8297

### DIFF
--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -109,7 +109,7 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
         this.state = {
             pagination: {
                 offset: this.queryParam('offset'),
-                limit: parseLimit(this.queryParam('limit')) || savedOptions.paginationLimit || 500
+                limit: parseLimit(this.queryParam('limit')) || savedOptions.paginationLimit || 50
             },
             namespace: Utils.getNamespace(this.props.match.params.namespace) || '',
             selectedPhases: phaseQueryParam.length > 0 ? (phaseQueryParam as WorkflowPhase[]) : savedOptions.selectedPhases,


### PR DESCRIPTION
Signed-off-by: Dillen Padhiar <dpadhiar99@gmail.com>

Fixes #8297 

Previously, the default number of workflows displayed by the UI was 500. This can cause the UI to load for a long time if there are too many workflows being shown. Instead, we can list only by default to decrease this load.