### PR TITLE
feat: fix bugs in retryWorkflow if failed pod node has children nodes. Fix #9244

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -873,7 +873,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 				deletedNodes[descendantNodeID] = true
 				descendantNode := wf.Status.Nodes[descendantNodeID]
 				if descendantNode.Type == wfv1.NodeTypePod {
-					podsToDelete = deletePodNodeDuringRetryWorkflow(wf, node, deletedPods, podsToDelete)
+					podsToDelete = deletePodNodeDuringRetryWorkflow(wf, descendantNode, deletedPods, podsToDelete)
 				}
 			}
 		} else if node.Name == wf.ObjectMeta.Name {

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -926,8 +926,6 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 				// These should all be running since the child node #3 belongs up to node #1.
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
-				//assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["3"].Phase)
-				//assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["4"].Phase)
 			}
 		}
 	})
@@ -959,7 +957,6 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 				// This should be running since it's node #1's child node and node #1 is being retried.
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
 				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-				//assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["4"].Phase)
 			}
 		}
 	})
@@ -1055,113 +1052,45 @@ var retryWorkflowWithFailedNodeHasChildrenNodes = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  annotations:
-    workflows.argoproj.io/pod-name-format: v1
-  creationTimestamp: "2022-08-04T08:35:10Z"
-  generateName: test-pipeline-
-  generation: 10
   labels:
     workflows.argoproj.io/completed: "true"
     workflows.argoproj.io/phase: Failed
-    workflows.argoproj.io/resubmitted-from-workflow: test-pipeline-t5h77
-  managedFields:
-  - apiVersion: argoproj.io/v1alpha1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:annotations:
-          .: {}
-          f:workflows.argoproj.io/pod-name-format: {}
-        f:generateName: {}
-        f:labels:
-          .: {}
-          f:workflows.argoproj.io/resubmitted-from-workflow: {}
-      f:spec: {}
-    manager: argo
-    operation: Update
-    time: "2022-08-04T08:35:10Z"
-  - apiVersion: argoproj.io/v1alpha1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:labels:
-          f:workflows.argoproj.io/completed: {}
-          f:workflows.argoproj.io/phase: {}
-      f:status: {}
-    manager: workflow-controller
-    operation: Update
-    time: "2022-08-04T08:36:31Z"
   name: test-pipeline-bnzwv
   namespace: argo-system
-  resourceVersion: "2588589"
-  uid: 1ce08a8a-0d95-46a3-b7d8-b6e04a0e6136
 spec:
-  arguments: {}
   entrypoint: test-pipeline-dag
   templates:
   - dag:
       tasks:
-      - arguments: {}
-        name: t1
+      - name: t1
         template: succeeded
-      - arguments: {}
-        depends: t1
+      - depends: t1
         name: t2
         template: failed
-      - arguments: {}
-        depends: t2 || t2.Failed
+      - depends: t2 || t2.Failed
         name: t3
         template: succeeded
-      - arguments: {}
-        depends: t3
+      - depends: t3
         name: t4-1
         template: succeeded
-      - arguments: {}
-        depends: t3
+      - depends: t3
         name: t4-2
         template: succeeded
-      - arguments: {}
-        depends: t3
+      - depends: t3
         name: t4-3
         template: failed
-    inputs: {}
-    metadata: {}
     name: test-pipeline-dag
-    outputs: {}
   - container:
       command:
       - "true"
       image: alpine
-      name: ""
-      resources: {}
-    inputs: {}
-    metadata: {}
     name: succeeded
-    outputs: {}
   - container:
       command:
       - "false"
       image: alpine
-      name: ""
-      resources: {}
-    inputs: {}
-    metadata: {}
     name: failed
-    outputs: {}
 status:
-  artifactRepositoryRef:
-    artifactRepository:
-      s3:
-        accessKeySecret:
-          key: accessKey
-          name: minio-secret
-        bucket: argo-artifact
-        endpoint: minio-service.middleware-system.svc:9000
-        insecure: true
-        secretKeySecret:
-          key: secretKey
-          name: minio-secret
-    default: true
   conditions:
   - status: "False"
     type: PodRunning
@@ -1182,9 +1111,6 @@ status:
       - test-pipeline-bnzwv-782035594
       phase: Failed
       progress: 4/6
-      resourcesDuration:
-        cpu: 32
-        memory: 32
       startedAt: "2022-08-04T08:35:10Z"
       templateName: test-pipeline-dag
       templateScope: local/test-pipeline-bnzwv
