### PR TITLE
fix: remove unused argument which is triggering in lint (needed for PRs to pass CI)

### DIFF
--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -15,7 +14,7 @@ import (
 
 // applyExecutionControl will ensure a pod's execution control annotation is up-to-date
 // kills any pending and running pods when workflow has reached it's deadline
-func (woc *wfOperationCtx) applyExecutionControl(ctx context.Context, pod *apiv1.Pod, wfNodesLock *sync.RWMutex) {
+func (woc *wfOperationCtx) applyExecutionControl(pod *apiv1.Pod, wfNodesLock *sync.RWMutex) {
 	if pod == nil {
 		return
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1020,7 +1020,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) error {
 		go func(pod *apiv1.Pod) {
 			defer wg.Done()
 			performAssessment(pod)
-			woc.applyExecutionControl(ctx, pod, wfNodesLock)
+			woc.applyExecutionControl(pod, wfNodesLock)
 			<-parallelPodNum
 		}(pod)
 	}


### PR DESCRIPTION
golangcli-lint recently went from version 1.47.0 to 1.47.1. I think that must be why we're all of a sudden seeing this error:
`Error: workflow/controller/exec_control.go:18:50: (*wfOperationCtx).applyExecutionControl - ctx is unused (unparam)`

as here: https://github.com/argoproj/argo-workflows/runs/7419737341?check_suite_focus=true