### PR TITLE
fix: Allow script and container image to be set in templateDefault. Fixes #9633

### DIFF
--- a/test/e2e/functional/template-default-image.yaml
+++ b/test/e2e/functional/template-default-image.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: template-default-
+spec:
+  entrypoint: entrypoint
+  templateDefaults:
+    script:
+      image: argoproj/argosay:v1
+      command: [sh]
+      workingDir: "/src"
+    container:
+      image: argoproj/argosay:v1
+      command: [sh, -c]
+      workingDir: "/src"
+  templates:
+    - name: entrypoint
+      steps:
+      - - name: test-script
+          template: test-script
+        - name: test-container
+          template: test-container
+    
+    - name: test-script
+      script:
+        source: |
+          pwd
+
+    - name: test-container
+      container:
+        args: ["pwd"]

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1179,3 +1179,11 @@ func (s *FunctionalSuite) TestTTY() {
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded)
 }
+
+func (s *FunctionalSuite) TestTemplateDefaultImage() {
+	s.Given().
+		Workflow(`@functional/template-default-image.yaml`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded)
+}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2282,6 +2282,143 @@ func TestInvalidWfNoImageFieldScript(t *testing.T) {
 	assert.EqualError(t, err, "templates.whalesay.script.image may not be empty")
 }
 
+var invalidWfNoImageScriptInTemplateDefault = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world-right-env-12
+spec:
+  entrypoint: whalesay
+  templateDefaults:
+    script:
+      command: [cowsay]
+  templates:
+  - name: whalesay
+    script:
+      args:
+      - hello world
+      env: []`
+
+func TestIinvalidWfNoImageScriptInTemplateDefault(t *testing.T) {
+	err := validate(invalidWfNoImageScriptInTemplateDefault)
+	assert.EqualError(t, err, "templates.whalesay.script.image may not be empty")
+}
+
+var validWfImageScriptInTemplateDefault = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world-right-env-12
+spec:
+  entrypoint: whalesay
+  templateDefaults:
+    script:
+      image: alpine:latest
+  templates:
+  - name: whalesay
+    script:
+      command:
+      - cowsay
+      args:
+      - hello world
+      env: []`
+
+func TestValidWfImageScriptInTemplateDefault(t *testing.T) {
+	err := validate(validWfImageScriptInTemplateDefault)
+	assert.NoError(t, err)
+}
+
+var validWfImageContainerInTemplateDefault = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world-right-env-12
+spec:
+  entrypoint: whalesay
+  templateDefaults:
+    container:
+      image: alpine:latest
+  templates:
+  - name: whalesay
+    container:
+      command:
+      - cowsay
+      args:
+      - hello world
+      env: []`
+
+func TestValidWfImageContainerInTemplateDefault(t *testing.T) {
+	err := validate(validWfImageContainerInTemplateDefault)
+	assert.NoError(t, err)
+}
+
+var templateRefScriptImageDefaultTarget = `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: template-ref-no-script-image
+spec:
+  entrypoint: whalesay
+  templateDefaults:
+    script:
+      image: alpine:latest
+  templates:
+  - name: whalesay
+    script:
+      command: [cowsay]
+      args: [hello world]
+`
+
+var wfWithWFTRefScriptImageInDefault = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+  namespace: default
+spec:
+  workflowTemplateRef:
+    name: template-ref-no-script-image
+`
+
+func TestValidateFieldsWithWFTRefScriptImageInDefault(t *testing.T) {
+	err := createWorkflowTemplateFromSpec(templateRefScriptImageDefaultTarget)
+	assert.NoError(t, err)
+	err = validate(wfWithWFTRefScriptImageInDefault)
+	assert.NoError(t, err)
+}
+
+var templateRefContainerImageDefaultTarget = `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: template-ref-no-container-image
+spec:
+  entrypoint: whalesay
+  templateDefaults:
+    container:
+      image: alpine:latest
+  templates:
+  - name: whalesay
+    container:
+      command: [cowsay]
+      args: [hello world]
+`
+
+var wfWithWFTRefContainerImageInDefault = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: hello-world-
+  namespace: default
+spec:
+  workflowTemplateRef:
+    name: template-ref-no-container-image
+`
+
+func TestValidateFieldsWithWFTRefContainerImageInDefault(t *testing.T) {
+	err := createWorkflowTemplateFromSpec(templateRefContainerImageDefaultTarget)
+	assert.NoError(t, err)
+	err = validate(wfWithWFTRefContainerImageInDefault)
+	assert.NoError(t, err)
+}
+
 var templateRefWithParam = `
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate


### PR DESCRIPTION
Made changes to validation to check if the script/container Image has been set in templateDefaults

**Testing**
Added unit tests to verify these situations

Also created the following via the locally deployed UI and then submitted both via the UI and they were successful:
```
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  generateName: demo-
spec:
  entrypoint: demo
  templateDefaults:
    script:
      image: alpine:latest
      command: [sh]
      workingDir: "/src"
  templates:
    - name: demo
      script:
        source: |
          pwd
```
and a cron workflow
```
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  generateName: demo-cron
spec:
  schedule: "00 4 * * 2"
  timezone: "UTC"
  workflowMetadata:
    generateName: demo-cron-test-
  workflowSpec:
    entrypoint: demo
    templateDefaults:
      script:
        image: alpine:latest
        command: [sh]
        workingDir: "/src"
    templates:
      - name: demo
        script:
          source: |
            pwd
```

Fixes #9633 

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
