### PR TITLE
fix: Set scheduling constraints to the agent pod by the workflow. Fixes #9704

### DIFF
--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -238,6 +238,8 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 		},
 	}
 
+	addSchedulingConstraints(pod, woc.execWf.Spec.DeepCopy(), &wfv1.Template{})
+
 	if woc.controller.Config.InstanceID != "" {
 		pod.ObjectMeta.Labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
 	}


### PR DESCRIPTION
Fixes #9704 

Set scheduling constraints to the agent pod by the workflow
