### PR TITLE
fix: Added vulnerability fixes for gorestlful gopkg & OS vulnerabilities in golang:1.20-alpine3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.20-alpine3.16 as builder
+FROM golang:1.20-alpine3.18 as builder
 
 RUN apk update && apk add --no-cache \
     git \

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.10.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7fo
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
-github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.10.0 h1:X4gma4HM7hFm6WMeAsTfqA0GOfdNoCzBIkHGoRLGXuM=
+github.com/emicklei/go-restful/v3 v3.10.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

We at LitmusChaos are using Argo-Workflows for orchestrating Chaos Experiments. We want to upgrade to latest version of Argo-Workflows & currently it's v3.4.9. On scanning via Twistlock, we found some vulnerabilities due to an old version of go - go1.20.4 & one due to an older version of go package - `https://github.com/emicklei/go-restful/v3`.

On checking, found that Dockerfile is using golang:1.20-alpine3.16, which is using go1.20.4. There are some vulnerabilities which were fixed in latest version i.e. `1.20.5`. Looks like golang:1.20-alpine3.16 is not getting build with latest version of go anymore.

```
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
|       CVE        | SEVERITY | CVSS |              PACKAGE              | VERSION |          STATUS          | PUBLISHED  | DISCOVERED |                    DESCRIPTION                     |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| CVE-2023-29405   | critical | 9.80 | go                                | 1.20.4  | fixed in 1.20.5, 1.19.10 | 59 days    | < 1 hour   | The go command may execute arbitrary code at build |
|                  |          |      |                                   |         | 51 days ago              |            |            | time when using cgo. This may occur when running   |
|                  |          |      |                                   |         |                          |            |            | \"go get\" on a malicious module, or when running  |
|                  |          |      |                                   |         |                          |            |            | ...                                                |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| CVE-2023-29404   | critical | 9.80 | go                                | 1.20.4  | fixed in 1.20.5, 1.19.10 | 59 days    | < 1 hour   | The go command may execute arbitrary code at build |
|                  |          |      |                                   |         | 51 days ago              |            |            | time when using cgo. This may occur when running   |
|                  |          |      |                                   |         |                          |            |            | \"go get\" on a malicious module, or when running  |
|                  |          |      |                                   |         |                          |            |            | ...                                                |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| CVE-2023-29402   | critical | 9.80 | go                                | 1.20.4  | fixed in 1.20.5, 1.19.10 | 59 days    | < 1 hour   | The go command may generate unexpected code at     |
|                  |          |      |                                   |         | 51 days ago              |            |            | build time when using cgo. This may result in      |
|                  |          |      |                                   |         |                          |            |            | unexpected behavior when running a go program      |
|                  |          |      |                                   |         |                          |            |            | which uses ...                                     |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| CVE-2023-29403   | high     | 7.80 | go                                | 1.20.4  | fixed in 1.20.5, 1.19.10 | 59 days    | < 1 hour   | On Unix platforms, the Go runtime does not         |
|                  |          |      |                                   |         | 52 days ago              |            |            | behave differently when a binary is run with       |
|                  |          |      |                                   |         |                          |            |            | the setuid/setgid bits. This can be dangerous in   |
|                  |          |      |                                   |         |                          |            |            | certain cases...                                   |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| PRISMA-2022-0227 | high     | 7.50 | github.com/emicklei/go-restful/v3 | v3.8.0  | fixed in v3.10.0         | > 1 years  | < 1 hour   | github.com/emicklei/go-restful/v3 module prior     |
|                  |          |      |                                   |         | > 9 months ago           |            |            | to v3.10.0 is vulnerable to Authentication Bypass  |
|                  |          |      |                                   |         |                          |            |            | by Primary Weakness. There is an inconsistency in  |
|                  |          |      |                                   |         |                          |            |            | how...                                             |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| CVE-2023-2253    | high     | 7.00 | github.com/docker/distribution    | v2.8.1  | fixed in 2.8.2-beta.1    | 61 days    | < 1 hour   | A flaw was found in the `/v2/_catalog` endpoint    |
|                  |          |      |                                   |         | 87 days ago              |            |            | in distribution/distribution, which accepts a      |
|                  |          |      |                                   |         |                          |            |            | parameter to control the maximum number of records |
|                  |          |      |                                   |         |                          |            |            | retur...                                           |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| CVE-2023-29406   | medium   | 6.50 | go                                | 1.20.4  | fixed in 1.20.6, 1.19.11 | 26 days    | < 1 hour   | The HTTP/1 client does not fully validate the      |
|                  |          |      |                                   |         | 18 days ago              |            |            | contents of the Host header. A maliciously crafted |
|                  |          |      |                                   |         |                          |            |            | Host header can inject additional headers or       |
|                  |          |      |                                   |         |                          |            |            | entire r...                                        |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
| PRISMA-2023-0056 | medium   | 6.20 | github.com/sirupsen/logrus        | v1.9.2  | fixed in v1.9.3          | > 3 months | < 1 hour   | The github.com/sirupsen/logrus module of all       |
|                  |          |      |                                   |         | > 5 months ago           |            |            | versions is vulnerable to denial of service.       |
|                  |          |      |                                   |         |                          |            |            | Logging more than 64kb of data in a single entry   |
|                  |          |      |                                   |         |                          |            |            | without new...                                     |
+------------------+----------+------+-----------------------------------+---------+--------------------------+------------+------------+----------------------------------------------------+
```

<!-- TODO: Say why you made your changes. -->

### Modifications

I have updated Base Image in Dockerfile to golang:1.20-alpine3.18 (This is having latest version of go i.e. 1.20.5).
Also updated version of `https://github.com/emicklei/go-restful/v3` to v3.10.0.

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
