### PR TITLE
Add call-stack variable to workflow executor

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -130,7 +130,7 @@ returns `0`. Please review the Sprig documentation to understand which functions
 | `inputs.parameters.<NAME>`| Input parameter to a template |
 | `inputs.parameters`| All input parameters to a template as a JSON string |
 | `inputs.artifacts.<NAME>` | Input artifact to a template |
-
+| `call-stack` | Returns step/dag trace to this point in the workflow |
 ### Steps Templates
 
 | Variable | Description|

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1672,6 +1672,12 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	if resolvedTmpl.IsPodType() && woc.retryStrategy(resolvedTmpl) == nil {
 		localParams[common.LocalVarPodName] = woc.getPodName(nodeName, resolvedTmpl.Name)
 	}
+	if !localParams["call-stack"] {
+		localParams["call-stack"] = ""
+	}
+
+	localParams["call-stack"] = localParams["call-stack"] + "." + orgTmpl.GetName()
+
 	if orgTmpl.IsDAGTask() {
 		localParams["tasks.name"] = orgTmpl.GetName()
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1672,11 +1672,11 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	if resolvedTmpl.IsPodType() && woc.retryStrategy(resolvedTmpl) == nil {
 		localParams[common.LocalVarPodName] = woc.getPodName(nodeName, resolvedTmpl.Name)
 	}
-	if localParams["call-stack"] == nil {
+	if callStack, err := localParams["call-stack"]; err {
 		localParams["call-stack"] = ""
+	} else {
+		localParams["call-stack"] = callStack + "." + orgTmpl.GetName()
 	}
-
-	localParams["call-stack"] = localParams["call-stack"] + "." + orgTmpl.GetName()
 
 	if orgTmpl.IsDAGTask() {
 		localParams["tasks.name"] = orgTmpl.GetName()

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1675,7 +1675,9 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	if callStack, err := localParams["call-stack"]; err {
 		localParams["call-stack"] = ""
 	} else {
-		localParams["call-stack"] = callStack + "." + orgTmpl.GetName()
+		if orgTmpl.IsDAGTask() || orgTmpl.IsWorkflowStep() {
+			localParams["call-stack"] = callStack + "." + orgTmpl.GetName()
+		}
 	}
 
 	if orgTmpl.IsDAGTask() {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1672,7 +1672,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	if resolvedTmpl.IsPodType() && woc.retryStrategy(resolvedTmpl) == nil {
 		localParams[common.LocalVarPodName] = woc.getPodName(nodeName, resolvedTmpl.Name)
 	}
-	if !localParams["call-stack"] {
+	if localParams["call-stack"] == nil {
 		localParams["call-stack"] = ""
 	}
 

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -607,6 +607,7 @@ func resolveAllVariables(scope map[string]interface{}, globalParams map[string]s
 			} else if strings.HasPrefix(tag, common.GlobalVarWorkflowDuration) {
 			} else if strings.HasPrefix(tag, "tasks.name") {
 			} else if strings.HasPrefix(tag, "steps.name") {
+			} else if strings.HasPrefix(tag, "call-stack") {
 			} else {
 				return fmt.Errorf("failed to resolve {{%s}}", tag)
 			}


### PR DESCRIPTION
This adds a new feature to reference the current call stack at the point. Our main purpose of this is for a feature in a argo unit test framework that my team is working on.

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->