### PR TITLE
fix: example wf, port data format and missing command

### DIFF
--- a/docs/walk-through/sidecars.md
+++ b/docs/walk-through/sidecars.md
@@ -20,6 +20,7 @@ spec:
     sidecars:
     - name: nginx
       image: nginx:1.13
+      command: [nginx, -g, daemon off;]
 ```
 
 In the above example, we create a sidecar container that runs Nginx as a simple web server. The order in which containers come up is random, so in this example the main container polls the Nginx container until it is ready to service requests. This is a good design pattern when designing multi-container systems: always wait for any services you need to come up before running your main code.

--- a/examples/daemon-nginx.yaml
+++ b/examples/daemon-nginx.yaml
@@ -24,7 +24,7 @@ spec:
       readinessProbe:
         httpGet:
           path: /
-          port: "80"
+          port: 80
         initialDelaySeconds: 2
         timeoutSeconds: 1
 

--- a/examples/daemon-step.yaml
+++ b/examples/daemon-step.yaml
@@ -50,7 +50,7 @@ spec:
       readinessProbe:
         httpGet:
           path: /ping
-          port: "8086"
+          port: 8086
         initialDelaySeconds: 5
         timeoutSeconds: 1
 

--- a/examples/dag-daemon-task.yaml
+++ b/examples/dag-daemon-task.yaml
@@ -59,7 +59,7 @@ spec:
       readinessProbe:
         httpGet:
           path: /ping
-          port: "8086"
+          port: 8086
         initialDelaySeconds: 5
         timeoutSeconds: 1
 

--- a/examples/influxdb-ci.yaml
+++ b/examples/influxdb-ci.yaml
@@ -203,7 +203,7 @@ spec:
       readinessProbe:
         httpGet:
           path: /ping
-          port: "8086"
+          port: 8086
         initialDelaySeconds: 5
         timeoutSeconds: 1
       command: ["/bin/sh", "-c"]


### PR DESCRIPTION
- Fix minor issues so that user can run examples without error
- Modified validator, ignores integer port number error

the integer port number error is due to the limitation of swagger 2.0 which only allows users to specify 1 data type for a given field.

https://github.com/argoproj/argo-workflows/blob/master/api/openapi-spec/swagger.json#L14353-L14355

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->