### PR TITLE
feat: Add workflow var for originName

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -246,6 +246,7 @@ For `Template`-level metrics:
 | Variable | Description|
 |----------|------------|
 | `workflow.name` | Workflow name |
+| `workflow.originName` | Workflow template name. This works only for template names, it may give wrong answers for non-generated names |
 | `workflow.namespace` | Workflow namespace |
 | `workflow.mainEntrypoint` | Workflow's initial entrypoint |
 | `workflow.serviceAccountName` | Workflow service account name |

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -165,6 +165,8 @@ const (
 
 	// GlobalVarWorkflowName is a global workflow variable referencing the workflow's metadata.name field
 	GlobalVarWorkflowName = "workflow.name"
+	// GlobalVarWorkflowOriginName is a global workflow variable referencing the workflow's name reverse engineered to the template name from a generateName
+	GlobalVarWorkflowOriginName = "workflow.originName"
 	// GlobalVarWorkflowNamespace is a global workflow variable referencing the workflow's metadata.namespace field
 	GlobalVarWorkflowNamespace = "workflow.namespace"
 	// GlobalVarWorkflowMainEntrypoint is a global workflow variable referencing the workflow's top level entrypoint name

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -577,9 +577,21 @@ func (woc *wfOperationCtx) getWorkflowDeadline() *time.Time {
 	return &deadline
 }
 
+// originNameFromName tries to strip the suffix for a cronworkflow [\d]{10} or from a
+// generateName [a-z0-9]{5} from the name.
+var originNameFromName = regexp.MustCompile(`^(.{3,}?)(\-?[\d]{10})?(\-?[a-z0-9]{5})?$`)
+
+func getOriginNameFromName(name string) string {
+	if originNameFromName.MatchString(name) {
+		return originNameFromName.ReplaceAllString(name, "$1")
+	}
+	return name
+}
+
 // setGlobalParameters sets the globalParam map with global parameters
 func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Arguments) error {
 	woc.globalParams[common.GlobalVarWorkflowName] = woc.wf.ObjectMeta.Name
+	woc.globalParams[common.GlobalVarWorkflowOriginName] = getOriginNameFromName(woc.wf.ObjectMeta.Name)
 	woc.globalParams[common.GlobalVarWorkflowNamespace] = woc.wf.ObjectMeta.Namespace
 	woc.globalParams[common.GlobalVarWorkflowMainEntrypoint] = woc.execWf.Spec.Entrypoint
 	woc.globalParams[common.GlobalVarWorkflowServiceAccountName] = woc.execWf.Spec.ServiceAccountName

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -366,6 +366,7 @@ func TestGlobalParams(t *testing.T) {
 
 	assert.Contains(t, woc.globalParams, "workflow.duration")
 	assert.Contains(t, woc.globalParams, "workflow.name")
+	assert.Contains(t, woc.globalParams, "workflow.originName")
 	assert.Contains(t, woc.globalParams, "workflow.namespace")
 	assert.Contains(t, woc.globalParams, "workflow.mainEntrypoint")
 	assert.Contains(t, woc.globalParams, "workflow.parameters")
@@ -377,6 +378,22 @@ func TestGlobalParams(t *testing.T) {
 	// Ensure that the phase label is included after the first operation
 	woc.operate(ctx)
 	assert.Contains(t, woc.globalParams, "workflow.labels.workflows.argoproj.io/phase")
+}
+
+func TestOriginName(t *testing.T) {
+	for input, expected := range map[string]string{
+		`template-name-1234567890`:       `template-name`, // Cronworkflows run on a cron
+		`template-name1234567890`:        `template-name`, // Cronworkflow without trailing -
+		`foobar-fs4hy`:                   `foobar`,        // Standard template submission
+		`foobar-foobar-ashda`:            `foobar-foobar`,
+		`foobarfs4hy`:                    `foobar`, // Template without trailing -
+		`foobar`:                         `foobar`, // We don't replace the end of this
+		`foo-bar`:                        `foo-bar`,
+		`foobar-foobar-0987654321-4ab1a`: `foobar-foobar`, // Cronworkflow, resubmitted
+		`foobar-foobar`:                  `foobar-f`,      // Can't really prevent this kind of thing, not desired though
+	} {
+		assert.Equal(t, expected, getOriginNameFromName(input))
+	}
 }
 
 // TestSidecarWithVolume verifies ia sidecar can have a volumeMount reference to both existing or volumeClaimTemplate volumes

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -65,6 +65,7 @@ type templateValidationCtx struct {
 func newTemplateValidationCtx(wf *wfv1.Workflow, opts ValidateOpts) *templateValidationCtx {
 	globalParams := make(map[string]string)
 	globalParams[common.GlobalVarWorkflowName] = placeholderGenerator.NextPlaceholder()
+	globalParams[common.GlobalVarWorkflowOriginName] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowNamespace] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowMainEntrypoint] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowServiceAccountName] = placeholderGenerator.NextPlaceholder()


### PR DESCRIPTION
Add a global workflow variables to allow generic template metrics to identify which workflow they originate from.

Issue #6772 asks for the template name, but we cannot always know what this is (simplest unknowable is kubectl apply of a workflow with a generateName). So provide that by deduction as originName. See the tests added in this commit for what we're aiming for there.

I have added both variables and tested them by invoking very simple workflows. The regex used to generate originName from the Name has a test suite, and has been checked from simple workflows also.

Fixes #6772 
