### PR TITLE
ci: Pin buildx action version to fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -104,6 +106,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
 
       - name: Cache Docker layers
         uses: actions/cache@v3


### PR DESCRIPTION
This fixes the release workflow:

```
docker.io/***/workflow-controller:latest-linux-arm64 is a manifest list
```

https://github.com/argoproj/argo-workflows/actions/runs/4077164697/jobs/7026848613

Co-authored-by: Jesse Suen <jesse@akuity.io>

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>
