### PR TITLE
build: Disable auto-approve/merge dependabot PRs on forks

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'argoproj/argo-workflows'}}
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
The auto-approved/merged PRs land on forks and has diverged significantly from the upstream (since we got different dependabot PRs), e.g. https://github.com/terrytangyuan/argo-workflows (master branch in the fork is [18 commits ahead](https://github.com/terrytangyuan/argo-workflows/compare/argoproj:master...master), [132 commits behind](https://github.com/terrytangyuan/argo-workflows/compare/master...argoproj:master) argoproj:master.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
