### PR TITLE
feat(exit_handler): Make current step outputs available to exit handler expressions

### DIFF
--- a/docs/lifecyclehook.md
+++ b/docs/lifecyclehook.md
@@ -25,7 +25,7 @@ In other words, a `LifecycleHook` functions like an [exit handler](https://githu
 
 ## Unsupported conditions
 
-- [`outputs`](https://argoproj.github.io/argo-workflows/fields/#outputs) are not usable since `LifecycleHook` executes during execution time and `outputs` are not produced until the step is completed. You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status variable are available there so you can still conditionally decide what to do.
+- [`outputs`](https://argoproj.github.io/argo-workflows/fields/#outputs) are not usable since `LifecycleHook` executes during execution time and `outputs` are not produced until the step is completed. You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status and output variables (for completed steps, including the current step), are there so you can still conditionally decide what to do.
 
 ## Notification use case
 

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -282,6 +282,8 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		if !childNode.Fulfilled() {
 			completed = false
 		} else if childNode.Completed() {
+			prefix := fmt.Sprintf("steps.%s", step.Name)
+			woc.buildLocalScope(stepsCtx.scope, prefix, &childNode)
 			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.GetExitHook(woc.execWf.Spec.Arguments), &childNode, stepsCtx.boundaryID, stepsCtx.tmplCtx, "steps."+step.Name, stepsCtx.scope)
 			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
 				// The onExit node is either not complete or has errored out, return.


### PR DESCRIPTION
The [documentation][docs] currently states

> You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status variable are available there so you can still conditionally decide what to do.

This implies that expressions will have outputs from the current step available too. They don't though - the scope for an exit hook does not have the outputs in it.

It should be possible to do this for exit hooks. They only run when their step is finished. When that is the case, their outputs will be available. Add current step outputs to the exit hook's context. This allows much more powerful exit hook expressions to be written, such as sending a message conditionally if a certain output is set. For example, imagine a step which opens a pull request which may be a draft. That would be an output parameter, and we could conditionally run an exit hook to post a status update in that case.

Beef up the tests to verify that previous step outputs are there also.

(All of this applies to DAG tasks too.)

[docs]: https://argoproj.github.io/argo-workflows/lifecyclehook/#unsupported-conditions