### PR TITLE
build: Skip react-router-dom on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,4 +25,6 @@ updates:
     ignore:
       - dependency-name: raw-loader
       - dependency-name: style-loader
+      - dependency-name: react-router-dom
+      - dependency-name: @types/react-router-dom
     open-pull-requests-limit: 10


### PR DESCRIPTION
This PR:
- Tells dependabot to ignore updates to react-router-dom and @types/react-router-dom
- The goal is to temporarily avoid future ui issues related to react router migrations as we've seen in #10590 and #10587

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
