### PR TITLE
docs: Add Swagger UI to the API reference page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -618,7 +618,7 @@ docs/cli/argo.md: $(CLI_PKGS) go.sum server/static/files.go hack/cli/main.go
 .PHONY: docs-spellcheck
 docs-spellcheck: /usr/local/bin/mdspell
 	# check docs for spelling mistakes
-	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name fields.md -not -name upgrading.md -not -name executor_swagger.md -not -path '*/cli/*')
+	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name fields.md -not -name upgrading.md -not -name swagger.md -not -name executor_swagger.md -not -path '*/cli/*')
 
 /usr/local/bin/markdown-link-check:
 	npm i -g markdown-link-check
@@ -626,7 +626,7 @@ docs-spellcheck: /usr/local/bin/mdspell
 .PHONY: docs-linkcheck
 docs-linkcheck: /usr/local/bin/markdown-link-check
 	# check docs for broken links
-	markdown-link-check -q -c .mlc_config.json $(shell find docs -name '*.md' -not -name fields.md -not -name executor_swagger.md)
+	markdown-link-check -q -c .mlc_config.json $(shell find docs -name '*.md' -not -name fields.md -not -name swagger.md -not -name executor_swagger.md)
 
 /usr/local/bin/markdownlint:
 	npm i -g  markdownlint-cli
@@ -634,7 +634,7 @@ docs-linkcheck: /usr/local/bin/markdown-link-check
 .PHONY: docs-lint
 docs-lint: /usr/local/bin/markdownlint
 	# lint docs
-	markdownlint docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md
+	markdownlint docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md
 
 /usr/local/bin/mkdocs:
 	python -m pip install mkdocs==1.2.4 mkdocs_material==8.1.9  mkdocs-spellcheck==0.2.1

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,3 +1,27 @@
 # API Reference
 
-[Open the Swagger API docs](https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/openapi-spec/swagger.json).
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta
+  name="description"
+  content="SwaggerUI"
+  />
+  <title>SwaggerUI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css" />
+ </head>
+ <body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js" crossorigin></script>
+  <script>
+   window.onload = () => {
+   window.ui = SwaggerUIBundle({
+    url: "https://raw.githubusercontent.com/argoproj/argo-workflows/master/api/openapi-spec/swagger.json",
+    dom_id: "#swagger-ui",
+   });
+   };
+  </script>
+ </body>
+</html>


### PR DESCRIPTION
### Description
Currently the link in the [API reference page](https://argoproj.github.io/argo-workflows/swagger/) points to the API spec in JSON, which is not readable. This PR adds a simple HTML code snippet that renders Swagger UI with the spec to `swagger.md` so that it displays the API docs directly.

We can also put the HTML code in a separate file and simply make the link in the API reference page point to that file. I think it's more straightforward to embed Swagger UI like this.

One issue with Swagger UI is that it's slow when it loads information about a certain path or schema after a user clicks on it. This is probably because the API spec is too large. I tested generating Swagger UI in static HTML, but it also took some time for my browser to load a certain path.

### Test
`make docs`

Though I also updated Makefile to exempt `swagger.md` from checks because it has HTML code, which is not allowed by the linter.

### Screenshot

![Peek 2023-04-15 10-31](https://user-images.githubusercontent.com/4591982/232202949-b67f3ae9-7fbd-4c11-88a5-d74fcb3dc42b.gif)
