### PR TITLE
feat: Enable local docker ip in for communication with outside k3d

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
   "hostRequirements": {
     "cpus": 4
   },
+  "runArgs": ["--add-host=host.docker.internal:host-gateway"],
   "onCreateCommand": ".devcontainer/pre-build.sh",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/go/src/github.com/argoproj/argo-workflows,type=bind",
   "workspaceFolder": "/home/vscode/go/src/github.com/argoproj/argo-workflows",

--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -14,7 +14,7 @@ k3d cluster get k3s-default || k3d cluster create --wait
 k3d kubeconfig merge --kubeconfig-merge-default
 
 # install kubectl
-curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl
+curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/$(go env GOARCH)/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 kubectl cluster-info

--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -31,3 +31,6 @@ sudo chown -R vscode:vscode /home/vscode/go
 
 # download dependencies and do first-pass compile
 CI=1 kit pre-up
+
+# Patch CoreDNS to have host.docker.internal inside the cluster available
+kubectl get cm coredns -n kube-system -o yaml | sed "s/  NodeHosts: |/  NodeHosts: |\n    `grep host.docker.internal /etc/hosts`/" | kubectl apply -f -

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -12,7 +12,7 @@ generation does not work.
 
 ## Development Container
 
-A development container is a running Docker container with a well-defined tool/runtime stack and its prerequisites. It should be able to do everything you need to do to develop argo workflows using the development container without installing tools on your local machine. It takes quite a long time to build the container. It will run k3d inside the container so you'll have a cluster to use to test against. To communicate with services running either in other development containers or directly on the local developer machine (e.g., a database) the following combination of hostname and port can be used in the workflow spec: `host.docker.internal:<PORT>`. This facilitates the implementation of workflows, which need to connect to a database or an API server.
+A development container is a running Docker container with a well-defined tool/runtime stack and its prerequisites. It should be able to do everything you need to do to develop argo workflows using the development container without installing tools on your local machine. It takes quite a long time to build the container. It will run k3d inside the container so you'll have a cluster to use to test against. To communicate with services running either in other development containers or directly on the local developer machine (e.g., a database) the following URL can be used in the workflow spec: `host.docker.internal:<PORT>`. This facilitates the implementation of workflows, which need to connect to a database or an API server.
 
 You can use the development container in a few different ways:
 

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -12,7 +12,7 @@ generation does not work.
 
 ## Development Container
 
-A development container is a running Docker container with a well-defined tool/runtime stack and its prerequisites. It should be able to do everything you need to do to develop argo workflows using the development container without installing tools on your local machine. It takes quite a long time to build the container. It will run k3d inside the container so you'll have a cluster to use to test against.
+A development container is a running Docker container with a well-defined tool/runtime stack and its prerequisites. It should be able to do everything you need to do to develop argo workflows using the development container without installing tools on your local machine. It takes quite a long time to build the container. It will run k3d inside the container so you'll have a cluster to use to test against. To communicate with services running either in other development containers or directly on the local developer machine (e.g., a database) the following combination of hostname and port can be used in the workflow spec: `host.docker.internal:<PORT>`. This facilitates the implementation of workflows, which need to connect to a database or an API server.
 
 You can use the development container in a few different ways:
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


### Motivation

This PR introduces the possibility to connect to services outside the `k3d` cluster used in DevContainer by setting up a distinct hostname. 

### Modifications

The magic hostname `host.docker.internal` is re-used and injected in the `devcontainer.json` and the CoreDNS configmap.

### Verification

Within the same Docker environment a Web container running `nginx` has been created. After that, VSCode with DevContainer is started. When DevContainer is up and running, exec a shell in a pod and issue:

```
kubectl exec -ti deploy/minio -- curl -v telnet://host.docker.internal:80
* Rebuilt URL to: telnet://host.docker.internal:80/
*   Trying 172.17.0.1...
* TCP_NODELAY set
* Connected to host.docker.internal (172.17.0.1) port 80 (#0)
