### PR TITLE
feat(operator): Add hostNodeName as a template variable

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -53,6 +53,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Commodus Tech](https://www.commodus.tech)
 1. [Concierge Render](https://www.conciergerender.com)
 1. [Cookpad](https://cookpad.com/)
+1. [Coralogix](https://coralogix.com)
 1. [CoreFiling](https://www.corefiling.com/)
 1. [CoreWeave Cloud](https://www.coreweave.com)
 1. [Cratejoy](https://www.cratejoy.com/)

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -143,6 +143,7 @@ returns `0`. Please review the Sprig documentation to understand which functions
 | `steps.<STEPNAME>.exitCode` | Exit code of any previous script or container step |
 | `steps.<STEPNAME>.startedAt` | Time-stamp when the step started |
 | `steps.<STEPNAME>.finishedAt` | Time-stamp when the step finished |
+| `steps.<TASKNAME>.hostNodeName` | Host node where task ran |
 | `steps.<STEPNAME>.outputs.result` | Output result of any previous container or script step |
 | `steps.<STEPNAME>.outputs.parameters` | When the previous step uses `withItems` or `withParams`, this contains a JSON array of the output parameter maps of each invocation |
 | `steps.<STEPNAME>.outputs.parameters.<NAME>` | Output parameter of any previous step. When the previous step uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
@@ -159,6 +160,7 @@ returns `0`. Please review the Sprig documentation to understand which functions
 | `tasks.<TASKNAME>.exitCode` | Exit code of any previous script or container task |
 | `tasks.<TASKNAME>.startedAt` | Time-stamp when the task started |
 | `tasks.<TASKNAME>.finishedAt` | Time-stamp when the task finished |
+| `tasks.<TASKNAME>.hostNodeName` | Host node where task ran |
 | `tasks.<TASKNAME>.outputs.result` | Output result of any previous container or script task |
 | `tasks.<TASKNAME>.outputs.parameters` | When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter maps of each invocation |
 | `tasks.<TASKNAME>.outputs.parameters.<NAME>` | Output parameter of any previous task. When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2829,6 +2829,10 @@ func (woc *wfOperationCtx) buildLocalScope(scope *wfScope, prefix string, node *
 		key := fmt.Sprintf("%s.status", prefix)
 		scope.addParamToScope(key, string(node.Phase))
 	}
+	if node.HostNodeName != "" {
+		key := fmt.Sprintf("%s.hostNodeName", prefix)
+		scope.addParamToScope(key, string(node.HostNodeName))
+	}
 	woc.addOutputsToLocalScope(prefix, node.Outputs, scope)
 }
 

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3977,6 +3977,7 @@ status:
         cpu: 10
         memory: 0
       startedAt: "2020-04-02T16:29:18Z"
+      hostNodeName: ip-127-0-1-1
       templateName: influxdb
       type: Pod
     daemon-step-dvbnn-3639466923:
@@ -4020,6 +4021,7 @@ func TestRetryNodeOutputs(t *testing.T) {
 	assert.Contains(t, scope.scope, "steps.influx.id")
 	assert.Contains(t, scope.scope, "steps.influx.startedAt")
 	assert.Contains(t, scope.scope, "steps.influx.finishedAt")
+	assert.Contains(t, scope.scope, "steps.influx.hostNodeName")
 }
 
 var workflowWithPVCAndFailingStep = `

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -963,6 +963,7 @@ func (ctx *templateValidationCtx) addOutputsToScope(tmpl *wfv1.Template, prefix 
 	scope[fmt.Sprintf("%s.id", prefix)] = true
 	scope[fmt.Sprintf("%s.startedAt", prefix)] = true
 	scope[fmt.Sprintf("%s.finishedAt", prefix)] = true
+	scope[fmt.Sprintf("%s.hostNodeName", prefix)] = true
 	if tmpl.Daemon != nil && *tmpl.Daemon {
 		scope[fmt.Sprintf("%s.ip", prefix)] = true
 	}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -143,6 +143,7 @@ spec:
       - name: startedat
       - name: finishedat
       - name: id
+      - name: hostnodename
     container:
       image: alpine:3.7
       command: [echo, "{{inputs.parameters.message}}"]
@@ -166,6 +167,8 @@ spec:
             value: "test"
           - name: id
             value: "1"
+          - name: hostnodename
+            value: "test"
       - name: B
         dependencies: [A]
         template: echo
@@ -179,6 +182,8 @@ spec:
             value: "{{tasks.A.finishedAt}}"
           - name: id
             value: "{{tasks.A.id}}"
+          - name: hostnodename
+            value: "{{tasks.A.hostNodeName}}"
       - name: C
         dependencies: [B]
         template: echo
@@ -192,6 +197,8 @@ spec:
             value: "{{tasks.A.finishedAt}}"
           - name: id
             value: "{{tasks.A.id}}"
+          - name: hostnodename
+            value: "{{tasks.A.hostNodeName}}"
 `
 
 var dagResolvedVarNotAncestor = `


### PR DESCRIPTION
This PR adds the ability to template tasks hostNodeName. We would like to use it to utilize some node local caching/setups (eg with things like node attached SSDs).  
This will make our lives easier with templating nodeSelectors.

I've also added my current employer as a user; please let me know if you wish it to be in a different PR.

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
