### PR TITLE
DEPPRICIATED PodPriority:fixes 8762

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -362,6 +362,8 @@ type WorkflowSpec struct {
 	PodPriorityClassName string `json:"podPriorityClassName,omitempty" protobuf:"bytes,23,opt,name=podPriorityClassName"`
 
 	// Priority to apply to workflow pods.
+	//DEPPRECIATED
+	//USE [PodPriorityClass] instead.
 	PodPriority *int32 `json:"podPriority,omitempty" protobuf:"bytes,24,opt,name=podPriority"`
 
 	// +patchStrategy=merge


### PR DESCRIPTION
PodPriority is depreciated as Kubernetes uses PodPriorityClass. I have added the comment as the word Deppriciated.