### PR TITLE
feat: Add Artifact GC Strategies for "OnWorkflowSuccessOrDeletion" and "OnWorkflowFailureOrDeletion"

### DIFF
--- a/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
@@ -426,6 +426,8 @@ spec:
                               - ""
                               - OnWorkflowCompletion
                               - OnWorkflowDeletion
+                              - OnWorkflowSuccessOrDeletion
+                              - OnWorkflowFailureOrDeletion
                               - Never
                               type: string
                           type: object
@@ -952,6 +954,8 @@ spec:
                     - ""
                     - OnWorkflowCompletion
                     - OnWorkflowDeletion
+                    - OnWorkflowSuccessOrDeletion
+                    - OnWorkflowFailureOrDeletion
                     - Never
                     type: string
                 type: object
@@ -1036,6 +1040,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -3912,6 +3918,8 @@ spec:
                                             - ""
                                             - OnWorkflowCompletion
                                             - OnWorkflowDeletion
+                                            - OnWorkflowSuccessOrDeletion
+                                            - OnWorkflowFailureOrDeletion
                                             - Never
                                             type: string
                                         type: object
@@ -4474,6 +4482,8 @@ spec:
                                                   - ""
                                                   - OnWorkflowCompletion
                                                   - OnWorkflowDeletion
+                                                  - OnWorkflowSuccessOrDeletion
+                                                  - OnWorkflowFailureOrDeletion
                                                   - Never
                                                   type: string
                                               type: object
@@ -5087,6 +5097,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -6250,6 +6262,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -6900,6 +6914,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -7473,6 +7489,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -12001,6 +12019,8 @@ spec:
                                               - ""
                                               - OnWorkflowCompletion
                                               - OnWorkflowDeletion
+                                              - OnWorkflowSuccessOrDeletion
+                                              - OnWorkflowFailureOrDeletion
                                               - Never
                                               type: string
                                           type: object
@@ -12563,6 +12583,8 @@ spec:
                                                     - ""
                                                     - OnWorkflowCompletion
                                                     - OnWorkflowDeletion
+                                                    - OnWorkflowSuccessOrDeletion
+                                                    - OnWorkflowFailureOrDeletion
                                                     - Never
                                                     type: string
                                                 type: object
@@ -13176,6 +13198,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -14339,6 +14363,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -14989,6 +15015,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -15562,6 +15590,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object

--- a/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
@@ -447,6 +447,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -973,6 +975,8 @@ spec:
                         - ""
                         - OnWorkflowCompletion
                         - OnWorkflowDeletion
+                        - OnWorkflowSuccessOrDeletion
+                        - OnWorkflowFailureOrDeletion
                         - Never
                         type: string
                     type: object
@@ -1057,6 +1061,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -3933,6 +3939,8 @@ spec:
                                                 - ""
                                                 - OnWorkflowCompletion
                                                 - OnWorkflowDeletion
+                                                - OnWorkflowSuccessOrDeletion
+                                                - OnWorkflowFailureOrDeletion
                                                 - Never
                                                 type: string
                                             type: object
@@ -4495,6 +4503,8 @@ spec:
                                                       - ""
                                                       - OnWorkflowCompletion
                                                       - OnWorkflowDeletion
+                                                      - OnWorkflowSuccessOrDeletion
+                                                      - OnWorkflowFailureOrDeletion
                                                       - Never
                                                       type: string
                                                   type: object
@@ -5108,6 +5118,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -6271,6 +6283,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -6921,6 +6935,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -7494,6 +7510,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -12022,6 +12040,8 @@ spec:
                                                   - ""
                                                   - OnWorkflowCompletion
                                                   - OnWorkflowDeletion
+                                                  - OnWorkflowSuccessOrDeletion
+                                                  - OnWorkflowFailureOrDeletion
                                                   - Never
                                                   type: string
                                               type: object
@@ -12584,6 +12604,8 @@ spec:
                                                         - ""
                                                         - OnWorkflowCompletion
                                                         - OnWorkflowDeletion
