### PR TITLE
feat: add support for codegen/pre-commit via Nix. Fixes #11443

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export SHELLOPTS:=$(if $(SHELLOPTS),$(SHELLOPTS):)pipefail:errexit
 # NOTE: Please ensure dependencies are synced with the flake.nix file in dev/nix/flake.nix before upgrading
 # any external dependency. There is documentation on how to do this under the Developer Guide
 
+USE_NIX := false
 # https://stackoverflow.com/questions/4122831/disable-make-builtin-rules-and-variables-from-inside-the-make-file
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
@@ -164,8 +165,10 @@ ui/dist/app/index.html: $(shell find ui/src -type f && find ui -maxdepth 1 -type
 	JOBS=max yarn --cwd ui build
 
 $(GOPATH)/bin/staticfiles:
-	go install bou.ke/staticfiles@dd04075 # update this in Nix when upgrading it here
-
+# update this in Nix when updating it here
+ifneq ($(USE_NIX), true)
+	go install bou.ke/staticfiles@dd04075 
+endif
 
 ifeq ($(STATIC_FILES),true)
 server/static/files.go: $(GOPATH)/bin/staticfiles ui/dist/app/index.html
@@ -254,8 +257,8 @@ argoexec-image:
 .PHONY: codegen
 codegen: types swagger manifests $(GOPATH)/bin/mockery docs/fields.md docs/cli/argo.md
 	go generate ./...
-	make --directory sdks/java generate
-	make --directory sdks/python generate
+	make --directory sdks/java USE_NIX=$(USE_NIX) generate
+	make --directory sdks/python USE_NIX=$(USE_NIX) generate
 
 .PHONY: check-pwd
 check-pwd:
@@ -285,36 +288,60 @@ swagger: \
 
 
 $(GOPATH)/bin/mockery:
-	go install github.com/vektra/mockery/v2@v2.26.0 # update this in Nix when upgrading it here
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install github.com/vektra/mockery/v2@v2.26.0
+endif
 $(GOPATH)/bin/controller-gen:
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
+endif
 $(GOPATH)/bin/go-to-protobuf:
-	go install k8s.io/code-generator/cmd/go-to-protobuf@v0.21.5 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install k8s.io/code-generator/cmd/go-to-protobuf@v0.21.5
+endif
 $(GOPATH)/src/github.com/gogo/protobuf:
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
 	[ -e $(GOPATH)/src/github.com/gogo/protobuf ] || git clone --depth 1 https://github.com/gogo/protobuf.git -b v1.3.2 $(GOPATH)/src/github.com/gogo/protobuf
+endif
 $(GOPATH)/bin/protoc-gen-gogo:
-	go install github.com/gogo/protobuf/protoc-gen-gogo@v1.3.2 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install github.com/gogo/protobuf/protoc-gen-gogo@v1.3.2
+endif
 $(GOPATH)/bin/protoc-gen-gogofast:
-	go install github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.2 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.2
+endif
 $(GOPATH)/bin/protoc-gen-grpc-gateway:
-	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.16.0 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.16.0
+endif
 $(GOPATH)/bin/protoc-gen-swagger:
-	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.16.0 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.16.0
+endif
 $(GOPATH)/bin/openapi-gen:
-	go install k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20220124234850-424119656bbf # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20220124234850-424119656bbf
+endif
 $(GOPATH)/bin/swagger:
-	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.28.0
+endif
 $(GOPATH)/bin/goimports:
-	go install golang.org/x/tools/cmd/goimports@v0.1.7 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install golang.org/x/tools/cmd/goimports@v0.1.7
+endif
 
 /usr/local/bin/clang-format:
 ifeq (, $(shell which clang-format))
@@ -626,8 +653,10 @@ docs/cli/argo.md: $(CLI_PKGS) go.sum server/static/files.go hack/cli/main.go
 # docs
 
 /usr/local/bin/mdspell:
-	npm i -g markdown-spellcheck@1.3.1 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	npm i -g markdown-spellcheck@1.3.1
+endif
 
 .PHONY: docs-spellcheck
 docs-spellcheck: /usr/local/bin/mdspell
@@ -635,8 +664,10 @@ docs-spellcheck: /usr/local/bin/mdspell
 	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name upgrading.md -not -name swagger.md -not -name executor_swagger.md -not -path '*/cli/*')
 
 /usr/local/bin/markdown-link-check:
