### PR TITLE
fix: Make devcontainer able to pre-commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,4 +16,8 @@
   "onCreateCommand": ".devcontainer/pre-build.sh",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/go/src/github.com/argoproj/argo-workflows,type=bind",
   "workspaceFolder": "/home/vscode/go/src/github.com/argoproj/argo-workflows"
+  "remoteEnv": {
+	"PATH": "${containerEnv:PATH}:/home/vscode/go/bin",
+    "GOPATH": "/home/vscode/go"
+  }
 }

--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -22,5 +22,12 @@ kubectl cluster-info
 # install kit
 curl -q https://raw.githubusercontent.com/kitproj/kit/main/install.sh | sh
 
+# install protocol buffer compiler (protoc)
+sudo apt update
+sudo apt install -y protobuf-compiler
+
+# Make sure go path is owned by vscode
+sudo chown -R vscode:vscode /home/vscode/go
+
 # download dependencies and do first-pass compile
 CI=1 kit pre-up


### PR DESCRIPTION
make pre-commit doesn't work in devcontainer, with this commit it does.


### Motivation

I'd like an easy way for everyone to be able to maintain workflows, and devcontainers are nearly there.

### Modifications

This fixes that by
a) Moving GOPATH to /home/vscode/go
b) Installing protoc (apt package protobuf-compiler)
c) Ensuring ~/go is writable (so subdirs can be created)
d) Ensuring /home/vscode/go/bin is on the path too

Using /home/vscode/go rather than /go is necessary when doing all the protocol malarky due to requirements on subdirectories.

### Verification

Launched a new devcontainer with these changes, and ensure `make pre-commit` reaches the end successfully. The resulting tree is unchanged, so all the generated code matches that in git.