### PR TITLE
feat: support slash in synchronization lock names. Fixes #9394

### DIFF
--- a/workflow/sync/lock_name_test.go
+++ b/workflow/sync/lock_name_test.go
@@ -1,0 +1,78 @@
+package sync
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeLockName(t *testing.T) {
+	type args struct {
+		lockName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *LockName
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			"TestMutexLockNameValidation",
+			args{"default/Mutex/test"},
+			&LockName{
+				Namespace:    "default",
+				ResourceName: "test",
+				Key:          "",
+				Kind:         LockKindMutex,
+			},
+			func(t assert.TestingT, err error, i ...interface{}) bool {
+				return true
+			},
+		},
+		{
+			"TestMutexLocksCanContainSlashes",
+			args{"default/Mutex/test/foo/bar/baz"},
+			&LockName{
+				Namespace:    "default",
+				ResourceName: "test/foo/bar/baz",
+				Key:          "",
+				Kind:         LockKindMutex,
+			},
+			func(t assert.TestingT, err error, i ...interface{}) bool {
+				return true
+			},
+		},
+		{
+			"TestConfigMapLockNamesWork",
+			args{"default/ConfigMap/foo/bar"},
+			&LockName{
+				Namespace:    "default",
+				ResourceName: "foo",
+				Key:          "bar",
+				Kind:         LockKindConfigMap,
+			},
+			func(t assert.TestingT, err error, i ...interface{}) bool {
+				return true
+			},
+		},
+		{
+			"TestConfigMapKeysCannotContainSlashes",
+			args{"default/ConfigMap/foo/bar/baz/qux"},
+			nil,
+			func(t assert.TestingT, err error, i ...interface{}) bool {
+				return err == nil // this should error
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeLockName(tt.args.lockName)
+			if !tt.wantErr(t, err, fmt.Sprintf("DecodeLockName(%v)", tt.args.lockName)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "DecodeLockName(%v)", tt.args.lockName)
+			got.ValidateEncoding(tt.args.lockName)
+		})
+	}
+}


### PR DESCRIPTION
Add support for slashes in mutex names. 

Fixes #9394

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->