### PR TITLE
test: add and refactor test for parameters with double and single quote for template replace

### DIFF
--- a/util/template/template_test.go
+++ b/util/template/template_test.go
@@ -11,10 +11,10 @@ type SimpleValue struct {
 	Value string `json:"value,omitempty"`
 }
 
-func processTemplate(t *testing.T, tmpl SimpleValue) SimpleValue {
+func processTemplate(t *testing.T, tmpl SimpleValue, replaceMap map[string]string) SimpleValue {
 	tmplBytes, err := json.Marshal(tmpl)
 	assert.NoError(t, err)
-	r, err := Replace(string(tmplBytes), map[string]string{}, true)
+	r, err := Replace(string(tmplBytes), replaceMap, true)
 	assert.NoError(t, err)
 	var newTmpl SimpleValue
 	err = json.Unmarshal([]byte(r), &newTmpl)
@@ -26,58 +26,65 @@ func Test_Template_Replace(t *testing.T) {
 	t.Run("ExpressionWithEscapedCharacters", func(t *testing.T) {
 		t.Run("SingleQuotes", func(t *testing.T) {
 			tmpl := SimpleValue{Value: "{{='test'}}"}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, "test", newTmpl.Value)
 		})
 		t.Run("DoubleQuotes", func(t *testing.T) {
 			tmpl := SimpleValue{Value: `{{="test"}}`}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, "test", newTmpl.Value)
 		})
 		t.Run("EscapedBackslashInString", func(t *testing.T) {
 			tmpl := SimpleValue{Value: `{{='some\\path\\with\\backslashes'}}`}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, `some\path\with\backslashes`, newTmpl.Value)
 		})
 		t.Run("EscapedNewlineInString", func(t *testing.T) {
 			tmpl := SimpleValue{Value: `{{='some\nstring\nwith\nescaped\nnewlines'}}`}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, "some\nstring\nwith\nescaped\nnewlines", newTmpl.Value)
 		})
 		t.Run("Newline", func(t *testing.T) {
 			tmpl := SimpleValue{Value: "{{=1 + \n1}}"}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, "2", newTmpl.Value)
 		})
 		t.Run("StringAsJson", func(t *testing.T) {
 			tmpl := SimpleValue{Value: "{{=toJson('test')}}"}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, `"test"`, newTmpl.Value)
 		})
 		t.Run("ObjectAsJson", func(t *testing.T) {
 			tmpl := SimpleValue{Value: "{{=toJson({test: 1})}}"}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, `{"test":1}`, newTmpl.Value)
 		})
 		t.Run("ArrayAsJson", func(t *testing.T) {
 			tmpl := SimpleValue{Value: "{{=toJson([1, '2', {an: 'object'}])}}"}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, `[1,"2",{"an":"object"}]`, newTmpl.Value)
 		})
 		t.Run("SingleQuoteAsString", func(t *testing.T) {
 			tmpl := SimpleValue{Value: `{{="'"}}`}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, `'`, newTmpl.Value)
 		})
 		t.Run("DoubleQuoteAsString", func(t *testing.T) {
 			tmpl := SimpleValue{Value: `{{='"'}}`}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, `"`, newTmpl.Value)
 		})
 		t.Run("Boolean", func(t *testing.T) {
 			tmpl := SimpleValue{Value: `{{=true == false}}`}
-			newTmpl := processTemplate(t, tmpl)
+			newTmpl := processTemplate(t, tmpl, map[string]string{})
 			assert.Equal(t, "false", newTmpl.Value)
+		})
+	})
+	t.Run("SimpleWithEscapedCharacters", func(t *testing.T) {
+		t.Run("DoubleQuoteAsString", func(t *testing.T) {
+			tmpl := SimpleValue{Value: `{{customParam}}`}
+			newTmpl := processTemplate(t, tmpl, map[string]string{"customParam": `This is " John`})
+			assert.Equal(t, `This is " John`, newTmpl.Value)
 		})
 	})
 }

