### PR TITLE
fix: if artifact GC Pod fails make sure error is propagated as a Condition

### DIFF
--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -184,7 +184,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 // Want to verify that this causes the ArtifactGCError Condition in the Workflow
 func (s *ArtifactsSuite) TestArtifactGC_InsufficientRole() {
 	ctx := context.Background()
-	s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "artgc-role-test-sa"}}, metav1.CreateOptions{})
+	_, err := s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "artgc-role-test-sa"}}, metav1.CreateOptions{})
+	assert.NoError(s.T(), err)
 	s.T().Cleanup(func() {
 		_ = s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Delete(ctx, "artgc-role-test-sa", metav1.DeleteOptions{})
 	})

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -561,7 +561,7 @@ func (woc *wfOperationCtx) processCompletedArtifactGCPod(ctx context.Context, po
 	}
 
 	for _, task := range taskList.Items {
-		allArtifactsSucceeded, err := woc.processCompletedWorkflowArtifactGCTask(ctx, &task, strategy)
+		allArtifactsSucceeded, err := woc.processCompletedWorkflowArtifactGCTask(&task, strategy)
 		if err != nil {
 			return err
 		}

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -580,7 +580,7 @@ func (woc *wfOperationCtx) processCompletedArtifactGCPod(ctx context.Context, po
 
 // process the Status in the WorkflowArtifactGCTask which was completed and reflect it in Workflow Status; then delete the Task CRD Object
 // return true if all artifacts succeeded, else false
-func (woc *wfOperationCtx) processCompletedWorkflowArtifactGCTask(ctx context.Context, artifactGCTask *wfv1.WorkflowArtifactGCTask, strategy wfv1.ArtifactGCStrategy) (bool, error) {
+func (woc *wfOperationCtx) processCompletedWorkflowArtifactGCTask(artifactGCTask *wfv1.WorkflowArtifactGCTask, strategy wfv1.ArtifactGCStrategy) (bool, error) {
 	woc.log.Debugf("processing WorkflowArtifactGCTask %s", artifactGCTask.Name)
 
 	foundGCFailure := false

--- a/workflow/controller/artifact_gc_test.go
+++ b/workflow/controller/artifact_gc_test.go
@@ -563,7 +563,7 @@ func TestProcessCompletedWorkflowArtifactGCTask(t *testing.T) {
 	// - Artifact.Deleted
 	// - Conditions
 
-	err := woc.processCompletedWorkflowArtifactGCTask(ctx, wfat, "OnWorkflowCompletion")
+	_, err := woc.processCompletedWorkflowArtifactGCTask(ctx, wfat, "OnWorkflowCompletion")
 	assert.Nil(t, err)
 
 	for _, expectedArtifact := range []struct {

--- a/workflow/controller/artifact_gc_test.go
+++ b/workflow/controller/artifact_gc_test.go
@@ -555,7 +555,6 @@ func TestProcessCompletedWorkflowArtifactGCTask(t *testing.T) {
 	cancel, controller := newController(wf)
 	defer cancel()
 
-	ctx := context.Background()
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.wf.Status.ArtifactGCStatus = &wfv1.ArtGCStatus{}
 
@@ -563,7 +562,7 @@ func TestProcessCompletedWorkflowArtifactGCTask(t *testing.T) {
 	// - Artifact.Deleted
 	// - Conditions
 
-	_, err := woc.processCompletedWorkflowArtifactGCTask(ctx, wfat, "OnWorkflowCompletion")
+	_, err := woc.processCompletedWorkflowArtifactGCTask(wfat, "OnWorkflowCompletion")
 	assert.Nil(t, err)
 
 	for _, expectedArtifact := range []struct {


### PR DESCRIPTION
Partial fix to #9953 

Issue was that we were only adding the Condition based on failure of individual artifacts. In this case, the GC Pod never got to the point of attempting deletion of an artifact (it couldn't read what the artifacts were in fact), so there was no reporting of individual artifacts' status. Now a Condition will be written if the Pod fails as well.

Signed-off-by: Julie Vogelman <julie_vogelman@intuit.com>

Fixes #TODO

Please do not open a pull request until you have checked ALL of these:

* [ ] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [ ] Sign-off your commits (otherwise the DCO check will fail).
* [ ] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
