### PR TITLE
ci: add PR title conventional commits checker

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+name: PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
To provide the same contributing settings for Argo projects. since other projects like the argo-rollouts and argo-cd have already adopted the PR title checker to conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).