### PR TITLE
fix: Correct limit in controller List API calls. Fixes #11134

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -810,6 +810,8 @@ func (wfc *WorkflowController) tweakListOptions(options *metav1.ListOptions) {
 	labelSelector := labels.NewSelector().
 		Add(util.InstanceIDRequirement(wfc.Config.InstanceID))
 	options.LabelSelector = labelSelector.String()
+	// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
+	// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
 	options.ResourceVersion = ""
 }
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -810,6 +810,7 @@ func (wfc *WorkflowController) tweakListOptions(options *metav1.ListOptions) {
 	labelSelector := labels.NewSelector().
 		Add(util.InstanceIDRequirement(wfc.Config.InstanceID))
 	options.LabelSelector = labelSelector.String()
+	options.ResourceVersion = ""
 }
 
 func getWfPriority(obj interface{}) (int32, time.Time) {

--- a/workflow/controller/informer/tolerant_cluster_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_cluster_workflow_template_informer.go
@@ -21,8 +21,11 @@ type tolerantClusterWorkflowTemplateInformer struct {
 
 // a drop-in replacement for `extwfv1.ClusterWorkflowTemplateInformer` that ignores malformed resources
 func NewTolerantClusterWorkflowTemplateInformer(dynamicInterface dynamic.Interface, defaultResync time.Duration) extwfv1.ClusterWorkflowTemplateInformer {
-	return &tolerantClusterWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, "", func(options *metav1.ListOptions) {}).
-		ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.ClusterWorkflowTemplatePlural})}
+	return &tolerantClusterWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, "", func(options *metav1.ListOptions) {
+		// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
+		// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
+		options.ResourceVersion = ""
+	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.ClusterWorkflowTemplatePlural})}
 }
 
 func (t *tolerantClusterWorkflowTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/workflow/controller/informer/tolerant_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_workflow_template_informer.go
@@ -22,6 +22,8 @@ type tolerantWorkflowTemplateInformer struct {
 // a drop-in replacement for `extwfv1.WorkflowTemplateInformer` that ignores malformed resources
 func NewTolerantWorkflowTemplateInformer(dynamicInterface dynamic.Interface, defaultResync time.Duration, namespace string) extwfv1.WorkflowTemplateInformer {
 	return &tolerantWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, namespace, func(options *metav1.ListOptions) {
+		// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
+		// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
 		options.ResourceVersion = ""
 	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural})}
 }

--- a/workflow/controller/informer/tolerant_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_workflow_template_informer.go
@@ -21,8 +21,9 @@ type tolerantWorkflowTemplateInformer struct {
 
 // a drop-in replacement for `extwfv1.WorkflowTemplateInformer` that ignores malformed resources
 func NewTolerantWorkflowTemplateInformer(dynamicInterface dynamic.Interface, defaultResync time.Duration, namespace string) extwfv1.WorkflowTemplateInformer {
-	return &tolerantWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, namespace, func(options *metav1.ListOptions) {}).
-		ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural})}
+	return &tolerantWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, namespace, func(options *metav1.ListOptions) {
+		options.ResourceVersion = ""
+	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural})}
 }
 
 func (t *tolerantWorkflowTemplateInformer) Informer() cache.SharedIndexInformer {


### PR DESCRIPTION
Fixes #11134. 

The reason for this change is that `resourceVersion=0` does not honor the `limit` in API calls (related issue https://github.com/kubernetes/kubernetes/issues/59684#issuecomment-364627127), which results in making significant LIST calls without `limit`. Below are some screenshots from experiments (credit to Jesse). Same results for other non-pod resources.

![image](https://github.com/argoproj/argo-workflows/assets/4269898/f36566e2-dd75-4bc3-accf-9469ea99f29f)
![image](https://github.com/argoproj/argo-workflows/assets/4269898/58263ae0-a905-4a88-b4d2-14c975e84546)

Even though we may see `limit=100&resourceVersion=0` in the controller logs, the API server does not honor the limit. 
