### PR TITLE
feat: logging for client-side throttling

### DIFF
--- a/util/logs/log-k8s-requests.go
+++ b/util/logs/log-k8s-requests.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"net/http"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
@@ -9,14 +10,24 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/k8s"
 )
 
+var (
+	extraLongThrottleLatency = 5 * time.Second
+)
+
 type k8sLogRoundTripper struct {
 	roundTripper http.RoundTripper
 }
 
 func (m k8sLogRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	now := time.Now()
 	x, err := m.roundTripper.RoundTrip(r)
+	latency := time.Since(now)
+
 	if x != nil {
 		verb, kind := k8s.ParseRequest(r)
+		if latency > extraLongThrottleLatency {
+			log.Warnf("Waited for %v, request: %s:%s", latency, verb, r.URL.String())
+		}
 		log.Debugf("%s %s %d", verb, kind, x.StatusCode)
 	}
 	return x, err


### PR DESCRIPTION
Implemented logging of throttling.
when a delay of more than 5 seconds occurs.

Fixes #11387 #11402 

### Motivation

To make it faster for users to notice when client-side throttling is happening.

### Modifications

Implemented to output a warning if latency is greater than 5 seconds when qps, burst is set very low

### Verification