### PR TITLE
docs(cli): clarify `stop` v. `terminate` with `Long` descriptions

### DIFF
--- a/cmd/argo/commands/stop.go
+++ b/cmd/argo/commands/stop.go
@@ -38,6 +38,7 @@ func NewStopCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "stop WORKFLOW WORKFLOW2...",
 		Short: "stop zero or more workflows allowing all exit handlers to run",
+		Long:  "Stop a workflow but still run exit handlers.",
 		Example: `# Stop a workflow:
 
   argo stop my-wf

--- a/cmd/argo/commands/terminate.go
+++ b/cmd/argo/commands/terminate.go
@@ -46,6 +46,7 @@ func NewTerminateCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "terminate WORKFLOW WORKFLOW2...",
 		Short: "terminate zero or more workflows immediately",
+		Long:  "Immediately stop a workflow and do not run any exit handlers.",
 		Example: `# Terminate a workflow:
 
   argo terminate my-wf

--- a/docs/cli/argo_stop.md
+++ b/docs/cli/argo_stop.md
@@ -2,6 +2,10 @@
 
 stop zero or more workflows allowing all exit handlers to run
 
+### Synopsis
+
+Stop a workflow but still run exit handlers.
+
 ```
 argo stop WORKFLOW WORKFLOW2... [flags]
 ```

--- a/docs/cli/argo_terminate.md
+++ b/docs/cli/argo_terminate.md
@@ -2,6 +2,10 @@
 
 terminate zero or more workflows immediately
 
+### Synopsis
+
+Immediately stop a workflow and do not run any exit handlers.
+
 ```
 argo terminate WORKFLOW WORKFLOW2... [flags]
 ```


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Similar to #11625, this is another one of the most frequently asked questions by users and so could definitely use some clarification

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Following the same pattern as #11625, add a `Long` description to the CLI commands that details how `stop` and `terminate` work in more detail
  - via `make codegen`, this resulted in a `### Synopsis` section in the generated docs as well, which is also helpful
  
Descriptions loosely follow the official issue response in https://github.com/argoproj/argo-workflows/issues/4454#issuecomment-721821469.
This is effectively a follow-up to #4653

### Verification

<!-- TODO: Say how you tested your changes. -->

- `make codegen` passes

### Notes for Reviewers

- I wrote this as a "fix" commit so that it can be added as a patch to the CLI (and make it into any cherry-picks), but could make it a "docs" commit instead.

- Feel free to add more modifications to the long descriptions!


### Future Work

I'd like to add these descriptions to the API docs as well, but that seems to be a larger effort as the API docs have _no_ descriptions right now 😕 I'm also not sure where codegen tries to pull the descriptions from, as there are GoDoc descriptions, but perhaps not in the right places?