### PR TITLE
fix: default overrides not respected for empty fields. Fixes #11130

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	jsonpatch "github.com/evanphx/json-patch"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -121,11 +122,20 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			if err := json.Unmarshal(a, &c); err != nil {
 				return nil, err
 			}
-			if err = json.Unmarshal(b, &c); err != nil {
+			patch, err := jsonpatch.CreateMergePatch(a, b)
+			if err != nil {
 				return nil, err
 			}
+			result, err := jsonpatch.MergePatch(a, patch)
+			if err != nil {
+				return nil, err
+			}
+			var output apiv1.Container
+			if err := json.Unmarshal(result, &output); err != nil {
+				return nil, err
+			}
+			c = output
 		}
-
 		mainCtrs[i] = c
 	}
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11130 

### Motivation

`json.Unmarshal` ignores a field if it is set to an empty object and doesn't override in main container settings if set in `workflow-controller-configmap`

### Modifications

Used `jsonpatch` to create a merge patch for empty field overrides

### Verification

Tested locally
