### PR TITLE
fix: change log severity when artifact is not found

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -264,7 +264,7 @@ func saveArtifact(srcPath string) error {
 		return nil
 	}
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) { // might be optional, so we ignore
-		logger.WithError(err).Errorf("cannot save artifact %s", srcPath)
+		logger.WithError(err).Warnf("cannot save artifact %s", srcPath)
 		return nil
 	}
 	dstPath := filepath.Join(varRunArgo, "/outputs/artifacts/", strings.TrimSuffix(srcPath, "/")+".tgz")


### PR DESCRIPTION
Artifacts can be optional, logging a missing output artifact as error has too high severity, this will be highly visible in the logs requiring attention. Change severity to warning, similar with what is being logged in wait container: https://github.com/argoproj/argo-workflows/blob/master/workflow/executor/executor.go#L316

Fixes #change log severity when artifact is not found

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
