### PR TITLE
docs: fix some small typos on Security page

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -29,7 +29,7 @@ If the user only has permission to create workflows, then they will be typically
 !!! Warning
     If you allow users to create workflows in the controller's namespace (typically `argo`), it may be possible for users to modify the controller itself.  In a namespace-install the managed namespace should therefore not be the controller's namespace.
 
-You can typically further restrict what a user can do to just being able to submit workflows from templates using [the workflow requirements feature](workflow-restrictions.md).
+You can typically further restrict what a user can do to just being able to submit workflows from templates using [the workflow restrictions feature](workflow-restrictions.md).
 
 ### Workflow Pod Permissions
 
@@ -44,7 +44,7 @@ This service account typically needs [permissions](workflow-rbac.md).
 
 Different service accounts should be used if a workflow pod needs to have elevated permissions, e.g. to create other resources.
 
-The main container will have the service account token mounted , allowing the main container to patch pods (among other permissions). Set `automountServiceAccountToken` to false to prevent this. See [fields](fields.md).
+The main container will have the service account token mounted, allowing the main container to patch pods (among other permissions). Set `automountServiceAccountToken` to false to prevent this. See [fields](fields.md).
 
 By default, workflows pods run as `root`. To further secure workflow pods, set the [workflow pod security context](workflow-pod-security-context.md).
 
@@ -64,7 +64,7 @@ Finally, you should configure the `argo-server` role and role binding with the c
 
 ### Read-Only
 
-You can achieve this by configuring the `argo-server` role ([example](https://github.com/argoproj/argo-workflows/blob/master/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml) with only read access (i.e. only `get`/`list`/`watch` verbs).
+You can achieve this by configuring the `argo-server` role ([example](https://github.com/argoproj/argo-workflows/blob/master/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml) with only read access (i.e. only `get`/`list`/`watch` verbs)).
 
 ## Network Security
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

Was looking to make an addition to the Security page and stumbled upon a few typos

<!-- TODO: Say why you made your changes. -->

### Modifications

- "workflow requirements features" -> "workflow restrictions feature"
- remove extra space
- add missing closing paren

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

n/a

<!-- TODO: Say how you tested your changes. -->
