### PR TITLE
chore: Print out transient S3 errors

### DIFF
--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	argos3 "github.com/argoproj/pkg/s3"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-workflows/v3/util/errors"
 )
@@ -27,6 +28,7 @@ func isTransientS3Err(err error) bool {
 	}
 	for _, transientErrCode := range s3TransientErrorCodes {
 		if argos3.IsS3ErrCode(err, transientErrCode) {
+			log.Infof("Transient S3 error: %v", err)
 			return true
 		}
 	}

--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -28,7 +28,7 @@ func isTransientS3Err(err error) bool {
 	}
 	for _, transientErrCode := range s3TransientErrorCodes {
 		if argos3.IsS3ErrCode(err, transientErrCode) {
-			log.Infof("Transient S3 error: %v", err)
+			log.Errorf("Transient S3 error: %v", err)
 			return true
 		}
 	}


### PR DESCRIPTION
These errors are in the backoff retry loop and users are not clear what/whether errors are retried.