### PR TITLE
feat: Support retry on nested DAG and node groups

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -884,9 +884,9 @@ func (s *CLISuite) TestWorkflowRetryNestedDag() {
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step2.dag2-step1.dag3-step3").Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step2.dag2-step1.dag3-step2").Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step2.dag2-step1.dag3-step1").Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("dag3-step3").Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("dag3-step2").Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("dag3-step1").Phase)
 		})
 }
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -868,8 +868,6 @@ func (s *CLISuite) TestWorkflowRetry() {
 }
 
 func (s *CLISuite) TestWorkflowRetryNestedDag() {
-	var retryTime metav1.Time
-
 	s.Given().
 		Workflow("@testdata/retry-nested-dag-test.yaml").
 		When().
@@ -879,7 +877,6 @@ func (s *CLISuite) TestWorkflowRetryNestedDag() {
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step3-tofail").Phase)
 		}).
-		Wait(3*time.Second).
 		RunCli([]string{"retry", "@latest", "--restart-successful", "--node-field-selector", "name=retry-nested-dag.dag1-step2.dag2-step1.dag3-step1"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
 				assert.Contains(t, output, "Name:")
@@ -889,9 +886,9 @@ func (s *CLISuite) TestWorkflowRetryNestedDag() {
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("fail-nested-dag.dag1-step2.dag2-step1.dag3-step3").Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("fail-nested-dag.dag1-step2.dag2-step1.dag3-step2").Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("fail-nested-dag.dag1-step2.dag2-step1.dag3-step1").Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step2.dag2-step1.dag3-step3").Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step2.dag2-step1.dag3-step2").Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step2.dag2-step1.dag3-step1").Phase)
 		})
 }
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -874,9 +874,6 @@ func (s *CLISuite) TestWorkflowRetryNestedDag() {
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step3-tofail").Phase)
-		}).
 		RunCli([]string{"retry", "retry-nested-dag", "--restart-successful", "--node-field-selector", "name=retry-nested-dag.dag1-step2.dag2-step1.dag3-step1"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
 				assert.Contains(t, output, "Name:")

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -877,12 +877,13 @@ func (s *CLISuite) TestWorkflowRetryNestedDag() {
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("retry-nested-dag.dag1-step3-tofail").Phase)
 		}).
-		RunCli([]string{"retry", "@latest", "--restart-successful", "--node-field-selector", "name=retry-nested-dag.dag1-step2.dag2-step1.dag3-step1"}, func(t *testing.T, output string, err error) {
+		RunCli([]string{"retry", "retry-nested-dag", "--restart-successful", "--node-field-selector", "name=retry-nested-dag.dag1-step2.dag2-step1.dag3-step1"}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
 				assert.Contains(t, output, "Name:")
 				assert.Contains(t, output, "Namespace:")
 			}
 		}).
+		When().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -43,9 +43,6 @@ func (g *Given) Workflow(text string) *Given {
 	g.t.Helper()
 	g.wf = &wfv1.Workflow{}
 	g.readResource(text, g.wf)
-	if g.wf.Name != "" {
-		g.t.Fatalf("workflow %q, but should use generate name", text)
-	}
 	g.checkImages(g.wf.Spec.Templates)
 	return g
 }

--- a/test/e2e/testdata/retry-nested-dag-test.yaml
+++ b/test/e2e/testdata/retry-nested-dag-test.yaml
@@ -1,0 +1,54 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: retry-nested-dag
+spec:
+  entrypoint: outer-dag
+  templates:
+    - name: outer-dag
+      dag:
+        tasks:
+          - name: dag1-step1
+            template: gen-random-int-javascript
+          - name: dag1-step2
+            dependencies: [dag1-step1]
+            template: middle-dag
+          - name: dag1-step3-tofail
+            dependencies: [dag1-step2]
+            template: node-to-fail
+            container:
+              image: alpine:latest
+              command: [sh, -c]
+              args: ["exit 1"]
+
+    - name: middle-dag
+      dag:
+        tasks:
+          - name: dag2-step1
+            template: inner-dag
+
+    - name: inner-dag
+      dag:
+        tasks:
+          - name: dag3-step1
+            template: gen-random-int-javascript
+          - name: dag3-step2
+            dependencies: [dag3-step1]
+            template: gen-random-int-javascript
+          - name: dag3-step3
+            dependencies: [dag3-step2]
+            template: gen-random-int-javascript
+
+    - name: gen-random-int-javascript
+      script:
+        image: node:9.1-alpine
+        command: [node]
+        source: |
+          var rand = Math.floor(Math.random() * 100);
+          console.log(rand);
+
+    - name: node-to-fail
+      container:
+        image: alpine:latest
+        command: [sh, -c]
+        args: ["exit 1"]

--- a/test/e2e/testdata/retry-nested-dag-test.yaml
+++ b/test/e2e/testdata/retry-nested-dag-test.yaml
@@ -9,17 +9,13 @@ spec:
       dag:
         tasks:
           - name: dag1-step1
-            template: gen-random-int-javascript
+            template: node-to-succeed
           - name: dag1-step2
             dependencies: [dag1-step1]
             template: middle-dag
           - name: dag1-step3-tofail
             dependencies: [dag1-step2]
             template: node-to-fail
-            container:
-              image: alpine:latest
-              command: [sh, -c]
-              args: ["exit 1"]
 
     - name: middle-dag
       dag:
@@ -31,24 +27,22 @@ spec:
       dag:
         tasks:
           - name: dag3-step1
-            template: gen-random-int-javascript
+            template: node-to-succeed
           - name: dag3-step2
             dependencies: [dag3-step1]
-            template: gen-random-int-javascript
+            template: node-to-succeed
           - name: dag3-step3
             dependencies: [dag3-step2]
-            template: gen-random-int-javascript
+            template: node-to-succeed
 
-    - name: gen-random-int-javascript
-      script:
-        image: node:9.1-alpine
-        command: [node]
-        source: |
-          var rand = Math.floor(Math.random() * 100);
-          console.log(rand);
+    - name: node-to-succeed
+      container:
+        image: argoproj/argosay:v2
+        command: [ sh, -c ]
+        args: [ "exit 0" ]
 
     - name: node-to-fail
       container:
-        image: alpine:latest
+        image: argoproj/argosay:v2
         command: [sh, -c]
         args: ["exit 1"]


### PR DESCRIPTION
Currently, retry does not work on nested DAG and node groups. As a result, these node statuses will be missing. This PR fixes it.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

