### PR TITLE
feat(server): add kube-api throttle options

### DIFF
--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -56,6 +56,8 @@ func NewServerCommand() *cobra.Command {
 		frameOptions             string
 		accessControlAllowOrigin string
 		apiRateLimit             uint64
+		kubeAPIQPS               float32
+		kubeAPIBurst             int
 		allowedLinkProtocol      []string
 		logFormat                string // --log-format
 	)
@@ -77,8 +79,8 @@ See %s`, help.ArgoServer),
 			}
 			version := argo.GetVersion()
 			config = restclient.AddUserAgent(config, fmt.Sprintf("argo-workflows/%s argo-server", version.Version))
-			config.Burst = 30
-			config.QPS = 20.0
+			config.Burst = kubeAPIBurst
+			config.QPS = kubeAPIQPS
 
 			namespace := client.Namespace()
 			clients := &types.Clients{
@@ -231,6 +233,8 @@ See %s`, help.ArgoServer),
 	command.Flags().Uint64Var(&apiRateLimit, "api-rate-limit", 1000, "Set limit per IP for api ratelimiter")
 	command.Flags().StringArrayVar(&allowedLinkProtocol, "allowed-link-protocol", defaultAllowedLinkProtocol, "Allowed link protocol in configMap. Used if the allowed configMap links protocol are different from http,https. Defaults to the environment variable ALLOWED_LINK_PROTOCOL")
 	command.Flags().StringVar(&logFormat, "log-format", "text", "The formatter to use for logs. One of: text|json")
+	command.Flags().Float32Var(&kubeAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with kube-apiserver.")
+	command.Flags().IntVar(&kubeAPIBurst, "kube-api-burst", 30, "Burst to use while talking with kube-apiserver.")
 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")

--- a/docs/cli/argo_server.md
+++ b/docs/cli/argo_server.md
@@ -28,6 +28,8 @@ See https://argoproj.github.io/argo-workflows/argo-server/
       --event-worker-count int               how many event workers to run (default 4)
   -h, --help                                 help for server
       --hsts                                 Whether or not we should add a HTTP Secure Transport Security header. This only has effect if secure is enabled. (default true)
+      --kube-api-burst int                   Burst to use while talking with kube-apiserver. (default 30)
+      --kube-api-qps float32                 QPS to use while talking with kube-apiserver. (default 20)
       --log-format string                    The formatter to use for logs. One of: text|json (default "text")
       --managed-namespace string             namespace that watches, default to the installation namespace
       --namespaced                           run as namespaced mode


### PR DESCRIPTION
Signed-off-by: scott <scottwangsxll@gmail.com>

Fixes:

> Please correct me if I'm wrong.

Every time argo-server reads and writes resources, it performs r/w on kube-apiserver. Therefore rest.Config.Burst and QPS are both key parameters.
https://github.com/kubernetes/client-go/blob/release-1.26/rest/config.go#L114-L120

So I set it as flag to support setting when the user starts the argo server (when the user does not specify, we use 30 as burst and 20.0 as qps), like...

```bash
argo server --kube-api-qps 100 --kube-api-burst 200
````

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