+                                                        - OnWorkflowSuccessOrDeletion
+                                                        - OnWorkflowFailureOrDeletion
                                                         - Never
                                                         type: string
                                                     type: object
@@ -13197,6 +13219,8 @@ spec:
                                           - ""
                                           - OnWorkflowCompletion
                                           - OnWorkflowDeletion
+                                          - OnWorkflowSuccessOrDeletion
+                                          - OnWorkflowFailureOrDeletion
                                           - Never
                                           type: string
                                       type: object
@@ -14360,6 +14384,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -15010,6 +15036,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -15583,6 +15611,8 @@ spec:
                                           - ""
                                           - OnWorkflowCompletion
                                           - OnWorkflowDeletion
+                                          - OnWorkflowSuccessOrDeletion
+                                          - OnWorkflowFailureOrDeletion
                                           - Never
                                           type: string
                                       type: object

--- a/manifests/base/crds/full/argoproj.io_workflowartifactgctasks.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowartifactgctasks.yaml
@@ -498,6 +498,8 @@ spec:
                                 - ""
                                 - OnWorkflowCompletion
                                 - OnWorkflowDeletion
+                                - OnWorkflowSuccessOrDeletion
+                                - OnWorkflowFailureOrDeletion
                                 - Never
                                 type: string
                             type: object

--- a/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
+++ b/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
@@ -75,6 +75,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object

--- a/manifests/base/crds/full/argoproj.io_workflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflows.yaml
@@ -440,6 +440,8 @@ spec:
                               - ""
                               - OnWorkflowCompletion
                               - OnWorkflowDeletion
+                              - OnWorkflowSuccessOrDeletion
+                              - OnWorkflowFailureOrDeletion
                               - Never
                               type: string
                           type: object
@@ -966,6 +968,8 @@ spec:
                     - ""
                     - OnWorkflowCompletion
                     - OnWorkflowDeletion
+                    - OnWorkflowSuccessOrDeletion
+                    - OnWorkflowFailureOrDeletion
                     - Never
                     type: string
                 type: object
@@ -1050,6 +1054,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -3926,6 +3932,8 @@ spec:
                                             - ""
                                             - OnWorkflowCompletion
                                             - OnWorkflowDeletion
+                                            - OnWorkflowSuccessOrDeletion
+                                            - OnWorkflowFailureOrDeletion
                                             - Never
                                             type: string
                                         type: object
@@ -4488,6 +4496,8 @@ spec:
                                                   - ""
                                                   - OnWorkflowCompletion
                                                   - OnWorkflowDeletion
+                                                  - OnWorkflowSuccessOrDeletion
+                                                  - OnWorkflowFailureOrDeletion
                                                   - Never
                                                   type: string
                                               type: object
@@ -5101,6 +5111,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -6264,6 +6276,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -6914,6 +6928,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -7487,6 +7503,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -12015,6 +12033,8 @@ spec:
                                               - ""
                                               - OnWorkflowCompletion
                                               - OnWorkflowDeletion
+                                              - OnWorkflowSuccessOrDeletion
+                                              - OnWorkflowFailureOrDeletion
                                               - Never
                                               type: string
                                           type: object
@@ -12577,6 +12597,8 @@ spec:
                                                     - ""
                                                     - OnWorkflowCompletion
                                                     - OnWorkflowDeletion
+                                                    - OnWorkflowSuccessOrDeletion
+                                                    - OnWorkflowFailureOrDeletion
                                                     - Never
                                                     type: string
                                                 type: object
@@ -13190,6 +13212,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -14353,6 +14377,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -15003,6 +15029,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -15576,6 +15604,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -19271,6 +19301,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -19838,6 +19870,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -20430,6 +20464,8 @@ spec:
                               - ""
                               - OnWorkflowCompletion
                               - OnWorkflowDeletion
