### PR TITLE
fix: Permit enums w/o values. Fixes #11471.

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -865,10 +865,11 @@ func validateArgumentsValues(prefix string, arguments wfv1.Arguments, allowEmpty
 			if len(param.Enum) == 0 {
 				return errors.Errorf(errors.CodeBadRequest, "%s%s.enum should contain at least one value", prefix, param.Name)
 			}
-			if param.Value == nil && !allowEmptyValues {
+			if param.Value == nil {
+				if allowEmptyValues {
+					return nil
+				}
 				return errors.Errorf(errors.CodeBadRequest, "%s%s.value is required", prefix, param.Name)
-			} else if param.Value == nil {
-				return nil
 			}
 			valueSpecifiedInEnumList := false
 			for _, enum := range param.Enum {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -865,8 +865,10 @@ func validateArgumentsValues(prefix string, arguments wfv1.Arguments, allowEmpty
 			if len(param.Enum) == 0 {
 				return errors.Errorf(errors.CodeBadRequest, "%s%s.enum should contain at least one value", prefix, param.Name)
 			}
-			if param.Value == nil {
+			if param.Value == nil && !allowEmptyValues {
 				return errors.Errorf(errors.CodeBadRequest, "%s%s.value is required", prefix, param.Name)
+			} else if param.Value == nil {
+				return nil
 			}
 			valueSpecifiedInEnumList := false
 			for _, enum := range param.Enum {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -2710,9 +2710,9 @@ func TestWorkflowTemplateWithArgumentValueNotFromEnumList(t *testing.T) {
 
 func TestWorkflowTemplateWithEnumValueWithoutValue(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{})
-	assert.EqualError(t, err, "spec.arguments.message.value is required")
+	assert.Nil(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Lint: true})
-	assert.EqualError(t, err, "spec.arguments.message.value is required")
+	assert.Nil(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Submit: true})
 	assert.EqualError(t, err, "spec.arguments.message.value is required")
 }


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11471 

### Motivation

As described in the above issue, it's currently pretty impossible to use `enum` fields and have `lint` pass. This makes them effectively useless in workflow templates.

### Modifications

Updated the enum checks in the validate code in order to respect `allowEmptyValues`.

### Verification

Updated unit tests and tweaked code until they passed as expected.
