### PR TITLE
fix: Set namespace to user namespace obtained from /userinfo service

### DIFF
--- a/ui/src/app/app-router.tsx
+++ b/ui/src/app/app-router.tsx
@@ -65,6 +65,7 @@ export const AppRouter = ({popupManager, history, notificationsManager}: {popupM
     useEffect(() => {
         services.info.getUserInfo().then(userInfo => {
             Utils.userNamespace = userInfo.serviceAccountNamespace;
+            setNamespace(Utils.currentNamespace);
         });
         services.info
             .getInfo()

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -103,7 +103,7 @@ export const Utils = {
     },
 
     get currentNamespace() {
-        // we always prefer the managed namespace
+        // we always prefer the user namespace
         return this.userNamespace || this.managedNamespace || this.fixLocalStorageString(localStorage.getItem(currentNamespaceKey));
     },
 


### PR DESCRIPTION
The namespace is `undefined` upon clicking the workflows tab on the lefthand menu (see screenshot). This can be resolved upon refreshing or re-opening the tab. The issue is that the namespace state variable in React is not being set after we get the user namespace. This PR will fix the issue.

![image](https://user-images.githubusercontent.com/4269898/180043563-a4b5b4ce-e97a-43db-97e0-9991b842d87d.png)

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>