### PR TITLE
fix: Resolve high severity vulnerabilities in UI deps

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -92,6 +92,8 @@
     "resolutions": {
         "lodash": "4.17.21",
         "prismjs": "1.27.0",
-        "@types/react": "16.8.5"
+        "@types/react": "16.8.5",
+        "autolinker": "3.16.1",
+        "fast-json-patch": "3.1.1"
     }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2402,12 +2402,12 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autolinker@^3.11.0:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-3.14.2.tgz#71856274eb768fb7149039e24d3a2be2f5c55a63"
-  integrity sha512-VO66nXUCZFxTq7fVHAaiAkZNXRQ1l3IFi6D5P7DLoyIEAn2E8g7TWbyEgLlz1uW74LfWmu1A17IPWuPQyGuNVg==
+autolinker@3.16.1, autolinker@^3.11.0:
+  version "3.16.1"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-3.16.1.tgz#92f015cd4f4e5fcb81a41794de0c210a57f95883"
+  integrity sha512-DaCB8hJAVC7gfCMeh+rJ2iJEIMpbvCWzY5Bm3/i7Am7ZDrvpy4tZxMTYoc3iuvZqABrogfRgqPyxfA9ExATWaQ==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.3.0"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -4277,10 +4277,10 @@ fast-diff@^1.1.1:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-json-patch@^3.0.0-1:
-  version "3.0.0-1"
-  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz#4c68f2e7acfbab6d29d1719c44be51899c93dabb"
-  integrity sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw==
+fast-json-patch@3.1.1, fast-json-patch@^3.0.0-1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
+  integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
@@ -9803,7 +9803,7 @@ ts-node@^9.1.1:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -9812,6 +9812,11 @@ tslib@^2.0.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslint-config-prettier@^1.18.0:
   version "1.18.0"


### PR DESCRIPTION
This fixes the following:

```
Issues with no direct upgrade or patch:
  ✗ Authentication Bypass by Spoofing [High Severity][https://security.snyk.io/vuln/SNYK-JS-AUTOLINKER-2438289] in autolinker@3.14.2
    introduced by swagger-ui-react@4.12.0 > remarkable@2.0.1 > autolinker@3.14.2
  This issue was fixed in versions: 3.16.1
  ✗ Prototype Pollution [High Severity][https://security.snyk.io/vuln/SNYK-JS-FASTJSONPATCH-3182961] in fast-json-patch@3.0.0-1
    introduced by swagger-ui-react@4.12.0 > swagger-client@3.18.5 > fast-json-patch@3.0.0-1
  This issue was fixed in versions: 3.1.1

```