### PR TITLE
fix: Correct limit in WorkflowTaskResultInformer List API calls. Fixes #11607

### DIFF
--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -31,6 +31,9 @@ func (wfc *WorkflowController) newWorkflowTaskResultInformer() cache.SharedIndex
 		},
 		func(options *metav1.ListOptions) {
 			options.LabelSelector = labelSelector
+			// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
+			// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
+			options.ResourceVersion = ""
 		},
 	)
 	informer.AddEventHandler(


### PR DESCRIPTION
Potentially fixes #11607. This seems like a similar issue that we fixed in https://github.com/argoproj/argo-workflows/pull/11343.