### PR TITLE
fix: ensure HTTP reconciliation occurs for onExit step nodes

### DIFF
--- a/workflow/controller/http_template_test.go
+++ b/workflow/controller/http_template_test.go
@@ -24,7 +24,7 @@ func TestNodeRequiresHttpReconciliation(t *testing.T) {
 					"test-wf-3939368189": v1alpha1.NodeStatus{
 						Name:     "parent",
 						Type:     v1alpha1.NodeTypeSteps,
-						Children: []string{"child-http"},
+						Children: []string{"test-wf-1430055856"},
 					},
 					"test-wf-1430055856": v1alpha1.NodeStatus{
 						Name: "child-http",

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -112,7 +112,8 @@ func (woc *wfOperationCtx) nodeRequiresTaskSetReconciliation(nodeName string) bo
 	}
 	for _, child := range node.Children {
 		// If any of the node's children need an HTTP reconciliation, the parent node will also need one
-		if woc.nodeRequiresTaskSetReconciliation(child) {
+		childNodeName := woc.wf.Status.Nodes[child].Name
+		if woc.nodeRequiresTaskSetReconciliation(childNodeName) {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/7080

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.

## Introdcution
Fix for the bug of exit-handler problem for this PR: https://github.com/argoproj/argo-workflows/pull/7084 (Using NodeID to get child node in GetNodeByName function by mistake)

<img width="422" alt="Screenshot 2022-12-08 at 21 36 25" src="https://user-images.githubusercontent.com/18108042/206646742-86851771-6833-44af-a2b3-ed07e1e9a018.png">


Detailed introduction can be found in the argo-workflows slack channel: https://cloud-native.slack.com/archives/C01QW9QSSSK/p1670507275924099