### PR TITLE
fix: trivialVersions is no longer a supported argument for controller-gen

### DIFF
--- a/hack/crdgen.sh
+++ b/hack/crdgen.sh
@@ -8,7 +8,7 @@ add_header() {
   mv tmp "$1"
 }
 
-controller-gen crd:trivialVersions=true,maxDescLen=0 paths=./pkg/apis/... output:dir=manifests/base/crds/full
+controller-gen crd:maxDescLen=0 paths=./pkg/apis/... output:dir=manifests/base/crds/full
 
 find manifests/base/crds/full -name 'argoproj.io*.yaml' | while read -r file; do
   echo "Patching ${file}"


### PR DESCRIPTION
I upgraded from controller-gen version 0.4.1 to 0.8 recently and noticed that the `trivialVersions` argument is no longer supported. When running `make codegen` I'd get:
```
Error: unable to parse option "crd:trivialVersions=true,maxDescLen=0": [unknown argument "trivialVersions" (at <input>:1:16) extra arguments provided: "true,maxDescLen=0" (at <input>:1:17)]
Usage:
  controller-gen [flags]
```

There seems to be no change to the generated files by removing it.

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
