### PR TITLE
feat: Add user info to suspended node when resuming

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1705,7 +1705,7 @@ spec:
 			}
 			nodeStatus = status.Nodes.FindByDisplayName("approve")
 			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, "Test message", nodeStatus.Message)
+				assert.Equal(t, "Test message; Resumed by: map[User:system:serviceaccount:argo:argo-server]", nodeStatus.Message)
 			}
 		})
 }

--- a/workflow/creator/creator.go
+++ b/workflow/creator/creator.go
@@ -49,3 +49,21 @@ func dnsFriendly(s string) string {
 	value = regexp.MustCompile("[^a-z0-9A-Z]*$").ReplaceAllString(value, "")
 	return value
 }
+
+func UserInfoMap(ctx context.Context) map[string]string {
+	claims := auth.GetClaims(ctx)
+	if claims == nil {
+		return nil
+	}
+	res := map[string]string{}
+	if claims.Subject != "" {
+		res["User"] = claims.Subject
+	}
+	if claims.Email != "" {
+		res["Email"] = claims.Email
+	}
+	if claims.PreferredUsername != "" {
+		res["PreferredUsername"] = claims.PreferredUsername
+	}
+	return res
+}

--- a/workflow/creator/creator_test.go
+++ b/workflow/creator/creator_test.go
@@ -130,3 +130,20 @@ func TestLabel(t *testing.T) {
 		}
 	})
 }
+
+func TestUserInfoMap(t *testing.T) {
+	t.Run("NotEmpty", func(t *testing.T) {
+		ctx := context.WithValue(context.TODO(), auth.ClaimsKey,
+			&types.Claims{Claims: jwt.Claims{Subject: strings.Repeat("x", 63) + "y"}, Email: "my@email", PreferredUsername: "username"})
+		uim := UserInfoMap(ctx)
+		assert.Equal(t, map[string]string{
+			"User":              strings.Repeat("x", 63) + "y",
+			"Email":             "my@email",
+			"PreferredUsername": "username",
+		}, uim)
+	})
+	t.Run("Empty", func(t *testing.T) {
+		uim := UserInfoMap(context.TODO())
+		assert.Nil(t, uim)
+	})
+}


### PR DESCRIPTION
Signed-off-by: toyamagu-2021 <toyamagu2021@gmail.com>

<!-- Does this PR fix an issue -->

Relates #11148 

### Motivation

- Add resumer on suspended nodes message for auditing, and tracing purposes.

### Modifications

- Add message about resumed user to node status when resuming workflow.

### Verification

- ![image](https://github.com/argoproj/argo-workflows/assets/83329336/5b9baa8a-2ebb-44a9-b4a4-33af7e59c8f8)
