### PR TITLE
fix: Print valid JSON/YAML when workflow list empty #10873

### DIFF
--- a/util/printer/workflow-printer.go
+++ b/util/printer/workflow-printer.go
@@ -17,7 +17,11 @@ import (
 
 func PrintWorkflows(workflows wfv1.Workflows, out io.Writer, opts PrintOpts) error {
 	if len(workflows) == 0 {
-		_, _ = fmt.Fprintln(out, "No workflows found")
+		if opts.Output == "json" || opts.Output == "yaml" {
+			_, _ = fmt.Fprintln(out, "[]")
+		} else {
+			_, _ = fmt.Fprintln(out, "No workflows found")
+		}
 		return nil
 	}
 

--- a/util/printer/workflow-printer_test.go
+++ b/util/printer/workflow-printer_test.go
@@ -52,6 +52,18 @@ func TestPrintWorkflows(t *testing.T) {
 		assert.Equal(t, `No workflows found
 `, b.String())
 	})
+	t.Run("EmptyJSON", func(t *testing.T) {
+		var b bytes.Buffer
+		assert.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{Output: "json"}))
+		assert.Equal(t, `[]
+`, b.String())
+	})
+	t.Run("EmptyYAML", func(t *testing.T) {
+		var b bytes.Buffer
+		assert.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{Output: "yaml"}))
+		assert.Equal(t, `[]
+`, b.String())
+	})
 	t.Run("Default", func(t *testing.T) {
 		var b bytes.Buffer
 		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{}))


### PR DESCRIPTION
Fixes #10873.

### Motivation

Tools with `-o json` are expected to output to valid JSON. Same for YAML.

### Modifications

I kept the change minimal. Since `PrintWorkflows` fails fast at `len(workflows) == 0`, I stuck with that.

### Verification

```
$ make dist/argo-linux-amd64
<...>
$ dist/argo-linux-amd64 -v list -o json
DEBU[2023-08-25T23:26:48.261Z] CLI version                                   version="{latest+9cc740c.dirty 2023-08-26T05:59:15Z 9cc740cc49a9ff91a955bd1356dbacb8dcf4fe50 untagged dirty go1.20.4 gc linux/amd64}"
DEBU[2023-08-25T23:26:48.261Z] Client options                                opts="(argoServerOpts=(url=,path=,secure=true,insecureSkipVerify=false,http=false),instanceID=)"
I0825 23:26:48.263036 1745777 loader.go:372] Config loaded from file:  /home/ag/.kube/config
I0825 23:26:48.264209 1745777 loader.go:372] Config loaded from file:  /home/ag/.kube/config
DEBU[2023-08-25T23:26:48.264Z]                                               listOpts="&ListOptions{LabelSelector:,FieldSelector:,Watch:false,ResourceVersion:,TimeoutSeconds:nil,Limit:0,Continue:,AllowWatchBookmarks:false,ResourceVersionMatch:,}"
I0825 23:26:48.270409 1745777 round_trippers.go:553] GET https://<KUBE_API>:6443/apis/argoproj.io/v1alpha1/namespaces/default/workflows?labelSelector=%21workflows.argoproj.io%2Fcontroller-instanceid 200 OK in 5 milliseconds
DEBU[2023-08-25T23:26:48.273Z] CanI                                          name= namespace=default resource=workflows verb=list
I0825 23:26:48.275370 1745777 round_trippers.go:553] POST https://<KUBE_API>:6443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews 201 Created in 1 milliseconds
DEBU[2023-08-25T23:26:48.275Z] CanI                                          name= namespace=default resource=workflows status="{true false  }" verb=list
[]
```
