### PR TITLE
fix: long code blocks overflow in ui. Fixes #8916

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -68,7 +68,7 @@ interface Props {
 const AttributeRow = (attr: {title: string; value: any}) => (
     <div className='row white-box__details-row' key={attr.title}>
         <div className='columns small-4'>{attr.title}</div>
-        <div className='columns columns--narrower-height small-8' style={{whiteSpace: 'pre-wrap'}}>
+        <div className='columns columns--narrower-height small-8' style={{overflow: 'auto hidden'}}>
             {attr.value}
         </div>
     </div>


### PR DESCRIPTION
Signed-off-by: Dakota Lillie <dakota.lillie@icloud.com>

Fixes #8916

This PR addresses an issue where code blocks would overflow their container in the UI.

**Before:**

![Screen Shot 2022-06-10 at 9 30 25 AM](https://user-images.githubusercontent.com/20373585/173110870-93497bce-f101-41a7-b5e5-c0de3df1e8a1.png)

**After:**

![Screen Shot 2022-06-10 at 9 31 24 AM](https://user-images.githubusercontent.com/20373585/173111004-91f04dcc-8776-4dde-b3aa-ceb7ba02e711.png)

I have tested this in Chrome, Firefox, and Safari. Safari does have an issue where the scrollbar does not increase the height of the element (notice the lack of padding below the code block):

![Screen Shot 2022-06-10 at 10 12 15 AM](https://user-images.githubusercontent.com/20373585/173117514-5f777546-0619-49ba-8491-1c8cd88fb87c.png)

Without the `hidden` overflow-y setting, this would cause an additional vertical scrollbar to appear. I'm inclined to believe this is a bug in Safari, as manually updating any height-related style in the browser, even a random one like "line-height", causes Safari to fix itself:

https://user-images.githubusercontent.com/20373585/173118493-043429b7-796f-4331-b2fc-df49fdee27e3.mov

Needless to say, changing the "line-height" in the code does not fix the issue.

I chose to add a scrollbar, rather than wrapping the text, because I find line-wrapped code to be more difficult to read. I can switch approaches if folks would prefer differently, but hopefully this should become a largely moot issue once #8917 is implemented.

I verified to ensure this change does not cause a regression for the bug fixed in #7876. It appears it does not:

![Screen Shot 2022-06-10 at 10 34 22 AM](https://user-images.githubusercontent.com/20373585/173120647-61407c7c-88a1-40f8-bb34-4a15afe65614.png)

Even with the removal of `white-space: pre-wrap`, the text still wraps due to `overflow-wrap: break-word` [set here](https://github.com/argoproj/argo-ui/blob/a5f7fa7197d297a0aec9a7ee7c6d919763611060/src/styles/elements/containers.scss#L97).

I had to disable the pre-commit checks to make this commit, as `make test` runs a test which [attempts to clone a private GitHub repository](https://github.com/argoproj/argo-workflows/blob/750c4e1f699b770a309843f2189b4e703305e44f/workflow/artifacts/git/git_test.go#L35) I don't have access to. I was successfully able to run `make pre-commit -B`.

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->