### PR TITLE
fix(ui): containerset archive log query params. Fixes #9669

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -191,7 +191,7 @@ const WorkflowNodeSummary = (props: Props) => {
                     </Button>
                 )}{' '}
                 {props.node.type === 'Container' && props.onShowContainerLogs && (
-                    <Button icon='bars' onClick={() => props.onShowContainerLogs(props.node.name.replace(/.[^.]*$/, ''), props.node.name.replace(/.*\./, ''))}>
+                    <Button icon='bars' onClick={() => props.onShowContainerLogs(props.node.name.replace(/(\([^)]*\))*.([^.]*$)/, ''), props.node.name.replace(/.*\./, ''))}>
                         logs
                     </Button>
                 )}{' '}

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -191,7 +191,16 @@ const WorkflowNodeSummary = (props: Props) => {
                     </Button>
                 )}{' '}
                 {props.node.type === 'Container' && props.onShowContainerLogs && (
-                    <Button icon='bars' onClick={() => props.onShowContainerLogs(props.node.name.replace(/(\([^)]*\))*.([^.]*$)/, ''), props.node.name.replace(/.*\./, ''))}>
+                    <Button
+                        icon='bars'
+                        onClick={() =>
+                            props.onShowContainerLogs(
+                                // find parent node id using node name,
+                                // in container set, the parent of the selected node id contains log output
+                                Object.keys(props.workflow.status.nodes).find(key => props.workflow.status.nodes[key].name === props.node.name.replace(/.[^.]*$/, '')),
+                                props.node.name.replace(/.*\./, '')
+                            )
+                        }>
                         logs
                     </Button>
                 )}{' '}


### PR DESCRIPTION
Fixes #9669 

In containerset, the log is stored in the parent of the selected node.
We retrieve the log info through `workflow.status.nodes[nodeid]`

it happens in the existing approach the `nodename - .[^.]*$` is same as `nodeid` of parent node for simple container set wf.
However, when we have multiple container sets in a wf this is no longer valid.


<!---
In containerset the node name includes extra `.containername` e.g. `podname.container1`
The original code removes the container name when querying log so that we can find the correct node info/podname

When retryStrategy is specified, the node name then becomes `podname(run0).container1`
This fix added optional removal of the `(run0)`.

Due naming convention and validation, user won't be able to use `()` as part of node name
It now displays the following instead of UI panic
--->

Tests:
<details>
    <summary>container set with retry</summary>

  ```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: sequence-
  labels:
    workflows.argoproj.io/test: "true"
  annotations:
    workflows.argoproj.io/description: |
      This workflow demonstrates running a sequence of containers within a single pod.
    workflows.argoproj.io/version: ">= 3.1.0"
spec:
  entrypoint: main
  templates:
    - name: main
      containerSet:
        containers:
          - name: a
            image: argoproj/argosay:v2
            args: ["echo", "aaaa"]
          - name: b
            image: argoproj/argosay:v2
            dependencies: ["a"]
            args: ["echo", "bbbb"]
  retryStrategy:
    limit: '3'
    retryPolicy: Always
  ```
</details>

<details>
    <summary>container set</summary>

  ```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: sequence-
  labels:
    workflows.argoproj.io/test: "true"
  annotations:
    workflows.argoproj.io/description: |
      This workflow demonstrates running a sequence of containers within a single pod.
    workflows.argoproj.io/version: ">= 3.1.0"
spec:
  entrypoint: main
  templates:
    - name: main
      containerSet:
        containers:
          - name: a
            image: argoproj/argosay:v2
            args: ["echo", "aaaa"]
          - name: b
            image: argoproj/argosay:v2
            dependencies: ["a"]
            args: ["echo", "bbbb"]
  ```
</details>

<details>
    <summary>container sets with retry</summary>

  ```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: outputs-result-
  labels:
    workflows.argoproj.io/test: "true"
  annotations:
    workflows.argoproj.io/description: |
      This workflow demonstrates collecting outputs (specifically the stdout result) from a pod.

      Specifially, you must have a container named "main".
    workflows.argoproj.io/version: ">= 3.1.0"
spec:
  entrypoint: main
  templates:
    - name: main
      dag:
        tasks:
          - name: a
            template: group
          - name: b
            template: verify
            arguments:
              parameters:
                - name: x
                  value: "{{tasks.a.outputs.result}}"
            dependencies: [ "a" ]

    - name: group
      containerSet:
        containers:
          - name: main
            image: python:alpine3.6
            command:
              - python
              - -c
            args:
              - |
                print("hi")

    - name: verify
      inputs:
        parameters:
          - name: x
      script:
        image: python:alpine3.6
        command:
          - python
        source: |
          assert "{{inputs.parameters.x}}" == "hi"
  retryStrategy:
    limit: '3'
    retryPolicy: Always
  ```
</details>

<details>
    <summary>container sets</summary>

  ```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: outputs-result-
  labels:
    workflows.argoproj.io/test: "true"
  annotations:
    workflows.argoproj.io/description: |
      This workflow demonstrates collecting outputs (specifically the stdout result) from a pod.

      Specifially, you must have a container named "main".
    workflows.argoproj.io/version: ">= 3.1.0"
spec:
  entrypoint: main
  templates:
    - name: main
      dag:
        tasks:
          - name: a
            template: group
          - name: b
            template: verify
            arguments:
              parameters:
                - name: x
                  value: "{{tasks.a.outputs.result}}"
            dependencies: [ "a" ]

    - name: group
      containerSet:
        containers:
          - name: main
            image: python:alpine3.6
            command:
              - python
              - -c
            args:
              - |
                print("hi")

    - name: verify
      inputs:
        parameters:
          - name: x
      script:
        image: python:alpine3.6
        command:
          - python
        source: |
          assert "{{inputs.parameters.x}}" == "hi"
  retryStrategy:
    limit: '3'
    retryPolicy: Always
  ```
</details>


---

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
