### PR TITLE
feat: Add lastRetry.message

### DIFF
--- a/docs/retries.md
+++ b/docs/retries.md
@@ -63,7 +63,7 @@ access to the following variables:
 - `lastRetry.exitCode`: The exit code of the last retry, or "-1" if not available
 - `lastRetry.status`: The phase of the last retry: Error, Failed
 - `lastRetry.duration`: The duration of the last retry, in seconds
-- `lastRetry.message`: The message output from the last retry
+- `lastRetry.message`: The message output from the last retry (available from version 3.5)
 
 If `expression` evaluates to false, the step will not be retried.
 

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -63,6 +63,7 @@ access to the following variables:
 - `lastRetry.exitCode`: The exit code of the last retry, or "-1" if not available
 - `lastRetry.status`: The phase of the last retry: Error, Failed
 - `lastRetry.duration`: The duration of the last retry, in seconds
+- `lastRetry.message`: The message output from the last retry
 
 If `expression` evaluates to false, the step will not be retried.
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -189,8 +189,9 @@ When using the `expression` field within `retryStrategy`, special variables are 
 | Variable | Description|
 |----------|------------|
 | `lastRetry.exitCode` | Exit code of the last retry |
-| `lastRetry.Status` | Status of the last retry |
-| `lastRetry.Duration` | Duration in seconds of the last retry |
+| `lastRetry.status` | Status of the last retry |
+| `lastRetry.duration` | Duration in seconds of the last retry |
+| `lastRetry.message` | Message output from the last retry |
 
 Note: These variables evaluate to a string type. If using advanced expressions, either cast them to int values (`expression: "{{=asInt(lastRetry.exitCode) >= 2}}"`) or compare them to string values (`expression: "{{=lastRetry.exitCode != '2'}}"`).
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -191,7 +191,7 @@ When using the `expression` field within `retryStrategy`, special variables are 
 | `lastRetry.exitCode` | Exit code of the last retry |
 | `lastRetry.status` | Status of the last retry |
 | `lastRetry.duration` | Duration in seconds of the last retry |
-| `lastRetry.message` | Message output from the last retry |
+| `lastRetry.message` | Message output from the last retry (available from version 3.5) |
 
 Note: These variables evaluate to a string type. If using advanced expressions, either cast them to int values (`expression: "{{=asInt(lastRetry.exitCode) >= 2}}"`) or compare them to string values (`expression: "{{=lastRetry.exitCode != '2'}}"`).
 

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -224,6 +224,8 @@ const (
 	LocalVarRetriesLastStatus = "lastRetry.status"
 	// LocalVarRetriesLastDuration is a variable that references information about the last retry's duration, in seconds
 	LocalVarRetriesLastDuration = "lastRetry.duration"
+	// LocalVarRetriesLastMessage is a variable that references information about the last retry's failure message
+	LocalVarRetriesLastMessage = "lastRetry.message"
 
 	KubeConfigDefaultMountPath    = "/kube/config"
 	KubeConfigDefaultVolumeName   = "kubeconfig"

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1729,6 +1729,7 @@ func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[s
 	localScope[common.LocalVarRetriesLastExitCode] = exitCode
 	localScope[common.LocalVarRetriesLastStatus] = string(lastChildNode.Phase)
 	localScope[common.LocalVarRetriesLastDuration] = fmt.Sprint(lastChildNode.GetDuration().Seconds())
+	localScope[common.LocalVarRetriesLastMessage] = lastChildNode.Message
 
 	return localScope
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7861,11 +7861,12 @@ func TestBuildRetryStrategyLocalScope(t *testing.T) {
 
 	localScope := buildRetryStrategyLocalScope(retryNode, wf.Status.Nodes)
 
-	assert.Len(t, localScope, 4)
+	assert.Len(t, localScope, 5)
 	assert.Equal(t, "1", localScope[common.LocalVarRetries])
 	assert.Equal(t, "1", localScope[common.LocalVarRetriesLastExitCode])
 	assert.Equal(t, string(wfv1.NodeFailed), localScope[common.LocalVarRetriesLastStatus])
 	assert.Equal(t, "6", localScope[common.LocalVarRetriesLastDuration])
+	assert.Equal(t, "Error (exit code 1)", localScope[common.LocalVarRetriesLastMessage])
 }
 
 var exitHandlerWithRetryNodeParam = `

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -415,10 +415,12 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 		localParams[common.LocalVarRetriesLastExitCode] = placeholderGenerator.NextPlaceholder()
 		localParams[common.LocalVarRetriesLastStatus] = placeholderGenerator.NextPlaceholder()
 		localParams[common.LocalVarRetriesLastDuration] = placeholderGenerator.NextPlaceholder()
+		localParams[common.LocalVarRetriesLastMessage] = placeholderGenerator.NextPlaceholder()
 		scope[common.LocalVarRetries] = placeholderGenerator.NextPlaceholder()
 		scope[common.LocalVarRetriesLastExitCode] = placeholderGenerator.NextPlaceholder()
 		scope[common.LocalVarRetriesLastStatus] = placeholderGenerator.NextPlaceholder()
 		scope[common.LocalVarRetriesLastDuration] = placeholderGenerator.NextPlaceholder()
+		scope[common.LocalVarRetriesLastMessage] = placeholderGenerator.NextPlaceholder()
 	}
 	if tmpl.IsLeaf() {
 		for _, art := range tmpl.Outputs.Artifacts {


### PR DESCRIPTION
As requested in #9937 add a message field to lastRetry to allow fine grained control of retries.

Tested with unit test and a manually with a simple workflow which conditionally retried on `lastRetry.message=="some words"`

Fixes #9937
