### PR TITLE
ci: better naming for various steps/jobs

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -10,12 +10,12 @@ permissions:
 
 jobs:
   generate_changelog:
+    name: Generate changelog
+    if: github.repository == 'argoproj/argo-workflows'
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
-    if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
-    name: Generate changelog
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   tests:
-    name: Unit Tests
+    name: Go Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -29,11 +29,11 @@ jobs:
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
       # engineers just ignore this in PRs, so lets not even run it
-      - run: bash <(curl -s https://codecov.io/bash)
-        if: github.ref == 'refs/heads/master'
+      - if: github.ref == 'refs/heads/master'
+        run: bash <(curl -s https://codecov.io/bash)
 
   argoexec-image:
-    name: Create argoexec image
+    name: argoexec image
     # needs: [ lint ]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   tests:
-    name: Go Unit Tests
+    name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
 
   argoexec-image:
-    name: argoexec image
+    name: argoexec-image
     # needs: [ lint ]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -33,10 +33,10 @@ jobs:
         if: github.ref == 'refs/heads/master'
 
   argoexec-image:
-    name: argoexec-image
+    name: Create argoexec image
+    # needs: [ lint ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # needs: [ lint ]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -49,7 +49,8 @@ jobs:
           target: argoexec
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - uses: actions/upload-artifact@v3
+      - name: Upload
+        uses: actions/upload-artifact@v3
         with:
           name: argoexec
           path: /tmp/argoexec_image.tar
@@ -57,9 +58,9 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
+    needs: [ argoexec-image ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [ argoexec-image ]
     env:
       KUBECONFIG: /home/runner/.kubeconfig
     strategy:
@@ -96,22 +97,23 @@ jobs:
             install_k3s_version: v1.25.11-k3s1
             profile: minimal
     steps:
-      - name: Install socat
-        # needed by Kubernetes v1.25
+      - name: Install socat (needed by Kubernetes v1.25)
         run: sudo apt-get -y install socat
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: "1.21"
           cache: true
-      - uses: actions/setup-java@v3
+      - name: Install Java for the SDK
         if: ${{matrix.test == 'test-java-sdk'}}
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: adopt
           cache: maven
-      - uses: actions/setup-python@v4
+      - name: Install Python for the SDK
         if: ${{matrix.test == 'test-python-sdk'}}
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
           cache: pip
@@ -129,13 +131,13 @@ jobs:
           echo "  user:" >> $KUBECONFIG
           echo "    token: xxxxxx" >> $KUBECONFIG
           until kubectl cluster-info ; do sleep 10s ; done
-      - uses: actions/download-artifact@v3
-        name: Download argoexec image
+      - name: Download argoexec image
+        uses: actions/download-artifact@v3
         with:
           name: argoexec
           path: /tmp
-      - run: docker load < /tmp/argoexec_image.tar
-        name: Load argoexec image
+      - name: Load argoexec image
+        run: docker load < /tmp/argoexec_image.tar
       - name: Set-up /etc/hosts
         run: |
           echo '127.0.0.1 dex'      | sudo tee -a /etc/hosts
@@ -143,58 +145,61 @@ jobs:
           echo '127.0.0.1 postgres' | sudo tee -a /etc/hosts
           echo '127.0.0.1 mysql'    | sudo tee -a /etc/hosts
           echo '127.0.0.1 azurite'  | sudo tee -a /etc/hosts
-      - run: make install PROFILE=${{matrix.profile}} STATIC_FILES=false
-        name: Install manifests
-      - run: make controller kit STATIC_FILES=false
-        name: Build controller
-      - run: make cli STATIC_FILES=false
+      - name: Install manifests
+        run: make install PROFILE=${{matrix.profile}} STATIC_FILES=false
+      - name: Build controller
+        run: make controller kit STATIC_FILES=false
+      - name: Build CLI
+        run: make cli STATIC_FILES=false
         if: ${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}}
-        name: Build CLI
-      - run: make start PROFILE=${{matrix.profile}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info API=${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}} UI=false > /tmp/argo.log 2>&1 &
-        name: Start controller/API
-      - run: make wait API=${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}}
+      - name: Start controller/API
+        run: make start PROFILE=${{matrix.profile}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info API=${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}} UI=false > /tmp/argo.log 2>&1 &
+      - name: Wait for controller to be up
+        run: make wait API=${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}}
         timeout-minutes: 5
-        name: Wait for controller to be up
       - name: Run tests ${{matrix.test}}
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false
-      - if: ${{ failure() }}
-        name: MinIO/MySQL deployment
+
+      # failure debugging below
+      - name: Failure debug - get MinIO/MySQL deployment
+        if: ${{ failure() }}
         run: |
           set -eux
           kubectl get deploy
           kubectl describe deploy
