### PR TITLE
fix(workflow): match discovery burst and qps for `kubectl` with upstream kubectl binary

### DIFF
--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -372,9 +372,14 @@ func runKubectl(args ...string) ([]byte, error) {
 	}()
 	var buf bytes.Buffer
 	if err := kubectlcmd.NewKubectlCommand(kubectlcmd.KubectlOptions{
-		Arguments:   args,
-		ConfigFlags: genericclioptions.NewConfigFlags(true),
-		IOStreams:   genericclioptions.IOStreams{Out: &buf, ErrOut: os.Stderr},
+		Arguments: args,
+		// TODO(vadasambar): use `DefaultConfigFlags` variable from upstream
+		// as value for `ConfigFlags` once https://github.com/kubernetes/kubernetes/pull/120024 is merged
+		ConfigFlags: genericclioptions.NewConfigFlags(true).
+			WithDeprecatedPasswordFlag().
+			WithDiscoveryBurst(300).
+			WithDiscoveryQPS(50.0),
+		IOStreams: genericclioptions.IOStreams{Out: &buf, ErrOut: os.Stderr},
 	}).Execute(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

May fix or alleviate issues like https://github.com/argoproj/argo-workflows/issues/11156 and https://github.com/argoproj/argo-workflows/issues/9934

### Motivation

We migrated to using `kubectl` as a package starting v3.4.7:
* v3.4.7: https://github.com/argoproj/argo-workflows/blob/v3.4.7/go.mod#L71
* v3.4.8: https://github.com/argoproj/argo-workflows/blob/v3.4.8/go.mod#L71
* master: https://github.com/argoproj/argo-workflows/blob/master/go.mod#L71

Before v3.4.7 we used `kubectl` binary ([ref1](https://github.com/argoproj/argo-workflows/blob/v3.4.6/Dockerfile#L82-L83), [ref2](https://github.com/argoproj/argo-workflows/blob/988706dd131cf98808f09fb7cc03780e2af94c73/workflow/executor/resource.go#L39))

`kubectl` binary uses uses higher values for discovery burst and QPS [since v1.24](https://github.com/kubernetes/kubernetes/pull/107131 ). `kubectl` passes the new QPS and burst through [`NewDefaultKubectlCommand`](https://github.com/kubernetes/kubernetes/blob/a5d2d6fec3a1a9538255d796eaf58e0777940135/cmd/kubectl/kubectl.go#L29) while in argo workflows we use [`NewKubectlCommand`](https://github.com/argoproj/argo-workflows/blob/1adc6c208717d0f2a460cefe452f651baa1dd6c8/workflow/executor/resource.go#L374) instead [which uses default burst of `100`](https://github.com/kubernetes/cli-runtime/blob/4fdf49ae46a0caa7fafdfe97825c6129d5153f06/pkg/genericclioptions/config_flags.go#L442) ([we are using `v.0.24.3` version of `kubectl` pkg](https://github.com/argoproj/argo-workflows/blob/7b80ce19e8afe6690aed5c2f3d6c123c812e468b/go.mod#L74) at the time of writing this) 

If there are 100 or more CRDs in the cluster, discovery can take time. This leaves less time for pod to run because of which pod can exceed `activeDeadlineSeconds` (check https://github.com/argoproj/argo-workflows/issues/11156 and https://github.com/argoproj/argo-workflows/issues/9934). Related: https://github.com/kubernetes/kubectl/issues/1126


### Modifications

This PR matches the the new discovery burst and QPS set in the upstream. 
Related:
* https://github.com/kubernetes/kubernetes/pull/120024 is merged

Note that in 1.26 version (v0.26.x for kubectl package), [default burst across all client-go clients was bumped up to 300](https://github.com/kubernetes/kubernetes/pull/109141) (no increase in the default QPS though) but we can't use this since we are on v0.24.3. Upgrading the `kubectl` package is an option but I am not sure about the consequences of doing that. We might want to re-visit this PR again in the future and remove lines which are already set in the upstream. 


### Verification

<!-- TODO: Say how you tested your changes. -->
