### PR TITLE
docs: update typo in step reference

### DIFF
--- a/docs/conditional-artifacts-parameters.md
+++ b/docs/conditional-artifacts-parameters.md
@@ -40,15 +40,15 @@ under step/DAG level output parameter. Both use the
             template: flip-coin
         - - name: heads
             template: heads
-            when: "{{steps.flipcoin.outputs.result}} == heads"
+            when: "{{steps.flip-coin.outputs.result}} == heads"
           - name: tails
             template: tails
-            when: "{{steps.flipcoin.outputs.result}} == tails"
+            when: "{{steps.flip-coin.outputs.result}} == tails"
       outputs:
         parameters:
           - name: stepresult
             valueFrom:
-              expression: "steps.flipcoin.outputs.result == 'heads' ? steps.heads.outputs.result : steps.tails.outputs.result"
+              expression: "steps['flip-coin'].outputs.result == 'heads' ? steps.heads.outputs.result : steps.tails.outputs.result"
 ```
 
 * [Steps parameter example](https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/conditional-parameters.yaml)


### PR DESCRIPTION
Signed-off-by: Amritpal Nagra <amritpalnagrame@gmail.com>

Typo fixes in a documented example.

<img width="1879" alt="image" src="https://user-images.githubusercontent.com/23359428/208732343-352654ef-6a8e-4ca1-8cc9-8c1af0f86952.png">
