### PR TITLE
fix: ui getPodName should use v2 format by default (fixes #11015)

### DIFF
--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -28,9 +28,12 @@ describe('pod names', () => {
     });
 
     test('getPodName', () => {
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, POD_NAME_V2)).toEqual('wfname-templatename-1454367246');
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, POD_NAME_V1)).toEqual(nodeID);
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, '')).toEqual(nodeID);
+        const v1podName = nodeID;
+        const v2podName = `${shortWfName}-${shortTemplateName}-${createFNVHash(nodeName)}`;
+        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, POD_NAME_V2)).toEqual(v2podName);
+        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, POD_NAME_V1)).toEqual(v1podName);
+        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, '')).toEqual(v2podName);
+        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, undefined)).toEqual(v2podName);
 
         const name = getPodName(longWfName, nodeName, longTemplateName, nodeID, POD_NAME_V2);
         expect(name.length).toEqual(maxK8sResourceNameLength);

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -6,12 +6,11 @@ export const POD_NAME_V2 = 'v2';
 export const maxK8sResourceNameLength = 253;
 export const k8sNamingHashLength = 10;
 
-// getPodName returns a deterministic pod name. It returns a combination of the
-// workflow name, template name, and a hash if the POD_NAME_V2 annotation is
-// set. If the templateName or templateRef is not defined on a given node, it
-// falls back to POD_NAME_V1
+// getPodName returns a deterministic pod name
+// In case templateName is not defined or that version is explicitly set to  POD_NAME_V1, it will return the nodeID (v1)
+// In other cases it will return a combination of workflow name, template name, and a hash (v2)
 export const getPodName = (workflowName: string, nodeName: string, templateName: string, nodeID: string, version: string): string => {
-    if (version === POD_NAME_V2 && templateName !== '') {
+    if (version !== POD_NAME_V1 && templateName !== '') {
         if (workflowName === nodeName) {
             return workflowName;
         }


### PR DESCRIPTION
I noticed that sometimes the UI shows the wrong pod name. Specifically for running pods.

I noticed that this change https://github.com/argoproj/argo-workflows/commit/cc9d14cf0d60812e177ebb447181df933199b722 made pod name format v2 to be default even when the annotation is missing in the backend, but this behavior was never coded into the UI code.

This tries to fix it.

Fixes #11015

