### PR TITLE
fix: Match retryConditional example with its summary

### DIFF
--- a/examples/retry-conditional.yaml
+++ b/examples/retry-conditional.yaml
@@ -30,7 +30,7 @@ spec:
         parameters:
             - name: safe-to-retry
       retryStrategy:
-        limit: "3"
+        limit: "10"
         # Only continue retrying if the last exit code is greater than 1 and the input parameter is true
         expression: "asInt(lastRetry.exitCode) > 1 && {{inputs.parameters.safe-to-retry}} == true"
       script:


### PR DESCRIPTION
The retry-conditional example summary says it'll try a maximum of 10 times, but the limit was set to 3.

This matches the limit to the description.
