### PR TITLE
chore: remove unused code: validate.ValidateWorkflow() no longer sets wfConditions 

### DIFF
--- a/pkg/apiclient/offline-workflow-service-client.go
+++ b/pkg/apiclient/offline-workflow-service-client.go
@@ -82,7 +82,7 @@ func (o offlineClusterWorkflowTemplateNamespacedGetter) Get(name string) (*wfv1.
 }
 
 func (o OfflineWorkflowServiceClient) LintWorkflow(_ context.Context, req *workflowpkg.WorkflowLintRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
-	_, err := validate.ValidateWorkflow(&offlineWorkflowTemplateNamespacedGetter{}, &offlineClusterWorkflowTemplateNamespacedGetter{}, req.Workflow, validate.ValidateOpts{Lint: true})
+	err := validate.ValidateWorkflow(&offlineWorkflowTemplateNamespacedGetter{}, &offlineClusterWorkflowTemplateNamespacedGetter{}, req.Workflow, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}

--- a/server/clusterworkflowtemplate/cluster_workflow_template_server.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server.go
@@ -32,7 +32,7 @@ func (cwts *ClusterWorkflowTemplateServer) CreateClusterWorkflowTemplate(ctx con
 	cwts.instanceIDService.Label(req.Template)
 	creator.Label(ctx, req.Template)
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{})
+	err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (cwts *ClusterWorkflowTemplateServer) LintClusterWorkflowTemplate(ctx conte
 	wfClient := auth.GetWfClient(ctx)
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{Lint: true})
+	err := validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (cwts *ClusterWorkflowTemplateServer) UpdateClusterWorkflowTemplate(ctx con
 	wfClient := auth.GetWfClient(ctx)
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err = validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{})
+	err = validate.ValidateClusterWorkflowTemplate(nil, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -62,7 +62,7 @@ func (s *workflowServer) CreateWorkflow(ctx context.Context, req *workflowpkg.Wo
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err := validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, req.Workflow, validate.ValidateOpts{})
+	err := validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, req.Workflow, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ func (s *workflowServer) LintWorkflow(ctx context.Context, req *workflowpkg.Work
 	s.instanceIDService.Label(req.Workflow)
 	creator.Label(ctx, req.Workflow)
 
-	_, err := validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, req.Workflow, validate.ValidateOpts{Lint: true})
+	err := validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, req.Workflow, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +628,7 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{Submit: true})
+	err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{Submit: true})
 	if err != nil {
 		return nil, err
 	}

--- a/server/workflowtemplate/workflow_template_server.go
+++ b/server/workflowtemplate/workflow_template_server.go
@@ -33,7 +33,7 @@ func (wts *WorkflowTemplateServer) CreateWorkflowTemplate(ctx context.Context, r
 	creator.Label(ctx, req.Template)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{})
+	err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (wts *WorkflowTemplateServer) LintWorkflowTemplate(ctx context.Context, req
 	creator.Label(ctx, req.Template)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{Lint: true})
+	err := validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{Lint: true})
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (wts *WorkflowTemplateServer) UpdateWorkflowTemplate(ctx context.Context, r
 	wfClient := auth.GetWfClient(ctx)
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
-	_, err = validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{})
+	err = validate.ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, req.Template, validate.ValidateOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3497,8 +3497,7 @@ func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) error {
 		// Validate the execution wfSpec
 		err := waitutil.Backoff(retry.DefaultRetry,
 			func() (bool, error) {
-				var validationErr error
-				validationErr = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, woc.wf, validateOpts)
+				validationErr := validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, woc.wf, validateOpts)
 				if validationErr != nil {
 					return !errorsutil.IsTransientErr(validationErr), validationErr
 				}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3495,11 +3495,10 @@ func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) error {
 		cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(woc.controller.wfclientset.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
 		// Validate the execution wfSpec
-		var wfConditions *wfv1.Conditions
 		err := waitutil.Backoff(retry.DefaultRetry,
 			func() (bool, error) {
 				var validationErr error
-				wfConditions, validationErr = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, woc.wf, validateOpts)
+				validationErr = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, woc.wf, validateOpts)
 				if validationErr != nil {
 					return !errorsutil.IsTransientErr(validationErr), validationErr
 				}
@@ -3509,12 +3508,6 @@ func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) error {
 			msg := fmt.Sprintf("invalid spec: %s", err.Error())
 			woc.markWorkflowFailed(ctx, msg)
 			return err
-		}
-
-		// If we received conditions during validation (such as SpecWarnings), add them to the Workflow object
-		if len(*wfConditions) > 0 {
-			woc.wf.Status.Conditions.JoinConditions(wfConditions)
-			woc.updated = true
 		}
 	}
 	err := woc.setGlobalParameters(woc.execWf.Spec.Arguments)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -177,7 +177,7 @@ func SubmitWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, wfClie
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	_, err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{Submit: true})
+	err = validate.ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, validate.ValidateOpts{Submit: true})
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -33,7 +33,7 @@ spec:
 `
 
 func TestDAGCycle(t *testing.T) {
-	_, err := validate(dagCycle)
+	err := validate(dagCycle)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "cycle")
 	}
@@ -62,7 +62,7 @@ spec:
 `
 
 func TestAnyWithoutExpandingTask(t *testing.T) {
-	_, err := validate(dagAnyWithoutExpandingTask)
+	err := validate(dagAnyWithoutExpandingTask)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "does not contain any items")
 	}
