### PR TITLE
fix: deprecated Link(Help-Contact) Issue

### DIFF
--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -25,7 +25,7 @@ export const Help = () => {
                     <div className='help-box'>
                         <div className='help-box__ico help-box__ico--email' />
                         <h3>Contact</h3>
-                        <a className='help-box__link' target='_blank' href='https://argoproj.slack.com'>
+                        <a className='help-box__link' target='_blank' href='https://slack.cncf.io/'>
                             Slack
                         </a>
                     </div>


### PR DESCRIPTION

<!-- Does this PR fix an issue -->

Fixes #11615 

### Motivation

I wanted to communicate when I wanted to ask questions or get help while using Argo workflow.

However, I accessed the contact field link on the help page, but was connected to the deleted argo workflow slack workspace. 😭

I think In order to smoothly maintain the Argo workflow ecosystem, a forum for active communication should be provided 💪

### Modifications

I simply modified the Contact link in the help.tsx source code among UI components.
Link (https://argoproj.slack.com/   ->  https://slack.cncf.io/ (Changed))

![image](https://github.com/argoproj/argo-workflows/assets/96514378/585780e8-0d63-4dcb-a5bd-2bdfb6cbd565)

<img width="1439" alt="image" src="https://github.com/argoproj/argo-workflows/assets/96514378/ab013bd3-60b8-4d7d-a7fb-a9bde103b578">

### Verification

<!-- TODO: Say how you tested your changes. -->
