### PR TITLE
docs: Remove references to Couler in examples

### DIFF
--- a/examples/coinflip.yaml
+++ b/examples/coinflip.yaml
@@ -9,8 +9,7 @@ metadata:
   generateName: coinflip-
   annotations:
     workflows.argoproj.io/description: |
-      This is an example of coin flip defined as a sequence of conditional steps.
-      You can also run it in Python: https://couler-proj.github.io/couler/examples/#coin-flip
+      This is an example of coin flip defined as a sequence of conditional steps.\
 spec:
   entrypoint: coinflip
   templates:

--- a/examples/dag-coinflip.yaml
+++ b/examples/dag-coinflip.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     workflows.argoproj.io/description: |
       This is an example of coin flip defined as a DAG.
-      You can also run it in Python: https://couler-proj.github.io/couler/examples/#dag
 spec:
   entrypoint: diamond
   templates:

--- a/examples/hello-world.yaml
+++ b/examples/hello-world.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     workflows.argoproj.io/description: |
       This is a simple hello world example.
-      You can also run it in Python: https://couler-proj.github.io/couler/examples/#hello-world
 spec:
   entrypoint: whalesay
   templates:


### PR DESCRIPTION
Couler is no longer actively maintained by me: https://github.com/couler-proj/couler