### PR TITLE
fix (argo wait): use functions to constrain ctx instead of blocks

### DIFF
--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -32,8 +32,8 @@ func waitContainer(ctx context.Context) error {
 	defer stats.LogStats()
 	stats.StartStatsTicker(5 * time.Minute)
 
-	// use a block to constrain the scope of ctx
-	{
+	// use a function to constrain the scope of ctx
+	func() {
 		// this allows us to gracefully shutdown, capturing artifacts
 		ctx, cancel := signal.NotifyContext(ctx, syscall.SIGTERM)
 		defer cancel()
@@ -43,7 +43,7 @@ func waitContainer(ctx context.Context) error {
 		if err != nil {
 			wfExecutor.AddError(err)
 		}
-	}
+	}()
 	// Capture output script result
 	err := wfExecutor.CaptureScriptResult(ctx)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: scott <scottwangsxll@gmail.com>

Fixes: as the title says

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
