### PR TITLE
chore: use k8s 1.27 for CI

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -87,13 +87,13 @@ jobs:
           - test: test-python-sdk
             profile: minimal
           - test: test-executor
-            install_k3s_version: v1.21.2+k3s1
+            install_k3s_version: v1.27.2+k3s1
             profile: minimal
           - test: test-corefunctional
-            install_k3s_version: v1.21.2+k3s1
+            install_k3s_version: v1.27.2+k3s1
             profile: minimal
           - test: test-functional
-            install_k3s_version: v1.21.2+k3s1
+            install_k3s_version: v1.27.2+k3s1
             profile: minimal
     steps:
       - name: Install socat

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -87,13 +87,13 @@ jobs:
           - test: test-python-sdk
             profile: minimal
           - test: test-executor
-            install_k3s_version: v1.24.15-k3s1
+            install_k3s_version: v1.25.11-k3s1
             profile: minimal
           - test: test-corefunctional
-            install_k3s_version: v1.24.15-k3s1
+            install_k3s_version: v1.25.11-k3s1
             profile: minimal
           - test: test-functional
-            install_k3s_version: v1.24.15-k3s1
+            install_k3s_version: v1.25.11-k3s1
             profile: minimal
     steps:
       - name: Install socat

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -87,13 +87,13 @@ jobs:
           - test: test-python-sdk
             profile: minimal
           - test: test-executor
-            install_k3s_version: v1.27.2+k3s1
+            install_k3s_version: v1.24.15-k3s1
             profile: minimal
           - test: test-corefunctional
-            install_k3s_version: v1.27.2+k3s1
+            install_k3s_version: v1.24.15-k3s1
             profile: minimal
           - test: test-functional
-            install_k3s_version: v1.27.2+k3s1
+            install_k3s_version: v1.24.15-k3s1
             profile: minimal
     steps:
       - name: Install socat
@@ -118,7 +118,7 @@ jobs:
       - name: Install and start K3S
         run: |
           if ! echo "${{ matrix.install_k3s_version }}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+\+k3s1$'; then
-            export INSTALL_K3S_VERSION=v1.26.3+k3s1
+            export INSTALL_K3S_VERSION=v1.27.2+k3s1
           else
             export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
           fi

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -38,12 +38,12 @@ Otherwise, we typically release every two weeks:
 
 ## Kubernetes Compatibility Matrix
 
-| Argo Workflows \ Kubernetes | 1.17 | 1.18 | 1.19 | 1.20 | 1.21 | 1.22 | 1.23 | 1.24 | 1.25 |
-|-----------------------|------|------|------|------|------|------|------|------|------|
-| **3.4**           | `x` | `x` | `x` | `?` | `✓` | `✓` | `✓` | `✓` | `✓` |
-| **3.3**           | `?` | `?` | `?` | `?` | `✓` | `✓` | `✓` | `?` | `?` |
-| **3.2**           | `?` | `?` | `✓` | `✓` | `✓` | `?` | `?` | `?` | `?` |
-| **3.1**           | `✓` | `✓` | `✓` | `?` | `?` | `?` | `?` | `?` | `?` |
+| Argo Workflows \ Kubernetes | 1.17 | 1.18 | 1.19 | 1.20 | 1.21 | 1.22 | 1.23 | 1.24 | 1.25 | 1.26 | 1.27 |
+|-----------------------|------|------|------|------|------|------|------|------|------|------|------|
+| **3.4**           | `x` | `x` | `x` | `?` | `✓` | `✓` | `✓` | `✓` | `✓` | `✓` | `✓` |
+| **3.3**           | `?` | `?` | `?` | `?` | `✓` | `✓` | `✓` | `?` | `?` | `?` | `?` |
+| **3.2**           | `?` | `?` | `✓` | `✓` | `✓` | `?` | `?` | `?` | `?` | `?` | `?` |
+| **3.1**           | `✓` | `✓` | `✓` | `?` | `?` | `?` | `?` | `?` | `?` | `?` | `?` |
 
 * `✓` Fully supported versions.
 * `?` Due to breaking changes might not work. Also, we haven't thoroughly tested against this version.
@@ -53,4 +53,4 @@ Otherwise, we typically release every two weeks:
 
 Argo versions may be compatible with newer and older versions than what it is listed but only three minor versions are supported per Argo release unless otherwise noted.
 
-The main branch of `Argo Workflows` is currently tested on `Kubernetes` 1.21.
+The main branch of `Argo Workflows` is currently tested on `Kubernetes` 1.27.


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->



### Motivation

We currently test against k8s 1.21. This has been out of support for some time (since 2022-06-28), nobody should be using it.
This PR updates the CI to run against k8s 1.27. 1.27 goes EOL on 2024-06-28.

### Modifications
- Updated CI to test against k8s 1.27
- Modifed docs to explain this fact.

### Verification
CI passes. (it has passed, there's some github issue causing the results to not come back to prs properly)
