### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -5,8 +5,14 @@ on:
     tags:
       - v*
       - "!v0.0.0"
+permissions:
+  contents: read
+
 jobs:
   generate_changelog:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
     name: Generate changelog

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Unit Tests

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build-linux-amd64:
     name: Build & push linux/amd64
@@ -317,6 +320,8 @@ jobs:
           done
 
   publish-release:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     runs-on: ubuntu-latest
     if: github.repository == 'argoproj/argo-workflows'
     needs: [ push-images, test-images-linux-amd64, test-images-windows ]

--- a/.github/workflows/sdks.yaml
+++ b/.github/workflows/sdks.yaml
@@ -3,8 +3,16 @@ on:
   push:
     tags:
       - v*
+
+permissions:
+  contents: read
+
 jobs:
   sdk:
+    permissions:
+      contents: read
+      packages: write # for publishing packages
+      contents: write  # for creating releases
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
     name: Publish SDK

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,6 +2,9 @@ name: Snyk
 on:
   schedule:
     - cron: "30 2 * * *"
+permissions:
+  contents: read
+
 jobs:
   # we do not scan images here, they're scanned here: https://app.snyk.io/org/argoproj/projects
 


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

GitHub Actions workflows have a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflows:
https://github.com/argoproj/argo-workflows/runs/8125260622?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- changelog.yaml
- ci-build.yaml
- gh-pages.yaml
- release.yaml
- sdks.yaml
- snyk.yml

The following workflow file already has the least privileged token permission set:

- dependabot-reviewer.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>