### PR TITLE
feat: add artifact delete to argoexec CLI. Fixes #8669

### DIFF
--- a/cmd/argoexec/commands/artifact/delete.go
+++ b/cmd/argoexec/commands/artifact/delete.go
@@ -1,0 +1,50 @@
+package artifact
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	executor "github.com/argoproj/argo-workflows/v3/workflow/artifacts"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
+)
+
+func NewArtifactDeleteCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "delete",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			a := &wfv1.Artifact{}
+			if err := json.Unmarshal([]byte(os.Getenv(common.EnvVarArtifact)), a); err != nil {
+				return fmt.Errorf("failed to unmarshal artifact: %w", err)
+			}
+
+			drv, err := executor.NewDriver(cmd.Context(), a, &resources{})
+			if err != nil {
+				return fmt.Errorf("failed to create driver: %w", err)
+			}
+
+			if err := drv.Delete(a); err != nil {
+				return fmt.Errorf("failed to delete artifact: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+type resources struct{}
+
+func (r resources) GetSecret(ctx context.Context, name, key string) (string, error) {
+	file, err := os.ReadFile(filepath.Join(common.SecretVolMountPath, name, key))
+	return string(file), err
+
+}
+
+func (r resources) GetConfigMapKey(ctx context.Context, name, key string) (string, error) {
+	return "", fmt.Errorf("not supported")
+}

--- a/cmd/argoexec/commands/artifact/root.go
+++ b/cmd/argoexec/commands/artifact/root.go
@@ -1,0 +1,13 @@
+package artifact
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewArtifactCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "artifact",
+	}
+	cmd.AddCommand(NewArtifactDeleteCommand())
+	return cmd
+}

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/argoproj/argo-workflows/v3"
+	"github.com/argoproj/argo-workflows/v3/cmd/argoexec/commands/artifact"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-workflows/v3/util"
@@ -64,6 +65,7 @@ func NewRootCommand() *cobra.Command {
 	command.AddCommand(NewWaitCommand())
 	command.AddCommand(NewDataCommand())
 	command.AddCommand(cmd.NewVersionCmd(CLIName))
+	command.AddCommand(artifact.NewArtifactCommand())
 
 	clientConfig = kubecli.AddKubectlFlagsToCmd(&command)
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -141,6 +141,7 @@ const (
 	EnvAgentTaskWorkers = "ARGO_AGENT_TASK_WORKERS"
 	// EnvAgentPatchRate is the rate that the Argo Agent will patch the Workflow TaskSet
 	EnvAgentPatchRate = "ARGO_AGENT_PATCH_RATE"
+	EnvVarArtifact    = "ARGO_ARTIFACT"
 
 	// Finalizer to block deletion of the workflow if deletion of artifacts fail for some reason.
 	FinalizerArtifactGC = workflow.WorkflowFullName + "/artifact-gc"


### PR DESCRIPTION
Signed-off-by: Dillen Padhiar <dillen_padhiar@intuit.com>

Fixes #8669 

Implemented `argoexec artifact delete` per Alex's original PoC for artifact garbage collection.