### PR TITLE
ci: bump `lint` timeout to 15 minutes

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -228,7 +228,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: [ tests, codegen ]
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       GOPATH: /home/runner/go
     steps:


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- it's timed out a [few](https://github.com/argoproj/argo-workflows/pull/11710#issuecomment-1698280827) [times](https://github.com/argoproj/argo-workflows/pull/11626#issuecomment-1685131400) on my PRs (as well as [others](https://github.com/argoproj/argo-workflows/pull/9805#issuecomment-1328566629))
  - note that the `golangci-lint` is [set to `12m`](https://github.com/argoproj/argo-workflows/blame/c31132d6e123b95af7db2f7ddc1eaf5872513605/.golangci.yml#L3)
    - `make lint` runs that and more, so it should always be _strictly greater than_ `golanci-lint`'s timeout
    - and CI also runs `checkout` and `setup-go` on top of that as well

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Bump CI Lint timeout from 10 minutes to 15 minutes
- `golangci-lint`'s own timeout was already bumped recently as part of #11586

### Verification

<!-- TODO: Say how you tested your changes. -->

n/a, this is a pure CI change. CI Lint should pass on this PR as verification.