### PR TITLE
Skip Artifact GC test if Workflow fails

### DIFF
--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -150,6 +150,13 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 				assert.Contains(t, objectMeta.Finalizers, common.FinalizerArtifactGC)
 			})
 
+		if when.WorkflowCondition(func(wf *wfv1.Workflow) bool {
+			return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError
+		}) {
+			fmt.Println("can't reliably verify Artifact GC since workflow failed")
+			continue
+		}
+
 		// wait for all pods to have started and been completed and recouped
 		when.
 			WaitForWorkflow(

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -154,7 +154,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError
 		}) {
 			fmt.Println("can't reliably verify Artifact GC since workflow failed")
-			when = when.RemoveFinalizers(false)
+			when.RemoveFinalizers(false)
 			continue
 		}
 
@@ -258,7 +258,7 @@ spec:
 		return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError
 	}) {
 		fmt.Println("can't reliably verify Artifact GC (Insufficient Role test) since workflow failed")
-		when = when.RemoveFinalizers(false)
+		when.RemoveFinalizers(false)
 		return
 	}
 

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -154,6 +154,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError
 		}) {
 			fmt.Println("can't reliably verify Artifact GC since workflow failed")
+			when = when.RemoveFinalizers(false)
 			continue
 		}
 
@@ -223,7 +224,7 @@ func (s *ArtifactsSuite) TestArtifactGC_InsufficientRole() {
 		_ = s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Delete(ctx, "artgc-role-test-sa", metav1.DeleteOptions{})
 	})
 
-	s.Given().Workflow(`
+	when := s.Given().Workflow(`
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -251,12 +252,22 @@ spec:
             serviceAccountName: artgc-role-test-sa`).
 		When().
 		SubmitWorkflow().
-		WaitForWorkflow(
-			fixtures.WorkflowCompletionOkay(true),
-			fixtures.Condition(func(wf *wfv1.Workflow) (bool, string) {
-				return wf.Status.ArtifactGCStatus != nil &&
-					len(wf.Status.ArtifactGCStatus.PodsRecouped) == 1, "for pod to have been recouped"
-			})).
+		WaitForWorkflow(fixtures.ToBeCompleted)
+
+	if when.WorkflowCondition(func(wf *wfv1.Workflow) bool {
+		return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError
+	}) {
+		fmt.Println("can't reliably verify Artifact GC (Insufficient Role test) since workflow failed")
+		when = when.RemoveFinalizers(false)
+		return
+	}
+
+	when.WaitForWorkflow(
+		fixtures.WorkflowCompletionOkay(true),
+		fixtures.Condition(func(wf *wfv1.Workflow) (bool, string) {
+			return wf.Status.ArtifactGCStatus != nil &&
+				len(wf.Status.ArtifactGCStatus.PodsRecouped) == 1, "for pod to have been recouped"
+		})).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			failCondition := false

--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -609,6 +609,11 @@ func (w *When) ShutdownWorkflow(strategy wfv1.ShutdownStrategy) *When {
 	return w
 }
 
+// test condition function on Workflow
+func (w *When) WorkflowCondition(condition func(wf *wfv1.Workflow) bool) bool {
+	return condition(w.wf)
+}
+
 func (w *When) Then() *Then {
 	return &Then{
 		t:           w.t,


### PR DESCRIPTION
Fixes #10230 

Artifact GC can't be reliably tested if the Workflow being executed fails (i.e. the artifact may have not been successfully written to minio in the first place so we can't verify the condition that certain artifacts should still be there). Skip the test in this case. 

Ideally, we'd determine the root cause for the intermittent failure of the Workflows (I did some analysis [here](https://github.com/argoproj/argo-workflows/issues/10230#issuecomment-1362084926)) but until then, this will prevent false test failures.
