### PR TITLE
docs: update style guidelines for documentation contributions

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -45,6 +45,7 @@ Dataflow
 DeleteObject
 DevOps
 Dex
+EditorConfig
 EtcD
 EventRouter
 FailFast
@@ -104,6 +105,7 @@ s3
 SDKs
 ServiceAccount
 Sharding
+shortcodes
 Singer.io
 Snyk
 Sumit

--- a/docs/doc-changes.md
+++ b/docs/doc-changes.md
@@ -2,14 +2,16 @@
 
 Docs help our customers understand how to use workflows and fix their own problems.
 
-Doc changes are checked for spelling, broken links, and lint issues by CI. To check locally run `make docs`.
+Doc changes are checked for spelling, broken links, and lint issues by CI. To check locally, run `make docs`.
+
+General guidelines:
 
 * Explain when you would want to use a feature.
 * Provide working examples.
-* Use simple short sentences and avoid jargon.
-* Format code using back-ticks to avoid it being reported spelling error.
-* Avoid use title-case mid-sentence. E.g. instead of "the Workflow", write "the workflow".
-* Headings should be title-case. E.g. instead of "and", write "And".
+* Format code using back-ticks to avoid it being reported as a spelling error.
+* Follow the recommendations in the official [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/).
+    * Particularly useful sections include [Content best practices](https://kubernetes.io/docs/contribute/style/style-guide/#content-best-practices) and [Patterns to avoid](https://kubernetes.io/docs/contribute/style/style-guide/#patterns-to-avoid).
+    * **Note**: Argo does not use the same tooling, so the sections on "shortcodes" and "EditorConfig" are not relevant.
 
 ## Running Locally
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Update documentation guidelines to reference the much more detailed upstream k8s guidelines
- Stumbled upon this for the first time in a long while, during recent PR reviews for the Developer tab of the docs

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- refer to the [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/), which is pretty highly quality with good examples
  - and which I use often to guide my technical writing, including in many previous PRs to this repo
  - remove duplicative content that is already mentioned in the k8s style guide, such as "avoid jargon"
  - remove an example that contradicts the k8s style guide
    - it actually should be "the Workflow" as it is an API object: https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects

- remove incorrect title-case comment
  - "And" is in fact usually _not_ capitalized by most title-case writing standards
    - [Wikipedia style manual](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Titles_of_works#Capital_letters) specifically excludes "short coordinating conjunctions" and specifically lists "and"
    - same with [AMA style manual](https://titlecaseconverter.com/rules/#AMA)

- fix a missing comma and missing words here as well
  - e.g. "being reported spelling error" -> "being reported as a spelling error"
  - add a title to this bulleted list

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes