### PR TITLE
fix: Treat "connection refused" error as a transient network error.

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -86,6 +86,9 @@ func isTransientNetworkErr(err error) bool {
 	} else if strings.Contains(errorString, "http2: client connection lost") {
 		// If err is http2 transport ping timeout, retry.
 		return true
+	} else if strings.Contains(errorString, "connect: connection refused") {
+		// If err is connection refused, retry.
+		return true
 	}
 
 	return false

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -44,6 +44,7 @@ var (
 	connectionTimedoutUErr  *url.Error = urlError("connection timed out")
 	connectionResetUErr     *url.Error = urlError("connection reset by peer")
 	EOFUErr                 *url.Error = urlError("EOF")
+	connectionRefusedErr    *url.Error = urlError("connect: connection refused")
 )
 
 const transientEnvVarKey = "TRANSIENT_ERROR_PATTERN"
@@ -100,6 +101,9 @@ func TestIsTransientErr(t *testing.T) {
 	})
 	t.Run("ExplicitTransientErr", func(t *testing.T) {
 		assert.True(t, IsTransientErr(NewErrTransient("")))
+	})
+	t.Run("ConnectionRefusedTransientErr", func(t *testing.T) {
+		assert.True(t, IsTransientErr(connectionRefusedErr))
 	})
 }
 


### PR DESCRIPTION
Fixes #11236

This treats ```Connection refused``` network errors as transient so that they can be retried.