### PR TITLE
fix: Fixed path separator in .tgz output artifacts created on windows. Fixes #10562

### DIFF
--- a/util/archive/archive.go
+++ b/util/archive/archive.go
@@ -88,7 +88,7 @@ func tarDir(sourcePath string, tw *tar.Writer) error {
 		if err != nil {
 			return errors.InternalWrapError(err)
 		}
-		nameInArchive = filepath.Join(baseName, nameInArchive)
+		nameInArchive = filepath.ToSlash(filepath.Join(baseName, nameInArchive))
 		log.Debugf("writing %s", nameInArchive)
 		count++
 


### PR DESCRIPTION
### Motivation

Output artifacts in .tgz format that are created on Windows result in wrong directory and file structure when unpacked by 7-zip or on Linux.

Example:
1. Folder structure Windows is
`A\B\C.txt `

2. An output artifact in .tgz format is generated from this (on Windows)

3. The resulting .tgz archive is opened in 7zip
```
(folder) "A\"
(folder) "A\B\"
(file)   "A\B\C.txt"
```

### Modifications

When generating the tar archive the pathes that are written to the tar-file's file header are converted to use forward slashes instead of backslashes independent of the current operation systems path format.

### Verification

When the above example is repeaded after this fix then 7zip shows the correct folder structure:
```
(folder) A
(folder)   B
(file)       C.txt
```
