### PR TITLE
docs(cli): clarify the difference b/t `retry` and `resubmit`

### DIFF
--- a/cmd/argo/commands/resubmit.go
+++ b/cmd/argo/commands/resubmit.go
@@ -37,6 +37,7 @@ func NewResubmitCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "resubmit [WORKFLOW...]",
 		Short: "resubmit one or more workflows",
+		Long:  "Submit a completed workflow again. Optionally override parameters and memoize. Similar to running `argo submit` again with the same parameters.",
 		Example: `# Resubmit a workflow:
 
   argo resubmit my-wf

--- a/cmd/argo/commands/retry.go
+++ b/cmd/argo/commands/retry.go
@@ -40,11 +40,12 @@ func NewRetryCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "retry [WORKFLOW...]",
 		Short: "retry zero or more workflows",
+		Long:  "Rerun a failed Workflow. All steps that failed are marked as pending and then executed as normal. The same Workflow object is used and no new Workflows are created.",
 		Example: `# Retry a workflow:
 
   argo retry my-wf
 
-# Retry multiple workflows: 
+# Retry multiple workflows:
 
   argo retry my-wf my-other-wf my-third-wf
 

--- a/cmd/argo/commands/retry.go
+++ b/cmd/argo/commands/retry.go
@@ -40,7 +40,7 @@ func NewRetryCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "retry [WORKFLOW...]",
 		Short: "retry zero or more workflows",
-		Long:  "Rerun a failed Workflow. All steps that failed are marked as pending and then executed as normal. The same Workflow object is used and no new Workflows are created.",
+		Long:  "Rerun a failed Workflow. Specifically, rerun all failed steps. The same Workflow object is used and no new Workflows are created.",
 		Example: `# Retry a workflow:
 
   argo retry my-wf

--- a/docs/cli/argo_resubmit.md
+++ b/docs/cli/argo_resubmit.md
@@ -2,6 +2,10 @@
 
 resubmit one or more workflows
 
+### Synopsis
+
+Submit a completed workflow again. Optionally override parameters and memoize. Similar to running `argo submit` again with the same parameters.
+
 ```
 argo resubmit [WORKFLOW...] [flags]
 ```

--- a/docs/cli/argo_retry.md
+++ b/docs/cli/argo_retry.md
@@ -2,6 +2,10 @@
 
 retry zero or more workflows
 
+### Synopsis
+
+Rerun a failed Workflow. All steps that failed are marked as pending and then executed as normal. The same Workflow object is used and no new Workflows are created.
+
 ```
 argo retry [WORKFLOW...] [flags]
 ```
@@ -13,7 +17,7 @@ argo retry [WORKFLOW...] [flags]
 
   argo retry my-wf
 
-# Retry multiple workflows: 
+# Retry multiple workflows:
 
   argo retry my-wf my-other-wf my-third-wf
 

--- a/docs/cli/argo_retry.md
+++ b/docs/cli/argo_retry.md
@@ -4,7 +4,7 @@ retry zero or more workflows
 
 ### Synopsis
 
-Rerun a failed Workflow. All steps that failed are marked as pending and then executed as normal. The same Workflow object is used and no new Workflows are created.
+Rerun a failed Workflow. Specifically, rerun all failed steps. The same Workflow object is used and no new Workflows are created.
 
 ```
 argo retry [WORKFLOW...] [flags]


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #10906

### Motivation

<!-- TODO: Say why you made your changes. -->

This is one of the most frequently asked questions by users and so could definitely use some clarification


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add a `Long` description to the CLI commands that details how `retry` and `resubmit` work in more detail
  - via `make codegen`, this resulted in a `### Synopsis` section in the generated docs as well, which is also helpful
  
Descriptions loosely follow the official issue response in https://github.com/argoproj/argo-workflows/issues/2320#issuecomment-592060487 with some minor copy-edits, such as mentioning `resubmit`'s memoization functionality.

### Verification

<!-- TODO: Say how you tested your changes. -->

- `make codegen` passes

### Notes for Reviewers

- I wrote this as a "fix" commit so that it can be added as a patch to the CLI (and make it into any cherry-picks), but could make it a "docs" commit instead.

- Feel free to add more modifications to the long descriptions!


### Future Work

I'd like to add these descriptions to the API docs as well, but that seems to be a larger effort as the API docs have _no_ descriptions right now 😕 I'm also not sure where codegen tries to pull the descriptions from, as there are GoDoc descriptions, but perhaps not in the right places?