### PR TITLE
docs(sso): cluster SA _must_ be mapped to before NS SA can apply

### DIFF
--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -65,7 +65,7 @@ sso:
 ```
 
 !!! Note
-    Not all OIDC provider support the groups scope. Please speak to your provider about their options.
+    Not all OIDC providers support the `groups` scope. Please speak to your provider about their options.
 
 To configure a service account to be used, annotate it:
 
@@ -96,7 +96,7 @@ metadata:
 
 If no rule matches, we deny the user access.
 
-TIp: You'll probably want to configure a default account to use if no other rule matches, e.g. a read-only account, you can do this as follows:
+Tip: You'll probably want to configure a default account to use if no other rule matches, e.g. a read-only account, you can do this as follows:
 
 ```yaml
 metadata:
@@ -135,6 +135,9 @@ metadata:
     workflows.argoproj.io/rbac-rule: "true"
     workflows.argoproj.io/rbac-rule-precedence: "0"
 ```
+
+!!! Note
+    All users MUST map to a cluster service account (such as the one above) before a namespace service account can apply.
 
 Now, for the namespace that you own, configure a service account which would allow members of your team to perform operations in your namespace.
 Make sure that the precedence of the namespace service account is higher than the precedence of the login service account. Create appropriate role that you want to grant to this service account and bind it with a role-binding.


### PR DESCRIPTION
## Summary

Add a `!!! Note` section to the cluster SA for NS delegation explicitly stating that it is _required_

## Details

- my team did not realize that this was strictly required before NS delegation would work, so we had a pretty confusing time of debugging
  - in particular we thought the RO "optional" suggestion meant that if we didn't want to give users RO to the whole cluster, we could skip it -- but it actually means that we don't have to give any RBAC at the cluster level at all, but still do need _some_ SA, even if it has no RBAC bound to it
  - there's a decent bit of nuance here, so figure this can be more explicitly called out as a pre-req as such

- also fix some typos / grammar / formatting on this page

## References

Something else my team and I had trouble with while debugging #10927

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
