### PR TITLE
feat: Add node ID to node info panel

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -93,6 +93,7 @@ const WorkflowNodeSummary = (props: Props) => {
 
     const attributes = [
         {title: 'NAME', value: <ClipboardText text={props.node.name} />},
+        {title: 'ID', value: <ClipboardText text={props.node.id} />},
         {title: 'TYPE', value: props.node.type},
         {
             title: 'PHASE',


### PR DESCRIPTION
This is useful for debugging purposes. When there are a lot of similar node names, I had to look for the unique IDs from node statuses. 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
