### PR TITLE
fix: override storedWorkflowSpec when override parameter (#11631)

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -313,6 +313,9 @@ func overrideParameters(wf *wfv1.Workflow, parameters []string) error {
 			newParams = append(newParams, param)
 		}
 		wf.Spec.Arguments.Parameters = newParams
+		if wf.Status.StoredWorkflowSpec != nil {
+			wf.Status.StoredWorkflowSpec.Arguments.Parameters = newParams
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: toyamagu-2021 <toyamagu2021@gmail.com>

<!-- Does this PR fix an issue -->

Fixes #11631

### Motivation

- Override parameter when retrying workflow submitted from WorkflowTemplate

### Modifications

- Override `.Status.StoredWorkflowSpec.Arguments.Parameters` when overriding parameter.

### Verification

Retry workflow submitted from WorkflowTemplate with parameter

```yaml
spec:
  templates:
    - name: argosay
      inputs:
        parameters:
          - name: code
            value: '{{workflow.parameters.code}}'
      outputs: {}
      metadata: {}
      container:
        name: main
        image: argoproj/argosay:v2
        command:
          - sh
          - '-c'
        args:
          - exit '{{workflow.parameters.code}}'
        resources: {}
  entrypoint: argosay
  arguments:
    parameters:
      - name: code
```


```console
(⎈|k3d-k3s-default:argo)➜  argo-workflows git:(fix-11631) ./dist/argo retry exit-9xj9g --parameter code=0
INFO[2023-08-20T16:17:11.967Z] Deleting pod                                  podDeleted=exit-9xj9g
INFO[2023-08-20T16:17:11.972Z] Workflow to be dehydrated                     Workflow Size=1485
Name:                exit-9xj9g
Namespace:           argo
ServiceAccount:      unset
Status:              Running
Conditions:          
 PodRunning          False
 Completed           False
Created:             Sun Aug 20 16:16:29 +0900 (42 seconds ago)
Started:             Sun Aug 20 16:17:11 +0900 (now)
Duration:            0 seconds
EstimatedDuration:   6 seconds
Progress:            0/1
ResourcesDuration:   3s*(1 cpu),2s*(100Mi memory)
Parameters:          
  code:              0
```