@@ -84,7 +84,7 @@ spec:
 `
 
 func TestDAGUndefinedTemplate(t *testing.T) {
-	_, err := validate(dagUndefinedTemplate)
+	err := validate(dagUndefinedTemplate)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "undefined")
 	}
@@ -302,21 +302,21 @@ spec:
 `
 
 func TestDAGVariableResolution(t *testing.T) {
-	_, err := validate(dagUnresolvedVar)
+	err := validate(dagUnresolvedVar)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.A.outputs.parameters.unresolvable}}")
 	}
-	_, err = validate(dagResolvedVar)
+	err = validate(dagResolvedVar)
 	assert.NoError(t, err)
 
-	_, err = validate(dagResolvedVarNotAncestor)
+	err = validate(dagResolvedVarNotAncestor)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "templates.unresolved.tasks.C missing dependency 'B' for parameter 'message'")
 	}
 
-	_, err = validate(dagResolvedGlobalVar)
+	err = validate(dagResolvedGlobalVar)
 	assert.NoError(t, err)
-	_, err = validate(dagResolvedGlobalVarReversed)
+	err = validate(dagResolvedGlobalVarReversed)
 	assert.NoError(t, err)
 }
 
@@ -374,7 +374,7 @@ spec:
 `
 
 func TestDAGArtifactResolution(t *testing.T) {
-	_, err := validate(dagResolvedArt)
+	err := validate(dagResolvedArt)
 	assert.NoError(t, err)
 }
 
@@ -608,24 +608,24 @@ spec:
 `
 
 func TestDAGStatusReference(t *testing.T) {
-	_, err := validate(dagStatusReference)
+	err := validate(dagStatusReference)
 	assert.NoError(t, err)
 
-	_, err = validate(dagStatusNoFutureReferenceSimple)
+	err = validate(dagStatusNoFutureReferenceSimple)
 	// Can't reference the status of steps that have not run yet
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
 	}
-	_, err = validate(dagStatusNoFutureReferenceWhenFutureReferenceHasChild)
+	err = validate(dagStatusNoFutureReferenceWhenFutureReferenceHasChild)
 	// Can't reference the status of steps that have not run yet, even if the referenced steps have children
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
 	}
 
-	_, err = validate(dagStatusPastReferenceChain)
+	err = validate(dagStatusPastReferenceChain)
 	assert.NoError(t, err)
 
