### PR TITLE
fix: removed error check which prevented deleting successful artGC wfs. 

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -299,9 +299,6 @@ func (s *workflowServer) DeleteWorkflow(ctx context.Context, req *workflowpkg.Wo
 	if err != nil {
 		return nil, err
 	}
-	if wf.Finalizers != nil && !req.Force {
-		return nil, fmt.Errorf("%s has finalizer. Use argo delete --force to delete this workflow", wf.Name)
-	}
 	if req.Force {
 		_, err := auth.GetWfClient(ctx).ArgoprojV1alpha1().Workflows(wf.Namespace).Patch(ctx, wf.Name, types.MergePatchType, []byte("{\"metadata\":{\"finalizers\":null}}"), metav1.PatchOptions{})
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Dillen Padhiar <dillen_padhiar@intuit.com>

Quick fix for artifactGC. Error message check is preventing successful artifact GC workflows from being deleted. Will add better check before 3.4 release.