### PR TITLE
docs: Use new Google Analytics 4 site tag

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ theme:
 extra:
   analytics:
     provider: google
-    property: UA-105170809-7
+    property: G-5Z1VTPDL73
 markdown_extensions:
   - codehilite
   - admonition


### PR DESCRIPTION
- Contributes to https://github.com/argoproj/argo-site/issues/102
- As mentioned in that umbrella issue, the UA site tag is [connected] from the new GA4 site tag and so will continue receiving events.

/cc @alexmt 

[connected]: https://support.google.com/analytics/answer/9973999