### PR TITLE
fix: Allow hooks to be specified in workflowDefaults

### DIFF
--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -16,6 +16,8 @@ func MergeTo(patch, target *wfv1.Workflow) error {
 		return nil
 	}
 
+	patchHooks := patch.Spec.Hooks
+	patch.Spec.Hooks = nil
 	patchWfBytes, err := json.Marshal(patch)
 	if err != nil {
 		return err
@@ -35,6 +37,13 @@ func MergeTo(patch, target *wfv1.Workflow) error {
 	err = json.Unmarshal(mergedWfByte, target)
 	if err != nil {
 		return err
+	}
+
+	for name, hook := range patchHooks {
+		// If the patch hook doesn't exist in target
+		if _, ok := target.Spec.Hooks[name]; !ok {
+			target.Spec.Hooks[name] = hook
+		}
 	}
 	return nil
 }

--- a/workflow/util/merge_test.go
+++ b/workflow/util/merge_test.go
@@ -271,3 +271,40 @@ func TestJoinWorkflowMetaData(t *testing.T) {
 		assert.Equal("wf", wf2.Annotations["testAnnotation"])
 	})
 }
+
+var baseHookWF = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-hello-world-
+spec:
+  hooks:
+    foo:
+      template: a
+      expression: workflow.status == "Pending"
+`
+
+var patchHookWF = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+spec:
+  hooks:
+    foo:
+      template: c
+      expression: workflow.status == "Pending"
+    bar:
+      template: b
+      expression: workflow.status == "Pending"
+`
+
+// Ensure hook bar ends up in result, but foo is unchanged
+func TestMergeHooks(t *testing.T) {
+	patchHookWf := wfv1.MustUnmarshalWorkflow(patchHookWF)
+	targetHookWf := wfv1.MustUnmarshalWorkflow(baseHookWF)
+
+	err := MergeTo(patchHookWf, targetHookWf)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(targetHookWf.Spec.Hooks))
+	assert.Equal(t, "a", targetHookWf.Spec.Hooks[`foo`].Template)
+	assert.Equal(t, "b", targetHookWf.Spec.Hooks[`bar`].Template)
+}


### PR DESCRIPTION
Any hook in workflowDefaults will cause `Error: merging object in json
but data type is not struct, instead is: map`.

This is down to how StrategicMergePatch handles maps of objects and limitations in merging them (a starting point for understading this is https://github.com/golang/go/issues/33487).

Instead, we copy the map of hooks, patch it out of the patch, perform the merge as before and then manually apply it.

Fixes: #11095

### Verification 

There is a new test that covers the merging. Verified by changing workflowDefaults to add a hook and checking that I could run the resulting workflow.