### PR TITLE
docs: Fix comments

### DIFF
--- a/docs/walk-through/loops.md
+++ b/docs/walk-through/loops.md
@@ -55,9 +55,7 @@ metadata:
 spec:
   entrypoint: loop-map-example
   templates:
-  - name: loop-map-example parameter specifies the list to iterate over
-
-
+  - name: loop-map-example # parameter specifies the list to iterate over
     steps:
     - - name: test-linux
         template: cat-os-release


### PR DESCRIPTION
An error occurred in the example due to the lack of annotation symbols.
Add missing symbols and delete blank lines.

Fixes #TODO
