### PR TITLE
fix: cron workflow initial filter value. Fixes #11685

### DIFF
--- a/ui/src/app/cron-workflows/components/cron-workflow-spec-editior.tsx
+++ b/ui/src/app/cron-workflows/components/cron-workflow-spec-editior.tsx
@@ -24,8 +24,9 @@ export const CronWorkflowSpecEditor = ({onChange, spec}: {spec: CronWorkflowSpec
                 </div>
                 <div className='row white-box__details-row'>
                     <div className='columns small-3'>Concurrency Policy</div>
-                    <div className='columns small-9'>
+                    <div className='columns small-9' style={{lineHeight: '30px'}}>
                         <Select
+                            placeholder='Select concurrency policy'
                             options={['Allow', 'Forbid', 'Replace']}
                             value={spec.concurrencyPolicy}
                             onChange={x =>

--- a/ui/src/app/shared/components/checkbox-filter/checkbox-filter.tsx
+++ b/ui/src/app/shared/components/checkbox-filter/checkbox-filter.tsx
@@ -13,6 +13,7 @@ interface Props {
 export class CheckboxFilter extends React.Component<Props> {
     constructor(props: any) {
         super(props);
+        this.props.items.forEach(item => this.props.selected.push(item.name));
     }
 
     public render() {


### PR DESCRIPTION
Fixes #11685

### Modifications

Encountering some issues while using the Cron workflow feature.

### Modifications

1. When I enter the cron workflow, the lists are displayed, but all the filters are removed and set to default values. This can confuse users compared to having all the phases filters selected from the beginning. Therefore, the state of the cron workflow should start with all selections made.<img width="979" alt="스크린샷 2023-08-27 오전 2 14 12" src="https://github.com/argoproj/argo-workflows/assets/28799597/70122138-5bf9-484e-8a31-4e5860dce01f">

2. The second issue is related to modifying the cron in the cron workflow. The style of the Concurrency Policy is broken. The position and height of the Select box and Select arrow need to be adjusted.<img width="1177" alt="스크린샷 2023-08-27 오전 2 06 07" src="https://github.com/argoproj/argo-workflows/assets/28799597/5c576f25-00b3-4651-b75c-b4ec8788849a">


