### PR TITLE
docs: Update buildkit-template.yaml

### DIFF
--- a/examples/buildkit-template.yaml
+++ b/examples/buildkit-template.yaml
@@ -134,6 +134,9 @@ spec:
           secret:
             secretName: docker-config
       container:
+        readinessProbe:
+          exec:
+            command: [ sh, -c, "buildctl debug workers" ]
         image: moby/buildkit:v0.9.3-rootless
         volumeMounts:
           - name: work


### PR DESCRIPTION
add readinessProbe

<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

we got this error `could not connect to unix:///run/buildkit/buildkitd.sock after 10 trials`, when we test buildkit-daemonless.sh build.

Add readinessProbe to make sure The buildkit service start succeeded.

https://github.com/docker/buildx/blob/bab60779cf4df24e73b5692e98f61a80555d1537/driver/kubernetes/manifest/manifest.go#L57-L63

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
