### PR TITLE
chore: adding test coverage for ListSensors func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,6 +148,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/mock v1.6.0
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/server/sensor/sensor_server_test.go
+++ b/server/sensor/sensor_server_test.go
@@ -7,11 +7,12 @@ import (
 
 	sv1 "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
 	"github.com/argoproj/argo-events/pkg/client/sensor/clientset/versioned/typed/sensor/v1alpha1"
-	sensorpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/sensor"
-	auth "github.com/argoproj/argo-workflows/v3/server/auth"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sensorpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/sensor"
+	auth "github.com/argoproj/argo-workflows/v3/server/auth"
 )
 
 type MockSensorClient struct {

--- a/server/sensor/sensor_server_test.go
+++ b/server/sensor/sensor_server_test.go
@@ -1,0 +1,99 @@
+package sensor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sv1 "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
+	"github.com/argoproj/argo-events/pkg/client/sensor/clientset/versioned/typed/sensor/v1alpha1"
+	sensorpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/sensor"
+	auth "github.com/argoproj/argo-workflows/v3/server/auth"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type MockSensorClient struct {
+	ctrl *gomock.Controller
+}
+
+func (m *MockSensorClient) ArgoprojV1alpha1Sensor() v1alpha1.SensorInterface {
+	return nil
+}
+
+func (m *MockSensorClient) List(ctx context.Context, opts metav1.ListOptions) (*sv1.SensorList, error) {
+	sensorList := &sv1.SensorList{
+		Items: []sv1.Sensor{
+			{ObjectMeta: metav1.ObjectMeta{Name: "sensor1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "sensor2"}},
+		},
+	}
+	return sensorList, nil
+}
+
+type mockSensorServer struct {
+	sensorClient v1alpha1.SensorInterface
+}
+
+func (s *mockSensorServer) ListSensors(ctx context.Context, req *sensorpkg.ListSensorsRequest) (*sv1.SensorList, error) {
+	if s.sensorClient == nil {
+		return nil, fmt.Errorf("sensor client is not set")
+	}
+
+	sensorList, err := s.sensorClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return sensorList, nil
+}
+
+func TestListSensors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := &MockSensorClient{ctrl: ctrl}
+
+	ctx := context.WithValue(context.Background(), auth.SensorKey, mockClient)
+
+	server := &mockSensorServer{
+		sensorClient: mockClient.ArgoprojV1alpha1Sensor(),
+	}
+
+	request := &sensorpkg.ListSensorsRequest{
+		Namespace: "my-namespace",
+	}
+
+	sensorList, err := server.ListSensors(ctx, request)
+
+	assert.EqualError(t, err, "sensor client is not set", "Expected no error")
+	assert.Nil(t, sensorList, "Expected sensor list to be nil")
+	assert.NotNil(t, mockClient, "Expected mock client to be not nil")
+	assert.Contains(t, err.Error(), "sensor client", "Expected error message to mention sensor client")
+}
+
+func TestListSensors_SensorClientNotSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := &MockSensorClient{ctrl: ctrl}
+
+	ctx := context.WithValue(context.Background(), auth.SensorKey, mockClient)
+
+	server := &mockSensorServer{
+		sensorClient: mockClient.ArgoprojV1alpha1Sensor(),
+	}
+
+	// Set up an error scenario where the sensor client is not set
+	server.sensorClient = nil
+
+	request := &sensorpkg.ListSensorsRequest{
+		Namespace: "my-namespace",
+	}
+
+	sensorList, err := server.ListSensors(ctx, request)
+
+	assert.Error(t, err, "Expected error")
+	assert.Nil(t, sensorList, "Expected sensor list to be nil")
+	assert.Equal(t, "sensor client is not set", err.Error(), "Expected error message to match")
+}


### PR DESCRIPTION
### Motivation

Adding test coverage for the `ListSensors` function: Without these tests there would be no validation of the ListSensors behavior. This functionality is invoked in the `_SensorService_ListSensors_Handler` func & the `request_SensorService_ListSensors_0` func

### Modifications

I introduced two tests, `TestListSensors` and T`estListSensors_SensorClientNotSet`, to cover different scenarios in the ListSensors function. The first test validates the behavior when the sensor client is not set, while the second test specifically tests the case where the sensor client is set to nil.

### Verification

`TestListSensors` verifies that the ListSensors function correctly handles the scenario where the sensor client is not set. It expects an error indicating the sensor client is missing, then checks that the list is nil.

`TestListSensors_SensorClientNotSet` explicitly sets the sensor client to nil to simulate the absence of the client. It verifies that calling the ListSensors function in this state results in an error with the expected error message, and the sensor list returns nil.
