### PR TITLE
chore: Change K8s request logs to debug level

### DIFF
--- a/util/logs/log-k8s-requests.go
+++ b/util/logs/log-k8s-requests.go
@@ -17,7 +17,7 @@ func (m k8sLogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	x, err := m.roundTripper.RoundTrip(r)
 	if x != nil {
 		verb, kind := k8s.ParseRequest(r)
-		log.Infof("%s %s %d", verb, kind, x.StatusCode)
+		log.Debugf("%s %s %d", verb, kind, x.StatusCode)
 	}
 	return x, err
 }


### PR DESCRIPTION
These are too verbose. They should be at debug level.

```
time="2023-04-18T15:09:31.320Z" level=info msg="Get leases 200"
time="2023-04-18T15:09:31.336Z" level=info msg="Update leases 200"
time="2023-04-18T15:09:36.355Z" level=info msg="Get leases 200"
time="2023-04-18T15:09:36.364Z" level=info msg="Update leases 200"
```