### PR TITLE
feat: Add support to configure Plugin Agent Retry Backoff Policy.

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -129,6 +129,10 @@ spec:
 | `REMOVE_LOCAL_ART_PATH`                | `bool`          | `false` | Whether to remove local artifacts.                                                                     |
 | `RESOURCE_STATE_CHECK_INTERVAL`        | `time.Duration` | `5s`    | The time interval between resource status checks against the specified success and failure conditions. |
 | `WAIT_CONTAINER_STATUS_CHECK_INTERVAL` | `time.Duration` | `5s`    | The time interval for wait container to check whether the containers have completed.                   |
+| `PLUGIN_RETRY_BACKOFF_DURATION`        | `time.Duration` | `1s`    | The retry back-off duration when the plugin agent pod performs retries.                                |
+| `PLUGIN_RETRY_BACKOFF_FACTOR`          | `float`         | `2`     | The retry back-off factor when the plugin agent pod performs retries.                                  |
+| `PLUGIN_RETRY_BACKOFF_JITTER`          | `float`         | `0.2`   | The retry back-off jitter when the plugin agent pod performs retries.                                  |
+| `PLUGIN_RETRY_BACKOFF_STEPS`           | `int`           | `5`     | The retry back-off steps when the plugin agent pod  performs retries.                                  |
 
 You can set the environment variables for executor by customizing executor container's environment variables in your
 controller's config-map like the following:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -129,10 +129,6 @@ spec:
 | `REMOVE_LOCAL_ART_PATH`                | `bool`          | `false` | Whether to remove local artifacts.                                                                     |
 | `RESOURCE_STATE_CHECK_INTERVAL`        | `time.Duration` | `5s`    | The time interval between resource status checks against the specified success and failure conditions. |
 | `WAIT_CONTAINER_STATUS_CHECK_INTERVAL` | `time.Duration` | `5s`    | The time interval for wait container to check whether the containers have completed.                   |
-| `PLUGIN_RETRY_BACKOFF_DURATION`        | `time.Duration` | `1s`    | The retry back-off duration when the plugin agent pod performs retries.                                |
-| `PLUGIN_RETRY_BACKOFF_FACTOR`          | `float`         | `2`     | The retry back-off factor when the plugin agent pod performs retries.                                  |
-| `PLUGIN_RETRY_BACKOFF_JITTER`          | `float`         | `0.2`   | The retry back-off jitter when the plugin agent pod performs retries.                                  |
-| `PLUGIN_RETRY_BACKOFF_STEPS`           | `int`           | `5`     | The retry back-off steps when the plugin agent pod  performs retries.                                  |
 
 You can set the environment variables for executor by customizing executor container's environment variables in your
 controller's config-map like the following:

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -149,6 +149,11 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 		})
 	}
 
+	// Add Environment Vars from Executor Config
+	if woc.controller.Config.Executor != nil {
+		envVars = append(envVars, woc.controller.Config.Executor.Env...)
+	}
+
 	serviceAccountName := woc.execWf.Spec.ServiceAccountName
 	tokenVolume, tokenVolumeMount, err := woc.getServiceAccountTokenVolume(ctx, serviceAccountName)
 	if err != nil {

--- a/workflow/executor/plugins/rpc/plugin.go
+++ b/workflow/executor/plugins/rpc/plugin.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"github.com/argoproj/argo-workflows/v3/util/env"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -14,10 +15,10 @@ type plugin struct{ rpc.Client }
 
 func New(address, token string) *plugin {
 	return &plugin{Client: rpc.New(address, token, 30*time.Second, wait.Backoff{
-		Duration: time.Second,
-		Jitter:   0.2,
-		Factor:   2,
-		Steps:    5,
+		Duration: env.LookupEnvDurationOr("PLUGIN_RETRY_BACKOFF_DURATION", time.Second),
+		Jitter:   env.LookupEnvFloatOr("PLUGIN_RETRY_BACKOFF_JITTER", 0.2),
+		Factor:   env.LookupEnvFloatOr("PLUGIN_RETRY_BACKOFF_FACTOR", 2),
+		Steps:    env.LookupEnvIntOr("PLUGIN_RETRY_BACKOFF_STEPS", 5),
 	})}
 }
 

--- a/workflow/executor/plugins/rpc/plugin.go
+++ b/workflow/executor/plugins/rpc/plugin.go
@@ -15,10 +15,10 @@ type plugin struct{ rpc.Client }
 
 func New(address, token string) *plugin {
 	return &plugin{Client: rpc.New(address, token, 30*time.Second, wait.Backoff{
-		Duration: env.LookupEnvDurationOr("PLUGIN_RETRY_BACKOFF_DURATION", time.Second),
-		Jitter:   env.LookupEnvFloatOr("PLUGIN_RETRY_BACKOFF_JITTER", 0.2),
-		Factor:   env.LookupEnvFloatOr("PLUGIN_RETRY_BACKOFF_FACTOR", 2),
-		Steps:    env.LookupEnvIntOr("PLUGIN_RETRY_BACKOFF_STEPS", 5),
+		Duration: env.LookupEnvDurationOr("EXECUTOR_RETRY_BACKOFF_DURATION", time.Second),
+		Jitter:   env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_JITTER", 0.2),
+		Factor:   env.LookupEnvFloatOr("EXECUTOR_RETRY_BACKOFF_FACTOR", 2),
+		Steps:    env.LookupEnvIntOr("EXECUTOR_RETRY_BACKOFF_STEPS", 5),
 	})}
 }
 


### PR DESCRIPTION
Signed-off-by: sid8489 <agrawal8489@gmail.com>

<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


### Motivation
Plugin agent Pod main container makes http call to plugin containers. That Http call is auto retried for transient errors using a Retry Backoff Policy. Currently the Retry Backoff Policy is hardcoded to default values. These default values might not be fit for certain use cases (eg: My Plugin Container is a python http server, but I am downloading the source code at run time, so this can take some seconds and default retry policy is too aggressive for this). So proposing to make it configurable .


### Modifications
- Modified Retry Backoff Policy used by Plugin agent to lookup for environment variables and configure correspondingly.
- Added support to supply Env Variable to Extended Agent Pod Init and Main  containers  through Executor Config of Workflow Controller

### Verification

 TODO: If these changes are acceptable, I will add the verification details. 
