### PR TITLE
feat: Added tar archives can be used as input. Fixes #9818

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -224,8 +224,8 @@ func (we *WorkflowExecutor) LoadArtifacts(ctx context.Context) error {
 				isGzip, err = isgzip(tempArtPath)
 				if err != nil {
 					return err
-                }
-            }
+				}
+			}
 		} else if art.GetArchive().Zip != nil {
 			// explicitly a zip
 			isZip = true

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -466,7 +466,7 @@ func (we *WorkflowExecutor) stageArchiveFile(containerName string, art *wfv1.Art
 	// localArtPath now points to a .tgz file, and the archive strategy is *not* tar. We need to untar it
 	log.Infof("Untaring %s archive before upload", localArtPath)
 	unarchivedArtPath := path.Join(filepath.Dir(localArtPath), art.Name)
-	err = untar(localArtPath, unarchivedArtPath)
+	err = ungzip(localArtPath, unarchivedArtPath)
 	if err != nil {
 		return "", "", err
 	}

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -219,7 +219,7 @@ func (we *WorkflowExecutor) LoadArtifacts(ctx context.Context) error {
 			isZip = false
 		} else if art.GetArchive().Tar != nil {
 			// check if tar only or tar + gzip
-			isTar, err = istar(tempArtPath)
+			isTar, _ = istar(tempArtPath)
 			if !isTar {
 				isGzip, err = isgzip(tempArtPath)
 				if err != nil {
@@ -232,7 +232,7 @@ func (we *WorkflowExecutor) LoadArtifacts(ctx context.Context) error {
 		} else {
 			// auto-detect if tarball
 			// (don't try to autodetect zip files for backwards compatibility)
-			isTar, err = istar(tempArtPath)
+			isTar, _ = istar(tempArtPath)
 			if !isTar {
 				isGzip, err = isgzip(tempArtPath)
 				if err != nil {

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -231,10 +231,36 @@ func TestDefaultParametersEmptyString(t *testing.T) {
 	assert.Equal(t, "", we.Template.Outputs.Parameters[0].Value.String())
 }
 
-func TestIsTarball(t *testing.T) {
+func TestIstar(t *testing.T) {
 	tests := []struct {
 		path      string
-		isTarball bool
+		isTar     bool
+		expectErr bool
+	}{
+		{"testdata/file", false, false},
+		{"testdata/file.zip", false, false},
+		{"testdata/file.tar", true, false},
+		{"testdata/file.gz", false, false},
+		{"testdata/file.tar.gz", false, false},
+		{"testdata/file.tgz", false, false},
+		{"testdata/not-found", false, true},
+	}
+
+	for _, test := range tests {
+		ok, err := istar(test.path)
+		if test.expectErr {
+			assert.Error(t, err, test.path)
+		} else {
+			assert.NoError(t, err, test.path)
+		}
+		assert.Equal(t, test.isTar, ok, test.path)
+	}
+}
+
+func TestIsgzip(t *testing.T) {
+	tests := []struct {
+		path      string
+		isGzip    bool
 		expectErr bool
 	}{
 		{"testdata/file", false, false},
@@ -247,13 +273,13 @@ func TestIsTarball(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ok, err := isTarball(test.path)
+		ok, err := isgzip(test.path)
 		if test.expectErr {
 			assert.Error(t, err, test.path)
 		} else {
 			assert.NoError(t, err, test.path)
 		}
-		assert.Equal(t, test.isTarball, ok, test.path)
+		assert.Equal(t, test.isGzip, ok, test.path)
 	}
 }
 

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -302,11 +302,29 @@ func TestUnzip(t *testing.T) {
 }
 
 func TestUntar(t *testing.T) {
-	tarPath := "testdata/file.tar.gz"
+	tarPath := "testdata/file.tar"
 	destPath := "testdata/untarredFile"
 
 	// test
 	err := untar(tarPath, destPath)
+	assert.NoError(t, err)
+
+	// check untarred file
+	fileInfo, err := os.Stat(destPath)
+	assert.NoError(t, err)
+	assert.True(t, fileInfo.Mode().IsRegular())
+
+	// cleanup
+	err = os.Remove(destPath)
+	assert.NoError(t, err)
+}
+
+func TestUngzip(t *testing.T) {
+	tarPath := "testdata/file.tar.gz"
+	destPath := "testdata/untarredFile"
+
+	// test
+	err := ungzip(tarPath, destPath)
 	assert.NoError(t, err)
 
 	// check untarred file


### PR DESCRIPTION
Signed-off-by: dhaven <dev_ddh@pm.me>

Fixes #9818 

This features allows to use uncompressed tar archives as input. Instead of always assuming that a tar archive is gzipped we check first if it is just a tar and apply the appropriate unpacking thereafter. An alternative implementation would be to extend the workflow template to allow a tar (non gzip) archive strategy which would allow to support both output and input. Happy to receive some feedback at this point!



Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
