### PR TITLE
fix: fix iam permissions to retrieve logs from aws s3

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -76,10 +76,16 @@ $ cat > policy.json <<EOF
          "Action":[
             "s3:PutObject",
             "s3:GetObject",
-            "s3:ListBucket"
          ],
          "Resource":"arn:aws:s3:::$mybucket/*"
-      }
+      },
+      {
+         "Effect":"Allow",
+         "Action":[
+            "s3:ListBucket"
+         ],
+         "Resource":"arn:aws:s3:::$mybucket"
+      },
    ]
 }
 EOF


### PR DESCRIPTION
Signed-off-by: Lukas Heppe <lukas.heppe@agido.com>

Fixes #TODO

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.

### Description

When using the IAM policy provided in the docs I couldn't view the logs via UI. By allowing the `ListBucket` Policy on the bucket instead of the objects within, I was able to retrieve those. 

The prinicple is also described in the AWS Blog post https://aws.amazon.com/de/blogs/security/writing-iam-policies-how-to-grant-access-to-an-amazon-s3-bucket/. 
