### PR TITLE
ci: fix `snyk.yaml` and `release.yaml` for Node v20

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -250,7 +250,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "20" # change in Snyk when changed here
+          node-version: "20" # change in all GH Workflows
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - run: yarn --cwd ui install

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -250,7 +250,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "20" # change in Snyk when changed here
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - run: yarn --cwd ui install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -280,14 +280,14 @@ jobs:
     if: github.repository == 'argoproj/argo-workflows'
     needs: [ push-images, test-images-linux-amd64, test-images-windows ]
     env:
-      NODE_OPTIONS: --openssl-legacy-provider --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=4096
       COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
       COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "20" # change in all GH Workflows
       - uses: actions/setup-go@v4
         with:
           go-version: "1.20"

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "20" # change in ci-build when changed here
+          node-version: "20" # change in all GH Workflows
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - run: yarn --cwd ui install

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -32,6 +32,11 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20" # change in ci-build when changed here
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
       - run: yarn --cwd ui install
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11459 , Fixes https://github.com/argoproj/argo-workflows/pull/11410#issuecomment-1653775914

### Motivation

<!-- TODO: Say why you made your changes. -->

There was some breakage in different CI workflows due to the node v20 upgrade in #11410
- node was updated in `ci-build.yaml` but not `synk.yaml`
  - caused Snyk to (correctly) error on the `node.engines` requirement
    - see https://github.com/argoproj/argo-workflows/actions/runs/5676115276/job/15382363976
- `--openssl-legacy-provider` was set in `release.yaml`'s `NODE_OPTIONS` env, but not the others
  - it is already set in-line in [the `package.json`](https://github.com/argoproj/argo-workflows/blob/90930ab88b18b7fba3074cdc06059eb6460b50d9/ui/package.json#L9-L10), so no need to set it globally as an env var
      - setting it as an env var also breaks GH's default runner version that runs for `checkout`: https://github.com/argoproj/argo-workflows/actions/runs/5676125574/job/15383405669
      - this was removed from some of the GH workflows during iteration on #11410, but this one reference seems to have been left in

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- add `actions/setup-node@v3` with `node-version: "20"` to `snyk.yaml`
  - also add comments about updating Node in all GH workflows, not just one
- remove `--openssl-legacy-provider` from `release.yaml`

### Verification

<!-- TODO: Say how you tested your changes. -->

CI build should pass now
