### PR TITLE
build: run openapi-generator-cli in docker with current user.

### DIFF
--- a/sdks/java/Makefile
+++ b/sdks/java/Makefile
@@ -11,7 +11,7 @@ endif
 # work dir
 WD                    := $(shell echo "`pwd`/client")
 
-DOCKER = docker run --rm -v $(WD):/wd --workdir /wd
+DOCKER = docker run --rm --user $(shell id -u):$(shell id -g) -v $(WD):/wd --workdir /wd
 MVN = $(DOCKER) -v $(HOME)/.m2:/root/.m2 -e JAVA_SDK_MAVEN_PASSWORD=${JAVA_SDK_MAVEN_PASSWORD} maven:3-openjdk-8 mvn -s settings.xml
 CHOWN = chown -R $(shell id -u):$(shell id -g)
 

--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -7,7 +7,7 @@ endif
 # work dir
 WD := $(shell echo "`pwd`/client")
 
-DOCKER = docker run --rm -v $(WD):/wd --workdir /wd
+DOCKER = docker run --rm --user $(shell id -u):$(shell id -g) -v $(WD):/wd --workdir /wd
 CHOWN = chown -R $(shell id -u):$(shell id -g)
 
 publish: generate


### PR DESCRIPTION
### Motivation
Due to docker running under root, it is necessary to modify the owner of the generated file.

### Modifications
Add --user with docker run
I've read [link](https://vsupalov.com/docker-shared-permissions/#set-the-docker-user-when-running-your-container)
bash and openapi-generator-cli works normally