### PR TITLE
fix: Fixed artifact retrieval when templateRef in use. Fixes #9631, #9644.

### DIFF
--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -391,6 +391,10 @@ func (a *ArtifactServer) getArtifactAndDriver(ctx context.Context, nodeId, artif
 	// 4. Template defines ArchiveLocation
 
 	templateName := wf.Status.Nodes[nodeId].TemplateName
+	templateRef := wf.Status.Nodes[nodeId].TemplateRef
+	if templateName == "" && templateRef != nil {
+		templateName = templateRef.Template
+	}
 	template := wf.GetTemplateByName(templateName)
 	if template == nil {
 		return nil, nil, fmt.Errorf("no template found by the name of '%s' (which is the template associated with nodeId '%s'??", templateName, nodeId)

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -28,6 +28,7 @@ import (
 	artifact "github.com/argoproj/argo-workflows/v3/workflow/artifacts"
 	"github.com/argoproj/argo-workflows/v3/workflow/artifacts/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
+	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
 
 type ArtifactServer struct {
@@ -390,11 +391,7 @@ func (a *ArtifactServer) getArtifactAndDriver(ctx context.Context, nodeId, artif
 	// 3. Workflow spec defines artifactRepositoryRef which is a ConfigMap which defines the location
 	// 4. Template defines ArchiveLocation
 
-	templateName := wf.Status.Nodes[nodeId].TemplateName
-	templateRef := wf.Status.Nodes[nodeId].TemplateRef
-	if templateName == "" && templateRef != nil {
-		templateName = templateRef.Template
-	}
+	templateName := util.GetTemplateFromNode(wf.Status.Nodes[nodeId])
 	template := wf.GetTemplateByName(templateName)
 	if template == nil {
 		return nil, nil, fmt.Errorf("no template found by the name of '%s' (which is the template associated with nodeId '%s'??", templateName, nodeId)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -755,7 +755,7 @@ func getDescendantNodeIDs(wf *wfv1.Workflow, node wfv1.NodeStatus) []string {
 }
 
 func deletePodNodeDuringRetryWorkflow(wf *wfv1.Workflow, node wfv1.NodeStatus, deletedPods map[string]bool, podsToDelete []string) (map[string]bool, []string) {
-	templateName := getTemplateFromNode(node)
+	templateName := GetTemplateFromNode(node)
 	version := GetWorkflowPodNameVersion(wf)
 	podName := PodName(wf.Name, node.Name, templateName, node.ID, version)
 	if _, ok := deletedPods[podName]; !ok {
@@ -999,7 +999,7 @@ func resetNode(node wfv1.NodeStatus) wfv1.NodeStatus {
 	return node
 }
 
-func getTemplateFromNode(node wfv1.NodeStatus) string {
+func GetTemplateFromNode(node wfv1.NodeStatus) string {
 	if node.TemplateRef != nil {
 		return node.TemplateRef.Template
 	}

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1083,7 +1083,7 @@ func TestGetTemplateFromNode(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := getTemplateFromNode(tc.inputNode)
+		actual := GetTemplateFromNode(tc.inputNode)
 		assert.Equal(t, tc.expectedTemplateName, actual)
 	}
 }


### PR DESCRIPTION
Handle artifact retrieval when the workflow node has no templateName set but
does have templateRef set instead. Added a unit test that was broken before
the changes and works after the changes.

Fixes #9631, #9644
Signed-off-by: Brian Loss <brianloss@gmail.com>

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->