### PR TITLE
fix: offset reset when pagination limit onchange

### DIFF
--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -40,8 +40,9 @@ export class PaginationPanel extends React.Component<{pagination: Pagination; on
                             // Only return the offset if we're actually going to be limiting
                             // the results we're requesting.  If we're requesting all records,
                             // we should not skip any by setting an offset.
+                            // The offset must be initialized whenever the pagination limit is changed.
                             if (limit) {
-                                newValue.offset = this.props.pagination.offset;
+                                newValue.offset = '';
                             }
 
                             this.props.onChange(newValue);


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11702

### Motivation

<!-- TODO: Say why you made your changes. -->
Upon investigating the cause, it was found that when changing the pagination limit in the onChange function, the offset used as the pagination reference was not reset. Instead, the offset value received from the server was directly used.

As a solution, I have modified the onChange function to reset the offset during each change. This change ensures that when the pagination limit is modified, the search restarts from the beginning with the updated limit.

### Modifications

<!-- TODO: Say what changes you made. -->
I just set offset '' in page limit onChange function.

![image](https://github.com/argoproj/argo-workflows/assets/29159013/3b71ac4f-09e2-4f81-aed1-92e5801e1693)


<!-- TODO: Attach screenshots if you changed the UI. -->
1. Set the limit to 5 on the workflows page or workflow templates page from the frontend. and Click "Next Page."
![image](https://github.com/argoproj/argo-workflows/assets/29159013/349790e2-8100-4929-b4e4-1fb822e8c0ea)

2. While on the next page, change the limit to 10. they  appear.
![image](https://github.com/argoproj/argo-workflows/assets/29159013/61940361-3f44-48f9-b6fd-c32151e6d71e)
![image](https://github.com/argoproj/argo-workflows/assets/29159013/3c662bc2-41f7-4246-a9ee-baa85ed8fbfd)



### Verification

<!-- TODO: Say how you tested your changes. -->