+                              - OnWorkflowSuccessOrDeletion
+                              - OnWorkflowFailureOrDeletion
                               - Never
                               type: string
                           type: object
@@ -23691,6 +23727,8 @@ spec:
                                               - ""
                                               - OnWorkflowCompletion
                                               - OnWorkflowDeletion
+                                              - OnWorkflowSuccessOrDeletion
+                                              - OnWorkflowFailureOrDeletion
                                               - Never
                                               type: string
                                           type: object
@@ -24253,6 +24291,8 @@ spec:
                                                     - ""
                                                     - OnWorkflowCompletion
                                                     - OnWorkflowDeletion
+                                                    - OnWorkflowSuccessOrDeletion
+                                                    - OnWorkflowFailureOrDeletion
                                                     - Never
                                                     type: string
                                                 type: object
@@ -24866,6 +24906,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -26029,6 +26071,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -26679,6 +26723,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -27252,6 +27298,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -30123,6 +30171,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -30649,6 +30699,8 @@ spec:
                         - ""
                         - OnWorkflowCompletion
                         - OnWorkflowDeletion
+                        - OnWorkflowSuccessOrDeletion
+                        - OnWorkflowFailureOrDeletion
                         - Never
                         type: string
                     type: object
@@ -30733,6 +30785,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -33609,6 +33663,8 @@ spec:
                                                 - ""
                                                 - OnWorkflowCompletion
                                                 - OnWorkflowDeletion
+                                                - OnWorkflowSuccessOrDeletion
+                                                - OnWorkflowFailureOrDeletion
                                                 - Never
                                                 type: string
                                             type: object
@@ -34171,6 +34227,8 @@ spec:
                                                       - ""
                                                       - OnWorkflowCompletion
                                                       - OnWorkflowDeletion
+                                                      - OnWorkflowSuccessOrDeletion
+                                                      - OnWorkflowFailureOrDeletion
                                                       - Never
                                                       type: string
                                                   type: object
@@ -34784,6 +34842,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -35947,6 +36007,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -36597,6 +36659,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -37170,6 +37234,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -41698,6 +41764,8 @@ spec:
                                                   - ""
                                                   - OnWorkflowCompletion
                                                   - OnWorkflowDeletion
+                                                  - OnWorkflowSuccessOrDeletion
+                                                  - OnWorkflowFailureOrDeletion
                                                   - Never
                                                   type: string
                                               type: object
@@ -42260,6 +42328,8 @@ spec:
                                                         - ""
                                                         - OnWorkflowCompletion
                                                         - OnWorkflowDeletion
+                                                        - OnWorkflowSuccessOrDeletion
+                                                        - OnWorkflowFailureOrDeletion
                                                         - Never
                                                         type: string
                                                     type: object
@@ -42873,6 +42943,8 @@ spec:
                                           - ""
                                           - OnWorkflowCompletion
                                           - OnWorkflowDeletion
+                                          - OnWorkflowSuccessOrDeletion
+                                          - OnWorkflowFailureOrDeletion
                                           - Never
                                           type: string
                                       type: object
@@ -44036,6 +44108,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -44686,6 +44760,8 @@ spec:
                                         - ""
                                         - OnWorkflowCompletion
                                         - OnWorkflowDeletion
+                                        - OnWorkflowSuccessOrDeletion
+                                        - OnWorkflowFailureOrDeletion
                                         - Never
                                         type: string
                                     type: object
@@ -45259,6 +45335,8 @@ spec:
                                           - ""
                                           - OnWorkflowCompletion
                                           - OnWorkflowDeletion
+                                          - OnWorkflowSuccessOrDeletion
+                                          - OnWorkflowFailureOrDeletion
                                           - Never
                                           type: string
                                       type: object

--- a/manifests/base/crds/full/argoproj.io_workflowtaskresults.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtaskresults.yaml
@@ -64,6 +64,8 @@ spec:
                           - ""
                           - OnWorkflowCompletion
                           - OnWorkflowDeletion
