### PR TITLE
feat(cli): Add a flag status to delete cmd like list cmd of argo cli

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -25,7 +25,7 @@ func NewDeleteCommand() *cobra.Command {
 		force         bool
 	)
 	command := &cobra.Command{
-		Use:   "delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmitted] [--prefix PREFIX] [--selector SELECTOR] [--force] ]",
+		Use:   "delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmitted] [--prefix PREFIX] [--selector SELECTOR] [--force] [--status STATUS] ]",
 		Short: "delete workflows",
 		Example: `# Delete a workflow:
 
@@ -36,7 +36,10 @@ func NewDeleteCommand() *cobra.Command {
   argo delete @latest
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 && !(all || allNamespaces || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.fields != "" || flags.finishedAfter != "") {
+			hasFilterFlag := all || allNamespaces || flags.completed || flags.resubmitted || flags.prefix != "" ||
+				flags.labels != "" || flags.fields != "" || flags.finishedAfter != "" || len(flags.status) > 0
+
+			if len(args) == 0 && !hasFilterFlag {
 				cmd.HelpFunc()(cmd, args)
 				os.Exit(1)
 			}
@@ -52,7 +55,7 @@ func NewDeleteCommand() *cobra.Command {
 					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: flags.namespace},
 				})
 			}
-			if all || flags.completed || flags.resubmitted || flags.prefix != "" || flags.labels != "" || flags.fields != "" || flags.finishedAfter != "" {
+			if hasFilterFlag {
 				listed, err := listWorkflows(ctx, serviceClient, flags)
 				errors.CheckError(err)
 				workflows = append(workflows, listed...)
@@ -84,9 +87,10 @@ func NewDeleteCommand() *cobra.Command {
 	command.Flags().BoolVar(&flags.completed, "completed", false, "Delete completed workflows")
 	command.Flags().BoolVar(&flags.resubmitted, "resubmitted", false, "Delete resubmitted workflows")
 	command.Flags().StringVar(&flags.prefix, "prefix", "", "Delete workflows by prefix")
-	command.Flags().StringVar(&flags.finishedAfter, "older", "", "Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
 	command.Flags().StringVarP(&flags.labels, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&flags.fields, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
+	command.Flags().StringVar(&flags.finishedAfter, "older", "", "Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
+	command.Flags().StringSliceVar(&flags.status, "status", []string{}, "Delete by status (comma separated)")
 	command.Flags().Int64VarP(&flags.chunkSize, "query-chunk-size", "", 0, "Run the list query in chunks (deletes will still be executed individually)")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Do not delete the workflow, only print what would happen")
 	command.Flags().BoolVar(&force, "force", false, "Force delete workflows by removing finalizers")

--- a/docs/cli/argo_delete.md
+++ b/docs/cli/argo_delete.md
@@ -3,7 +3,7 @@
 delete workflows
 
 ```
-argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmitted] [--prefix PREFIX] [--selector SELECTOR] [--force] ] [flags]
+argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmitted] [--prefix PREFIX] [--selector SELECTOR] [--force] [--status STATUS] ] [flags]
 ```
 
 ### Examples
@@ -34,6 +34,7 @@ argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmit
       --query-chunk-size int    Run the list query in chunks (deletes will still be executed individually)
       --resubmitted             Delete resubmitted workflows
   -l, --selector string         Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --status strings          Delete by status (comma separated)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

For https://github.com/argoproj/argo-workflows/issues/11555. @tooptoop4 wants to filter workflows more accurately and flexibly by status.

There are two supported flags associated with it: 

- `--field-selector`: `metadata.name=foo`, `metadata.namespace=bar`
- `--selector`: `workflows.argoproj.io/phase=Succeeded`

It is not feasible to use the `--field-selector` to filter workflows by status because of the [well-known reasons](https://github.com/kubernetes/kubernetes/issues/53459).

Using `-l(--selector)` would satisfy the need, but the labels are too long with a common prefix `workflows.argoproj.io/`. It is not convenient to use.

Luckily, `argo list` has a directly related flag `--status` to filter workflows by status like `argo list --status Running`. It is more convenient to use. I think it could be taken a step further by exempting users from using the shell combination like `argo delete $(argo list --status Succeeded | awk '{print $1}')`

### Modifications

1. Add a flag `--status` to `argo delete` to filter workflows by status. It's an existing field of struct `listFlags` and can be used directly.

### Verification

There was no test code for `argo delete` before. I run it locally and it works as expected.

![image](https://github.com/argoproj/argo-workflows/assets/29922079/7bb29a59-b751-43e5-98d1-91ffea213fce)
