### PR TITLE
fix: Add ^ to semver version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -90,7 +90,7 @@
         "webpack-dev-server": "^4.15.0"
     },
     "resolutions": {
-        "semver": "7.5.2",
+        "semver": "^7.5.2",
         "lodash": "4.17.21",
         "prismjs": "1.27.0",
         "@types/react": "16.8.5",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8985,10 +8985,10 @@ selfsigned@^2.1.1:
   dependencies:
     node-forge "^1"
 
-"semver@2 || 3 || 4 || 5", semver@7.5.2, semver@7.x, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.3.2, semver@^7.3.8, semver@~5.3.0:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
-  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
+"semver@2 || 3 || 4 || 5", semver@7.x, semver@^5.3.0, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.3.2, semver@^7.3.8, semver@^7.5.2, semver@~5.3.0:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
We know it's safe to do this for this particular one. The other pinned ones might be there for a reason (potentially breaking)