### PR TITLE
fix(controller): Enable dummy metrics server on non-leader workflow controller

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -298,9 +298,6 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		log.Fatal("Timed out waiting for caches to sync")
 	}
 
-	// Start the metrics server
-	go wfc.metrics.RunServer(ctx)
-
 	for i := 0; i < podCleanupWorkers; i++ {
 		go wait.UntilWithContext(ctx, wfc.runPodCleanup, time.Second)
 	}
@@ -321,6 +318,10 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		go wait.JitterUntilWithContext(ctx, wfc.syncAllCacheForGC, cacheGCPeriod, 0.0, true)
 	}
 	<-ctx.Done()
+}
+
+func (wfc *WorkflowController) RunMetricsServer(ctx context.Context, isDummy bool) {
+	go wfc.metrics.RunServer(ctx, isDummy)
 }
 
 // Create and the Synchronization Manager

--- a/workflow/metrics/server_test.go
+++ b/workflow/metrics/server_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,6 +23,7 @@ func TestDisableMetricsServer(t *testing.T) {
 	defer cancel()
 
 	m.RunServer(ctx, false)
+	time.Sleep(1 * time.Second) // to confirm that the server doesn't start, even if we wait
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	if resp != nil {
 		defer resp.Body.Close()
@@ -43,6 +45,7 @@ func TestMetricsServer(t *testing.T) {
 	defer cancel()
 
 	m.RunServer(ctx, false)
+	time.Sleep(1 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -68,6 +71,7 @@ func TestDummyMetricsServer(t *testing.T) {
 	defer cancel()
 
 	m.RunServer(ctx, true)
+	time.Sleep(1 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/workflow/metrics/server_test.go
+++ b/workflow/metrics/server_test.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunServer(t *testing.T) {
+	config := ServerConfig{
+		Enabled: true,
+		Path:    DefaultMetricsServerPath,
+		Port:    DefaultMetricsServerPort,
+	}
+	m := New(config, config)
+
+	server := func(isDummy bool, shouldBodyBeEmpty bool) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go m.RunServer(ctx, isDummy)
+
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+
+		bodyString := string(bodyBytes)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		if shouldBodyBeEmpty {
+			assert.Empty(t, bodyString)
+		} else {
+			assert.NotEmpty(t, bodyString)
+		}
+	}
+
+	t.Run("dummy metrics server", func(t *testing.T) {
+		server(true, true) // dummy metrics server does not provide any metrics responses
+	})
+
+	t.Run("prometheus metrics server", func(t *testing.T) {
+		server(false, false) // prometheus metrics server provides responses for any metrics
+	})
+}

--- a/workflow/metrics/server_test.go
+++ b/workflow/metrics/server_test.go
@@ -21,7 +21,7 @@ func TestDisableMetricsServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go m.RunServer(ctx, false)
+	m.RunServer(ctx, false)
 	_, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	assert.Contains(t, err.Error(), "connection refused") // expect that the metrics server not to start
 }
@@ -37,7 +37,7 @@ func TestSameMetricsServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go m.RunServer(ctx, false)
+	m.RunServer(ctx, false)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -67,7 +67,7 @@ func TestOwnMetricsServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go m.RunServer(ctx, false)
+	m.RunServer(ctx, false)
 	mresp, merr := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	tresp, terr := http.Get(fmt.Sprintf("http://localhost:%d%s", 9091, DefaultMetricsServerPath))
 
@@ -100,7 +100,7 @@ func TestDummyMetricsServer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go m.RunServer(ctx, true)
+	m.RunServer(ctx, true)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/workflow/metrics/server_test.go
+++ b/workflow/metrics/server_test.go
@@ -26,7 +26,7 @@ func TestDisableMetricsServer(t *testing.T) {
 	assert.Contains(t, err.Error(), "connection refused") // expect that the metrics server not to start
 }
 
-func TestSameMetricsServer(t *testing.T) {
+func TestMetricsServer(t *testing.T) {
 	config := ServerConfig{
 		Enabled: true,
 		Path:    DefaultMetricsServerPath,
@@ -49,44 +49,6 @@ func TestSameMetricsServer(t *testing.T) {
 
 	bodyString := string(bodyBytes)
 	assert.NotEmpty(t, bodyString)
-}
-
-func TestOwnMetricsServer(t *testing.T) {
-	metricsConfig := ServerConfig{
-		Enabled: true,
-		Path:    DefaultMetricsServerPath,
-		Port:    DefaultMetricsServerPort,
-	}
-	telemetryConfig := ServerConfig{
-		Enabled: true,
-		Path:    DefaultMetricsServerPath,
-		Port:    9091,
-	}
-	m := New(metricsConfig, telemetryConfig)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	m.RunServer(ctx, false)
-	mresp, merr := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
-	tresp, terr := http.Get(fmt.Sprintf("http://localhost:%d%s", 9091, DefaultMetricsServerPath))
-
-	assert.NoError(t, merr)
-	assert.NoError(t, terr)
-	assert.Equal(t, http.StatusOK, mresp.StatusCode)
-	assert.Equal(t, http.StatusOK, tresp.StatusCode)
-
-	defer mresp.Body.Close()
-	defer tresp.Body.Close()
-
-	mbodyBytes, err := io.ReadAll(mresp.Body)
-	tbodyBytes, err := io.ReadAll(tresp.Body)
-	assert.NoError(t, err)
-
-	mbodyString := string(mbodyBytes)
-	tbodyString := string(tbodyBytes)
-	assert.NotEmpty(t, mbodyString)
-	assert.NotEmpty(t, tbodyString)
 }
 
 func TestDummyMetricsServer(t *testing.T) {

--- a/workflow/metrics/server_test.go
+++ b/workflow/metrics/server_test.go
@@ -22,7 +22,12 @@ func TestDisableMetricsServer(t *testing.T) {
 	defer cancel()
 
 	m.RunServer(ctx, false)
-	_, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "connection refused") // expect that the metrics server not to start
 }
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #10037

### Motivation

<!-- TODO: Say why you made your changes. -->
Our datadog agents on GKE collect prometheus metrics from multiple workflow-controllers through the k8s Service. However, the metrics server only starts on the leader workflow-controller, causing some datadog agents to frequently output "Connection refused" error logs.
Therefore, I am aiming to resolve this issue.


### Modifications

<!-- TODO: Say what changes you made. -->
I have tried to implement the comment: https://github.com/argoproj/argo-workflows/issues/8283#issuecomment-1379988006

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
I have added tests and verified the functionality locally.
