### PR TITLE
docs: replace duplicate Expression docs with a link

### DIFF
--- a/docs/conditional-artifacts-parameters.md
+++ b/docs/conditional-artifacts-parameters.md
@@ -2,10 +2,8 @@
 
 > v3.1 and after
 
-The Conditional Artifacts and Parameters feature enables to assign the Step/DAG level artifacts or parameters based on
-expression. This introduces a new field `fromExpression: ...` under Step/DAG level output artifact and `expression: ...`
-under step/DAG level output parameter. Both use the
-[expr](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md) syntax.
+The Conditional Artifacts and Parameters feature enables to assign the Step/DAG level artifacts or parameters based on an [expression](variables.md#expression).
+This introduces a new field `fromExpression` under Step/DAG level output artifact and `expression` under step/DAG level output parameter.
 
 ## Conditional Artifacts
 
@@ -53,20 +51,4 @@ under step/DAG level output parameter. Both use the
 
 * [Steps parameter example](https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/conditional-parameters.yaml)
 * [DAG parameter example](https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/dag-conditional-parameters.yaml)
-
-## Built-In Functions
-
-Convenient functions added to support more use cases:
-
-1. `asInt`    - convert the string to integer (e.g: `asInt('1')`)
-2. `asFloat`  - convert the string to Float (e.g: `asFloat('1.23')`)
-3. `string`   - convert the int/float to string (e.g: `string(1)`)
-4. `jsonpath` - Extract the element from JSON using JSON Path (
-   e.g: `jsonpath('{"employee":{"name":"sonoo","salary":56000,"married":true}}", "$.employee.name" )` )
-5. [Sprig](http://masterminds.github.io/sprig/) - Support all `sprig` functions
-
 * [Advanced example: fibonacci Sequence](https://raw.githubusercontent.com/argoproj/argo-workflows/master/examples/fibonacci-seq-conditional-param.yaml)
-
-!!! NOTE
-    Expressions will decode the `-` as operator if template name has `-`, it will fail the expression. So here solution
-    for template name which has `-` in its name. `step['one-two-three'].outputs.artifacts`

--- a/docs/conditional-artifacts-parameters.md
+++ b/docs/conditional-artifacts-parameters.md
@@ -2,8 +2,8 @@
 
 > v3.1 and after
 
-The Conditional Artifacts and Parameters feature enables to assign the Step/DAG level artifacts or parameters based on an [expression](variables.md#expression).
-This introduces a new field `fromExpression` under Step/DAG level output artifact and `expression` under step/DAG level output parameter.
+You can set Step/DAG level artifacts or parameters based on an [expression](variables.md#expression).
+Use `fromExpression` under a Step/DAG level output artifact and `expression` under a Step/DAG level output parameter.
 
 ## Conditional Artifacts
 


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Conditional Artifacts and Parameters docs had a sizeable amount of duplication about `expr` usage
- Stumbled upon this while answering some user questions

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove duplication and instead link to the main Expression docs under Workflow Variables, which lists all of this information already and more

- also rewrite the first paragraph while at it
  - use active voice, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-active-voice)
  - use more direct language, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)


### Verification

<!-- TODO: Say how you tested your changes. -->

n/a