-	npm i -g markdown-link-check@3.11.1 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	npm i -g markdown-link-check@3.11.1
+endif
 
 .PHONY: docs-linkcheck
 docs-linkcheck: /usr/local/bin/markdown-link-check
@@ -644,7 +675,10 @@ docs-linkcheck: /usr/local/bin/markdown-link-check
 	markdown-link-check -q -c .mlc_config.json $(shell find docs -name '*.md' -not -name fields.md -not -name swagger.md -not -name executor_swagger.md)
 
 /usr/local/bin/markdownlint:
-	npm i -g markdownlint-cli@0.33.0 # update this in Nix when upgrading it here
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	npm i -g markdownlint-cli@0.33.0 
+endif
 
 
 .PHONY: docs-lint
@@ -653,8 +687,10 @@ docs-lint: /usr/local/bin/markdownlint
 	markdownlint docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md
 
 /usr/local/bin/mkdocs:
-	python -m pip install mkdocs==1.2.4 mkdocs_material==8.1.9  mkdocs-spellcheck==0.2.1 # update this in Nix when upgrading it here
-
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	python -m pip install mkdocs==1.2.4 mkdocs_material==8.1.9  mkdocs-spellcheck==0.2.1
+endif
 
 .PHONY: docs
 docs: /usr/local/bin/mkdocs \

--- a/dev/nix/flake.nix
+++ b/dev/nix/flake.nix
@@ -191,9 +191,12 @@
               src = pkgs.fetchFromGitHub {
                 owner = "vektra";
                 repo = "mockery";
-                rev = "v${version}";
+                rev = "v${version}"; # Look 4 lines below this one!!!
                 sha256 = "sha256-udzBhCkESd/5GEJf9oVz0nAQDmsk4tenvDP6tbkBIao=";
               };
+              ldflags = [
+                "-X github.com/vektra/mockery/v2/pkg/config.SemVer=v${version}"  # IMPERATIVE TO LOOK AT SOURCE CODE WHEN UPDATING VERSION!!!
+              ];
               doCheck = false;
               vendorHash = "sha256-iuQx2znOh/zsglnJma7Y4YccVArSFul/IOaNh449SpA=";
             };
@@ -335,6 +338,7 @@
                 clang-tools
                 protobuf
                 myyarn
+                diffutils
               ];
             };
 
@@ -364,6 +368,7 @@
                     clang-tools
                     protobuf
                     myyarn
+                    diffutils
                   ];
                   enterShell = ''
                     unset GOPATH;

--- a/sdks/java/Makefile
+++ b/sdks/java/Makefile
@@ -1,3 +1,4 @@
+USE_NIX := false
 GIT_TAG               := $(shell git describe --exact-match --tags --abbrev=0 2> /dev/null || echo untagged)
 ifeq ($(GIT_TAG),untagged)
 # "SNAPSHOT" is "latest" for Java
@@ -19,6 +20,12 @@ publish: generate
 	$(MVN) deploy -DskipTests -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/argoproj/argo-workflows
 
 generate:
+ifeq ($(USE_NIX), true)
+	chmod -R 777 client || exit 0
+	rm -rf $(WD)
+	nix build
+	cp -r result/data/client ./client
+else 
 	rm -Rf $(WD)
 	mkdir -p $(WD)
 	cp settings.xml $(WD)/settings.xml
@@ -71,6 +78,7 @@ generate:
 	$(CHOWN) $(WD) || sudo $(CHOWN) $(WD)
 	# adding kubernetes-client
 	cd client && sed 's/<dependencies>/<dependencies><dependency><groupId>io.kubernetes<\/groupId><artifactId>client-java<\/artifactId><version>14.0.1<\/version><\/dependency>/g' pom.xml > tmp && mv tmp pom.xml
