### PR TITLE
fix: Look in correct bucket when downloading artifacts (Template.ArchiveLocation configured)

### DIFF
--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -53,7 +53,28 @@ func (a *fakeArtifactDriver) Load(_ *wfv1.Artifact, path string) error {
 	return ioutil.WriteFile(path, a.data, 0o600)
 }
 
+var bucketsOfKeys = map[string][]string{
+	"my-bucket": []string{
+		"my-wf/my-node-1/my-s3-input-artifact.tgz",
+		"my-wf/my-node-1/my-s3-artifact-directory",
+		"my-wf/my-node-1/my-s3-artifact-directory/a.txt",
+		"my-wf/my-node-1/my-s3-artifact-directory/subdirectory/b.txt",
+		"my-wf/my-node-1/my-gcs-artifact",
+		"my-wf/my-node-1/my-gcs-artifact.tgz",
+		"my-wf/my-node-1/my-oss-artifact.zip",
+		"my-wf/my-node-1/my-s3-artifact.tgz",
+	},
+	"my-bucket-2": []string{
+		"my-wf/my-node-2/my-s3-artifact-bucket-2",
+	},
+	"my-bucket-3": []string{
+		"my-wf/my-node-2/my-s3-artifact-bucket-3",
+	},
+}
+
 func (a *fakeArtifactDriver) OpenStream(artifact *wfv1.Artifact) (io.ReadCloser, error) {
+	//fmt.Printf("deletethis: artifact=%+v\n", artifact)
+
 	key, err := artifact.ArtifactLocation.GetKey()
 	if err != nil {
 		return nil, err
@@ -63,6 +84,25 @@ func (a *fakeArtifactDriver) OpenStream(artifact *wfv1.Artifact) (io.ReadCloser,
 	} else if strings.HasSuffix(key, "somethingElseWentWrong.txt") {
 		return nil, errors.New("whatever")
 	}
+
+	if artifact.S3 != nil {
+		// make sure it's a recognizable bucket/key
+		keysInBucket, found := bucketsOfKeys[artifact.S3.Bucket]
+		if !found {
+			return nil, fmt.Errorf("artifact bucket not found: %+v", artifact)
+		}
+		foundKey := false
+		for _, recognizableKey := range keysInBucket {
+			if key == recognizableKey {
+				foundKey = true
+				break
+			}
+		}
+		if !foundKey {
+			return nil, fmt.Errorf("artifact key '%s' not found in bucket '%s'", key, artifact.S3.Bucket)
+		}
+	}
+
 	return io.NopCloser(bytes.NewReader(a.data)), nil
 }
 
@@ -91,15 +131,15 @@ func (a *fakeArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, err
 	if artifact.Name == "my-s3-artifact-directory" {
 		if strings.HasSuffix(key, "subdirectory") {
 			return []string{
-				"my-wf/my-node/my-s3-artifact-directory/subdirectory/b.txt",
-				"my-wf/my-node/my-s3-artifact-directory/subdirectory/c.txt",
+				"my-wf/my-node-1/my-s3-artifact-directory/subdirectory/b.txt",
+				"my-wf/my-node-1/my-s3-artifact-directory/subdirectory/c.txt",
 			}, nil
 		} else {
 			return []string{
-				"my-wf/my-node/my-s3-artifact-directory/a.txt",
-				"my-wf/my-node/my-s3-artifact-directory/index.html",
-				"my-wf/my-node/my-s3-artifact-directory/subdirectory/b.txt",
-				"my-wf/my-node/my-s3-artifact-directory/subdirectory/c.txt",
+				"my-wf/my-node-1/my-s3-artifact-directory/a.txt",
+				"my-wf/my-node-1/my-s3-artifact-directory/index.html",
+				"my-wf/my-node-1/my-s3-artifact-directory/subdirectory/b.txt",
+				"my-wf/my-node-1/my-s3-artifact-directory/subdirectory/c.txt",
 			}, nil
 		}
 	}
@@ -114,16 +154,36 @@ func newServer() *ArtifactServer {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Name: "my-wf", Labels: map[string]string{
 			common.LabelKeyControllerInstanceID: instanceId,
 		}},
+		Spec: wfv1.WorkflowSpec{
+			Templates: []wfv1.Template{
+				{
+					Name: "template-1",
+				},
+				{
+					Name: "template-2",
+					ArchiveLocation: &wfv1.ArtifactLocation{
+						S3: &wfv1.S3Artifact{
+							Key: "key-1",
+							S3Bucket: wfv1.S3Bucket{
+								Bucket:   "my-bucket-2",
+								Endpoint: "minio:9000",
+							},
+						},
+					},
+				},
+			},
+		},
 		Status: wfv1.WorkflowStatus{
 			Nodes: wfv1.Nodes{
-				"my-node": wfv1.NodeStatus{
+				"my-node-1": wfv1.NodeStatus{
+					TemplateName: "template-1",
 					Inputs: &wfv1.Inputs{
 						Artifacts: wfv1.Artifacts{
 							{
 								Name: "my-s3-input-artifact",
 								ArtifactLocation: wfv1.ArtifactLocation{
 									S3: &wfv1.S3Artifact{
-										Key: "my-wf/my-node/my-s3-input-artifact.tgz",
+										Key: "my-wf/my-node-1/my-s3-input-artifact.tgz",
 									},
 								},
 							},
@@ -136,7 +196,7 @@ func newServer() *ArtifactServer {
 								ArtifactLocation: wfv1.ArtifactLocation{
 									S3: &wfv1.S3Artifact{
 										// S3 is a configured artifact repo, so does not need key
-										Key: "my-wf/my-node/my-s3-artifact.tgz",
+										Key: "my-wf/my-node-1/my-s3-artifact.tgz",
 									},
 								},
 							},
@@ -145,7 +205,7 @@ func newServer() *ArtifactServer {
 								ArtifactLocation: wfv1.ArtifactLocation{
 									S3: &wfv1.S3Artifact{
 										// S3 is a configured artifact repo, so does not need key
-										Key: "my-wf/my-node/my-s3-artifact-directory",
+										Key: "my-wf/my-node-1/my-s3-artifact-directory",
 									},
 								},
 							},
@@ -157,7 +217,7 @@ func newServer() *ArtifactServer {
 										GCSBucket: wfv1.GCSBucket{
 											Bucket: "my-bucket",
 										},
-										Key: "my-wf/my-node/my-gcs-artifact",
+										Key: "my-wf/my-node-1/my-gcs-artifact",
 									},
 								},
 							},
@@ -169,7 +229,7 @@ func newServer() *ArtifactServer {
 										GCSBucket: wfv1.GCSBucket{
 											Bucket: "my-bucket",
 										},
-										Key: "my-wf/my-node/my-gcs-artifact.tgz",
+										Key: "my-wf/my-node-1/my-gcs-artifact.tgz",
 									},
 								},
 							},
@@ -181,7 +241,37 @@ func newServer() *ArtifactServer {
 										OSSBucket: wfv1.OSSBucket{
 											Bucket: "my-bucket",
 										},
-										Key: "my-wf/my-node/my-oss-artifact.zip",
+										Key: "my-wf/my-node-1/my-oss-artifact.zip",
+									},
+								},
+							},
+						},
+					},
+				},
+
+				"my-node-2": wfv1.NodeStatus{
+					TemplateName: "template-2",
+					Outputs: &wfv1.Outputs{
+						Artifacts: wfv1.Artifacts{
+							{
+								Name: "my-s3-artifact-1-template-2",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									S3: &wfv1.S3Artifact{
+										// S3 is a configured artifact repo, so does not need key
+										Key: "my-wf/my-node-2/my-s3-artifact-bucket-3",
+									},
+								},
+							},
+							{
+								Name: "my-s3-artifact-2-template-2",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									S3: &wfv1.S3Artifact{
+										// S3 is a configured artifact repo, so does not need key
+										Key: "my-wf/my-node-2/my-s3-artifact-bucket-2",
+										S3Bucket: wfv1.S3Bucket{
+											Bucket:   "my-bucket-2",
+											Endpoint: "minio:9000",
+										},
 									},
 								},
 							},
@@ -231,17 +321,17 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 		directoryFiles []string // verify these files are in there, if this is a directory
 	}{
 		{
-			path:       "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory",
+			path:       "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory",
 			statusCode: 307, // redirect
-			location:   "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/",
+			location:   "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/",
 		},
 		{
-			path:       "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/",
+			path:       "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/",
 			statusCode: 307, // redirect
-			location:   "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/index.html",
+			location:   "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/index.html",
 		},
 		{
-			path:        "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/subdirectory/",
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/subdirectory/",
 			statusCode:  200,
 			isDirectory: true,
 			directoryFiles: []string{
@@ -251,27 +341,37 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 			},
 		},
 		{
-			path:        "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/a.txt",
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/a.txt",
 			statusCode:  200,
 			isDirectory: false,
 		},
 		{
-			path:        "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/subdirectory/b.txt",
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/subdirectory/b.txt",
 			statusCode:  200,
 			isDirectory: false,
 		},
 		{
-			path:        "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/deletedFile.txt",
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/deletedFile.txt",
 			statusCode:  404,
 			isDirectory: false,
 		},
 		{
-			path:        "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-s3-artifact-directory/somethingElseWentWrong.txt",
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/somethingElseWentWrong.txt",
 			statusCode:  500,
 			isDirectory: false,
 		},
 		{
-			path:        "/artifact-files/my-ns/workflows/my-wf/my-node/outputs/my-gcs-artifact-file/my-gcs-artifact.tgz",
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-gcs-artifact-file/my-gcs-artifact.tgz",
+			statusCode:  200,
+			isDirectory: false,
+		},
+		{
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-2/outputs/my-s3-artifact-bucket-3",
+			statusCode:  200,
+			isDirectory: false,
+		},
+		{
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-2/outputs/my-s3-artifact-bucket-2",
 			statusCode:  200,
 			isDirectory: false,
 		},
@@ -332,7 +432,7 @@ func TestArtifactServer_GetOutputArtifact(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.artifactName, func(t *testing.T) {
 			r := &http.Request{}
-			r.URL = mustParse(fmt.Sprintf("/artifacts/my-ns/my-wf/my-node/%s", tt.artifactName))
+			r.URL = mustParse(fmt.Sprintf("/artifacts/my-ns/my-wf/my-node-1/%s", tt.artifactName))
 			recorder := httptest.NewRecorder()
 
 			s.GetOutputArtifact(recorder, r)
@@ -364,7 +464,7 @@ func TestArtifactServer_GetInputArtifact(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.artifactName, func(t *testing.T) {
 			r := &http.Request{}
-			r.URL = mustParse(fmt.Sprintf("/input-artifacts/my-ns/my-wf/my-node/%s", tt.artifactName))
+			r.URL = mustParse(fmt.Sprintf("/input-artifacts/my-ns/my-wf/my-node-1/%s", tt.artifactName))
 			recorder := httptest.NewRecorder()
 			s.GetInputArtifact(recorder, r)
 			if assert.Equal(t, 200, recorder.Result().StatusCode) {
@@ -396,7 +496,7 @@ func TestArtifactServer_NodeWithoutArtifact(t *testing.T) {
 func TestArtifactServer_GetOutputArtifactWithoutInstanceID(t *testing.T) {
 	s := newServer()
 	r := &http.Request{}
-	r.URL = mustParse("/artifacts/my-ns/your-wf/my-node/my-artifact")
+	r.URL = mustParse("/artifacts/my-ns/your-wf/my-node-1/my-artifact")
 	w := &testhttp.TestResponseWriter{}
 	s.GetOutputArtifact(w, r)
 	assert.NotEqual(t, 200, w.StatusCode)
@@ -405,7 +505,7 @@ func TestArtifactServer_GetOutputArtifactWithoutInstanceID(t *testing.T) {
 func TestArtifactServer_GetOutputArtifactByUID(t *testing.T) {
 	s := newServer()
 	r := &http.Request{}
-	r.URL = mustParse("/artifacts/my-uuid/my-node/my-artifact")
+	r.URL = mustParse("/artifacts/my-uuid/my-node-1/my-artifact")
 	w := &testhttp.TestResponseWriter{}
 	s.GetOutputArtifactByUID(w, r)
 	assert.Equal(t, 401, w.StatusCode)
@@ -415,7 +515,7 @@ func TestArtifactServer_GetArtifactByUIDInvalidRequestPath(t *testing.T) {
 	s := newServer()
 	r := &http.Request{}
 	// missing my-artifact part to have a valid URL
-	r.URL = mustParse("/input-artifacts/my-uuid/my-node")
+	r.URL = mustParse("/input-artifacts/my-uuid/my-node-1")
 	w := &testhttp.TestResponseWriter{}
 	s.GetInputArtifactByUID(w, r)
 	// make sure there is no index out of bounds error

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -165,7 +165,7 @@ func newServer() *ArtifactServer {
 						S3: &wfv1.S3Artifact{
 							Key: "key-1",
 							S3Bucket: wfv1.S3Bucket{
-								Bucket:   "my-bucket-2",
+								Bucket:   "my-bucket-3",
 								Endpoint: "minio:9000",
 							},
 						},
@@ -254,7 +254,7 @@ func newServer() *ArtifactServer {
 					Outputs: &wfv1.Outputs{
 						Artifacts: wfv1.Artifacts{
 							{
-								Name: "my-s3-artifact-1-template-2",
+								Name: "my-s3-artifact-bucket-3",
 								ArtifactLocation: wfv1.ArtifactLocation{
 									S3: &wfv1.S3Artifact{
 										// S3 is a configured artifact repo, so does not need key
@@ -263,7 +263,7 @@ func newServer() *ArtifactServer {
 								},
 							},
 							{
-								Name: "my-s3-artifact-2-template-2",
+								Name: "my-s3-artifact-bucket-2",
 								ArtifactLocation: wfv1.ArtifactLocation{
 									S3: &wfv1.S3Artifact{
 										// S3 is a configured artifact repo, so does not need key


### PR DESCRIPTION
This is a partial fix for Issue [9277](https://github.com/argoproj/argo-workflows/issues/9277)

There are 2 issues:
1. The UI shows the wrong bucket name if Template.ArchiveLocation is configured
2. The file cannot be downloaded from the back end if Template.ArchiveLocation is configured (because we look in the wrong bucket).

This fixes problem 2 but not problem 1.

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->