### PR TITLE
fix: Ensure the SSO http client takes into consideration http proxies, Fixes #9259

### DIFF
--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -109,7 +109,7 @@ func newSso(
 		return nil, err
 	}
 	// Create http client with TLSConfig to allow skipping of CA validation if InsecureSkipVerify is set.
-	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify}}}
+	httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify}, Proxy: http.ProxyFromEnvironment}}
 	oidcContext := oidc.ClientContext(ctx, httpClient)
 	// Some offspec providers like Azure, Oracle IDCS have oidc discovery url different from issuer url which causes issuerValidation to fail
 	// This providerCtx will allow the Verifier to succeed if the alternate/alias URL is in the config


### PR DESCRIPTION
Fixes #9259

Due to the custom `http.Transport` created inside `newSso`. All the OAuth2 related API calls are missing the proxy information because of:

```go
// Create http client with TLSConfig to allow skipping of CA validation if InsecureSkipVerify is set.
httpClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: c.InsecureSkipVerify}}}
```

Which is used in:
```go
func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request)

...

oauth2Context := context.WithValue(ctx, oauth2.HTTPClient, s.httpClient)
oauth2Token, err := s.config.Exchange(oauth2Context, r.URL.Query().Get("code"), redirectOption)
```

The [`DefaultTransport`](https://go.dev/src/net/http/transport.go ) of `http` sets the Proxy. And since `s.httpClient` was created with a custom Transport, its missing the proxy config. And as a result, the `s.config.Exchange` fails to use the http proxies configured.

### Testing

I've done a manual test in our internal infrastructure with this fork to ensure it is going through the correctly configured `HTTP_PROXY` variable URL.

### Checklist

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
