### PR TITLE
fix: Flaky test about lifecycle hooks. Fixes #10897

### DIFF
--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,5 +1,5 @@
-//go:build functional
-// +build functional
+//go:build functional || local
+// +build functional local
 
 package e2e
 
@@ -187,6 +187,15 @@ spec:
                 template: hook
               failed:
                 expression: steps["step-1"].status == "Failed"
+                template: hook
+            template: argosay
+        - - name: step-2
+            hooks:
+              running:
+                expression: steps["step-2"].status == "Running"
+                template: hook
+              failed:
+                expression: steps["step-2"].status == "Failed"
                 template: hook
             template: argosay
     - name: argosay

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,5 +1,5 @@
-//go:build functional || local
-// +build functional local
+//go:build functional
+// +build functional
 
 package e2e
 
@@ -187,15 +187,6 @@ spec:
                 template: hook
               failed:
                 expression: steps["step-1"].status == "Failed"
-                template: hook
-            template: argosay
-        - - name: step-2
-            hooks:
-              running:
-                expression: steps["step-2"].status == "Running"
-                template: hook
-              failed:
-                expression: steps["step-2"].status == "Failed"
                 template: hook
             template: argosay
     - name: argosay

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -45,7 +45,8 @@ spec:
     - name: argosay
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -88,12 +89,14 @@ spec:
     - name: argosay
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay", "sleep 5", "exit 1"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay; exit 1"]
         
     - name: hook
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -143,7 +146,8 @@ spec:
     - name: argosay
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -192,11 +196,13 @@ spec:
     - name: argosay
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay", "sleep 5", "exit 1"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay; exit 1"]
     - name: hook
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -248,7 +254,8 @@ spec:
     - name: argosay
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -298,11 +305,13 @@ spec:
     - name: argosay
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay", "sleep 5", "exit 1"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay; exit 1"]
     - name: hook
       container:
         image: argoproj/argosay:v2
-        command: ["/argosay"]
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,6 +1,7 @@
 //go:build functional
 // +build functional
 
+
 package e2e
 
 import (

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,7 +1,6 @@
 //go:build functional
 // +build functional
 
-
 package e2e
 
 import (

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -46,7 +46,7 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay"]
+        args: ["/bin/sleep 1; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -90,13 +90,13 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay; exit 1"]
+        args: ["/bin/sleep 1; /argosay; exit 1"]
         
     - name: hook
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay"]
+        args: ["/bin/sleep 1; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -147,7 +147,7 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay"]
+        args: ["/bin/sleep 1; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -197,12 +197,12 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay; exit 1"]
+        args: ["/bin/sleep 1; /argosay; exit 1"]
     - name: hook
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay"]
+        args: ["/bin/sleep 1; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -255,7 +255,7 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay"]
+        args: ["/bin/sleep 1; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -306,12 +306,12 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay; exit 1"]
+        args: ["/bin/sleep 1; /argosay; exit 1"]
     - name: hook
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 3; /argosay"]
+        args: ["/bin/sleep 1; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,7 +1,6 @@
 //go:build functional
 // +build functional
 
-
 package e2e
 
 import (
@@ -47,7 +46,7 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
+        args: ["/bin/sleep 3; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -91,13 +90,13 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay; exit 1"]
+        args: ["/bin/sleep 3; /argosay; exit 1"]
         
     - name: hook
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
+        args: ["/bin/sleep 3; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -148,7 +147,7 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
+        args: ["/bin/sleep 3; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -198,12 +197,12 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay; exit 1"]
+        args: ["/bin/sleep 3; /argosay; exit 1"]
     - name: hook
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
+        args: ["/bin/sleep 3; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -256,7 +255,7 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
+        args: ["/bin/sleep 3; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -307,12 +306,12 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay; exit 1"]
+        args: ["/bin/sleep 3; /argosay; exit 1"]
     - name: hook
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
+        args: ["/bin/sleep 3; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).


### PR DESCRIPTION
Fixes #10897
also relate with https://github.com/argoproj/argo-workflows/issues/10807#issuecomment-1503807149

This issue unreproducible at local but pretty consistent on ci enviroment.
I guess if task end to early, running hook can't meet conditions so never trigger. (on slow environment)

This issue can prevent by sleeping 1 second.

You guys think this is bug that need to make new ticket?