+                          - OnWorkflowSuccessOrDeletion
+                          - OnWorkflowFailureOrDeletion
                           - Never
                           type: string
                       type: object

--- a/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
@@ -2085,6 +2085,8 @@ spec:
                                               - ""
                                               - OnWorkflowCompletion
                                               - OnWorkflowDeletion
+                                              - OnWorkflowSuccessOrDeletion
+                                              - OnWorkflowFailureOrDeletion
                                               - Never
                                               type: string
                                           type: object
@@ -2647,6 +2649,8 @@ spec:
                                                     - ""
                                                     - OnWorkflowCompletion
                                                     - OnWorkflowDeletion
+                                                    - OnWorkflowSuccessOrDeletion
+                                                    - OnWorkflowFailureOrDeletion
                                                     - Never
                                                     type: string
                                                 type: object
@@ -3260,6 +3264,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -4423,6 +4429,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -5073,6 +5081,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -5646,6 +5656,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -8164,6 +8176,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object

--- a/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
@@ -425,6 +425,8 @@ spec:
                               - ""
                               - OnWorkflowCompletion
                               - OnWorkflowDeletion
+                              - OnWorkflowSuccessOrDeletion
+                              - OnWorkflowFailureOrDeletion
                               - Never
                               type: string
                           type: object
@@ -951,6 +953,8 @@ spec:
                     - ""
                     - OnWorkflowCompletion
                     - OnWorkflowDeletion
+                    - OnWorkflowSuccessOrDeletion
+                    - OnWorkflowFailureOrDeletion
                     - Never
                     type: string
                 type: object
@@ -1035,6 +1039,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -3911,6 +3917,8 @@ spec:
                                             - ""
                                             - OnWorkflowCompletion
                                             - OnWorkflowDeletion
+                                            - OnWorkflowSuccessOrDeletion
+                                            - OnWorkflowFailureOrDeletion
                                             - Never
                                             type: string
                                         type: object
@@ -4473,6 +4481,8 @@ spec:
                                                   - ""
                                                   - OnWorkflowCompletion
                                                   - OnWorkflowDeletion
+                                                  - OnWorkflowSuccessOrDeletion
+                                                  - OnWorkflowFailureOrDeletion
                                                   - Never
                                                   type: string
                                               type: object
@@ -5086,6 +5096,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -6249,6 +6261,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -6899,6 +6913,8 @@ spec:
                                   - ""
                                   - OnWorkflowCompletion
                                   - OnWorkflowDeletion
+                                  - OnWorkflowSuccessOrDeletion
+                                  - OnWorkflowFailureOrDeletion
                                   - Never
                                   type: string
                               type: object
@@ -7472,6 +7488,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -12000,6 +12018,8 @@ spec:
                                               - ""
                                               - OnWorkflowCompletion
                                               - OnWorkflowDeletion
+                                              - OnWorkflowSuccessOrDeletion
+                                              - OnWorkflowFailureOrDeletion
                                               - Never
                                               type: string
                                           type: object
@@ -12562,6 +12582,8 @@ spec:
                                                     - ""
                                                     - OnWorkflowCompletion
                                                     - OnWorkflowDeletion
+                                                    - OnWorkflowSuccessOrDeletion
+                                                    - OnWorkflowFailureOrDeletion
                                                     - Never
                                                     type: string
                                                 type: object
@@ -13175,6 +13197,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object
@@ -14338,6 +14362,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -14988,6 +15014,8 @@ spec:
                                     - ""
                                     - OnWorkflowCompletion
                                     - OnWorkflowDeletion
+                                    - OnWorkflowSuccessOrDeletion
+                                    - OnWorkflowFailureOrDeletion
                                     - Never
                                     type: string
                                 type: object
@@ -15561,6 +15589,8 @@ spec:
                                       - ""
                                       - OnWorkflowCompletion
                                       - OnWorkflowDeletion
