### PR TITLE
fix: Upgraded docker distribution go package to v2.8.2 for fixing a high vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,6 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM gcr.io/distroless/static as argoexec
 
-USER 8737
-
 COPY --from=argoexec-build /go/src/github.com/argoproj/argo-workflows/dist/argoexec /bin/
 COPY --from=argoexec-build /etc/mime.types /etc/mime.types
 COPY hack/ssh_known_hosts /etc/ssh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,8 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 FROM gcr.io/distroless/static as argoexec
 
+USER 8737
+
 COPY --from=argoexec-build /go/src/github.com/argoproj/argo-workflows/dist/argoexec /bin/
 COPY --from=argoexec-build /etc/mime.types /etc/mime.types
 COPY hack/ssh_known_hosts /etc/ssh/

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
-	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,9 @@ github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/docker/cli v20.10.17+incompatible h1:eO2KS7ZFeov5UJeaDmIs1NFEDRf32PaqRpvoEkKBy5M=
 github.com/docker/cli v20.10.17+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.24+incompatible h1:Ugvxm7a8+Gz6vqQYQQ2W7GYq5EUPaAiuPgIfVyI3dYE=
 github.com/docker/docker v20.10.24+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->
Here from LitmusChaos Again!!

After our last PR - https://github.com/argoproj/argo-workflows/pull/11538 got merged, we scanned the latest images again, we found one more vulnerability in both workflow-controller and argoexec which may have been missed earlier - 

```
Scan results for: image [quay.io/argoproj/argoexec:latest] sha256:ee7f51a0169c160f6c04e4a85d3fddae14b5ff640d0b2202a8e8fb7ffc4ddef4
Vulnerabilities
+---------------+----------+------+--------------------------------+---------+-----------------------+-----------+------------+----------------------------------------------------+
|      CVE      | SEVERITY | CVSS |            PACKAGE             | VERSION |        STATUS         | PUBLISHED | DISCOVERED |                    DESCRIPTION                     |
+---------------+----------+------+--------------------------------+---------+-----------------------+-----------+------------+----------------------------------------------------+
| CVE-2023-2253 | high     | 7.00 | [github.com/docker/distribution] | v2.8.1  | fixed in 2.8.2-beta.1 | 64 days   | < 1 hour   | A flaw was found in the `/v2/_catalog` endpoint    |
|               |          |      |                                |         | 90 days ago           |           |            | in distribution/distribution, which accepts a      |
|               |          |      |                                |         |                       |           |            | parameter to control the maximum number of records |
|               |          |      |                                |         |                       |           |            | retur...                                           |
+---------------+----------+------+--------------------------------+---------+-----------------------+-----------+------------+----------------------------------------------------+

Vulnerabilities found for image [quay.io/argoproj/argoexec:latest]: total - 1, critical - 0, high - 1, medium - 0, low - 0
```

and also there was one compliance issue (only in argoexec but not in workflow-controller), on checking Dockerfile, we found that argoexec container doesn't have a USER set like other containers (workflow-controller, UI,etc) - 

```
Compliance Issues
+----------+------------------------------------------------------------------------------+
| SEVERITY |                                 DESCRIPTION                                  |
+----------+------------------------------------------------------------------------------+
| high     | (CIS_Docker_v1.5.0 - 4.1) Image should be created with a non-root user       |
```

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

Have updated the docker distribution go package to 2.8.2 & also added USER instruction `USER 8737` in argoexec build stage just like workflow-controller. 

**NOTE - Do let us know if USER instruction is not required, will remove it again! Thanks!!**

### Verification

<!-- TODO: Say how you tested your changes. -->
