### PR TITLE
Add --tls-certificate-secret-name parameter to server command. Fixes #5582

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,6 +421,9 @@ test: server/static/files.go
 .PHONY: install
 install: githooks
 	kubectl get ns $(KUBE_NAMESPACE) || kubectl create ns $(KUBE_NAMESPACE)
+	# install cert-manager if Certificate CRD is not available
+	kubectl get ns cert-manager || kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
+	kubectl wait --for=condition=Ready pods --all --namespace cert-manager
 	kubectl config set-context --current --namespace=$(KUBE_NAMESPACE)
 	@echo "installing PROFILE=$(PROFILE)"
 	kubectl kustomize --load-restrictor=LoadRestrictionsNone test/e2e/manifests/$(PROFILE) | sed 's|quay.io/argoproj/|$(IMAGE_NAMESPACE)/|' | sed 's/namespace: argo/namespace: $(KUBE_NAMESPACE)/' | kubectl -n $(KUBE_NAMESPACE) apply --prune -l app.kubernetes.io/part-of=argo -f -

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following commands install Argo Workflows as well as some commmonly used com
 
 ```bash
 kubectl create ns argo
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
 kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo-workflows/master/manifests/quick-start-postgres.yaml
 ```
 

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -46,7 +46,7 @@ func NewServerCommand() *cobra.Command {
 		baseHRef                 string
 		secure                   bool
 		tlsCertificateSecretName string
-		htst                     bool
+		hsts                     bool
 		namespaced               bool   // --namespaced
 		managedNamespace         string // --managed-namespace
 		enableOpenBrowser        bool
@@ -153,7 +153,7 @@ See %s`, help.ArgoServer),
 			opts := apiserver.ArgoServerOpts{
 				BaseHRef:                 baseHRef,
 				TLSConfig:                tlsConfig,
-				HSTS:                     htst,
+				HSTS:                     hsts,
 				Namespaced:               namespaced,
 				Namespace:                namespace,
 				Clients:                  clients,
@@ -217,7 +217,8 @@ See %s`, help.ArgoServer),
 	command.Flags().StringVar(&baseHRef, "basehref", defaultBaseHRef, "Value for base href in index.html. Used if the server is running behind reverse proxy under subpath different from /. Defaults to the environment variable BASE_HREF.")
 	// "-e" for encrypt, like zip
 	command.Flags().BoolVarP(&secure, "secure", "e", true, "Whether or not we should listen on TLS.")
-	command.Flags().BoolVar(&htst, "hsts", true, "Whether or not we should add a HTTP Secure Transport Security header. This only has effect if secure is enabled.")
+	command.Flags().StringVar(&tlsCertificateSecretName, "tls-certificate-secret-name", "", "The name of a Kubernetes secret that contains the server certificates")
+	command.Flags().BoolVar(&hsts, "hsts", true, "Whether or not we should add a HTTP Secure Transport Security header. This only has effect if secure is enabled.")
 	command.Flags().StringArrayVar(&authModes, "auth-mode", []string{"client"}, "API server authentication mode. Any 1 or more length permutation of: client,server,sso")
 	command.Flags().StringVar(&configMap, "configmap", common.ConfigMapName, "Name of K8s configmap to retrieve workflow controller configuration")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run as namespaced mode")

--- a/docs/cli/argo_server.md
+++ b/docs/cli/argo_server.md
@@ -32,6 +32,7 @@ See https://argoproj.github.io/argo-workflows/argo-server/
       --managed-namespace string             namespace that watches, default to the installation namespace
       --namespaced                           run as namespaced mode
   -p, --port int                             Port to listen on (default 2746)
+      --tls-certificate-secret-name string   The name of a Kubernetes secret that contains the server certificates
       --x-frame-options string               Set X-Frame-Options header in HTTP responses. (default "DENY")
 ```
 

--- a/manifests/base/argo-server/argo-server-certificate.yaml
+++ b/manifests/base/argo-server/argo-server-certificate.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: argo-workflows-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argo-server-cert
+spec:
+  dnsNames:
+  - argo-server.argo.svc.cluster.local
+  - argo-server.argo.svc
+  - argo-server
+  issuerRef:
+    kind: Issuer
+    name: argo-workflows-issuer
+  secretName: argo-server-tls

--- a/manifests/base/argo-server/argo-server-deployment.yaml
+++ b/manifests/base/argo-server/argo-server-deployment.yaml
@@ -22,7 +22,9 @@ spec:
             capabilities:
               drop:
                 - ALL
-          args: [ server ]
+          args:
+            - server
+            - --tls-certificate-secret-name=argo-server-tls
           env: []
           ports:
             - name: web

--- a/manifests/base/argo-server/kustomization.yaml
+++ b/manifests/base/argo-server/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- argo-server-certificate.yaml
 - argo-server-deployment.yaml
 - argo-server-sa.yaml
 - argo-server-service.yaml

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -1809,3 +1809,24 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: argo
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argo-server-cert
+spec:
+  dnsNames:
+  - argo-server.argo.svc.cluster.local
+  - argo-server.argo.svc
+  - argo-server
+  issuerRef:
+    kind: Issuer
+    name: argo-workflows-issuer
+  secretName: argo-server-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: argo-workflows-issuer
+spec:
+  selfSigned: {}

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -1898,3 +1898,24 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: argo
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argo-server-cert
+spec:
+  dnsNames:
+  - argo-server.argo.svc.cluster.local
+  - argo-server.argo.svc
+  - argo-server
+  issuerRef:
+    kind: Issuer
+    name: argo-workflows-issuer
+  secretName: argo-server-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: argo-workflows-issuer
+spec:
+  selfSigned: {}

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -1890,3 +1890,24 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: argo
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argo-server-cert
+spec:
+  dnsNames:
+  - argo-server.argo.svc.cluster.local
+  - argo-server.argo.svc
+  - argo-server
+  issuerRef:
+    kind: Issuer
+    name: argo-workflows-issuer
+  secretName: argo-server-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: argo-workflows-issuer
+spec:
+  selfSigned: {}

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -334,7 +334,10 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize)),
 	}
 	if as.tlsConfig != nil {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(as.tlsConfig)))
+		tlsConfig := as.tlsConfig
+		tlsConfig.InsecureSkipVerify = true
+		dCreds := credentials.NewTLS(tlsConfig)
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(dCreds))
 	} else {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}


### PR DESCRIPTION
Signed-off-by: vladimir ivanov <vladimir.ivanov@grasshopperasia.com>

Fixes #5582

Add --tls-certificate-secret-name parameter to server command.
Since server runs on localhost:2746, get an error in the UI "certificate is valid for ... not for localhost". Therefore the merge request set `InsecureSkipVerify` on TLSconfig for grpc client on the gateway.

Tested to to work with secret provided by cert-manager (added to manifests).