### PR TITLE
fix: mount secret with SSE-C key if needed, fix secret key read. Fixes #9867

### DIFF
--- a/workflow/artifacts/artifacts.go
+++ b/workflow/artifacts/artifacts.go
@@ -60,7 +60,7 @@ func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 					return nil, fmt.Errorf("serverSideCustomerKeySecret and kmsKeyId cannot be set together")
 				}
 
-				serverSideCustomerKeyBytes, err := ri.GetSecret(ctx, art.S3.EncryptionOptions.ServerSideCustomerKeySecret.Name, art.S3.SecretKeySecret.Key)
+				serverSideCustomerKeyBytes, err := ri.GetSecret(ctx, art.S3.EncryptionOptions.ServerSideCustomerKeySecret.Name, art.S3.EncryptionOptions.ServerSideCustomerKeySecret.Key)
 				if err != nil {
 					return nil, err
 				}

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -1171,6 +1171,10 @@ func createSecretVolumesFromArtifactLocations(volMap map[string]apiv1.Volume, ar
 		if artifactLocation.S3 != nil {
 			createSecretVal(volMap, artifactLocation.S3.AccessKeySecret, keyMap)
 			createSecretVal(volMap, artifactLocation.S3.SecretKeySecret, keyMap)
+			sseCUsed := artifactLocation.S3.EncryptionOptions != nil && artifactLocation.S3.EncryptionOptions.EnableEncryption && artifactLocation.S3.EncryptionOptions.ServerSideCustomerKeySecret != nil
+			if sseCUsed {
+				createSecretVal(volMap, artifactLocation.S3.EncryptionOptions.ServerSideCustomerKeySecret, keyMap)
+			}
 		} else if artifactLocation.Git != nil {
 			createSecretVal(volMap, artifactLocation.Git.UsernameSecret, keyMap)
 			createSecretVal(volMap, artifactLocation.Git.PasswordSecret, keyMap)


### PR DESCRIPTION
# TODO:

- [ ] update `github.com/argoproj/pkg` once https://github.com/argoproj/pkg/pull/225 si merged and released

Fixes #9867

Adds mount of the SSE-C secret, if SSE-C is configured. Fixed the secret key used when reading the SSE-C key. Adds unit test to validate the mounts. Also tested inside a different project, where Argo and another component both read/write SSE-C encrypted objects from/to AWS S3.

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
