### PR TITLE
build: Fix nix build

### DIFF
--- a/dev/nix/flake.nix
+++ b/dev/nix/flake.nix
@@ -13,7 +13,7 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       imports = [ inputs.treefmt-nix.flakeModule ];
-      perSystem = { pkgs, lib, config, ... }:
+      perSystem = { pkgs, lib, config, system, ... }:
         let
           argoConfig = import ./conf.nix;
           myyarn = pkgs.yarn.override { nodejs = pkgs.nodejs-16_x-openssl_1_1; };
@@ -175,12 +175,22 @@
           uiCmd = mkExec "yarn" argoConfig.ui.env argoConfig.ui.args;
         in
         {
+          _module.args = import inputs.nixpkgs {
+            inherit system;
+            overlays = [
+              (self: super: {
+                go = super.go_1_20;
+                buildGoModule = super.buildGo120Module;
+              })
+            ];
+          };
+
           packages = {
             ${package.name} = pkgs.buildGoModule {
               pname = package.name;
               inherit (package) version;
               inherit src;
-              vendorSha256 = "sha256-OKUiHkVZ/rfjPFs7Md5WDa5K1SNJQvLMxlYClUe7Umk=";
+              vendorSha256 = "sha256-KRg9ibAxKm3t+8skxlMjomWUry335BZ576db2nANpj8=";
               doCheck = false;
             };
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

Current `./dev/nix/flake.nix` is using go 1.19 for `pkgs.buildGoModule`, and the build fails.

Previously it worked well anyway, but after [this change](https://github.com/argoproj/argo-workflows/pull/11368/files#diff-b655785d3d88b4f926fa9bb629e20bee6b91d8f361832ba7942dfe266d0834beR21), the added `cmd.WaitDelay` makes the build completely fail on versions below go 1.20.

```sh
$ nix develop --extra-experimental-features nix-command --extra-experimental-features flakes ./dev/nix/ --impure
...
# github.com/argoproj/argo-workflows/v3/workflow/executor/os-specific
workflow/executor/os-specific/command.go:21:7: cmd.WaitDelay undefined (type *exec.Cmd has no field or method WaitDelay)
note: module requires Go 1.20
...

```

### Modifications

- Update `_module.args`, and add overlays for `go`, `buildGoModule` to use go 1.20.
- Update controller's `vendorSha256` hash

### Verification

```sh
$ nix develop --extra-experimental-features nix-command --extra-experimental-features flakes ./dev/nix/ --impure
(devenv) bash-5.1$
```