### PR TITLE
chore: reorder `OWNERS` file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,13 +2,13 @@ owners:
 - sarabala1979
 - terrytangyuan
 
-reviewers:
-- isubasinghe
-- tczhao
-
 approvers:
 - alexec
 - alexmt
 - edlee2121
 - jessesuen
 - juliev0
+
+reviewers:
+- isubasinghe
+- tczhao


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- to be in order of most to least privilege
  - previously `reviewers` was in the middle, basically making it unordered

Stumbled upon this when looking at who had approver permissions (or CI retry permissions, to be specific) and was a bit disoriented by the (lack of) ordering. Thought I might as well fix it, especially after seeing that other Argo projects have a consistent order.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- move `reviewers` to the bottom. Order is now `owners` > `approvers` > `reviewers`

- matches [argoproj](https://github.com/argoproj/argoproj/blob/2f51907659dee1c11be2e69b0e36a6e2b7398c72/OWNERS) and [Argo CD](https://github.com/argoproj/argo-cd/blob/ef7f32eb844739d8ae5b5feb987f32fa63024226/OWNERS)


### Verification

<!-- TODO: Say how you tested your changes. -->

n/a. purely stylistic changes, no semantic changes