### PR TITLE
fix: Make defaultWorkflow hooks work more than once

### DIFF
--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -17,8 +17,10 @@ func MergeTo(patch, target *wfv1.Workflow) error {
 	}
 
 	patchHooks := patch.Spec.Hooks
+	// Temporarily remove hooks as they don't merge
 	patch.Spec.Hooks = nil
 	patchWfBytes, err := json.Marshal(patch)
+	patch.Spec.Hooks = patchHooks
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As workflowDefaults are passed by pointer we're modifying them directly here before modifying them such that StrategicMerge can work.

Undo the modification we make directly so that the next time we patch it's still there.

Fixes a bug introduced in the fix in #11214 

### Verification

Run with workflowDefaults having hooks more than once.