-	_, err = validate(dagStatusOnlyDirectAncestors)
+	err = validate(dagStatusOnlyDirectAncestors)
 	// Can't reference steps that are not direct ancestors of node
 	// Here Node E references the status of Node B, even though it is not its descendent
 	if assert.NotNil(t, err) {
@@ -664,7 +664,7 @@ spec:
 `
 
 func TestDAGNonExistantTarget(t *testing.T) {
-	_, err := validate(dagNonexistantTarget)
+	err := validate(dagNonexistantTarget)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "target 'DOESNTEXIST' is not defined")
 	}
@@ -705,7 +705,7 @@ spec:
 `
 
 func TestDAGTargetSubstitution(t *testing.T) {
-	_, err := validate(dagTargetSubstitution)
+	err := validate(dagTargetSubstitution)
 	assert.NoError(t, err)
 }
 
@@ -739,7 +739,7 @@ spec:
 `
 
 func TestDAGTargetMissingInputParam(t *testing.T) {
-	_, err := validate(dagTargetMissingInputParam)
+	err := validate(dagTargetMissingInputParam)
 	assert.NotNil(t, err)
 }
 
@@ -770,7 +770,7 @@ spec:
 `
 
 func TestDependsAndDependencies(t *testing.T) {
-	_, err := validate(dagDependsAndDependencies)
+	err := validate(dagDependsAndDependencies)
 	assert.Error(t, err, "templates.dag-target cannot use both 'depends' and 'dependencies' in the same DAG template")
 }
 
@@ -802,7 +802,7 @@ spec:
 `
 
 func TestDependsAndContinueOn(t *testing.T) {
-	_, err := validate(dagDependsAndContinueOn)
+	err := validate(dagDependsAndContinueOn)
 	assert.Error(t, err, "templates.dag-target cannot use 'continueOn' when using 'depends'. Instead use 'dep-task.Failed'/'dep-task.Errored'")
 }
 
@@ -854,7 +854,7 @@ spec:
 `
 
 func TestDAGDependsDigit(t *testing.T) {
-	_, err := validate(dagDependsDigit)
+	err := validate(dagDependsDigit)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 	}
@@ -908,7 +908,7 @@ spec:
 `
 
 func TestDAGDependenciesDigit(t *testing.T) {
-	_, err := validate(dagDependenciesDigit)
+	err := validate(dagDependenciesDigit)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 	}
@@ -939,7 +939,7 @@ spec:
 `
 
 func TestDAGWithDigitNameNoDepends(t *testing.T) {
-	_, err := validate(dagWithDigitNoDepends)
+	err := validate(dagWithDigitNoDepends)
 	assert.NoError(t, err)
 }
 
@@ -1029,7 +1029,7 @@ spec:
 `
 
 func TestDAGOutputsResolveTaskAggregatedOutputs(t *testing.T) {
-	_, err := validate(dagOutputsResolveTaskAggregatedOutputs)
+	err := validate(dagOutputsResolveTaskAggregatedOutputs)
 	assert.NoError(t, err)
 }
 
@@ -1066,7 +1066,7 @@ spec:
 `
 
 func TestDAGMissingParamValueInTask(t *testing.T) {
-	_, err := validate(dagMissingParamValueInTask)
+	err := validate(dagMissingParamValueInTask)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "templates.root.tasks.task missing value for parameter 'data'")
 	}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -42,7 +42,7 @@ func deleteWorkflowTemplate(name string) error {
 
 // validate is a test helper to accept Workflow YAML as a string and return
 // its validation result.
-func validate(yamlStr string) (*wfv1.Conditions, error) {
+func validate(yamlStr string) error {
 	wf := unmarshalWf(yamlStr)
 	return ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 }
@@ -51,7 +51,7 @@ func validate(yamlStr string) (*wfv1.Conditions, error) {
 // its validation result.
 func validateWorkflowTemplate(yamlStr string, opts ValidateOpts) error {
 	wftmpl := unmarshalWftmpl(yamlStr)
-	_, err := ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, opts)
+	err := ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, opts)
 	return err
 }
 
@@ -122,15 +122,15 @@ spec:
 `
 
 func TestDuplicateOrEmptyNames(t *testing.T) {
-	_, err := validate(dupTemplateNames)
+	err := validate(dupTemplateNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "not unique")
 	}
-	_, err = validate(dupInputNames)
+	err = validate(dupInputNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "not unique")
 	}
-	_, err = validate(emptyName)
+	err = validate(emptyName)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "name is required")
 	}
@@ -201,15 +201,15 @@ spec:
 `
 
 func TestUnresolved(t *testing.T) {
-	_, err := validate(unresolvedInput)
+	err := validate(unresolvedInput)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve")
 	}
-	_, err = validate(unresolvedStepInput)
+	err = validate(unresolvedStepInput)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve")
 	}
-	_, err = validate(unresolvedOutput)
+	err = validate(unresolvedOutput)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve")
 	}
