### PR TITLE
fix: Enable the workflow created by a wftmpl to retry after manually stopped

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -820,6 +820,9 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 	newWF.Status.Message = ""
 	newWF.Status.StartedAt = metav1.Time{Time: time.Now().UTC()}
 	newWF.Status.FinishedAt = metav1.Time{}
+	if newWF.Status.StoredWorkflowSpec != nil {
+		newWF.Status.StoredWorkflowSpec.Shutdown = ""
+	}
 	newWF.Spec.Shutdown = ""
 	newWF.Status.PersistentVolumeClaims = []apiv1.Volume{}
 	if newWF.Spec.ActiveDeadlineSeconds != nil && *newWF.Spec.ActiveDeadlineSeconds == 0 {


### PR DESCRIPTION
…ally after manually stopped

<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

No, I just met a problem in my work, but I made no issue but fix it myself because of time constraints

### Motivation

Most of the users I am responsible for use workflow-templates to create workflows. However, there is a problem that has been bothering us: after the workflows created through the workflow templates are manually stopped, when retrying the failed node (because of the Stop operation) and all subsequent nodes will be skipped. Here is an example:

After manually stopped:
<img width="1083" alt="image" src="https://github.com/argoproj/argo-workflows/assets/37112055/c67fc8fe-558a-4e82-bb2e-5d306633563c">

Ater manually retried:
![image](https://github.com/argoproj/argo-workflows/assets/37112055/aff1ef40-fac4-4ba6-9855-233ba9b2bad6)

### Modifications

<!-- TODO: Say what changes you made. -->
After carefully reading the relevant code, we finally realized that in the `FormulaRetryWorkflow` function, `newWF.Status.StoredWorkflowSpec.Shutdown` should be set to an empty string instead of keeping the shutdown information.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
The following is a sample workflow template file：
```yaml
metadata:
  name: clf-test-retry
  namespace: argo
spec:
  templates:
    - name: echo
      inputs:
        parameters:
          - name: message
      outputs: {}
      metadata: {}
      container:
        name: ''
        image: alpine:3.7
        command:
          - sleep
          - 1000s
        resources: {}
    - name: diamond
      inputs: {}
      outputs: {}
      metadata: {}
      dag:
        tasks:
          - name: A
            template: echo
            arguments:
              parameters:
                - name: message
                  value: A
          - name: B
            template: echo
            arguments:
              parameters:
                - name: message
                  value: B
            dependencies:
              - A
          - name: C
            template: echo
            arguments:
              parameters:
                - name: message
                  value: C
            dependencies:
              - A
          - name: D
            template: echo
            arguments:
              parameters:
                - name: message
                  value: D
            dependencies:
              - B
              - C
  entrypoint: diamond
  arguments: {}
```
You can just stop and retry the workflow when node A is running and the images in the ***Motivation*** can be reproduced.
After our fix, the workflow after retrying is as follows:
![image](https://github.com/argoproj/argo-workflows/assets/37112055/6ffe51be-132c-48ec-94bd-e0330f78ebc3)

Signed-off-by: tongkangheng.tkh <tongkangheng.tkh@bytedance.com>


