### PR TITLE
feat: filter sso groups based on regex

### DIFF
--- a/config/sso.go
+++ b/config/sso.go
@@ -18,10 +18,10 @@ type SSOConfig struct {
 	Scopes        []string        `json:"scopes,omitempty"`
 	SessionExpiry metav1.Duration `json:"sessionExpiry,omitempty"`
 	// customGroupClaimName will override the groups claim name
-	CustomGroupClaimName string `json:"customGroupClaimName,omitempty"`
-	UserInfoPath         string `json:"userInfoPath,omitempty"`
-	InsecureSkipVerify   bool   `json:"insecureSkipVerify,omitempty"`
-	FilterGroupsRegex    string `json:"filterGroupsRegex,omitempty"`
+	CustomGroupClaimName string   `json:"customGroupClaimName,omitempty"`
+	UserInfoPath         string   `json:"userInfoPath,omitempty"`
+	InsecureSkipVerify   bool     `json:"insecureSkipVerify,omitempty"`
+	FilterGroupsRegex    []string `json:"filterGroupsRegex,omitempty"`
 }
 
 func (c SSOConfig) GetSessionExpiry() time.Duration {

--- a/config/sso.go
+++ b/config/sso.go
@@ -21,6 +21,7 @@ type SSOConfig struct {
 	CustomGroupClaimName string `json:"customGroupClaimName,omitempty"`
 	UserInfoPath         string `json:"userInfoPath,omitempty"`
 	InsecureSkipVerify   bool   `json:"insecureSkipVerify,omitempty"`
+	FilterSSOGroupsRegex string `json:"filterSSOGroupsRegex,omitempty"`
 }
 
 func (c SSOConfig) GetSessionExpiry() time.Duration {

--- a/config/sso.go
+++ b/config/sso.go
@@ -21,7 +21,7 @@ type SSOConfig struct {
 	CustomGroupClaimName string `json:"customGroupClaimName,omitempty"`
 	UserInfoPath         string `json:"userInfoPath,omitempty"`
 	InsecureSkipVerify   bool   `json:"insecureSkipVerify,omitempty"`
-	FilterSSOGroupsRegex string `json:"filterSSOGroupsRegex,omitempty"`
+	FilterGroupsRegex    string `json:"filterGroupsRegex,omitempty"`
 }
 
 func (c SSOConfig) GetSessionExpiry() time.Duration {

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -187,14 +187,14 @@ func newSso(
 	if c.IssuerAlias != "" {
 		lf["issuerAlias"] = c.IssuerAlias
 	}
-	var filterGroupRegex []*regexp.Regexp
+	var filterGroupsRegex []*regexp.Regexp
 	if c.FilterGroupsRegex != nil && len(c.FilterGroupsRegex) > 0 {
 		for _, regex := range c.FilterGroupsRegex {
 			compiledRegex, err := regexp.Compile(regex)
 			if err != nil {
 				return nil, fmt.Errorf("failed to compile sso.filterGroupRegex: %s %w", regex, err)
 			}
-			filterGroupRegex = append(filterGroupRegex, compiledRegex)
+			filterGroupsRegex = append(filterGroupsRegex, compiledRegex)
 		}
 	}
 	log.WithFields(lf).Info("SSO configuration")
@@ -212,7 +212,7 @@ func newSso(
 		customClaimName:   c.CustomGroupClaimName,
 		userInfoPath:      c.UserInfoPath,
 		issuer:            c.Issuer,
-		filterGroupsRegex: filterGroupRegex,
+		filterGroupsRegex: filterGroupsRegex,
 	}, nil
 }
 

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -195,12 +195,9 @@ func newSso(
 		}
 	}
 
-	lf := log.Fields{"redirectUrl": config.RedirectURL, "issuer": c.Issuer, "issuerAlias": "DISABLED", "clientId": c.ClientID, "scopes": config.Scopes, "insecureSkipVerify": c.InsecureSkipVerify}
+	lf := log.Fields{"redirectUrl": config.RedirectURL, "issuer": c.Issuer, "issuerAlias": "DISABLED", "clientId": c.ClientID, "scopes": config.Scopes, "insecureSkipVerify": c.InsecureSkipVerify, "filterGroupsRegex": c.FilterGroupsRegex}
 	if c.IssuerAlias != "" {
 		lf["issuerAlias"] = c.IssuerAlias
-	}
-	if c.FilterGroupsRegex != nil && len(c.FilterGroupsRegex) > 0 {
-		lf["filterGroupsRegex"] = c.FilterGroupsRegex
 	}
 	log.WithFields(lf).Info("SSO configuration")
 

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -195,9 +195,12 @@ func newSso(
 		}
 	}
 
-	lf := log.Fields{"redirectUrl": config.RedirectURL, "issuer": c.Issuer, "issuerAlias": "DISABLED", "clientId": c.ClientID, "scopes": config.Scopes, "insecureSkipVerify": c.InsecureSkipVerify, "filterGroupsRegex": c.FilterGroupsRegex}
+	lf := log.Fields{"redirectUrl": config.RedirectURL, "issuer": c.Issuer, "issuerAlias": "DISABLED", "clientId": c.ClientID, "scopes": config.Scopes, "insecureSkipVerify": c.InsecureSkipVerify}
 	if c.IssuerAlias != "" {
 		lf["issuerAlias"] = c.IssuerAlias
+	}
+	if c.FilterGroupsRegex != nil && len(c.FilterGroupsRegex) > 0 {
+		lf["filterGroupsRegex"] = c.FilterGroupsRegex
 	}
 	log.WithFields(lf).Info("SSO configuration")
 
@@ -309,7 +312,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		}
 		groups = filteredGroups
 	}
-	
+
 	argoClaims := &types.Claims{
 		Claims: jwt.Claims{
 			Issuer:  issuer,


### PR DESCRIPTION
<!--

### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Fixes #10153 #9530

### Motivation
- Currently users logging in via SSO with lot of groups, exceed the 4KB Cookie limit
- This happens because we send the full set of claims as part of cookie
- Adding capability to filter sso groups matching a regex.
- This would eliminate all SSO groups which won't be used in SSO RBAC and reduce the number of groups in the authorization cookie

### Modifications
- Add a property `filterGroupsRegex ` in SSO config
- FIlter groups based on the property

### Verification
- Tested locally with `filterGroupsRegex `

### Example usage:
```
scopes:
- groups
- email
- profile
rbac:
  enabled: true
filterGroupsRegex:
- ".*argowf.*"
```
