### PR TITLE
chore: Upgrade Go to v1.19

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
       # engineers just ignore this in PRs, so lets not even run it
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           cache: true
       - uses: actions/setup-java@v3
         if: ${{matrix.test == 'test-java-sdk'}}
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           cache: true
       - run: make lint STATIC_FILES=false
       - run: git diff --exit-code

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -25,7 +25,7 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/setup-node@v3
         with:
           node-version: "19"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -351,7 +351,7 @@ jobs:
           node-version: "19"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/cache@v3
         with:
           path: ui/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.2
 
-FROM golang:1.18-alpine3.16 as builder
+FROM golang:1.19-alpine3.16 as builder
 
 RUN apk update && apk add --no-cache \
     git \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -8,7 +8,7 @@ ARG IMAGE_OS_VERSION=1809
 
 # had issues with official golange image for windows so I'm using plain servercore
 FROM mcr.microsoft.com/windows/servercore:${IMAGE_OS_VERSION} as builder
-ENV GOLANG_VERSION=1.18
+ENV GOLANG_VERSION=1.19
 SHELL ["powershell", "-Command"]
 
 # install chocolatey package manager

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/storage v1.29.0


### PR DESCRIPTION
v1.18 has reached end of life: https://endoflife.date/go