@@ -257,7 +257,7 @@ spec:
 `
 
 func TestResolveIOArtifactPathPlaceholders(t *testing.T) {
-	_, err := validate(ioArtifactPaths)
+	err := validate(ioArtifactPaths)
 	assert.NoError(t, err)
 }
 
@@ -281,7 +281,7 @@ spec:
 `
 
 func TestResolveOutputParameterPathPlaceholder(t *testing.T) {
-	_, err := validate(outputParameterPath)
+	err := validate(outputParameterPath)
 	assert.NoError(t, err)
 }
 
@@ -318,7 +318,7 @@ spec:
 `
 
 func TestStepOutputReference(t *testing.T) {
-	_, err := validate(stepOutputReferences)
+	err := validate(stepOutputReferences)
 	assert.NoError(t, err)
 }
 
@@ -356,7 +356,7 @@ spec:
 `
 
 func TestStepStatusReference(t *testing.T) {
-	_, err := validate(stepStatusReferences)
+	err := validate(stepStatusReferences)
 	assert.NoError(t, err)
 }
 
@@ -394,7 +394,7 @@ spec:
 `
 
 func TestStepStatusReferenceNoFutureReference(t *testing.T) {
-	_, err := validate(stepStatusReferencesNoFutureReference)
+	err := validate(stepStatusReferencesNoFutureReference)
 	// Can't reference the status of steps that have not run yet
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{steps.two.status}}")
@@ -453,7 +453,7 @@ spec:
 `
 
 func TestStepArtReference(t *testing.T) {
-	_, err := validate(stepArtReferences)
+	err := validate(stepArtReferences)
 	assert.NoError(t, err)
 }
 
@@ -478,7 +478,7 @@ spec:
 `
 
 func TestParamWithValueFromConfigMapRef(t *testing.T) {
-	_, err := validate(paramWithValueFromConfigMapRef)
+	err := validate(paramWithValueFromConfigMapRef)
 	assert.NoError(t, err)
 }
 
@@ -499,7 +499,7 @@ spec:
 `
 
 func TestParamWithoutValue(t *testing.T) {
-	_, err := validate(paramWithoutValue)
+	err := validate(paramWithoutValue)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "not supplied")
 	}
