### PR TITLE
Fixes #8622: fix http1 keep alive connection leak

### DIFF
--- a/pkg/apiclient/http1/facade.go
+++ b/pkg/apiclient/http1/facade.go
@@ -112,6 +112,7 @@ func (h Facade) do(in interface{}, out interface{}, method string, path string) 
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: h.insecureSkipVerify,
 			},
+			DisableKeepAlives: true,
 		},
 	}
 	resp, err := client.Do(req)


### PR DESCRIPTION
Signed-off-by: lijie <lijie0123lj@gmail.com>

Fixes #8622
http Body.Close() is not enough for some keep-alive http connections
http1 tcp connection leak because of set http keep alive but http.Client just dispose without close its connection
To fix this, there are three solutions:
1. reuse http client, which is a larger change
2. invoke client.CloseIdleConnection() before it dispose, which has no advantage over solution-3
3. disable http keep alive, which is choosed

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->