### PR TITLE
docs: categorize / re-order Walk Through pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,27 +42,36 @@ nav:
           - walk-through/index.md
           - walk-through/argo-cli.md
           - walk-through/hello-world.md
+          # basics
           - walk-through/parameters.md
           - walk-through/steps.md
           - walk-through/dag.md
-          - walk-through/artifacts.md
           - walk-through/the-structure-of-workflow-specs.md
-          - walk-through/secrets.md
+          # artifacts
+          - walk-through/artifacts.md
+          - walk-through/hardwired-artifacts.md
+          # outputs
           - walk-through/scripts-and-results.md
           - walk-through/output-parameters.md
+          # mounts
+          - walk-through/secrets.md
+          - walk-through/volumes.md
+          # control flow
           - walk-through/loops.md
           - walk-through/conditionals.md
-          - walk-through/retrying-failed-or-errored-steps.md
           - walk-through/recursion.md
+          # exit conditions
+          - walk-through/retrying-failed-or-errored-steps.md
           - walk-through/exit-handlers.md
           - walk-through/timeouts.md
-          - walk-through/volumes.md
+          # template types
           - walk-through/suspending.md
+          - walk-through/kubernetes-resources.md
+          # container configuration
           - walk-through/daemon-containers.md
           - walk-through/sidecars.md
-          - walk-through/hardwired-artifacts.md
-          - walk-through/kubernetes-resources.md
           - walk-through/docker-in-docker-using-sidecars.md
+          # misc
           - walk-through/custom-template-variable-reference.md
           - walk-through/continuous-integration-examples.md
   - User Guide:


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Per the Modifications section below, several related pages were not next to each other, sometimes in very confusing ways (e.g. Hardwired Artifacts and Artifacts were nowhere near each other)

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

- Artifacts and Hardwired Artifacts should be next to each other
  - if not condensed into one
- Sidecars and DinD w/ Sidecars should be next to each other

- misc ordering & categorization -- see in-line comments
  - Artifacts is not mentioned in "The Structure of Workflow Specs", so can put it after - have pages on the "basics" first, then more advanced/intermediate topics - technically Output Parameters are mentioned as well, but those specifically mention `script` `results` at the moment, so they require introducing scripts first - which are a bit more advanced than just Steps, DAGs, and Parameters
  - put Secrets and Volumes next to each other as they are both types of mounts
  - put Recursion along with Loops and Conditionals as "Control Flow"
  - put Retries next to Exit Handlers and Timeouts as they are related to what to do on exiting or when to exit
  - put Resource Templates next to Suspend Templates as they are both Template Types
  - categorize Daemons and Sidecars together as special configurations on top of `container` templates
  - then just the rest as "misc"

### Verification

<!-- TODO: Say how you tested your changes. -->

n/a

### Future Work

See also #11450's same section.
1. Condense Hardwired Artifacts into Artifacts in the Walk Through
1. There is also a separate [Artifacts section](https://github.com/argoproj/argo-workflows/blob/49905176ca744b0ffeea138ba3fecec993ad4249/mkdocs.yml#L81) in the User Guide 😕 These would be good to reference or consolidate as well