### PR TITLE
feat(ui): Ignore missing vars in custom links

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -35,4 +35,4 @@ In addition to the above variables, we can now access all [workflow fields](fiel
 For example, one may find it useful to define a custom label in the workflow and access it by `${workflow.metadata.labels.custom_label_name}`
 
 We can also access workflow fields in a pod link. For example, `${workflow.metadata.name}` returns
-the name of the workflow instead of the name of the pod.
+the name of the workflow instead of the name of the pod. If the field doesn't exist on the workflow then the value will be an empty string.

--- a/ui/src/app/shared/components/links.test.ts
+++ b/ui/src/app/shared/components/links.test.ts
@@ -43,4 +43,17 @@ describe('process URL', () => {
 
         expect(ProcessURL('https://logging?from=${status.startedAtEpoch}&to=${status.finishedAtEpoch}', object)).toBe(`https://logging?from=null&to=null`);
     });
+
+    test('ignore missing workflow var', () => {
+        const object = {
+            status: {},
+            workflow: {
+                annotations: {
+                    logQuery: 'query=env:qa'
+                }
+            }
+        };
+
+        expect(ProcessURL('https://logging?${workflow.annotations.logQuery}${workflow.annotations.additionalLogParams}', object)).toBe('https://logging?query=env:qa');
+    });
 });

--- a/ui/src/app/shared/components/links.tsx
+++ b/ui/src/app/shared/components/links.tsx
@@ -24,12 +24,11 @@ const addEpochTimestamp = (jsonObject: {metadata: ObjectMeta; workflow?: Workflo
 export const ProcessURL = (url: string, jsonObject: any) => {
     addEpochTimestamp(jsonObject);
     /* replace ${} from input url with corresponding elements from object
-    return null if element is not found*/
+    only return null for known variables, otherwise empty string*/
     return url.replace(/\${[^}]*}/g, x => {
-        const res = x
-            .replace(/(\$%7B|%7D|\${|})/g, '')
-            .split('.')
-            .reduce((p: any, c: string) => (p && p[c]) || null, jsonObject);
+        const parts = x.replace(/(\$%7B|%7D|\${|})/g, '').split('.');
+        const emptyVal = parts[0] === 'workflow' ? '' : null;
+        const res = parts.reduce((p: any, c: string) => (p && p[c]) || emptyVal, jsonObject);
         return res;
     });
 };


### PR DESCRIPTION
### Motivation

Some workflows have specific context which can help greatly in the logs. This would allow the custom link created to optionally contain values from the workflow. As it stands now, `null` is returned which messes up the url.

ex: The link can have a url
`https://app.datadoghq.com/logs?query=pod_name:${metadata.name}-*&from_ts=${status.startedAtEpoch}&to_ts=${status.finishedAtEpoch}&live=false${workflow.metadta.annotations.additionalLogParams}`.
For the workflows that have defined `metadata.annotations.additionalLogParams: '&col=service,@client_id'` the link will be something like 
`https://app.datadoghq.com/logs?query=pod_name:mypod-*&from_ts=874654846548764464&to_ts=null&live=false&col=service,12345` 
and for those that don't have it defined the url will be
`https://app.datadoghq.com/logs?query=pod_name:mypod-*&from_ts=874654846548764464&to_ts=null&live=false`

### Modifications

Updated the UI code responsible for generating the links to return empty strings if the object is source off of `workflow` during the url interpolation process. 
Documentation updated to reflect this.

No visual changes, so no screenshots.

### Verification

Added tests
