### PR TITLE
fix: deprecated Link(Help-Contact) Issue

### DIFF
--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -25,9 +25,8 @@ export const Help = () => {
                     <div className='help-box'>
                         <div className='help-box__ico help-box__ico--email' />
                         <h3>Contact</h3>
-                        <a className='help-box__link' target='_blank' href='https://argoproj.slack.com'>
-                            Slack
-                        </a>
+                        <a className='help-box__link' target='_blank' href='https://argoproj.github.io/community/join-slack/'>
+                            Slack</a>
                     </div>
                 </div>
                 <div className='columns large-4 medium-12'>

--- a/ui/src/app/help/components/help.tsx
+++ b/ui/src/app/help/components/help.tsx
@@ -26,7 +26,8 @@ export const Help = () => {
                         <div className='help-box__ico help-box__ico--email' />
                         <h3>Contact</h3>
                         <a className='help-box__link' target='_blank' href='https://argoproj.github.io/community/join-slack/'>
-                            Slack</a>
+                            Slack
+                        </a>
                     </div>
                 </div>
                 <div className='columns large-4 medium-12'>


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes #11615 

### Motivation

I wanted to communicate when I wanted to ask questions or get help while using Argo workflow.

However, I accessed the contact field link on the help page, but was connected to the deleted argo workflow slack workspace. 😭

I think In order to smoothly maintain the Argo workflow ecosystem, a forum for active communication should be provided 💪

### Modifications

I simply modified the Contact link in the help.tsx source code among UI components.
Link (https://argoproj.slack.com/   ->  https://argoproj.github.io/community/join-slack/ (Changed))

![image](https://github.com/argoproj/argo-workflows/assets/96514378/585780e8-0d63-4dcb-a5bd-2bdfb6cbd565)

<img width="1440" alt="image" src="https://github.com/argoproj/argo-workflows/assets/96514378/98f05c69-9e76-4f40-bd2d-61b320ddbdcb">


### Verification

<!-- TODO: Say how you tested your changes. -->