@@ -633,13 +633,13 @@ spec:
 `
 
 func TestGlobalParam(t *testing.T) {
-	_, err := validate(globalParam)
+	err := validate(globalParam)
 	assert.NoError(t, err)
 
-	_, err = validate(nestedGlobalParam)
+	err = validate(nestedGlobalParam)
 	assert.NoError(t, err)
 
-	_, err = validate(unsuppliedArgValue)
+	err = validate(unsuppliedArgValue)
 	assert.EqualError(t, err, "spec.arguments.missing.value is required")
 }
 
@@ -660,7 +660,7 @@ spec:
 `
 
 func TestInvalidTemplateName(t *testing.T) {
-	_, err := validate(invalidTemplateNames)
+	err := validate(invalidTemplateNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
@@ -687,7 +687,7 @@ spec:
 `
 
 func TestInvalidArgParamName(t *testing.T) {
-	_, err := validate(invalidArgParamNames)
+	err := validate(invalidArgParamNames)
 	assert.NotNil(t, err)
 }
 
@@ -718,7 +718,7 @@ spec:
 `
 
 func TestInvalidArgArtName(t *testing.T) {
-	_, err := validate(invalidArgArtNames)
+	err := validate(invalidArgArtNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
@@ -765,7 +765,7 @@ spec:
 `
 
 func TestInvalidStepName(t *testing.T) {
-	_, err := validate(invalidStepNames)
+	err := validate(invalidStepNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
@@ -791,7 +791,7 @@ spec:
 `
 
 func TestInvalidInputParamName(t *testing.T) {
-	_, err := validate(invalidInputParamNames)
+	err := validate(invalidInputParamNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
@@ -843,7 +843,7 @@ spec:
 `
 
 func TestInvalidInputArtName(t *testing.T) {
-	_, err := validate(invalidInputArtNames)
+	err := validate(invalidInputArtNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
@@ -869,7 +869,7 @@ spec:
 `
 
 func TestInvalidOutputArtName(t *testing.T) {
-	_, err := validate(invalidOutputArtNames)
+	err := validate(invalidOutputArtNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
@@ -984,23 +984,23 @@ spec:
 `
 
 func TestInvalidOutputParam(t *testing.T) {
-	_, err := validate(invalidOutputParamNames)
+	err := validate(invalidOutputParamNames)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
-	_, err = validate(invalidOutputMissingValueFrom)
+	err = validate(invalidOutputMissingValueFrom)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "does not have valueFrom or value specified")
 	}
-	_, err = validate(invalidOutputMultipleValueFrom)
+	err = validate(invalidOutputMultipleValueFrom)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "multiple valueFrom")
 	}
-	_, err = validate(invalidOutputIncompatibleValueFromPath)
+	err = validate(invalidOutputIncompatibleValueFromPath)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), ".path must be specified for Container templates")
 	}
-	_, err = validate(invalidOutputIncompatibleValueFromParam)
+	err = validate(invalidOutputIncompatibleValueFromParam)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), ".parameter or expression must be specified for Steps templates")
 	}
@@ -1029,7 +1029,7 @@ spec:
 `
 
 func TestMultipleTemplateTypes(t *testing.T) {
-	_, err := validate(multipleTemplateTypes)
+	err := validate(multipleTemplateTypes)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "multiple template types specified")
 	}
@@ -1073,11 +1073,11 @@ spec:
 
 func TestExitHandler(t *testing.T) {
 	// ensure {{workflow.status}} is not available when not in exit handler
-	_, err := validate(workflowStatusNotOnExit)
+	err := validate(workflowStatusNotOnExit)
 	assert.NotNil(t, err)
 
 	// ensure {{workflow.status}} is available in exit handler
-	_, err = validate(exitHandlerWorkflowStatusOnExit)
+	err = validate(exitHandlerWorkflowStatusOnExit)
 	assert.NoError(t, err)
 }
 
@@ -1098,7 +1098,7 @@ spec:
 `
 
 func TestPriorityVariable(t *testing.T) {
-	_, err := validate(workflowWithPriority)
+	err := validate(workflowWithPriority)
 	assert.NoError(t, err)
 }
 
@@ -1138,7 +1138,7 @@ func TestVolumeMountArtifactPathCollision(t *testing.T) {
 	// ensure we detect and reject path collisions
 	wf := unmarshalWf(volumeMountArtifactPathCollision)
 
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "already mounted")
@@ -1146,7 +1146,7 @@ func TestVolumeMountArtifactPathCollision(t *testing.T) {
 	// tweak the mount path and validation should now be successful
 	wf.Spec.Templates[0].Container.VolumeMounts[0].MountPath = "/differentpath"
 
-	_, err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
 	assert.NoError(t, err)
 }
@@ -1168,7 +1168,7 @@ spec:
 `
 
 func TestValidActiveDeadlineSeconds(t *testing.T) {
-	_, err := validate(activeDeadlineSeconds)
+	err := validate(activeDeadlineSeconds)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "activeDeadlineSeconds must be a positive integer > 0")
 	}
@@ -1191,7 +1191,7 @@ spec:
 `
 
 func TestLeafWithParallelism(t *testing.T) {
-	_, err := validate(leafWithParallelism)
+	err := validate(leafWithParallelism)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "is only valid")
 	}
@@ -1253,11 +1253,11 @@ spec:
 `
 
 func TestInvalidArgumentNoFromOrLocation(t *testing.T) {
-	_, err := validate(invalidStepsArgumentNoFromOrLocation)
+	err := validate(invalidStepsArgumentNoFromOrLocation)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "from, artifact location, or key is required")
 	}
-	_, err = validate(invalidDAGArgumentNoFromOrLocation)
+	err = validate(invalidDAGArgumentNoFromOrLocation)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "from, artifact location, or key is required")
 	}
@@ -1290,7 +1290,7 @@ spec:
 `
 
 func TestInvalidArgumentNoValue(t *testing.T) {
-	_, err := validate(invalidArgumentNoValue)
+	err := validate(invalidArgumentNoValue)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), ".value is required")
 	}
@@ -1331,7 +1331,7 @@ spec:
 `
 
 func TestValidWithItems(t *testing.T) {
-	_, err := validate(validWithItems)
+	err := validate(validWithItems)
 	assert.NoError(t, err)
 }
 
@@ -1365,12 +1365,12 @@ spec:
 `
 
 func TestPodNameVariable(t *testing.T) {
-	_, err := validate(podNameVariable)
+	err := validate(podNameVariable)
 	assert.NoError(t, err)
 }
 
 func TestGlobalParamWithVariable(t *testing.T) {
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wfv1.MustUnmarshalWorkflow("@../../test/e2e/functional/global-outputs-variable.yaml"), ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wfv1.MustUnmarshalWorkflow("@../../test/e2e/functional/global-outputs-variable.yaml"), ValidateOpts{})
 
 	assert.NoError(t, err)
 }
@@ -1397,9 +1397,9 @@ spec:
 func TestSpecArgumentNoValue(t *testing.T) {
 	wf := unmarshalWf(specArgumentNoValue)
 
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 	assert.NoError(t, err)
-	_, err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
 	assert.NotNil(t, err)
 }
@@ -1436,7 +1436,7 @@ spec:
 func TestSpecArgumentSnakeCase(t *testing.T) {
 	wf := unmarshalWf(specArgumentSnakeCase)
 
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
 	assert.NoError(t, err)
 }
@@ -1473,7 +1473,7 @@ spec:
 func TestSpecBadSequenceCountAndEnd(t *testing.T) {
 	wf := unmarshalWf(specBadSequenceCountAndEnd)
 
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
 	assert.Error(t, err)
 }
@@ -1495,7 +1495,7 @@ spec:
 func TestCustomTemplatVariable(t *testing.T) {
 	wf := unmarshalWf(customVariableInput)
 
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
 	assert.Equal(t, err, nil)
 }
@@ -1554,9 +1554,8 @@ func TestNestedTemplateRef(t *testing.T) {
 	assert.NoError(t, err)
 	err = createWorkflowTemplateFromSpec(templateRefNestedTarget)
 	assert.NoError(t, err)
-	wfConditions, err := validate(nestedTemplateRef)
+	err = validate(nestedTemplateRef)
 	assert.NoError(t, err)
-	assert.Empty(t, wfConditions)
 }
 
 var undefinedTemplateRef = `
@@ -1576,7 +1575,7 @@ spec:
 `
 
 func TestUndefinedTemplateRef(t *testing.T) {
-	_, err := validate(undefinedTemplateRef)
+	err := validate(undefinedTemplateRef)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "not found")
 	}
@@ -1604,7 +1603,7 @@ spec:
 func TestValidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(validResourceWorkflow)
 
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
 	assert.Equal(t, err, nil)
 }
@@ -1648,11 +1647,11 @@ spec:
 // TestInvalidResourceWorkflow verifies an error against a workflow of an invalid resource.
 func TestInvalidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(invalidResourceWorkflow)
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "templates.whalesay.resource.manifest must be a valid yaml")
 
 	wf = unmarshalWf(invalidActionResourceWorkflow)
-	_, err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "templates.whalesay.resource.action must be one of: get, create, apply, delete, replace, patch")
 }
 
@@ -1672,7 +1671,7 @@ spec:
 // TestIncorrectPodGCStrategy verifies pod gc strategy is correct.
 func TestIncorrectPodGCStrategy(t *testing.T) {
 	wf := unmarshalWf(invalidPodGC)
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "podGC.strategy unknown strategy 'Foo'")
 }
 
@@ -1691,7 +1690,7 @@ spec:
     container:
       image: docker/whalesay
 `)
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "podGC.labelSelector invalid: \"InvalidOperator\" is not a valid pod selector operator")
 }
 
