### PR TITLE
fix(ui): don't use `Buffer` for FNV hash

### DIFF
--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -8,6 +8,7 @@ describe('pod names', () => {
         expect(createFNVHash('You cannot alter your fate. However, you can rise to meet it.')).toEqual(827171719);
     });
 
+    // note: the below is intended to be equivalent to the server-side Go code in workflow/util/pod_name_test.go
     const nodeName = 'nodename';
     const nodeID = '1';
 

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -9,6 +9,7 @@ export const k8sNamingHashLength = 10;
 // getPodName returns a deterministic pod name
 // In case templateName is not defined or that version is explicitly set to  POD_NAME_V1, it will return the nodeID (v1)
 // In other cases it will return a combination of workflow name, template name, and a hash (v2)
+// note: this is inteded to be equivalent to the server-side Go code in workflow/util/pod_name.go
 export const getPodName = (workflowName: string, nodeName: string, templateName: string, nodeID: string, version: string): string => {
     if (version !== POD_NAME_V1 && templateName !== '') {
         if (workflowName === nodeName) {
@@ -35,17 +36,17 @@ export const ensurePodNamePrefixLength = (prefix: string): string => {
 };
 
 export const createFNVHash = (input: string): number => {
-    const data = Buffer.from(input);
-
     let hashint = 2166136261;
 
-    /* tslint:disable:no-bitwise */
-    for (const character of data) {
+    for (let i = 0; i < input.length; i++) {
+        const character = input.charCodeAt(i);
+        /* tslint:disable:no-bitwise */
         hashint = hashint ^ character;
         hashint += (hashint << 1) + (hashint << 4) + (hashint << 7) + (hashint << 8) + (hashint << 24);
     }
 
     return hashint >>> 0;
+    /* tslint:enable:no-bitwise */
 };
 
 export const getTemplateNameFromNode = (node: NodeStatus): string => {

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -9,7 +9,7 @@ export const k8sNamingHashLength = 10;
 // getPodName returns a deterministic pod name
 // In case templateName is not defined or that version is explicitly set to  POD_NAME_V1, it will return the nodeID (v1)
 // In other cases it will return a combination of workflow name, template name, and a hash (v2)
-// note: this is inteded to be equivalent to the server-side Go code in workflow/util/pod_name.go
+// note: this is intended to be equivalent to the server-side Go code in workflow/util/pod_name.go
 export const getPodName = (workflowName: string, nodeName: string, templateName: string, nodeID: string, version: string): string => {
     if (version !== POD_NAME_V1 && templateName !== '') {
         if (workflowName === nodeName) {


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #11764

### Motivation

<!-- TODO: Say why you made your changes. -->

- `Buffer` requires a polyfill in client-side JS
  - #11628 upgraded to Webpack v5, which [no longer auto adds Node polyfills](https://github.com/webpack/changelog-v5#automatic-nodejs-polyfills-removed)
    - which ended up breaking 2 year old code from #6925
  - this seems to be the only one we use (as far as I can tell) -- and this code quite literally copies server-side Go code, so makes sense that it may use server-side libraries
    - add comments in the code about where this is copied from so that it is easier to track (I had to go through the `blame` + commit history)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use `charCodeAt` to extract an int from a character of a string instead of converting the string to a Buffer
  - was inspired by looking at some JS FNV implementations and stumbled upon some lines like this: https://github.com/schwarzkopfb/fnv1a/blob/2c5ee2889e42a6bd38c64a29b227eaf9e048e40d/index.js#L22

- also re-enable the `tslint` rule at the end of the code

### Verification

<!-- TODO: Say how you tested your changes. -->

- unit tests for FNV hashing still pass, so think the implementation is equivalent and we're good!


### Misc Notes

I decided not to replace the FNV hash implementation with a library as basically [all](https://www.npmjs.com/search?q=fnv1a) of them are unmaintained and this change only ended up being a few LoC. Some of the libraries are also [quite large](https://github.com/tjwebb/fnv-plus/blob/v1.3.0/index.js) (implementing many different algorithms and are not tree-shakeable), or have [build issues](https://github.com/schwarzkopfb/fnv1a/issues/2), or [use BigInt](https://github.com/sindresorhus/fnv1a/blob/ddbe4f242c6d9a86258400dcf6a1dabae156a3e1/index.js#L5) (which is not supported in older browsers... although those are all EoL and I wouldn't personally support such old browsers, but still something to consider).