### PR TITLE
docs: fix typos and simplify wording on SSO page

### DIFF
--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -140,7 +140,7 @@ metadata:
     All users MUST map to a cluster service account (such as the one above) before a namespace service account can apply.
 
 Now, for the namespace that you own, configure a service account which would allow members of your team to perform operations in your namespace.
-Make sure that the precedence of the namespace service account is higher than the precedence of the login service account. Create an appropriate role that you want to grant to this service account and bind it with a role-binding.
+Make sure that the precedence of the namespace service account is higher than the precedence of the login service account. Create an appropriate role for this service account and bind it with a role-binding.
 
 ```yaml
 apiVersion: v1
@@ -153,7 +153,7 @@ metadata:
     workflows.argoproj.io/rbac-rule-precedence: "1"
 ```
 
-Using this, whenever a user is logged in via SSO, makes a request in `my-namespace`, and the `rbac-rule` matches, we will use this service account to allow the user to perform that operation in the namespace. If no service account matches in the namespace, the first service account (`user-default-login`) and its associated role will be used to perform the operation in the namespace.
+With this configuration, when a user is logged in via SSO, makes a request in `my-namespace`, and the `rbac-rule` matches, this service account allows the user to perform that operation in the namespace. If no service account matches in the namespace, the first service account (`user-default-login`) and its associated role will be used to perform the operation in the namespace.
 
 ## SSO Login Time
 

--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -124,7 +124,7 @@ To enable the feature, set env variable `SSO_DELEGATE_RBAC_TO_NAMESPACE=true` in
 
 ### Recommended usage
 
-Configure a default account in the installation namespace which would allow all users of your organization. We will use this service account to allow a user to login to the cluster. You could optionally add workflow read-only role and role-binding if you wish to.
+Configure a default account in the installation namespace that allows access to all users of your organization. This service account allows a user to login to the cluster. You could optionally add a workflow read-only role and role-binding.
 
 ```yaml
 apiVersion: v1
@@ -139,7 +139,7 @@ metadata:
 !!! Note
     All users MUST map to a cluster service account (such as the one above) before a namespace service account can apply.
 
-Now, for the namespace that you own, configure a service account which would allow members of your team to perform operations in your namespace.
+Now, for the namespace that you own, configure a service account that allows members of your team to perform operations in your namespace.
 Make sure that the precedence of the namespace service account is higher than the precedence of the login service account. Create an appropriate role for this service account and bind it with a role-binding.
 
 ```yaml
@@ -153,7 +153,7 @@ metadata:
     workflows.argoproj.io/rbac-rule-precedence: "1"
 ```
 
-With this configuration, when a user is logged in via SSO, makes a request in `my-namespace`, and the `rbac-rule` matches, this service account allows the user to perform that operation in the namespace. If no service account matches in the namespace, the first service account (`user-default-login`) and its associated role will be used to perform the operation in the namespace.
+With this configuration, when a user is logged in via SSO, makes a request in `my-namespace`, and the `rbac-rule` matches, this service account allows the user to perform that operation. If no service account matches in the namespace, the first service account (`user-default-login`) and its associated role will be used to perform the operation.
 
 ## SSO Login Time
 

--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -140,7 +140,7 @@ metadata:
     All users MUST map to a cluster service account (such as the one above) before a namespace service account can apply.
 
 Now, for the namespace that you own, configure a service account which would allow members of your team to perform operations in your namespace.
-Make sure that the precedence of the namespace service account is higher than the precedence of the login service account. Create appropriate role that you want to grant to this service account and bind it with a role-binding.
+Make sure that the precedence of the namespace service account is higher than the precedence of the login service account. Create an appropriate role that you want to grant to this service account and bind it with a role-binding.
 
 ```yaml
 apiVersion: v1
@@ -153,7 +153,7 @@ metadata:
     workflows.argoproj.io/rbac-rule-precedence: "1"
 ```
 
-Using this, whenever a user is logged in via SSO and makes a request in 'my-namespace', and the `rbac-rule`matches, we will use this service account to allow the user to perform that operation in the namespace. If no service account matches in the namespace, the first service account(`user-default-login`) and its associated role will be used to perform the operation in the namespace.
+Using this, whenever a user is logged in via SSO, makes a request in `my-namespace`, and the `rbac-rule` matches, we will use this service account to allow the user to perform that operation in the namespace. If no service account matches in the namespace, the first service account (`user-default-login`) and its associated role will be used to perform the operation in the namespace.
 
 ## SSO Login Time
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

- Stumbled upon some typos on the page
- Use simpler and more direct language, per the [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
  - there are (many) more changes that could be made to the docs according to the k8s style guide, but (significantly) limited myself right now to places I'm already applying fixes to 😅
    - didn't want to do wholesale copy-editing of all docs at this point 😅  
    - for example, using ["you"](https://kubernetes.io/docs/contribute/style/style-guide/#address-the-reader-as-you) and avoiding ["we"](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-using-we), which are switched between many times in the docs. (also, replacing ["latin phrases"](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-latin-phrases), etc etc)

<!-- TODO: Say why you made your changes. -->

### Modifications

- fix missing spaces, fix missing article ("an", "a")
- use code backticks when referring to a namespace

- simpler + more direct language:
  - "which would allow" -> "that allows" (also prefer [present tense](https://kubernetes.io/docs/contribute/style/style-guide/#use-present-tense))
  - "we will use this to allow" -> "this allows"
  - "that you want to grant to" -> "for"
  - "whenever" -> "when"
  - "we will use this service account to allow" -> "this service account allows"  
- reduce repetition
  - "if you wish to" is redundant when it is "optional"
  - "in the namespace" is redundant when it is initially stated that "makes a request in `my-namespace`"


<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

n/a

<!-- TODO: Say how you tested your changes. -->
