### PR TITLE
docs: Modify keyFormat in GCS docs to refer to workflow

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -398,7 +398,7 @@ data:
   artifactRepository: |
     gcs:
       bucket: my-bucket
-      keyFormat: prefix/in/bucket     #optional, it could reference workflow variables, such as "{{workflow.name}}/{{pod.name}}"
+      keyFormat: prefix/in/bucket/{{workflow.name}}/{{pod.name}}     #it should reference workflow variables, such as "{{workflow.name}}/{{pod.name}}"
       serviceAccountKeySecret:
         name: my-gcs-credentials
         key: serviceAccountKey


### PR DESCRIPTION
In old docs, `keyFormat` was incorrectly saying that workflow variables are optional. They're mandatory, without them all artifacts are saved to same place and overriding each other.

More context [in this slack thread](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1677707500865799)

Please do not open a pull request until you have checked ALL of these:

* [x] Create the PR as draft .
* [x] Run `make pre-commit -B` to fix codegen and lint problems.
* [x] Sign-off your commits (otherwise the DCO check will fail).
* [ ] Use [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/) (otherwise the commit message check will fail).
* [ ] "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* [x] Add unit or e2e tests. Say how you tested your changes. If you changed the UI, attach screenshots.
* [ ] Github checks are green.
* [ ] Once required tests have passed, mark your PR "Ready for review".

If changes were requested, and you've made them, dismiss the review to get it reviewed again.
