### PR TITLE
refactor: remove nesting during dry-run of `argo delete`

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -64,17 +64,18 @@ func NewDeleteCommand() *cobra.Command {
 			}
 
 			for _, wf := range workflows {
-				if !dryRun {
-					_, err := serviceClient.DeleteWorkflow(ctx, &workflowpkg.WorkflowDeleteRequest{Name: wf.Name, Namespace: wf.Namespace, Force: force})
-					if err != nil && status.Code(err) == codes.NotFound {
-						fmt.Printf("Workflow '%s' not found\n", wf.Name)
-						continue
-					}
-					errors.CheckError(err)
-					fmt.Printf("Workflow '%s' deleted\n", wf.Name)
-				} else {
+				if dryRun {
 					fmt.Printf("Workflow '%s' deleted (dry-run)\n", wf.Name)
+					continue
 				}
+
+				_, err := serviceClient.DeleteWorkflow(ctx, &workflowpkg.WorkflowDeleteRequest{Name: wf.Name, Namespace: wf.Namespace, Force: force})
+				if err != nil && status.Code(err) == codes.NotFound {
+					fmt.Printf("Workflow '%s' not found\n", wf.Name)
+					continue
+				}
+				errors.CheckError(err)
+				fmt.Printf("Workflow '%s' deleted\n", wf.Name)
 			}
 		},
 	}


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Reduces the complexity of code a tiny bit
- Noticed this while reviewing #11577 and #11557 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- invert the `if` conditional and `continue` early on it instead of having nesting with an `if` / `else`


### Verification

<!-- TODO: Say how you tested your changes. -->

No semantic changes, just stylistic changes. Unfortunately `delete` still does not have any tests though

"Ignore whitespace" makes [the diff](https://github.com/argoproj/argo-workflows/pull/11596/files?diff=unified&w=1) pretty easy to read and verify
