### PR TITLE
docs: Improve release instructions

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,18 +2,22 @@
 
 ## Cherry-Picking Fixes
 
-✋ Before you start, make sure the release branch is passing CI.
+✋ Before you start, make sure you have created a release branch (e.g. `release-3.3`) and it's passing CI.
 
-Get a list of commits you may want to cherry-pick:
+Then get a list of commits you may want to cherry-pick:
 
 ```bash
-./hack/what-to-cherry-pick.sh release-3.3
+./hack/what-to-cherry-pick.sh release-3.3 "fix"
+./hack/what-to-cherry-pick.sh release-3.3 "chore(deps)"
+./hack/what-to-cherry-pick.sh release-3.3 "build"
+./hack/what-to-cherry-pick.sh release-3.3 "ci"
 ```
 
 Ignore:
 
 * Fixes for features only on master.
-* Dependency upgrades, unless it fixes a known security issue.
+* Dependency upgrades, unless they fix known security issues.
+* Build or CI improvements, unless the release pipeline is blocked without them.
 
 Cherry-pick the first commit. Run `make test` locally before pushing. If the build timeouts the build caches may have
 gone, try re-running.

--- a/hack/what-to-cherry-pick.sh
+++ b/hack/what-to-cherry-pick.sh
@@ -3,6 +3,8 @@ set -eu
 # this script prints out a list a commits that are on master that you should probably cherry-pick to the release branch
 
 br=$1;# branch
+commitPrefix=$2;# examples: fix, chore(deps), build, ci
+commitGrepPattern="^${commitPrefix}:.*(#"
 
 # find the branch point
 base=$(git merge-base $br master)
@@ -16,7 +18,7 @@ prNo() {
 # list the PRs on each branch
 prs() {
   set -eu
-  git log --format=%s --grep '^fix:.*(#' $1...$2 | prNo | sort > /tmp/$2
+  git log --format=%s --grep ${commitGrepPattern} $1...$2 | prNo | sort > /tmp/$2
 }
 
 prs $base $br
@@ -26,6 +28,6 @@ prs $base master
 diff /tmp/$br /tmp/master | grep '^> ' | cut -c 3- > /tmp/prs
 
 # print all the commits that need cherry-picking
-git log --oneline --grep '^fix:.*(#' $base...master | while read -r m; do
+git log --oneline --grep ${commitGrepPattern} $base...master | while read -r m; do
   grep -q "$(echo $m | prNo)" /tmp/prs && echo $m
 done


### PR DESCRIPTION
Currently the script only works for "fix" commits so this PR generalizes it and added more clarity in the instructions.