### PR TITLE
feat: validate the name of workflow template.

### DIFF
--- a/docs/workflow-inputs.md
+++ b/docs/workflow-inputs.md
@@ -34,7 +34,7 @@ Inputs to `DAGTemplate`s use the `arguments` format:
 dag:
   tasks:
   - name: step-A
-    template: step-template-A
+    template: step-template-a
     arguments:
       parameters:
       - name: template-param-1
@@ -58,13 +58,13 @@ spec:
     dag:
       tasks:
       - name: step-A 
-        template: step-template-A
+        template: step-template-a
         arguments:
           parameters:
           - name: template-param-1
             value: "{{workflow.parameters.workflow-param-1}}"
  
-  - name: step-template-A
+  - name: step-template-a
     inputs:
       parameters:
         - name: template-param-1

--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -25,7 +25,7 @@ spec:
     - - name: leafA
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               parameters:
               - name: input
@@ -34,7 +34,7 @@ spec:
     - - name: leafB
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               parameters:
               - name: input
@@ -51,7 +51,7 @@ spec:
         valueFrom:
           default: "welcome"
           path: /tmp/hello_world.txt
-  - name: exitContainer
+  - name: exitcontainer
 
     container:
       image: docker/whalesay
@@ -93,7 +93,7 @@ spec:
       - name: leafA
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               parameters:
               - name: input
@@ -103,7 +103,7 @@ spec:
         dependencies: [leafA]
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               parameters:
               - name: input
@@ -120,7 +120,7 @@ spec:
         valueFrom:
           default: "welcome"
           path: /tmp/hello_world.txt
-  - name: exitContainer
+  - name: exitcontainer
     container:
       image: docker/whalesay
       command: [cowsay]
@@ -161,7 +161,7 @@ spec:
     - - name: leafA
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               artifacts:
               - name: input
@@ -170,13 +170,13 @@ spec:
   - name: whalesay
     container:
       image: docker/whalesay
-      command: [cowsay]
-      args: ["hello world"]
+      command: [sh, -c]
+      args: ["cowsay hello world | tee /tmp/hello_world.txt"]
     outputs:
       artifacts:
       - name: result
         path: /tmp/hello_world.txt
-  - name: exitContainer
+  - name: exitcontainer
     inputs:
       artifacts:
       - name: input
@@ -236,7 +236,7 @@ spec:
       - name: leafA
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               artifacts:
               - name: input
@@ -251,7 +251,7 @@ spec:
       artifacts:
       - name: result
         path: /tmp/hello_world.txt
-  - name: exitContainer
+  - name: exitcontainer
     inputs:
       artifacts:
       - name: input
@@ -308,12 +308,12 @@ spec:
   - name: suspend
     steps:
     - - name: leafA
-        onExit: exitContainer1
+        onExit: exitcontainer1
         template: whalesay
     - - name: leafB
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               parameters:
               - name: input
@@ -330,7 +330,7 @@ spec:
         valueFrom:
           default: "welcome"
           path: /tmp/hello_world.txt
-  - name: exitContainer
+  - name: exitcontainer
     inputs:
       parameters:
       - name: input
@@ -338,7 +338,7 @@ spec:
       image: docker/whalesay
       command: [cowsay]
       args: ["goodbye world"]
-  - name: exitContainer1
+  - name: exitcontainer1
     container:
       image: docker/whalesay
       command: [cowsay]
@@ -411,13 +411,13 @@ spec:
     dag:
       tasks:
       - name: leafA
-        onExit: exitContainer1
+        onExit: exitcontainer1
         template: whalesay
       - name: leafB
         dependencies: [leafA]
         hooks:
           exit: 
-            template: exitContainer
+            template: exitcontainer
             arguments:
               parameters:
               - name: input
@@ -434,7 +434,7 @@ spec:
         valueFrom:
           default: "welcome"
           path: /tmp/hello_world.txt
-  - name: exitContainer
+  - name: exitcontainer
     inputs:
       parameters:
       - name: input
@@ -442,7 +442,7 @@ spec:
       image: docker/whalesay
       command: [cowsay]
       args: ["goodbye world  {{inputs.parameters.input}}"]
-  - name: exitContainer1
+  - name: exitcontainer1
     container:
       image: docker/whalesay
       command: [cowsay]

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -58,9 +58,9 @@ metadata:
   name: script-wf
   namespace: default
 spec: 
-  entrypoint: scriptTmpl
+  entrypoint: scripttmpl
   templates:
-  - name: scriptTmpl
+  - name: scripttmpl
     synchronization: 
       semaphore: 
         configMapKeyRef: 
@@ -84,9 +84,9 @@ metadata:
   name: resource-wf
   namespace: default
 spec: 
-  entrypoint: resourceTmpl
+  entrypoint: resourcetmpl
   templates:
-  - name: resourceTmpl 
+  - name: resourcetmpl 
     synchronization: 
       semaphore: 
         configMapKeyRef: 

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3318,7 +3318,7 @@ spec:
   - name: suspend
     steps:
     - - name: leafA
-        onExit: exitContainer
+        onExit: exitcontainer
         template: whalesay
     - - name: leafB
         onExit: exitContainer
@@ -3330,7 +3330,7 @@ spec:
       command: [cowsay]
       args: ["hello world"]
 
-  - name: exitContainer
+  - name: exitcontainer
     container:
       image: docker/whalesay
       command: [cowsay]

--- a/workflow/controller/testdata/workflow-sub-test-5.yaml
+++ b/workflow/controller/testdata/workflow-sub-test-5.yaml
@@ -8,9 +8,9 @@ metadata:
   annotations:
     schedulerName: myScheduler
 spec:
-  entrypoint: myTemplate
+  entrypoint: mytemplate
   templates:
-    - name: myTemplate
+    - name: mytemplate
       steps:
         - - name: whalesay
             templateRef:


### PR DESCRIPTION
Signed-off-by: scott <scottwangsxll@gmail.com>

Fixes 

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.


---

A note for reviewers:

Please correct me if I'm wrong thx:

> The name of the template (not workflowTemplate) affects the name of the Workflow Pod.

In order to prevent the pod names created by `workflow-controller` from not conforming to [kubernetes named constraints](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names). If we can verify when submitting the workflow, there will be a better user experience. Otherwise, the argo-workflow CR resource has been generated but cannot be run because the Pod name is invalid, which brings a complicated troubleshooting process.
