### PR TITLE
chore: Enable blank issues for pipekit fork

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 
 contact_links:
   - name: Have you read the docs?


### PR DESCRIPTION
Sometimes we need to report issues that aren't easily within the existing options. Additionally, some of the reporting requirements are a little overly prescriptive for a small team. Let's enable blank issues on our fork