### PR TITLE
fix: prevent stdout from disappearing in script templates. Fixes #11330

### DIFF
--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -40,11 +40,20 @@ func TestEmissary(t *testing.T) {
 		assert.Equal(t, "1", string(data))
 	})
 	t.Run("Stdout", func(t *testing.T) {
+		_ = os.Remove(varRunArgo + "/ctr/main/stdout")
 		err := run("echo hello")
 		assert.NoError(t, err)
 		data, err := os.ReadFile(varRunArgo + "/ctr/main/stdout")
 		assert.NoError(t, err)
 		assert.Contains(t, string(data), "hello")
+	})
+	t.Run("Sub-process", func(t *testing.T) {
+		_ = os.Remove(varRunArgo + "/ctr/main/stdout")
+		err := run("(sleep 60; echo 'should not wait for sub-process')& echo -n hello")
+		assert.NoError(t, err)
+		data, err := os.ReadFile(varRunArgo + "/ctr/main/stdout")
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", string(data))
 	})
 	t.Run("Combined", func(t *testing.T) {
 		err := run("echo hello > /dev/stderr")

--- a/workflow/executor/os-specific/command.go
+++ b/workflow/executor/os-specific/command.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/term"
@@ -16,7 +17,12 @@ func simpleStart(cmd *exec.Cmd) (func(), error) {
 		return nil, err
 	}
 
-	return func() {}, nil
+	closer := func() {
+		cmd.WaitDelay = 100 * time.Millisecond
+		_ = cmd.Wait()
+	}
+
+	return closer, nil
 }
 
 func isTerminal(stdin io.Reader) bool {

--- a/workflow/executor/os-specific/command_test.go
+++ b/workflow/executor/os-specific/command_test.go
@@ -1,0 +1,47 @@
+package os_specific
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleStartCloser(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo -n A123456789B123456789C123456789D123456789E123456789")
+	var stdoutWriter bytes.Buffer
+	slowWriter := SlowWriter{
+		&stdoutWriter,
+	}
+	// Command outputs are asynchronously written to cmd.Stdout.
+	// Using SlowWriter causes the situation where the invoked command has exited but its outputs have not been written yet.
+	cmd.Stdout = slowWriter
+
+	closer, err := StartCommand(cmd)
+	assert.NoError(t, err)
+	err = cmd.Process.Release()
+	assert.NoError(t, err)
+	// Wait for echo command to exit before calling closer
+	time.Sleep(100 * time.Millisecond)
+	closer()
+
+	assert.Equal(t, "A123456789B123456789C123456789D123456789E123456789", stdoutWriter.String())
+}
+
+type SlowWriter struct {
+	Writer io.Writer
+}
+
+func (s SlowWriter) Write(data []byte) (n int, err error) {
+	for i := range data {
+		_, err := s.Writer.Write(data[i : i+1])
+		if err != nil {
+			return i, err
+		}
+		time.Sleep(7 * time.Millisecond)
+	}
+	return len(data), nil
+}


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11330

### Motivation

<!-- TODO: Say why you made your changes. -->
Outputs of the executed command are asynchronously read and copied to `cmd.Stdout`. `cmd.Stdout` must be closed after copies are done otherwise command outputs are gone. 

As described below, however, copies can never be end because sub-processes can keep running and can write to stdout indefinitely.

https://github.com/argoproj/argo-workflows/blob/6166464aa6961bcb375705753ed0b58707d68222/workflow/executor/os-specific/signal_darwin.go#L27-L38

### Modifications

<!-- TODO: Say what changes you made. -->
`Wait()` is added to wait the copy.
`WaitDelay` is also added. It will close the pipes (stdout/stderr) of the executed command to stop sub-processes writing any more texts. 

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
Tests were added.
I also ran the following command for more than an hour.

```sh
$ docker run \
    --rm -it \
    --cpus 0.5 \
    -e ARGO_CONTAINER_NAME=main \
    -e ARGO_INCLUDE_SCRIPT_OUTPUT=true \
    -v $PWD/dist/argoexec:/var/run/argo/argoexec \
    busybox:1.35 \
    sh
$ echo '{}' > /var/run/argo/template
$ while :; do
    rm -f /var/run/argo/ctr/main/*
    < /dev/null /var/run/argo/argoexec emissary --loglevel info --log-format text -- echo hello
    ls -l /var/run/argo/ctr/main
    [ ! -s /var/run/argo/ctr/main/stdout ] && break
    [ ! -s /var/run/argo/ctr/main/combined ] && break
done
```
