### PR TITLE
fix: Datepicker Style Malfunction Issue. Fixes #11476

### DIFF
--- a/ui/src/app/workflows/components/workflow-filters/workflow-filters.scss
+++ b/ui/src/app/workflows/components/workflow-filters/workflow-filters.scss
@@ -26,3 +26,10 @@
     background-color: transparent;
     border: 0;
 }
+
+.wf-filters-container__content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}

--- a/ui/src/app/workflows/components/workflow-filters/workflow-filters.tsx
+++ b/ui/src/app/workflows/components/workflow-filters/workflow-filters.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 import * as models from '../../../../models';
 import {WorkflowPhase} from '../../../../models';
 import {CheckboxFilter} from '../../../shared/components/checkbox-filter/checkbox-filter';
@@ -96,7 +97,7 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                     </div>
                     <div className='columns small-5 xlarge-12'>
                         <p className='wf-filters-container__title'>Started Time</p>
-                        <div>
+                        <div className='wf-filters-container__content'>
                             <DatePicker
                                 selected={this.props.minStartedAt}
                                 onChange={date => {
@@ -114,7 +115,7 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                                 <i className='fa fa-times-circle' />
                             </a>
                         </div>
-                        <div>
+                        <div className='wf-filters-container__content'>
                             <DatePicker
                                 selected={this.props.maxStartedAt}
                                 onChange={date => {


### PR DESCRIPTION
Fixes #11476 

### Motivation

The date filter is a crucial element when viewing the list of workflows. However, when clicking on the date-picker to change the date, the styles get messed up, resulting in a UI state where the filter functionality cannot be used properly. Moreover, the close button overlaps with the selected date, making it difficult to select the desired date.

### Modifications

This issue is more related to layout and styles rather than a major functional problem. Therefore, we plan to make the following two modifications:

1. Move the close button to the right so that it doesn't overlap with the date-picker.
2. Adjust the styles of the date-picker using the calendar to ensure proper functionality.

<img width="1680" alt="스크린샷 2023-07-29 오후 7 22 32" src="https://github.com/argoproj/argo-workflows/assets/28799597/69ee0a03-7067-4829-83d4-cb2858f4cc99">
<img width="285" alt="KakaoTalk_20230729_153542342" src="https://github.com/argoproj/argo-workflows/assets/28799597/a811cdf5-6550-4a4e-922c-45430c663843">

### Verification