-      - if: ${{ failure() }}
-        name: MinIO/MySQL pods
+      - name: Failure debug - get MinIO/MySQL pods
+        if: ${{ failure() }}
         run: |
           set -eux
           kubectl get pods -l '!workflows.argoproj.io/workflow'
           kubectl describe pods -l '!workflows.argoproj.io/workflow'
-      - if: ${{ failure() }}
-        name: MinIO/MySQL logs
+      - name: Failure debug - MinIO/MySQL logs
+        if: ${{ failure() }}
         run: kubectl logs -l '!workflows.argoproj.io/workflow' --prefix
-      - if: ${{ failure() }}
-        name: Controller/API logs
+      - name: Failure debug - Controller/API logs
+        if: ${{ failure() }}
         run: |
           [ -e /tmp/argo.log ] && cat /tmp/argo.log
       - if: ${{ failure() }}
-        name: Workflows
+        name: Failure debug - get Workflows
         run: |
           set -eux
           kubectl get wf
           kubectl describe wf
-      - if: ${{ failure() }}
-        name: Workflow pods
+      - name: Failure debug - get Workflow pods
+        if: ${{ failure() }}
         run: |
           set -eux
           kubectl get pods -l workflows.argoproj.io/workflow
           kubectl describe pods -l workflows.argoproj.io/workflow
-      - if: ${{ failure() }}
-        name: Wait container logs
+      - name: Failure debug - Wait container logs
+        if: ${{ failure() }}
         run: kubectl logs -c wait -l workflows.argoproj.io/workflow --prefix
+
   codegen:
     name: Codegen
-    runs-on: ubuntu-latest
     needs: [ tests ]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       GOPATH: /home/runner/go
@@ -214,21 +219,24 @@ jobs:
           sudo find /usr/local/include -type f | xargs sudo chmod a+r
           sudo find /usr/local/include -type d | xargs sudo chmod a+rx
           ls /usr/local/include/google/protobuf/
-      - run: |
+      - name: Pull OpenAPI Generator CLI Docker image
+        run: |
           docker pull openapitools/openapi-generator-cli:v5.4.0 &
           docker pull openapitools/openapi-generator-cli:v5.2.1 &
-      - name: Create links
+      - name: Create symlinks
         run: |
           mkdir -p /home/runner/go/src/github.com/argoproj
           ln -s "$PWD" /home/runner/go/src/github.com/argoproj/argo-workflows
       - run: make codegen -B STATIC_FILES=false
-      - run: git diff --exit-code
+      # if codegen makes changes that are not in the PR, fail the build
+      - name: Check if codegen made changes not present in the PR
+        run: git diff --exit-code
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
     needs: [ tests, codegen ]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 15 # must be strictly greater than the timeout in .golancgi.yml
     env:
       GOPATH: /home/runner/go
     steps:
@@ -238,7 +246,9 @@ jobs:
           go-version: "1.21"
           cache: true
       - run: make lint STATIC_FILES=false
-      - run: git diff --exit-code
+      # if lint makes changes that are not in the PR, fail the build
+      - name: Check if lint made changes not present in the PR
+        run: git diff --exit-code
 
   ui:
     name: UI

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -162,13 +162,13 @@ jobs:
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false
 
       # failure debugging below
-      - name: Failure debug - get MinIO/MySQL deployment
+      - name: Failure debug - describe MinIO/MySQL deployment
         if: ${{ failure() }}
         run: |
           set -eux
           kubectl get deploy
           kubectl describe deploy
-      - name: Failure debug - get MinIO/MySQL pods
+      - name: Failure debug - describe MinIO/MySQL pods
         if: ${{ failure() }}
         run: |
           set -eux
@@ -182,12 +182,12 @@ jobs:
         run: |
           [ -e /tmp/argo.log ] && cat /tmp/argo.log
       - if: ${{ failure() }}
-        name: Failure debug - get Workflows
+        name: Failure debug - describe Workflows
         run: |
           set -eux
           kubectl get wf
           kubectl describe wf
-      - name: Failure debug - get Workflow pods
+      - name: Failure debug - describe Workflow pods
         if: ${{ failure() }}
         run: |
           set -eux

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -29,7 +29,8 @@ jobs:
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
       # engineers just ignore this in PRs, so lets not even run it
-      - if: github.ref == 'refs/heads/master'
+      - name: Upload coverage report
+        if: github.ref == 'refs/heads/master'
         run: bash <(curl -s https://codecov.io/bash)
 
   argoexec-image:

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -7,11 +7,11 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'argoproj/argo-workflows'}}
     permissions:
       pull-requests: write
       contents: write
-    if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'argoproj/argo-workflows'}}
+    runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,7 +42,7 @@ jobs:
           name: docs
           path: site
           if-no-files-found: error
