### PR TITLE
chore: update go to 1.20 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.19"
+      "version": "1.20"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "16"


### PR DESCRIPTION
### Motivation

Commit a5581f83abd4b6d45b1bad6c9a5d471077e8427f updated golang required to build in go.mod to 1.20.

This makes the devcontainer compatible

### Modifications

Update the version of golang to 1.20 in the devcontainer specification

### Verification

Smoke test that I can now run make using this container, as opposed to it failing immediately.