### PR TITLE
build: Use alpine, buildkit, and refactor pkg caching. Fixes #10134

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,6 @@ FROM builder as argocli-build
 
 RUN mkdir -p ui/dist
 COPY --from=argo-ui ui/dist/app ui/dist/app
-# stop make from trying to re-build this without yarn installed
-RUN touch ui/dist/node_modules.marker
-RUN touch ui/dist/app/index.html
 
 # Tell git to forget about all of the files that were not included because of .dockerignore in order to ensure that
 # the git state is "clean" even though said .dockerignore files are not present

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.2
 
-FROM golang:1.19-alpine3.16 as builder
+FROM golang:1.18-alpine3.16 as builder
 
 RUN apk update && apk add \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM golang:1.18-alpine3.16 as builder
 
-RUN apk update && apk add \
+RUN apk update && apk add --no-cache \
     git \
     make \
     ca-certificates \
@@ -24,7 +24,7 @@ COPY . .
 
 FROM node:16-alpine as argo-ui
 
-RUN apk update && apk add git
+RUN apk update && apk add --no-cache git
 
 COPY ui/package.json ui/yarn.lock ui/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ COPY . .
 
 FROM node:16-alpine as argo-ui
 
+RUN apk update && apk add git
+
 COPY ui/package.json ui/yarn.lock ui/
 
 RUN --mount=type=cache,target=/root/.yarn \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ COPY ui ui
 COPY api api
 
 RUN --mount=type=cache,target=/root/.yarn \
-  --mount=type=cache,target=/assets \
   YARN_CACHE_FOLDER=/root/.yarn JOBS=max \
   NODE_OPTIONS="--max-old-space-size=2048" JOBS=max yarn --cwd ui build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,20 @@ RUN apk update && apk add \
     jq \
     mailcap
 
+
+# NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
+RUN curl -o /usr/local/bin/kubectl \
+    https://storage.googleapis.com/kubernetes-release/release/v1.24.8/bin/linux/arm64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
 WORKDIR /tmp
 
 WORKDIR /go/src/github.com/argoproj/argo-workflows
 COPY go.mod .
 COPY go.sum .
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
 
 ####################################################################################################
 
@@ -41,14 +49,6 @@ RUN --mount=type=cache,target=/root/.yarn \
 
 FROM builder as argoexec-build
 
-COPY hack/arch.sh hack/os.sh /bin/
-
-# NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
-RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.8/bin/$(os.sh)/$(arch.sh)/kubectl && \
-    chmod +x /usr/local/bin/kubectl
-
-COPY . .
-
 # Tell git to forget about all of the files that were not included because of .dockerignore in order to ensure that
 # the git state is "clean" even though said .dockerignore files are not present
 RUN cat .dockerignore >> .gitignore
@@ -60,8 +60,6 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM builder as workflow-controller-build
 
-COPY . .
-
 # Tell git to forget about all of the files that were not included because of .dockerignore in order to ensure that
 # the git state is "clean" even though said .dockerignore files are not present
 RUN cat .dockerignore >> .gitignore
@@ -72,8 +70,6 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 ####################################################################################################
 
 FROM builder as argocli-build
-
-COPY . .
 
 RUN mkdir -p ui/dist
 COPY --from=argo-ui ui/dist/app ui/dist/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk update && apk add \
     curl \
     gcc \
     bash \
+    jq \
     mailcap
 
 WORKDIR /tmp
@@ -45,9 +46,6 @@ COPY hack/arch.sh hack/os.sh /bin/
 # NOTE: kubectl version should be one minor version less than https://storage.googleapis.com/kubernetes-release/release/stable.txt
 RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.8/bin/$(os.sh)/$(arch.sh)/kubectl && \
     chmod +x /usr/local/bin/kubectl
-
-RUN curl -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-  chmod +x /usr/local/bin/jq
 
 COPY . .
 
@@ -95,7 +93,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 FROM gcr.io/distroless/static as argoexec
 
 COPY --from=argoexec-build /usr/local/bin/kubectl /bin/
-COPY --from=argoexec-build /usr/local/bin/jq /bin/
+COPY --from=argoexec-build /usr/bin/jq /bin/
 COPY --from=argoexec-build /go/src/github.com/argoproj/argo-workflows/dist/argoexec /bin/
 COPY --from=argoexec-build /etc/mime.types /etc/mime.types
 COPY hack/ssh_known_hosts /etc/ssh/

--- a/Makefile
+++ b/Makefile
@@ -231,9 +231,10 @@ argoexec-image:
 
 %-image:
 	[ ! -e dist/$* ] || mv dist/$* .
-	docker build \
+	docker buildx build \
 		-t $(IMAGE_NAMESPACE)/$*:$(VERSION) \
 		--target $* \
+		--load \
 		 .
 	[ ! -e $* ] || mv $* dist/
 	docker run --rm -t $(IMAGE_NAMESPACE)/$*:$(VERSION) version


### PR DESCRIPTION
This PR:
- Refactors the Dockerfile to cache packages in the builder stage
- Caches go modules
- Caches node modules
- Uses alpine images for the builder and ui
- Refactors the makefile to use buildkit

Note: On this PR, I can get the build of all three images needed to run the codebase down to about 30 seconds total (with caching), where a build of all three images on the master branch takes about 30 minutes total on my machine

Fixes #10134

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
