### PR TITLE
ci: Grant write permission to docs workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   docs:


### PR DESCRIPTION
This should fix the issue below:

```
remote: Permission to argoproj/argo-workflows.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/argoproj/argo-workflows.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```