### PR TITLE
docs: fix typo exit handler status to Succeeded

### DIFF
--- a/docs/lifecyclehook.md
+++ b/docs/lifecyclehook.md
@@ -61,4 +61,4 @@ spec:
        url: http://dummy.restapiexample.com/api/v1/employees
 ```
 
-> Put differently, an exit handler is like a workflow-level `LifecycleHook` with an expression of `workflow.status == "Completed"` or `workflow.status == "Failed"` or `workflow.status == "Error"`.
+> Put differently, an exit handler is like a workflow-level `LifecycleHook` with an expression of `workflow.status == "Succeeded"` or `workflow.status == "Failed"` or `workflow.status == "Error"`.


### PR DESCRIPTION
### Motivation

There is a typo in the documentation https://argoproj.github.io/argo-workflows/lifecyclehook/ :

>  Put differently, an exit handler is like a workflow-level LifecycleHook with an expression of workflow.status == "Completed" or workflow.status == "Failed" or workflow.status == "Error".

It should be workflow.status == "Succeeded"  and not "Completed"

### Verification

- We can see here what the `workflow.status` values may be for exit handler: https://argoproj.github.io/argo-workflows/variables/#exit-handler

```md
### Exit Handler

| Variable | Description|
|----------|------------|
| `workflow.status` | Workflow status. One of: `Succeeded`, `Failed`, `Error` |
```


- Additionally, tested on my environment with argo-workflows v3.4.7

### Modifications

Changed word from "Completed" -> "Succeeded"