### PR TITLE
fix: typo in examples/README.md: overriten => overridden

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -152,7 +152,7 @@ The argo CLI provides a convenient way to override parameters used to invoke the
 argo submit arguments-parameters.yaml -p message="goodbye world"
 ```
 
-In case of multiple parameters that can be overriten, the argo CLI provides a command to load parameters files in YAML or JSON format. Here is an example of that kind of parameter file:
+In case of multiple parameters that can be overridden, the argo CLI provides a command to load parameters files in YAML or JSON format. Here is an example of that kind of parameter file:
 
 ```yaml
 message: goodbye world


### PR DESCRIPTION
Fixes a typo in `examples/README.md`: overriten => overridden

See: https://dictionary.cambridge.org/us/dictionary/english/overridden

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --sign-off -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->