### PR TITLE
build: pin versions of NPM global deps in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -626,7 +626,7 @@ docs/cli/argo.md: $(CLI_PKGS) go.sum server/static/files.go hack/cli/main.go
 # docs
 
 /usr/local/bin/mdspell:
-	npm i -g markdown-spellcheck # update this in Nix when upgrading it here
+	npm i -g markdown-spellcheck@1.3.1 # update this in Nix when upgrading it here
 
 
 .PHONY: docs-spellcheck
@@ -635,7 +635,7 @@ docs-spellcheck: /usr/local/bin/mdspell
 	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name upgrading.md -not -name swagger.md -not -name executor_swagger.md -not -path '*/cli/*')
 
 /usr/local/bin/markdown-link-check:
-	npm i -g markdown-link-check # update this in Nix when upgrading it here
+	npm i -g markdown-link-check@3.11.1 # update this in Nix when upgrading it here
 
 
 .PHONY: docs-linkcheck
@@ -644,7 +644,7 @@ docs-linkcheck: /usr/local/bin/markdown-link-check
 	markdown-link-check -q -c .mlc_config.json $(shell find docs -name '*.md' -not -name fields.md -not -name swagger.md -not -name executor_swagger.md)
 
 /usr/local/bin/markdownlint:
-	npm i -g  markdownlint-cli # update this in Nix when upgrading it here
+	npm i -g markdownlint-cli@0.33.0 # update this in Nix when upgrading it here
 
 
 .PHONY: docs-lint


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Make sure that there are no version inconsistencies due to NPM global deps installed in the `Makefile` (which is used locally as well as in CI)
- This has been a bit concerning to me ever since I noticed the installs are not pinned 😅 
- This also makes the "# update this in Nix" comments make more sense as there's a version specified now

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- add `@<version>` for each `npm i -g`
  - use the versions from [`dev/nix/node-packages.nix`](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/dev/nix/node-packages.nix#L853) and [`dev/nix/package.json#dependencies`](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/dev/nix/package.json#L5)


### Verification

<!-- TODO: Say how you tested your changes. -->

Ran in my devcontainer successfully:

```bash
npm i -g markdown-spellcheck@1.3.1
npm i -g markdownlint-cli@0.33.0
```
