### PR TITLE
fix: Make Plugin Executor Main and init Pod Honour Workflow Controller Log Level

### DIFF
--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -197,11 +197,11 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	// the `init` container populates the shared empty-dir volume with tokens
 	agentInitCtr := agentCtrTemplate.DeepCopy()
 	agentInitCtr.Name = common.InitContainerName
-	agentInitCtr.Args = []string{"agent", "init"}
+	agentInitCtr.Args = []string{"agent", "init", "--loglevel", getExecutorLogLevel()}
 	// the `main` container runs the actual work
 	agentMainCtr := agentCtrTemplate.DeepCopy()
 	agentMainCtr.Name = common.MainContainerName
-	agentMainCtr.Args = []string{"agent", "main"}
+	agentMainCtr.Args = []string{"agent", "main", "--loglevel", getExecutorLogLevel()}
 
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Make Plugin Executor Main and init Pod Honour Workflow Controller Log Level
Signed-off-by: sid8489 <agrawal8489@gmail.com>

<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes 
Make Plugin Executor Main and init Pod Honour Workflow Controller  LogLevel Configuration.

### Motivation
If one wants to see debug logs of the executor main container there is no way to do so currently. This fixes that

### Modifications
Have added loglevel flags to the Container args.

### Verification
Builded workflow controller and set workflow controller log level to debug. Below logs shows log level is taking effect
![image](https://github.com/argoproj/argo-workflows/assets/85802930/9c7f64ec-3e42-41c5-b2c6-fd03c5e1798c)

