### PR TITLE
Remove wrong braces in documentation

### DIFF
--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -7,7 +7,7 @@ You have two options:
 
 ## Git Clone
 
-Clone the Git repo into: `$(GOPATH)/src/github.com/argoproj/argo-workflows`. Any other path will mean the code
+Clone the Git repo into: `$GOPATH/src/github.com/argoproj/argo-workflows`. Any other path will mean the code
 generation does not work.
 
 ## Development Container
@@ -152,7 +152,7 @@ make start PROFILE=mysql AUTH_MODE=client STATIC_FILES=false API=true
 If you want to run Azure tests against a local Azurite:
 
 ```bash
-kubectl -n $(KUBE_NAMESPACE) apply -f test/e2e/azure/deploy-azurite.yaml
+kubectl -n $KUBE_NAMESPACE apply -f test/e2e/azure/deploy-azurite.yaml
 make start
 ```
 
@@ -221,7 +221,7 @@ git commit --signoff -m 'feat: Added a new feature. Fixes #1234'
 
 * When running `make pre-commit -B`, if you encounter errors like
   `make: *** [pkg/apiclient/clusterworkflowtemplate/cluster-workflow-template.swagger.json] Error 1`, ensure that you
-  have checked out your code into `$(GOPATH)/src/github.com/argoproj/argo-workflows`.
+  have checked out your code into `$GOPATH/src/github.com/argoproj/argo-workflows`.
 * If you encounter "out of heap" issues when building UI through Docker, please validate resources allocated to Docker.
   Compilation may fail if allocated RAM is less than 4Gi.
 


### PR DESCRIPTION
The documentation used round braces around variable names (GOPATH and KUBE_NAMESPACE). However, round braces around variable names are correct only in Makefiles. In a shell context they stand for command substitution.

Removing the braces allows to paste the examples in the terminal.

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
