### PR TITLE
chore: Surface batch action error message on workflow list view

### DIFF
--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -52,10 +52,10 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
         const promises: Promise<any>[] = [];
         this.props.selectedWorkflows.forEach((wf: Workflow) => {
             promises.push(
-                action(wf).catch(() => {
+                action(wf).catch(reason => {
                     this.props.loadWorkflows();
                     ctx.notifications.show({
-                        content: `Unable to ${title} workflow`,
+                        content: `Unable to ${title} workflow: ${reason.toString()}`,
                         type: NotificationType.Error
                     });
                 })


### PR DESCRIPTION
Currently, there's no error message indicating why a batch action failed. This PR surfaces that error.