### PR TITLE
fix: add query string to workflow detail page(#11371)

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -67,8 +67,8 @@ export const WorkflowsService = {
         return requests.get(`api/v1/workflows/${namespace}/${name}`).then(res => res.body as Workflow);
     },
 
-    getArchived(namespace: string, name: string) {
-        return requests.get(`api/v1/archived-workflows/?name=${name}&namespace=${namespace}`).then(res => res.body as models.Workflow);
+    getArchived(namespace: string, uid: string) {
+        return requests.get(`api/v1/archived-workflows/${uid}?namespace=${namespace}`).then(res => res.body as models.Workflow);
     },
 
     watch(query: {
@@ -126,6 +126,13 @@ export const WorkflowsService = {
         return requests
             .put(`api/v1/workflows/${namespace}/${name}/resubmit`)
             .send(opts)
+            .then(res => res.body as Workflow);
+    },
+
+    resubmitArchived(uid: string, namespace: string, opts?: ResubmitOpts) {
+        return requests
+            .put(`api/v1/archived-workflows/${uid}/resubmit`)
+            .send({namespace, ...opts})
             .then(res => res.body as Workflow);
     },
 

--- a/ui/src/app/workflows/components/resubmit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/resubmit-workflow-panel.tsx
@@ -9,6 +9,7 @@ import {Utils} from '../../shared/utils';
 
 interface Props {
     workflow: Workflow;
+    isArchived: boolean;
 }
 
 interface State {
@@ -98,9 +99,16 @@ export class ResubmitWorkflowPanel extends React.Component<Props, State> {
             memoized: this.state.memoized
         };
 
-        services.workflows
-            .resubmit(this.props.workflow.metadata.name, this.props.workflow.metadata.namespace, opts)
-            .then((submitted: Workflow) => (document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`)))
-            .catch(error => this.setState({error, isSubmitting: false}));
+        if (!this.props.isArchived) {
+            services.workflows
+                .resubmit(this.props.workflow.metadata.name, this.props.workflow.metadata.namespace, opts)
+                .then((submitted: Workflow) => (document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`)))
+                .catch(error => this.setState({error, isSubmitting: false}));
+        } else {
+            services.workflows
+                .resubmitArchived(this.props.workflow.metadata.uid, this.props.workflow.metadata.namespace, opts)
+                .then((submitted: Workflow) => (document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`)))
+                .catch(error => this.setState({error, isSubmitting: false}));
+        }
     }
 }

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -386,7 +386,7 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
     }, [namespace, name]);
 
     useEffect(() => {
-        if (!workflow && !isWfInCluster) {
+        if (!workflow && !isWfInCluster && uid !== '') {
             services.workflows
                 .getArchived(namespace, uid)
                 .then(wf => {

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import {useContext, useEffect, useRef, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
-import {ArtifactRepository, execSpec, isArchivedWorkflow, Link, NodeStatus, Parameter, Workflow, archivalStatus} from '../../../../models';
+import {archivalStatus, ArtifactRepository, execSpec, isArchivedWorkflow, Link, NodeStatus, Parameter, Workflow} from '../../../../models';
 import {ANNOTATION_KEY_POD_NAME_VERSION} from '../../../shared/annotations';
 import {artifactRepoHasLocation, findArtifact} from '../../../shared/artifacts';
 import {uiUrl} from '../../../shared/base';
@@ -369,8 +369,8 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
                     if (hasArtifactGCError(e.object.status.conditions)) {
                         setError(new Error('Artifact garbage collection failed'));
                     }
-                    if (e.object.metadata.labels?.[archivalStatus] === "Archived") {
-                        setIsWfInDB(true)
+                    if (e.object.metadata.labels?.[archivalStatus] === 'Archived') {
+                        setIsWfInDB(true);
                     }
                     setWorkflow(e.object);
                     setIsWfInCluster(true);

--- a/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
@@ -50,7 +50,12 @@ export class WorkflowsRow extends React.Component<WorkflowsRowProps, WorkflowRow
                         />
                         <PhaseIcon value={wf.status.phase} />
                     </div>
-                    <Link to={uiUrl(`workflows/${wf.metadata.namespace}/${wf.metadata.name}`)} className='small-11 row'>
+                    <Link
+                        to={{
+                            pathname: uiUrl(`workflows/${wf.metadata.namespace}/${wf.metadata.name}`),
+                            search: `?uid=${wf.metadata.uid}`
+                        }}
+                        className='small-11 row'>
                         <div className='columns small-2'>
                             {(wf.metadata.annotations && wf.metadata.annotations[ANNOTATION_TITLE]) || wf.metadata.name}
                             {wf.metadata.annotations && wf.metadata.annotations[ANNOTATION_DESCRIPTION] ? <p>{wf.metadata.annotations[ANNOTATION_DESCRIPTION]}</p> : null}

--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -1,6 +1,6 @@
 import {NotificationType} from 'argo-ui';
 import * as React from 'react';
-import {archivalStatus, Workflow} from '../../../../models';
+import {isArchivedWorkflow, isWorkflowInCluster, Workflow} from '../../../../models';
 import {Consumer} from '../../../shared/context';
 import {services} from '../../../shared/services';
 import * as Actions from '../../../shared/workflow-operations-map';
@@ -60,7 +60,7 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
         this.props.selectedWorkflows.forEach((wf: Workflow) => {
             if (title === 'DELETE') {
                 // The ones without archivalStatus label or with 'Archived' labels are the live workflows.
-                if (!wf.metadata.labels.hasOwnProperty(archivalStatus) || wf.metadata.labels[archivalStatus] === 'Archived') {
+                if (isWorkflowInCluster(wf)) {
                     promises.push(
                         services.workflows.delete(wf.metadata.name, wf.metadata.namespace).catch(reason =>
                             ctx.notifications.show({
@@ -70,7 +70,7 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
                         )
                     );
                 }
-                if (deleteArchived && (wf.metadata.labels[archivalStatus] === 'Archived' || wf.metadata.labels[archivalStatus] === 'Persisted')) {
+                if (deleteArchived && isArchivedWorkflow(wf)) {
                     promises.push(
                         services.workflows.deleteArchived(wf.metadata.uid, wf.metadata.namespace).catch(reason =>
                             ctx.notifications.show({

--- a/ui/src/models/workflows.ts
+++ b/ui/src/models/workflows.ts
@@ -541,7 +541,17 @@ export const execSpec = (w: Workflow) => Object.assign({}, w.status.storedWorkfl
 
 export const archivalStatus = 'workflows.argoproj.io/workflow-archiving-status';
 
+export function isWorkflowInCluster(wf: Workflow): boolean {
+    if (!wf) {
+        return false;
+    }
+    return !wf.metadata.labels[archivalStatus] || wf.metadata.labels[archivalStatus] === 'Pending' || wf.metadata.labels[archivalStatus] === 'Archived';
+}
+
 export function isArchivedWorkflow(wf: Workflow): boolean {
+    if (!wf) {
+        return false;
+    }
     return wf.metadata.labels && (wf.metadata.labels[archivalStatus] === 'Archived' || wf.metadata.labels[archivalStatus] === 'Persisted');
 }
 


### PR DESCRIPTION
Signed-off-by: toyamagu2021@gmail.com <toyamagu2021@gmail.com>

<!-- Does this PR fix an issue -->

Fixes #11371 

### Motivation


### Modifications

- Add query string `uid` to the workflow detail page.
- Pass `uid` from the workflow list page.
- Use `uid` in the following functions
  - `getArchived`
  - `resubmitArchived`

### Verification

#### Resubmit Workflow

1. Prepare two archived workflows
   ![image](https://github.com/argoproj/argo-workflows/assets/83329336/02a20723-1665-4f78-85d9-7f1d41cfd859)
1. Successfully opened
    ![image](https://github.com/argoproj/argo-workflows/assets/83329336/0f17fed9-364b-428d-a3cf-464cd43fc7a2)
1. Resubmit with changed param
    ![image](https://github.com/argoproj/argo-workflows/assets/83329336/22705646-0a90-44d5-b6d8-10b6da9b165e)

#### Workflow GC

1. Create a finite-ttl workflow 
   URL: `http://localhost:8080/workflows/argo/omniscient-dragon?tab=workflow`
   ![image](https://github.com/argoproj/argo-workflows/assets/83329336/3e4a30f1-974a-48f7-af43-c45bd822012a)
2. Workflow gone by GC
   URL is set to: `http://localhost:8080/workflows/argo/omniscient-dragon?tab=summary&uid=4dd0192a-d976-4584-a13b-3e3a8eb196af`
   ![image](https://github.com/argoproj/argo-workflows/assets/83329336/0c7f9605-26e9-4ecc-9951-c86806476e65)
3. Refresh page
   ![image](https://github.com/argoproj/argo-workflows/assets/83329336/be58fa35-3ff5-4c2e-91b7-0f0d598e09c9)