### PR TITLE
refactor(ui): simplify Webpack config a bit

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -7,8 +7,12 @@ const webpack = require("webpack");
 const path = require("path");
 
 const isProd = process.env.NODE_ENV === "production";
+const proxyConf = {
+  target: isProd ? "" : "http://localhost:2746",
+  secure: false
+};
 
-console.log("isProd=", isProd)
+console.log(`Bundling for ${isProd ? 'production' : 'development'}...`);
 
 const config = {
   mode: isProd ? "production" : "development",
@@ -59,22 +63,27 @@ const config = {
       "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "development"),
       SYSTEM_INFO: JSON.stringify({
         version: process.env.VERSION || "latest"
-      }), 
+      }),
       "process.env.DEFAULT_TZ": JSON.stringify("UTC"),
     }),
     new HtmlWebpackPlugin({ template: "src/app/index.html" }),
     new CopyWebpackPlugin([{
-      from: "node_modules/argo-ui/src/assets", to: "assets"
+      from: "node_modules/argo-ui/src/assets",
+      to: "assets"
     }, {
-      from: "node_modules/@fortawesome/fontawesome-free/webfonts", to: "assets/fonts"
+      from: "node_modules/@fortawesome/fontawesome-free/webfonts",
+      to: "assets/fonts"
     }, {
-      from: "../api/openapi-spec/swagger.json", to: "assets/openapi-spec/swagger.json"
+      from: "../api/openapi-spec/swagger.json",
+      to: "assets/openapi-spec/swagger.json"
     }, {
-      from: "../api/jsonschema/schema.json", to: "assets/jsonschema/schema.json"
+      from: "../api/jsonschema/schema.json",
+      to: "assets/jsonschema/schema.json"
     }, {
-      from: 'node_modules/monaco-editor/min/vs/base/browser/ui/codiconLabel/codicon/codicon.ttf', to: "."
+      from: 'node_modules/monaco-editor/min/vs/base/browser/ui/codiconLabel/codicon/codicon.ttf',
+      to: "."
     }]),
-    new MonacoWebpackPlugin({"languages":["json","yaml"]})
+    new MonacoWebpackPlugin({ languages: ["json", "yaml"] })
   ],
   devServer: {
     // this needs to be disable to allow EventSource to work
@@ -86,34 +95,13 @@ const config = {
       'X-Frame-Options': 'SAMEORIGIN'
     },
     proxy: {
-      "/api/v1": {
-        "target": isProd ? "" : "http://localhost:2746",
-        "secure": false
-      },
-      "/artifact-files": {
-        "target": isProd ? "" : "http://localhost:2746",
-        "secure": false
-      },
-      "/artifacts": {
-        "target": isProd ? "" : "http://localhost:2746",
-        "secure": false
-      },
-      "/input-artifacts": {
-        "target": isProd ? "" : "http://localhost:2746",
-        "secure": false
-      },
-      "/artifacts-by-uid": {
-        "target": isProd ? "" : "http://localhost:2746",
-        "secure": false
-      },
-      "/input-artifacts-by-uid": {
-        "target": isProd ? "" : "http://localhost:2746",
-        "secure": false
-      },
-      '/oauth2': {
-        'target': isProd ? '' : 'http://localhost:2746',
-        'secure': false,
-      },
+      "/api/v1": proxyConf,
+      "/artifact-files": proxyConf,
+      "/artifacts": proxyConf,
+      "/input-artifacts": proxyConf,
+      "/artifacts-by-uid": proxyConf,
+      "/input-artifacts-by-uid": proxyConf,
+      "/oauth2": proxyConf,
     }
   }
 };


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Simplify the Webpack config a tiny bit after having to work with it for #11593 and #11585 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- makes it more similar to Argo CD's [current config](https://github.com/argoproj/argo-cd/blob/bfaac2b5ac4b96c8af8158902c1b086f7ced7389/ui/src/app/webpack.config.js#L10)
  - using a `proxyConf` variable borrowed from there, though I thought that was a good simplification either way
  - `console.log` statement is very similar now, though slightly modified wording ("in" -> "for")
    - I was pretty confused by the `isProd= ` log before, thought it had some significance, and thought it might have an error (due to the space), but it was actually just a log statement. So make it more clear this way
  - separate `from:` and `to:` to separate lines
    - better readability and usually formatters have rules for this style -- but there may be no formatter running on the config?

### Verification

<!-- TODO: Say how you tested your changes. -->

No semantic changes, just stylistic. Been using it for my local builds already, so builds definitely still pass. Just split this out as a separate, independent PR.
