### PR TITLE
build: Upgrade to Node 19 to fix release build

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version: '1.18'
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "19"
       # Use the same make target both locally and on CI to make it easier to debug failures.
       - run: make docs
       # If markdownlint fixes issues, files will be changed. If so, fail the build.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -348,7 +348,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "19"
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
         "test": "jest"
     },
     "engines": {
-        "node": ">=16"
+        "node": ">=19"
     },
     "dependencies": {
         "argo-ui": "https://github.com/argoproj/argo-ui.git#v2.5.0",


### PR DESCRIPTION
Signed-off-by: Alex Collins <alexec@users.noreply.github.com>

Fixed the [broken builds](https://github.com/argoproj/argo-workflows/actions/workflows/release.yaml).