### PR TITLE
docs: Update quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -105,3 +105,5 @@ kubectl -n argo port-forward deployment/argo-server 2746:2746
 * Click `+ Submit New Workflow` and then `Edit using full workflow options`
 
 * You can find an example workflow already in the text field. Press `+ Create` to start the workflow.
+
+> Pay close attention to the URI. It uses `https` and not `http`. Navigating to `http://localhost:2746` result in server-side error that breaks the port-forwarding.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -52,6 +52,8 @@ kubectl -n argo port-forward deployment/argo-server 2746:2746
 
 This will serve the UI on <https://localhost:2746>. Due to the self-signed certificate, you will receive a TLS error which you will need to manually approve.
 
+> Pay close attention to the URI. It uses `https` and not `http`. Navigating to `http://localhost:2746` result in server-side error that breaks the port-forwarding.
+
 ## Install the Argo Workflows CLI
 
 Next, Download the latest Argo CLI from the same [releases page](https://github.com/argoproj/argo-workflows/releases/latest).
@@ -105,5 +107,3 @@ kubectl -n argo port-forward deployment/argo-server 2746:2746
 * Click `+ Submit New Workflow` and then `Edit using full workflow options`
 
 * You can find an example workflow already in the text field. Press `+ Create` to start the workflow.
-
-> Pay close attention to the URI. It uses `https` and not `http`. Navigating to `http://localhost:2746` result in server-side error that breaks the port-forwarding.


### PR DESCRIPTION
Add extra not emphasising on using `https` rather than `http` to access server UI

Added context to help who might fall for the same sequence explained in https://github.com/argoproj/argo-workflows/issues/10719 
