### PR TITLE
fix: Disable unreliable test

### DIFF
--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -903,6 +904,9 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 	})
 
 	t.Run("PendingShuttingdownStoppingWf", func(t *testing.T) {
+		if githubActions, ok := os.LookupEnv(`GITHUB_ACTIONS`); ok && githubActions == "true" {
+			t.Skip("This test regularly fails in Github Actions CI")
+		}
 		// Create and acquire the lock for the first workflow
 		wf := wfv1.MustUnmarshalWorkflow(pendingWfWithShutdownStrategy)
 		wf.Name = "one-stopping"


### PR DESCRIPTION
### Motivation

The test TestSynchronizationForPendingShuttingdownWfs/PendingShuttingdownStoppingWf regularly fails in github actions unit test stage.

This should probably be looked at, but for now stop needing quite so many retries to push through simple changes.

### Modifications

Commented out test with a note on reason why.
