### PR TITLE
feat: Add support for retrieving ClientId, ClientSecret and SSO secret from env var as opposed to creating a kube Secret

### DIFF
--- a/config/sso.go
+++ b/config/sso.go
@@ -22,6 +22,10 @@ type SSOConfig struct {
 	UserInfoPath         string   `json:"userInfoPath,omitempty"`
 	InsecureSkipVerify   bool     `json:"insecureSkipVerify,omitempty"`
 	FilterGroupsRegex    []string `json:"filterGroupsRegex,omitempty"`
+	// support providing PrivateKey, ClientID and ClientSecret via env var
+	PrivateKeyEnvName   string `json:"privateKeyEnvName,omitempty"`
+	ClientIDEnvName     string `json:"clientIdEnvName,omitempty"`
+	ClientSecretEnvName string `json:"clientSecretEnvName,omitempty"`
 }
 
 func (c SSOConfig) GetSessionExpiry() time.Duration {

--- a/docs/argo-server-sso-argocd.md
+++ b/docs/argo-server-sso-argocd.md
@@ -107,6 +107,44 @@ data:
     redirectUrl: https://argo-workflows.mydomain.com/oauth2/callback
 ```
 
+## Example SSO config with Secrets from environment variable
+
+The following example shows how you can use environment variables to get your secrets. This is
+especially useful if you use CSI driver to get your secrets from, say, Azure Key Vault.
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  # SSO Configuration for the Argo server.
+  # You must also start argo server with `--auth-mode sso`.
+  # https://argoproj.github.io/argo-workflows/argo-server-auth-mode/
+  sso: |
+    # This is the root URL of the OIDC provider (required).
+    issuer: https://argo-cd.mydomain.com/api/dex
+    # This is the redirect URL supplied to the provider (required). It must
+    # be in the form <argo-server-root-url>/oauth2/callback. It must be
+    # browser-accessible.
+    redirectUrl: https://argo-workflows.mydomain.com/oauth2/callback
+    # This is the environment variable name that will contain the Client ID; this is equivalent to
+    # what is in the secret `argo-workflows-sso.client-id`. If this is not provided, then we
+    # default to using kube Secret above.
+    # (required if clientId is not provided).
+    clientIdEnvName: ARGO_OIDC_CLIENT_ID
+    # This is the environment variable name that contains OIDC client
+    # secret issued to the application by the provider; this is equivalent to
+    # what is in the secret `argo-workflows-sso.client-secret`. If this is not provided, then we
+    # default to using kube Secret above.
+    # (required if clientSecret is not provided).
+    clientSecretEnvName: ARGO_OIDC_CLIENT_SECRET
+    # This is the environment variable name that contains PKCS1 private key, if this is not
+    # provided, then Argo will create one dynamically and store in Kube Secret.
+    privateKeyEnvName: ARGO_OIDC_PRIVATE_KEY
+```
+
 ## Example Helm chart configuration for authenticating against Argo CD's Dex
 
 `argo-cd/values.yaml`:

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -395,6 +395,20 @@ data:
     # be in the form <argo-server-root-url>/oauth2/callback. It must be
     # browser-accessible. If omitted, will be automatically generated.
     redirectUrl: https://argo-server/oauth2/callback
+    # This is the environment variable name that will contain the Client ID; this is equivalent to
+    # what is in the secret `argo-workflows-sso.client-id`. If this is not provided, then we
+    # default to using kube Secret above.
+    # (required if clientId is not provided).
+    clientIdEnvName: ARGO_OIDC_CLIENT_ID
+    # This is the environment variable name that contains OIDC client
+    # secret issued to the application by the provider; this is equivalent to
+    # what is in the secret `argo-workflows-sso.client-secret`. If this is not provided, then we
+    # default to using kube Secret above.
+    # (required if clientSecret is not provided).
+    clientSecretEnvName: ARGO_OIDC_CLIENT_SECRET
+    # This is the environment variable name that contains PKCS1 private key, if this is not
+    # provided, then Argo will create one dynamically and store in Kube Secret.
+    privateKeyEnvName: ARGO_OIDC_PRIVATE_KEY
     # Additional scopes to request. Typically needed for SSO RBAC. >= v2.12
     scopes:
      - groups

--- a/server/auth/types/claims_test.go
+++ b/server/auth/types/claims_test.go
@@ -221,8 +221,22 @@ func TestGetUserInfoGroups(t *testing.T) {
 		httpClient = &HttpClientMock{StatusCode: 200, Body: body}
 
 		claims := &Claims{}
-		groups, err := claims.GetUserInfoGroups("Bearer fake", "https://fake.okta.com", "/user-info")
-		assert.Equal(t, groups, []string{"Everyone"})
+		groups, err := claims.GetUserInfoGroups("Bearer fake", "https://fake.okta.com", "/user-info", "")
+		assert.Equal(t, []string{"Everyone"}, groups)
+		assert.Equal(t, nil, err)
+	})
+}
+
+func TestGetUserInfoGroup(t *testing.T) {
+	t.Run("UserInfoGroupsReturn", func(t *testing.T) {
+		userInfo := `{"group": ["Everyone"]}`
+		body := io.NopCloser(bytes.NewReader([]byte(userInfo)))
+
+		httpClient = &HttpClientMock{StatusCode: 200, Body: body}
+
+		claims := &Claims{}
+		groups, err := claims.GetUserInfoGroups("Bearer fake", "https://fake.okta.com", "/user-info", "group")
+		assert.Equal(t, []string{"Everyone"}, groups)
 		assert.Equal(t, nil, err)
 	})
 }


### PR DESCRIPTION
Fixes #10395
Fixes #11772

### Motivation

This change adds support for retrieving ClientId, ClientSecret and SSO secret from env var as opposed to creating a kube Secret, allowing us to provide our own and not use Kube Secrets at all.

### Modifications

The changes made were:

In the SSO auth code and config, to solve the above problem statement, we believe the following
would be required:

- Allow setting clientId from environment variable
- Allow setting clientSecret from environment variable
- Allow setting of PKCS1 SSO secret from environment variable

### Verification

We successfully:

1. backed up the `sso` secret
2. deleted the `sso` resource in our Kube namespace.
3. created 3 environment variables from our secret store:
    1. `ARGO_CLIENT_ID`: our SSO client ID
    2. `ARGO_CLIENT_SECRET`: our client secret
    3. `ARGO_PRIVATE_KEY`: PKCS1 key, encoded in base64
4. Added the the new mapping into the `sso` configmap:
```yaml
      privateKeyEnvName: ARGO_PRIVATE_KEY
      clientIdEnvName: ARGO_CLIENT_ID
      clientSecretEnvName: ARGO_CLIENT_SECRET
```
5. started workflow server successfully
6. able to login with our SSO and use our custom groups 

Regarding fix #10395:

In this PR, we are fixing issue: https://github.com/argoproj/argo-workflows/issues/10395
    - this issue was caused by the creation of a new httpClient and not
      re-using the existing one in `sso.go`, where `InsecureSkipVerify`
      is being set and not propagated tot the groups claim call