### PR TITLE
fix: link to "get artifacts from logs" was assuming Node ID was equal to Pod Name

### DIFF
--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -148,7 +148,7 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
                         <InfoIcon /> Wait containers logs are useful when debugging output artifact problems.
                     </>
                 )}
-                {podName && (
+                {podName && podNamesToNodeIDs.get(podName) && (
                     <>
                         Still waiting for data or an error? Try getting{' '}
                         <a href={services.workflows.getArtifactLogsPath(workflow, podNamesToNodeIDs.get(podName), selectedContainer, archived)}>logs from the artifacts</a>.

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -71,7 +71,8 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
     }
     const podNameVersion = annotations[ANNOTATION_KEY_POD_NAME_VERSION];
 
-    const podNamesToNodeNames = new Map<string,string>();
+    // map pod names to corresponding node IDs
+    const podNamesToNodeIDs = new Map<string, string>();
 
     const podNames = [{value: '', label: 'All'}].concat(
         Object.values(workflow.status.nodes || {})
@@ -80,12 +81,11 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
                 const {name, id, displayName} = targetNode;
                 const templateName = getTemplateNameFromNode(targetNode);
                 const targetPodName = getPodName(workflow.metadata.name, name, templateName, id, podNameVersion);
-                podNamesToNodeNames.set(targetPodName,id);
+                podNamesToNodeIDs.set(targetPodName, id);
                 return {value: targetPodName, label: (displayName || name) + ' (' + targetPodName + ')'};
             })
     );
 
-    
     const node = workflow.status.nodes[nodeId];
     const templates = execSpec(workflow).templates.filter(t => !node || t.name === node.templateName);
 
@@ -110,8 +110,14 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
             )}
             <div style={{marginBottom: 10}}>
                 <i className='fa fa-box' />{' '}
-                <Autocomplete items={podNames} value={(podNames.find(x => x.value[0] === podName) || {label: ''}).label} onSelect={(_, item) => {setPodName(item.value)}} /> /{' '}
-                <Autocomplete items={containers} value={selectedContainer} onSelect={setContainer} />
+                <Autocomplete
+                    items={podNames}
+                    value={(podNames.find(x => x.value[0] === podName) || {label: ''}).label}
+                    onSelect={(_, item) => {
+                        setPodName(item.value);
+                    }}
+                />{' '}
+                / <Autocomplete items={containers} value={selectedContainer} onSelect={setContainer} />
                 <span className='fa-pull-right'>
                     <i className='fa fa-filter' /> <input type='search' defaultValue={logFilter} onChange={v => setLogFilter(v.target.value)} placeholder='Filter (regexp)...' />
                 </span>
@@ -145,7 +151,7 @@ export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container,
                 {podName && (
                     <>
                         Still waiting for data or an error? Try getting{' '}
-                        <a href={services.workflows.getArtifactLogsPath(workflow, podNamesToNodeNames.get(podName), selectedContainer, archived)}>logs from the artifacts</a>.
+                        <a href={services.workflows.getArtifactLogsPath(workflow, podNamesToNodeIDs.get(podName), selectedContainer, archived)}>logs from the artifacts</a>.
                     </>
                 )}
                 {execSpec(workflow).podGC && (

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -26,9 +26,8 @@ function identity<T>(value: T) {
     return () => value;
 }
 
-export const WorkflowLogsViewer = ({workflow, nodeId: initialNodeId, initialPodName, container, archived}: WorkflowLogsViewerProps) => {
+export const WorkflowLogsViewer = ({workflow, nodeId, initialPodName, container, archived}: WorkflowLogsViewerProps) => {
     const [podName, setPodName] = useState(initialPodName || '');
-    const [nodeId, setNodeId] = useState(initialNodeId || '')
     const [selectedContainer, setContainer] = useState(container);
     const [grep, setGrep] = useState('');
     const [error, setError] = useState<Error>();
@@ -38,7 +37,7 @@ export const WorkflowLogsViewer = ({workflow, nodeId: initialNodeId, initialPodN
     useEffect(() => {
         setError(null);
         setLoaded(false);
-        const source = services.workflows.getContainerLogs(workflow, podName, initialNodeId, selectedContainer, grep, archived).pipe(
+        const source = services.workflows.getContainerLogs(workflow, podName, nodeId, selectedContainer, grep, archived).pipe(
             map(e => (!podName ? e.podName + ': ' : '') + e.content + '\n'),
             // this next line highlights the search term in bold with a yellow background, white text
             map(x => {
@@ -87,7 +86,7 @@ export const WorkflowLogsViewer = ({workflow, nodeId: initialNodeId, initialPodN
     );
 
     
-    const node = workflow.status.nodes[initialNodeId];
+    const node = workflow.status.nodes[nodeId];
     const templates = execSpec(workflow).templates.filter(t => !node || t.name === node.templateName);
 
     const containers = [


### PR DESCRIPTION
Hoping this Fixes #9434 but we'll see
At least it does fix the issue seen when running examples/dag-coinflip.yaml

Root cause was that this UI code was never updated to reflect the change to POD_NAMES v2, so it was still assuming that the Pod Name and Node ID would be equal.

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->