### PR TITLE
Fix/docs lint error for juijeong8324

### DIFF
--- a/docs/artifact-visualization.md
+++ b/docs/artifact-visualization.md
@@ -10,7 +10,7 @@ Use cases:
 * Visualizing end results of ML pipeline runs.
 * Debugging workflows where visual artifacts are the most helpful.
 
-> **Click image to play demo video**      
+> **Click image to play demo video**
 [![Demo](https://img.youtube.com/vi/whoRfYY9Fhk/0.jpg)](https://youtu.be/whoRfYY9Fhk)
 
 * Artifacts appear as elements in the workflow DAG that you can click on.

--- a/docs/artifact-visualization.md
+++ b/docs/artifact-visualization.md
@@ -10,8 +10,8 @@ Use cases:
 * Visualizing end results of ML pipeline runs.
 * Debugging workflows where visual artifacts are the most helpful.
 
-> **Click image to play demo video**
-[![Demo](https://img.youtube.com/vi/whoRfYY9Fhk/0.jpg)](https://youtu.be/whoRfYY9Fhk)
+[![Demo](https://img.youtube.com/vi/whoRfYY9Fhk/0.jpg)](https://youtu.be/whoRfYY9Fhk)<br>
+*[Click image to play demo video]*
 
 * Artifacts appear as elements in the workflow DAG that you can click on.
 * When you click on the artifact, a panel appears.

--- a/docs/artifact-visualization.md
+++ b/docs/artifact-visualization.md
@@ -10,7 +10,7 @@ Use cases:
 * Visualizing end results of ML pipeline runs.
 * Debugging workflows where visual artifacts are the most helpful.
 
-> **Click img to play demo video**      
+> **Click image to play demo video**      
 [![Demo](https://img.youtube.com/vi/whoRfYY9Fhk/0.jpg)](https://youtu.be/whoRfYY9Fhk)
 
 * Artifacts appear as elements in the workflow DAG that you can click on.

--- a/docs/artifact-visualization.md
+++ b/docs/artifact-visualization.md
@@ -10,6 +10,7 @@ Use cases:
 * Visualizing end results of ML pipeline runs.
 * Debugging workflows where visual artifacts are the most helpful.
 
+> **Click img to play demo video**      
 [![Demo](https://img.youtube.com/vi/whoRfYY9Fhk/0.jpg)](https://youtu.be/whoRfYY9Fhk)
 
 * Artifacts appear as elements in the workflow DAG that you can click on.


### PR DESCRIPTION
CI가 실패하는 이유는 이전 스텝인 `make docs`에서 lint 수정이 발생했고, 그에 따라 unstage 상태의 변경사항이 감지된 것이에요.
따라서 문제를 해결하기 위해 공백을 제거하면 CI를 통과할 수 있어요.

하지만, 그 이외에도 추가적인 수정이 필요해 보여서 PR을 더해봐요.
지금 수정대로면 분명 문서가 아래처럼 깨질거에요.
![image](https://github.com/argoproj/argo-workflows/assets/41275199/8f476339-3a53-42c4-903e-61d96b66164c)

그리고 볼드체가 들어가는 것도 별로 좋아 보이지는 않아서 아래와 같이 수정해 봤어요.
![image](https://github.com/argoproj/argo-workflows/assets/41275199/a36727c5-c0c4-4811-b509-56be950be36f)