### PR TITLE
fix: base href does not work #11401 #10194 #2134

### DIFF
--- a/server/static/static.go
+++ b/server/static/static.go
@@ -11,15 +11,22 @@ type FilesServer struct {
 	hsts            bool
 	xframeOpts      string
 	corsAllowOrigin string
+	Hash            func(string) string
 }
 
 func NewFilesServer(baseHRef string, hsts bool, xframeOpts string, corsAllowOrigin string) *FilesServer {
-	return &FilesServer{baseHRef, hsts, xframeOpts, corsAllowOrigin}
+	return &FilesServer{baseHRef, hsts, xframeOpts, corsAllowOrigin, Hash}
 }
 
 func (s *FilesServer) ServerFiles(w http.ResponseWriter, r *http.Request) {
+	if s.baseHRef != "/" {
+		p := strings.TrimPrefix(r.URL.Path, s.baseHRef)
+		if len(p) < len(r.URL.Path) {
+			r.URL.Path = p
+		}
+	}
 	// If there is no stored static file, we'll redirect to the js app
-	if Hash(strings.TrimLeft(r.URL.Path, "/")) == "" {
+	if s.Hash(strings.TrimLeft(r.URL.Path, "/")) == "" {
 		r.URL.Path = "index.html"
 	}
 

--- a/server/static/static_test.go
+++ b/server/static/static_test.go
@@ -1,0 +1,28 @@
+package static
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServeFile(t *testing.T) {
+	t.Run("should handle base href for static file", func(t *testing.T) {
+		filesServer := NewFilesServer("/argotest/", false, "", "")
+		filesServer.Hash = func(s string) string {
+			resources := map[string]string{
+				"main.js": "main.js",
+			}
+			return resources[s]
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/argotest/main.js", nil)
+		w := httptest.NewRecorder()
+
+		filesServer.ServerFiles(w, req)
+
+		if req.URL.Path != "main.js" {
+			t.Errorf("should handle base href, expect %v, got %v", "main.js", req.URL.Path)
+		}
+	})
+}


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fix #11401 
Fix #10194 
Fix #11643
Fix #7767
Related #2134


### Motivation

Support BASE_HREF on the document https://argoproj.github.io/argo-workflows/argo-server/
<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
Add handle base href for static file and test

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
make test

<!-- TODO: Say how you tested your changes. -->

### More
As I check this issue, I see the lib to embed static files into Go binary has been deprecated (https://github.com/bouk/staticfiles). We should replace it.
