### PR TITLE
fix: controller watches global configMap in the namespace where it is running and not in managedNamespace - fixes #11463

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -398,7 +398,7 @@ func (wfc *WorkflowController) runConfigMapWatcher(stopCh <-chan struct{}) {
 	ctx := context.Background()
 	retryWatcher, err := apiwatch.NewRetryWatcher("1", &cache.ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.managedNamespace).Watch(ctx, metav1.ListOptions{})
+			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.namespace).Watch(ctx, metav1.ListOptions{})
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #11463 

### Motivation

There was a bug by which the workflow controller did not pick up changes made to its configMap until its pod was deleted. This only manifestated when the controller is running in a particular namespace (`--namespaced`) but is managing workflows in a different namespace (`--managed-namespace=<some_other_ns>`)

### Modifications

Fixed the namespace that the controller watches for changes made to its own configMap, so that it watches the same namespace that it initially reads. See the analysis in #11463 for more details. 

### Verification

I did manual verification by:
1. Deploying into a cluster using both flags (`--namespaced` `--managed-namespace=<other_ns>`) 
2. Making changes to the config map (e.g. to the workflowDefaults)
3. Reading the controller logs
4. Starting a workflow to validate whether the changed made to the configmap had been picked up or not

I also ran all tests, but given that this bug is related to configmaps and namespaces in a k8s cluster, and I don't see a clear way of simulating that in `workflow/controller/controller_test.go`, I haven't added any new tests, but I'm obviously open to do it if there's any example of how to mock the namespaces and configmaps to actually test the watcher (which, as far as I can tell, relies on k8s control plane actually being there and is thus complicated to test without a real k8s cluster).