--- a/util/template/template_test.go
+++ b/util/template/template_test.go
@@ -23,29 +23,46 @@ func processTemplate(t *testing.T, tmpl SimpleValue, replaceMap map[string]strin
 }
 
 func Test_Template_Replace(t *testing.T) {
-	testCases := map[string]struct {
-		input, want string
-		replaceMap  map[string]string
-	}{
-		"ExprSingleQuotes":             {input: "{{='test'}}", want: "test", replaceMap: map[string]string{}},
-		"ExprDoubleQuotes":             {input: `{{="test"}}`, want: "test", replaceMap: map[string]string{}},
-		"ExprEscapedBackslashInString": {input: `{{='some\\path\\with\\backslashes'}}`, want: `some\path\with\backslashes`, replaceMap: map[string]string{}},
-		"ExprEscapedNewlineInString":   {input: `{{='some\nstring\nwith\nescaped\nnewlines'}}`, want: "some\nstring\nwith\nescaped\nnewlines", replaceMap: map[string]string{}},
-		"ExprNewline":                  {input: "{{=1 + \n1}}", want: "2", replaceMap: map[string]string{}},
-		"ExprStringAsJson":             {input: "{{=toJson('test')}}", want: `"test"`, replaceMap: map[string]string{}},
-		"ExprObjectAsJson":             {input: "{{=toJson({test: 1})}}", want: `{"test":1}`, replaceMap: map[string]string{}},
-		"ExprArrayAsJson":              {input: "{{=toJson([1, '2', {an: 'object'}])}}", want: `[1,"2",{"an":"object"}]`, replaceMap: map[string]string{}},
-		"ExprSingleQuoteAsString":      {input: `{{="'"}}`, want: `'`, replaceMap: map[string]string{}},
-		"ExprDoubleQuoteAsString":      {input: `{{='"'}}`, want: `"`, replaceMap: map[string]string{}},
-		"ExprBoolean":                  {input: `{{=true == false}}`, want: "false", replaceMap: map[string]string{}},
-		"SimpleDoubleQuoteAsString":    {input: `{{customParam}}`, want: `This is " John`, replaceMap: map[string]string{"customParam": `This is " John`}},
-	}
+	t.Run("ExpressionWithEscapedCharacters", func(t *testing.T) {
+		testCases := map[string]struct {
+			input, want string
+		}{
+			"ExprSingleQuotes":             {input: "{{='test'}}", want: "test"},
+			"ExprDoubleQuotes":             {input: `{{="test"}}`, want: "test"},
+			"ExprEscapedBackslashInString": {input: `{{='some\\path\\with\\backslashes'}}`, want: `some\path\with\backslashes`},
+			"ExprEscapedNewlineInString":   {input: `{{='some\nstring\nwith\nescaped\nnewlines'}}`, want: "some\nstring\nwith\nescaped\nnewlines"},
+			"ExprNewline":                  {input: "{{=1 + \n1}}", want: "2"},
+			"ExprStringAsJson":             {input: "{{=toJson('test')}}", want: `"test"`},
+			"ExprObjectAsJson":             {input: "{{=toJson({test: 1})}}", want: `{"test":1}`},
+			"ExprArrayAsJson":              {input: "{{=toJson([1, '2', {an: 'object'}])}}", want: `[1,"2",{"an":"object"}]`},
+			"ExprSingleQuoteAsString":      {input: `{{="'"}}`, want: `'`},
+			"ExprDoubleQuoteAsString":      {input: `{{='"'}}`, want: `"`},
+			"ExprBoolean":                  {input: `{{=true == false}}`, want: "false"},
+		}
 
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			tmpl := SimpleValue{Value: tc.input}
-			newTmpl := processTemplate(t, tmpl, tc.replaceMap)
-			assert.Equal(t, tc.want, newTmpl.Value)
-		})
-	}
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				tmpl := SimpleValue{Value: tc.input}
+				newTmpl := processTemplate(t, tmpl, map[string]string{})
+				assert.Equal(t, tc.want, newTmpl.Value)
+			})
+		}
+	})
+
+	t.Run("SimpleWithEscapedCharacters", func(t *testing.T) {
+		testCases := map[string]struct {
+			input, want string
+			replaceMap  map[string]string
+		}{
+			"SimpleSingleQuoteAsString": {input: `{{customParam}}`, want: `This is ' John`, replaceMap: map[string]string{"customParam": `This is ' John`}},
+			"SimpleDoubleQuoteAsString": {input: `{{customParam}}`, want: `This is " John`, replaceMap: map[string]string{"customParam": `This is " John`}},
+		}
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				tmpl := SimpleValue{Value: tc.input}
+				newTmpl := processTemplate(t, tmpl, tc.replaceMap)
+				assert.Equal(t, tc.want, newTmpl.Value)
+			})
+		}
+	})
 }

