### PR TITLE
fix: Setup /etc/hosts for running inside devcontainer

### DIFF
--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
 set -eux
 
+# Add hosts
+sudo bash -c 'echo "127.0.0.1 dex" >> /etc/hosts'
+sudo bash -c 'echo "127.0.0.1 minio" >> /etc/hosts'
+sudo bash -c 'echo "127.0.0.1 postgres" >> /etc/hosts'
+sudo bash -c 'echo "127.0.0.1 mysql" >> /etc/hosts'
+sudo bash -c 'echo "127.0.0.1 azurite" >> /etc/hosts'
+
 # install kubernetes
 wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 k3d cluster get k3s-default || k3d cluster create --wait


### PR DESCRIPTION
If you attempt `make start` from inside a devcontainer you will be told you need to setup various entries in hosts as per docs/running-locally.md. This fix does that step for you.

### Motivation

I develop inside the supplied devcontainer with just the devcontainer CLI, and this commit would mean I can skip a step in getting started.

### Modifications

Only changes to the devcontainer startup. There are few other options as to how to do this change, as /etc/hosts is initially managed by devcontainer itself.

### Verification

After the change /etc/hosts in a container brought up with `devcontainer up` contain the entries listed in running-locally.md that are necessary for make start.