### PR TITLE
feat: compress bearer token (fixes #10153 #9530)

### DIFF
--- a/config/sso.go
+++ b/config/sso.go
@@ -21,6 +21,8 @@ type SSOConfig struct {
 	CustomGroupClaimName string `json:"customGroupClaimName,omitempty"`
 	UserInfoPath         string `json:"userInfoPath,omitempty"`
 	InsecureSkipVerify   bool   `json:"insecureSkipVerify,omitempty"`
+	CompressBearerToken  bool   `json:"compressBearerToken,omitempty"`
+	MaxConcurrentUsers   int    `json:"maxConcurrentUsers,omitempty"`
 }
 
 func (c SSOConfig) GetSessionExpiry() time.Duration {
@@ -28,4 +30,11 @@ func (c SSOConfig) GetSessionExpiry() time.Duration {
 		return c.SessionExpiry.Duration
 	}
 	return 10 * time.Hour
+}
+
+func (c SSOConfig) GetMaxConcurrentUsers() int {
+	if c.MaxConcurrentUsers > 0 {
+		return c.MaxConcurrentUsers
+	}
+	return 1000
 }

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
+++ b/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
@@ -16,6 +16,7 @@ data:
     - profile
     rbac:
       enabled: true
+    compressBearerToken: true
 kind: ConfigMap
 metadata:
   name: workflow-controller-configmap

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -8,11 +8,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/google/uuid"
-	"k8s.io/utils/lru"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"k8s.io/utils/lru"
 
 	"github.com/argoproj/argo-workflows/v3/config"
 


### PR DESCRIPTION
# Description
- Implementing the change after discussion with @sarabala1979 
- Currently users logging in via SSO with lot of groups, exceed the 4KB Cookie limit
- This happens because we send the full set of claims as part of cookie
- Inorder to fix this, instead of the full encrypted claims, we will just generate a UUID and send it as part of the cookie
- And we will use this UUID for authorization
- Users can choose to opt in by setting `compressBearerToken` to `true` (defaults to `false`)
- Users can also control max number of sessions to keep in memory by `maxConcurrentUsers` (defaults to 1000)
- Any change in config will require a restart

# Knows issues
- Whenever the argo server restarts, users will have to re-login
- Might have to increase argo server memory if the users have extremely large claims

Fixes #10153 #9530 

# Before
<img width="683" alt="Screenshot 2023-04-15 at 11 17 50" src="https://user-images.githubusercontent.com/20828431/232187024-180a9fc7-f27f-40a9-80f7-9e7a8fd7044c.png">

# After
<img width="375" alt="Screenshot 2023-04-15 at 10 52 31" src="https://user-images.githubusercontent.com/20828431/232184743-ea138d11-931b-4a2a-a35b-8111e5d1baf3.png">

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
