### PR TITLE
fix: pass correct error obj for azure blob failures

### DIFF
--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -119,7 +119,7 @@ func (azblobDriver *ArtifactDriver) Load(artifact *wfv1.Artifact, path string) e
 		}
 		isEmptyFile = true
 	} else if !IsAzureError(origErr, azblob.StorageErrorCodeBlobNotFound) {
-		return fmt.Errorf("unable to download blob %s: %s", artifact.Azure.Blob, err)
+		return fmt.Errorf("unable to download blob %s: %s", artifact.Azure.Blob, origErr)
 	}
 
 	isDir, err := azblobDriver.IsDirectory(artifact)
@@ -227,7 +227,7 @@ func (azblobDriver *ArtifactDriver) OpenStream(artifact *wfv1.Artifact) (io.Read
 			return response.Body(nil), nil
 		}
 	} else if !IsAzureError(origErr, azblob.StorageErrorCodeBlobNotFound) {
-		return nil, fmt.Errorf("unable to open stream for blob %s: %s", artifact.Azure.Blob, err)
+		return nil, fmt.Errorf("unable to open stream for blob %s: %s", artifact.Azure.Blob, origErr)
 	}
 
 	isDir, err := azblobDriver.IsDirectory(artifact)


### PR DESCRIPTION
In certain cases, if there is a failure reading from azure blob storage,
an empty error was used in the return error format string rather than
the correct original error.

Signed-off-by: Brian Loss <brianloss@gmail.com>

Fixes #TODO

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->