### PR TITLE
chore: Fix formatting in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,5 +26,5 @@ updates:
       - dependency-name: raw-loader
       - dependency-name: style-loader
       - dependency-name: react-router-dom
-      - dependency-name: @types/react-router-dom
+      - dependency-name: "@types/react-router-dom"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes the following error from https://jsonformatter.org/yaml-validator:

```
Error : bad indentation of a sequence entry at line 29, column 26:
          - dependency-name: @types/react-router-dom
                             ^
Line : undefined  undefined
```

and the following error in https://github.com/argoproj/argo-workflows/network/updates:
```
(<unknown>): found character that cannot start any token while scanning for the next token at line 29 column 26
```