@@ -1793,7 +1792,7 @@ spec:
 func TestAllowPlaceholderInVariableTakenFromInputs(t *testing.T) {
 	{
 		wf := unmarshalWf(allowPlaceholderInVariableTakenFromInputs)
-		_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+		err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
 		assert.NoError(t, err)
 	}
@@ -1852,7 +1851,7 @@ spec:
 // TestInvalidResourceWorkflow verifies an error against a workflow of an invalid resource.
 func TestRuntimeResolutionOfVariableNames(t *testing.T) {
 	wf := unmarshalWf(runtimeResolutionOfVariableNames)
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
 	assert.NoError(t, err)
 }
@@ -1901,7 +1900,7 @@ spec:
 `
 
 func TestStepWithItemParam(t *testing.T) {
-	_, err := validate(stepWithItemParam)
+	err := validate(stepWithItemParam)
 	assert.NoError(t, err)
 }
 
@@ -1925,7 +1924,7 @@ spec:
 `
 
 func TestInvalidMetricName(t *testing.T) {
-	_, err := validate(invalidMetricName)
+	err := validate(invalidMetricName)
 	assert.EqualError(t, err, "templates.whalesay metric name 'invalid.metric.name' is invalid. Metric names must contain alphanumeric characters, '_', or ':'")
 }
 
@@ -1952,7 +1951,7 @@ spec:
 `
 
 func TestInvalidMetricLabelName(t *testing.T) {
-	_, err := validate(invalidMetricLabelName)
+	err := validate(invalidMetricLabelName)
 	assert.EqualError(t, err, "metric label 'invalid.key' is invalid: keys may only contain alphanumeric characters, '_', or ':'")
 }
 
@@ -1975,7 +1974,7 @@ spec:
 `
 
 func TestInvalidMetricHelp(t *testing.T) {
-	_, err := validate(invalidMetricHelp)
+	err := validate(invalidMetricHelp)
 	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' must contain a help string under 'help: ' field")
 }
 
@@ -2000,7 +1999,7 @@ spec:
 `
 
 func TestInvalidMetricGauge(t *testing.T) {
-	_, err := validate(invalidRealtimeMetricGauge)
+	err := validate(invalidRealtimeMetricGauge)
 	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' error: 'resourcesDuration.*' metrics cannot be used in real-time")
 }
 
@@ -2024,7 +2023,7 @@ spec:
 `
 
 func TestInvalidNoValueMetricGauge(t *testing.T) {
-	_, err := validate(invalidNoValueMetricGauge)
+	err := validate(invalidNoValueMetricGauge)
 	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' error: missing gauge.value")
 }
 
@@ -2058,7 +2057,7 @@ spec:
 `
 
 func TestValidMetricGauge(t *testing.T) {
-	_, err := validate(validMetricGauges)
+	err := validate(validMetricGauges)
 	assert.NoError(t, err)
 }
 
@@ -2107,7 +2106,7 @@ spec:
 `
 
 func TestWorkflowGlobalVariables(t *testing.T) {
-	_, err := validate(globalVariables)
+	err := validate(globalVariables)
 	assert.NoError(t, err)
 }
 
@@ -2163,7 +2162,7 @@ spec:
 func TestWorkflowWithWFTRefWithEntrypoint(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateWithEntrypoint)
 	assert.NoError(t, err)
-	_, err = validate(wfWithWFTRefNoEntrypoint)
+	err = validate(wfWithWFTRefNoEntrypoint)
 	assert.NoError(t, err)
 }
 
