### PR TITLE
docs: add a README to the Nixfiles, improve formatting

### DIFF
--- a/dev/nix/README.md
+++ b/dev/nix/README.md
@@ -1,0 +1,3 @@
+# Argo Nixfiles
+
+See [Try Argo using Nix](../../docs/running-nix.md).

--- a/docs/running-nix.md
+++ b/docs/running-nix.md
@@ -4,17 +4,16 @@ Nix is a package manager / build tool which focuses on reproducible build enviro
 Argo Workflows has some basic support for Nix which is enough to get Argo Workflows up and running with minimal effort.
 Here are the steps to follow:
 
-  1. Modify the hosts file according to [this](https://argoproj.github.io/argo-workflows/running-locally/), don't worry about the other instructions.
-  2. Set up a kubernetes cluster, k3d is the recommended solution here.
-  3. Install [Nix](https://nixos.org/download.html).
-  4. Run "nix develop --extra-experimental-features nix-command --extra-experimental-features flakes ./dev/nix/ --impure" (you can add the extra features as a default in your nix.conf file).
-  5. Run "devenv up".
+  1. Modify your hosts file and set up a Kubernetes cluster according to [Running Locally](https://argoproj.github.io/argo-workflows/running-locally/). Don't worry about the other instructions.
+  1. Install [Nix](https://nixos.org/download.html).
+  1. Run `nix develop --extra-experimental-features nix-command --extra-experimental-features flakes ./dev/nix/ --impure` (you can add the extra features as a default in your `nix.conf` file).
+  1. Run `devenv up`.
 
 ## Warning
 
 This is still bare-bones at the moment, any feature in the Makefile not mentioned here is excluded for now.
-In practice this means that only a "make start UI=true" equivalent is supported at the moment, as an additional caveat, there are no LDFlags set in the build,
-as a result the UI will show "0.0.0-unknown" for the version.
+In practice, this means that only a `make start UI=true` equivalent is supported at the moment.
+As an additional caveat, there are no LDFlags set in the build; as a result the UI will show `0.0.0-unknown` for the version.
 
 ## How do I upgrade a dependency?
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

There is already documentation for this, so just link to [the existing docs](https://argoproj.github.io/argo-workflows/running-nix/)
- just handy to have a back-link for those less familiar with Nix and who stumble upon it
- Similar to #10969


### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- add a README with a one-line link to `dev/nix/`

- also improve some grammar and formatting in the Nix docs
  - use code backticks for all commands
  - use markdown convention of using `1.` for all items of an ordered list and having the renderer determine the numbering
  - use the name of the doc (Running Locally) instead of "this"
    - more consistent with the rest of the docs, as well as k8s style guide: https://kubernetes.io/docs/contribute/style/style-guide/#links
    - also merge 1 and 2 as they're both mentioned in Running Locally
  - separate run-on sentence


### Verification

<!-- TODO: Say how you tested your changes. -->

Double-checked that the relative link worked locally
