### PR TITLE
docs: update nodejs to >= 16.15.0

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -43,7 +43,7 @@ Note:
 * [Docker](https://docs.docker.com/get-docker/)
 * [`protoc`](http://google.github.io/proto-lens/installing-protoc.html)
 * [`jq`](https://stedolan.github.io/jq/download/)
-* [`node` >= 16](https://nodejs.org/download/release/latest-v16.x/) for running the UI
+* [`node` >= 18](https://nodejs.org/download/release/latest-v18.x/) for running the UI
 * A local Kubernetes cluster ([`k3d`](https://k3d.io/), [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), or [`minikube`](https://minikube.sigs.k8s.io/docs/start/))
 
 We recommend using [K3D](https://k3d.io/) to set up the local Kubernetes cluster since this will allow you to test RBAC

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -43,7 +43,7 @@ Note:
 * [Docker](https://docs.docker.com/get-docker/)
 * [`protoc`](http://google.github.io/proto-lens/installing-protoc.html)
 * [`jq`](https://stedolan.github.io/jq/download/)
-* [`node` >= 18](https://nodejs.org/download/release/latest-v18.x/) for running the UI
+* [`node` >= 16.15.0](https://nodejs.org/download/release/latest-v16.x/) for running the UI
 * A local Kubernetes cluster ([`k3d`](https://k3d.io/), [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), or [`minikube`](https://minikube.sigs.k8s.io/docs/start/))
 
 We recommend using [K3D](https://k3d.io/) to set up the local Kubernetes cluster since this will allow you to test RBAC


### PR DESCRIPTION
Updated document for ui development to use node >= 16.15.0,

There is an issue: `--no-experimental-fetch is not allowed in NODE_OPTIONS`  when run `yarn --cwd ui start` with `node < 16.15.0` and the `yarn --cwd ui start` is using on makefile (`make start UI=true`).

FYI: There is no issue when run `cd ui && yarn start` it worked well with node >= `v16.0.0`.

Tested with `yarn --cwd ui start`:
- if node is `< v16.15.0`, node will get `--no-experimental-fetch is not allowed in NODE_OPTIONS`.
![Screen Shot 2565-10-16 at 14 15 29](https://user-images.githubusercontent.com/686676/196023623-b8813302-4efc-4be1-9f5a-ca16a5453df4.png)
- if it node `>= v16.15.0` node will ignore this config
![Screen Shot 2565-10-16 at 14 17 22](https://user-images.githubusercontent.com/686676/196023629-c34d64d5-3848-4c7a-8543-f12aff439ccd.png)

References:
- node18: [docs](https://nodejs.org/dist/latest-v18.x/docs/api/cli.html#--no-experimental-fetch)
- node17: [docs](https://nodejs.org/dist/latest-v17.x/docs/api/cli.html#--no-experimental-fetch) (optional is not available)
- node16: [docs](https://nodejs.org/dist/latest-v16.x/docs/api/cli.html#--no-experimental-fetch) (optional is not available)