@@ -2194,7 +2193,7 @@ spec:
 func TestWorkflowWithWFTRef(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefTarget)
 	assert.NoError(t, err)
-	_, err = validate(wfWithWFTRef)
+	err = validate(wfWithWFTRef)
 	assert.NoError(t, err)
 }
 
@@ -2221,7 +2220,7 @@ spec:
 func TestValidateFieldsWithWFTRef(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefTarget)
 	assert.NoError(t, err)
-	_, err = validate(invalidWFWithWFTRef)
+	err = validate(invalidWFWithWFTRef)
 	assert.Error(t, err)
 }
 
@@ -2241,7 +2240,7 @@ spec:
       env: []`
 
 func TestInvalidWfNoImageField(t *testing.T) {
-	_, err := validate(invalidWfNoImage)
+	err := validate(invalidWfNoImage)
 	assert.EqualError(t, err, "templates.whalesay.container.image may not be empty")
 }
 
@@ -2261,7 +2260,7 @@ spec:
       env: []`
 
 func TestInvalidWfNoImageFieldScript(t *testing.T) {
-	_, err := validate(invalidWfNoImageScript)
+	err := validate(invalidWfNoImageScript)
 	assert.EqualError(t, err, "templates.whalesay.script.image may not be empty")
 }
 
@@ -2300,7 +2299,7 @@ spec:
 func TestWorkflowWithWFTRefWithOverrideParam(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefWithParam)
 	assert.NoError(t, err)