-      - name: Publish on master
+      - name: Publish to GH Pages (when on master)
         if: github.repository == 'argoproj/argo-workflows' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,4 +1,4 @@
-name: Docs
+name: Upload Docs to GH Pages
 
 on:
   push:
@@ -30,16 +30,20 @@ jobs:
         with:
           node-version: "19"
       # Use the same make target both locally and on CI to make it easier to debug failures.
-      - run: make docs
+      - name: Build & Lint docs
+        run: make docs
       # If markdownlint fixes issues, files will be changed. If so, fail the build.
-      - run: git diff --exit-code
+      - name: Check if markdownlint --fix made changes
+        run: git diff --exit-code
       # Upload the site so reviewers see it.
-      - uses: actions/upload-artifact@v3
+      - name: Upload Docs Site
+        uses: actions/upload-artifact@v3
         with:
           name: docs
           path: site
           if-no-files-found: error
-      - uses: peaceiris/actions-gh-pages@v3
+      - name: Publish on master
+        uses: peaceiris/actions-gh-pages@v3
         if: github.repository == 'argoproj/argo-workflows' && github.ref == 'refs/heads/master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,4 +1,4 @@
-name: Upload Docs to GH Pages
+name: Docs
 
 on:
   push:
@@ -43,8 +43,8 @@ jobs:
           path: site
           if-no-files-found: error
       - name: Publish on master
-        uses: peaceiris/actions-gh-pages@v3
         if: github.repository == 'argoproj/argo-workflows' && github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: PR
+name: PR Title Check
 
 on:
   pull_request_target:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   title-check:
+    name: Check PR Title's semantic conformance
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: PR Title Check
+name: PR
 
 on:
   pull_request_target:
@@ -10,9 +10,9 @@ on:
 
 jobs:
   title-check:
-    name: Check PR Title's semantic conformance
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Check PR Title's semantic conformance
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdks.yaml
+++ b/.github/workflows/sdks.yaml
@@ -8,13 +8,13 @@ permissions:
   contents: read
 
 jobs:
-  sdk:
+  sdks:
+    name: Publish SDKs
+    if: github.repository == 'argoproj/argo-workflows'
     permissions:
       packages: write # for publishing packages
       contents: write  # for creating releases
-    if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
-    name: Publish SDK
     strategy:
       matrix:
         name:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,4 @@
-name: Snyk
+name: Snyk Dependency Scan
 on:
   schedule:
     - cron: "30 2 * * *"
@@ -14,18 +14,20 @@ jobs:
   # we do not scan images here, they're scanned here: https://app.snyk.io/org/argoproj/projects
 
   golang:
+    name: Scan Go deps
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - name: Run Snyk to check for vulnerabilities
+      - name: Run Snyk to check for Go vulnerabilities
         uses: snyk/actions/golang@master
         with:
           args: --severity-threshold=high
 
   node:
+    name: Scan Node deps
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: ubuntu-latest
     env:
@@ -38,7 +40,7 @@ jobs:
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - run: yarn --cwd ui install
-      - name: Run Snyk to check for vulnerabilities
+      - name: Run Snyk to check for Node vulnerabilities
         uses: snyk/actions/node@master
         with:
           args: --file=ui/package.json --severity-threshold=high

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,4 @@
-name: Snyk Dependency Scan
+name: Snyk
 on:
   schedule:
     - cron: "30 2 * * *"


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- partly inspired by #11670
  - as well as seeing users be confused by some steps
    - `git diff --exit-code` had [some confusion](https://github.com/argoproj/argo-workflows/pull/10806#issuecomment-1537913872) in particular
  - and me just reading more closely and wanting better descriptions (as I am working on a few CI changes)
    - for example, I did not even realize that the steps after an E2E test failure were for debugging purposes until I read the CI code itself
      - GH runs some post action hooks etc, so thought that was just clean-up or something

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add names to more steps & jobs in GH Actions Workflows
  - specific names for all `git diff --exit-code` as per above
  - names for Docs steps
  - names PR Title check steps
  - names for Snyk dependency scans workflow
  - CI workflow names:
    - all E2E test failure debugging steps per above
    - add a "get" (as in `kubectl get`) in front of the ones that just log out a resource for clarity as well
    - Java and Python SDK set-up/install steps
    - a few other clarifications / improvements
    - additions where there were no names

- also add some new lines and comments in a few places for clarity & readability

- reordering of fields
  - follow a consistent order of `name` -> `if` -> `needs`
  - then `uses`, `steps`, or `run` depending on the context

### Verification

<!-- TODO: Say how you tested your changes. -->

- Purely stylistic and DX changes, no semantic changes
- CI on this PR should pass with all the new names too 🙂 