### PR TITLE
docs: Add more links in contributor workshop

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,4 +66,8 @@ See [the pull request template](https://github.com/argoproj/argo-workflows/blob/
 
 ### Contributor Workshop
 
-We have a [90m video on YouTube](https://youtu.be/zZv0lNCDG9w) show you have to get hands-on contributing.
+Please check out the following resources if you are interested in contributing:
+
+* [90m hands-on contributor workshop](https://youtu.be/zZv0lNCDG9w).
+* [Deep-dive into components and hands-on experiments](https://docs.google.com/presentation/d/1IU0a3unnr3tBRi38Zn3EHQZj3z6yvocfG9x9icRu1LE/edit?usp=sharing).
+* [Architecture overview](https://github.com/argoproj/argo-workflows/blob/master/docs/architecture.md).


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/11167.