### PR TITLE
feat: log workflow size before hydrating/dehydrating. Fixes #8976

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -603,6 +603,7 @@ func (wfc *WorkflowController) deleteOffloadedNodesForWorkflow(uid string, versi
 		// workflow might still be hydrated
 		if wfc.hydrator.IsHydrated(wf) {
 			log.WithField("uid", wf.UID).Info("Hydrated workflow encountered")
+			log.WithField("Workflow size", wf.Size()).Info("Hydrated workflow size")
 			err = wfc.hydrator.Dehydrate(wf)
 			if err != nil {
 				return err
@@ -887,6 +888,7 @@ func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj inter
 	if err != nil {
 		return fmt.Errorf("failed to convert to workflow from unstructured: %w", err)
 	}
+	log.WithField("Workflow size", wf.Size()).Info("Workflow to archive size")
 	err = wfc.hydrator.Hydrate(wf)
 	if err != nil {
 		return fmt.Errorf("failed to hydrate workflow: %w", err)

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -602,8 +602,7 @@ func (wfc *WorkflowController) deleteOffloadedNodesForWorkflow(uid string, versi
 		defer wfc.workflowKeyLock.Unlock(key)
 		// workflow might still be hydrated
 		if wfc.hydrator.IsHydrated(wf) {
-			log.WithField("uid", wf.UID).Info("Hydrated workflow encountered")
-			log.WithField("Workflow size", wf.Size()).Info("Hydrated workflow size")
+			log.WithFields(log.Fields{"uid": wf.UID, "Workflow size": wf.Size()}).Info("Hydrated workflow encountered")
 			err = wfc.hydrator.Dehydrate(wf)
 			if err != nil {
 				return err

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -602,7 +602,7 @@ func (wfc *WorkflowController) deleteOffloadedNodesForWorkflow(uid string, versi
 		defer wfc.workflowKeyLock.Unlock(key)
 		// workflow might still be hydrated
 		if wfc.hydrator.IsHydrated(wf) {
-			log.WithFields(log.Fields{"uid": wf.UID, "Workflow size": wf.Size()}).Info("Hydrated workflow encountered")
+			log.WithField("uid", wf.UID).Info("Hydrated workflow encountered")
 			err = wfc.hydrator.Dehydrate(wf)
 			if err != nil {
 				return err
@@ -887,7 +887,6 @@ func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj inter
 	if err != nil {
 		return fmt.Errorf("failed to convert to workflow from unstructured: %w", err)
 	}
-	log.WithField("Workflow size", wf.Size()).Info("Workflow to archive size")
 	err = wfc.hydrator.Hydrate(wf)
 	if err != nil {
 		return fmt.Errorf("failed to hydrate workflow: %w", err)

--- a/workflow/hydrator/hydrator.go
+++ b/workflow/hydrator/hydrator.go
@@ -85,6 +85,7 @@ func (h hydrator) Hydrate(wf *wfv1.Workflow) error {
 		}
 		h.HydrateWithNodes(wf, offloadedNodes)
 	}
+	log.WithField("Workflow Size", wf.Size()).Info("Workflow hydrated")
 	return nil
 }
 
@@ -93,6 +94,7 @@ func (h hydrator) Dehydrate(wf *wfv1.Workflow) error {
 		return nil
 	}
 	var err error
+	log.WithField("Workflow Size", wf.Size()).Info("Workflow to be dehydrated")
 	if !alwaysOffloadNodeStatus {
 		err = packer.CompressWorkflowIfNeeded(wf)
 		if err == nil {

--- a/workflow/hydrator/hydrator.go
+++ b/workflow/hydrator/hydrator.go
@@ -84,8 +84,9 @@ func (h hydrator) Hydrate(wf *wfv1.Workflow) error {
 			return err
 		}
 		h.HydrateWithNodes(wf, offloadedNodes)
+		log.WithField("Workflow Size", wf.Size()).Info("Workflow hydrated")
 	}
-	log.WithField("Workflow Size", wf.Size()).Info("Workflow hydrated")
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Dillen Padhiar <dillen_padhiar@intuit.com>

Fixes #8976 

If a workflow fails to be hydrated / dehydrated, it can be hard to tell what the issue may be. Many times, it may be because the workflow is too large and thus this change will log the size of the workflow so they may investigate for this case. 