### PR TITLE
docs: Add changelog instructions to release docs

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,7 +15,7 @@ Ignore:
 * Fixes for features only on master.
 * Dependency upgrades, unless it fixes a known security issue.
 
-Cherry-pick a the first commit. Run `make test` locally before pushing. If the build timeouts the build caches may have
+Cherry-pick the first commit. Run `make test` locally before pushing. If the build timeouts the build caches may have
 gone, try re-running.
 
 Don't cherry-pick another commit until the CI passes. It is harder to find the cause of a new failed build if the last
@@ -32,8 +32,19 @@ Push a new tag to the release branch. E.g.:
 
 ```bash
 git tag v3.3.4
-git push upstream v3.3.4 ;# or origin if you do not use upstream
+git push upstream v3.3.4 # or origin if you do not use upstream
 ```
 
-Github Actions will automatically build and publish your release. This takes about 1h. Set your self a reminder to check
+GitHub Actions will automatically build and publish your release. This takes about 1h. Set your self a reminder to check
 this was successful.
+
+## Update Changelog
+
+Once the tag is published, GitHub Actions will automatically open a PR to update the changelog. Once the PR is ready,
+you can approve it, enable auto-merge, and then run the following to force trigger the CI build:
+
+```bash
+git checkout --track upstream/create-pull-request/changelog
+git commit -s --allow-empty -m "docs: Force trigger CI"
+git push upstream create-pull-request/changelog
+```


### PR DESCRIPTION
The CI is not triggered for changelog PRs. These notes could be useful.