### PR TITLE
fix: Workflow controller crash on nil pointer 

### DIFF
--- a/workflow/controller/healthz.go
+++ b/workflow/controller/healthz.go
@@ -33,6 +33,11 @@ func (wfc *WorkflowController) Healthz(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return err
 		}
+		// the wfc.wfInformer is nil if it is not the leader
+		if wfc.wfInformer == nil {
+			log.Info("healthz: current pod is not the leader")
+			return nil
+		}
 		lister := v1alpha1.NewWorkflowLister(wfc.wfInformer.GetIndexer())
 		list, err := lister.Workflows(wfc.managedNamespace).List(seletor)
 		if err != nil {


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes #11769

### Motivation

To fix the workflow controller crash on nil pointer.

### Modifications

Check if `wfc.wfInformer` is nil when calling healthz func.

### Verification

After the code modification, tested the workflow-controller deployment in my environment with
multiple replicas (1, 5 and 10), all work ok.

10 for example:
```
workflow-controller-85bfb69457-2sgl8   1/1     Running   0          10m
workflow-controller-85bfb69457-8qdfq   1/1     Running   0          10m
workflow-controller-85bfb69457-95bc6   1/1     Running   0          10m
workflow-controller-85bfb69457-bmj2s   1/1     Running   0          10m
workflow-controller-85bfb69457-cmmkp   1/1     Running   0          10m
workflow-controller-85bfb69457-df4j6   1/1     Running   0          10m
workflow-controller-85bfb69457-fdng8   1/1     Running   0          10m
workflow-controller-85bfb69457-hj8zs   1/1     Running   0          10m
workflow-controller-85bfb69457-j7gs8   1/1     Running   0          10m
workflow-controller-85bfb69457-llnmv   1/1     Running   0          10m
```

Got the expected log:
```
time="2023-09-07T05:04:36.689Z" level=info msg="Persistence configuration enabled"
time="2023-09-07T05:04:36.710Z" level=info msg="Persistence Session created successfully"
time="2023-09-07T05:04:36.710Z" level=info msg="Node status offloading is enabled"
time="2023-09-07T05:04:36.710Z" level=info msg="Workflow archiving is enabled"
time="2023-09-07T05:04:36.710Z" level=info executorImage="quay.io/argoproj/argoexec:v0.0.0" executorImagePullPolicy=Always managedNamespace=
time="2023-09-07T05:04:36.712Z" level=info msg="Starting dummy metrics server at localhost:9090/metrics"
I0907 05:04:36.713234       1 leaderelection.go:248] attempting to acquire leader lease argo/workflow-controller...
time="2023-09-07T05:04:36.721Z" level=info msg="new leader" leader=workflow-controller-85bfb69457-mpdvf
time="2023-09-07T05:04:56.682Z" level=info msg="new leader" leader=workflow-controller-85bfb69457-95bc6
time="2023-09-07T05:06:16.390Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:06:19.065Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:06:25.405Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:06:29.670Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:07:29.670Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:08:29.670Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:09:29.670Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:09:36.673Z" level=info msg="Alloc=3934 TotalAlloc=7814 Sys=23677 NumGC=5 Goroutines=17"
time="2023-09-07T05:10:29.670Z" level=info msg="healthz: current pod is not the leader"
time="2023-09-07T05:11:29.671Z" level=info msg="healthz: current pod is not the leader"
```
