### PR TITLE
fix: DB sessions are recreated whenever controller configmap updates. Fixes #10498

### DIFF
--- a/persist/sqldb/sqldb.go
+++ b/persist/sqldb/sqldb.go
@@ -100,12 +100,7 @@ func CreatePostGresDBSession(kubectlConfig kubernetes.Interface, namespace strin
 	if err != nil {
 		return nil, "", err
 	}
-
-	if persistPool != nil {
-		session.SetMaxOpenConns(persistPool.MaxOpenConns)
-		session.SetMaxIdleConns(persistPool.MaxIdleConns)
-		session.SetConnMaxLifetime(time.Duration(persistPool.ConnMaxLifetime))
-	}
+	session = ConfigureDBSession(session, persistPool)
 	return session, cfg.TableName, nil
 }
 
@@ -135,12 +130,7 @@ func CreateMySQLDBSession(kubectlConfig kubernetes.Interface, namespace string, 
 	if err != nil {
 		return nil, "", err
 	}
-
-	if persistPool != nil {
-		session.SetMaxOpenConns(persistPool.MaxOpenConns)
-		session.SetMaxIdleConns(persistPool.MaxIdleConns)
-		session.SetConnMaxLifetime(time.Duration(persistPool.ConnMaxLifetime))
-	}
+	session = ConfigureDBSession(session, persistPool)
 	// this is needed to make MySQL run in a Golang-compatible UTF-8 character set.
 	_, err = session.Exec("SET NAMES 'utf8mb4'")
 	if err != nil {
@@ -151,4 +141,14 @@ func CreateMySQLDBSession(kubectlConfig kubernetes.Interface, namespace string, 
 		return nil, "", err
 	}
 	return session, cfg.TableName, nil
+}
+
+// ConfigureDBSession configures the DB session
+func ConfigureDBSession(session sqlbuilder.Database, persistPool *config.ConnectionPool) sqlbuilder.Database {
+	if persistPool != nil {
+		session.SetMaxOpenConns(persistPool.MaxOpenConns)
+		session.SetMaxIdleConns(persistPool.MaxIdleConns)
+		session.SetConnMaxLifetime(time.Duration(persistPool.ConnMaxLifetime))
+	}
+	return session
 }

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
-	
+
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 	apiv1 "k8s.io/api/core/v1"

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 	apiv1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Fixes #10498. The issue is that after change https://github.com/argoproj/argo-workflows/commit/b0f0c589e626650ca01a635f773af983e213fbec introduced in 3.4.5, new DB sessions are re-created every time when the configmap changes. This PR allows reusing the DB session.