### PR TITLE
docs: correct the dominator of memory and examples in resource-durati…

### DIFF
--- a/docs/resource-duration.md
+++ b/docs/resource-duration.md
@@ -18,7 +18,7 @@ Each indicator is divided by a common denominator depending on resource type.
 Each resource type has a denominator used to make large values smaller.
 
 * CPU: `1`
-* Memory: `1Gi`
+* Memory: `100Mi`
 * Storage: `10Gi`
 * Ephemeral Storage: `10Gi`
 * All others: `1`
@@ -26,8 +26,8 @@ Each resource type has a denominator used to make large values smaller.
 The requested fraction of the base amount will be multiplied by the container's run time to get
 the container's Resource Duration.
 
-For example, if you've requested `100Mi` of memory (one tenth of the base amount), and the container
-runs 120sec, then the reported Resource Duration will be `12sec * (1Gi memory)`.
+For example, if you've requested `50Mi` of memory (half of the base amount), and the container
+runs 120sec, then the reported Resource Duration will be `60sec * (100Mi memory)`.
 
 ### Request Defaults
 
@@ -39,13 +39,13 @@ set `requests` and/or `limits` for all containers.
 
 ### Example
 
-A pod that runs for 3min, with a CPU limit of `2000m`, no memory request and an `nvidia.com/gpu`
+A pod that runs for 3min, with a CPU limit of `2000m`, a memory limit of `1Gi` and an `nvidia.com/gpu`
 resource limit of `1`:
 
 ```text
 CPU:    3min * 2000m / 1000m = 6min * (1 cpu)
-Memory: 3min * 100Mi / 1Gi   = 18sec * (100Mi memory)
-GPU:    3min * 1     / 1     = 2min * (1 nvidia.com/gpu)
+Memory: 3min * 1Gi / 100Mi   = 30min * (100Mi memory)
+GPU:    3min * 1     / 1     = 3min * (1 nvidia.com/gpu)
 ```
 
 ### Web/CLI reporting
@@ -55,8 +55,3 @@ this context, resources like `memory` refer to the "base amounts".
 
 For example, `memory` means "amount of time a resource requested 1Gi of memory." If a container only
 uses 100Mi, each second it runs will only count as a tenth-second of `memory`.
-
-## Rounding Down
-
-For short running pods (<10s), the memory value may be 0s. This is because the default is `100Mi`,
-but the denominator is `1Gi`.


### PR DESCRIPTION
### Motivation

The dominator of memory should be `100Mi` instead of `1Gi`. [Source code](https://github.com/argoproj/argo-workflows/blob/7f22085d16316bdd77bdb1060455140d9d6e1664/pkg/apis/workflow/v1alpha1/workflow_types.go#L2012)

### Modifications

- Fix the wrong examples in the document
- Remove "Rounding Down" section, because it's not likely to happen

### Verification

These changes are consisitent with the source code.
