### PR TITLE
fix: set default connection life to 300s. Fixes #10498

### DIFF
--- a/persist/sqldb/sqldb.go
+++ b/persist/sqldb/sqldb.go
@@ -101,6 +101,9 @@ func CreatePostGresDBSession(kubectlConfig kubernetes.Interface, namespace strin
 		return nil, "", err
 	}
 
+	// default for connMaxLifetime to 300 seconds
+	session.SetConnMaxLifetime(300 * time.Second)
+
 	if persistPool != nil {
 		session.SetMaxOpenConns(persistPool.MaxOpenConns)
 		session.SetMaxIdleConns(persistPool.MaxIdleConns)


### PR DESCRIPTION
This PR sets the default for `connMaxLifetime` to 300 seconds

Fixes #10498 

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
