### PR TITLE
chore: Fix missing resources when running E2E tests with postgres profile

### DIFF
--- a/test/e2e/manifests/postgres/kustomization.yaml
+++ b/test/e2e/manifests/postgres/kustomization.yaml
@@ -2,14 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../../../manifests/quick-start/postgres
+  - ../../../../manifests/quick-start/postgres
+  - https://raw.githubusercontent.com/argoproj/argo-events/stable/manifests/base/crds/argoproj.io_eventbus.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-events/stable/manifests/base/crds/argoproj.io_eventsources.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-events/stable/manifests/base/crds/argoproj.io_sensors.yaml
+  - ../mixins/argo-server.service-account-token-secret.yaml
 
 patchesStrategicMerge:
-- ../mixins/argo-server-deployment.yaml
-- ../mixins/workflow-controller-configmap.yaml
-- ../mixins/workflow-controller-deployment.yaml
-- ../mixins/cluster-workflow-template-rbac.yaml
-- ../mixins/minio-deployment.yaml
+  - ../mixins/argo-server-deployment.yaml
+  - ../mixins/workflow-controller-configmap.yaml
+  - ../mixins/workflow-controller-deployment.yaml
+  - ../mixins/cluster-workflow-template-rbac.yaml
+  - ../mixins/minio-deployment.yaml
 
 commonLabels:
   app.kubernetes.io/part-of: argo


### PR DESCRIPTION
Fix missing resources(eventbus, eventsources, sensors) when running E2E tests with postgres profile.