### PR TITLE
feat: Add `Check All` checkbox to workflow dag filter options. Fixes #11129

### DIFF
--- a/ui/src/app/shared/components/filter-drop-down.tsx
+++ b/ui/src/app/shared/components/filter-drop-down.tsx
@@ -36,8 +36,8 @@ export const FilterDropDown = (props: FilterDropDownProps) => {
                                 .map(([label, checked]) => (
                                     <li key={label} className={classNames('top-bar__filter-item')}>
                                         <React.Fragment>
-                                            <Checkbox id={`filter__${label}`} checked={checked} onChange={v => item.onChange(label, v)} />
-                                            <label htmlFor={`filter__${label}`}>{label}</label>
+                                            <Checkbox id={`filter__${i}_${label}`} checked={checked} onChange={v => item.onChange(label, v)} />
+                                            <label htmlFor={`filter__${i}_${label}`}>{label}</label>
                                         </React.Fragment>
                                     </li>
                                 ))}


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11129 

### Motivation

So users don't have to manually check and uncheck workflow DAG filter checkboxes

### Modifications

- [x] consolidate node prop interface to one, didn't need 3 IMO
- [x] DRY up checkbox handling
- [x] add `Select All` checkbox
- [x] fixed bug where if you clicked a checkbox under one grouping that had same label
as another group, it would alter the checked state of the other group.  This was due
to non-unique ID attribute.  Changed it so IDs were unique by including grouping index.

<!-- TODO: Attach screenshots if you changed the UI. -->

All unchecked, `Select All` unchecked:

![Screenshot 2023-05-25 at 12 59 37 PM](https://github.com/argoproj/argo-workflows/assets/35014/ee93f589-d0a3-4aaa-a722-86c17606312d)

All checked, `Select All` is checked:

![Screenshot 2023-05-25 at 12 59 44 PM](https://github.com/argoproj/argo-workflows/assets/35014/20114386-52c6-463d-a806-76a1cd61aab9)

One unchecked, `Select All` is unchecked:

![Screenshot 2023-05-25 at 12 59 50 PM](https://github.com/argoproj/argo-workflows/assets/35014/d26dc72c-ce26-4fd8-9d89-0fa6a401fc5f)

### Verification

Tested locally/manually
