### PR TITLE
fix: sync cluster Workflow Template Informer before it's used

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -420,6 +420,14 @@ func (wfc *WorkflowController) createClusterWorkflowTemplateInformer(ctx context
 	if cwftGetAllowed && cwftListAllowed && cwftWatchAllowed {
 		wfc.cwftmplInformer = informer.NewTolerantClusterWorkflowTemplateInformer(wfc.dynamicInterface, clusterWorkflowTemplateResyncPeriod)
 		go wfc.cwftmplInformer.Informer().Run(ctx.Done())
+
+		// since the above call is asynchronous, make sure we populate our cache before we try to use it later
+		if !cache.WaitForCacheSync(
+			ctx.Done(),
+			wfc.cwftmplInformer.Informer().HasSynced,
+		) {
+			log.Fatal("Timed out waiting for ClusterWorkflowTemplate cache to sync")
+		}
 	} else {
 		log.Warnf("Controller doesn't have RBAC access for ClusterWorkflowTemplates")
 	}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -263,6 +263,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	go wfc.configMapInformer.Run(ctx.Done())
 	go wfc.wfTaskSetInformer.Informer().Run(ctx.Done())
 	go wfc.taskResultInformer.Run(ctx.Done())
+	wfc.createClusterWorkflowTemplateInformer(ctx)
 
 	// Wait for all involved caches to be synced, before processing items from the queue is started
 	if !cache.WaitForCacheSync(
@@ -276,8 +277,6 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	) {
 		log.Fatal("Timed out waiting for caches to sync")
 	}
-
-	wfc.createClusterWorkflowTemplateInformer(ctx)
 
 	// Start the metrics server
 	go wfc.metrics.RunServer(ctx)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2100,7 +2100,6 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) (*wfv1.Templat
 		}
 		return tmpl, nil
 	}
-
 	return woc.wf.GetTemplateByName(node.TemplateName), nil
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1156,10 +1156,6 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		woc.log.Error(err)
 		return nil
 	}
-	if tmpl == nil {
-		woc.log.Errorf("failed to get old node template corresponding to node status: %v, yet err=nil???", old)
-		return nil
-	}
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		new.Phase = wfv1.NodePending

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1156,6 +1156,10 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		woc.log.Error(err)
 		return nil
 	}
+	if tmpl == nil {
+		woc.log.Errorf("failed to get old node template corresponding to node status: %v, yet err=nil???", old)
+		return nil
+	}
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		new.Phase = wfv1.NodePending

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1166,7 +1166,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		new.Daemoned = nil
 	case apiv1.PodFailed:
 		// ignore pod failure for daemoned steps
-		if tmpl.IsDaemon() {
+		if tmpl != nil && tmpl.IsDaemon() {
 			new.Phase = wfv1.NodeSucceeded
 		} else {
 			new.Phase, new.Message = woc.inferFailedReason(pod, tmpl)
@@ -1176,7 +1176,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		// Daemons are a special case we need to understand the rules:
 		// A node transitions into "daemoned" only if it's a daemon template and it becomes running AND ready.
 		// A node will be unmarked "daemoned" when its boundary node completes, anywhere killDaemonedChildren is called.
-		if tmpl.IsDaemon() {
+		if tmpl != nil && tmpl.IsDaemon() {
 			if !old.Fulfilled() {
 				// pod is running and template is marked daemon. check if everything is ready
 				for _, ctrStatus := range pod.Status.ContainerStatuses {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2099,7 +2099,6 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) *wfv1.Template
 		}
 		return tmpl
 	}
-
 	return woc.wf.GetTemplateByName(node.TemplateName)
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2100,6 +2100,7 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) (*wfv1.Templat
 		}
 		return tmpl, nil
 	}
+
 	return woc.wf.GetTemplateByName(node.TemplateName), nil
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1152,6 +1152,9 @@ func printPodSpecLog(pod *apiv1.Pod, wfName string) {
 func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus) *wfv1.NodeStatus {
 	new := old.DeepCopy()
 	tmpl := woc.GetNodeTemplate(old)
+	if tmpl == nil {
+		return nil
+	}
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		new.Phase = wfv1.NodePending
@@ -2088,6 +2091,7 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) *wfv1.Template
 		tmplCtx, err := woc.createTemplateContext(node.GetTemplateScope())
 		if err != nil {
 			woc.markNodeError(node.Name, err)
+			return nil
 		}
 		tmpl, err := tmplCtx.GetTemplateFromRef(node.TemplateRef)
 		if err != nil {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2099,6 +2099,7 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) *wfv1.Template
 		}
 		return tmpl
 	}
+
 	return woc.wf.GetTemplateByName(node.TemplateName)
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1153,6 +1153,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 	new := old.DeepCopy()
 	tmpl, err := woc.GetNodeTemplate(old)
 	if err != nil {
+		woc.log.Error(err)
 		return nil
 	}
 	switch pod.Status.Phase {


### PR DESCRIPTION
After Controller leader election we need to make sure cluster Workflow Template Informer's cache is updated first. Otherwise, we call Lister() on it before it's ready.

Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

Fixes #8956 

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->