### PR TITLE
fix: TERM signal was catched but not handled properly, which causing …

### DIFF
--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -21,7 +21,7 @@ func NewResourceCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx := context.Background()
+			ctx := cmd.Context()
 			err := execResource(ctx, args[0])
 			if err != nil {
 				log.Fatalf("%+v", err)


### PR DESCRIPTION
TERM signal was catched but not handled properly, which causing waiting so long to delete a pod

Fixes #10658

### Motivation

pod can't be stopped via `argo terminate`, works after I changed the context.

### Modifications

changed the parent context in `argoexec resource` subcommand.

### Verification

1. stop pod via `kubectl delete pod`, no more 30s needed.
2. stop via `argo terminate` works.
