### PR TITLE
fix: download specific version of kit. Fixes #10768

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,7 +461,7 @@ ifeq ($(shell uname),Darwin)
 	brew tap kitproj/kit --custom-remote https://github.com/kitproj/kit
 	brew install kit
 else
-	curl -q https://raw.githubusercontent.com/kitproj/kit/main/install.sh | sh
+	curl -q https://raw.githubusercontent.com/kitproj/kit/main/install.sh | tag=v0.1.8 sh
 endif
 endif
 


### PR DESCRIPTION
> Say why you made your changes.

To improve the reliability of builds.

> Say what changes you made.

Download a specific version of kit. This skips the curl command to get the latest version.

> Say how you tested your changes.

Written and tested using Codespaces.


Fixes #10768

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
