### PR TITLE
fix: sync lock should be released only if we're retrying

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1902,8 +1902,6 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	if err != nil {
 		node = woc.markNodeError(nodeName, err)
 
-		woc.controller.syncManager.Release(woc.wf, node.ID, processedTmpl.Synchronization)
-
 		// If retry policy is not set, or if it is not set to Always or OnError, we won't attempt to retry an errored container
 		// and we return instead.
 		retryStrategy := woc.retryStrategy(processedTmpl)
@@ -1911,6 +1909,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 			(retryStrategy.RetryPolicy != wfv1.RetryPolicyAlways &&
 				retryStrategy.RetryPolicy != wfv1.RetryPolicyOnError &&
 				retryStrategy.RetryPolicy != wfv1.RetryPolicyOnTransientError) {
+			woc.controller.syncManager.Release(woc.wf, node.ID, processedTmpl.Synchronization)
 			return node, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

We shouldn't be performing this release logic except in the case of our returning. 