### PR TITLE
docs: use relative links in Lifecycle Hook

### DIFF
--- a/docs/lifecyclehook.md
+++ b/docs/lifecyclehook.md
@@ -4,9 +4,9 @@
 
 ## Introduction
 
-A [`LifecycleHook`](https://argoproj.github.io/argo-workflows/fields/#lifecyclehook) triggers an action based on a conditional expression or on completion of a step or template. It is configured either at the workflow-level or template-level, for instance as a function of the `workflow.status` or `steps.status`, respectively. A `LifecycleHook` executes during execution time and executes once. It will execute in parallel to its step or template once the expression is satisfied.
+A [`LifecycleHook`](fields.md#lifecyclehook) triggers an action based on a conditional expression or on completion of a step or template. It is configured either at the workflow-level or template-level, for instance as a function of the `workflow.status` or `steps.status`, respectively. A `LifecycleHook` executes during execution time and executes once. It will execute in parallel to its step or template once the expression is satisfied.
 
-In other words, a `LifecycleHook` functions like an [exit handler](https://github.com/argoproj/argo-workflows/blob/master/examples/exit-handlers.yaml) with a conditional expression. You must not name a `LifecycleHook` `exit` or it becomes an exit handler, otherwise the hook name has no relevance.
+In other words, a `LifecycleHook` functions like an [exit handler](https://github.com/argoproj/argo-workflows/blob/master/examples/exit-handlers.yaml) with a conditional expression. You must not name a `LifecycleHook` `exit` or it becomes an exit handler; otherwise the hook name has no relevance.
 
 **Workflow-level `LifecycleHook`**: Executes the template when a configured expression is met during the workflow.
 
@@ -18,14 +18,14 @@ In other words, a `LifecycleHook` functions like an [exit handler](https://githu
 
 ## Supported conditions
 
-- [Exit handler variables](https://github.com/argoproj/argo-workflows/blob/master/docs/variables.md#exit-handler): `workflow.status` and `workflow.failures`
-- [`template`](https://argoproj.github.io/argo-workflows/fields/#template)
-- [`templateRef`](https://argoproj.github.io/argo-workflows/fields/#templateref)
+- [Exit handler variables](variables.md#exit-handler): `workflow.status` and `workflow.failures`
+- [`template`](fields.md#template)
+- [`templateRef`](fields.md#templateref)
 - [`arguments`](https://github.com/argoproj/argo-workflows/blob/master/examples/conditionals.yaml)
 
 ## Unsupported conditions
 
-- [`outputs`](https://argoproj.github.io/argo-workflows/fields/#outputs) are not usable since `LifecycleHook` executes during execution time and `outputs` are not produced until the step is completed. You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status variable are available there so you can still conditionally decide what to do.
+- [`outputs`](fields.md#outputs) are not usable since `LifecycleHook` executes during execution time and `outputs` are not produced until the step is completed. You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status variable are available there so you can still conditionally decide what to do.
 
 ## Notification use case
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- this doc was using absolute links everywhere, but the convention is to use a relative link when possible
  - i.e. examples use absolute links, but docs links should be relative
  - this ensure the links work both on the website and on GitHub
    - consistently, website links go to website, GH links go to GH
    - and when editing the repo locally, it will redirect within the local repo itself as well

- _most_ of the absolute links referenced the website, but _one_ referenced GH
  - meaning if you were reading the docs on GH, you'd get sent to the website most of the time
  - and if you were reading on the website, that one link would send you to GH, confusingly
  
Stumbled upon this while verifying #11416, which I also happened to stumble upon

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- Convert all docs links on the Lifecycle Hook page to be relative links
  - do not change links to examples
  
- also fix one line of incorrect punctuation
  - `,` -> `;` -- the comma was confusing and made it a run-on sentence

### Verification

<!-- TODO: Say how you tested your changes. -->

Can see [this line](https://github.com/argoproj/argo-workflows/blob/6e209cdaa6d01180239551d6c13bf320d380b887/docs/scaling.md?plain=1#L57) as an example of an existing relative link (from an unrelated recent PR of mine)