@@ -1200,9 +1126,6 @@ status:
         exitCode: "0"
       phase: Succeeded
       progress: 1/1
-      resourcesDuration:
-        cpu: 5
-        memory: 5
       startedAt: "2022-08-04T08:36:11Z"
       templateName: succeeded
       templateScope: local/test-pipeline-bnzwv
@@ -1219,9 +1142,6 @@ status:
         exitCode: "1"
       phase: Failed
       progress: 0/1
-      resourcesDuration:
-        cpu: 4
-        memory: 4
       startedAt: "2022-08-04T08:36:11Z"
       templateName: failed
       templateScope: local/test-pipeline-bnzwv
@@ -1237,9 +1157,6 @@ status:
         exitCode: "0"
       phase: Succeeded
       progress: 1/1
-      resourcesDuration:
-        cpu: 8
-        memory: 8
       startedAt: "2022-08-04T08:36:11Z"
       templateName: succeeded
       templateScope: local/test-pipeline-bnzwv
@@ -1258,9 +1175,6 @@ status:
         exitCode: "1"
       phase: Failed
       progress: 0/1
-      resourcesDuration:
-        cpu: 5
-        memory: 5
       startedAt: "2022-08-04T08:35:30Z"
       templateName: failed
       templateScope: local/test-pipeline-bnzwv
@@ -1280,9 +1194,6 @@ status:
         exitCode: "0"
       phase: Succeeded
       progress: 1/1
-      resourcesDuration:
-        cpu: 5
-        memory: 5
       startedAt: "2022-08-04T08:35:50Z"
       templateName: succeeded
       templateScope: local/test-pipeline-bnzwv
@@ -1300,9 +1211,6 @@ status:
         exitCode: "0"
       phase: Succeeded
       progress: 1/1
-      resourcesDuration:
-        cpu: 5
-        memory: 5
       startedAt: "2022-08-04T08:35:10Z"
       templateName: succeeded
       templateScope: local/test-pipeline-bnzwv

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -920,13 +920,14 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		assert.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=3", nil)
 		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 5) {
+			// node #3 & node #4 are deleted and will be recreated. so only 3 nodes in wf.Status.Nodes
+			if assert.Len(t, wf.Status.Nodes, 3) {
 				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-1"].Phase)
 				// These should all be running since the child node #3 belongs up to node #1.
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["3"].Phase)
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["4"].Phase)
+				//assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["3"].Phase)
+				//assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["4"].Phase)
 			}
 		}
 	})
@@ -950,14 +951,15 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		assert.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "", nil)
 		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 5) {
+			// node #4 is deleted and will be recreated. so only 4 nodes in wf.Status.Nodes
+			if assert.Len(t, wf.Status.Nodes, 4) {
 				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-2"].Phase)
 				// This should be running since it's node #4's parent node.
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
 				// This should be running since it's node #1's child node and node #1 is being retried.
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
 				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["4"].Phase)
+				//assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["4"].Phase)
 			}
 		}
 	})

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1048,3 +1048,280 @@ func TestGetTemplateFromNode(t *testing.T) {
 		assert.Equal(t, tc.expectedTemplateName, actual)
 	}
 }