+                                      - OnWorkflowSuccessOrDeletion
+                                      - OnWorkflowFailureOrDeletion
                                       - Never
                                       type: string
                                   type: object

--- a/manifests/base/crds/minimal/argoproj.io_workflowtaskresults.yaml
+++ b/manifests/base/crds/minimal/argoproj.io_workflowtaskresults.yaml
@@ -63,6 +63,8 @@ spec:
                           - ""
                           - OnWorkflowCompletion
                           - OnWorkflowDeletion
+                          - OnWorkflowSuccessOrDeletion
+                          - OnWorkflowFailureOrDeletion
                           - Never
                           type: string
                       type: object

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -276,6 +276,8 @@ spec:
                           - ""
                           - OnWorkflowCompletion
                           - OnWorkflowDeletion
+                          - OnWorkflowSuccessOrDeletion
+                          - OnWorkflowFailureOrDeletion
                           - Never
                           type: string
                       type: object

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -276,6 +276,8 @@ spec:
                           - ""
                           - OnWorkflowCompletion
                           - OnWorkflowDeletion
+                          - OnWorkflowSuccessOrDeletion
+                          - OnWorkflowFailureOrDeletion
                           - Never
                           type: string
                       type: object

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -276,6 +276,8 @@ spec:
                           - ""
                           - OnWorkflowCompletion
                           - OnWorkflowDeletion
