### PR TITLE
docs(auth): add link to FAQ on invalid token error

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,8 +1,11 @@
 # FAQ
 
-## "token not valid for running mode", "any bearer token is able to login in the UI or use the API"
+## "token not valid", "any bearer token is able to login in the UI or use the API"
 
-You've not configured Argo Server authentication correctly. If you want SSO, try running with `--auth-mode=sso`.
+You may not have configured Argo Server authentication correctly.
+
+If you want SSO, try running with `--auth-mode=sso`.
+If you're using `--auth-mode=client`, make sure you have `Bearer ` in front of the token, as mentioned in [Access Token](access-token.md#token-creation).
 
 [Learn more about the Argo Server set-up](argo-server.md)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,7 @@
 You may not have configured Argo Server authentication correctly.
 
 If you want SSO, try running with `--auth-mode=sso`.
-If you're using `--auth-mode=client`, make sure you have `Bearer ` in front of the token, as mentioned in [Access Token](access-token.md#token-creation).
+If you're using `--auth-mode=client`, make sure you have `Bearer` in front of the token, as mentioned in [Access Token](access-token.md#token-creation).
 
 [Learn more about the Argo Server set-up](argo-server.md)
 

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -190,7 +190,7 @@ func (s gatekeeper) getClients(ctx context.Context, req interface{}) (*servertyp
 		}
 	}
 	if !valid {
-		return nil, nil, status.Error(codes.Unauthenticated, "token not valid for running mode")
+		return nil, nil, status.Error(codes.Unauthenticated, "token not valid. see https://argoproj.github.io/argo-workflows/faq/")
 	}
 	switch mode {
 	case Client:


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->
- link was requested by Alex, fixes #5832

- also shorten the error message to "token not valid" as, in my experience at least, "for running mode" actually significantly increased confusion (c.f. https://github.com/argoproj/argo-workflows/issues/4991#issuecomment-1466465686)
  - everyone on my teams thought that it meant we misconfigured our auth or that only one mode could be used at a time - but actually, we were just missing the `"Bearer "` prefix for our token

- my comment about the `"Bearer "` prefix (https://github.com/argoproj/argo-workflows/issues/4991#issuecomment-1466465686) got a few upvotes, so thought this would be worth documenting as well

### Modifications

- add a link to the auth error message in `gatekeeper.go` when the token is invalid
  -  shorten the error message as well, per above motivation

- add the `"Bearer "` prefix as another common reason for this error in the FAQ

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Ran `make docs`

<!-- TODO: Say how you tested your changes. -->
