### PR TITLE
docs: add all remaining controller configurations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -85,8 +85,8 @@ type Config struct {
 	// Defaults to the Kubernetes default of 30 seconds.
 	PodGCGracePeriodSeconds *int64 `json:"podGCGracePeriodSeconds,omitempty"`
 
-	// PodGCDeleteDelayDuration specifies the duration in seconds before the pods in the GC queue get deleted.
-	// Value must be non-negative integer. A zero value indicates that the pods will be deleted immediately.
+	// PodGCDeleteDelayDuration specifies the duration before pods in the GC queue get deleted.
+	// Value must be non-negative. A zero value indicates that the pods will be deleted immediately.
 	// Defaults to 5 seconds.
 	PodGCDeleteDelayDuration *metav1.Duration `json:"podGCDeleteDelayDuration,omitempty"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ type ResourceRateLimit struct {
 	Burst int     `json:"burst"`
 }
 
-// Config contain the configuration settings for the workflow controller
+// Config contains the configuration settings for the workflow controller
 type Config struct {
 
 	// NodeEvents configures how node events are emitted
@@ -93,13 +93,14 @@ type Config struct {
 	// WorkflowRestrictions restricts the controller to executing Workflows that meet certain restrictions
 	WorkflowRestrictions *WorkflowRestrictions `json:"workflowRestrictions,omitempty"`
 
-	// Adding configurable initial delay (for K8S clusters with mutating webhooks) to prevent workflow getting modified by MWC.
+	// Adds configurable initial delay (for K8S clusters with mutating webhooks) to prevent workflow getting modified by MWC.
 	InitialDelay metav1.Duration `json:"initialDelay,omitempty"`
 
 	// The command/args for each image, needed when the command is not specified and the emissary executor is used.
 	// https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
 	Images map[string]Image `json:"images,omitempty"`
 
+	// Workflow retention by number of workflows
 	RetentionPolicy *RetentionPolicy `json:"retentionPolicy,omitempty"`
 
 	// NavColor is an ui navigation bar background color

--- a/config/retention_policy.go
+++ b/config/retention_policy.go
@@ -1,5 +1,6 @@
 package config
 
+// Workflow retention by number of workflows
 type RetentionPolicy struct {
 	Completed int `json:"completed,omitempty"`
 	Failed    int `json:"failed,omitempty"`

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -13,6 +13,9 @@ data:
   # controller watches workflows and pods that *are not* labeled with an instance id.
   instanceID: my-ci-controller
 
+  # Namespace is a label selector filter to limit the controller's watch to a specific namespace
+  namespace: my-namespace
+
   # Parallelism limits the max total parallel workflows that can execute at the same time
   # (available since Argo v2.3). Controller must be restarted to take effect.
   parallelism: 10
@@ -77,6 +80,16 @@ data:
     - name: Completed Workflows
       scope: workflow-list
       url: http://workflows?label=workflows.argoproj.io/completed=true
+
+  # Columns are custom columns that will be exposed in the Workflow List View.
+  columns: |
+    # Adds a column to the Workflow List View
+    - # The name of this column, e.g., "Workflow Completed".
+      name: Workflow Completed
+      # The type of this column, "label" or "annotation".
+      type: label
+      # The key of the label or annotation, e.g., "workflows.argoproj.io/completed".
+      key: workflows.argoproj.io/completed
 
   # uncomment following lines if you want to change navigation bar background color
   # navColor: red
@@ -318,6 +331,30 @@ data:
     #   passwordSecret:
     #     name: argo-mysql-config
     #     key: password
+
+  # PodSpecLogStrategy enables the logging of pod specs in the controller log.
+  # podSpecLogStrategy: |
+  #   failedPod: true
+  #   allPods: false
+
+  # PodGCGracePeriodSeconds specifies the duration in seconds before a terminating pod is forcefully killed.
+  # Value must be non-negative integer. A zero value indicates that the pod will be forcefully terminated immediately.
+  # Defaults to the Kubernetes default of 30 seconds.
+  podGCGracePeriodSeconds: "60"
+
+  # PodGCDeleteDelayDuration specifies the duration in seconds before the pods in the GC queue get deleted.
+  # Value must be non-negative integer. A zero value indicates that the pods will be deleted immediately.
+  # Defaults to 5 seconds.
+  podGCDeleteDelayDuration: 30s
+
+  # configurable initial delay (for K8S clusters with mutating webhooks) to prevent workflow getting modified by MWC.
+  # initialDelay: 5s
+
+  # Workflow retention by number of workflows
+  # retentionPolicy: |
+  #   completed: 10
+  #   failed: 3
+  #   errored: 3
 
   # Default values that will apply to all Workflows from this controller, unless overridden on the Workflow-level
   # See more: docs/default-workflow-specs.md

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -18,7 +18,7 @@ data:
 
   # Parallelism limits the max total parallel workflows that can execute at the same time
   # (available since Argo v2.3). Controller must be restarted to take effect.
-  parallelism: 10
+  parallelism: "10"
 
   # Limit the maximum number of incomplete workflows in a namespace.
   # Intended for cluster installs that are multi-tenancy environments, to prevent too many workflows in one
@@ -193,11 +193,11 @@ data:
 
   # kubelet port when using kubelet executor (default: 10250) (kubelet executor will be deprecated use emissary instead)
   # (removed in v3.4)
-  kubeletPort: 10250
+  kubeletPort: "10250"
 
   # disable the TLS verification of the kubelet executor (default: false)
   # (removed in v3.4)
-  kubeletInsecure: false
+  kubeletInsecure: "false"
 
   # The command/args for each image, needed when the command is not specified and the emissary executor is used.
   # https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -347,7 +347,7 @@ data:
   # Defaults to 5 seconds.
   podGCDeleteDelayDuration: 30s
 
-  # configurable initial delay (for K8S clusters with mutating webhooks) to prevent workflow getting modified by MWC.
+  # adds initial delay (for K8S clusters with mutating webhooks) to prevent workflow getting modified by MWC.
   # initialDelay: 5s
 
   # Workflow retention by number of workflows

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -342,8 +342,8 @@ data:
   # Defaults to the Kubernetes default of 30 seconds.
   podGCGracePeriodSeconds: "60"
 
-  # PodGCDeleteDelayDuration specifies the duration in seconds before the pods in the GC queue get deleted.
-  # Value must be non-negative integer. A zero value indicates that the pods will be deleted immediately.
+  # PodGCDeleteDelayDuration specifies the duration before pods in the GC queue get deleted.
+  # Value must be non-negative. A zero value indicates that the pods will be deleted immediately.
   # Defaults to 5 seconds.
   podGCDeleteDelayDuration: 30s
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

Several configurations were missing, and, as a result, entirely undocumented
  - several of these can be very useful for different use-cases, lack of docs makes these settings hard to discover
  - addresses https://github.com/argoproj/argo-workflows/pull/11293#issuecomment-1622162284 and https://github.com/argoproj/argo-workflows/issues/8539

### Modifications

#### Primary Changes
- add namespace, columns, podSpecLogStrategy, podGCGracePeriodSeconds, podGCDeleteDelayDuration, initialDelay, and retentionPolicy
  - add comments for all of the above, primarily copying from `config.go`: https://github.com/argoproj/argo-workflows/blob/30a916880ff21027ad1004c4ae176037f1a956da/config/config.go#L22
    - a few comments from other places, like `info.go` for Column: https://github.com/argoproj/argo-workflows/blob/8ec5623093181cfb5ef7c34a5df8a8c917282b7b/pkg/apis/workflow/v1alpha1/info.go#L18
    - `argo-helm` for retentionPolicy: https://github.com/argoproj/argo-helm/blob/5f55ef2c4cc16d4c91faaf1bdb7e0c1d7385435a/charts/argo-workflows/values.yaml#L322
      - big kudos to the `argo-helm` maintainers and contributors for keeping all the config up-to-date despite lack of docs!

#### Minor Secondary Changes
- fix typing issues -- configmap values must be strings
- minor copy-edits to docs and comments
  - add comments for RetentionPolicy as it was the odd one out with no comments
  - fix comment that said DeleteDelayDuration was integer seconds when it is actually a Duration type

### Verification

n/a

<!-- TODO: Say how you tested your changes. -->
