### PR TITLE
docs: add `CONTRIBUTING.md` at root of repo, directing to `docs/`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Add a root `CONTRIBUTING.md` that directs to `docs/CONTRIBUTING.md`

## Details

- having a `CONTRIBUTING.md` at the root of the repo is a common convention
  - I looked at the root of the repo initially, didn't find it, then checked the website, but potential contributors may think it doesn't exist as a result

<!--

Do not open a PR until you have:

* Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
* [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
* Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


When you open your PR

* "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
* Create the PR as draft.
* Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->
