### PR TITLE
fix(server): Surface underlying error when getting a workflow

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -640,14 +640,15 @@ func (s *workflowServer) getWorkflow(ctx context.Context, wfClient versioned.Int
 		log.Debugf("Resolved alias %s to workflow %s.\n", latestAlias, latest.Name)
 		return latest, nil
 	}
-	wf, err := wfClient.ArgoprojV1alpha1().Workflows(namespace).Get(ctx, name, options)
-	if wf == nil || err != nil {
+	var err error
+	wf, origErr := wfClient.ArgoprojV1alpha1().Workflows(namespace).Get(ctx, name, options)
+	if wf == nil || origErr != nil {
 		wf, err = s.wfArchiveServer.GetArchivedWorkflow(ctx, &workflowarchivepkg.GetArchivedWorkflowRequest{
 			Namespace: namespace,
 			Name:      name,
 		})
 		if err != nil {
-			return nil, sutils.ToStatusError(err, codes.Internal)
+			return nil, sutils.ToStatusError(fmt.Errorf("%v %v", origErr, err), codes.Internal)
 		}
 	}
 	return wf, nil

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -648,7 +648,7 @@ func (s *workflowServer) getWorkflow(ctx context.Context, wfClient versioned.Int
 			Name:      name,
 		})
 		if err != nil {
-			return nil, sutils.ToStatusError(fmt.Errorf("%v %v", origErr, err), codes.Internal)
+			return nil, sutils.ToStatusError(fmt.Errorf("%v %v", origErr, err), codes.NotFound)
 		}
 	}
 	return wf, nil

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -648,7 +648,7 @@ func (s *workflowServer) getWorkflow(ctx context.Context, wfClient versioned.Int
 			Name:      name,
 		})
 		if err != nil {
-			return nil, sutils.ToStatusError(fmt.Errorf("%v %v", origErr, err), codes.NotFound)
+			return nil, sutils.ToStatusError(fmt.Errorf("%v %v", origErr, err), codes.Internal)
 		}
 	}
 	return wf, nil

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -648,7 +648,9 @@ func (s *workflowServer) getWorkflow(ctx context.Context, wfClient versioned.Int
 			Name:      name,
 		})
 		if err != nil {
-			return nil, sutils.ToStatusError(fmt.Errorf("%v %v", origErr, err), codes.Internal)
+			log.Errorf("failed to get live workflow: %v; failed to get archived workflow: %v", origErr, err)
+			// We only return the original error to preserve the original status code.
+			return nil, sutils.ToStatusError(origErr, codes.Internal)
 		}
 	}
 	return wf, nil

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -606,8 +606,8 @@ func (s *CLISuite) TestWorkflowDeleteNotFound() {
 	s.Given().
 		When().
 		RunCli([]string{"delete", "not-found"}, func(t *testing.T, output string, err error) {
-			if assert.EqualError(t, err, "exit status 1") {
-				assert.Contains(t, output, `workflows.argoproj.io \"not-found\" not found`)
+			if assert.NoError(t, err) {
+				assert.Contains(t, output, "Workflow 'not-found' not found")
 			}
 		})
 }

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -606,8 +606,8 @@ func (s *CLISuite) TestWorkflowDeleteNotFound() {
 	s.Given().
 		When().
 		RunCli([]string{"delete", "not-found"}, func(t *testing.T, output string, err error) {
-			if assert.NoError(t, err) {
-				assert.Contains(t, output, "Workflow 'not-found' not found")
+			if assert.EqualError(t, err, "exit status 1") {
+				assert.Contains(t, output, `workflows.argoproj.io \"not-found\" not found`)
 			}
 		})
 }


### PR DESCRIPTION
This surfaces the underlying error. See https://github.com/argoproj/argo-workflows/issues/11661#issuecomment-1693722430

The new error message is: `workflows.argoproj.io "hello-world-2gs6g" not found rpc error: code = Internal desc = getting archived workflows not supported`