### PR TITLE
fix: Apply the creator labels about the user who resubmitted a Workflow

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -428,7 +428,7 @@ func (s *workflowServer) ResubmitWorkflow(ctx context.Context, req *workflowpkg.
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}
 
-	newWF, err := util.FormulateResubmitWorkflow(wf, req.Memoized, req.Parameters)
+	newWF, err := util.FormulateResubmitWorkflow(ctx, wf, req.Memoized, req.Parameters)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -262,7 +262,7 @@ func (w *archivedWorkflowServer) ResubmitArchivedWorkflow(ctx context.Context, r
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
 
-	newWF, err := util.FormulateResubmitWorkflow(wf, req.Memoized, req.Parameters)
+	newWF, err := util.FormulateResubmitWorkflow(ctx, wf, req.Memoized, req.Parameters)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5478,12 +5478,12 @@ status:
       name: my-wf
       phase: Failed
 `)
-	wf, err := util.FormulateResubmitWorkflow(wf, true, nil)
+	ctx := context.Background()
+	wf, err := util.FormulateResubmitWorkflow(ctx, wf, true, nil)
 	if assert.NoError(t, err) {
 		cancel, controller := newController(wf)
 		defer cancel()
 
-		ctx := context.Background()
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
@@ -5527,12 +5527,12 @@ status:
       name: my-wf
       phase: Failed
 `)
-	wf, err := util.FormulateResubmitWorkflow(wf, true, []string{"message=modified"})
+	ctx := context.Background()
+	wf, err := util.FormulateResubmitWorkflow(ctx, wf, true, []string{"message=modified"})
 	if assert.NoError(t, err) {
 		cancel, controller := newController(wf)
 		defer cancel()
 
-		ctx := context.Background()
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)

--- a/workflow/creator/creator.go
+++ b/workflow/creator/creator.go
@@ -15,13 +15,27 @@ import (
 func Label(ctx context.Context, obj metav1.Object) {
 	claims := auth.GetClaims(ctx)
 	if claims != nil {
-		labels.Label(obj, common.LabelKeyCreator, dnsFriendly(claims.Subject))
+		if claims.Subject != "" {
+			labels.Label(obj, common.LabelKeyCreator, dnsFriendly(claims.Subject))
+		} else {
+			labels.UnLabel(obj, common.LabelKeyCreator)
+		}
 		if claims.Email != "" {
 			labels.Label(obj, common.LabelKeyCreatorEmail, dnsFriendly(strings.Replace(claims.Email, "@", ".at.", 1)))
+		} else {
+			labels.UnLabel(obj, common.LabelKeyCreatorEmail)
 		}
 		if claims.PreferredUsername != "" {
 			labels.Label(obj, common.LabelKeyCreatorPreferredUsername, dnsFriendly(claims.PreferredUsername))
+		} else {
+			labels.UnLabel(obj, common.LabelKeyCreatorPreferredUsername)
 		}
+	} else {
+		// If the object already has creator-related labels, but the actual request lacks auth information,
+		// remove the creator-related labels from the object.
+		labels.UnLabel(obj, common.LabelKeyCreator)
+		labels.UnLabel(obj, common.LabelKeyCreatorEmail)
+		labels.UnLabel(obj, common.LabelKeyCreatorPreferredUsername)
 	}
 }
 

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -66,7 +66,7 @@ func TestResubmitWorkflowWithOnExit(t *testing.T) {
 		Name:  onExitName,
 		Phase: wfv1.NodeSucceeded,
 	}
-	newWF, err := FormulateResubmitWorkflow(&wf, true, nil)
+	newWF, err := FormulateResubmitWorkflow(context.Background(), &wf, true, nil)
 	assert.NoError(t, err)
 	newWFOnExitName := newWF.ObjectMeta.Name + ".onExit"
 	newWFOneExitID := newWF.NodeID(newWFOnExitName)
@@ -639,7 +639,7 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 				},
 			},
 		}
