### PR TITLE
feat: Ignore SIGURG in argoexec emissary. Fixes #10129

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -133,9 +133,13 @@ func NewEmissaryCommand() *cobra.Command {
 				}
 				go func() {
 					for s := range signals {
-						if !osspecific.IsSIGCHLD(s) {
-							_ = osspecific.Kill(command.Process.Pid, s.(syscall.Signal))
+						if osspecific.CanIgnoreSignal(s) {
+							logger.Debugf("ignore signal %s", s)
+							continue
 						}
+
+						logger.Debugf("forwarding signal %s", s)
+						_ = osspecific.Kill(command.Process.Pid, s.(syscall.Signal))
 					}
 				}()
 				pid := command.Process.Pid

--- a/workflow/executor/os-specific/signal_darwin.go
+++ b/workflow/executor/os-specific/signal_darwin.go
@@ -8,7 +8,9 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/errors"
 )
 
-func IsSIGCHLD(s os.Signal) bool { return s == syscall.SIGCHLD }
+func CanIgnoreSignal(s os.Signal) bool {
+	return s == syscall.SIGCHLD || s == syscall.SIGURG
+}
 
 func Kill(pid int, s syscall.Signal) error {
 	pgid, err := syscall.Getpgid(pid)

--- a/workflow/executor/os-specific/signal_windows.go
+++ b/workflow/executor/os-specific/signal_windows.go
@@ -6,8 +6,8 @@ import (
 	"syscall"
 )
 
-func IsSIGCHLD(s os.Signal) bool {
-	return false // this does not exist on windows
+func CanIgnoreSignal(s os.Signal) bool {
+	return false
 }
 
 func Kill(pid int, s syscall.Signal) error {


### PR DESCRIPTION
SIGURG is frequently sent from argoexec emissary to user's commands. This is noise because some applications, such as OpenMPI, log the signals they receive. SIGURG is used for goroutine preemption from go1.14.

https://github.com/golang/proposal/blob/master/design/24543-non-cooperative-preemption.md#other-considerations

Therefore we ignore and don't forward SIGURG to the user command.

Fixes #10129

Please do not open a pull request until you have checked ALL of these:

* [ ] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [ ] Sign-off your commits (otherwise the DCO check will fail).
* [ ] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
