### PR TITLE
fix: ensure error returns before attrs is accessed. Fixes #10691

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -194,14 +194,14 @@ func listByPrefix(client *storage.Client, bucket, prefix, delim string) ([]strin
 		if err == iterator.Done {
 			break
 		}
+		if err != nil {
+			return nil, err
+		}
 		// skip "folder" path like objects
 		// note that we still download content (including "subfolders")
 		// this is just a consequence of how objects are stored in GCS (no real hierarchy)
 		if strings.HasSuffix(attrs.Name, "/") {
 			continue
-		}
-		if err != nil {
-			return nil, err
 		}
 		results = append(results, attrs.Name)
 	}


### PR DESCRIPTION
All this does is change the order, it lets the error check run before the attrs.Name is accessed. 
Fixes #10691
