### PR TITLE
fix: Absolute submodules in git artifacts. Fixes #8377

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,4 +188,4 @@ require (
 	github.com/whilp/git-urls v1.0.0 // indirect
 )
 
-replace github.com/go-git/go-git/v5 => github.com/argoproj-labs/go-git/v5 v5.4.3
+replace github.com/go-git/go-git/v5 => github.com/argoproj-labs/go-git/v5 v5.4.4

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/ardielle/ardielle-go v1.5.2/go.mod h1:I4hy1n795cUhaVt/ojz83SNVCYIGsAF
 github.com/ardielle/ardielle-tools v1.5.4/go.mod h1:oZN+JRMnqGiIhrzkRN9l26Cej9dEx4jeNG6A+AdkShk=
 github.com/argoproj-labs/argo-dataflow v0.10.1 h1:UAFwYvQs9+m+XuPG05hbPOdkcljiTYktNQrCntFqxEU=
 github.com/argoproj-labs/argo-dataflow v0.10.1/go.mod h1:hnDmKWfl1VodADSNetxgt6L66EN7kCyJulxc78qzCm4=
-github.com/argoproj-labs/go-git/v5 v5.4.3 h1:BXJaKSYj5sK2k8LQENV6T7cs+y1uX3BDOPAdzZstkmA=
-github.com/argoproj-labs/go-git/v5 v5.4.3/go.mod h1:Lv1K45bcCda9jDMEZCGCVuXSGdBaSGAXUvptnVtaEsA=
+github.com/argoproj-labs/go-git/v5 v5.4.4 h1:xXa015ZCEElgNMxaevPsK68oAsbjpmNGo9W+os1oeBU=
+github.com/argoproj-labs/go-git/v5 v5.4.4/go.mod h1:Lv1K45bcCda9jDMEZCGCVuXSGdBaSGAXUvptnVtaEsA=
 github.com/argoproj/argo-events v0.17.1-0.20220223155401-ddda8800f9f8 h1:LqF/eUExbdTg7MEHUJt4DfZIg5hJN5lneybM7u7MbWI=
 github.com/argoproj/argo-events v0.17.1-0.20220223155401-ddda8800f9f8/go.mod h1:AhwDnZwUrrwPgN0CYFMfZQ7liL+G+iL4ujNiLMv2l58=
 github.com/argoproj/pkg v0.11.0 h1:kho8cjBRe/K7tFiMfNG7vnF6VBy9+p0idV21f9bbUO4=


### PR DESCRIPTION
Upgrades argoproj-labs/go-git fork to v5.4.4

This brings in a fix for support of gitmodules with absolute paths.
Fixes  #8377
