### PR TITLE
fix: make archived logs more human friendly in UI

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -226,13 +226,16 @@ export const WorkflowsService = {
         return of(hasArtifactLogs(workflow, nodeId, container)).pipe(
             switchMap(isArtifactLogs => {
                 if (!isArtifactLogs) {
+                    if (!nodeId) {
+                        throw new Error('Should specify a node when we get archived logs');
+                    }
                     throw new Error('no artifact logs are available');
                 }
 
                 return from(requests.get(this.getArtifactLogsPath(workflow, nodeId, container, archived)));
             }),
             mergeMap(r => r.text.split('\n')),
-            map(content => ({content} as LogEntry)),
+            map(content => ({content, podName: workflow.status.nodes[nodeId].displayName} as LogEntry)),
             filter(x => !!x.content.match(grep))
         );
     },


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11419

### Motivation

- Make archived logs more human friendly

### Modifications

1. Fix the error message when we don't select a node.
   ![image](https://github.com/argoproj/argo-workflows/assets/83329336/e7a64664-1ed5-4b67-8e36-404d624bcf45)
2. Show `node.displayName` in logs.
   ![image](https://github.com/argoproj/argo-workflows/assets/83329336/af420e27-997f-41e9-acd8-66b3a4a3a21a)

### Verification

I've checked regressions.
