### PR TITLE
fix: fix not working dex deployment in quickstart manifests

### DIFF
--- a/manifests/quick-start/sso/dex/dex-deploy.yaml
+++ b/manifests/quick-start/sso/dex/dex-deploy.yaml
@@ -16,8 +16,9 @@ spec:
       serviceAccountName: dex
       containers:
         - name: dex
-          image: quay.io/dexidp/dex:v2.35.0
+          image: ghcr.io/dexidp/dex:v2.35.0
           args:
+            - dex
             - serve
             - /data/config.yaml
           ports:


### PR DESCRIPTION
Signed-off-by: Jiacheng Xu <xjcmaxwellcjx@gmail.com>
This PR fixes the not working dex in quickstart manifests:
1. https://quay.io/repository/dexidp/dex only has tags <= `v2.28.1` and upstream switched to use `ghcr.io` for images(https://github.com/dexidp/dex/releases)
2. Dex pods crash because the `serve` command is not in `$PATH` and the command should be `dex serve /data/config.yaml`.

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
