### PR TITLE
fix: Workflow operation error. Fixes #10285

### DIFF
--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -55,7 +55,10 @@ func (woc *wfOperationCtx) taskResultReconciliation() {
 	for _, obj := range objs {
 		result := obj.(*wfv1.WorkflowTaskResult)
 		nodeID := result.Name
-		old := woc.wf.Status.Nodes[nodeID]
+		old, exist := woc.wf.Status.Nodes[nodeID]
+		if !exist {
+			continue
+		}
 		new := old.DeepCopy()
 		if result.Outputs.HasOutputs() {
 			if new.Outputs == nil {


### PR DESCRIPTION
Say why you made your changes.
fix issue that stop/termante workflow then retry meet error: Workflow operation error
https://github.com/argoproj/argo-workflows/issues/10285

Say what changes you made.
Update taskresult.go, when does not get node by node id, do not return the empty node

Say how you tested your changes.
I  merge this change to v3.3.10, retry as described in issue https://github.com/argoproj/argo-workflows/issues/10285, this issue does not appear


<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
