### PR TITLE
chore: remove ui source map for production build

### DIFF
--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -24,7 +24,7 @@ const config = {
     path: __dirname + "/../../dist/app"
   },
 
-  devtool: "source-map",
+  devtool: isProd ? false : "source-map",
 
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".json", ".ttf"],

--- a/ui/src/app/webpack.config.js
+++ b/ui/src/app/webpack.config.js
@@ -24,7 +24,7 @@ const config = {
     path: __dirname + "/../../dist/app"
   },
 
-  devtool: isProd ? false : "source-map",
+  devtool: isProd ? false : "eval",
 
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".json", ".ttf"],


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->

- Reduce release package size, container size (~20MB)

### Modifications

<!-- TODO: Say what changes you made. -->

- Disable source map for production build

<!-- TODO: Attach screenshots if you changed the UI. -->

### Opinion
- The source map is unnecessary to add to the release package. If we want to have the source map to debug, we can run a dev ui and connect to API
