### PR TITLE
build: Create ./git/hooks directory when missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,6 +654,7 @@ docs-serve: docs
 # pre-commit checks
 
 .git/hooks/%: hack/git/hooks/%
+	@mkdir -p .git/hooks
 	cp hack/git/hooks/$* .git/hooks/$*
 
 .PHONY: githooks


### PR DESCRIPTION
Seeing the following during development:
```
make start ui=true
GIT_COMMIT=92b7b580018e155b265d815e8fbbd5a05d9fdf3c GIT_BRANCH=user-namespace GIT_TAG=untagged GIT_TREE_STATE=clean RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=arn:aws:eks:us-west-2:541216676946:cluster/akp-001-tst-usw2 DOCKER_DESKTOP=false K3D=false DOCKER_PUSH=false
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
cp hack/git/hooks/pre-commit .git/hooks/pre-commit
cp: .git/hooks/pre-commit: No such file or directory
make: *** [.git/hooks/pre-commit] Error 1
```

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
