### PR TITLE
docs: podDisruptionBudget.minAvailable should be numeric

### DIFF
--- a/examples/default-pdb-support.yaml
+++ b/examples/default-pdb-support.yaml
@@ -7,7 +7,7 @@ spec:
   entrypoint: pdbcreate
   serviceAccountName: default
   podDisruptionBudget:
-    minAvailable: "9999"   # Provide arbitrary big number if you don't know how many pods workflow creates
+    minAvailable: 9999   # Provide arbitrary big number if you don't know how many pods workflow creates
   templates:
   - name: pdbcreate
     container:

--- a/examples/validator.go
+++ b/examples/validator.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"path/filepath"
+	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
 	"sigs.k8s.io/yaml"
@@ -67,15 +67,16 @@ func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[s
 			errorDescriptions := []string{}
 			for _, err := range result.Errors() {
 				// port should be port number or port reference string, using string port number will cause issue
-				// due swagger 2.0 limitation, we can only specify one data type (we use string, same as k8s api swagger)
-				if strings.HasSuffix(err.Field(), "httpGet.port") && err.Description() == "Invalid type. Expected: string, given: integer" {
+				// due swagger 2.0 limitation, we can only specify one data type (we use string, same as k8s api swagger).
+				// Similarly, we cannot use string minAvailable either.
+				if (strings.HasSuffix(err.Field(), "httpGet.port") || strings.HasSuffix(err.Field(), "podDisruptionBudget.minAvailable")) && err.Description() == "Invalid type. Expected: string, given: integer" {
 					incorrectError = true
 					continue
 				} else {
 					errorDescriptions = append(errorDescriptions, fmt.Sprintf("%s in %s", err.Description(), err.Context().String()))
 				}
 			}
-			
+
 			if !(incorrectError && len(errorDescriptions) == 1) {
 				failed[path] = errorDescriptions
 			}


### PR DESCRIPTION

This fixes the error:

```
Unable to create PDB resource for workflow, test-pdb error: PodDisruptionBudget.policy "test-pdb" is invalid: spec.minAvailable: Invalid value: intstr.IntOrString{Type:1, IntVal:0, StrVal:"9999"}: a valid percent string must be a numeric string followed by an ending '%' (e.g. '1%',  or '93%', regex used for validation is '[0-9]+%')
```