### PR TITLE
docs: link to Installation instead of `manifests/README.md`

### DIFF
--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -4,4 +4,4 @@ Argo Workflows public API is defined by the following:
 
 * The file `api/openapi-spec/swagger.json`
 * The schema of the table `argo_archived_workflows`.
-* The installation options listed in `manifests/README.md`.
+* The [installation](installation.md) options.


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- `manifests/README.md` just has a one-line link to the Installation docs
  - instead of redirecting a contributor twice, just redirect once

- also follows existing pattern of the docs using relative links to other pages

Stumbled upon this for the first time recently during PR reviews for the Developer tab of the docs

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Modify `public-api.md` to link to `installation.md` directly
- instead of `manifests/README.md` which [itself then links](https://github.com/argoproj/argo-workflows/blob/f00b6ff631bae954f749f52d2d94c5dbc6a0df53/manifests/README.md?plain=1#L3) to `installation.md`

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes