### PR TITLE
fix: Ensure target Workflow hooks not nil (#11521)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -58,7 +58,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     needs: [ argoexec-image ]
     env:
       KUBECONFIG: /home/runner/.kubeconfig

--- a/test/e2e/testdata/workflow-templates/success-hook.yaml
+++ b/test/e2e/testdata/workflow-templates/success-hook.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: hook
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        # To avoid flakiness, we sleep 1 second.
+        args: ["/bin/sleep 1; /argosay"]
+
+  hooks:
+    running:
+      expression: workflow.status == "Running"
+      template: main
+    succeed:
+      expression: workflow.status == "Succeeded"
+      template: main

--- a/test/e2e/workflow_template_test.go
+++ b/test/e2e/workflow_template_test.go
@@ -4,10 +4,12 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -124,6 +126,36 @@ spec:
 			assert.Contains(t, status.Message, "error in exit template execution")
 		}).
 		ExpectPVCDeleted()
+}
+
+func (s *WorkflowTemplateSuite) TestWorkflowTemplateWithHook() {
+	s.Given().
+		WorkflowTemplate("@testdata/workflow-templates/success-hook.yaml").
+		Workflow(`
+metadata:
+  generateName: workflow-template-hook-
+spec:
+  workflowTemplateRef:
+    name: hook
+`).
+		When().
+		CreateWorkflowTemplates().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+		}).
+		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
+			return strings.Contains(status.Name, "hooks.running")
+		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
+			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
+		}).
+		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
+			return strings.Contains(status.Name, "hooks.succeed")
+		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
+			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
+		})
 }
 
 func (s *WorkflowTemplateSuite) TestWorkflowTemplateInvalidEntryPoint() {

--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -39,6 +39,9 @@ func MergeTo(patch, target *wfv1.Workflow) error {
 		return err
 	}
 
+	if len(patchHooks) != 0 && target.Spec.Hooks == nil {
+		target.Spec.Hooks = make(wfv1.LifecycleHooks)
+	}
 	for name, hook := range patchHooks {
 		// If the patch hook doesn't exist in target
 		if _, ok := target.Spec.Hooks[name]; !ok {


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11521

### Motivation

- Ensure `target.spec.Hooks` in MergeTo is not nil when we should patch

### Modifications

- make(map) if  `target.spec.Hooks` is nil.
- Add corresponding tests.

### Verification

- Create WorkflowTemplate  from #11521 and confirm submitted succesflly.
  ![image](https://github.com/argoproj/argo-workflows/assets/83329336/95b1abe0-4af4-4315-9b6f-be6df9dc50a7)