+endif
 
 client/pom.xml: generate
 

--- a/sdks/java/flake.lock
+++ b/sdks/java/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1689243103,
+        "narHash": "sha256-IfBt2AD8qCwZs+m6BlOGEitBIkVJ0iMscMueb6QYUk4=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "f1dca68b908f3dd656b923b9fb62f7d755133662",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/sdks/java/flake.nix
+++ b/sdks/java/flake.nix
@@ -1,0 +1,101 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    flake-parts = { url = "github:hercules-ci/flake-parts"; inputs.nixpkgs-lib.follows = "nixpkgs"; };
+    nix-filter = { url = "github:numtide/nix-filter"; };
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      imports = [ inputs.treefmt-nix.flakeModule ];
+      perSystem = { pkgs, lib, config, ... }:
+        let
+
+          openapi_generator_cli_5_2_1 = pkgs.openapi-generator-cli.overrideAttrs (oldAttrs: rec {
+            pname = "openapi-generator-cli";
+            version = "5.2.1"; # update this when updating sdk Makefile
+            jarfilename = "${pname}-${version}.jar";
+            src = pkgs.fetchurl {
+              url = "mirror://maven/org/openapitools/${pname}/${version}/${jarfilename}";
+              sha256 = "sha256-stRtSZCvPUQuTiKOHmJ7k8o3Gtly9Up+gicrDOeWjIs=";
+            };
+          });
+          argoConfig = import ../../conf.nix;
+          filter = inputs.nix-filter.lib;
+          mysrc = filter {
+            root = ./../../.;
+            include = [
+              "sdks/java/settings.xml"
+              "api/openapi-spec/swagger.json"
+            ];
+            exclude = [
+              "Makefile"
+            ];
+          };
+        in
+        {
+          packages = rec {
+            argo_workflows_java_sdk = pkgs.stdenv.mkDerivation rec {
+              version = argoConfig.version;
+              pname = "argo-client-java-${version}";
+
+              nativeBuildInputs = [
+                openapi_generator_cli_5_2_1
+                pkgs.gnused
+                pkgs.openjdk8-bootstrap
+              ];
+
+              src = mysrc;
+
+              buildPhase = ''
+                pushd sdks/java
+                export WD=$(echo `pwd`/client)
+                mkdir -p $WD 
+                cp settings.xml $WD/settings.xml
+                cat ../../api/openapi-spec/swagger.json | sed 's/io.k8s.api.core.v1.//' | sed 's/io.k8s.apimachinery.pkg.apis.meta.v1.//' > $WD/swagger.json
+                export GIT_TAG=$(git describe --exact-match --tags --abbrev=0 2> /dev/null || echo untagged)
+                if [ "$GIT_TAG" == "untagged" ]; then
+                  export VERSION=0.0.0-SNAPSHOT
+                else
+                  export VERSION=$(echo "$GIT_TAG" | sed -e "s/^v//")
+                fi
+                mkdir -p $out/data
+                openapi-generator-cli generate -i client/swagger.json -g java -o ./client -p hideGenerationTimestamp=true -p serializationLibrary=jsonb -p dateLibrary=java8 --api-package io.argoproj.workflow.apis --invoker-package io.argoproj.workflow --model-package io.argoproj.workflow.models --skip-validate-spec --group-id io.argoproj.workflow --artifact-id argo-client-java --artifact-version $VERSION --import-mappings Time=java.time.Instant --import-mappings Affinity=io.kubernetes.client.openapi.models.V1Affinity --import-mappings ConfigMapKeySelector=io.kubernetes.client.openapi.models.V1ConfigMapKeySelector --import-mappings Container=io.kubernetes.client.openapi.models.V1Container --import-mappings ContainerPort=io.kubernetes.client.openapi.models.V1ContainerPort --import-mappings EnvFromSource=io.kubernetes.client.openapi.models.V1EnvFromSource --import-mappings EnvVar=io.kubernetes.client.openapi.models.V1EnvVar --import-mappings HostAlias=io.kubernetes.client.openapi.models.V1HostAlias --import-mappings Lifecycle=io.kubernetes.client.openapi.models.V1Lifecycle --import-mappings ListMeta=io.kubernetes.client.openapi.models.V1ListMeta --import-mappings LocalObjectReference=io.kubernetes.client.openapi.models.V1LocalObjectReference --import-mappings ObjectMeta=io.kubernetes.client.openapi.models.V1ObjectMeta --import-mappings ObjectReference=io.kubernetes.client.openapi.models.V1ObjectReference --import-mappings PersistentVolumeClaim=io.kubernetes.client.openapi.models.V1PersistentVolumeClaim --import-mappings PodDisruptionBudgetSpec=io.kubernetes.client.openapi.models.V1beta1PodDisruptionBudgetSpec --import-mappings PodDNSConfig=io.kubernetes.client.openapi.models.V1PodDNSConfig --import-mappings PodSecurityContext=io.kubernetes.client.openapi.models.V1PodSecurityContext --import-mappings Probe=io.kubernetes.client.openapi.models.V1Probe --import-mappings ResourceRequirements=io.kubernetes.client.openapi.models.V1ResourceRequirements --import-mappings SecretKeySelector=io.kubernetes.client.openapi.models.V1SecretKeySelector --import-mappings SecurityContext=io.kubernetes.client.openapi.models.V1SecurityContext --import-mappings Toleration=io.kubernetes.client.openapi.models.V1Toleration --import-mappings Volume=io.kubernetes.client.openapi.models.V1Volume --import-mappings VolumeDevice=io.kubernetes.client.openapi.models.V1VolumeDevice --import-mappings VolumeMount=io.kubernetes.client.openapi.models.V1VolumeMount --generate-alias-as-model
+                pushd client 
+                sed 's/<dependencies>/<dependencies><dependency><groupId>io.kubernetes<\/groupId><artifactId>client-java<\/artifactId><version>14.0.1<\/version><\/dependency>/g' pom.xml > tmp && mv tmp pom.xml
+                popd
+
+                popd
+              '';
+
+              installPhase = ''
+                pushd sdks/java
+                mkdir -p $out/data
+                cp ./client/swagger.json $out/data/swagger.json
+                cp -r ./client $out/data
+                popd
+              '';
+            };
+            default = argo_workflows_java_sdk;
+          };
+
+          devShells = {
+            default = pkgs.mkShell {
+              packages = with pkgs; [
+                openapi_generator_cli_5_2_1
+                openjdk8-bootstrap
+                gnused
+              ];
+            };
+          };
+
+          treefmt = {
+            projectRootFile = "flake.nix";
+            programs.nixpkgs-fmt.enable = true;
+          };
+        };
+    };
+
+}