-	_, err = validate(wfWithWFTRefOverrideParam)
+	err = validate(wfWithWFTRefOverrideParam)
 	assert.NoError(t, err)
 }
 
@@ -2372,7 +2371,7 @@ spec:
 func TestWorkflowWithWFTRefWithOutOwnArtifactArgument(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefWithArtifactArgument)
 	assert.NoError(t, err)
-	_, err = validate(wfWithWFTRefAndNoOwnArtifact)
+	err = validate(wfWithWFTRefAndNoOwnArtifact)
 	assert.NoError(t, err)
 }
 
@@ -2395,7 +2394,7 @@ spec:
 func TestWorkflowWithWFTRefWithArtifactArgument(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefWithArtifactArgument)
 	assert.NoError(t, err)
-	_, err = validate(wfWithWFTRefAndOwnArtifactArgument)
+	err = validate(wfWithWFTRefAndOwnArtifactArgument)
 	assert.NoError(t, err)
 }
 
@@ -2568,15 +2567,15 @@ func TestValidActiveDeadlineSecondsArgoVariable(t *testing.T) {
 
 func TestMaxLengthName(t *testing.T) {
 	wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	_, err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 	assert.EqualError(t, err, "workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	wftmpl := &wfv1.WorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	_, err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, ValidateOpts{})
+	err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, ValidateOpts{})
 	assert.EqualError(t, err, "workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwftmpl := &wfv1.ClusterWorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	_, err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl, ValidateOpts{})
+	err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl, ValidateOpts{})
 	assert.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 60)}}
@@ -2610,7 +2609,7 @@ spec:
 `
 
 func TestInvalidContainerSetDependencyNotFound(t *testing.T) {
-	_, err := validate(invalidContainerSetDependencyNotFound)
+	err := validate(invalidContainerSetDependencyNotFound)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "templates.main.containerSet.containers.b dependency 'c' not defined")
 	}
@@ -2766,7 +2765,7 @@ spec:
       container:
         image: alpine:3.7
         command: [echo, "{{inputs.parameters.startedat}}"]`
-	_, err := validate(wf)
+	err := validate(wf)
 	assert.NoError(t, err)
 }
 
@@ -2797,7 +2796,7 @@ spec:
 `
 
 func TestTemplateReferenceWorkflowConfigMapRefArgument(t *testing.T) {
-	_, err := validate(templateReferenceWorkflowConfigMapRefArgument)
+	err := validate(templateReferenceWorkflowConfigMapRefArgument)
 	assert.NoError(t, err)
 }
 
@@ -2844,7 +2843,7 @@ spec:
 `
 
 func TestStepsOutputParametersForScript(t *testing.T) {
-	_, err := validate(stepsOutputParametersForScript)
+	err := validate(stepsOutputParametersForScript)
 	assert.NoError(t, err)
 }
 
@@ -2894,7 +2893,7 @@ spec:
 `
 
 func TestStepsOutputParametersForContainerSet(t *testing.T) {
-	_, err := validate(stepsOutputParametersForContainerSet)
+	err := validate(stepsOutputParametersForContainerSet)
 	assert.NoError(t, err)
 }
 
@@ -2921,7 +2920,7 @@ spec:
       args: ["{{workflow.annotations}},  {{workflow.labels}}"]`
 
 func TestResolveAnnotationsAndLabelsJSson(t *testing.T) {
-	_, err := validate(globalAnnotationsAndLabels)
+	err := validate(globalAnnotationsAndLabels)
 	assert.NoError(t, err)
 }
 
@@ -2957,7 +2956,7 @@ spec:
 `
 
 func TestInitContainerHasName(t *testing.T) {
-	_, err := validate(testInitContainerHasName)
+	err := validate(testInitContainerHasName)
 	assert.EqualError(t, err, "templates.main.tasks.spurious initContainers must all have container name")
 }
 
@@ -3012,7 +3011,7 @@ func TestSubstituteGlobalVariablesLabelsAnnotations(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			_, err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+			err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 			if tt.expectedSuccess {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
validate.ValidateWorkflow() no longer sets wfConditions so removing it to clean up the code

Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

