### PR TITLE
docs(cli): a stopped workflow cannot be resumed

### DIFF
--- a/cmd/argo/commands/resume.go
+++ b/cmd/argo/commands/resume.go
@@ -20,8 +20,8 @@ func NewResumeCommand() *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "resume WORKFLOW1 WORKFLOW2...",
-		Short: "resume zero or more workflows",
-		Example: `# Resume a workflow that has been stopped or suspended:
+		Short: "resume zero or more workflows (opposite of suspend)",
+		Example: `# Resume a workflow that has been suspended:
 
   argo resume my-wf
 

--- a/cmd/argo/commands/suspend.go
+++ b/cmd/argo/commands/suspend.go
@@ -13,7 +13,7 @@ import (
 func NewSuspendCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "suspend WORKFLOW1 WORKFLOW2...",
-		Short: "suspend zero or more workflow",
+		Short: "suspend zero or more workflows (opposite of resume)",
 		Example: `# Suspend a workflow:
 
   argo suspend my-wf

--- a/docs/cli/argo.md
+++ b/docs/cli/argo.md
@@ -117,12 +117,12 @@ argo [flags]
 * [argo logs](argo_logs.md)	 - view logs of a pod or workflow
 * [argo node](argo_node.md)	 - perform action on a node in a workflow
 * [argo resubmit](argo_resubmit.md)	 - resubmit one or more workflows
-* [argo resume](argo_resume.md)	 - resume zero or more workflows
+* [argo resume](argo_resume.md)	 - resume zero or more workflows (opposite of suspend)
 * [argo retry](argo_retry.md)	 - retry zero or more workflows
 * [argo server](argo_server.md)	 - start the Argo Server
 * [argo stop](argo_stop.md)	 - stop zero or more workflows allowing all exit handlers to run
 * [argo submit](argo_submit.md)	 - submit a workflow
-* [argo suspend](argo_suspend.md)	 - suspend zero or more workflow
+* [argo suspend](argo_suspend.md)	 - suspend zero or more workflows (opposite of resume)
 * [argo template](argo_template.md)	 - manipulate workflow templates
 * [argo terminate](argo_terminate.md)	 - terminate zero or more workflows immediately
 * [argo version](argo_version.md)	 - print version information

--- a/docs/cli/argo_resume.md
+++ b/docs/cli/argo_resume.md
@@ -1,6 +1,6 @@
 ## argo resume
 
-resume zero or more workflows
+resume zero or more workflows (opposite of suspend)
 
 ```
 argo resume WORKFLOW1 WORKFLOW2... [flags]
@@ -9,7 +9,7 @@ argo resume WORKFLOW1 WORKFLOW2... [flags]
 ### Examples
 
 ```
-# Resume a workflow that has been stopped or suspended:
+# Resume a workflow that has been suspended:
 
   argo resume my-wf
 

--- a/docs/cli/argo_suspend.md
+++ b/docs/cli/argo_suspend.md
@@ -1,6 +1,6 @@
 ## argo suspend
 
-suspend zero or more workflow
+suspend zero or more workflows (opposite of resume)
 
 ```
 argo suspend WORKFLOW1 WORKFLOW2... [flags]


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11511 

### Motivation

<!-- TODO: Say why you made your changes. -->

The CLI had incorrectly stated that `argo resume` could be used on a stopped workflow, resulting in confusion for some users, such as in #11511


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove the "stopped" statement in `argo resume`
- specify that `resume` and `suspend` are opposites (and therefore unrelated to `stop` / `terminate`)


### Verification

<!-- TODO: Say how you tested your changes. -->

- `make codegen` passes

#### Behavior Verification

To make sure that `argo resume` does not affect stopped workflows, I looked through the source code:
- `stop` and `terminate` are two ["shutdown strategies"](https://github.com/argoproj/argo-workflows/blob/5eb50f42897e969995ad86eef764230e3a023641/pkg/apis/workflow/v1alpha1/workflow_types.go#L540) with minor differences
- the shutdown strategy is marked on a Workflow [via `spec.shutdown`](https://github.com/argoproj/argo-workflows/blob/524b4cb58672d07ce2ed9cff3dd0c58bbcf9d293/workflow/util/util.go#L1092) by the Server. then the [operator](https://github.com/argoproj/argo-workflows/blob/524b4cb58672d07ce2ed9cff3dd0c58bbcf9d293/workflow/controller/operator.go#L423) and [exec controller](https://github.com/argoproj/argo-workflows/blob/524b4cb58672d07ce2ed9cff3dd0c58bbcf9d293/workflow/controller/exec_control.go#L40) determine how to handle it (i.e. whether to run exit handlers or not).
- meanwhile, `suspend` and `resume` are marked [via `spec.suspend`](https://github.com/argoproj/argo-workflows/blob/5eb50f42897e969995ad86eef764230e3a023641/workflow/util/util.go#L353), which is an unrelated flag.

As I had originally thought, `stop` and `resume` are unrelated operations. Not sure if there were related at some point in the past though.

### Notes for Reviewers

I wrote this as a "fix" commit so that it can be added as a patch to the CLI (and make it into any cherry-picks), but could make it a "docs" commit instead