### PR TITLE
build: use only relevant files in build

### DIFF
--- a/dev/nix/flake.lock
+++ b/dev/nix/flake.lock
@@ -134,6 +134,21 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1681154353,
+        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1678875422,
@@ -246,6 +261,7 @@
       "inputs": {
         "devenv": "devenv",
         "flake-parts": "flake-parts",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix"
       }

--- a/dev/nix/flake.nix
+++ b/dev/nix/flake.nix
@@ -23,7 +23,7 @@
           src = filter {
             root = ../../.;
             include = [
-              "." # Way easier to tell it what to exlcude than what to include so include all. 
+              "." # Way easier to tell it what to exclude than what to include so include all. 
             ];
             exclude = [
               ".devcontainer"

--- a/dev/nix/flake.nix
+++ b/dev/nix/flake.nix
@@ -5,6 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     flake-parts = { url = "github:hercules-ci/flake-parts"; inputs.nixpkgs-lib.follows = "nixpkgs"; };
     devenv.url = "github:cachix/devenv";
+    nix-filter.url = "github:numtide/nix-filter";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };
 
@@ -16,10 +17,29 @@
         let
           argoConfig = import ./conf.nix;
           myyarn = pkgs.yarn.override { nodejs = pkgs.nodejs-16_x-openssl_1_1; };
-          src =
-            builtins.filterSource
-              (path: type: !(type == "directory" && baseNameOf path == "hack"))
-              (lib.sourceFilesBySuffices inputs.self [ ".go" ".mod" ".sum" ]);
+          filter = inputs.nix-filter.lib;
+
+          # dependencies for building the go binaries
+          src = filter {
+            root = ../../.;
+            include = [
+              "." # Way easier to tell it what to exlcude than what to include so include all. 
+            ];
+            exclude = [
+              ".devcontainer"
+              ".git"
+              ".github"
+              "community"
+              "docs"
+              "examples"
+              "hack"
+              "manifests"
+              "sdks"
+              (filter.matchExt ".md")
+              (filter.matchExt ".yaml")
+              (filter.matchExt ".yml")
+            ];
+          };
           package = {
             name = "controller";
             version = argoConfig.version;


### PR DESCRIPTION
This optimises the nix build time by depending on the required files, changing the docs for example shouldn't force a rebuild. 