### PR TITLE
docs: add GC details to Cost Optimization

### DIFF
--- a/docs/cost-optimisation.md
+++ b/docs/cost-optimisation.md
@@ -35,6 +35,8 @@ Consider:
 * Data storage costs (object storage vs. volume)
 * Requirement for parallel access to data (NFS vs. block storage vs. artifact)
 
+When using volume claims, consider configuring [Volume Claim GC](fields.md#volumeclaimgc). By default, claims are only deleted when a workflow is successful.
+
 ### Limit The Total Number Of Workflows And Pods
 
 > Suitable for all.
@@ -48,8 +50,8 @@ You should delete workflows once they are no longer needed, or enable a [Workflo
 Limit the total number of workflows using:
 
 * Active Deadline Seconds - terminate running workflows that do not complete in a set time. This will make sure workflows do not run forever.
-* [Workflow TTL Strategy](fields.md#ttlstrategy) - delete completed workflows after a time
-* [Pod GC](fields.md#podgc) - delete completed pods after a time
+* [Workflow TTL Strategy](fields.md#ttlstrategy) - delete completed workflows after a set time.
+* [Pod GC](fields.md#podgc) - delete completed pods. By default, Pods are not deleted.
 
 Example
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

## Summary

Add details for `podGC` and `volumeClaimGC` in the Cost Optimization doc, including both of their default settings
- Follow-up to https://github.com/argoproj/argo-workflows/pull/10971#issuecomment-1566556322 . I didn't get a response there unfortunately, so used my best judgment here. Feel free to modify!

### Motivation

Same as #10971

<!-- TODO: Say why you made your changes. -->

### Modifications

- per feedback on #10971, mention the `podGC` default here
  - `podGC` also causes Pods to be deleted _immediately_ upon the configured condition - as in, not "after a set time"
    - for instance, when `OnWorkflowCompletion` is set, all Pods iare deleted as soon as the Workflow completes, with no wait time
      - my teams actually had problems due to the lack of wait time, as `fluentd` would sometimes fail to capture Pod details if they were deleted too fast - I had to put a `suspend` at the end of Workflows to workaround that
  - also consistently use the phrase "set time" (instead of just "time"), as the time is specifically configured

- mention `volumeClaimGC` and its default under the Volume section

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

N/A

<!-- TODO: Say how you tested your changes. -->

### Misc

It would be great if `podGC` and `volumeClaimGC` had a TTL to them! That would permanently fix the quick deletion issue that I had to workaround above.
- Potentially, I could set the Workflow `ttlStrategy` instead, which should hopefully delete all Pods and PVCs that are descendant from it, but unfortunately my teams had yet to implement the [Workflow Archive](https://argoproj.github.io/argo-workflows/workflow-archive/), so we could not delete any Workflows yet (especially for compliance purposes)