### PR TITLE
fix: Remove 401 Unauthorized when customClaimGroup retrieval fails, Fixes #11032

### DIFF
--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -263,8 +263,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	if s.customClaimName != "" {
 		groups, err = c.GetCustomGroup(s.customClaimName)
 		if err != nil {
-			w.WriteHeader(401)
-			return
+			log.Warn(err)
 		}
 	}
 


### PR DESCRIPTION
Changed way customClaimGroups are handled in `server/auth/sso/sso.go` `HandleCallback`. 

Before: if failed to retrieve, throws 401 Unauthorized 
After: keeps `groups` nil, logs the error encountered

Fixes #11032