### PR TITLE
docs: add Resource Template page

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -198,6 +198,7 @@ v1.2
 v1.3
 v1.24
 v2
+v2.0
 v2.10
 v2.11
 v2.12
@@ -236,6 +237,6 @@ devenv
 vendored
 nix.conf
 LDFlags
-dev 
+dev
 vendorSha256
 dependabot

--- a/docs/resource-template.md
+++ b/docs/resource-template.md
@@ -1,0 +1,5 @@
+# Resource Template
+
+> v2.0
+
+See [Kubernetes Resources](../walk-through/kubernetes-resources.md).

--- a/docs/resource-template.md
+++ b/docs/resource-template.md
@@ -2,4 +2,4 @@
 
 > v2.0
 
-See [Kubernetes Resources](../walk-through/kubernetes-resources.md).
+See [Kubernetes Resources](walk-through/kubernetes-resources.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
           - http-template.md
           - container-set-template.md
           - data-sourcing-and-transformation.md
+          - resource-template.md
           - inline-templates.md
       - Artifacts:
           - workflow-inputs.md


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- previously, the Template Types section of the User Guide never mentioned Resource Templates
  - the Walk Through section of Getting Started did have a page on this though
    - so just link the two together as that one already documents it in detail
    
- I felt like something was missing in this section, finally realized what 😅
  - Was trying to find this doc while answering a question [on Slack](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1690286713376469?thread_ts=1690276970.326629&cid=C01QW9QSSSK) and went to Template Types only to not see it 💭 

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- create a new Resource Template page under Template Types of the User Guide
  - just link to the existing docs in the Walk Through 
  - also add a version as all the Template Type pages have one
    - this was released in a 2.0 alpha as part of #622
- add `v2.0` to the `.spelling` ignore file

### Verification

<!-- TODO: Say how you tested your changes. -->

Used `make docs-serve` and confirmed it works on local. Screenshot:

<img width="1054" alt="Screenshot 2023-07-27 at 1 42 42 PM" src="https://github.com/argoproj/argo-workflows/assets/4970083/a0bec8ac-a5d6-4269-99ca-094c89d930a3">


### Misc Notes

Not the first time I've found myself thinking that some of the docs could be consolidated and go to one page only to realize that the relevant docs are on another page (e.g. #11296). I am perhaps a more unique user as both an Argo Operator and User (and Developer nowadays), so some of those are perhaps a given. But the Walk Through seems like it addresses the same audience as the User Guide, no?