### PR TITLE
docs: restore work-avoidance page

### DIFF
--- a/docs/work-avoidance.md
+++ b/docs/work-avoidance.md
@@ -1,0 +1,36 @@
+# Work Avoidance
+
+> v2.9 and after
+
+You can make workflows faster and more robust by employing **work avoidance**. A workflow that utilizes this is simply a workflow containing steps that do not run if the work has already been done. This simplest way to do this is to use **marker files**.
+
+Use cases:
+
+* An expensive step appears across multiple workflows - you want to avoid repeating them.
+* A workflow has unreliable tasks - you want to be able resubmit the workflow.
+
+A **marker file** is a file on that indicates the work has already been done, before doing the work you check to see if the marker has already been done:
+
+```sh
+if [ -e /work/markers/name-of-task ]; then
+    echo "work already done"
+    exit 0
+fi
+echo "working very hard"
+touch /work/markers/name-of-task
+```
+
+Choose a name for the file that is unique for the task, e.g. the template name and all the parameters:
+
+```sh
+touch /work/markers/$(date +%Y-%m-%d)-echo-{{inputs.parameters.num}}
+```
+
+You need to store the marker files between workflows and this can be achieved using [a PVC](fields.md#persistentvolumeclaim) and [optional input artifact](fields.md#artifact).
+
+[This complete work avoidance example](https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/work-avoidance.yaml) has the following:
+
+* A PVC to store the markers on.
+* A `load-markers` step that loads the marker files from artifact storage.
+* Multiple `echo` tasks that avoid work using marker files.
+* A `save-markers` exit handler to save the marker files, even if they are not needed.

--- a/docs/work-avoidance.md
+++ b/docs/work-avoidance.md
@@ -7,9 +7,9 @@ You can make workflows faster and more robust by employing **work avoidance**. A
 Use cases:
 
 * An expensive step appears across multiple workflows - you want to avoid repeating them.
-* A workflow has unreliable tasks - you want to be able resubmit the workflow.
+* A workflow has unreliable tasks - you want to be able to resubmit the workflow.
 
-A **marker file** is a file on that indicates the work has already been done, before doing the work you check to see if the marker has already been done:
+A **marker file** is a file that indicates the work has already been done. Before doing the work you check to see if the marker has already been done:
 
 ```sh
 if [ -e /work/markers/name-of-task ]; then

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
           - cron-backfill.md
           - workflow-of-workflows.md
           - workflow-notifications.md
+          - work-avoidance.md
       - UI Features:
           - artifact-visualization.md
           - widgets.md


### PR DESCRIPTION
Signed-off-by: mikutas <23391543+mikutas@users.noreply.github.com>

https://argoproj.github.io/argo-workflows/work-avoidance/ (404)

Is it deleted accidentally (in #8562) ?

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->