### PR TITLE
ci: reduce test & CI flakes with retries + longer waits & timeouts

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -153,7 +153,7 @@ jobs:
       - run: make start PROFILE=${{matrix.profile}} AUTH_MODE=client STATIC_FILES=false LOG_LEVEL=info API=${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}} UI=false > /tmp/argo.log 2>&1 &
         name: Start controller/API
       - run: make wait API=${{matrix.test == 'test-api' || matrix.test == 'test-cli' || matrix.test == 'test-java-sdk' || matrix.test == 'test-python-sdk'}}
-        timeout-minutes: 4
+        timeout-minutes: 5
         name: Wait for controller to be up
       - name: Run tests ${{matrix.test}}
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false

--- a/hack/recurl.sh
+++ b/hack/recurl.sh
@@ -6,7 +6,7 @@ url=$2
 
 if [ ! -f "$file" ]; then
   # loop forever
-  while ! curl -L -o "$file" -- "$url" ;do
+  while ! curl -L --fail -o "$file" -- "$url" ; do
     echo "sleeping before trying again"
     sleep 10s
   done

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -140,7 +140,7 @@ spec:
 `).
 		When().
 		SubmitWorkflow().
-		WaitForWorkflow(time.Minute).
+		WaitForWorkflow(time.Minute + 5*time.Second).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)

--- a/test/e2e/signals_test.go
+++ b/test/e2e/signals_test.go
@@ -31,7 +31,7 @@ func (s *SignalsSuite) TestStopBehavior() {
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToHaveRunningPod, killDuration).
 		ShutdownWorkflow(wfv1.ShutdownStrategyStop).
-		WaitForWorkflow(killDuration + 5*time.Second). // this one takes especially long in CI
+		WaitForWorkflow(killDuration + 10*time.Second). // this one takes especially long in CI
 		Then().
 		ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Contains(t, []wfv1.WorkflowPhase{wfv1.WorkflowFailed, wfv1.WorkflowError}, status.Phase)

--- a/test/e2e/signals_test.go
+++ b/test/e2e/signals_test.go
@@ -31,7 +31,7 @@ func (s *SignalsSuite) TestStopBehavior() {
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToHaveRunningPod, killDuration).
 		ShutdownWorkflow(wfv1.ShutdownStrategyStop).
-		WaitForWorkflow(killDuration).
+		WaitForWorkflow(killDuration + 5*time.Second). // this one takes especially long in CI
 		Then().
 		ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Contains(t, []wfv1.WorkflowPhase{wfv1.WorkflowFailed, wfv1.WorkflowError}, status.Phase)


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Partial fix for #10807

### Motivation

<!-- TODO: Say why you made your changes. -->

- signal_test.go was flaking quite a bit in CI
   - examples (all same test, same error): [1](https://github.com/argoproj/argo-workflows/actions/runs/6090397163/job/16525212870?pr=11752), [2](https://github.com/argoproj/argo-workflows/actions/runs/6090397163/job/16525214144?pr=11752), [3](https://github.com/argoproj/argo-workflows/actions/runs/6057348108/job/16438451395?pr=11727), [4](https://github.com/argoproj/argo-workflows/actions/runs/6024154407/job/16342412510?pr=11716), [5](https://github.com/argoproj/argo-workflows/actions/runs/5910880044/job/16032931699?pr=11568), [6](https://github.com/argoproj/argo-workflows/actions/runs/5910880485/job/16032933770?pr=11567), [7](https://github.com/argoproj/argo-workflows/actions/runs/6066706542/job/16457612480), [8](https://github.com/argoproj/argo-workflows/actions/runs/6008824810/job/16297128151), [9](https://github.com/argoproj/argo-workflows/actions/runs/6076177904/job/16483849857), [10](https://github.com/argoproj/argo-workflows/actions/runs/5979752022/job/16224632564?pr=11637), [11](https://github.com/argoproj/argo-workflows/actions/runs/5922167534/job/16055845745), [12](https://github.com/argoproj/argo-workflows/actions/runs/6092222043/job/16530030316), [13](https://github.com/argoproj/argo-workflows/actions/runs/6088747445/job/16520226969), [14](https://github.com/argoproj/argo-workflows/actions/runs/6019750405/job/16330112382), [15](https://github.com/argoproj/argo-workflows/actions/runs/6005141116/job/16287356878), [16](https://github.com/argoproj/argo-workflows/actions/runs/5980829119/job/16227812975), [17](https://github.com/argoproj/argo-workflows/actions/runs/5959534969/job/16165466761), [18](https://github.com/argoproj/argo-workflows/actions/runs/5898116342/job/15998761453), [19](https://github.com/argoproj/argo-workflows/actions/runs/5886793569/job/15965217053)
     - the most frequent test flake I've seen by a good margin (~20x (?) more than any other one, anecdotally)

- the rest are incidental, but related, fixes for flakes that occurred in CI runs for this PR _itself_ (and that have been seen in CI runs elsewhere too)

<details>
  <summary> <code>signals_test</code> failure logs for posterity </summary>

```  
  stop-terminate-4lf2q : Failed Stopped with strategy 'Stop'
    signals_test.go:44: 
        	Error Trace:	/home/runner/work/argo-workflows/argo-workflows/test/e2e/signals_test.go:44
        	            				/home/runner/work/argo-workflows/argo-workflows/test/e2e/fixtures/then.go:68
        	            				/home/runner/work/argo-workflows/argo-workflows/test/e2e/fixtures/then.go:43
        	            				/home/runner/work/argo-workflows/argo-workflows/test/e2e/signals_test.go:36
        	Error:      	Not equal: 
        	            	expected: "Succeeded"
        	            	actual  : "Running"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-(v1alpha1.NodePhase) (len=9) "Succeeded"
        	            	+(v1alpha1.NodePhase) (len=7) "Running"
        	            	 
        	Test:       	TestSignalsSuite/TestStopBehavior
=== FAIL: SignalsSuite/TestStopBehavior
```
  
</details>

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- `TestStopBehavior` in particular was flaking in checking onExit (all examples above are on the exact same line), so bumped that specifically
  - did not bump `killDuration` entirely (as #11064 did) as that bumps lots of other waits and makes the whole test suite a good bit longer
    - we may want to reduce this in some places and have more targeted wait times in order to reduce total test time
    - and may want to have a different wait on CI vs. local as well

- `TestStatusCondition` flaked on this PR (see [below comment](https://github.com/argoproj/argo-workflows/pull/11753#issuecomment-1707712532)), so bumped its wait as well

- `make codegen` flaked on this PR (see [below comment](https://github.com/argoproj/argo-workflows/pull/11753#issuecomment-1709026360)), so fixed that as well

- and bumped a timeout for another E2E flake on `make wait`
  - it's timed out a few times, so bump it up one minute to 5m
    - examples: [1](https://github.com/argoproj/argo-workflows/actions/runs/6101699486/job/16558698083?pr=11766)
      - can't seem to find another example but I've definitely seen it more than once before

### Verification

<!-- TODO: Say how you tested your changes. -->

This is only reproducible on CI unfortunately 


### Future Work

As mentioned above:
1. More granular `killDuration` / wait per test as they increase total test time
1. Different wait times on CI vs local

Also:
1. Bump k8s swagger as mentioned [below](https://github.com/argoproj/argo-workflows/pull/11753#issuecomment-1709026360)
1. Authenticate some of the GH requests to get rate limited less? It would be great if GH recognized it was coming from itself and increased limits without needing to re-auth