### PR TITLE
fix: download subdirs in azure artifact. Fixes #11385

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go v62.0.0+incompatible // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -154,6 +154,10 @@ func (azblobDriver *ArtifactDriver) Load(artifact *wfv1.Artifact, path string) e
 func DownloadFile(containerClient *container.Client, blobName, path string) error {
 	blobClient := containerClient.NewBlobClient(blobName)
 
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return fmt.Errorf("unable to create dir for file %s: %s", path, err)
+	}
 	outFile, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("unable to create file %s: %s", path, err)
@@ -178,7 +182,7 @@ func (azblobDriver *ArtifactDriver) DownloadDirectory(containerClient *container
 		return fmt.Errorf("unable to list blob %s in Azure Storage: %s", artifact.Azure.Blob, err)
 	}
 
-	err = os.Mkdir(path, 0755)
+	err = os.MkdirAll(path, 0755)
 	if err != nil {
 		return fmt.Errorf("unable to create local directory %s: %s", path, err)
 	}

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -1,8 +1,15 @@
 package azure
 
 import (
+	"context"
+	"errors"
 	"net/url"
+	"path/filepath"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -36,4 +43,42 @@ func TestDetermineAccountName(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "", accountName)
 	}
+}
+
+func TestArtifactDriver_DownloadDirectory_Subdir(t *testing.T) {
+	t.Skipf("This test needs azurite. docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite:latest azurite-blob")
+
+	driver := ArtifactDriver{
+		AccountKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", // default azurite key
+		Container:  "test",
+		Endpoint:   "http://127.0.0.1:10000/devstoreaccount1",
+	}
+
+	// ensure container exists
+	containerClient, err := driver.newAzureContainerClient()
+	assert.NoError(t, err)
+	_, err = containerClient.Create(context.Background(), nil)
+	var responseError *azcore.ResponseError
+	if err != nil && !(errors.As(err, &responseError) && responseError.ErrorCode == "ContainerAlreadyExists") {
+		assert.NoError(t, err)
+	}
+
+	// put a file in a subdir on the azurite blob storage
+	blobClient := containerClient.NewBlockBlobClient("dir/subdir/file-in-subdir.txt")
+	_, err = blobClient.UploadBuffer(context.Background(), []byte("foo"), nil)
+	assert.NoError(t, err)
+
+	// download the dir, containing a subdir
+	azureArtifact := wfv1.AzureArtifact{
+		Blob: "dir",
+	}
+	argoArtifact := wfv1.Artifact{
+		ArtifactLocation: wfv1.ArtifactLocation{
+			Azure: &azureArtifact,
+		},
+	}
+	dstDir := t.TempDir()
+	err = driver.DownloadDirectory(containerClient, &argoArtifact, filepath.Join(dstDir, "dir"))
+	assert.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dstDir, "dir", "subdir", "file-in-subdir.txt"))
 }


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11385

### Motivation

To fix #11385

### Modifications

Before, azure artifact driver would not create/make the local subdir for the file to be downloaded into. Now it does.

### Verification

Tested with azurite. The test is included but skipped by default.
