### PR TITLE
feat: Improve logging in the oauth2 callback handler

### DIFF
--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -230,6 +230,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(state)
 	http.SetCookie(w, &http.Cookie{Name: state, MaxAge: 0})
 	if err != nil {
+		log.WithError(err).Error("failed to get cookie")
 		w.WriteHeader(400)
 		return
 	}
@@ -238,25 +239,28 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	oauth2Context := context.WithValue(ctx, oauth2.HTTPClient, s.httpClient)
 	oauth2Token, err := s.config.Exchange(oauth2Context, r.URL.Query().Get("code"), redirectOption)
 	if err != nil {
+		log.WithError(err).Error("failed to get oauth2Token by using code from the oauth2 server")
 		w.WriteHeader(401)
 		return
 	}
 	rawIDToken, ok := oauth2Token.Extra("id_token").(string)
 	if !ok {
+		log.Error("failed to extract id_token from the response")
 		w.WriteHeader(401)
 		return
 	}
 	idToken, err := s.idTokenVerifier.Verify(ctx, rawIDToken)
 	if err != nil {
+		log.WithError(err).Error("failed to verify the id token issued")
 		w.WriteHeader(401)
 		return
 	}
 	c := &types.Claims{}
 	if err := idToken.Claims(c); err != nil {
+		log.WithError(err).Error("failed to get claims from the id token")
 		w.WriteHeader(401)
 		return
 	}
-
 	// Default to groups claim but if customClaimName is set
 	// extract groups based on that claim key
 	groups := c.Groups
@@ -266,17 +270,16 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 			log.Warn(err)
 		}
 	}
-
 	// Some SSO implementations (Okta) require a call to
 	// the OIDC user info path to get attributes like groups
 	if s.userInfoPath != "" {
 		groups, err = c.GetUserInfoGroups(oauth2Token.AccessToken, s.issuer, s.userInfoPath)
 		if err != nil {
+			log.WithError(err).Errorf("failed to get groups claim from the given userInfoPath(%s)", s.userInfoPath)
 			w.WriteHeader(401)
 			return
 		}
 	}
-
 	argoClaims := &types.Claims{
 		Claims: jwt.Claims{
 			Issuer:  issuer,
@@ -291,9 +294,9 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		PreferredUsername:       c.PreferredUsername,
 		ServiceAccountNamespace: c.ServiceAccountNamespace,
 	}
-
 	raw, err := jwt.Encrypted(s.encrypter).Claims(argoClaims).CompactSerialize()
 	if err != nil {
+		log.WithError(err).Errorf("failed to encrypt and serialize the jwt token")
 		w.WriteHeader(401)
 		return
 	}


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11369

### Motivation

<!-- TODO: Say why you made your changes. -->
The current implementation of the OAuth2 callback handler lacks sufficient logging, making it difficult to identify errors and misconfigurations related to SSO (Single Sign-On). By adding detailed logs, we can simplify the process of configuring SSO and troubleshoot any issues that may arise.


Due to the insufficient logs in the oauth2 callback handler, it wasn't easy to identify the errors and misconfigurations about sso.

If the servers writes detailed logs, it would help the process configuring sso.

### Modifications

<!-- TODO: Say what changes you made. -->
I have added error logging to the `/oauth2/callback` handler.

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
To verify these changes, I performed the following tests:

1. Test with an incorrect client secret - I set the client secret to `foobarbaz`, which is an invalid value.
  ```
  # before
  time="2023-07-16T12:04:06.600Z" level=info duration=8.976035ms method=GET path=/oauth2/callback size=0 status=401
  
  # after
  time="2023-07-16T12:20:25.064Z" level=error msg="failed to get oauth2Token by using code from the oauth2 server" error="oauth2: \"unauthorized_client\" \"Invalid client secret\""
time="2023-07-16T12:20:25.064Z" level=info duration=9.112831ms method=GET path=/oauth2/callback size=0 status=401
  ```
2. Test with an incorrect ID token issuer - I set the issuer to include the unnecessary port (80).
  ```
  # before
  time="2023-07-16T12:08:36.733Z" level=info duration=65.410745ms method=GET path=/oauth2/callback size=0 status=401
  
  # after
  time="2023-07-16T12:18:16.333Z" level=error msg="failed to verify the id token issued" error="oidc: id token issued by a different provider, expected \"http://keycloak-http.keycloak:80/auth/realms/myrealm\" got \"http://keycloak-http.keycloak/auth/realms/myrealm\""
  time="2023-07-16T12:18:16.333Z" level=info duration=19.251945ms method=GET path=/oauth2/callback size=0 status=401
  ```