+
+var retryWorkflowWithFailedNodeHasChildrenNodes = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    workflows.argoproj.io/pod-name-format: v1
+  creationTimestamp: "2022-08-04T08:35:10Z"
+  generateName: test-pipeline-
+  generation: 10
+  labels:
+    workflows.argoproj.io/completed: "true"
+    workflows.argoproj.io/phase: Failed
+    workflows.argoproj.io/resubmitted-from-workflow: test-pipeline-t5h77
+  managedFields:
+  - apiVersion: argoproj.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:workflows.argoproj.io/pod-name-format: {}
+        f:generateName: {}
+        f:labels:
+          .: {}
+          f:workflows.argoproj.io/resubmitted-from-workflow: {}
+      f:spec: {}
+    manager: argo
+    operation: Update
+    time: "2022-08-04T08:35:10Z"
+  - apiVersion: argoproj.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          f:workflows.argoproj.io/completed: {}
+          f:workflows.argoproj.io/phase: {}
+      f:status: {}
+    manager: workflow-controller
+    operation: Update
+    time: "2022-08-04T08:36:31Z"
+  name: test-pipeline-bnzwv
+  namespace: argo-system
+  resourceVersion: "2588589"
+  uid: 1ce08a8a-0d95-46a3-b7d8-b6e04a0e6136
+spec:
+  arguments: {}
+  entrypoint: test-pipeline-dag
+  templates:
+  - dag:
+      tasks:
+      - arguments: {}
+        name: t1
+        template: succeeded
+      - arguments: {}
+        depends: t1
+        name: t2
+        template: failed
+      - arguments: {}
+        depends: t2 || t2.Failed
+        name: t3
+        template: succeeded
+      - arguments: {}
+        depends: t3
+        name: t4-1
+        template: succeeded
+      - arguments: {}
+        depends: t3
+        name: t4-2
+        template: succeeded
+      - arguments: {}
+        depends: t3
+        name: t4-3
+        template: failed
+    inputs: {}
+    metadata: {}
+    name: test-pipeline-dag
+    outputs: {}
+  - container:
+      command:
+      - "true"
+      image: alpine
+      name: ""
+      resources: {}
+    inputs: {}
+    metadata: {}
+    name: succeeded
+    outputs: {}
+  - container:
+      command:
+      - "false"
+      image: alpine
+      name: ""
+      resources: {}
+    inputs: {}
+    metadata: {}
+    name: failed
+    outputs: {}
+status:
+  artifactRepositoryRef:
+    artifactRepository:
+      s3:
+        accessKeySecret:
+          key: accessKey
+          name: minio-secret
+        bucket: argo-artifact
+        endpoint: minio-service.middleware-system.svc:9000
+        insecure: true
+        secretKeySecret:
+          key: secretKey
+          name: minio-secret
+    default: true
+  conditions:
+  - status: "False"
+    type: PodRunning
+  - status: "True"
+    type: Completed
+  finishedAt: "2022-08-04T08:36:31Z"
+  nodes:
+    test-pipeline-bnzwv:
+      children:
+      - test-pipeline-bnzwv-929756297
+      displayName: test-pipeline-bnzwv
+      finishedAt: "2022-08-04T08:36:31Z"
+      id: test-pipeline-bnzwv
+      name: test-pipeline-bnzwv
+      outboundNodes:
+      - test-pipeline-bnzwv-748480356
+      - test-pipeline-bnzwv-798813213
+      - test-pipeline-bnzwv-782035594
+      phase: Failed
+      progress: 4/6
+      resourcesDuration:
+        cpu: 32
+        memory: 32
+      startedAt: "2022-08-04T08:35:10Z"
+      templateName: test-pipeline-dag
+      templateScope: local/test-pipeline-bnzwv
+      type: DAG
+    test-pipeline-bnzwv-748480356:
+      boundaryID: test-pipeline-bnzwv
+      displayName: t4-1
+      finishedAt: "2022-08-04T08:36:19Z"
+      hostNodeName: node2
+      id: test-pipeline-bnzwv-748480356
+      name: test-pipeline-bnzwv.t4-1
+      outputs:
+        exitCode: "0"
+      phase: Succeeded
+      progress: 1/1
+      resourcesDuration:
+        cpu: 5
+        memory: 5
+      startedAt: "2022-08-04T08:36:11Z"
+      templateName: succeeded
+      templateScope: local/test-pipeline-bnzwv
+      type: Pod
+    test-pipeline-bnzwv-782035594:
+      boundaryID: test-pipeline-bnzwv
+      displayName: t4-3
+      finishedAt: "2022-08-04T08:36:16Z"
+      hostNodeName: node1
+      id: test-pipeline-bnzwv-782035594
+      message: Error (exit code 1)
+      name: test-pipeline-bnzwv.t4-3
+      outputs:
+        exitCode: "1"
+      phase: Failed
+      progress: 0/1
+      resourcesDuration:
+        cpu: 4
+        memory: 4
+      startedAt: "2022-08-04T08:36:11Z"
+      templateName: failed
+      templateScope: local/test-pipeline-bnzwv
+      type: Pod
+    test-pipeline-bnzwv-798813213:
+      boundaryID: test-pipeline-bnzwv
+      displayName: t4-2
+      finishedAt: "2022-08-04T08:36:19Z"
+      hostNodeName: node1
+      id: test-pipeline-bnzwv-798813213
+      name: test-pipeline-bnzwv.t4-2
+      outputs:
+        exitCode: "0"
+      phase: Succeeded
+      progress: 1/1
+      resourcesDuration:
+        cpu: 8
+        memory: 8
+      startedAt: "2022-08-04T08:36:11Z"
+      templateName: succeeded
+      templateScope: local/test-pipeline-bnzwv
+      type: Pod
+    test-pipeline-bnzwv-879423440:
+      boundaryID: test-pipeline-bnzwv
+      children:
+      - test-pipeline-bnzwv-896201059
+      displayName: t2
+      finishedAt: "2022-08-04T08:35:39Z"
+      hostNodeName: node2
+      id: test-pipeline-bnzwv-879423440
+      message: Error (exit code 1)
+      name: test-pipeline-bnzwv.t2
+      outputs:
+        exitCode: "1"
+      phase: Failed
+      progress: 0/1
+      resourcesDuration:
+        cpu: 5
+        memory: 5
+      startedAt: "2022-08-04T08:35:30Z"
+      templateName: failed
+      templateScope: local/test-pipeline-bnzwv
+      type: Pod
+    test-pipeline-bnzwv-896201059:
+      boundaryID: test-pipeline-bnzwv
+      children:
+      - test-pipeline-bnzwv-748480356
+      - test-pipeline-bnzwv-798813213
+      - test-pipeline-bnzwv-782035594
+      displayName: t3
+      finishedAt: "2022-08-04T08:36:00Z"
+      hostNodeName: node2
+      id: test-pipeline-bnzwv-896201059
+      name: test-pipeline-bnzwv.t3
+      outputs:
+        exitCode: "0"
+      phase: Succeeded
+      progress: 1/1
+      resourcesDuration:
+        cpu: 5
+        memory: 5
+      startedAt: "2022-08-04T08:35:50Z"
+      templateName: succeeded
+      templateScope: local/test-pipeline-bnzwv
+      type: Pod
+    test-pipeline-bnzwv-929756297:
+      boundaryID: test-pipeline-bnzwv
+      children:
+      - test-pipeline-bnzwv-879423440
+      displayName: t1
+      finishedAt: "2022-08-04T08:35:18Z"
+      hostNodeName: node2
+      id: test-pipeline-bnzwv-929756297
+      name: test-pipeline-bnzwv.t1
+      outputs:
+        exitCode: "0"
+      phase: Succeeded
+      progress: 1/1
+      resourcesDuration:
+        cpu: 5
+        memory: 5
+      startedAt: "2022-08-04T08:35:10Z"
+      templateName: succeeded
+      templateScope: local/test-pipeline-bnzwv
+      type: Pod
+  phase: Failed
+  progress: 4/6
+  resourcesDuration:
+    cpu: 32
+    memory: 32
+  startedAt: "2022-08-04T08:35:10Z"
+`
+
+func TestRetryWorkflowWithFailedNodeHasChildrenNodes(t *testing.T) {
+	ctx := context.Background()
+	wf := wfv1.MustUnmarshalWorkflow(retryWorkflowWithFailedNodeHasChildrenNodes)
+
+	wf, _, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(wf.Status.Nodes))
+	t2Node := wf.Status.Nodes.FindByDisplayName("t2")
+	assert.Nil(t, t2Node)
+	t3Node := wf.Status.Nodes.FindByDisplayName("t3")
+	assert.Nil(t, t3Node)
+}


### PR DESCRIPTION
Fix bugs in retry workflow if the failed node has children nodes. Fix #9244.

For example.  node `t2` was failed, but it has child node `t3`.

    {
      "apiVersion": "argoproj.io/v1alpha1",
      "kind": "Workflow",
      "metadata": {
        "generateName": "test-pipeline-"
      },
      "spec": {
        "arguments": {},
        "entrypoint": "test-pipeline-dag",
        "templates": [
          {
            "dag": {
              "tasks": [
                {
                  "arguments": {},
                  "name": "t1",
                  "template": "succeeded"
                },
                {
                  "arguments": {},
                  "depends": "t1",
                  "name": "t2",
                  "template": "failed"
                },
                {
                  "arguments": {},
                  "depends": "t2 || t2.Failed",
                  "name": "t3",
                  "template": "succeeded"
                },
                {
                  "arguments": {},
                  "depends": "t3",
                  "name": "t4-1",
                  "template": "succeeded"
                },
                {
                  "arguments": {},
                  "depends": "t3",
                  "name": "t4-2",
                  "template": "succeeded"
                },
                {
                  "arguments": {},
                  "depends": "t3",
                  "name": "t4-3",
                  "template": "failed"
                }
              ]
            },
            "inputs": {},
            "metadata": {},
            "name": "test-pipeline-dag",
            "outputs": {}
          },
          {
            "container": {
              "command": [
                "true"
              ],
              "image": "alpine"
            },
            "name": "succeeded"
          },
          {
            "container": {
              "command": [
                "false"
              ],
              "image": "alpine",
              "resources": {}
            },
            "name": "failed"
          }
        ]
      },
      "status": {
        "finishedAt": null,
        "startedAt": null
      }
    }