### PR TITLE
build: Remove personal token for docs publishing

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -39,9 +39,9 @@ jobs:
           name: docs
           path: site
           if-no-files-found: error
-      - uses: peaceiris/actions-gh-pages@v2.9.0
+      - uses: peaceiris/actions-gh-pages@v3
         if: github.repository == 'argoproj/argo-workflows' && github.ref == 'refs/heads/master'
         env:
-          PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: ./site


### PR DESCRIPTION
This is more secure and supported https://github.com/peaceiris/actions-gh-pages#supported-tokens