### PR TITLE
fix: Upgrade windows container to ltsc2022

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,7 +190,7 @@ jobs:
   build-windows:
     name: Build & push windows
     if: github.repository == 'argoproj/argo-workflows'
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
       - name: Docker Login
@@ -336,7 +336,7 @@ jobs:
   test-images-windows:
     name: Try pulling windows
     if: github.repository == 'argoproj/argo-workflows'
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [ push-images ]
     steps:
       - name: Docker Login

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,7 +4,7 @@
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
 
-ARG IMAGE_OS_VERSION=ltsc2022
+ARG IMAGE_OS_VERSION=ltsc2022-amd64
 ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -4,7 +4,7 @@
 # Also used as the image in CI jobs so needs all dependencies
 ####################################################################################################
 
-ARG IMAGE_OS_VERSION=1809
+ARG IMAGE_OS_VERSION=ltsc2022
 ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #10738
and the fact that Windows builds were not releasing.


Older builds were on the 1809 container, which isn't supported any more. Chocolatey recently dropped support and this is what killed the build.

The container we are replacing went out of Microsoft support in November 2020, so this shouldn't be a huge surprise for Windows users: https://learn.microsoft.com/en-us/lifecycle/announcements/windows-10-1809-end-of-servicing

### Motivation

Updates to a supported version of Windows and allows the release mechanism to work again.

### Modifications

- Upgraded dockerfile to ltsc2022
- CI runs on server 2022

I'm not super familiar with how windows containers work (if they do at all :p) but I think this now means that workflows will only run on server 2022 - it looks like containers are pinned to their host in the least containery-way possible. So this probably requires a minor release of Workflows, not a patch.

### Verification
Built on the Pipekit fork and released as mentioned below in the comments.

![image](https://github.com/argoproj/argo-workflows/assets/45351296/550e3701-7c5a-4f1a-9dce-cca02215198c)
