### PR TITLE
fix: linter fails if objects are not sorted in order of import in multi-document yaml file (#10608)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ require (
 	gopkg.in/jcmturner/rpc.v0 v0.0.2 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/component-helpers v0.24.3 // indirect


### PR DESCRIPTION
Fixes #10608 

Fixes issue when using `argo lint --offline` on a yaml file that contains multiple documents in unsorted order.

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [x] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [x] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [ ] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
