### PR TITLE
fix: Devcontainer resets /etc/hosts (#11439)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,14 @@
   "hostRequirements": {
     "cpus": 4
   },
-  "runArgs": ["--add-host=host.docker.internal:host-gateway"],
+  "runArgs": [
+    "--add-host=host.docker.internal:host-gateway",
+    "--add-host=dex:127.0.0.1",
+    "--add-host=minio:127.0.0.1",
+    "--add-host=postgres:127.0.0.1",
+    "--add-host=mysql:127.0.0.1",
+    "--add-host=azurite:127.0.0.1"
+  ],
   "onCreateCommand": ".devcontainer/pre-build.sh",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/go/src/github.com/argoproj/argo-workflows,type=bind",
   "workspaceFolder": "/home/vscode/go/src/github.com/argoproj/argo-workflows",

--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -1,13 +1,6 @@
 #!/usr/bin/env sh
 set -eux
 
-# Add hosts
-sudo bash -c 'echo "127.0.0.1 dex" >> /etc/hosts'
-sudo bash -c 'echo "127.0.0.1 minio" >> /etc/hosts'
-sudo bash -c 'echo "127.0.0.1 postgres" >> /etc/hosts'
-sudo bash -c 'echo "127.0.0.1 mysql" >> /etc/hosts'
-sudo bash -c 'echo "127.0.0.1 azurite" >> /etc/hosts'
-
 # install kubernetes
 wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 k3d cluster get k3s-default || k3d cluster create --image rancher/k3s:v1.27.3-k3s1 --wait


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11439 

### Motivation

A container created by Devcontainer keeps resetting /etc/hosts whenever I reboot or restart the container.

### Modifications

.devcontainer/devcontainer.json
.devcontainer/pre-build.sh
~~.devcontainer/post-start.sh~~

### Verification

To ensure this issue is fixed, I manually tested by running devcontainer commands that after I made this change.
I also tested with VsCode devcontainer extension.