### PR TITLE
fix: use urlencode instead of htmlencode to sanitize url

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,8 +18,8 @@ func TestSanitize(t *testing.T) {
 		c   Config
 		err string
 	}{
-		{Config{Links: []*wfv1.Link{{URL: "javascript:foo"}}}, "detect javascript link: javascript:foo"},
-		{Config{Links: []*wfv1.Link{{URL: "javASCRipt: //foo"}}}, "detect javascript link: javASCRipt: //foo"},
+		{Config{Links: []*wfv1.Link{{URL: "javascript:foo"}}}, "protocol javascript is not allowed"},
+		{Config{Links: []*wfv1.Link{{URL: "javASCRipt: //foo"}}}, "protocol javascript is not allowed"},
 		{Config{Links: []*wfv1.Link{{URL: "http://foo.bar/?foo=<script>abc</script>bar"}}}, ""},
 	}
 	for _, tt := range tests {

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -82,7 +82,7 @@ func (s *ArgoServerSuite) TestInfo() {
 			Equal("workflow")
 		json.
 			Path("$.links[0].url").
-			Equal("http://logging-facility?namespace=${metadata.namespace}&amp;workflowName=${metadata.name}&amp;startedAt=${status.startedAt}&amp;finishedAt=${status.finishedAt}")
+			Equal("http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}")
 	})
 }
 


### PR DESCRIPTION
HtmlEncode replaces special characters with character strings that are recognised by the HTML engine itself to render the content of the page

URLEncode replaces special characters with characters that can be understood by web browsers/web servers for the purpose of addressing

Should use URLEncode instead, since the config links are JS buttons to an external page

Fixes #9435

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->