### PR TITLE
chore: Remove legacy recursion preventer from template resolution

### DIFF
--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -14,9 +14,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
-// maxResolveDepth is the limit of template reference resolution.
-const maxResolveDepth int = 10
-
 // workflowTemplateInterfaceWrapper is an internal struct to wrap clientset.
 type workflowTemplateInterfaceWrapper struct {
 	clientset typed.WorkflowTemplateInterface
@@ -104,7 +101,7 @@ func NewContextFromClientset(wftmplClientset typed.WorkflowTemplateInterface, cl
 
 // GetTemplateByName returns a template by name in the context.
 func (ctx *Context) GetTemplateByName(name string) (*wfv1.Template, error) {
-	ctx.log.Debug("Getting the template by name")
+	ctx.log.Debugf("Getting the template by name: %s", name)
 
 	tmpl := ctx.tmplBase.GetTemplateByName(name)
 	if tmpl == nil {
@@ -172,24 +169,18 @@ func (ctx *Context) GetTemplateScope() string {
 // ResolveTemplate digs into referenes and returns a merged template.
 // This method is the public start point of template resolution.
 func (ctx *Context) ResolveTemplate(tmplHolder wfv1.TemplateReferenceHolder) (*Context, *wfv1.Template, bool, error) {
-	return ctx.resolveTemplateImpl(tmplHolder, 0)
+	return ctx.resolveTemplateImpl(tmplHolder)
 }
 
 // resolveTemplateImpl digs into references and returns a merged template.
 // This method processes inputs and arguments so the inputs of the final
 // resolved template include intermediate parameter passing.
 // The other fields are just merged and shallower templates overwrite deeper.
-func (ctx *Context) resolveTemplateImpl(tmplHolder wfv1.TemplateReferenceHolder, depth int) (*Context, *wfv1.Template, bool, error) {
+func (ctx *Context) resolveTemplateImpl(tmplHolder wfv1.TemplateReferenceHolder) (*Context, *wfv1.Template, bool, error) {
 	ctx.log = ctx.log.WithFields(log.Fields{
-		"depth": depth,
-		"base":  common.GetTemplateGetterString(ctx.tmplBase),
-		"tmpl":  common.GetTemplateHolderString(tmplHolder),
+		"base": common.GetTemplateGetterString(ctx.tmplBase),
+		"tmpl": common.GetTemplateHolderString(tmplHolder),
 	})
-	// Avoid infinite references
-	if depth > maxResolveDepth {
-		return nil, nil, false, errors.Errorf(errors.CodeBadRequest, "template reference exceeded max depth (%d)", maxResolveDepth)
-	}
-
 	ctx.log.Debug("Resolving the template")
 
 	templateStored := false


### PR DESCRIPTION
The workflow template resolver used to be able to recurse. This was removed 2 years ago, but the code that prevents infinite recursion is still in the code base.
I have just removed code, and things still compile and tests pass. As I've changed a call interface and things still compile I'm happy I cannot have missed anything.
The UI has not changed

