### PR TITLE
feat: Add git-artifact insecureTLS, CABundle options

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2416,6 +2416,12 @@ type GitArtifact struct {
 
 	// Branch is the branch to fetch when `SingleBranch` is enabled
 	Branch string `json:"branch,omitempty" protobuf:"bytes,11,opt,name=branch"`
+
+	// InsecureSkipTLS disables HTTP TLS checking during git clone
+	InsecureSkipTLS bool `json:"insecureSkipTLS,omitempty" protobuf:"varint,12,opt,name=insecureSkipTLS"`
+
+	// CABundleSecret is the secret selector to specify a ca bundle for https connection
+	CABundleSecret *apiv1.SecretKeySelector `json:"caBundleSecret,omitempty" protobuf:"bytes,13,opt,name=caBundleSecret"`
 }
 
 func (g *GitArtifact) HasLocation() bool {

--- a/workflow/artifacts/artifacts.go
+++ b/workflow/artifacts/artifacts.go
@@ -144,6 +144,7 @@ func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 		gitDriver := git.ArtifactDriver{
 			InsecureIgnoreHostKey: art.Git.InsecureIgnoreHostKey,
 			DisableSubmodules:     art.Git.DisableSubmodules,
+			InsecureSkipTLS:       art.Git.InsecureSkipTLS,
 		}
 		if art.Git.UsernameSecret != nil {
 			usernameBytes, err := ri.GetSecret(ctx, art.Git.UsernameSecret.Name, art.Git.UsernameSecret.Key)
@@ -165,6 +166,13 @@ func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 				return nil, err
 			}
 			gitDriver.SSHPrivateKey = sshPrivateKeyBytes
+		}
+		if art.Git.CABundleSecret != nil {
+			caBundleBytes, err := ri.GetSecret(ctx, art.Git.CABundleSecret.Name, art.Git.CABundleSecret.Key)
+			if err != nil {
+				return nil, err
+			}
+			gitDriver.CABundle = []byte(caBundleBytes)
 		}
 
 		return &gitDriver, nil

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -200,8 +200,7 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 			defer resp.Body.Close()
 
 			CABundleBytes, err := io.ReadAll(resp.Body)
-
-			assert.NotNil(t, err)
+			assert.Nil(t, err)
 
 			driver := &ArtifactDriver{CABundle: CABundleBytes}
 


### PR DESCRIPTION
Signed-off-by: Thomas Decaux <ebuildy@gmail.com>

When using ``git-artifact`` from a self hosted git repository, such as gitlab with a self signed HTTPs certificate, this PR allows to configure "skipTLS check" or "use this CA bundle".

TODO: unit tests are missing a "self signed" endpoint?

Please do not open a pull request until you have checked ALL of these:

* [X] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [X] Sign-off your commits (otherwise the DCO check will fail).
* [X] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [X] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
