### PR TITLE
fix: log level for client-side throttling

### DIFF
--- a/util/logs/log-k8s-requests.go
+++ b/util/logs/log-k8s-requests.go
@@ -17,7 +17,7 @@ func (m k8sLogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	x, err := m.roundTripper.RoundTrip(r)
 	if x != nil {
 		verb, kind := k8s.ParseRequest(r)
-		log.Debugf("%s %s %d", verb, kind, x.StatusCode)
+		log.Warnf("%s %s %d", verb, kind, x.StatusCode)
 	}
 	return x, err
 }


### PR DESCRIPTION
Expresses when throttling occurs on the
client side by setting the log message level to Warn.

<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11387 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
