### PR TITLE
feat(ui): retry workflows with parameter (#10824)

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -2,7 +2,7 @@ import {EMPTY, from, Observable, of} from 'rxjs';
 import {catchError, filter, map, mergeMap, switchMap} from 'rxjs/operators';
 import * as models from '../../../models';
 import {Event, LogEntry, NodeStatus, Workflow, WorkflowList, WorkflowPhase} from '../../../models';
-import {ResubmitOpts} from '../../../models/resubmit-opts';
+import {ResubmitOpts, RetryOpts} from '../../../models';
 import {SubmitOpts} from '../../../models/submit-opts';
 import {uiUrl} from '../base';
 import {Pagination} from '../pagination';
@@ -118,8 +118,18 @@ export const WorkflowsService = {
         return requests.loadEventSource(url).pipe(map(data => data && (JSON.parse(data).result as models.kubernetes.WatchEvent<Workflow>)));
     },
 
-    retry(name: string, namespace: string) {
-        return requests.put(`api/v1/workflows/${namespace}/${name}/retry`).then(res => res.body as Workflow);
+    retry(name: string, namespace: string, opts?: RetryOpts) {
+        return requests
+            .put(`api/v1/workflows/${namespace}/${name}/retry`)
+            .send(opts)
+            .then(res => res.body as Workflow);
+    },
+
+    retryArchived(uid: string, namespace: string, opts?: RetryOpts) {
+        return requests
+            .put(`api/v1/archived-workflows/${uid}/retry`)
+            .send({namespace, ...opts})
+            .then(res => res.body as Workflow);
     },
 
     resubmit(name: string, namespace: string, opts?: ResubmitOpts) {

--- a/ui/src/app/shared/workflow-operations-map.tsx
+++ b/ui/src/app/shared/workflow-operations-map.tsx
@@ -30,7 +30,7 @@ export const WorkflowOperationsMap: WorkflowOperations = {
             const workflowPhase: NodePhase = wf && wf.status ? wf.status.phase : undefined;
             return workflowPhase === undefined || !(workflowPhase === 'Failed' || workflowPhase === 'Error');
         },
-        action: (wf: Workflow) => services.workflows.retry(wf.metadata.name, wf.metadata.namespace)
+        action: (wf: Workflow) => services.workflows.retry(wf.metadata.name, wf.metadata.namespace, null)
     },
     RESUBMIT: {
         title: 'RESUBMIT',

--- a/ui/src/app/workflows/components/retry-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/retry-workflow-panel.tsx
@@ -1,0 +1,128 @@
+import {Checkbox} from 'argo-ui';
+import * as React from 'react';
+import {Parameter, RetryOpts, Workflow} from '../../../models';
+import {uiUrl} from '../../shared/base';
+import {ErrorNotice} from '../../shared/components/error-notice';
+import {ParametersInput} from '../../shared/components/parameters-input/parameters-input';
+import {services} from '../../shared/services';
+import {Utils} from '../../shared/utils';
+
+interface Props {
+    workflow: Workflow;
+    isArchived: boolean;
+}
+
+interface State {
+    overrideParameters: boolean;
+    restartSuccessful: boolean;
+    workflowParameters: Parameter[];
+    nodeFieldSelector: string;
+    error?: Error;
+    isSubmitting: boolean;
+}
+
+export class RetryWorkflowPanel extends React.Component<Props, State> {
+    constructor(props: any) {
+        super(props);
+        const state: State = {
+            workflowParameters: JSON.parse(JSON.stringify(this.props.workflow.spec.arguments.parameters || [])),
+            isSubmitting: false,
+            overrideParameters: false,
+            nodeFieldSelector: '',
+            restartSuccessful: false
+        };
+        this.state = state;
+    }
+
+    public render() {
+        return (
+            <>
+                <h4>Retry Workflow</h4>
+                <h5>
+                    {this.props.workflow.metadata.namespace}/{this.props.workflow.metadata.name}
+                </h5>
+
+                <div key='warning-override-parameter-when-retrying'>
+                    <i className='fa fa-exclamation-triangle' style={{color: '#f4c030'}} />
+                    <a href='https://github.com/argoproj/argo-workflows/issues/11631'>When using WorkflowTemplate, parameter overrides are not supported</a>.
+                </div>
+
+                {this.state.error && <ErrorNotice error={this.state.error} />}
+                <div className='white-box'>
+                    <div key='override-parameters' style={{marginBottom: 25}}>
+                        <label>Override Parameters</label>
+                        <div className='columns small-9'>
+                            <Checkbox checked={this.state.overrideParameters} onChange={overrideParameters => this.setState({overrideParameters})} />
+                        </div>
+                    </div>
+
+                    {this.state.overrideParameters && (
+                        <div key='parameters' style={{marginBottom: 25}}>
+                            <label>Parameters</label>
+                            {this.state.workflowParameters.length > 0 && (
+                                <ParametersInput parameters={this.state.workflowParameters} onChange={workflowParameters => this.setState({workflowParameters})} />
+                            )}
+                            {this.state.workflowParameters.length === 0 ? (
+                                <>
+                                    <br />
+                                    <label>No parameters</label>
+                                </>
+                            ) : (
+                                <></>
+                            )}
+                        </div>
+                    )}
+
+                    <div key='restart-successful' style={{marginBottom: 25}}>
+                        <label>Restart Successful</label>
+                        <div className='columns small-9'>
+                            <Checkbox checked={this.state.restartSuccessful} onChange={restartSuccessful => this.setState({restartSuccessful})} />
+                        </div>
+                    </div>
+
+                    {this.state.restartSuccessful && (
+                        <div key='node-field-selector' style={{marginBottom: 25}}>
+                            <label>
+                                Node Field Selector to restart nodes. <a href='https://argoproj.github.io/argo-workflows/node-field-selector/'>See document</a>.
+                            </label>
+
+                            <div className='columns small-9'>
+                                <textarea className='argo-field' value={this.state.nodeFieldSelector} onChange={e => this.setState({nodeFieldSelector: e.target.value})} />
+                            </div>
+                        </div>
+                    )}
+
+                    <div key='retry'>
+                        <button onClick={() => this.submit()} className='argo-button argo-button--base' disabled={this.state.isSubmitting}>
+                            <i className='fa fa-plus' /> {this.state.isSubmitting ? 'Loading...' : 'Retry'}
+                        </button>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
+    private submit() {
+        this.setState({isSubmitting: true});
+        const parameters: RetryOpts['parameters'] = this.state.overrideParameters
+            ? [...this.state.workflowParameters.filter(p => Utils.getValueFromParameter(p) !== undefined).map(p => p.name + '=' + Utils.getValueFromParameter(p))]
+            : [];
+        const opts: RetryOpts = {
+            parameters,
+            restartSuccessful: this.state.restartSuccessful,
+            nodeFieldSelector: this.state.nodeFieldSelector
+        };
+
+        if (!this.props.isArchived) {
+            services.workflows
+                .retry(this.props.workflow.metadata.name, this.props.workflow.metadata.namespace, opts)
+                .then((submitted: Workflow) => (document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`)))
+                .catch(error => this.setState({error, isSubmitting: false}));
+        } else {
+            services.workflows
+                .retryArchived(this.props.workflow.metadata.uid, this.props.workflow.metadata.namespace, opts)
+                .then((submitted: Workflow) => (document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`)))
+                .catch(error => this.setState({error, isSubmitting: false}));
+        }
+    }
+}

--- a/ui/src/app/workflows/components/retry-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/retry-workflow-panel.tsx
@@ -42,11 +42,6 @@ export class RetryWorkflowPanel extends React.Component<Props, State> {
                     {this.props.workflow.metadata.namespace}/{this.props.workflow.metadata.name}
                 </h5>
 
-                <div key='warning-override-parameter-when-retrying'>
-                    <i className='fa fa-exclamation-triangle' style={{color: '#f4c030'}} />
-                    <a href='https://github.com/argoproj/argo-workflows/issues/11631'>When using WorkflowTemplate, parameter overrides are not supported</a>.
-                </div>
-
                 {this.state.error && <ErrorNotice error={this.state.error} />}
                 <div className='white-box'>
                     <div key='override-parameters' style={{marginBottom: 25}}>

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -27,6 +27,7 @@ import {WorkflowOperations} from '../../../shared/workflow-operations-map';
 import {WidgetGallery} from '../../../widgets/widget-gallery';
 import {EventsPanel} from '../events-panel';
 import {ResubmitWorkflowPanel} from '../resubmit-workflow-panel';
+import {RetryWorkflowPanel} from '../retry-workflow-panel';
 import {WorkflowArtifacts} from '../workflow-artifacts';
 import {WorkflowLogsViewer} from '../workflow-logs-viewer/workflow-logs-viewer';
 import {WorkflowNodeInfo} from '../workflow-node-info/workflow-node-info';
@@ -204,6 +205,8 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
                                 });
                         } else if (workflowOperation.title === 'RESUBMIT') {
                             setSidePanel('resubmit');
+                        } else if (workflowOperation.title === 'RETRY') {
+                            setSidePanel('retry');
                         } else {
                             popup.confirm('Confirm', `Are you sure you want to ${workflowOperation.title.toLowerCase()} this workflow?`).then(yes => {
                                 if (yes) {
@@ -567,7 +570,7 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
                     ))}
             </div>
             {workflow && (
-                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isMiddle={parsedSidePanel.type === 'resubmit'}>
+                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isMiddle={['resubmit', 'retry'].includes(parsedSidePanel.type)}>
                     {parsedSidePanel.type === 'logs' && (
                         <WorkflowLogsViewer
                             workflow={workflow}
@@ -581,6 +584,7 @@ export const WorkflowDetails = ({history, location, match}: RouteComponentProps<
                     {parsedSidePanel.type === 'share' && <WidgetGallery namespace={namespace} name={name} />}
                     {parsedSidePanel.type === 'yaml' && <WorkflowYamlViewer workflow={workflow} selectedNode={selectedNode} />}
                     {parsedSidePanel.type === 'resubmit' && <ResubmitWorkflowPanel workflow={workflow} isArchived={isArchivedWorkflow(workflow)} />}
+                    {parsedSidePanel.type === 'retry' && <RetryWorkflowPanel workflow={workflow} isArchived={isArchivedWorkflow(workflow)} />}
                     {!parsedSidePanel}
                 </SlidingPanel>
             )}

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -5,7 +5,7 @@ export * from './workflows';
 export * from './workflow-templates';
 export * from './cron-workflows';
 export * from './cluster-workflow-templates';
-export * from './resubmit-opts';
+export * from './submit-opts';
 export {EventSource} from './event-source';
 export {Sensor, SensorList} from './sensor';
 export {models as kubernetes} from 'argo-ui';

--- a/ui/src/models/resubmit-opts.ts
+++ b/ui/src/models/resubmit-opts.ts
@@ -1,4 +1,0 @@
-export interface ResubmitOpts {
-    parameters?: string[];
-    memoized?: boolean;
-}

--- a/ui/src/models/submit-opts.ts
+++ b/ui/src/models/submit-opts.ts
@@ -3,3 +3,14 @@ export interface SubmitOpts {
     parameters?: string[];
     labels?: string;
 }
+
+export interface ResubmitOpts {
+    parameters?: string[];
+    memoized?: boolean;
+}
+
+export interface RetryOpts {
+    parameters?: string[];
+    restartSuccessful?: boolean;
+    nodeFieldSelector?: string;
+}


### PR DESCRIPTION
Signed-off-by: toyamagu-2021 <toyamagu2021@gmail.com>

<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Closes #10824

### Motivation

- Resubmit workflow with parameter in UI

### Modifications

- Pop up retry panel when we click retry buttom.

### Verification

```yaml
spec:
  templates:
    - name: workflow
      inputs:
        parameters:
          - name: flag
            value: '{{workflow.parameters.flag}}'
      outputs: {}
      metadata: {}
      steps:
        - - name: success
            template: whalesay
            arguments: {}
          - name: fail
            template: intentional-fail
            arguments:
              parameters:
                - name: flag
                  value: '{{inputs.parameters.flag}}'
    - name: whalesay
      inputs: {}
      outputs: {}
      metadata: {}
      container:
        name: ''
        image: docker/whalesay:latest
        command:
          - sh
          - '-c'
        args:
          - cowsay worl
        resources: {}
    - name: intentional-fail
      inputs:
        parameters:
          - name: flag
      outputs: {}
      metadata: {}
      container:
        name: ''
        image: alpine:latest
        command:
          - sh
          - '-c'
        args:
          - exit {{inputs.parameters.flag}}
        resources: {}
  entrypoint: workflow
  arguments:
    parameters:
      - name: flag
        value: '1'
```

![image](https://github.com/argoproj/argo-workflows/assets/83329336/ebdd5c6b-d2da-4087-ac96-29b27e071837)


### Not archived

1. Don't retry the success node

<details>
<summary>Images</summary>

* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/74050116-fc3c-4b8c-a77c-db3d2d237f99)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/b1e9a914-f485-4cc3-9787-c987c7136232)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/14990818-e63b-429f-b06d-d48ba21ac9a9)
 
</details>  

2. Do retry the success node

<details>
<summary>Images</summary>

   * ![image](https://github.com/argoproj/argo-workflows/assets/83329336/d692eb6b-552e-43c8-b181-b2968b1e214e)
   * ![image](https://github.com/argoproj/argo-workflows/assets/83329336/7238498c-d9c2-49f7-ae1e-d04fa3cf1436)
   * ![image](https://github.com/argoproj/argo-workflows/assets/83329336/1b02514e-967c-4665-abf2-e2187cb5adf4)

</details> 


### Archived

1. Don't retry the success node

<details>
<summary>Images</summary>

* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/097bdea2-0e71-48a2-b8df-a0406b7d756b)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/9badf4ce-4976-447d-bcd5-08a3bae69d4a)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/a89ee268-c56b-41cf-883a-2ac461e80fcb)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/68f99020-aa93-41ae-84c1-8d6134947f64)

</details>

2. Do retry the success node

<details>
<summary>Images</summary>

* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/2274b7a5-7165-405f-86f5-b86b09f4b959)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/e4aa70c1-083b-45c5-8ff6-56fea514e37d)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/5dd3d886-e128-4da2-870d-59eda924bfce)
* ![image](https://github.com/argoproj/argo-workflows/assets/83329336/609ff25d-0b77-431a-9c76-bfe8ccf374af)

</details>