### PR TITLE
docs: Fix link to Argo CLI help page

### DIFF
--- a/util/help/topics.go
+++ b/util/help/topics.go
@@ -3,7 +3,7 @@ package help
 const (
 	root       = "https://argoproj.github.io/argo-workflows"
 	ArgoServer = root + "/argo-server/"
-	CLI        = root + "/cli/"
+	CLI        = root + "/cli/argo"
 
 	WorkflowTemplates                          = root + "/workflow-templates/"
 	WorkflowTemplatesReferencingOtherTemplates = WorkflowTemplates + "#referencing-other-workflowtemplates"


### PR DESCRIPTION
Getting an error message:
```
FATA[2023-05-16T16:05:39.091Z] this is impossible if you are not using the Argo Server, see https://argoproj.github.io/argo-workflows/cli/ 
```

However, the page https://argoproj.github.io/argo-workflows/cli/ has empty content.