### PR TITLE
chore: Upgrade mkdocs to 1.2.4 and remove unnecessary jinja2

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.17'
-      - run: pip install jinja2==3.0.0 mkdocs==1.2.3 mkdocs_material==8.1.9
+      - run: pip install mkdocs==1.2.4 mkdocs_material==8.1.9
       - run: mkdocs build
       - run: make parse-examples
       - uses: peaceiris/actions-gh-pages@v2.9.0


### PR DESCRIPTION
New version has been released https://github.com/mkdocs/mkdocs/issues/2799 that should fix the issue we we had https://github.com/argoproj/argo-workflows/pull/8254.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
