### PR TITLE
docs: Artifact GC documentation around dealing with failures needed improvement 

### DIFF
--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -241,7 +241,9 @@ If you don't use your own `ServiceAccount` and are just using `default` ServiceA
 
 ### What happens if Garbage Collection fails?
 
-If deletion of the artifact fails for some reason (other than the Artifact already have been deleted which is not considered a failure), the Workflow's Status will be marked with a new Condition to indicate "Artifact GC Failure", a Kubernetes Event will be issued, and the Argo Server UI will also indicate the failure. In that case, if the user needs to delete the Workflow and its child CRD objects, the user will need to patch the Workflow to remove the finalizer preventing the deletion:
+If deletion of the artifact fails for some reason (other than the Artifact already having been deleted which is not considered a failure), the Workflow's Status will be marked with a new Condition to indicate "Artifact GC Failure", a Kubernetes Event will be issued, and the Argo Server UI will also indicate the failure. For additional debugging, the user should find 1 or more Pods named `<wfName>-artgc-*` and can view the logs.
+
+If the user needs to delete the Workflow and its child CRD objects, they will need to patch the Workflow to remove the finalizer preventing the deletion:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -258,7 +260,7 @@ kubectl patch workflow my-wf \
     --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
 ```
 
-Or use the Argo CLI `argo delete` command with flag `--force`, which under the hood removes the finalizer before performing the deletion.
+Or for simplicity use the Argo CLI `argo delete` command with flag `--force`, which under the hood removes the finalizer before performing the deletion.
 
 ### Release Versions >= 3.5
 

--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -258,6 +258,8 @@ kubectl patch workflow my-wf \
     --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
 ```
 
+Or use the Argo CLI `argo delete` command with flag `--force`, which under the hood removes the finalizer before performing the deletion.
+
 ### Release Versions >= 3.5
 
 A flag has been added to the Workflow Spec called `forceFinalizerRemoval` (see [here](../fields.md#workflowlevelartifactgc)) to force the finalizer's removal even if Artifact GC fails:


### PR DESCRIPTION
Ahead of the kubecon presentation on Artifact GC, took another glance at the Artifact GC documentation, and it could use some improvement. (This will be referenced in the slides.)



<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
