### PR TITLE
fix[example]: missing `arguments`

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -49,6 +49,9 @@ metadata:
   name: my-wf-tmple
   namespace: argo
 spec:
+  arguments:
+    parameters:
+    - name: message
   templates:
     - name: main
       inputs:


### PR DESCRIPTION
I followed this step-by-step guide and I couldn't invoke the template passing a message, so I realised the template was missing the `arguments` declaration

Fixes #TODO

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [ ] Run `make pre-commit -B` to fix codegen and lint problems.
* [ ] Sign-off your commits (otherwise the DCO check will fail).
* [ ] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