-		wf, err := FormulateResubmitWorkflow(wf, false, nil)
+		wf, err := FormulateResubmitWorkflow(context.Background(), wf, false, nil)
 		if assert.NoError(t, err) {
 			assert.Contains(t, wf.GetLabels(), common.LabelKeyControllerInstanceID)
 			assert.Contains(t, wf.GetLabels(), common.LabelKeyClusterWorkflowTemplate)
@@ -663,7 +663,7 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 				},
 			}},
 		}
-		wf, err := FormulateResubmitWorkflow(wf, false, []string{"message=modified"})
+		wf, err := FormulateResubmitWorkflow(context.Background(), wf, false, []string{"message=modified"})
 		if assert.NoError(t, err) {
 			assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
 		}


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11414

### Motivation

<!-- TODO: Say why you made your changes. -->

There was a problem related to creator labels of a resubmitted Workflow.

When the creators of an existing Workflow and a new Workflow, created by resubmission, are different, incorrect creator labels are propagated to the new Workflow. A detailed illustration is in https://github.com/argoproj/argo-workflows/issues/11414.

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

I modified `FormulateResubmitWorkflow` to apply the creator labels for the actual user who resubmits a Workflow by adding a context argument to the `FormulateResubmitWorkflow` function.

### Verification

<!-- TODO: Say how you tested your changes. -->

1. Submit a Workflow and resubmit one based on the just-submitted Workflow.
    ```yaml
    # Submit a Workflow as the user 'foo'
    $ argo submit wf-whalesay.yaml --token ${FOO_TOKEN}
    Name:                hello-world-p485h
    Namespace:           argo
    ServiceAccount:      unset (will run with the default ServiceAccount)
    Status:              Pending
    Created:             Sat Jul 22 11:51:58 +0900 (now)
    Progress:
    
    # Resubmit a Workflow as the user 'bar'
    $ argo resubmit hello-world-p485h --token ${BAR_TOKEN}
    Name:                hello-world-tfbp9
    Namespace:           argo
    ServiceAccount:      unset (will run with the default ServiceAccount)
    Status:              Pending
    Created:             Sat Jul 22 11:52:30 +0900 (now)
    Progress:
    
    # Resubmit a Workflow without authentication
    $ argo resubmit hello-world-p485h
    Name:                hello-world-tdv6r
    Namespace:           argo
    ServiceAccount:      unset (will run with the default ServiceAccount)
    Status:              Pending
    Created:             Sat Jul 22 14:13:58 +0900 (now)
    Progress:
    ```
2. Compare the creator labels of the two Workflows. Now, we can see the creator labels of the second Workflow are correctly associated with user `bar` and the third Workflow doesn't have the creator labels.
    ```yaml
    $ kubectl get wf -o yaml | yq '.items[] | [{"name": .metadata.name, "labels": .metadata.labels}]'
    - name: hello-world-p485h
      labels:
        workflows.argoproj.io/completed: "true"
        workflows.argoproj.io/creator: 0af436c4-faee-418a-8f0d-860ba852c87b
        workflows.argoproj.io/creator-email: foo.at.example.com
        workflows.argoproj.io/creator-preferred-username: foo
        workflows.argoproj.io/phase: Succeeded
    - name: hello-world-tfbp9
      labels:
        workflows.argoproj.io/completed: "true"
        workflows.argoproj.io/creator: b8caf2ac-22ef-4947-b917-03201fc950b7
        workflows.argoproj.io/creator-email: bar.at.example.com
        workflows.argoproj.io/creator-preferred-username: bar
        workflows.argoproj.io/phase: Succeeded
        workflows.argoproj.io/resubmitted-from-workflow: hello-world-p485h
    - name: hello-world-tdv6r
      labels:
        workflows.argoproj.io/phase: Running
        workflows.argoproj.io/resubmitted-from-workflow: hello-world-p485h
    ```

~~If any additional test code are needed, I can write some.~~ -> I added some.