### PR TITLE
chore: Commits with parenthesis after prefix should also be cherry-picked

### DIFF
--- a/hack/what-to-cherry-pick.sh
+++ b/hack/what-to-cherry-pick.sh
@@ -4,7 +4,7 @@ set -eu
 
 br=$1;# branch
 commitPrefix=$2;# examples: fix, chore(deps), build, ci
-commitGrepPattern="^${commitPrefix}:.*(#"
+commitGrepPattern="^${commitPrefix}(*.*)*:.*(#"
 
 # find the branch point
 base=$(git merge-base $br master)


### PR DESCRIPTION
This was brought up in https://github.com/argoproj/argo-workflows/pull/11276#issuecomment-1655545804 (thanks @cbuchli for reporting!).

We missed certain fixes in patch releases. Some examples:
```
137d5f8cc fix(controller): Enable dummy metrics server on non-leader workflow controller (#11295)
6f1cb4843 fix(windows): Propagate correct numerical exitCode under Windows (Fixes #11271) (#11276)
48097ea0b fix(controller): Drop Checking daemoned children without nodeID (Fixes #10960) (#10974)
10111724b fix(agent): no more requeue when the node succeeded (#10681)
f62472a69 fix(ui): reword Workflow `DELETED` error (#10689)
7d2a8c3d2 fix(docs): container-set-template workflow example (#10452)
2a0e91b44 fix(controller): Add locking for read operationin controller. Fixes #… (#9985)
```