### PR TITLE
chore: Reduce release yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,9 @@ jobs:
             --build-arg GIT_TAG=$GIT_TAG \
             --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
             --output "type=image,push=true" \
+            --build-arg GIT_COMMIT=$GIT_COMMIT \
+            --build-arg GIT_TAG=$GIT_TAG \
+            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
             --platform="${PLATFORM}" \
             --target $TARGET \
             --provenance=false \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,9 @@ jobs:
           docker buildx build \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --build-arg GIT_COMMIT=$GIT_COMMIT \
+            --build-arg GIT_TAG=$GIT_TAG \
+            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
             --output "type=image,push=true" \
             --platform="${PLATFORM}" \
             --target $TARGET \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,9 +82,6 @@ jobs:
           docker buildx build \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            --build-arg GIT_COMMIT=$GIT_COMMIT \
-            --build-arg GIT_TAG=$GIT_TAG \
-            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
             --output "type=image,push=true" \
             --build-arg GIT_COMMIT=$GIT_COMMIT \
             --build-arg GIT_TAG=$GIT_TAG \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,7 @@ jobs:
             --output "type=image,push=true" \
             --platform="${PLATFORM}" \
             --target $TARGET \
+            --provenance=false \
             --tag $image_name \
             --tag quay.io/$image_name .
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,13 @@ permissions:
   contents: read
 
 jobs:
-  build-linux-amd64:
-    name: Build & push linux/amd64
+  build-linux:
+    name: Build & push linux
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [ linux/amd64 ]
+        platform: [ linux/amd64, linux/arm64 ]
         target: [ workflow-controller, argocli, argoexec ]
     steps:
       - uses: actions/checkout@v3
@@ -76,115 +76,17 @@ jobs:
   
           tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
           image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
+          cache_image_name="${DOCKERIO_ORG}/${TARGET}:cache"
 
           docker buildx build \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
+            --cache-from "type=registry,ref=${cache_image_name}" \
+            --cache-to "type=local,mode=max,dest=/tmp/.buildx-cache" \
+            --cache-to "type=registry,mode=max,ref=${cache_image_name}" \
             --output "type=image,push=true" \
-            --build-arg GIT_COMMIT=$GIT_COMMIT \
-            --build-arg GIT_TAG=$GIT_TAG \
-            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
             --platform="${PLATFORM}" \
             --target $TARGET \
-            --provenance=false \
-            --tag $image_name .
-
-          docker buildx build \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            --output "type=image,push=true" \
-            --build-arg GIT_COMMIT=$GIT_COMMIT \
-            --build-arg GIT_TAG=$GIT_TAG \
-            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
-            --platform="${PLATFORM}" \
-            --target $TARGET \
-            --provenance=false \
-            --tag quay.io/$image_name .
-
-  build-linux-arm64:
-    name: Build & push linux/arm64
-    if: github.repository == 'argoproj/argo-workflows'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [ linux/arm64 ]
-        target: [ workflow-controller, argocli, argoexec ]
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: v0.10.4
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-
-
-      - name: Docker Login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERIO_USERNAME }}
-          password: ${{ secrets.DOCKERIO_PASSWORD }}
-
-      - name: Docker Login
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_PASSWORD }}
-
-      - name: Docker Buildx
-        env:
-          DOCKERIO_ORG: ${{ secrets.DOCKERIO_ORG }}
-          PLATFORM: ${{ matrix.platform }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          set -eux
-          tag=$(basename $GITHUB_REF)
-          if [ $tag = "master" ]; then
-            tag="latest"
-          fi
-          # copied verbatim from Makefile
-          GIT_COMMIT=$(git rev-parse HEAD || echo unknown)
-          GIT_TAG=$(git describe --exact-match --tags --abbrev=0  2> /dev/null || echo untagged)
-          GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
-          
-          tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
-          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
-
-          docker buildx build \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            --output "type=image,push=true" \
-            --build-arg GIT_COMMIT=$GIT_COMMIT \
-            --build-arg GIT_TAG=$GIT_TAG \
-            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
-            --platform="${PLATFORM}" \
-            --target $TARGET \
-            --provenance=false \
-            --tag $image_name .
-
-          docker buildx build \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            --output "type=image,push=true" \
-            --build-arg GIT_COMMIT=$GIT_COMMIT \
-            --build-arg GIT_TAG=$GIT_TAG \
-            --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
-            --platform="${PLATFORM}" \
-            --target $TARGET \
-            --provenance=false \
+            --tag $image_name \
             --tag quay.io/$image_name .
 
   build-windows:
@@ -240,7 +142,7 @@ jobs:
     name: Push manifest with all images
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
-    needs: [ build-linux-amd64, build-linux-arm64, build-windows ]
+    needs: [ build-linux, build-windows ]
     steps:
       - uses: actions/checkout@v3
       - name: Docker Login

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,6 @@ jobs:
           GIT_COMMIT=$(git rev-parse HEAD || echo unknown)
           GIT_TAG=$(git describe --exact-match --tags --abbrev=0  2> /dev/null || echo untagged)
           GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
-  
           tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
           image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,13 +76,10 @@ jobs:
   
           tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
           image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
-          cache_image_name="${DOCKERIO_ORG}/${TARGET}:cache"
 
           docker buildx build \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-from "type=registry,ref=${cache_image_name}" \
-            --cache-to "type=local,mode=max,dest=/tmp/.buildx-cache" \
-            --cache-to "type=registry,mode=max,ref=${cache_image_name}" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache" \
             --output "type=image,push=true" \
             --platform="${PLATFORM}" \
             --target $TARGET \


### PR DESCRIPTION
### Motivation

I noticed some duplicate code in the release yaml that could be compacted down.

### Verification

Ran the release a number of times on our fork.

(If you're reviewing all my commits you'll see that I experimented with improving the caching. Due to the way the docker container is constructed, more agressive caching results in failed builds, so I have reverted those changes.)