### PR TITLE
fix: panic in offline linter + handling stdin

### DIFF
--- a/cmd/argo/commands/client/conn_test.go
+++ b/cmd/argo/commands/client/conn_test.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"context"
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,4 +19,30 @@ func TestNamespace(t *testing.T) {
 	_ = os.Setenv("ARGO_NAMESPACE", "my-ns")
 	defer func() { _ = os.Unsetenv("ARGO_NAMESPACE") }()
 	assert.Equal(t, "my-ns", Namespace())
+}
+
+func TestCreateOfflineClient(t *testing.T) {
+	t.Run("creating an offline client with no files should not fail", func(t *testing.T) {
+		defer func() { logrus.StandardLogger().ExitFunc = nil }()
+		var fatal bool
+		logrus.StandardLogger().ExitFunc = func(int) { fatal = true }
+
+		Offline = true
+		OfflineFiles = []string{}
+		NewAPIClient(context.TODO())
+
+		assert.False(t, fatal, "should have exited")
+	})
+
+	t.Run("creating an offline client with a non-existing file should fail", func(t *testing.T) {
+		defer func() { logrus.StandardLogger().ExitFunc = nil }()
+		var fatal bool
+		logrus.StandardLogger().ExitFunc = func(int) { fatal = true }
+
+		Offline = true
+		OfflineFiles = []string{"non-existing-file"}
+		NewAPIClient(context.TODO())
+
+		assert.True(t, fatal, "should have exited")
+	})
 }

--- a/cmd/argo/commands/lint_test.go
+++ b/cmd/argo/commands/lint_test.go
@@ -154,4 +154,19 @@ spec:
 
 		assert.False(t, fatal, "should not have exited")
 	})
+
+	t.Run("linting one file from stdin", func(t *testing.T) {
+		defer func() { logrus.StandardLogger().ExitFunc = nil }()
+		var fatal bool
+		logrus.StandardLogger().ExitFunc = func(int) { fatal = true }
+
+		oldStdin := os.Stdin
+		defer func() { os.Stdin = oldStdin }() // Restore original Stdin
+		os.Stdin, err = os.Open(clusterWftmplPath)
+		require.NoError(t, err)
+
+		runLint(context.Background(), []string{workflowPath, wftmplPath, "-"}, true, nil, "pretty", true)
+
+		assert.False(t, fatal, "should not have exited")
+	})
 }

--- a/cmd/argo/lint/lint.go
+++ b/cmd/argo/lint/lint.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/argoproj/pkg/errors"
@@ -20,6 +18,7 @@ import (
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
 	wf "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	fileutil "github.com/argoproj/argo-workflows/v3/util/file"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
@@ -64,12 +63,6 @@ type Formatter interface {
 }
 
 var (
-	lintExt = map[string]bool{
-		".yaml": true,
-		".yml":  true,
-		".json": true,
-	}
-
 	defaultFormatter = formatterPretty{}
 
 	formatters = map[string]Formatter{
@@ -121,41 +114,11 @@ func Lint(ctx context.Context, opts *LintOptions) (*LintResults, error) {
 	}
 
 	for _, file := range opts.Files {
-		err := filepath.Walk(file, func(path string, info os.FileInfo, err error) error {
-			var r io.Reader
-			switch {
-			case path == "-":
-				path = "stdin"
-				r = os.Stdin
-			case err != nil:
-				return err
-			case strings.HasPrefix(path, "/dev/") || lintExt[filepath.Ext(path)]:
-				f, err := os.Open(filepath.Clean(path))
-				if err != nil {
-					return err
-				}
-				defer func() {
-					if err := f.Close(); err != nil {
-						log.Fatalf("Error closing file[%s]: %v", path, err)
-					}
-				}()
-				r = f
-			case info.IsDir():
-				return nil // skip
-			default:
-				log.Debugf("ignoring file with unknown extension: %s", path)
-				return nil
-			}
-
-			data, err := ioutil.ReadAll(r)
-			if err != nil {
-				return err
-			}
-
+		err := fileutil.WalkManifests(file, func(path string, data []byte) error {
 			res := lintData(ctx, path, data, opts)
 			results.Results = append(results.Results, res)
 
-			_, err = w.Write([]byte(results.fmtr.Format(res)))
+			_, err := w.Write([]byte(results.fmtr.Format(res)))
 			return err
 		})
 		if err != nil {

--- a/util/file/fileutil.go
+++ b/util/file/fileutil.go
@@ -8,14 +8,24 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/klauspost/pgzip"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/utils/env"
 )
 
-var gzipImpl = env.GetString(GZipImplEnvVarKey, PGZIP)
+var (
+	gzipImpl    = env.GetString(GZipImplEnvVarKey, PGZIP)
+	manifestExt = map[string]bool{
+		".yaml": true,
+		".yml":  true,
+		".json": true,
+	}
+)
 
 const (
 	GZipImplEnvVarKey = "GZIP_IMPLEMENTATION"
@@ -118,4 +128,41 @@ func DecompressContent(content []byte) ([]byte, error) {
 	}
 	defer close(gzipReader)
 	return ioutil.ReadAll(gzipReader)
+}
+
+// WalkManifests is based on filepath.Walk but will only walk through Kubernetes manifests
+func WalkManifests(root string, fn func(path string, data []byte) error) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		var r io.Reader
+		switch {
+		case path == "-":
+			path = "stdin"
+			r = os.Stdin
+		case err != nil:
+			return err
+		case strings.HasPrefix(path, "/dev/") || manifestExt[filepath.Ext(path)]:
+			f, err := os.Open(filepath.Clean(path))
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					log.Fatalf("Error closing file[%s]: %v", path, err)
+				}
+			}()
+			r = f
+		case info.IsDir():
+			return nil // skip
+		default:
+			logrus.Debugf("ignoring file with unknown extension: %s", path)
+			return nil
+		}
+
+		bytes, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+
+		return fn(path, bytes)
+	})
 }


### PR DESCRIPTION
Follow-up to https://github.com/argoproj/argo-workflows/pull/10059 and https://github.com/argoproj/argo-workflows/pull/10559

The offline linter is working well in ideal scenarios, I am linting a set of files/directory in 5 seconds where it used to take ~5 minutes

However, I did find issues after testing some more:
Given an non-existent file, it panics (I inverted the `info.IsDir()` statement and the one checking for errors) 
There's a disconnect between the `filepath.Walk` in the linter and the one building the offline client which means that there were other issues (such as stdin not working)

To fix those issues once and for all, I extracted the walk func to a common path (`file.WalkManifests`); that way, we are sure that changes are always reflected in both locations

I also added some tests for non-existent files as well as offline linting from stdin

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [x] Github checks are green.
* [x] Once required tests have passed, mark your PR "Ready for review".
