### PR TITLE
fix: Workflow retry should also reset the selected nodes

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -796,6 +796,10 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 				}
 				continue
 			}
+			if doForceResetNode {
+				newNode := node.DeepCopy()
+				newWF.Status.Nodes[newNode.ID] = resetNode(*newNode)
+			}
 		case wfv1.NodeError, wfv1.NodeFailed, wfv1.NodeOmitted:
 			if !strings.HasPrefix(node.Name, onExitNodeName) && (node.Type == wfv1.NodeTypeDAG || node.Type == wfv1.NodeTypeTaskGroup || node.Type == wfv1.NodeTypeStepGroup) {
 				newNode := node.DeepCopy()


### PR DESCRIPTION
This fixed a corner case with additional test cases and should also fix the flaky test mentioned in https://github.com/argoproj/argo-workflows/issues/9146.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