+                          - OnWorkflowSuccessOrDeletion
+                          - OnWorkflowFailureOrDeletion
                           - Never
                           type: string
                       type: object

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -103,7 +103,7 @@ message Artifact {
 // ArtifactGC describes how to delete artifacts from completed Workflows
 message ArtifactGC {
   // Strategy is the strategy to use.
-  // +kubebuilder:validation:Enum="";OnWorkflowCompletion;OnWorkflowDeletion;Never
+  // +kubebuilder:validation:Enum="";OnWorkflowCompletion;OnWorkflowDeletion;OnWorkflowSuccessOrDeletion;OnWorkflowFailureOrDeletion;Never
   optional string strategy = 1;
 
   // PodMetadata is an optional field for specifying the Labels and Annotations that should be assigned to the Pod doing the deletion

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -88,15 +88,19 @@ type ArtifactGCStrategy string
 
 // ArtifactGCStrategy
 const (
-	ArtifactGCOnWorkflowCompletion ArtifactGCStrategy = "OnWorkflowCompletion"
-	ArtifactGCOnWorkflowDeletion   ArtifactGCStrategy = "OnWorkflowDeletion"
-	ArtifactGCNever                ArtifactGCStrategy = "Never"
-	ArtifactGCStrategyUndefined    ArtifactGCStrategy = ""
+	ArtifactGCOnWorkflowCompletion        ArtifactGCStrategy = "OnWorkflowCompletion"
+	ArtifactGCOnWorkflowDeletion          ArtifactGCStrategy = "OnWorkflowDeletion"
+	ArtifactGCOnWorkflowSuccessOrDeletion ArtifactGCStrategy = "OnWorkflowSuccessOrDeletion"
+	ArtifactGCOnWorkflowFailureOrDeletion ArtifactGCStrategy = "OnWorkflowFailureOrDeletion"
+	ArtifactGCNever                       ArtifactGCStrategy = "Never"
+	ArtifactGCStrategyUndefined           ArtifactGCStrategy = ""
 )
 
 var AnyArtifactGCStrategy = map[ArtifactGCStrategy]bool{
-	ArtifactGCOnWorkflowCompletion: true,
-	ArtifactGCOnWorkflowDeletion:   true,
+	ArtifactGCOnWorkflowCompletion:        true,
+	ArtifactGCOnWorkflowDeletion:          true,
+	ArtifactGCOnWorkflowSuccessOrDeletion: true,
+	ArtifactGCOnWorkflowFailureOrDeletion: true,
 }
 
 // PodGCStrategy is the strategy when to delete completed pods for GC.
@@ -1052,7 +1056,7 @@ func (podGC *PodGC) GetStrategy() PodGCStrategy {
 // ArtifactGC describes how to delete artifacts from completed Workflows
 type ArtifactGC struct {
 	// Strategy is the strategy to use.
-	// +kubebuilder:validation:Enum="";OnWorkflowCompletion;OnWorkflowDeletion;Never
+	// +kubebuilder:validation:Enum="";OnWorkflowCompletion;OnWorkflowDeletion;OnWorkflowSuccessOrDeletion;OnWorkflowFailureOrDeletion;Never
 	Strategy ArtifactGCStrategy `json:"strategy,omitempty" protobuf:"bytes,1,opt,name=strategy,casttype=ArtifactGCStategy"`
 
 	// PodMetadata is an optional field for specifying the Labels and Annotations that should be assigned to the Pod doing the deletion

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -92,6 +92,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			expectedArtifacts: []artifactState{
 				artifactState{"on-completion", "my-bucket-2", true, false},
 				artifactState{"on-deletion", "my-bucket-2", false, true},
+				artifactState{"success-or-deletion", "my-bucket-2", true, false},
+				artifactState{"failure-or-deletion", "my-bucket-2", false, true},
 			},
 		},
 		{
@@ -100,6 +102,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			expectedArtifacts: []artifactState{
 				artifactState{"on-completion", "my-bucket-2", true, false},
 				artifactState{"on-deletion", "my-bucket-2", false, true},
+				artifactState{"success-or-deletion", "my-bucket-2", true, false},
+				artifactState{"failure-or-deletion", "my-bucket-2", false, true},
 			},
 		},
 	} {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -164,10 +164,10 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 
 		for _, expectedArtifact := range tt.expectedArtifacts {
 
-			if expectedArtifact.deletedAtWFDeletion {
+			if expectedArtifact.deletedAtWFCompletion { // already checked this
 				continue
 			}
-			if expectedArtifact.deletedAtWFCompletion {
+			if expectedArtifact.deletedAtWFDeletion {
 				fmt.Printf("verifying artifact %s is deleted\n", expectedArtifact.key)
 				then.ExpectArtifactByKey(expectedArtifact.key, expectedArtifact.bucketName, func(t *testing.T, object minio.ObjectInfo, err error) {
 					assert.NotNil(t, err)

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -137,6 +137,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 
 		then := when.Then()
 
+		// verify that the artifacts that should have been deleted at completion time were
 		for _, expectedArtifact := range tt.expectedArtifacts {
 			if expectedArtifact.deletedAtWFCompletion {
 				fmt.Printf("verifying artifact %s is deleted at completion time\n", expectedArtifact.key)
@@ -162,7 +163,11 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 		then = when.Then()
 
 		for _, expectedArtifact := range tt.expectedArtifacts {
-			if expectedArtifact.deletedAtWFDeletion || expectedArtifact.deletedAtWFCompletion {
+
+			if expectedArtifact.deletedAtWFDeletion {
+				continue
+			}
+			if expectedArtifact.deletedAtWFCompletion {
 				fmt.Printf("verifying artifact %s is deleted\n", expectedArtifact.key)
 				then.ExpectArtifactByKey(expectedArtifact.key, expectedArtifact.bucketName, func(t *testing.T, object minio.ObjectInfo, err error) {
 					assert.NotNil(t, err)

--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -233,12 +233,16 @@ var ToBeWaitingOnAMutex Condition = func(wf *wfv1.Workflow) (bool, string) {
 	return wf.Status.Synchronization != nil && wf.Status.Synchronization.Mutex != nil, "to be waiting on a mutex"
 }
 
+type WorkflowCompletionOkay bool
+
 // Wait for a workflow to meet a condition:
 // Options:
 // * `time.Duration` - change the timeout - 30s by default
 // * `string` - either:
 //    * the workflow's name (not spaces)
 //    * or a new message (if it contain spaces) - default "to finish"
+// * `WorkflowCompletionOkay`` (bool alias): if this is true, we won't stop checking for the other options
+//    * just because the Workflow completed
 // * `Condition` - a condition - `ToFinish` by default
 func (w *When) WaitForWorkflow(options ...interface{}) *When {
 	w.t.Helper()
@@ -248,6 +252,7 @@ func (w *When) WaitForWorkflow(options ...interface{}) *When {
 		workflowName = w.wf.Name
 	}
 	condition := ToBeDone
+	var workflowCompletionOkay WorkflowCompletionOkay
 	for _, opt := range options {
 		switch v := opt.(type) {
 		case time.Duration:
@@ -256,6 +261,8 @@ func (w *When) WaitForWorkflow(options ...interface{}) *When {
 			workflowName = v
 		case Condition:
 			condition = v
+		case WorkflowCompletionOkay:
+			workflowCompletionOkay = v
 		default:
 			w.t.Fatal("unknown option type: " + reflect.TypeOf(opt).String())
 		}
@@ -294,11 +301,13 @@ func (w *When) WaitForWorkflow(options ...interface{}) *When {
 					w.wf = wf
 					return w
 				}
-				// once done the workflow is done, the condition can never be met
-				// rather than wait maybe 30s for something that can never happen
-				if ok, _ = ToBeDone(wf); ok {
-					w.t.Errorf("condition never and cannot be met because the workflow is done")
-					return w
+				if !workflowCompletionOkay {
+					// once done the workflow is done, the condition can never be met
+					// rather than wait maybe 30s for something that can never happen
+					if ok, _ = ToBeDone(wf); ok {
+						w.t.Errorf("condition never and cannot be met because the workflow is done")
+						return w
+					}
 				}
 			} else {
 				w.t.Errorf("not ok")

--- a/test/e2e/testdata/artifactgc/artgc-template.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-template.yaml
@@ -50,3 +50,33 @@ spec:
               key: secretkey
           artifactGC:
             strategy: OnWorkflowDeletion
+        - name: success-or-deletion
+          path: /tmp/message
+          s3:
+            key: success-or-deletion
+            bucket: my-bucket-2
+            endpoint: minio:9000
+            insecure: true
+            accessKeySecret:
+              name: my-minio-cred
+              key: accesskey
+            secretKeySecret:
+              name: my-minio-cred
+              key: secretkey
+          artifactGC:
+            strategy: OnWorkflowSuccessOrDeletion
+        - name: failure-or-deletion
+          path: /tmp/message
+          s3:
+            key: failure-or-deletion
+            bucket: my-bucket-2
+            endpoint: minio:9000
+            insecure: true
+            accessKeySecret:
+              name: my-minio-cred
+              key: accesskey
+            secretKeySecret:
+              name: my-minio-cred
+              key: secretkey
+          artifactGC:
+            strategy: OnWorkflowFailureOrDeletion

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -96,7 +96,7 @@ func (woc *wfOperationCtx) artifactGCStrategiesReady() map[wfv1.ArtifactGCStrate
 	}
 
 	// for any strategies we've already processed (searched for artifacts with/started pods for), remove them from our map:
-	for strategy, _ := range strategies {
+	for strategy := range strategies {
 		if woc.wf.Status.ArtifactGCStatus.IsArtifactGCStrategyProcessed(strategy) {
 			delete(strategies, strategy)
 		}


### PR DESCRIPTION
Fixes #9318 

Note the reason to add strategies for "OnWorkflowSuccessOrDeletion" and "OnWorkflowFailureOrDeletion" rather than "OnWorkflowSuccess" and "OnWorkflowFailure" is to ensure artifacts get deleted at some point.

We can add "OnWorkflowSuccess" and "OnWorkflowFailure" at some point if there's demand for those.

I also considered trying to consolidate multiple strategies into a single GC Pod but I decided it wasn't really worth the complexity - and I think having each in a separate Pod named by its strategy will make the inspection of ArtifactGCTasks and Pods more intuitive.

