### PR TITLE
docs: Add namespace in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -43,6 +43,6 @@ body:
     id: wait-logs
     attributes:
       label: Logs from in your workflow's wait container
-      value: kubectl logs -c wait -l workflows.argoproj.io/workflow=${workflow},workflow.argoproj.io/phase!=Succeeded
+      value: kubectl logs -n argo -c wait -l workflows.argoproj.io/workflow=${workflow},workflow.argoproj.io/phase!=Succeeded
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/regression.yaml
+++ b/.github/ISSUE_TEMPLATE/regression.yaml
@@ -44,6 +44,6 @@ body:
     id: wait-logs
     attributes:
       label: Logs from in your workflow's wait container
-      value: kubectl logs -c wait -l workflows.argoproj.io/workflow=${workflow},workflow.argoproj.io/phase!=Succeeded
+      value: kubectl logs -n argo -c wait -l workflows.argoproj.io/workflow=${workflow},workflow.argoproj.io/phase!=Succeeded
     validations:
       required: true


### PR DESCRIPTION
From observation, users will get and fill in “no resources found in default namespace” in the form if they are not in Argo namespace.