### PR TITLE
feat: mainEntrypoint variable

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -275,7 +275,7 @@ For `Template`-level metrics:
 
 ### Knowing where you are
 
-The idea with creating a `WorkflowTemplate` is that they are reusable bits of code you will using in many actual Workflows. Sometimes it is useful to know which workflow you are part of.
+The idea with creating a `WorkflowTemplate` is that they are reusable bits of code you will use in many actual Workflows. Sometimes it is useful to know which workflow you are part of.
 
 `workflow.mainEntrypoint` is one way you can do this. If each of your actual workflows has a differing entrypoint, you can identify the workflow you're part of. Given this use in a `WorkflowTemplate`:
 
@@ -332,4 +332,4 @@ spec:
 
 results in a log of `bar`
 
-This shouldn't that helpful in logging, you should be able to identify workflows through other labels in your clusters log tool, but can be helpful when generating metrics for the workflow for example.
+This shouldn't be that helpful in logging, you should be able to identify workflows through other labels in your cluster's log tool, but can be helpful when generating metrics for the workflow for example.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -44,7 +44,7 @@ The tag is substituted with the variable that has a name the same as the tag.
 Simple tags **may** have white-space between the brackets and variable as seen below. However, there is a known issue where variables may fail to interpolate with white-space, so it is recommended to avoid using white-space until this issue is resolved. [Please report](https://github.com/argoproj/argo-workflows/issues/8960) unexpected behavior with reproducible examples.
 
 ```yaml
-args: [ "{{ inputs.parameters.message }}" ]  
+args: [ "{{ inputs.parameters.message }}" ]
 ```
 
 ### Expression
@@ -247,6 +247,7 @@ For `Template`-level metrics:
 |----------|------------|
 | `workflow.name` | Workflow name |
 | `workflow.namespace` | Workflow namespace |
+| `workflow.mainEntrypoint` | Workflow's initial entrypoint |
 | `workflow.serviceAccountName` | Workflow service account name |
 | `workflow.uid` | Workflow UID. Useful for setting ownership reference to a resource, or a unique artifact location |
 | `workflow.parameters.<NAME>` | Input parameter to the workflow |
@@ -271,3 +272,64 @@ For `Template`-level metrics:
 |----------|------------|
 | `workflow.status` | Workflow status. One of: `Succeeded`, `Failed`, `Error` |
 | `workflow.failures` | A list of JSON objects containing information about nodes that failed or errored during execution. Available fields: `displayName`, `message`, `templateName`, `phase`, `podName`, and `finishedAt`. |
+
+### Knowing where you are
+
+The idea with creating a `WorkflowTemplate` is that they are reusable bits of code you will using in many actual Workflows. Sometimes it is useful to know which workflow you are part of.
+
+`workflow.mainEntrypoint` is one way you can do this. If each of your actual workflows has a differing entrypoint, you can identify the workflow you're part of. Given this use in a `WorkflowTemplate`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: say-main-entrypoint
+spec:
+  entrypoint: echo
+  templates:
+  - name: echo
+    container:
+      image: alpine
+      command: [echo]
+      args: ["{{workflow.mainEntrypoint}}"]
+```
+
+I can distinguish my caller:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: foo-
+spec:
+  entrypoint: foo
+  templates:
+    - name: foo
+      steps:
+      - - name: step
+          templateRef:
+            name: say-main-entrypoint
+            template: echo
+```
+
+results in a log of `foo`
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: bar-
+spec:
+  entrypoint: bar
+  templates:
+    - name: bar
+      steps:
+      - - name: step
+          templateRef:
+            name: say-main-entrypoint
+            template: echo
+```
+
+results in a log of `bar`
+
+This shouldn't that helpful in logging, you should be able to identify workflows through other labels in your clusters log tool, but can be helpful when generating metrics for the workflow for example.

--- a/test/e2e/functional/entrypointName-template.yaml
+++ b/test/e2e/functional/entrypointName-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: next-template
+spec:
+  entrypoint: next
+  templates:
+  - name: next
+    inputs:
+      parameters:
+        - name: test
+          value: "{{ workflow.mainEntrypoint }}"
+    container:
+      image: alpine
+      command: [echo]
+      args: ["We got here!"]

--- a/test/e2e/functional/entrypointName-workflow.yaml
+++ b/test/e2e/functional/entrypointName-workflow.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: bar-
+spec:
+  entrypoint: bar
+  templates:
+    - name: bar
+      steps:
+      - - name: step
+          templateRef:
+            name: next-template
+            template: next

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1184,3 +1184,19 @@ func (s *FunctionalSuite) TestTemplateDefaultImage() {
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded)
 }
+
+func (s *FunctionalSuite) TestEntrypointName() {
+	s.Given().
+		WorkflowTemplate(`@functional/entrypointName-template.yaml`).
+		Workflow(`@functional/entrypointName-workflow.yaml`).
+		When().
+		CreateWorkflowTemplates().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflowNode(wfv1.NodeWithDisplayName("step"), func(t *testing.T, n *wfv1.NodeStatus, p *apiv1.Pod) {
+			assert.Equal(t, wfv1.NodeSucceeded, n.Phase)
+			assert.Equal(t, "bar", n.Inputs.Parameters[0].Value.String())
+		})
+
+}

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -167,6 +167,8 @@ const (
 	GlobalVarWorkflowName = "workflow.name"
 	// GlobalVarWorkflowNamespace is a global workflow variable referencing the workflow's metadata.namespace field
 	GlobalVarWorkflowNamespace = "workflow.namespace"
+	// GlobalVarWorkflowMainEntrypoint is a global workflow variable referencing the workflow's top level entrypoint name
+	GlobalVarWorkflowMainEntrypoint = "workflow.mainEntrypoint"
 	// GlobalVarWorkflowServiceAccountName is a global workflow variable referencing the workflow's spec.serviceAccountName field
 	GlobalVarWorkflowServiceAccountName = "workflow.serviceAccountName"
 	// GlobalVarWorkflowUID is a global workflow variable referencing the workflow's metadata.uid field

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -581,6 +581,7 @@ func (woc *wfOperationCtx) getWorkflowDeadline() *time.Time {
 func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Arguments) error {
 	woc.globalParams[common.GlobalVarWorkflowName] = woc.wf.ObjectMeta.Name
 	woc.globalParams[common.GlobalVarWorkflowNamespace] = woc.wf.ObjectMeta.Namespace
+	woc.globalParams[common.GlobalVarWorkflowMainEntrypoint] = woc.execWf.Spec.Entrypoint
 	woc.globalParams[common.GlobalVarWorkflowServiceAccountName] = woc.execWf.Spec.ServiceAccountName
 	woc.globalParams[common.GlobalVarWorkflowUID] = string(woc.wf.ObjectMeta.UID)
 	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp] = woc.wf.ObjectMeta.CreationTimestamp.Format(time.RFC3339)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -66,6 +66,7 @@ func newTemplateValidationCtx(wf *wfv1.Workflow, opts ValidateOpts) *templateVal
 	globalParams := make(map[string]string)
 	globalParams[common.GlobalVarWorkflowName] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowNamespace] = placeholderGenerator.NextPlaceholder()
+	globalParams[common.GlobalVarWorkflowMainEntrypoint] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowServiceAccountName] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowUID] = placeholderGenerator.NextPlaceholder()
 	return &templateValidationCtx{


### PR DESCRIPTION
Issue #6772 asks for the template name, but we cannot always know what this is (simplest unknowable is kubectl apply of a workflow with a generateName). This is a split from PR #10745 to just provide the variable mainEndpoint, which is set to the name of the invoked entrypoint, which is controllable, knowable, and could be used in the same way, and seems like a useful thing to have anyway.

### Verification

See new test cases for verification.