### PR TITLE
chore: address flakey e2e test ("TestParametrizableAds")

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -713,13 +713,13 @@ spec:
 `).
 		When().
 		SubmitWorkflow().
-		WaitForWorkflow(10 * time.Second).
+		WaitForWorkflow(10*time.Second).
 		Then().
 		ExpectWorkflow(func(t *testing.T, md *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
-			if node := status.Nodes.FindByDisplayName(md.Name); assert.NotNil(t, node) {
-				assert.Contains(t, node.Message, "Pod was active on the node longer than the specified deadline")
-			}
+		}).
+		ExpectWorkflowNode(wfv1.FailedPodNode, func(t *testing.T, n *wfv1.NodeStatus, p *apiv1.Pod) {
+			assert.Equal(t, *p.Spec.ActiveDeadlineSeconds, int64(5))
 		})
 }
 


### PR DESCRIPTION
Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

partial fix to #9027 

This test fails intermittently (such as [here](https://github.com/argoproj/argo-workflows/actions/runs/2667409389/jobs/4152256492)) because the "Message" on the Pod sometimes gets cleared. The test is looking for the "Message" but it showed up and then got cleared. It seems to me that what we're verifying here is that the activeDeadlineSeconds got passed to the Pod so I've changed the check to that.