### PR TITLE
docs: add UI Access section to Security page

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -31,6 +31,46 @@ If the user only has permission to create workflows, then they will be typically
 
 You can typically further restrict what a user can do to just being able to submit workflows from templates using [the workflow requirements feature](workflow-restrictions.md).
 
+#### UI Access
+
+If you want a user to have read-only access to the entirety of the Argo UI for their namespace, a sample role for them may look like:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ui-user-read-only
+rules:
+  # k8s standard APIs
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+  # Argo APIs. See also https://github.com/argoproj/argo-workflows/blob/master/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml#L4
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - eventsources
+      - sensors
+      - workflows
+      - workfloweventbindings
+      - workflowtemplates
+      - clusterworkflowtemplates
+      - cronworkflows
+      - cronworkflows
+      - workflowtaskresults
+    verbs:
+      - get
+      - list
+      - watch
+```
+
 ### Workflow Pod Permissions
 
 Workflow pods run using either:


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

Full UI access has some requirements to it, so wanted to add an example `Role` somewhere in the docs for it
- I was looking for something like this myself, but couldn't find it
  - A centralized location that could be updated & reviewed sounded very helpful to me as a user
- `pods/log` and `events` were ones one of my teams missed on a first pass (causing #11326)
  
For one of our platforms, users _only_ have access to the Argo UI and do _not_ have k8s API access. So they would not be covered by traditional `view` roles that may be aggregated to. This was used in combination with [SSO RBAC Namespace Delegation](https://argoproj.github.io/argo-workflows/argo-server-sso/#sso-rbac-namespace-delegation).


<!-- TODO: Say why you made your changes. -->

### Modifications

- Create a "UI Access" subsection under "User Permissions" on the "Security" page
  - Primarily list out the YAML for a `Role` therein

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Based off existing `Role`s in the codebase and an internal codebase

<!-- TODO: Say how you tested your changes. -->

### Review Notes

I'm not 100% certain all of these are needed -- particularly `pods`. Per the Motivation above, having this go through code review when being edited is actually one of the motivators!
