### PR TITLE
chore: sign container images on quay and signed releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -429,7 +429,7 @@ jobs:
         run: |
           cosign sign-blob --key env://COSIGN_PRIVATE_KEY ./dist/argocd-workflows-checksums.txt > ./dist/argocd-workflows-checksums.sig
           # Retrieves the public key to release as an asset
-          cosign public-key --key env://COSIGN_PRIVATE_KEY > ./dist/argo-rollouts-cosign.pub
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > ./dist/argo-workflows-cosign.pub
 
       # https://github.com/softprops/action-gh-release
       # This will publish the release and upload assets.
@@ -445,7 +445,7 @@ jobs:
             dist/argo-*.gz
             dist/argo-workflows-checksums.txt
             dist/manifests/*.yaml
-            dist/argo-rollouts-cosign.pub
+            dist/argo-workflows-cosign.pub
             dist/sbom.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,18 +56,11 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.13.0'
-
       - name: Docker Buildx
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
           PLATFORM: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
@@ -92,10 +85,6 @@ jobs:
             --platform="${PLATFORM}" \
             --target $TARGET \
             --tag quay.io/$image_name .
-
-          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
-          # Displays the public key to share.
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
 
   build-linux-arm64:
     name: Build & push linux/arm64
@@ -138,18 +127,11 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.13.0'
-
       - name: Docker Buildx
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
           PLATFORM: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
@@ -175,10 +157,6 @@ jobs:
             --target $TARGET \
             --tag quay.io/$image_name .
 
-          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
-          # Displays the public key to share.
-          cosign public-key --key env://COSIGN_PRIVATE_KEY
-
   build-windows:
     name: Build & push windows
     if: github.repository == 'argoproj/argo-workflows'
@@ -197,17 +175,10 @@ jobs:
           login-server: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.13.0'
-
+   
       - name: Build & Push Windows Docker Images
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
-          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
-          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           docker_org=$DOCKERIO_ORG
 
@@ -225,9 +196,6 @@ jobs:
             docker tag $image_name quay.io/$image_name
             docker push quay.io/$image_name
 
-            cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
-            # Displays the public key to share.
-            cosign public-key --key env://COSIGN_PRIVATE_KEY
           done
 
   push-images:
@@ -427,7 +395,7 @@ jobs:
       - run: make checksums
       - name: Sign checksums and create public key for release assets
         run: |
-          cosign sign-blob --key env://COSIGN_PRIVATE_KEY ./dist/argocd-workflows-checksums.txt > ./dist/argocd-workflows-checksums.sig
+          cosign sign-blob --key env://COSIGN_PRIVATE_KEY ./dist/argo-workflows-cli-checksums.txt > ./dist/argo-workflows-cli-checksums.sig
           # Retrieves the public key to release as an asset
           cosign public-key --key env://COSIGN_PRIVATE_KEY > ./dist/argo-workflows-cosign.pub
 
@@ -443,7 +411,8 @@ jobs:
           body_path: release-notes
           files: |
             dist/argo-*.gz
-            dist/argo-workflows-checksums.txt
+            dist/argo-workflows-cli-checksums.txt
+            dist/argo-workflows-cli-checksums.sig
             dist/manifests/*.yaml
             dist/argo-workflows-cosign.pub
             dist/sbom.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,11 +56,18 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
+
       - name: Docker Buildx
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
           PLATFORM: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
@@ -85,6 +92,10 @@ jobs:
             --platform="${PLATFORM}" \
             --target $TARGET \
             --tag quay.io/$image_name .
+
+          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
 
   build-linux-arm64:
     name: Build & push linux/arm64
@@ -127,11 +138,18 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
+
       - name: Docker Buildx
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
           PLATFORM: ${{ matrix.platform }}
           TARGET: ${{ matrix.target }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           tag=$(basename $GITHUB_REF)
           if [ $tag = "master" ]; then
@@ -157,6 +175,10 @@ jobs:
             --target $TARGET \
             --tag quay.io/$image_name .
 
+          cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
+          # Displays the public key to share.
+          cosign public-key --key env://COSIGN_PRIVATE_KEY
+
   build-windows:
     name: Build & push windows
     if: github.repository == 'argoproj/argo-workflows'
@@ -176,9 +198,16 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
+
       - name: Build & Push Windows Docker Images
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           docker_org=$DOCKERIO_ORG
 
@@ -195,6 +224,10 @@ jobs:
 
             docker tag $image_name quay.io/$image_name
             docker push quay.io/$image_name
+
+            cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
+            # Displays the public key to share.
+            cosign public-key --key env://COSIGN_PRIVATE_KEY
           done
 
   push-images:
@@ -217,9 +250,16 @@ jobs:
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
+
       - name: Push Multiarch Image
         env:
           DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
           echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
 
@@ -244,6 +284,9 @@ jobs:
 
             docker manifest push $image_name
             docker manifest push quay.io/$image_name
+
+            cosign sign --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
+
           done
 
   test-images-linux-amd64:
@@ -327,6 +370,8 @@ jobs:
     needs: [ push-images, test-images-linux-amd64, test-images-windows ]
     env:
       NODE_OPTIONS: --max-old-space-size=4096
+      COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+      COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -347,6 +392,10 @@ jobs:
         with:
           path: /home/runner/go/pkg/mod
           key: GOMODCACHE-v2-${{ hashFiles('**/go.mod') }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.0'
       # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
       - run: |
           if [ ${GITHUB_REF##*/} = master ]; then
@@ -376,6 +425,12 @@ jobs:
       - name: Print version (please check it is not dirty)
         run: dist/argo-linux-amd64 version
       - run: make checksums
+      - name: Sign checksums and create public key for release assets
+        run: |
+          cosign sign-blob --key env://COSIGN_PRIVATE_KEY ./dist/argocd-workflows-checksums.txt > ./dist/argocd-workflows-checksums.sig
+          # Retrieves the public key to release as an asset
+          cosign public-key --key env://COSIGN_PRIVATE_KEY > ./dist/argo-rollouts-cosign.pub
+
       # https://github.com/softprops/action-gh-release
       # This will publish the release and upload assets.
       # If a conflict occurs (because you are not on a tag), the release will not be updated. This is a short coming
@@ -388,8 +443,9 @@ jobs:
           body_path: release-notes
           files: |
             dist/argo-*.gz
-            dist/argo-*.gz.sha256
+            dist/argo-workflows-checksums.txt
             dist/manifests/*.yaml
+            dist/argo-rollouts-cosign.pub
             dist/sbom.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -677,4 +677,5 @@ release-notes: /dev/null
 
 .PHONY: checksums
 checksums:
-	for f in ./dist/argo-*.gz; do openssl dgst -sha256 "$$f" | awk ' { print $$2 }' > "$$f".sha256 ; done
+	sha256sum ./dist/argo-*.gz | awk -F './dist/' '{print $$1 $$2}' > ./dist/argo-workflows-cli-checksums.txt
+


### PR DESCRIPTION
Signed releases #9769 
This PR implements container images to be signed using ```sigstore/cosign```  It also consolidates the checksums of the cli-binaries into a single file then signs it.   

#### Three GitHub secrets will need to be created before this PR is merged. The process to do this is listed below.

TLDR: https://docs.sigstore.dev/cosign/git_support

1. [Install Cosign](https://docs.sigstore.dev/cosign/installation) on your workstation. Linux, Homebrew, and container options are available.  Execute the command ```cosign --version``` to verified it has been installed correctly.
2. Create or have a valid GitHub PAT token available.
3. Export your PAT as the environment variable "GITHUB_TOKEN"
4. Execute ```cosign generate-key-pair github://argoproj/argo-workflows``` This will start the process of creating the GitHub Secrets automatically for you, and prompt you to enter a password.  This Password will be stored as the Github secret ```COSIGN_PASSWORD``` I would recommend to use well respected password generator such as KeePassXC or Bitwarden and use a paranoid level of characters of at least 32. 
5. Three GitHub secretes should have been created, please verify.  ```COSIGN_PASSWORD``` ```COSIGN_PRIVATE_KEY``` & ```COSIGN_PUBLIC_KEY```
6. Please comment on this PR with the newly created public key (cosign.pub)