--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -1,3 +1,4 @@
+USE_NIX := false
 VERSION := $(shell ./sdk_version.py)
 ifndef VERSION
   $(error "Failed to obtain a valid version for the SDK")
@@ -16,6 +17,12 @@ publish: generate
 	twine upload client/dist/* -u __token__ -p ${PYPI_API_TOKEN}
 
 generate:
+ifeq ($(USE_NIX), true) 
+	chmod -R 777 client || exit 0
+	rm -rf $(WD)
+	nix build
+	cp -r result/data/client ./client
+else
 	rm -Rf $(WD)
 	mkdir -p $(WD)
 	cat ../../api/openapi-spec/swagger.json | \
@@ -41,6 +48,7 @@ generate:
 		--generate-alias-as-model
 	# https://vsupalov.com/docker-shared-permissions/#set-the-docker-user-when-running-your-container
 	$(CHOWN) $(WD) || sudo $(CHOWN) $(WD)
+endif
 
 install:
 	pip3 install ./client

--- a/sdks/python/flake.lock
+++ b/sdks/python/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1689620039,
+        "narHash": "sha256-BtNwghr05z7k5YMdq+6nbue+nEalvDepuA7qdQMAKoQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "719c2977f958c41fa60a928e2fbc50af14844114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/sdks/python/flake.nix
+++ b/sdks/python/flake.nix
@@ -1,0 +1,102 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    flake-parts = { url = "github:hercules-ci/flake-parts"; inputs.nixpkgs-lib.follows = "nixpkgs"; };
+    nix-filter = { url = "github:numtide/nix-filter"; };
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      imports = [ inputs.treefmt-nix.flakeModule ];
+      perSystem = { pkgs, lib, config, ... }:
+        let
+
+          openapi_generator_cli_5_4_0 = pkgs.openapi-generator-cli.overrideAttrs (oldAttrs: rec {
+            pname = "openapi-generator-cli";
+            version = "5.4.0"; # update this when updating sdk Makefile
+            jarfilename = "${pname}-${version}.jar";
+            src = pkgs.fetchurl {
+              url = "mirror://maven/org/openapitools/${pname}/${version}/${jarfilename}";
+              sha256 = "sha256-8+0xIxDjkDJLM7ov//KQzoEpNSB6FJPsXAmNCkQb5Rw=";
+            };
+          });
+          pythonEnv = pkgs.python310.withPackages (ps: [
+            ps.pytest
+            ps.typing-extensions
+            ps.mypy
+            ps.autopep8
+            ps.pip
+            ps.build
+            ps.twine
+            ps.setuptools
+          ]);
+          argoConfig = import ../../conf.nix;
+          filter = inputs.nix-filter.lib;
+          mysrc = filter {
+            root = ./../../.;
+            include = [
+              "api/openapi-spec/swagger.json"
+              "sdks/python/sdk_version.py"
+              "hack/custom-boilerplate.go.txt"
+              "LICENSE"
+            ];
+            exclude = [
+              "Makefile"
+            ];
+          };
+        in
+        {
+          packages = rec {
+            argo_workflows_python_sdk = pkgs.stdenv.mkDerivation rec {
+              version = argoConfig.version;
+              pname = "argo-client-python-${version}";
+
+              nativeBuildInputs = [
+                openapi_generator_cli_5_4_0
+                pkgs.gnused
+                pythonEnv
+              ];
+
+              src = mysrc;
+
+              buildPhase = ''
+                pushd sdks/python
+                export WD=$(echo `pwd`/client)
+                mkdir -p $WD 
+                cat ../../api/openapi-spec/swagger.json | sed 's/io.k8s.api.core.v1.//' | sed 's/io.k8s.apimachinery.pkg.apis.meta.v1.//' > $WD/swagger.json
+                cp ../../LICENSE $WD/LICENSE
+                export VERSION=$(./sdk_version.py)
+                openapi-generator-cli generate --input-spec ./client/swagger.json --generator-name python --output ./client --additional-properties packageVersion=$VERSION --additional-properties packageName="argo_workflows" --additional-properties projectName="argo-workflows" --additional-properties hideGenerationTimestamp=true --remove-operation-id-prefix --model-name-prefix "" --model-name-suffix "" --artifact-id argo-python-client --global-property modelTests=false --global-property packageName=argo_workflows --generate-alias-as-model
+                popd
+              '';
+
+              installPhase = ''
+                pushd sdks/python
+                mkdir -p $out/data
+                cp -r client $out/data/
+                popd
+              '';
+            };
+            default = argo_workflows_python_sdk;
+          };
+
+          devShells = {
+            default = pkgs.mkShell {
+              packages = with pkgs; [
+                openapi_generator_cli_5_4_0
+                openjdk8-bootstrap
+                gnused
+              ];
+            };
+          };
+
+          treefmt = {
+            projectRootFile = "flake.nix";
+            programs.nixpkgs-fmt.enable = true;
+          };
+        };
+    };
+
+}


### PR DESCRIPTION
Fixes #11443

Simple change that doesn't install some software is USE_NIX flag is set. 
Relies on the Nix installed software to perform it's tasks. 

This means that sudoless codegen, pre-commit can be trivially achieved. 

Also one further step in taking the Nix build process from bare-bones to production ready. 


Verified to be the same codegen output by running make codegen and comparing output. 