### PR TITLE
fix: Workflow list page crashes for workflow rows without labels

### DIFF
--- a/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
@@ -88,7 +88,7 @@ export class WorkflowsRow extends React.Component<WorkflowsRowProps, WorkflowRow
                             </div>
                         </div>
                         {(this.props.columns || []).map(column => {
-                            const value = wf.metadata.labels[column.key];
+                            const value = wf.metadata?.labels[column.key];
                             return (
                                 <div key={column.name} className='columns small-1'>
                                     {value}


### PR DESCRIPTION
This fixes an issue that causes the workflow list page to crash when the workflow is just submitted and does not have labels yet.

```
./src/app/workflows/components/workflows-row/workflows-row.tsx/WorkflowsRow.prototype.render/WorkflowsRow<@http://localhost:8080/main.ac06adb506164b3d7bc2.js:392200:37
./src/app/workflows/components/workflows-row/workflows-row.tsx/WorkflowsRow.prototype.render@http://localhost:8080/main.ac06adb506164b3d7bc2.js:392199:48
finishClassComponent@http://localhost:8080/main.ac06adb506164b3d7bc2.js:296661:31
updateClassComponent@http://localhost:8080/main.ac06adb506164b3d7bc2.js:296611:44
beginWork@http://localhost:8080/main.ac06adb506164b3d7bc2.js:298121:16
callCallback@http://localhost:8080/main.ac06adb506164b3d7bc2.js:279689:14
invokeGuardedCallbackDev@http://localhost:8080/main.ac06adb506164b3d7bc2.js:279738:16
invokeGuardedCallback@http://localhost:8080/main.ac06adb506164b3d7bc2.js:279793:31
beginWork$1@http://localhost:8080/main.ac06adb506164b3d7bc2.js:302704:28
performUnitOfWork@http://localhost:8080/main.ac06adb506164b3d7bc2.js:301655:12
workLoopSync@http://localhost:8080/main.ac06adb506164b3d7bc2.js:301631:22
performSyncWorkOnRoot@http://localhost:8080/main.ac06adb506164b3d7bc2.js:301257:9
./node_modules/react-dom/cjs/react-dom.development.js/flushSyncCallbackQueueImpl/<@http://localhost:8080/main.ac06adb506164b3d7bc2.js:290590:24
unstable_runWithPriority@http://localhost:8080/main.ac06adb506164b3d7bc2.js:345103:12
runWithPriority$1@http://localhost:8080/main.ac06adb506164b3d7bc2.js:290540:10
flushSyncCallbackQueueImpl@http://localhost:8080/main.ac06adb506164b3d7bc2.js:290585:24
flushSyncCallbackQueue@http://localhost:8080/main.ac06adb506164b3d7bc2.js:290573:3
scheduleUpdateOnFiber@http://localhost:8080/main.ac06adb506164b3d7bc2.js:300700:9
enqueueSetState@http://localhost:8080/main.ac06adb506164b3d7bc2.js:292140:17
./node_modules/react/cjs/react.development.js/Component.prototype.setState@http://localhost:8080/main.ac06adb506164b3d7bc2.js:321916:16
./src/app/workflows/components/workflows-list/workflows-list.tsx/WorkflowsList.prototype.fetchWorkflows/this.listWatch<@http://localhost:8080/main.ac06adb506164b3d7bc2.js:391973:105
./src/app/shared/list-watch.ts/ListWatch/this.retryWatch<@http://localhost:8080/main.ac06adb506164b3d7bc2.js:384399:21
./src/app/shared/retry-observable.ts/RetryObservable.prototype.start/this.subscription<@http://localhost:8080/main.ac06adb506164b3d7bc2.js:384668:23
./node_modules/rxjs/_esm5/internal/Subscriber.js/SafeSubscriber.prototype.__tryOrUnsub@http://localhost:8080/main.ac06adb506164b3d7bc2.js:332770:16
./node_modules/rxjs/_esm5/internal/Subscriber.js/SafeSubscriber.prototype.next@http://localhost:8080/main.ac06adb506164b3d7bc2.js:332708:22
./node_modules/rxjs/_esm5/internal/Subscriber.js/Subscriber.prototype._next@http://localhost:8080/main.ac06adb506164b3d7bc2.js:332654:26
./node_modules/rxjs/_esm5/internal/Subscriber.js/Subscriber.prototype.next@http://localhost:8080/main.ac06adb506164b3d7bc2.js:332631:18
./node_modules/rxjs/_esm5/internal/operators/map.js/MapSubscriber.prototype._next@http://localhost:8080/main.ac06adb506164b3d7bc2.js:337702:26
./node_modules/rxjs/_esm5/internal/Subscriber.js/Subscriber.prototype.next@http://localhost:8080/main.ac06adb506164b3d7bc2.js:332631:18
./src/app/shared/services/requests.ts/</loadEventSource/</eventSource.onmessage@http://localhost:8080/main.ac06adb506164b3d7bc2.js:385084:68
```