### PR TITLE
chore: Adjust gc_controller log to be more accurate. Fixes #10929

### DIFF
--- a/workflow/gccontroller/gc_controller.go
+++ b/workflow/gccontroller/gc_controller.go
@@ -215,7 +215,7 @@ func (c *Controller) deleteWorkflow(ctx context.Context, key string) error {
 			return err
 		}
 	} else {
-		log.Infof("Successfully deleted '%s'", key)
+		log.Infof("Successfully request '%s' to be deleted", key)
 	}
 	return nil
 }


### PR DESCRIPTION
- Say why you made your changes:
This log can not reflect the workflow which is to be deleted correctly. The call of Delete function returns nil does not mean the workflow has been successfully. We have seen it in production environment sometimes which is confused us.

- Say what changes you made:
Adjust the log msg.

- Say how you tested your changes:
Add finalizer and wait gc_controller to delete

Fixes #10929
<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
