### PR TITLE
chore: Add python to devcontainer for make docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "16"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/python:1": {}
   },
   "hostRequirements": {
     "cpus": 4


### PR DESCRIPTION
The devcontainer is missing a python installation, this prevents contributors from performing a `make docs` command. This PR adds python to the devcontainer to overcome this issue.

`make docs` now successfully builds the docs within the devcontainer.