### PR TITLE
fix: change pod OwnerReference to clean workflowtaskresults in large-scale scenarios

### DIFF
--- a/workflow/executor/taskresult.go
+++ b/workflow/executor/taskresult.go
@@ -52,7 +52,7 @@ func (we *WorkflowExecutor) createTaskResult(ctx context.Context, result wfv1.No
 		[]metav1.OwnerReference{
 			{
 				APIVersion: "v1",
-				Kind:       "pods",
+				Kind:       "Pod",
 				Name:       we.PodName,
 				UID:        we.podUID,
 			},


### PR DESCRIPTION
In large-scale scenarios on cloud, we find the are so many workflowtaskresults left in the cluster (over a million), causing the cluster to fail to work. After investigation, we determined that there is something wrong with the pod owner reference.