### PR TITLE
feat: upgrade expr to v1.14 for richer language definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/alibabacloud-go/tea v1.2.1
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.8+incompatible
 	github.com/aliyun/credentials-go v1.3.1
-	github.com/antonmedv/expr v1.13.0
+	github.com/antonmedv/expr v1.14.0
 	github.com/argoproj/argo-events v1.7.3
 	github.com/argoproj/pkg v0.13.7-0.20230814141812-41dde703b79c
 	github.com/blushft/go-diagrams v0.0.0-20201006005127-c78c821223d9

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/antonmedv/expr v1.13.0 h1:8YrTtlCzlOtXw+hpeCLDLL2uo0C0k6jmYpYTGws5c5w=
-github.com/antonmedv/expr v1.13.0/go.mod h1:FPC8iWArxls7axbVLsW+kpg1mz29A1b2M6jt+hZfDkU=
+github.com/antonmedv/expr v1.14.0 h1:C4BHw+0cVyKy/ndU3uqYo6TV5rCtq/SY2Wdlwanvo/Q=
+github.com/antonmedv/expr v1.14.0/go.mod h1:FPC8iWArxls7axbVLsW+kpg1mz29A1b2M6jt+hZfDkU=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/argoproj-labs/go-git/v5 v5.4.7 h1:BXrXK/anGnbdj0MoKJyn++h6HZ7Wa0UhW2mNOmuTcV8=
 github.com/argoproj-labs/go-git/v5 v5.4.7/go.mod h1:hA0dcdz5GgO4KXyDY90CCfJaw4PIGMecmq5YwHdTBi0=


### PR DESCRIPTION
### Motivation

Updates antonmedv/expr from v1.13 to v1.14 which has a [much richer language definition](https://expr.medv.io/docs/Language-Definition) and includes useful helpers such as `hasPrefix`, `max`

I think this will really help with simplifying workflows. I also think it will make the WorkflowEventBinding much more useful and reduce the need for argo-events webhook eventsource.

The other problem that this will solve is that our docs constantly refer to the expr project to see how to write expressions. But if we continue to use the old version, users will hit unexpected errors. e.g.:

```
Non-transient error: failed to evaluate workflow template expression: unable to evaluate expression 'hasPrefix(payload.Key, \"foo\") == true': reflect: call of reflect.Value.Call on zero Value (1:1)\n | hasPrefix(payload.Key, \"foo\") == true\n | ^
```

In fact, this is how I discovered the new version in the first place (I was confused on why certain functions were unavailable).
