### PR TITLE
docs: mention PodGC `strategy` default in examples

### DIFF
--- a/examples/pod-gc-strategy-with-label-selector.yaml
+++ b/examples/pod-gc-strategy-with-label-selector.yaml
@@ -14,6 +14,7 @@ spec:
     # * OnPodSuccess - delete pods immediately when pod is successful
     # * OnWorkflowCompletion - delete pods when workflow is completed
     # * OnWorkflowSuccess - delete pods when workflow is successful
+    # Default: do not delete pods
     strategy: OnPodSuccess
     # Use label selector to only delete the pods whose labels match with the specified label selector (available since v3.0.0-rc3).
     labelSelector:

--- a/examples/pod-gc-strategy.yaml
+++ b/examples/pod-gc-strategy.yaml
@@ -12,6 +12,7 @@ spec:
     # * OnPodSuccess - delete pods immediately when pod is successful
     # * OnWorkflowCompletion - delete pods when workflow is completed
     # * OnWorkflowSuccess - delete pods when workflow is successful
+    # Default: do not delete pods
     strategy: OnPodSuccess
 
   templates:


### PR DESCRIPTION
### Summary

Mention the default `podGC.strategy` in the examples

Follow-up to https://github.com/argoproj/argo-workflows/pull/10971#pullrequestreview-1403456869

### Motivation

Same as #10971

### Modifications

Add a line in `pod-gc-strategy` and `pod-gc-strategy-with-label-selector` that mentions the default for `podGC.strategy`

### Verification

- by default, Pods are not deleted: https://github.com/argoproj/argo-workflows/blob/1ba8d317113509c48d9a7959f2bee6ee2e812802/pkg/apis/workflow/v1alpha1/workflow_types.go#L1050
