### PR TITLE
docs: Remove days in examples/retry-backoff.yaml

### DIFF
--- a/examples/retry-backoff.yaml
+++ b/examples/retry-backoff.yaml
@@ -10,9 +10,9 @@ spec:
     retryStrategy:
       limit: "10"
       backoff:
-        duration: "1"       # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+        duration: "1"       # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h"
         factor: "2"
-        maxDuration: "1m" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h", "1d"
+        maxDuration: "1m" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h"
     container:
       image: python:alpine3.6
       command: ["python", -c]


### PR DESCRIPTION
Why this PR: Wrong example yaml file for `retry-backoff.yaml`
Change I made: removed `1d` comment.
Fixes https://github.com/argoproj/argo-workflows/issues/4088

@alexec 

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
