### PR TITLE
fix: Fixed UI workflowDrawer information link broken. Fixes #11494

### DIFF
--- a/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
+++ b/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
@@ -66,7 +66,10 @@ export class WorkflowDrawer extends React.Component<WorkflowDrawerProps, Workflo
                                         left: (
                                             <div className='workflow-drawer__title'>
                                                 RESOURCES DURATION&nbsp;
-                                                <a href='https://github.com/argoproj/argo-workflows/blob/master/docs/resource-duration.md' target='_blank'>
+                                                <a
+                                                    href='https://github.com/argoproj/argo-workflows/blob/master/docs/resource-duration.md'
+                                                    onClick={e => e.stopPropagation()}
+                                                    target='_blank'>
                                                     <i className='fas fa-info-circle' />
                                                 </a>
                                             </div>


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11494 

### Motivation

In workflowDrawer, which can be accessed by clicking 'SHOW' text in workflow row, there is an information link about resource duration as the screen capture below.
This information link should go to `https://github.com/argoproj/argo-workflows/blob/master/docs/resource-duration.md` when click this, but this is broken.
When click this, it just goes to workflow detail page which is same behavior of clicking the row.

<img width="1337" alt="스크린샷 2023-07-30 오후 5 01 09" src="https://github.com/argoproj/argo-workflows/assets/20155452/ee5d0e7b-c811-4908-87d5-069a65b4caad">


### Modifications

I just add simple stop propagation in <a> tag. This will prevent 'i' icons from parent row clicking event propagation. 

### Verification

Simply test this in workflow page UI.
