### PR TITLE
ci: Pin golangci-lint to v1.47.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ dist/manifests/%: manifests/%
 # lint/test/etc
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.1 -- -b `go env GOPATH`/bin
 
 .PHONY: lint
 lint: server/static/files.go $(GOPATH)/bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ dist/manifests/%: manifests/%
 # lint/test/etc
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.1 -- -b `go env GOPATH`/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.47.1
 
 .PHONY: lint
 lint: server/static/files.go $(GOPATH)/bin/golangci-lint


### PR DESCRIPTION
See context in https://github.com/argoproj/argo-workflows/pull/9186. 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
