### PR TITLE
build(ui): fix `monaco-editor` font path

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -82,7 +82,7 @@ const config = {
         from: "../api/jsonschema/schema.json",
         to: "assets/jsonschema/schema.json"
       }, {
-        from: "node_modules/monaco-editor/min/vs/base/browser/ui/codiconLabel/codicon/codicon.ttf",
+        from: "node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/",
         to: "."
       }],
     }),


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- the path appears to have changed in newer versions of Monaco
  - but builds seem to have still passed in #11593
  - it then failed after #11628 was merged on top -- likely because the updated `CopyWebpackPlugin` now actually errors out on a missing file
    - #11628 itself passes but was built before #11593 was merged. The `master` branch build after merge [failed](https://github.com/argoproj/argo-workflows/actions/runs/5945948489/job/16125802136)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Update to the new path to `monaco-editor`'s font in the Webpack config
  - this `from` path is now equivalent to [Argo CD's config](https://github.com/argoproj/argo-cd/blob/24c080b5cbea6e3af547868e540caf553920dc73/ui/src/app/webpack.config.js#L89C28-L89C94)

### Verification

<!-- TODO: Say how you tested your changes. -->

- from `argo-workflows/ui/`
  - ```sh 
    ❯ ls node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf
    node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf
    ```
  - also there is no `codiconLabel` directory anymore
- build now passes
