### PR TITLE
fix: Support inputs for inline Steps

### DIFF
--- a/workflow/controller/inline_test.go
+++ b/workflow/controller/inline_test.go
@@ -39,3 +39,33 @@ spec:
 	woc.operate(context.Background())
 	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 }
+
+func TestInlineSteps(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: inline-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: a
+            inline:
+              container:
+                image: argoproj/argosay:v2
+                args:
+                  - echo
+                  - "{{inputs.parameters.foo}}"
+              inputs:
+                parameters:
+                  - name: foo
+                    value: bar
+`)
+	cancel, wfc := newController(wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(wf, wfc)
+	woc.operate(context.Background())
+	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -908,6 +908,12 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 			if errs := isValidWorkflowFieldName(step.Name); len(errs) != 0 {
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s.steps[%d].name '%s' is invalid: %s", tmpl.Name, i, step.Name, strings.Join(errs, ";"))
 			}
+			if i := step.Inline; i != nil {
+				for _, p := range i.Inputs.Parameters {
+					scope["inputs.parameters."+p.Name] = placeholderGenerator.NextPlaceholder()
+				}
+			}
+
 			stepNames[step.Name] = true
 			prefix := fmt.Sprintf("steps.%s", step.Name)
 			scope[fmt.Sprintf("%s.status", prefix)] = true


### PR DESCRIPTION
Make inline step templates work with inputs. Basically #7439 but for steps. Does not address any other concerns over inlines.

Fixes #7432 (which is closed, but left this unfixed)

### Verification

Test added and logs checked for correct behaviour