### PR TITLE
fix: Remove -f flag from 'kubectl patch' commands in resource executor (#11248)

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -125,31 +125,25 @@ func (we *WorkflowExecutor) getKubectlArguments(action string, manifestPath stri
 		output = "name"
 	}
 
-	appendFileFlag := true
 	if action == "patch" {
 		mergeStrategy := "strategic"
 		if we.Template.Resource.MergeStrategy != "" {
 			mergeStrategy = we.Template.Resource.MergeStrategy
-			if mergeStrategy == "json" {
-				// Action "patch" require flag "-p" with resource arguments.
-				// But kubectl disallow specify both "-f" flag and resource arguments.
-				// Flag "-f" should be excluded for action "patch" here if it's a json patch.
-				appendFileFlag = false
-			}
 		}
 
 		args = append(args, "--type")
 		args = append(args, mergeStrategy)
-
 		args = append(args, "-p")
 		args = append(args, string(buff))
 	}
-
 	if len(flags) != 0 {
 		args = append(args, flags...)
 	}
 
-	if len(buff) != 0 && appendFileFlag {
+	// Action "patch" require flag "-p" with resource arguments.
+	// But kubectl disallow specify both "-f" flag and resource arguments.
+	// Flag "-f" should be excluded for action "patch" here.
+	if len(buff) != 0 && action != "patch" {
 		args = append(args, "-f")
 		args = append(args, manifestPath)
 	}


### PR DESCRIPTION
Fixes #11248

As described by the already existing comment, the `kubectl patch` command is used with the `-p` flag in the Resource executor. 
Since the `-p` flag and the `-f` flag can't be used together, we need to ensure that the second is not added for _any_ patch operation, not just the json ones (restoring the behaviour present before [PR 5991](https://github.com/argoproj/argo-workflows/pull/5951))