### PR TITLE
fix: Template in Lifecycle hook should be optional

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -5998,9 +5998,6 @@
           "description": "TemplateRef is the reference to the template resource to execute by the hook"
         }
       },
-      "required": [
-        "template"
-      ],
       "type": "object"
     },
     "io.argoproj.workflow.v1alpha1.Link": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10434,9 +10434,6 @@
     },
     "io.argoproj.workflow.v1alpha1.LifecycleHook": {
       "type": "object",
-      "required": [
-        "template"
-      ],
       "properties": {
         "arguments": {
           "description": "Arguments hold arguments to the template",

--- a/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
@@ -1293,8 +1293,6 @@ spec:
                         template:
                           type: string
                       type: object
-                  required:
-                  - template
                   type: object
                 type: object
               hostAliases:
@@ -4377,8 +4375,6 @@ spec:
                                       template:
                                         type: string
                                     type: object
-                                required:
-                                - template
                                 type: object
                               type: object
                             inline: {}
@@ -11239,8 +11235,6 @@ spec:
                                         template:
                                           type: string
                                       type: object
-                                  required:
-                                  - template
                                   type: object
                                 type: object
                               inline: {}

--- a/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
@@ -1314,8 +1314,6 @@ spec:
                             template:
                               type: string
                           type: object
-                      required:
-                      - template
                       type: object
                     type: object
                   hostAliases:
@@ -4398,8 +4396,6 @@ spec:
                                           template:
                                             type: string
                                         type: object
-                                    required:
-                                    - template
                                     type: object
                                   type: object
                                 inline: {}
@@ -11260,8 +11256,6 @@ spec:
                                             template:
                                               type: string
                                           type: object
-                                      required:
-                                      - template
                                       type: object
                                     type: object
                                   inline: {}

--- a/manifests/base/crds/full/argoproj.io_workflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflows.yaml
@@ -1307,8 +1307,6 @@ spec:
                         template:
                           type: string
                       type: object
-                  required:
-                  - template
                   type: object
                 type: object
               hostAliases:
@@ -4391,8 +4389,6 @@ spec:
                                       template:
                                         type: string
                                     type: object
-                                required:
-                                - template
                                 type: object
                               type: object
                             inline: {}
@@ -11253,8 +11249,6 @@ spec:
                                         template:
                                           type: string
                                       type: object
-                                  required:
-                                  - template
                                   type: object
                                 type: object
                               inline: {}
@@ -21292,8 +21286,6 @@ spec:
                                         template:
                                           type: string
                                       type: object
-                                  required:
-                                  - template
                                   type: object
                                 type: object
                               inline: {}
@@ -26639,8 +26631,6 @@ spec:
                             template:
                               type: string
                           type: object
-                      required:
-                      - template
                       type: object
                     type: object
                   hostAliases:
@@ -29723,8 +29713,6 @@ spec:
                                           template:
                                             type: string
                                         type: object
-                                    required:
-                                    - template
                                     type: object
                                   type: object
                                 inline: {}
@@ -36585,8 +36573,6 @@ spec:
                                             template:
                                               type: string
                                           type: object
-                                      required:
-                                      - template
                                       type: object
                                     type: object
                                   inline: {}

--- a/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
@@ -2810,8 +2810,6 @@ spec:
                                         template:
                                           type: string
                                       type: object
-                                  required:
-                                  - template
                                   type: object
                                 type: object
                               inline: {}

--- a/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
@@ -1292,8 +1292,6 @@ spec:
                         template:
                           type: string
                       type: object
-                  required:
-                  - template
                   type: object
                 type: object
               hostAliases:
@@ -4376,8 +4374,6 @@ spec:
                                       template:
                                         type: string
                                     type: object
-                                required:
-                                - template
                                 type: object
                               type: object
                             inline: {}
@@ -11238,8 +11234,6 @@ spec:
                                         template:
                                           type: string
                                       type: object
-                                  required:
-                                  - template
                                   type: object
                                 type: object
                               inline: {}

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -2974,7 +2974,6 @@ func schema_pkg_apis_workflow_v1alpha1_LifecycleHook(ref common.ReferenceCallbac
 					"template": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Template is the name of the template to execute by the hook",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3000,7 +2999,6 @@ func schema_pkg_apis_workflow_v1alpha1_LifecycleHook(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"template"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1408,7 +1408,7 @@ func (lchs LifecycleHooks) HasExitHook() bool {
 
 type LifecycleHook struct {
 	// Template is the name of the template to execute by the hook
-	Template string `json:"template," protobuf:"bytes,1,opt,name=template"`
+	Template string `json:"template,omitempty" protobuf:"bytes,1,opt,name=template"`
 	// Arguments hold arguments to the template
 	Arguments Arguments `json:"arguments,omitempty" protobuf:"bytes,2,opt,name=arguments"`
 	// TemplateRef is the reference to the template resource to execute by the hook

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1LifecycleHook.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1LifecycleHook.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **arguments** | [**IoArgoprojWorkflowV1alpha1Arguments**](IoArgoprojWorkflowV1alpha1Arguments.md) |  |  [optional]
 **expression** | **String** | Expression is a condition expression for when a node will be retried. If it evaluates to false, the node will not be retried and the retry strategy will be ignored |  [optional]
-**template** | **String** | Template is the name of the template to execute by the hook | 
+**template** | **String** | Template is the name of the template to execute by the hook |  [optional]
 **templateRef** | [**IoArgoprojWorkflowV1alpha1TemplateRef**](IoArgoprojWorkflowV1alpha1TemplateRef.md) |  |  [optional]
 
 

--- a/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_lifecycle_hook.py
+++ b/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_lifecycle_hook.py
@@ -89,9 +89,9 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
         """
         lazy_import()
         return {
-            'template': (str,),  # noqa: E501
             'arguments': (IoArgoprojWorkflowV1alpha1Arguments,),  # noqa: E501
             'expression': (str,),  # noqa: E501
+            'template': (str,),  # noqa: E501
             'template_ref': (IoArgoprojWorkflowV1alpha1TemplateRef,),  # noqa: E501
         }
 
@@ -101,9 +101,9 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
 
 
     attribute_map = {
-        'template': 'template',  # noqa: E501
         'arguments': 'arguments',  # noqa: E501
         'expression': 'expression',  # noqa: E501
+        'template': 'template',  # noqa: E501
         'template_ref': 'templateRef',  # noqa: E501
     }
 
@@ -114,11 +114,8 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
 
     @classmethod
     @convert_js_args_to_python_args
-    def _from_openapi_data(cls, template, *args, **kwargs):  # noqa: E501
+    def _from_openapi_data(cls, *args, **kwargs):  # noqa: E501
         """IoArgoprojWorkflowV1alpha1LifecycleHook - a model defined in OpenAPI
-
-        Args:
-            template (str): Template is the name of the template to execute by the hook
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -153,6 +150,7 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             arguments (IoArgoprojWorkflowV1alpha1Arguments): [optional]  # noqa: E501
             expression (str): Expression is a condition expression for when a node will be retried. If it evaluates to false, the node will not be retried and the retry strategy will be ignored. [optional]  # noqa: E501
+            template (str): Template is the name of the template to execute by the hook. [optional]  # noqa: E501
             template_ref (IoArgoprojWorkflowV1alpha1TemplateRef): [optional]  # noqa: E501
         """
 
@@ -181,7 +179,6 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.template = template
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \
@@ -202,11 +199,8 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, template, *args, **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """IoArgoprojWorkflowV1alpha1LifecycleHook - a model defined in OpenAPI
-
-        Args:
-            template (str): Template is the name of the template to execute by the hook
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -241,6 +235,7 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             arguments (IoArgoprojWorkflowV1alpha1Arguments): [optional]  # noqa: E501
             expression (str): Expression is a condition expression for when a node will be retried. If it evaluates to false, the node will not be retried and the retry strategy will be ignored. [optional]  # noqa: E501
+            template (str): Template is the name of the template to execute by the hook. [optional]  # noqa: E501
             template_ref (IoArgoprojWorkflowV1alpha1TemplateRef): [optional]  # noqa: E501
         """
 
@@ -267,7 +262,6 @@ class IoArgoprojWorkflowV1alpha1LifecycleHook(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.template = template
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1LifecycleHook.md
+++ b/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1LifecycleHook.md
@@ -4,9 +4,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**template** | **str** | Template is the name of the template to execute by the hook | 
 **arguments** | [**IoArgoprojWorkflowV1alpha1Arguments**](IoArgoprojWorkflowV1alpha1Arguments.md) |  | [optional] 
 **expression** | **str** | Expression is a condition expression for when a node will be retried. If it evaluates to false, the node will not be retried and the retry strategy will be ignored | [optional] 
+**template** | **str** | Template is the name of the template to execute by the hook | [optional] 
 **template_ref** | [**IoArgoprojWorkflowV1alpha1TemplateRef**](IoArgoprojWorkflowV1alpha1TemplateRef.md) |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 


### PR DESCRIPTION
Since we also support `templateRef`.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
