### PR TITLE
fix(server): don't grab SAs if SSO RBAC is not enabled

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -142,8 +142,11 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (*argoServer, error
 		if err != nil {
 			return nil, err
 		}
-		resourceCache = cache.NewResourceCache(opts.Clients.Kubernetes, getResourceCacheNamespace(opts))
-		resourceCache.Run(ctx.Done())
+		if ssoIf.IsRBACEnabled() {
+			// resourceCache is only used for SSO RBAC
+			resourceCache = cache.NewResourceCache(opts.Clients.Kubernetes, getResourceCacheNamespace(opts))
+			resourceCache.Run(ctx.Done())
+		}
 		log.Info("SSO enabled")
 	} else {
 		log.Info("SSO disabled")


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-helm/issues/2159, Fixes https://github.com/argoproj/argo-helm/issues/1624
- I root caused this in https://github.com/argoproj/argo-helm/issues/2159#issuecomment-1646988596

### Motivation

<!-- TODO: Say why you made your changes. -->

- the `ResourceCache` creates a `ServiceAccountLister` `informer`, but this is only used when RBAC is enabled
  - if RBAC is not enabled, it is [not](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/server/auth/gatekeeper.go#L300) [used](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/server/auth/gatekeeper.go#L245), and so does not need to be created
  - also, if RBAC is not enabled, the Server's `ClusterRole` should not require `serviceaccount` permissions
    - without this change, whenever SSO is enabled, the `ClusterRole` will require `serviceaccount` permissions, despite not actually needing it (i.e. not "least privilege")

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- only create the `ResourceCache` when SSO RBAC is enabled

### Verification

<!-- TODO: Say how you tested your changes. -->

There's no unit tests for this specific file / for the `NewArgoServer` function. I might be able to write [an E2E test](https://github.com/argoproj/argo-workflows/blob/master/test/e2e/argo_server_test.go) for this, but am still learning that part of the codebase.
- I _think_ this would require having an [alternate](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/test/e2e/manifests/sso/kustomization.yaml#L1) manifest that does _not_ have [`rbac.enabled: true`](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml#L18). Then running a subset of the Server E2E tests. Non-trivial change as far as I can tell so far, and may require a decent bit of modifications to the `Makefile` etc to run a new test + install a new manifest as well 😅 

### Future Work

I feel like it might make sense to rename / move `resource_cache.go`? It is only used by SSO RBAC and nothing else right now, as far as I can tell. The name feels misleading as a result as it seems more generic.