--- a/util/template/template_test.go
+++ b/util/template/template_test.go
@@ -23,68 +23,29 @@ func processTemplate(t *testing.T, tmpl SimpleValue, replaceMap map[string]strin
 }
 
 func Test_Template_Replace(t *testing.T) {
-	t.Run("ExpressionWithEscapedCharacters", func(t *testing.T) {
-		t.Run("SingleQuotes", func(t *testing.T) {
-			tmpl := SimpleValue{Value: "{{='test'}}"}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, "test", newTmpl.Value)
+	testCases := map[string]struct {
+		input, want string
+		replaceMap  map[string]string
+	}{
+		"ExprSingleQuotes":             {input: "{{='test'}}", want: "test", replaceMap: map[string]string{}},
+		"ExprDoubleQuotes":             {input: `{{="test"}}`, want: "test", replaceMap: map[string]string{}},
+		"ExprEscapedBackslashInString": {input: `{{='some\\path\\with\\backslashes'}}`, want: `some\path\with\backslashes`, replaceMap: map[string]string{}},
+		"ExprEscapedNewlineInString":   {input: `{{='some\nstring\nwith\nescaped\nnewlines'}}`, want: "some\nstring\nwith\nescaped\nnewlines", replaceMap: map[string]string{}},
+		"ExprNewline":                  {input: "{{=1 + \n1}}", want: "2", replaceMap: map[string]string{}},
+		"ExprStringAsJson":             {input: "{{=toJson('test')}}", want: `"test"`, replaceMap: map[string]string{}},
+		"ExprObjectAsJson":             {input: "{{=toJson({test: 1})}}", want: `{"test":1}`, replaceMap: map[string]string{}},
+		"ExprArrayAsJson":              {input: "{{=toJson([1, '2', {an: 'object'}])}}", want: `[1,"2",{"an":"object"}]`, replaceMap: map[string]string{}},
+		"ExprSingleQuoteAsString":      {input: `{{="'"}}`, want: `'`, replaceMap: map[string]string{}},
+		"ExprDoubleQuoteAsString":      {input: `{{='"'}}`, want: `"`, replaceMap: map[string]string{}},
+		"ExprBoolean":                  {input: `{{=true == false}}`, want: "false", replaceMap: map[string]string{}},
+		"SimpleDoubleQuoteAsString":    {input: `{{customParam}}`, want: `This is " John`, replaceMap: map[string]string{"customParam": `This is " John`}},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tmpl := SimpleValue{Value: tc.input}
+			newTmpl := processTemplate(t, tmpl, tc.replaceMap)
+			assert.Equal(t, tc.want, newTmpl.Value)
 		})
-		t.Run("DoubleQuotes", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{="test"}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, "test", newTmpl.Value)
-		})
-		t.Run("EscapedBackslashInString", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{='some\\path\\with\\backslashes'}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, `some\path\with\backslashes`, newTmpl.Value)
-		})
-		t.Run("EscapedNewlineInString", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{='some\nstring\nwith\nescaped\nnewlines'}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, "some\nstring\nwith\nescaped\nnewlines", newTmpl.Value)
-		})
-		t.Run("Newline", func(t *testing.T) {
-			tmpl := SimpleValue{Value: "{{=1 + \n1}}"}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, "2", newTmpl.Value)
-		})
-		t.Run("StringAsJson", func(t *testing.T) {
-			tmpl := SimpleValue{Value: "{{=toJson('test')}}"}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, `"test"`, newTmpl.Value)
-		})
-		t.Run("ObjectAsJson", func(t *testing.T) {
-			tmpl := SimpleValue{Value: "{{=toJson({test: 1})}}"}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, `{"test":1}`, newTmpl.Value)
-		})
-		t.Run("ArrayAsJson", func(t *testing.T) {
-			tmpl := SimpleValue{Value: "{{=toJson([1, '2', {an: 'object'}])}}"}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, `[1,"2",{"an":"object"}]`, newTmpl.Value)
-		})
-		t.Run("SingleQuoteAsString", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{="'"}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, `'`, newTmpl.Value)
-		})
-		t.Run("DoubleQuoteAsString", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{='"'}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, `"`, newTmpl.Value)
-		})
-		t.Run("Boolean", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{=true == false}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{})
-			assert.Equal(t, "false", newTmpl.Value)
-		})
-	})
-	t.Run("SimpleWithEscapedCharacters", func(t *testing.T) {
-		t.Run("DoubleQuoteAsString", func(t *testing.T) {
-			tmpl := SimpleValue{Value: `{{customParam}}`}
-			newTmpl := processTemplate(t, tmpl, map[string]string{"customParam": `This is " John`})
-			assert.Equal(t, `This is " John`, newTmpl.Value)
-		})
-	})
+	}
 }


### PR DESCRIPTION
### Motivation
This PR adds some tests that were created during the investigation of #11131

### Modifications
Two new tests were added to `template_test.go`, which previously only tested templates with expressions (e.g. `{{= true == false}}`.
The new tests test the behavior of replacing variables with values from the `replaceMap`.

Also, `template_test.go` has been refactored to a table driven design, because there was a lot of duplicated code betwen the test cases.

### Verification

Ran `go test ./util/template/...`
