### PR TITLE
fix: Flaky test about lifecycle hooks

### DIFF
--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -459,13 +459,13 @@ spec:
         image: alpine:latest
         command: [/bin/sh]
         source: |
-          sleep 3
+          sleep 4
     - name: exit0
       script:
         image: alpine:latest
         command: [/bin/sh]
         source: |
-          sleep 1
+          sleep 2
           exit 0
 `).When().
 		SubmitWorkflow().

--- a/test/e2e/workflow_configmap_substitution_test.go
+++ b/test/e2e/workflow_configmap_substitution_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -52,6 +53,7 @@ spec:
 			"cmref-parameters",
 			map[string]string{"msg": "hello world"},
 			map[string]string{"workflows.argoproj.io/configmap-type": "Parameter"}).
+		Wait(1 * time.Second).
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		DeleteConfigMap("cmref-parameters").
@@ -95,6 +97,7 @@ spec:
 			"cmref-parameters",
 			map[string]string{"msg": "hello world"},
 			map[string]string{"workflows.argoproj.io/configmap-type": "Parameter"}).
+		Wait(1 * time.Second).
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		DeleteConfigMap("cmref-parameters").
@@ -173,6 +176,7 @@ spec:
 			"cmref-parameters",
 			map[string]string{"msg": "hello world"},
 			map[string]string{"workflows.argoproj.io/configmap-type": "Parameter"}).
+		Wait(1 * time.Second).
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		DeleteConfigMap("cmref-parameters").

--- a/test/e2e/workflow_inputs_orverridable_test.go
+++ b/test/e2e/workflow_inputs_orverridable_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -53,6 +54,7 @@ spec:
 			"cmref-parameters",
 			map[string]string{"cmref-key": "input-value"},
 			map[string]string{"workflows.argoproj.io/configmap-type": "Parameter"}).
+		Wait(1 * time.Second).
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		DeleteConfigMap("cmref-parameters").
@@ -105,6 +107,7 @@ spec:
 			"new-cmref-parameters",
 			map[string]string{"cmref-key": "arg-value"},
 			map[string]string{"workflows.argoproj.io/configmap-type": "Parameter"}).
+		Wait(1 * time.Second).
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		DeleteConfigMap("cmref-parameters").
@@ -188,6 +191,7 @@ spec:
 			"cmref-parameters",
 			map[string]string{"cmref-key": "arg-value"},
 			map[string]string{"workflows.argoproj.io/configmap-type": "Parameter"}).
+		Wait(1 * time.Second).
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		DeleteConfigMap("cmref-parameters").


### PR DESCRIPTION
Signed-off-by: toyamagu-2021 <toyamagu2021@gmail.com>

<!-- Does this PR fix an issue -->

Relates #10807

### Motivation

- Fix flaky tests about lifecycle hooks

### Modifications

- Add sleep in main step to invoke `Running` lifecycle hook
  - Same as #10898
- Wait after creating cm, since it fails several times.
   - TestArgsValueFromParamsOverrideInputParamsValueFrom
- Wait 2 seconds for  `TestTemplateLevelHooksWaitForTriggeredHookAndRespectSynchronization`
  - #11536
  - https://github.com/argoproj/argo-workflows/actions/runs/5780166938/job/15663480943?pr=11536

### Verification

Succeed 100% in 4x2+1=9 times

- https://github.com/argoproj/argo-workflows/actions/runs/5776394791/job/15655477551?pr=11534
- https://github.com/argoproj/argo-workflows/actions/runs/5776512356/job/15655733358?pr=11534
- https://github.com/argoproj/argo-workflows/actions/runs/5776793933/job/15656278721?pr=11534
- https://github.com/argoproj/argo-workflows/actions/runs/5785561347/job/15678470596
- https://github.com/argoproj/argo-workflows/actions/runs/5785773805/job/15679183088
- Following falils don't relates to this PR.
  - [3b9bd90](https://github.com/argoproj/argo-workflows/pull/11534/commits/3b9bd9060729a606f0f19c7638877246fa402f8b): TestArgsValueFromParamsOverrideInputParamsValueFrom
  - [1a97b87](https://github.com/argoproj/argo-workflows/pull/11534/commits/1a97b87690bae0b5e28d3efe549d55340f073712): TestArgsValueFromParamsOverrideInputParamsValueFrom
  - [4076420](https://github.com/argoproj/argo-workflows/pull/11534/commits/4076420c259d4cf1be2ba23e5a63019860aef06f)
  - [8fa4077](https://github.com/argoproj/argo-workflows/pull/11534/commits/8fa40775ece14d0fd360bcefadf1b6ecf711d7ad)
  - [72768d8](https://github.com/argoproj/argo-workflows/pull/11534/commits/72768d83f993a1ac7c427b6815659a2124af8c49)