### PR TITLE
chore: Force rebuild staticfiles when build argocli image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ COPY --from=argo-ui ui/dist/app ui/dist/app
 RUN cat .dockerignore >> .gitignore
 RUN git status --porcelain | cut -c4- | xargs git update-index --skip-worktree
 
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make dist/argo
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build STATIC_FILES=true make dist/argo
 
 ####################################################################################################
 


### PR DESCRIPTION
hi guys, I faced with a problem recently.  

I changed the code of ui and run `make argocli-image` to get new argocli image, but ui changes does not work.  
It finally turned out to be that I forgot to run `STATIC_FILES=true make server/static/files.go` to generate `server/static/files.go` from ui code.

I think it is better to force rebuild static files when build argocli image, it will helps avoid such problem in ui development.
