### PR TITLE
docs: back-link the `kubectl` + Argo CLI pages

### DIFF
--- a/docs/kubectl.md
+++ b/docs/kubectl.md
@@ -1,8 +1,7 @@
 # kubectl
 
-You can also create Workflows directly with `kubectl`. However, the Argo CLI offers extra features
-that `kubectl` does not, such as YAML validation, workflow visualization, parameter passing, retries
-and resubmits, suspend and resume, and more.
+You can also create Workflows directly with `kubectl`.
+However, the [Argo CLI](walk-through/argo-cli.md) offers extra features that `kubectl` does not, such as YAML validation, workflow visualization, parameter passing, retries and resubmits, suspend and resume, and more.
 
 ```bash
 kubectl create -n argo -f https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/hello-world.yaml

--- a/docs/walk-through/argo-cli.md
+++ b/docs/walk-through/argo-cli.md
@@ -10,13 +10,6 @@ argo logs hello-world-xxx       # print the logs from a workflow
 argo delete hello-world-xxx     # delete workflow
 ```
 
-You can also run workflow specs directly using `kubectl` but the Argo CLI provides syntax checking, nicer output, and requires less typing.
+You can also run workflow specs directly [using `kubectl`](../kubectl.md), but the Argo CLI provides syntax checking, nicer output, and requires less typing.
 
-```bash
-kubectl create -f hello-world.yaml
-kubectl get wf
-kubectl get wf hello-world-xxx
-kubectl get po --selector=workflows.argoproj.io/workflow=hello-world-xxx
-kubectl logs hello-world-xxx-yyy -c main
-kubectl delete wf hello-world-xxx
-```
+See the [CLI Reference](../cli/argo.md) for more details.


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->

- `kubectl` page referenced the CLI but did not link to it
- CLI page duplicated some of the content from the `kubectl` page instead of linking to it
- CLI page also did not link to the reference

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add link to CLI from `kubectl` page
- add link to `kubectl` page and CLI Reference from Argo CLI page
  - remove duplicative `kubectl`
- split lines based on sentences instead of length as that is more maintainable

### Verification

<!-- TODO: Say how you tested your changes. -->

Checked that the links worked