### PR TITLE
fix: Argo DB init conflict when deploy workflow-controller with multiple replicas #11177

### DIFF
--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -27,6 +27,7 @@ func (wfc *WorkflowController) updateConfig() error {
 	wfc.offloadNodeStatusRepo = sqldb.ExplosiveOffloadNodeStatusRepo
 	wfc.wfArchive = sqldb.NullWorkflowArchive
 	wfc.archiveLabelSelector = labels.Everything()
+
 	persistence := wfc.Config.Persistence
 	if persistence != nil {
 		log.Info("Persistence configuration enabled")
@@ -40,14 +41,7 @@ func (wfc *WorkflowController) updateConfig() error {
 				return err
 			}
 			log.Info("Persistence Session created successfully")
-			if !persistence.SkipMigration {
-				err = sqldb.NewMigrate(session, persistence.GetClusterName(), tableName).Exec(context.Background())
-				if err != nil {
-					return err
-				}
-			} else {
-				log.Info("DB migration is disabled")
-			}
+
 			wfc.session = session
 		}
 		sqldb.ConfigureDBSession(wfc.session, persistence.ConnectionPool)
@@ -75,6 +69,7 @@ func (wfc *WorkflowController) updateConfig() error {
 	} else {
 		log.Info("Persistence configuration disabled")
 	}
+
 	wfc.hydrator = hydrator.New(wfc.offloadNodeStatusRepo)
 	wfc.updateEstimatorFactory()
 	wfc.rateLimiter = wfc.newRateLimiter()
@@ -83,6 +78,27 @@ func (wfc *WorkflowController) updateConfig() error {
 		WithField("executorImagePullPolicy", wfc.executorImagePullPolicy()).
 		WithField("managedNamespace", wfc.GetManagedNamespace()).
 		Info()
+	return nil
+}
+
+// initDB inits argo DB tables
+func (wfc *WorkflowController) initDB() error {
+	persistence := wfc.Config.Persistence
+	if persistence != nil {
+		tableName, err := sqldb.GetTableName(persistence)
+		if err != nil {
+			return err
+		}
+		if !persistence.SkipMigration {
+			err = sqldb.NewMigrate(wfc.session, persistence.GetClusterName(), tableName).Exec(context.Background())
+			if err != nil {
+				return err
+			}
+		} else {
+			log.Info("DB migration is disabled")
+		}
+	}
+
 	return nil
 }
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -240,6 +240,11 @@ var indexers = cache.Indexers{
 func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers int) {
 	defer runtimeutil.HandleCrash(runtimeutil.PanicHandlers...)
 
+	// init DB after leader election (if enabled)
+	if err := wfc.initDB(); err != nil {
+		log.Fatalf("Failed to init db: %v", err)
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
Fixes #11177

### Motivation

Fix Argo DB init conflict when deploy workflow-controller with multiple replicas.

### Modifications

Move the DB init logic to after the leader election completed.

### Verification

After the code modification, tested the workflow-controller deployment in my environment with
multiple replicas (1, 5 and 10), all work ok.

10 for example:
```
workflow-controller-85bfb69457-4tcbz   1/1     Running   0          5s
workflow-controller-85bfb69457-dwvll   1/1     Running   0          6s
workflow-controller-85bfb69457-fvcvj   1/1     Running   0          5s
workflow-controller-85bfb69457-fzkv9   1/1     Running   0          5s
workflow-controller-85bfb69457-khs2v   1/1     Running   0          5s
workflow-controller-85bfb69457-mjwhs   1/1     Running   0          5s
workflow-controller-85bfb69457-npxb7   1/1     Running   0          5s
workflow-controller-85bfb69457-qq7zc   1/1     Running   0          5s
workflow-controller-85bfb69457-rmgc4   1/1     Running   0          5s
workflow-controller-85bfb69457-snrn9   1/1     Running   0          5s
```
