### PR TITLE
fix(ui): handle `undefined` dates in Workflows List filter

### DIFF
--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -262,8 +262,9 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
             // else false
             return isPending;
         }
-        const started = new Date(startedStr);
+        const started: Date = new Date(startedStr);
 
+        // check for undefined date filters as well
         if (minStartedAt && maxStartedAt) {
             return started > minStartedAt && started < maxStartedAt;
         } else if (minStartedAt && !maxStartedAt) {

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -262,9 +262,17 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
             // else false
             return isPending;
         }
-        const started: Date = new Date(startedStr);
+        const started = new Date(startedStr);
 
-        return started > minStartedAt && started < maxStartedAt;
+        if (minStartedAt && maxStartedAt) {
+            return started > minStartedAt && started < maxStartedAt;
+        } else if (minStartedAt && !maxStartedAt) {
+            return started > minStartedAt;
+        } else if (!minStartedAt && maxStartedAt) {
+            return started < maxStartedAt;
+        } else {
+            return true;
+        }
     }
 
     private fetchWorkflows(namespace: string, selectedPhases: WorkflowPhase[], selectedLabels: string[], minStartedAt: Date, maxStartedAt: Date, pagination: Pagination): void {


### PR DESCRIPTION
<!--
### Before you open your PR 

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).


### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


<!-- Does this PR fix an issue -->

Another fix for #9696

### Motivation

<!-- TODO: Say why you made your changes. -->

- when date filters are removed, they are set to undefined
  - the previous logic did not handle this correctly, comparing `undefined` with Dates    
    - comparing to `undefined` _always_ returns `false`
  - new logic only compares when Dates are set

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- only compare the Dates when they are actually set, otherwise return `true`

### Verification

<!-- TODO: Say how you tested your changes. -->

Can see in the below screenshot (in React DevTools) that `minStartedAt` was set to `undefined` after I hit the "x" button on the date filter:

![Screenshot 2023-09-10 at 12 10 20 AM](https://github.com/argoproj/argo-workflows/assets/4970083/119d41e7-bd6e-4587-b26e-db3cce2aec20)

Made sure that `undefined` did in fact act weirdly, and here's results from browser console REPL:
```js
undefined < new Date()
// false
undefined > new Date()
// false
new Date() > undefined
// false
new Date() < undefined
// false
```

Tested manually in the UI and made sure it works as expected
