### PR TITLE
chore: mark more files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 sdks/python/client/** linguist-generated
+sdks/java/client/** linguist-generated
+manifests/base/crds/*/argoproj.io*.yaml linguist-generated
+manifests/quick-start-*.yaml linguist-generated
+api/jsonschema/schema.json linguist-generated
+api/openapi-spec/swagger.json linguist-generated


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

There are several more files/folders that are generated (and _not_ [`.gitignore`](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/.gitignore#L25)'d)
- This makes diffs etc easier to read by collapsing these files by default

c.f. [GitHub](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) [Docs](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#generated-code)

<!-- TODO: Say why you made your changes. -->

### Modifications

- Java SDK docs are [generated](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/Makefile#L257), similar to Python
- CRDs are [generated](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/Makefile#L373)
- quick start manifests are [generated](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/Makefile#L399) from the other manifests
- top-level JSONSchema and OpenAPI spec/Swagger are [generated](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/Makefile#L606-L610) from other files

- did not include some auto-generated Go files as GitHub is [already picking up those](https://github.com/github-linguist/linguist/blob/e855ef2b6f90c34074061a2e17acbe853e61b483/lib/linguist/generated.rb#L321) by default
  - i.e. `*.pb.go`, `*.pb.gw.go`, etc
  - similar for `go-to-protobuf` [detection](https://github.com/github-linguist/linguist/blob/e855ef2b6f90c34074061a2e17acbe853e61b483/lib/linguist/generated.rb#L332)

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Review Notes

I do believe there are more generated files, but I wasn't as sure about those so did not include them. Can include them with confirmations. For instance,
- the entirety of `pkg/client/`, which I _believe_ is generated [here](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/Makefile#L569)
- some swagger files here and there
- [`docs/fields.md`  and `docs/cli/argo.md`](https://github.com/argoproj/argo-workflows/blob/5264584496ebb62c7098daa986692284b9e6478a/Makefile#L255) as those are user-facing docs, so potentially(??) good to code review and remind that some comments are user-facing etc. That's just my opinion so far though, could change / be changed