### PR TITLE
Allow optional space for param detection

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -1373,7 +1373,7 @@ func sortDAGTasks(tmpl *wfv1.Template, ctx *dagValidationContext) error {
 
 var (
 	// paramRegex matches a parameter. e.g. {{inputs.parameters.blah}}
-	paramRegex               = regexp.MustCompile(`{{[-a-zA-Z0-9]+(\.[-a-zA-Z0-9_]+)*}}`)
+	paramRegex               = regexp.MustCompile(`{{\s?[-a-zA-Z0-9]+(\.[-a-zA-Z0-9_]+)*\s?}}`)
 	paramOrArtifactNameRegex = regexp.MustCompile(`^[-a-zA-Z0-9_]+[-a-zA-Z0-9_]*$`)
 	workflowFieldNameRegex   = regexp.MustCompile("^" + workflowFieldNameFmt + "$")
 )


### PR DESCRIPTION
Really, I intend for this to be more of a discussion than anything. Now that I think I understand what's going on, i can proceed with my work, but want to make sure this is known.

I work for a company that has a large argo workflow, and we've been struggling to reconcile strange behaviors around the space needed for the interpolated variables. I believe this is because this specific regex is not meeting the contract that was documented, and does not allow for those additional white space between the bracket and variable.

https://github.com/argoproj/argo-workflows/blob/master/docs/variables.md#simple

> Simple tags may have white-space between the brackets and variable.


https://github.com/argoproj/argo-workflows/blob/master/util/template/simple_template.go#L13 provides that contract during the workflows actual execution (e.g. `argo submit`), however, there is a code path during `argo lint` that tries to use the file i'm changing to determine if it is or isn't a parameter, in order to detect if it should allow that as a "global" param, but it doesn't follow that same contract?

https://github.com/argoproj/argo-workflows/blob/master/workflow/validate/validate.go#L872



I posted about this in the slack:

https://cloud-native.slack.com/archives/C01QW9QSSSK/p1653497167145119

https://cloud-native.slack.com/archives/C01QW9QSSSK/p1653600495901169