### PR TITLE
docs: Enhance s3 setup docs with IRSA information

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -73,7 +73,8 @@ $ cat > policy.json <<EOF
          "Effect":"Allow",
          "Action":[
             "s3:PutObject",
-            "s3:GetObject"
+            "s3:GetObject",
+            "s3:DeleteObject"
          ],
          "Resource":"arn:aws:s3:::$mybucket/*"
       },
@@ -93,7 +94,7 @@ $ aws iam put-user-policy --user-name $mybucket-user --policy-name $mybucket-pol
 $ aws iam create-access-key --user-name $mybucket-user > access-key.json
 ```
 
-If you have Artifact Garbage Collection configured, you should also add "s3:DeleteObject" to the list of Actions above.
+If you do not have Artifact Garbage Collection configured, you should remove `s3:DeleteObject` from the list of Actions above.
 
 NOTE: if you want argo to figure out which region your buckets belong in, you
 must additionally set the following statement policy. Otherwise, you must
@@ -108,6 +109,20 @@ specify a bucket region in your workflow configuration.
          "Resource":"arn:aws:s3:::*"
       }
     ...
+```
+
+### AWS S3 IRSA
+
+If you wish to use S3 IRSA instead of passing in an `accessKey` and `secretKey`, you need to annotate the service account of both the running workflow (in order to save logs/artifacts) and the argo-server pod (in order to retrieve the logs/artifacts).
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::012345678901:role/mybucket
+  name: myserviceaccount
+  namespace: mynamespace
 ```
 
 ## Configuring GCS (Google Cloud Storage)


### PR DESCRIPTION
I found the IRSA documentation lacking so wanted to add to it.

Also favoured giving the full-blown s3 bucket policy for users who skim, and then using the sentence to encourage users to remove unused policy actions. This will reduce the questions in slack on the subject.