### PR TITLE
ci: Enable Snyk on release branches

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,6 +2,11 @@ name: Snyk
 on:
   schedule:
     - cron: "30 2 * * *"
+  push:
+    branches:
+      - master
+      - release-*
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Scan security vulnerabilities before release to avoid issues like https://github.com/argoproj/argo-workflows/issues/10811