### PR TITLE
fix: Fix inlined templates in templates

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -3280,6 +3280,10 @@ func resolveTemplateReference(callerScope ResourceScope, resourceName string, ca
 		return fmt.Sprintf("%s/%s/%s", referenceScope, tmplRef.Name, tmplRef.Template), true
 	} else if callerScope != ResourceScopeLocal {
 		// Either a WorkflowTemplate or a ClusterWorkflowTemplate is calling a template inside itself. Template storage is needed
+		if caller.GetTemplate() != nil {
+			// If we have an inlined template here, use the inlined name
+			return fmt.Sprintf("%s/%s/inline/%s", callerScope, resourceName, caller.GetName()), true
+		}
 		return fmt.Sprintf("%s/%s/%s", callerScope, resourceName, caller.GetTemplateName()), true
 	} else {
 		// A Workflow is calling a template inside itself. Template storage is not needed

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -1556,3 +1556,107 @@ func TestGetExecSpec(t *testing.T) {
 
 	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "spec-template")
 }
+
+// Check that inline tasks and steps are properly recovered from the store
+func TestInlineStore(t *testing.T) {
+	tests := map[ResourceScope]bool{
+		ResourceScopeLocal:      false,
+		ResourceScopeNamespaced: true,
+		ResourceScopeCluster:    true,
+	}
+
+	for scope, shouldStore := range tests {
+		t.Run(string(scope), func(t *testing.T) {
+			wf := Workflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: WorkflowSpec{
+					Templates: []Template{
+						{
+							Name: "dag-template",
+							DAG: &DAGTemplate{
+								Tasks: []DAGTask{
+									{
+										Name: "hello1",
+										Inline: &Template{
+											Script: &ScriptTemplate{
+												Source: "abc",
+											},
+										},
+									}, {
+										Name: "hello2",
+										Inline: &Template{
+											Script: &ScriptTemplate{
+												Source: "def",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "step-template",
+							Steps: []ParallelSteps{
+								ParallelSteps{
+									[]WorkflowStep{
+										{
+											Name: "hello1",
+											Inline: &Template{
+												Script: &ScriptTemplate{
+													Source: "ghi",
+												},
+											},
+										}, {
+											Name: "hello2",
+											Inline: &Template{
+												Script: &ScriptTemplate{
+													Source: "jkl",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			dagtmpl1 := &wf.Spec.Templates[0].DAG.Tasks[0]
+			dagtmpl2 := &wf.Spec.Templates[0].DAG.Tasks[1]
+			steptmpl1 := &wf.Spec.Templates[1].Steps[0].Steps[0]
+			steptmpl2 := &wf.Spec.Templates[1].Steps[0].Steps[1]
+			stored, err := wf.SetStoredTemplate(scope, "dag-template", dagtmpl1, dagtmpl1.Inline)
+			assert.Equal(t, shouldStore, stored, "DAG template 1 should be stored for non local scopes")
+			assert.Nil(t, err, "SetStoredTemplate for DAG1 should not return an error")
+			stored, err = wf.SetStoredTemplate(scope, "dag-template", dagtmpl2, dagtmpl2.Inline)
+			assert.Equal(t, shouldStore, stored, "DAG template 2 should be stored for non local scopes")
+			assert.Nil(t, err, "SetStoredTemplate for DAG2 should not return an error")
+			stored, err = wf.SetStoredTemplate(scope, "step-template", steptmpl1, steptmpl1.Inline)
+			assert.Equal(t, shouldStore, stored, "Step template 1 should be stored for non local scopes")
+			assert.Nil(t, err, "SetStoredTemplate for Step 1 should not return an error")
+			stored, err = wf.SetStoredTemplate(scope, "step-template", steptmpl2, steptmpl2.Inline)
+			assert.Equal(t, shouldStore, stored, "Step template 2 should be stored for non local scopes")
+			assert.Nil(t, err, "SetStoredTemplate for Step 2 should not return an error")
+			// For cases where we can store we should be able to retrieve and check
+			if shouldStore {
+				dagretrieved1 := wf.GetStoredTemplate(scope, "dag-template", dagtmpl1)
+				assert.NotNil(t, dagretrieved1, "We should retrieve DAG Template 1")
+				assert.Equal(t, dagtmpl1.Inline, dagretrieved1, "DAG template 1 should match what we stored")
+				dagretrieved2 := wf.GetStoredTemplate(scope, "dag-template", dagtmpl2)
+				assert.NotNil(t, dagretrieved2, "We should retrieve DAG Template 2")
+				assert.Equal(t, dagtmpl2.Inline, dagretrieved2, "DAG template 2 should match what we stored")
+				assert.NotEqual(t, dagretrieved1, dagretrieved2, "DAG template 1 and 2 should be different")
+
+				stepretrieved1 := wf.GetStoredTemplate(scope, "step-template", steptmpl1)
+				assert.NotNil(t, stepretrieved1, "We should retrieve Step Template 1")
+				assert.Equal(t, steptmpl1.Inline, stepretrieved1, "Step template 1 should match what we stored")
+				stepretrieved2 := wf.GetStoredTemplate(scope, "step-template", steptmpl2)
+				assert.NotNil(t, stepretrieved2, "We should retrieve Step Template 2")
+				assert.Equal(t, steptmpl2.Inline, stepretrieved2, "Step template 2 should match what we stored")
+				assert.NotEqual(t, stepretrieved1, stepretrieved2, "Step template 1 and 2 should be different")
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a template is inline inside a WorkflowTemplate or ClusterWorkflowTemplate we must still create a stored version of it. This fix changes the 'name' given to those from `/scope/templateName/` (where after the last / should be a name but there isn't) to /scope/templateName/inline/name' where name can be step name or task name.

I have added inline as it's possible to name an inline step the same as a template in the same WorkflowTemplate.

Tested against the test cases from #10737.

Fixes #10737

