### PR TITLE
fix: Generate useful error message when no expression on hook

### DIFF
--- a/workflow/controller/hooks.go
+++ b/workflow/controller/hooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/util/expr/argoexpr"
 	"github.com/argoproj/argo-workflows/v3/util/expr/env"
@@ -18,12 +19,15 @@ func (woc *wfOperationCtx) executeWfLifeCycleHook(ctx context.Context, tmplCtx *
 		if hookName == wfv1.ExitLifecycleEvent {
 			continue
 		}
+		hookNodeName := generateLifeHookNodeName(woc.wf.ObjectMeta.Name, string(hookName))
+		if hook.Expression == "" {
+			return true, errors.Errorf(errors.CodeBadRequest, "Expression required for hook %s", hookNodeName)
+		}
 		execute, err := argoexpr.EvalBool(hook.Expression, env.GetFuncMap(template.EnvMap(woc.globalParams)))
 		if err != nil {
 			return true, err
 		}
 		if execute {
-			hookNodeName := generateLifeHookNodeName(woc.wf.ObjectMeta.Name, string(hookName))
 			woc.log.WithField("lifeCycleHook", hookName).WithField("node", hookNodeName).Infof("Running workflow level hooks")
 			hookNode, err := woc.executeTemplate(ctx, hookNodeName, &wfv1.WorkflowStep{Template: hook.Template, TemplateRef: hook.TemplateRef}, tmplCtx, hook.Arguments, &executeTemplateOpts{})
 			if err != nil {
@@ -53,6 +57,10 @@ func (woc *wfOperationCtx) executeTmplLifeCycleHook(ctx context.Context, scope *
 		if hookName == wfv1.ExitLifecycleEvent {
 			continue
 		}
+		hookNodeName := generateLifeHookNodeName(parentNode.Name, string(hookName))
+		if hook.Expression == "" {
+			return false, errors.Errorf(errors.CodeBadRequest, "Expression required for hook %s", hookNodeName)
+		}
 		execute, err := argoexpr.EvalBool(hook.Expression, env.GetFuncMap(template.EnvMap(woc.globalParams.Merge(scope.getParameters()))))
 		if err != nil {
 			return false, err
@@ -63,7 +71,6 @@ func (woc *wfOperationCtx) executeTmplLifeCycleHook(ctx context.Context, scope *
 				lastChildNode := getChildNodeIndex(parentNode, woc.wf.Status.Nodes, -1)
 				outputs = lastChildNode.Outputs
 			}
-			hookNodeName := generateLifeHookNodeName(parentNode.Name, string(hookName))
 			woc.log.WithField("lifeCycleHook", hookName).WithField("node", hookNodeName).WithField("hookName", hookName).Info("Running hooks")
 			resolvedArgs := hook.Arguments
 			var err error

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -123,6 +123,18 @@ func SubstituteResourceManifestExpressions(manifest string) string {
 	return manifest
 }
 
+// validateHooks takes an array of hooks to validate and the name of the
+// container they are in and generates an error for the first invalid hook
+// or nil if they are all valid
+func validateHooks(hooks wfv1.LifecycleHooks, hookBaseName string) error {
+	for hookName, hook := range hooks {
+		if hookName != wfv1.ExitLifecycleEvent && hook.Expression == "" {
+			return errors.Errorf(errors.CodeBadRequest, "%s.%s %s", hookBaseName, hookName, "Expression required")
+		}
+	}
+	return nil
+}
+
 // ValidateWorkflow accepts a workflow and performs validation against it.
 func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wf *wfv1.Workflow, opts ValidateOpts) error {
 	ctx := newTemplateValidationCtx(wf, opts)
@@ -264,6 +276,10 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 		if err != nil {
 			return err
 		}
+	}
+	err = validateHooks(wf.Spec.Hooks, "hooks")
+	if err != nil {
+		return err
 	}
 
 	if !wf.Spec.PodGC.GetStrategy().IsValid() {
@@ -911,6 +927,11 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 				ctx.addOutputsToScope(resolvedTmpl, fmt.Sprintf("steps.%s", step.Name), scope, false, false)
 			}
 			resolvedTemplates[step.Name] = resolvedTmpl
+
+			err = validateHooks(step.Hooks, fmt.Sprintf("templates.%s.steps[%d].%s", tmpl.Name, i, step.Name))
+			if err != nil {
+				return err
+			}
 		}
 
 		stepBytes, err := json.Marshal(stepGroup)


### PR DESCRIPTION
The error message for a missing or empty expression was `unable to evaluate expression '': unexpected token EOF (1:1)`. This changes it to a more useful `Expression required for hook <hook path>`.

Also attempt to validate to prevent this problem upfront.

Fixes #10910
