### PR TITLE
fix: open minio dashboard on different port in quick-start

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -23,6 +23,7 @@ The actual repository used by a workflow is chosen by the following rules:
 3. From a workflow controller configmap.
 
 ## Configuring Minio
+NOTE: Minio is already included in the [quick-start manifests](quick-start.md).
 
 ```
 $ brew install helm # mac, helm 3.x

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -1263,9 +1263,14 @@ metadata:
   name: minio
 spec:
   ports:
-  - port: 9000
+  - name: api
+    port: 9000
     protocol: TCP
     targetPort: 9000
+  - name: dashboard
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
   selector:
     app: minio
 ---
@@ -1362,6 +1367,8 @@ spec:
       - command:
         - minio
         - server
+        - --console-address
+        - :9001
         - /data
         env:
         - name: MINIO_ACCESS_KEY
@@ -1385,6 +1392,9 @@ spec:
         name: main
         ports:
         - containerPort: 9000
+          name: api
+        - containerPort: 9001
+          name: dashboard
         readinessProbe:
           httpGet:
             path: /minio/health/ready

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -1293,9 +1293,14 @@ metadata:
   name: minio
 spec:
   ports:
-  - port: 9000
+  - name: api
+    port: 9000
     protocol: TCP
     targetPort: 9000
+  - name: dashboard
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
   selector:
     app: minio
 ---
@@ -1406,6 +1411,8 @@ spec:
       - command:
         - minio
         - server
+        - --console-address
+        - :9001
         - /data
         env:
         - name: MINIO_ACCESS_KEY
@@ -1429,6 +1436,9 @@ spec:
         name: main
         ports:
         - containerPort: 9000
+          name: api
+        - containerPort: 9001
+          name: dashboard
         readinessProbe:
           httpGet:
             path: /minio/health/ready

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -1293,9 +1293,14 @@ metadata:
   name: minio
 spec:
   ports:
-  - port: 9000
+  - name: api
+    port: 9000
     protocol: TCP
     targetPort: 9000
+  - name: dashboard
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
   selector:
     app: minio
 ---
@@ -1406,6 +1411,8 @@ spec:
       - command:
         - minio
         - server
+        - --console-address
+        - :9001
         - /data
         env:
         - name: MINIO_ACCESS_KEY
@@ -1429,6 +1436,9 @@ spec:
         name: main
         ports:
         - containerPort: 9000
+          name: api
+        - containerPort: 9001
+          name: dashboard
         readinessProbe:
           httpGet:
             path: /minio/health/ready

--- a/manifests/quick-start/base/minio/minio-deploy.yaml
+++ b/manifests/quick-start/base/minio/minio-deploy.yaml
@@ -23,7 +23,10 @@ spec:
               value: password
           ports:
             - containerPort: 9000
-          command: [minio, server, /data]
+              name: api
+            - containerPort: 9001
+              name: dashboard
+          command: [minio, server, --console-address, ":9001", /data]
           lifecycle:
             postStart:
               exec:

--- a/manifests/quick-start/base/minio/minio-service.yaml
+++ b/manifests/quick-start/base/minio/minio-service.yaml
@@ -8,6 +8,11 @@ spec:
   selector:
     app: minio
   ports:
-    - protocol: TCP
-      port: 9000
+    - port: 9000
+      name: api
+      protocol: TCP
       targetPort: 9000
+    - port: 9001
+      name: dashboard
+      protocol: TCP
+      targetPort: 9001


### PR DESCRIPTION
Minio is redirecting to random port when we try to access the dashboard with port forwarding using quick-start manifests.
Related discussion: https://stackoverflow.com/questions/68317358/minio-local-dashboard-is-not-opening

Potential solution: expose different port for dashboard

Signed-off-by: Grzegorz Bielski <pesiok@gmail.com>


<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --sign-off -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->