### PR TITLE
ci: Bump E2E_WAIT_TIMEOUT to avoid E2E test failures in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ KUBE_NAMESPACE        ?= argo
 MANAGED_NAMESPACE     ?= $(KUBE_NAMESPACE)
 
 # Timeout for wait conditions
-E2E_WAIT_TIMEOUT      ?= 1m
+E2E_WAIT_TIMEOUT      ?= 90s
 
 E2E_PARALLEL          ?= 20
 E2E_SUITE_TIMEOUT     ?= 15m


### PR DESCRIPTION
This is to avoid issues like the following, where a step takes longer to run than usual on GitHub Actions.

```

 ● retry-with-recreated-pvc   Workflow  0s      
 └ ● retry-with-recreated-pvc Steps     0s      
 └ ● [0]                      StepGroup 0s      
 └ ◷ generate                 Pod       0s      

    cli_test.go:897: timeout after 1m0s waiting for condition
../../dist/argo -n argo retry retry-with-recreated-pvc
exit status 1time="2023-07-19T01:36:47.880Z" level=fatal msg="rpc error: code = InvalidArgument desc = workflow must be Failed/Error to retry"

    cli_test.go:900: 
        	Error Trace:	/home/runner/work/argo-workflows/argo-workflows/test/e2e/cli_test.go:900
        	            				/home/runner/work/argo-workflows/argo-workflows/test/e2e/fixtures/then.go:265
        	            				/home/runner/work/argo-workflows/argo-workflows/test/e2e/cli_test.go:899
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestCLISuite/TestWorkflowRetryWithRecreatedPVC
        	Messages:   	time="2023-07-19T01:36:47.880Z" level=fatal msg="rpc error: code = InvalidArgument desc = workflow must be Failed/Error to retry"
```
