### PR TITLE
fix: fix bugs in throttler and syncManager initialization in WorkflowController

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -365,7 +365,7 @@ func (wfc *WorkflowController) initManagers(ctx context.Context) error {
 		labelSelector = labelSelector.Add(*req)
 	}
 	listOpts := metav1.ListOptions{LabelSelector: labelSelector.String()}
-	wfList, err := wfc.wfclientset.ArgoprojV1alpha1().Workflows(apiv1.NamespaceAll).List(ctx, listOpts)
+	wfList, err := wfc.wfclientset.ArgoprojV1alpha1().Workflows(wfc.GetManagedNamespace()).List(ctx, listOpts)
 	if err != nil {
 		return err
 	}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -365,7 +365,7 @@ func (wfc *WorkflowController) initManagers(ctx context.Context) error {
 		labelSelector = labelSelector.Add(*req)
 	}
 	listOpts := metav1.ListOptions{LabelSelector: labelSelector.String()}
-	wfList, err := wfc.wfclientset.ArgoprojV1alpha1().Workflows(wfc.namespace).List(ctx, listOpts)
+	wfList, err := wfc.wfclientset.ArgoprojV1alpha1().Workflows(apiv1.NamespaceAll).List(ctx, listOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes #9875
fixes bugs in throttler and syncManager initialization in WorkflowController.

### Motivation

Previously, we just list all running workflows in the `wc.namespace` to initialize throttler and syncManager.
https://github.com/argoproj/argo-workflows/blob/b07de995f3d2a7a38fddb29386fc3e844fb5f30c/workflow/controller/controller.go#L368
As we can install argo-workflows as `cluster-install`, we may create workflows in any namespaces, instead of just in the `wc.namespace`. 
this initialize function may broken the throttler and syncManager if there are workflows running in other namespaces. 

