### PR TITLE
fix: Upgrade kubectl to v1.24.8 to fix vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ FROM builder as argoexec-build
 COPY hack/arch.sh hack/os.sh /bin/
 
 # NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
-RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.5/bin/$(os.sh)/$(arch.sh)/kubectl && \
+RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.8/bin/$(os.sh)/$(arch.sh)/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 RUN curl -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ FROM builder as argoexec-build
 COPY hack/arch.sh hack/os.sh /bin/
 
 # NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
-RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/$(os.sh)/$(arch.sh)/kubectl && \
+RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.5/bin/$(os.sh)/$(arch.sh)/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
 RUN curl -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -29,7 +29,7 @@ FROM mcr.microsoft.com/windows/nanoserver:${IMAGE_OS_VERSION} as argoexec-base
 COPY --from=builder /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
 # NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
-ENV KUBECTL_VERSION=1.24.5
+ENV KUBECTL_VERSION=1.24.8
 ENV JQ_VERSION=1.6
 
 RUN mkdir C:\app && \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -29,7 +29,7 @@ FROM mcr.microsoft.com/windows/nanoserver:${IMAGE_OS_VERSION} as argoexec-base
 COPY --from=builder /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
 # NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
-ENV KUBECTL_VERSION=1.22.3
+ENV KUBECTL_VERSION=1.24.5
 ENV JQ_VERSION=1.6
 
 RUN mkdir C:\app && \


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>

Fixes #10006 

We are taking one minor version less than v1.25.3 (based on https://storage.googleapis.com/kubernetes-release/release/stable.txt)
which is v1.24 and v1.24.5 contains the security fixes.

Reference: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#important-security-information
