### PR TITLE
docs(dev-container): Fix buildkit doc for local dev

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -26,7 +26,7 @@ Note:
 
     ```json
     "features": {
-      "buildkit": false
+      "buildkit": true
     },
     ```
 
@@ -79,7 +79,7 @@ To start:
 Run:
 
 ```bash
-make start 
+make start
 ```
 
 Make sure you don't see any errors in your terminal.
@@ -87,7 +87,7 @@ Make sure you don't see any errors in your terminal.
 You can submit a workflow for testing using `kubectl`:
 
 ```bash
-kubectl create -f examples/hello-world.yaml 
+kubectl create -f examples/hello-world.yaml
 ```
 
 If you made changes to the executor, you need to build the image:
@@ -113,8 +113,8 @@ make start UI=true
 If you are making change to the CLI, you can build it:
 
 ```bash
-make cli 
-./dist/argo submit examples/hello-world.yaml ;# new CLI is created as `./dist/argo` 
+make cli
+./dist/argo submit examples/hello-world.yaml ;# new CLI is created as `./dist/argo`
 ```
 
 To test the workflow archive, use `PROFILE=mysql` or `PROFILE=postgres`:
@@ -139,7 +139,7 @@ make start UI=true PROFILE=sso
 Start up Argo Workflows using the following:
 
 ```bash
-make start PROFILE=mysql AUTH_MODE=client STATIC_FILES=false API=true 
+make start PROFILE=mysql AUTH_MODE=client STATIC_FILES=false API=true
 ```
 
 #### Running One Test
@@ -150,7 +150,7 @@ Our CI will run those concurrently when you create a PR, which will give you fee
 Find the test that you want to run in `test/e2e`
 
 ```bash
-make TestArtifactServer  
+make TestArtifactServer
 ```
 
 #### Running A Set Of Tests


### PR DESCRIPTION
The [text](https://argoproj.github.io/argo-workflows/running-locally/#development-container) states `Configure Docker Desktop to use BuildKit:` yet has `"buildkit": false`.  This changes it to `true`.

Matches the [Docker Desktop docs](https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds)

[Original PR that added this text](https://github.com/argoproj/argo-workflows/pull/8677)

Signed-off-by: jmeridth <jmeridth@gmail.com>

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->