### PR TITLE
fix: Workflow-controller panic when stop a wf using plugin. Fixes #9587

### DIFF
--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -20,7 +20,10 @@ func (woc *wfOperationCtx) applyExecutionControl(pod *apiv1.Pod, wfNodesLock *sy
 	}
 
 	nodeID := woc.nodeID(pod)
-	node := woc.wf.Status.Nodes[nodeID]
+	node, ok := woc.wf.Status.Nodes[nodeID]
+	if !ok {
+		return
+	}
 	//node is already completed
 	if node.Fulfilled() {
 		return


### PR DESCRIPTION
Fixes #9587 

This handles workflow-controller panic when stop a wf using plugin.

<!--

Before you commit your changes:

* Run `make pre-commit -B` to fix codegen and lint problems.
* Add you organization to [USERS.md](https://github.com/argoproj/argo-workflows/blob/master/USERS.md) if you like.

Then, you MUST:

* Sign-off your commit (otherwise the DCO check will fail).
* Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).

If you did not do this, reset all your commit and replace them with a single commit:

```
git reset HEAD~1 ;# change 1 to how many commits you made
git commit --signoff -m 'feat: my feat. Fixes #1234'
```

When creating your PR: 

* Make sure that "Fixes #" is in both the PR title (for release notes) and description (to automatically link and close the issue).
* Say how you tested your changes. If you changed the UI, attach screenshots.
* Set your PR as a draft initially.
* Your PR needs to pass the required checks before it can be approved. 
* Once required tests have passed, mark your PR "Ready for review".

If changes were requested, once you've made them, you MUST dismiss the review to get it reviewed again.

-->