### PR TITLE
docs: fix broken links + add back check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export SHELL:=bash
 export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 
-# NOTE: Please ensure dependencies are synced with the flake.nix file in nix-files/flake.nix before upgrading 
+# NOTE: Please ensure dependencies are synced with the flake.nix file in dev/nix/flake.nix before upgrading
 # any external dependency. There is documentation on how to do this under the Developer Guide
 
 # https://stackoverflow.com/questions/4122831/disable-make-builtin-rules-and-variables-from-inside-the-make-file
@@ -165,7 +165,7 @@ ui/dist/app/index.html: $(shell find ui/src -type f && find ui -maxdepth 1 -type
 
 $(GOPATH)/bin/staticfiles:
 	go install bou.ke/staticfiles@dd04075 # update this in Nix when upgrading it here
- 
+
 
 ifeq ($(STATIC_FILES),true)
 server/static/files.go: $(GOPATH)/bin/staticfiles ui/dist/app/index.html
@@ -660,8 +660,7 @@ docs-lint: /usr/local/bin/markdownlint
 docs: /usr/local/bin/mkdocs \
 	docs-spellcheck \
 	docs-lint \
-	# TODO: This is temporarily disabled to unblock merging PRs.
-	# docs-linkcheck
+	docs-linkcheck
 	# check environment-variables.md contains all variables mentioned in the code
 	./hack/check-env-doc.sh
 	# check all docs are listed in mkdocs.yml

--- a/docs/mentoring.md
+++ b/docs/mentoring.md
@@ -46,7 +46,7 @@ Mentors:
 
 ## How to Participate Google Summer of Code
 
-We are participating [Google Summer of Code (GSoC)](https://summerofcode.withgoogle.com/) as part of the [CNCF mentoring program](https://github.com/cncf/mentoring)! Please check out the list of project ideas [here](https://github.com/cncf/mentoring/blob/main/summerofcode/2022.md#argo).
+We are participating [Google Summer of Code (GSoC)](https://summerofcode.withgoogle.com/) as part of the [CNCF mentoring program](https://github.com/cncf/mentoring)! Please check out the list of project ideas [here](https://github.com/cncf/mentoring/blob//0c209dd666702b42d853a28434984772946d4c5f/programs/summerofcode/2022.md#argo).
 
 If you are interested in applying and working on a particular project, please take a look at the timeline [here](https://developers.google.com/open-source/gsoc/timeline) and submit your proposal only to the GSoC program website. Proposals submitted outside of the Google Summer of Code program site **will not be considered** for Google Summer of Code.
 

--- a/docs/workflow-concepts.md
+++ b/docs/workflow-concepts.md
@@ -45,7 +45,7 @@ These templates _define_ work to be done, usually in a Container.
 
 ##### [Container](fields.md#container)
 
-Perhaps the most common template type, it will schedule a Container. The spec of the template is the same as the [Kubernetes container spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core), so you can define a container here the same way you do anywhere else in Kubernetes.
+Perhaps the most common template type, it will schedule a Container. The spec of the template is the same as the [Kubernetes container spec](https://v1-26.docs.kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container), so you can define a container here the same way you do anywhere else in Kubernetes.
 
 Example:
 
@@ -56,7 +56,7 @@ Example:
       command: [cowsay]
       args: ["hello world"]
 ```
-  
+
 ##### [Script](fields.md#scripttemplate)
 
 A convenience wrapper around a `container`. The spec is the same as a container, but adds the `source:` field which allows you to define a script in-place.
@@ -93,7 +93,7 @@ This example creates a `ConfigMap` resource on the cluster:
         data:
           some: value
 ```
-  
+
 ##### [Suspend](fields.md#suspendtemplate)
 
 A suspend template will suspend execution, either for a duration or until it is resumed manually. Suspend templates can be resumed from the CLI (with `argo resume`), the API endpoint<!-- TODO: LINK -->, or the UI.
@@ -105,7 +105,7 @@ Example:
     suspend:
       duration: "20s"
 ```
-  
+
 #### Template Invocators
 
 These templates are used to invoke/call other templates and provide execution control.


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- `make docs-linkcheck` found two broken links
  - command runs fine on my local machine now, so maybe https://github.com/argoproj/argo-workflows/pull/10678 was due to an error that was patched

- while fixing that, noticed that the Nix folder got moved to `dev/nix/` in https://github.com/argoproj/argo-workflows/pull/10999/commits/c505e80f572242ebbbef850f6dbd36979ebb8c3d

### Modifications

- fixed both broken links by adding versioned permalinks to updated locations
- uncomment `docs-linkcheck` from `make docs`
- corrected Nix directory comment


<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Ran `make docs`

<!-- TODO: Say how you tested your changes. -->
