### PR TITLE
docs: improve directness and consistency of misc sentences

### DIFF
--- a/docs/access-token.md
+++ b/docs/access-token.md
@@ -9,7 +9,7 @@ If you want to automate tasks with the Argo Server API or CLI, you will need an 
 Firstly, create a role with minimal permissions. This example role for jenkins only permission to update and list workflows:
 
 ```bash
-kubectl create role jenkins --verb=list,update --resource=workflows.argoproj.io 
+kubectl create role jenkins --verb=list,update --resource=workflows.argoproj.io
 ```
 
 Create a service account for your service:
@@ -85,7 +85,7 @@ ARGO_NAMESPACE=sandbox
 
 ### Start container with settings above
 
-> Note: Example for  getting list of templates from an existing namespace
+Example for listing templates in a namespace:
 
 ```bash
 docker run --rm -it \

--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -53,7 +53,7 @@ To allow service accounts to manage resources in other namespaces create a role 
 
 RBAC config is installation-level, so any changes will need to be made by the team that installed Argo. Many complex rules will be burdensome on that team.
 
-Firstly, enable the `rbac:` setting in [workflow-controller-configmap.yaml](workflow-controller-configmap.yaml). You almost certainly want to be able to configure RBAC using groups, so add `scopes:` to the SSO settings:
+Firstly, enable the `rbac:` setting in [workflow-controller-configmap.yaml](workflow-controller-configmap.yaml). You likely want to configure RBAC using groups, so add `scopes:` to the SSO settings:
 
 ```yaml
 sso:

--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -1,8 +1,7 @@
 # Artifacts
 
-**Note:**
-You will need to configure an artifact repository to run this example.
-[Configuring an artifact repository here](https://argoproj.github.io/argo-workflows/configure-artifact-repository/).
+!!! Note
+    You will need to [configure an artifact repository](../configure-artifact-repository.md) to run this example.
 
 When running workflows, it is very common to have steps that generate or consume artifacts. Often, the output artifacts of one step may be used as input artifacts to a subsequent step.
 

--- a/docs/walk-through/hardwired-artifacts.md
+++ b/docs/walk-through/hardwired-artifacts.md
@@ -1,6 +1,6 @@
 # Hardwired Artifacts
 
-With Argo, you can use any container image that you like to generate any kind of artifact. In practice, however, we find certain types of artifacts are very common, so there is built-in support for git, HTTP, GCS and S3 artifacts.
+You can use any container image to generate any kind of artifact. In practice, however, certain types of artifacts are very common, so there is built-in support for git, HTTP, GCS, and S3 artifacts.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Simplify some misc docs and use more consistent style & formatting
- Just stumbled upon these while making other changes or responding to questions on Slack and put a few small adjustments from different pages together into one PR

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- per k8s style guide: https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language
  - "almost certainly want to be able to" -> "likely want to"
  - "getting list of" -> "listing"
  - "from an existing namespace" -> "in a namespace" ("existing" is a necessary pre-req)
- by the same logic, remove some redundant words
  - "With Argo" -> "" -- these are the Argo docs and they only reference Argo itself
  - "we find" -> "" -- make the statement without prefacing it
  - see also https://kubernetes.io/docs/contribute/style/style-guide/#avoid-using-we
  - also add a not-so-redundant Oxford comma

- use infobox for consistency in the docs instead of "**Note:**"
  - also modify link to be in-line instead of repeating the same words in a second sentence
  - also fix to use a relative link instead of an absolute link to the website, as is consistent in the rest of the docs
- remove "> Note:" where that was inconsistent
  - the rest of Access Token page does not use that. This also not an aside, but the actual description of the only code block in this section - "Note" is typically used as a "side note", not a direct caption. It can be stated directly in this case without preface

### Verification

<!-- TODO: Say how you tested your changes. -->

n/a
