### PR TITLE
Treat 'connection reset by peer' as a transient network error. Fixes #9013

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -80,6 +80,9 @@ func isTransientNetworkErr(err error) bool {
 	} else if strings.Contains(errorString, "connection timed out") {
 		// If err is a net.Dial timeout, retry.
 		return true
+	} else if strings.Contains(errorString, "connection reset by peer") {
+		// If err is a ECONNRESET, retry.
+		return true
 	}
 
 	return false

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -23,6 +23,7 @@ var (
 	tlsHandshakeTimeoutErr net.Error = netError("net/http: TLS handshake timeout")
 	ioTimeoutErr           net.Error = netError("i/o timeout")
 	connectionTimedout     net.Error = netError("connection timed out")
+	connectionReset        net.Error = netError("connection reset by peer")
 	transientErr           net.Error = netError("this error is transient")
 	transientExitErr                 = exec.ExitError{
 		ProcessState: &os.ProcessState{},
@@ -68,6 +69,9 @@ func TestIsTransientErr(t *testing.T) {
 	})
 	t.Run("ConnectionTimeout", func(t *testing.T) {
 		assert.True(t, IsTransientErr(connectionTimedout))
+	})
+	t.Run("ConnectionReset", func(t *testing.T) {
+		assert.True(t, IsTransientErr(connectionReset))
 	})
 	t.Run("TransientErrorPattern", func(t *testing.T) {
 		_ = os.Setenv(transientEnvVarKey, "this error is transient")


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/9013

This treats `connection reset by peer` network errors as transient so that they can be retried.