### PR TITLE
feat: Increased default significant figures in formatDuration. Fixes #8650

### DIFF
--- a/ui/src/app/shared/duration.ts
+++ b/ui/src/app/shared/duration.ts
@@ -3,10 +3,12 @@ import * as models from '../../models';
 /**
  * Format the given number number of seconds in the form _d_h_m_s.
  * @param seconds Number of seconds to format. Will be rounded to the nearest whole number.
- * @param sigfigs Level of significant figures to show
+ * @param sigfigs Level of significant figures to show.
+ *  Here, a sigfig is one of days, hours, minutes, or seconds.
+ *  Examples: 13h has one sigfig and 13h22s has two sigfigs.
  */
 
-export function formatDuration(seconds: number, sigfigs = 1) {
+export function formatDuration(seconds: number, sigfigs = 2) {
     let remainingSeconds = Math.abs(Math.round(seconds));
     let formattedDuration = '';
     const figs = [];


### PR DESCRIPTION
Fixes #8650

This increases the default number of significant figures when formatting durations.

## Testing

Before:
<img width="203" alt="Screen Shot 2022-05-09 at 5 55 15 PM" src="https://user-images.githubusercontent.com/11336049/167449332-02ce9167-3ad0-4a20-bf85-32f8077ca692.png">

After: 
<img width="236" alt="Screen Shot 2022-05-09 at 5 31 23 PM" src="https://user-images.githubusercontent.com/11336049/167448556-8c8b6ed9-b894-4008-88d7-5f2bea8680ed.png">


Signed-off-by: Immanuel Buder <immanuel_buder@intuit.com>

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->