### PR TITLE
fix: Argo DB init conflict when deploy workflow-controller with multiple replicas #11177

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -187,8 +187,6 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		wfc.executorPlugins = map[string]map[string]*spec.Plugin{}
 	}
 
-	wfc.UpdateConfig(ctx)
-
 	wfc.metrics = metrics.New(wfc.getMetricsServerConfig())
 	wfc.entrypoint = entrypoint.New(kubeclientset, wfc.Config.Images)
 
@@ -239,6 +237,9 @@ var indexers = cache.Indexers{
 // Run starts an Workflow resource controller
 func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWorkers, podCleanupWorkers int) {
 	defer runtimeutil.HandleCrash(runtimeutil.PanicHandlers...)
+
+	// init DB after leader election (if enabled)
+	wfc.UpdateConfig(ctx)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
Fixes #11177

### Motivation
Fix Argo DB init conflict when deploy workflow-controller with multiple replicas.

### Modifications
Move the DB init logic to after the leader election completed.

### Verification
After the code modification, tested the workflow-controller deployment in my environment with 
multiple replicas (3 and 5), both work ok.
