### PR TITLE
fix: Properly reset suspended and skipped nodes when retrying

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -822,22 +822,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 		switch node.Phase {
 		case wfv1.NodeSucceeded, wfv1.NodeSkipped:
 			if !strings.HasPrefix(node.Name, onExitNodeName) && !doForceResetNode {
-				if node.Phase == wfv1.NodeSkipped {
-					//newWF.Status.Nodes[node.ID].Phase = wfv1.NodeSkipped
-					deletedNodes[node.ID] = true
-					// TODO: If a node's parent is a suspend node, remove this node from the node statuses instead of setting it to running.
-				} else if node.Type == wfv1.NodeTypeSuspend {
-					for _, childId := range node.Children {
-						deletedNodes[childId] = true
-					}
-					//for _, n := range wf.Status.Nodes {
-					//	for _, childId := range node.Children {
-					//		if n.ID == childId {
-					//			deletedNodes[node.ID] = true
-					//		}
-					//	}
-					//}
-				} else if (node.Type == wfv1.NodeTypeDAG || node.Type == wfv1.NodeTypeTaskGroup || node.Type == wfv1.NodeTypeStepGroup) && node.BoundaryID != "" {
+				if (node.Type == wfv1.NodeTypeDAG || node.Type == wfv1.NodeTypeTaskGroup || node.Type == wfv1.NodeTypeStepGroup) && node.BoundaryID != "" {
 					// Reset parent node if this node is a step/task group or DAG.
 					parentNodeID := node.BoundaryID
 					if parentNodeID != wf.ObjectMeta.Name { // Skip root node

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -919,6 +919,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 }
 
 func resetNode(node wfv1.NodeStatus) wfv1.NodeStatus {
+	// The previously supplied parameters needed to be reset. Otherwise, `argo node reset` would not work as expected.
 	if node.Type == wfv1.NodeTypeSuspend {
 		if node.Outputs != nil {
 			for i, param := range node.Outputs.Parameters {
@@ -932,6 +933,7 @@ func resetNode(node wfv1.NodeStatus) wfv1.NodeStatus {
 		}
 	}
 	if node.Phase == wfv1.NodeSkipped {
+		// The skipped nodes need to be kept as skipped. Otherwise, the workflow will be stuck on running.
 		node.Phase = wfv1.NodeSkipped
 	} else {
 		node.Phase = wfv1.NodeRunning

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -923,7 +923,6 @@ func resetNode(node wfv1.NodeStatus) wfv1.NodeStatus {
 	if node.Type == wfv1.NodeTypeSuspend {
 		if node.Outputs != nil {
 			for i, param := range node.Outputs.Parameters {
-				node.Outputs.Parameters[i].Value = nil
 				node.Outputs.Parameters[i] = wfv1.Parameter{
 					Name:      param.Name,
 					Value:     nil,

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -901,6 +901,40 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 
 		}
 	})
+	t.Run("Skipped and Suspended Nodes", func(t *testing.T) {
+		wf := &wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "wf-with-skipped-and-suspended-nodes",
+				Labels: map[string]string{},
+			},
+			Status: wfv1.WorkflowStatus{
+				Phase: wfv1.WorkflowFailed,
+				Nodes: map[string]wfv1.NodeStatus{
+					"my-nested-dag-1": {ID: "my-nested-dag-1", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
+					"suspended": {ID: "suspended", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeSuspend, BoundaryID: "my-nested-dag-1", Outputs: &wfv1.Outputs{Parameters: []wfv1.Parameter{{
+						Name:      "param-1",
+						Value:     wfv1.AnyStringPtr("3"),
+						ValueFrom: &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}},
+					}}}},
+					"skipped": {ID: "skipped", Phase: wfv1.NodeSkipped, Type: wfv1.NodeTypeSkipped, BoundaryID: "suspended"},
+				}},
+		}
+		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
+		assert.NoError(t, err)
+		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=suspended", nil)
+		if assert.NoError(t, err) {
+			if assert.Len(t, wf.Status.Nodes, 3) {
+				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-1"].Phase)
+				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["suspended"].Phase)
+				assert.Equal(t, wfv1.Parameter{
+					Name:      "param-1",
+					Value:     nil,
+					ValueFrom: &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}},
+				}, wf.Status.Nodes["suspended"].Outputs.Parameters[0])
+				assert.Equal(t, wfv1.NodeSkipped, wf.Status.Nodes["skipped"].Phase)
+			}
+		}
+	})
 	t.Run("Nested DAG with Non-group Node Selected", func(t *testing.T) {
 		wf := &wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Issues that we are fixing in this PR:
* The skipped nodes need to be kept as skipped. Otherwise, the workflow will be stuck on running.
* The previously supplied parameters needed to be reset for suspended nodes. Otherwise, `argo node reset` would not work as expected.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>