### PR TITLE
fix: PVC in wf.status should be reset when retrying workflow

### DIFF
--- a/test/e2e/testdata/retry-with-recreated-pvc-test.yaml
+++ b/test/e2e/testdata/retry-with-recreated-pvc-test.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: retry-with-recreated-pvc
+spec:
+  volumeClaimGC:
+    strategy: OnWorkflowCompletion
+  entrypoint: volumes-pvc-example
+  volumeClaimTemplates:
+    - metadata:
+        name: workdir
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
+
+  templates:
+    - name: volumes-pvc-example
+      steps:
+        - - name: generate
+            template: whalesay
+        - - name: print
+            template: print-message
+
+    - name: whalesay
+      container:
+        image: argoproj/argosay:v2
+        command: [sh, -c]
+        args: ["echo generating message in volume; cowsay hello world | tee /mnt/vol/hello_world.txt"]
+        volumeMounts:
+          - name: workdir
+            mountPath: /mnt/vol
+
+    - name: print-message
+      container:
+        image: argoproj/argosay:v2
+        command: [sh, -c]
+        args: ["exit 1"]
+        volumeMounts:
+          - name: workdir
+            mountPath: /mnt/vol

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -821,6 +821,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 	newWF.Status.StartedAt = metav1.Time{Time: time.Now().UTC()}
 	newWF.Status.FinishedAt = metav1.Time{}
 	newWF.Spec.Shutdown = ""
+	newWF.Status.PersistentVolumeClaims = []apiv1.Volume{}
 	if newWF.Spec.ActiveDeadlineSeconds != nil && *newWF.Spec.ActiveDeadlineSeconds == 0 {
 		// if it was terminated, unset the deadline
 		newWF.Spec.ActiveDeadlineSeconds = nil


### PR DESCRIPTION
This fixes a bug where a retried workflow would fail with the error `persistentvolumeclaim xxx not found` if the PVC is deleted previously (e.g. volumeClaimGC strategy is set to `OnWorkflowCompletion`). We can fix this by resetting the PVC in workflow status so that the operator could recreate the PVC.