### PR TITLE
feat: add chunk size argument to delete cli command

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -87,6 +87,7 @@ func NewDeleteCommand() *cobra.Command {
 	command.Flags().StringVar(&flags.finishedAfter, "older", "", "Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
 	command.Flags().StringVarP(&flags.labels, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&flags.fields, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
+	command.Flags().Int64VarP(&flags.chunkSize, "query-chunk-size", "", 0, "Run the list query in chunks (deletes will still be executed individually)")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Do not delete the workflow, only print what would happen")
 	command.Flags().BoolVar(&force, "force", false, "Force delete workflows by removing finalizers")
 	return command

--- a/docs/cli/argo_delete.md
+++ b/docs/cli/argo_delete.md
@@ -31,7 +31,7 @@ argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmit
   -h, --help                    help for delete
       --older string            Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)
       --prefix string           Delete workflows by prefix
-      --query-chunk-size        Run the list query in chunks (deletes will still be executed individually)
+      --query-chunk-size int    Run the list query in chunks (deletes will still be executed individually)
       --resubmitted             Delete resubmitted workflows
   -l, --selector string         Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
 ```

--- a/docs/cli/argo_delete.md
+++ b/docs/cli/argo_delete.md
@@ -31,6 +31,7 @@ argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmit
   -h, --help                    help for delete
       --older string            Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)
       --prefix string           Delete workflows by prefix
+      --query-chunk-size        Run the list query in chunks (deletes will still be executed individually)
       --resubmitted             Delete resubmitted workflows
   -l, --selector string         Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
 ```


### PR DESCRIPTION
The `argo list` CLI command accepts an `--chunk-size n` argument, but the `argo delete` command does not. In our case, this was problematic because the large number of old workflows we had was causing unbounded list queries to fail, and the sensible remedy (deleting old workflows) was not possible because (for example) `argo delete --since 30d` could not be chunked in the same way that listing could.

This PR adds a `--query-chunk-size n` argument to `argo delete`, which is applied when the command is fetching the workflows it will delete. The name `query-chunk-size` is different from the list command option `chunk-size` to avoid the implication that it will delete according to the specified chunk - but please suggest a better name if you have one.

The flag is passed directly to `listWorkflows` so follows the same code path as the `list` command.