### PR TITLE
docs: Add doc for template vs step exit handlers, closes #9988

### DIFF
--- a/docs/walk-through/exit-handlers.md
+++ b/docs/walk-through/exit-handlers.md
@@ -56,12 +56,12 @@ spec:
       args: ["echo boohoo!"]
 ```
 
-**Note**: Exit handlers will NOT run if a workflow is [terminated](/cli/argo_terminate/). However, if a workflow is [stopped](/cli/argo_stop/), exit handlers will still run.
+**Note**: Exit handlers will NOT run if a workflow is [terminated](docs/cli/argo_terminate/). However, if a workflow is [stopped](docs/cli/argo_stop/), exit handlers will still run.
 
 ## Template-level vs. Step-level Exit handlers
 The above example demonstrates an exit handler at the template level.
 
 Exit handlers can also be used at the step level:
-- [Step-level exit handler example](/examples/exit-handler-step-level.yaml)
+- [Step-level exit handler example](examples/exit-handler-step-level.yaml)
 
-If you using [`templateRef`](/workflow-templates/#referencing-other-workflowtemplates) in combination with an exit handler, ensure you are using a template-level exit handler since the `templateRef` will only refer to the template level, not the step level.
+If you using [`templateRef`](docs/workflow-templates/#referencing-other-workflowtemplates) in combination with an exit handler, ensure you are using a template-level exit handler since the `templateRef` will only refer to the template level, not the step level.

--- a/docs/walk-through/exit-handlers.md
+++ b/docs/walk-through/exit-handlers.md
@@ -56,7 +56,7 @@ spec:
       args: ["echo boohoo!"]
 ```
 
-**Note**: Exit handlers will NOT run if a workflow is [terminated](/cli/argo_terminate/). However, if a workflow is [stopped](/cli/argo_stop/), exit handers will still run.
+**Note**: Exit handlers will NOT run if a workflow is [terminated](/cli/argo_terminate/). However, if a workflow is [stopped](/cli/argo_stop/), exit handlers will still run.
 
 ## Template-level vs. Step-level Exit handlers
 The above example demonstrates an exit handler at the template level.

--- a/docs/walk-through/exit-handlers.md
+++ b/docs/walk-through/exit-handlers.md
@@ -56,7 +56,7 @@ spec:
       args: ["echo boohoo!"]
 ```
 
-**Note**: Exit handlers will NOT run if a workflow is [terminated](docs/cli/argo_terminate/). However, if a workflow is [stopped](docs/cli/argo_stop/), exit handlers will still run.
+**Note**: Exit handlers will NOT run if a workflow is [terminated](docs/cli/argo_terminate.md). However, if a workflow is [stopped](docs/cli/argo_stop.md), exit handlers will still run.
 
 ## Template-level vs. Step-level Exit handlers
 The above example demonstrates an exit handler at the template level.
@@ -64,4 +64,4 @@ The above example demonstrates an exit handler at the template level.
 Exit handlers can also be used at the step level:
 - [Step-level exit handler example](examples/exit-handler-step-level.yaml)
 
-If you using [`templateRef`](docs/workflow-templates/#referencing-other-workflowtemplates) in combination with an exit handler, ensure you are using a template-level exit handler since the `templateRef` will only refer to the template level, not the step level.
+If you using [`templateRef`](docs/workflow-templates.md) in combination with an exit handler, ensure you are using a template-level exit handler since the `templateRef` will only refer to the template level, not the step level.

--- a/docs/walk-through/exit-handlers.md
+++ b/docs/walk-through/exit-handlers.md
@@ -55,3 +55,13 @@ spec:
       command: [sh, -c]
       args: ["echo boohoo!"]
 ```
+
+**Note**: Exit handlers will NOT run if a workflow is [terminated](/cli/argo_terminate/). However, if a workflow is [stopped](/cli/argo_stop/), exit handers will still run.
+
+## Template-level vs. Step-level Exit handlers
+The above example demonstrates an exit handler at the template level.
+
+Exit handlers can also be used at the step level:
+- [Step-level exit handler example](/examples/exit-handler-step-level.yaml)
+
+If you using [`templateRef`](/workflow-templates/#referencing-other-workflowtemplates) in combination with an exit handler, ensure you are using a template-level exit handler since the `templateRef` will only refer to the template level, not the step level.


### PR DESCRIPTION
Signed-off-by: Caelan U 

Fixes #9988 

Users are confused about how exit handlers are used at the template vs. step levels, about how to use them with `templateRef` and need additional clarification about how `terminate` and `stop` differ with respect to running exit handlers.

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
