### PR TITLE
refactor(ui): convert a few components to use hooks

### DIFF
--- a/ui/src/app/shared/components/resource-editor/resource-editor.tsx
+++ b/ui/src/app/shared/components/resource-editor/resource-editor.tsx
@@ -1,5 +1,6 @@
 import * as kubernetes from 'argo-ui/src/models/kubernetes';
 import * as React from 'react';
+import {useState} from 'react';
 import {Button} from '../button';
 import {ErrorNotice} from '../error-notice';
 import {ObjectEditor} from '../object-editor/object-editor';
@@ -15,69 +16,53 @@ interface Props<T> {
     onSubmit?: (value: T) => Promise<any>;
 }
 
-interface State<T> {
-    editing: boolean;
-    value: T;
-    error?: Error;
-}
+export function ResourceEditor<T extends {metadata?: kubernetes.ObjectMeta}>(props: Props<T>) {
+    const [editing, setEditing] = useState(props.editing);
+    const [value, setValue] = useState(props.value);
+    const [error, setError] = useState<Error>();
 
-export class ResourceEditor<T extends {metadata?: kubernetes.ObjectMeta}> extends React.Component<Props<T>, State<T>> {
-    constructor(props: Readonly<Props<T>>) {
-        super(props);
-        this.state = {editing: this.props.editing, value: this.props.value};
-    }
-
-    public render() {
-        return (
-            <>
-                {this.props.title && <h4>{this.props.title}</h4>}
-                {this.state.error && <ErrorNotice error={this.state.error} />}
-                <ObjectEditor
-                    key='editor'
-                    type={'io.argoproj.workflow.v1alpha1.' + this.props.kind}
-                    value={this.state.value}
-                    buttons={this.renderButtons()}
-                    onChange={value => this.setState({value})}
-                />
-            </>
-        );
-    }
-
-    private renderButtons() {
-        return (
-            <>
-                {this.state.editing ? (
-                    <>
-                        {this.props.upload && <UploadButton<T> onUpload={value => this.setState({value})} onError={error => this.setState({error})} />}
-                        {this.props.onSubmit && (
-                            <Button icon='plus' onClick={() => this.submit()} key='submit'>
-                                Submit
-                            </Button>
-                        )}
-                    </>
-                ) : (
-                    this.props.onSubmit && (
-                        <Button icon='edit' onClick={() => this.setState({editing: true})} key='edit'>
-                            Edit
-                        </Button>
-                    )
-                )}
-            </>
-        );
-    }
-
-    private submit() {
+    async function submit() {
         try {
-            const value = this.state.value;
-            if (value.metadata && !value.metadata.namespace && this.props.namespace) {
-                value.metadata.namespace = this.props.namespace;
+            if (value.metadata && !value.metadata.namespace && props.namespace) {
+                value.metadata.namespace = props.namespace;
             }
-            this.props
-                .onSubmit(value)
-                .then(() => this.setState({error: null}))
-                .catch(error => this.setState({error}));
-        } catch (error) {
-            this.setState({error});
+            await props.onSubmit(value);
+            setError(null);
+        } catch (newError) {
+            setError(newError);
         }
     }
+
+    return (
+        <>
+            {props.title && <h4>{props.title}</h4>}
+            <ErrorNotice error={error} />
+            <ObjectEditor
+                key='editor'
+                type={'io.argoproj.workflow.v1alpha1.' + props.kind}
+                value={value}
+                buttons={
+                    <>
+                        {editing ? (
+                            <>
+                                {props.upload && <UploadButton<T> onUpload={setValue} onError={setError} />}
+                                {props.onSubmit && (
+                                    <Button icon='plus' onClick={() => submit()} key='submit'>
+                                        Submit
+                                    </Button>
+                                )}
+                            </>
+                        ) : (
+                            props.onSubmit && (
+                                <Button icon='edit' onClick={() => setEditing(true)} key='edit'>
+                                    Edit
+                                </Button>
+                            )
+                        )}
+                    </>
+                }
+                onChange={setValue}
+            />
+        </>
+    );
 }

--- a/ui/src/app/shared/components/tags-input/tags-input.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.tsx
@@ -29,7 +29,7 @@ export function TagsInput(props: TagsInputProps) {
             props.onChange(tags);
             setTimeout(() => autoCompleteRef.current?.refresh());
         }
-    }, [props.onChange, tags, autoCompleteRef]);
+    }, [tags]);
 
     return (
         <div className={classNames('tags-input argo-field', {'tags-input--focused': focused || !!input})} onClick={() => inputRef.current?.focus()}>
@@ -75,7 +75,12 @@ export function TagsInput(props: TagsInputProps) {
                     <input
                         {...inputProps}
                         placeholder={props.placeholder}
-                        ref={inputRef}
+                        ref={ref => {
+                            inputRef.current = ref;
+                            if (typeof inputProps.ref === 'function') {
+                                inputProps.ref(ref);
+                            }
+                        }}
                         onFocus={e => {
                             inputProps.onFocus?.(e);
                             setFocused(true);

--- a/ui/src/app/shared/components/tags-input/tags-input.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
+import {useRef, useState} from 'react';
 
 import {Autocomplete, AutocompleteApi, AutocompleteOption} from 'argo-ui';
 
@@ -13,116 +14,100 @@ interface TagsInputProps {
 
 require('./tags-input.scss');
 
-export class TagsInput extends React.Component<TagsInputProps, {tags: string[]; input: string; focused: boolean; subTags: string[]; subTagsActive: boolean}> {
-    private inputElement: HTMLInputElement;
-    private autocompleteApi: AutocompleteApi;
+export function TagsInput(props: TagsInputProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const autoCompleteRef = useRef<AutocompleteApi>(null);
 
-    constructor(props: TagsInputProps) {
-        super(props);
-        this.state = {tags: props.tags || [], input: '', focused: false, subTags: [], subTagsActive: false};
-    }
+    const [tags, setTags] = useState(props.tags || []);
+    const [input, setInput] = useState('');
+    const [focused, setFocused] = useState(false);
+    const [subTags, setSubTags] = useState<string[]>([]);
+    const [subTagsActive, setSubTagsActive] = useState(false);
 
-    public render() {
-        return (
-            <div
-                className={classNames('tags-input argo-field', {'tags-input--focused': this.state.focused || !!this.state.input})}
-                onClick={() => this.inputElement && this.inputElement.focus()}>
-                {this.props.tags ? (
-                    this.props.tags.map((tag, i) => (
-                        <span className='tags-input__tag' key={tag}>
-                            {tag}{' '}
-                            <i
-                                className='fa fa-times'
-                                onClick={e => {
-                                    const newTags = [...this.state.tags.slice(0, i), ...this.state.tags.slice(i + 1)];
-                                    this.setState({tags: newTags});
-                                    this.onTagsChange(newTags);
-                                    e.stopPropagation();
-                                }}
-                            />
-                        </span>
-                    ))
-                ) : (
-                    <span />
-                )}
-                <Autocomplete
-                    filterSuggestions={true}
-                    autoCompleteRef={api => (this.autocompleteApi = api)}
-                    value={this.state.input}
-                    items={this.state.subTagsActive ? this.state.subTags : this.props.autocomplete}
-                    onChange={e => this.setState({input: e.target.value})}
-                    onSelect={value => {
-                        if (this.props.sublistQuery != null && !this.state.subTagsActive) {
-                            this.setState({subTagsActive: true});
-                            this.props.sublistQuery(value).then(list => {
-                                this.setState({
-                                    subTags: list || []
-                                });
-                            });
-                        } else {
-                            if (this.state.tags.indexOf(value) === -1) {
-                                const newTags = this.state.tags.concat(value);
-                                this.setState({input: '', tags: newTags, subTags: []});
-                                this.onTagsChange(newTags);
-                            }
-                            this.setState({subTagsActive: false});
-                        }
-                    }}
-                    renderInput={props => (
-                        <input
-                            {...props}
-                            placeholder={this.props.placeholder}
-                            ref={inputEl => {
-                                this.inputElement = inputEl;
-                                if (props.ref) {
-                                    (props.ref as any)(inputEl);
-                                }
-                            }}
-                            onFocus={e => {
-                                if (props.onFocus) {
-                                    props.onFocus(e);
-                                }
-                                this.setState({focused: true});
-                            }}
-                            onBlur={e => {
-                                if (props.onBlur) {
-                                    props.onBlur(e);
-                                }
-                                this.setState({focused: false});
-                            }}
-                            onKeyDown={e => {
-                                if (e.keyCode === 8 && this.state.tags.length > 0 && this.state.input === '') {
-                                    const newTags = this.state.tags.slice(0, this.state.tags.length - 1);
-                                    this.setState({tags: newTags});
-                                    this.onTagsChange(newTags);
-                                }
-                                if (props.onKeyDown) {
-                                    props.onKeyDown(e);
-                                }
-                            }}
-                            onKeyUp={e => {
-                                if (e.keyCode === 13 && this.state.input && this.state.tags.indexOf(this.state.input) === -1) {
-                                    const newTags = this.state.tags.concat(this.state.input);
-                                    this.setState({input: '', tags: newTags});
-                                    this.onTagsChange(newTags);
-                                }
-                                if (props.onKeyUp) {
-                                    props.onKeyUp(e);
-                                }
-                            }}
-                        />
-                    )}
-                />
-            </div>
-        );
-    }
-
-    private onTagsChange(tags: string[]) {
-        if (this.props.onChange) {
-            this.props.onChange(tags);
-            if (this.autocompleteApi) {
-                setTimeout(() => this.autocompleteApi.refresh());
-            }
+    function onTagsChange(tags: string[]) {
+        if (props.onChange) {
+            props.onChange(tags);
+            setTimeout(() => autoCompleteRef.current?.refresh());
         }
     }
+
+    return (
+        <div
+            className={classNames('tags-input argo-field', {'tags-input--focused': focused || !!input})}
+            onClick={() => inputRef.current?.focus()}>
+            {props.tags ? (
+                props.tags.map((tag, i) => (
+                    <span className='tags-input__tag' key={tag}>
+                        {tag}{' '}
+                        <i
+                            className='fa fa-times'
+                            onClick={e => {
+                                const newTags = [...tags.slice(0, i), ...tags.slice(i + 1)];
+                                setTags(newTags);
+                                onTagsChange(newTags);
+                                e.stopPropagation();
+                            }}
+                        />
+                    </span>
+                ))
+            ) : (
+                <span />
+            )}
+            <Autocomplete
+                filterSuggestions={true}
+                autoCompleteRef={ref => (autoCompleteRef.current = ref)}
+                value={input}
+                items={subTagsActive ? subTags : props.autocomplete}
+                onChange={e => setInput(e.target.value)}
+                onSelect={async value => {
+                    if (props.sublistQuery != null && !subTagsActive) {
+                        setSubTagsActive(true);
+                        const newSubTags = await props.sublistQuery(value);
+                        setSubTags(newSubTags || []);
+                    } else {
+                        if (tags.indexOf(value) === -1) {
+                            const newTags = tags.concat(value);
+                            setTags(newTags);
+                            setInput('');
+                            setSubTags([]);
+                            onTagsChange(newTags);
+                        }
+                        setSubTagsActive(false);
+                    }
+                }}
+                renderInput={inputProps => (
+                    <input
+                        {...inputProps}
+                        placeholder={props.placeholder}
+                        ref={inputRef}
+                        onFocus={e => {
+                            inputProps.onFocus?.(e);
+                            setFocused(true);
+                        }}
+                        onBlur={e => {
+                            inputProps.onBlur?.(e);
+                            setFocused(false);
+                        }}
+                        onKeyDown={e => {
+                            if (e.keyCode === 8 && tags.length > 0 && input === '') {
+                                const newTags = tags.slice(0, tags.length - 1);
+                                setTags(newTags);
+                                onTagsChange(newTags);
+                            }
+                            inputProps.onKeyDown?.(e);
+                        }}
+                        onKeyUp={e => {
+                            if (e.keyCode === 13 && input && tags.indexOf(input) === -1) {
+                                const newTags = tags.concat(input);
+                                setTags(newTags);
+                                setInput('');
+                                onTagsChange(newTags);
+                            }
+                            inputProps.onKeyUp?.(e);
+                        }}
+                    />
+                )}
+            />
+        </div>
+    );
 }

--- a/ui/src/app/shared/components/tags-input/tags-input.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import {useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {Autocomplete, AutocompleteApi, AutocompleteOption} from 'argo-ui';
 
@@ -24,12 +24,12 @@ export function TagsInput(props: TagsInputProps) {
     const [subTags, setSubTags] = useState<string[]>([]);
     const [subTagsActive, setSubTagsActive] = useState(false);
 
-    function onTagsChange(tags: string[]) {
+    useEffect(() => {
         if (props.onChange) {
             props.onChange(tags);
             setTimeout(() => autoCompleteRef.current?.refresh());
         }
-    }
+    }, [props.onChange, tags, autoCompleteRef]);
 
     return (
         <div
@@ -44,7 +44,6 @@ export function TagsInput(props: TagsInputProps) {
                             onClick={e => {
                                 const newTags = [...tags.slice(0, i), ...tags.slice(i + 1)];
                                 setTags(newTags);
-                                onTagsChange(newTags);
                                 e.stopPropagation();
                             }}
                         />
@@ -70,7 +69,6 @@ export function TagsInput(props: TagsInputProps) {
                             setTags(newTags);
                             setInput('');
                             setSubTags([]);
-                            onTagsChange(newTags);
                         }
                         setSubTagsActive(false);
                     }
@@ -92,7 +90,6 @@ export function TagsInput(props: TagsInputProps) {
                             if (e.keyCode === 8 && tags.length > 0 && input === '') {
                                 const newTags = tags.slice(0, tags.length - 1);
                                 setTags(newTags);
-                                onTagsChange(newTags);
                             }
                             inputProps.onKeyDown?.(e);
                         }}
@@ -101,7 +98,6 @@ export function TagsInput(props: TagsInputProps) {
                                 const newTags = tags.concat(input);
                                 setTags(newTags);
                                 setInput('');
-                                onTagsChange(newTags);
                             }
                             inputProps.onKeyUp?.(e);
                         }}

--- a/ui/src/app/shared/components/tags-input/tags-input.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.tsx
@@ -32,9 +32,7 @@ export function TagsInput(props: TagsInputProps) {
     }, [props.onChange, tags, autoCompleteRef]);
 
     return (
-        <div
-            className={classNames('tags-input argo-field', {'tags-input--focused': focused || !!input})}
-            onClick={() => inputRef.current?.focus()}>
+        <div className={classNames('tags-input argo-field', {'tags-input--focused': focused || !!input})} onClick={() => inputRef.current?.focus()}>
             {props.tags ? (
                 props.tags.map((tag, i) => (
                     <span className='tags-input__tag' key={tag}>

--- a/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
+++ b/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useEffect, useState} from 'react';
 import {Workflow} from '../../../../models';
 
 import {InlineTable} from '../../../shared/components/inline-table/inline-table';
@@ -18,109 +19,99 @@ interface WorkflowDrawerProps {
     onChange: (key: string) => void;
 }
 
-interface WorkflowDrawerState {
-    workflow?: Workflow;
-}
+export function WorkflowDrawer(props: WorkflowDrawerProps) {
+    const [wf, setWorkflow] = useState<Workflow>();
 
-export class WorkflowDrawer extends React.Component<WorkflowDrawerProps, WorkflowDrawerState> {
-    constructor(props: Readonly<WorkflowDrawerProps>) {
-        super(props);
-        this.state = {};
+    useEffect(() => {
+        (async () => {
+            const newWf = await services.workflows.get(props.namespace, props.name)
+            setWorkflow(newWf);
+        })();
+    }, [props.namespace, props.name]);
+
+    if (!wf) {
+        return <Loading />;
     }
 
-    public componentDidMount() {
-        services.workflows.get(this.props.namespace, this.props.name).then(workflow => {
-            this.setState({workflow});
-        });
-    }
-
-    public render() {
-        const wf = this.state.workflow;
-
-        if (!wf) {
-            return <Loading />;
-        }
-
-        return (
-            <div className='workflow-drawer'>
-                {!wf.status || !wf.status.message ? null : (
-                    <div className='workflow-drawer__section workflow-drawer__message'>
-                        <div className='workflow-drawer__title workflow-drawer__message--label'>MESSAGE</div>
-                        <div className='workflow-drawer__message--content'>{wf.status.message}</div>
-                    </div>
-                )}
-                {!wf.status || !wf.status.conditions ? null : (
-                    <div className='workflow-drawer__section'>
-                        <div className='workflow-drawer__title'>CONDITIONS</div>
-                        <div className='workflow-drawer__conditions'>
-                            <ConditionsPanel conditions={wf.status.conditions} />
-                        </div>
-                    </div>
-                )}
-                {!wf.status || !wf.status.resourcesDuration ? null : (
-                    <div className='workflow-drawer__section'>
-                        <div>
-                            <InlineTable
-                                rows={[
-                                    {
-                                        left: (
-                                            <div className='workflow-drawer__title'>
-                                                RESOURCES DURATION&nbsp;
-                                                <a
-                                                    href='https://github.com/argoproj/argo-workflows/blob/master/docs/resource-duration.md'
-                                                    onClick={e => e.stopPropagation()}
-                                                    target='_blank'>
-                                                    <i className='fas fa-info-circle' />
-                                                </a>
-                                            </div>
-                                        ),
-                                        right: (
-                                            <div>
-                                                <div>
-                                                    <span className='workflow-drawer__resourcesDuration--value'>{formatDuration(wf.status.resourcesDuration.cpu, 1)}</span>
-                                                    <span>(*1 CPU)</span>
-                                                </div>
-                                                <div>
-                                                    <span className='workflow-drawer__resourcesDuration--value'>{formatDuration(wf.status.resourcesDuration.memory, 1)}</span>
-                                                    <span>(*100Mi Memory)</span>
-                                                </div>
-                                            </div>
-                                        )
-                                    }
-                                ]}
-                            />
-                        </div>
-                    </div>
-                )}
+    return (
+        <div className='workflow-drawer'>
+            {!wf.status || !wf.status.message ? null : (
+                <div className='workflow-drawer__section workflow-drawer__message'>
+                    <div className='workflow-drawer__title workflow-drawer__message--label'>MESSAGE</div>
+                    <div className='workflow-drawer__message--content'>{wf.status.message}</div>
+                </div>
+            )}
+            {!wf.status || !wf.status.conditions ? null : (
                 <div className='workflow-drawer__section'>
-                    <div className='workflow-drawer__title'>FROM</div>
-                    <div className='workflow-drawer__workflowFrom'>
-                        <WorkflowFrom namespace={wf.metadata.namespace || 'default'} labels={wf.metadata.labels || {}} />
+                    <div className='workflow-drawer__title'>CONDITIONS</div>
+                    <div className='workflow-drawer__conditions'>
+                        <ConditionsPanel conditions={wf.status.conditions} />
                     </div>
                 </div>
-                <div className='workflow-drawer__section workflow-drawer__labels'>
-                    <div className='workflow-drawer__title'>LABELS</div>
-                    <div className='workflow-drawer__labels--list'>
-                        <WorkflowLabels
-                            workflow={wf}
-                            onChange={key => {
-                                this.props.onChange(key);
-                            }}
+            )}
+            {!wf.status || !wf.status.resourcesDuration ? null : (
+                <div className='workflow-drawer__section'>
+                    <div>
+                        <InlineTable
+                            rows={[
+                                {
+                                    left: (
+                                        <div className='workflow-drawer__title'>
+                                            RESOURCES DURATION&nbsp;
+                                            <a
+                                                href='https://github.com/argoproj/argo-workflows/blob/master/docs/resource-duration.md'
+                                                onClick={e => e.stopPropagation()}
+                                                target='_blank'>
+                                                <i className='fas fa-info-circle' />
+                                            </a>
+                                        </div>
+                                    ),
+                                    right: (
+                                        <div>
+                                            <div>
+                                                <span className='workflow-drawer__resourcesDuration--value'>{formatDuration(wf.status.resourcesDuration.cpu, 1)}</span>
+                                                <span>(*1 CPU)</span>
+                                            </div>
+                                            <div>
+                                                <span className='workflow-drawer__resourcesDuration--value'>{formatDuration(wf.status.resourcesDuration.memory, 1)}</span>
+                                                <span>(*100Mi Memory)</span>
+                                            </div>
+                                        </div>
+                                    )
+                                }
+                            ]}
                         />
                     </div>
                 </div>
-                <div className='workflow-drawer__section workflow-drawer__labels'>
-                    <div className='workflow-drawer__title'>Creator</div>
-                    <div className='workflow-drawer__labels--list'>
-                        <WorkflowCreatorInfo
-                            workflow={wf}
-                            onChange={key => {
-                                this.props.onChange(key);
-                            }}
-                        />
-                    </div>
+            )}
+            <div className='workflow-drawer__section'>
+                <div className='workflow-drawer__title'>FROM</div>
+                <div className='workflow-drawer__workflowFrom'>
+                    <WorkflowFrom namespace={wf.metadata.namespace || 'default'} labels={wf.metadata.labels || {}} />
                 </div>
             </div>
-        );
-    }
+            <div className='workflow-drawer__section workflow-drawer__labels'>
+                <div className='workflow-drawer__title'>LABELS</div>
+                <div className='workflow-drawer__labels--list'>
+                    <WorkflowLabels
+                        workflow={wf}
+                        onChange={key => {
+                            props.onChange(key);
+                        }}
+                    />
+                </div>
+            </div>
+            <div className='workflow-drawer__section workflow-drawer__labels'>
+                <div className='workflow-drawer__title'>Creator</div>
+                <div className='workflow-drawer__labels--list'>
+                    <WorkflowCreatorInfo
+                        workflow={wf}
+                        onChange={key => {
+                            props.onChange(key);
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
+++ b/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
@@ -24,7 +24,7 @@ export function WorkflowDrawer(props: WorkflowDrawerProps) {
 
     useEffect(() => {
         (async () => {
-            const newWf = await services.workflows.get(props.namespace, props.name)
+            const newWf = await services.workflows.get(props.namespace, props.name);
             setWorkflow(newWf);
         })();
     }, [props.namespace, props.name]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #9810 
Partial fix for #11740 

### Motivation

<!-- TODO: Say why you made your changes. -->

- Use newer, modern React hooks syntax instead of legacy React component lifecycle hooks

- Use newer, modern async/await syntax instead of Promise chains

Combined a few components together as previously requested. These are all components that make use of effects and other hooks (e.g. refs), but are not significantly complicated (unlike #11794, which is one complex component -- an entire page. and #11791 is all components _without_ effects).

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Convert 3 components to use hooks: `ResourceEditor`, `WorkflowDrawer`, and `TagsInput`
- `this.props` -> `props`
- `this.state` -> `useState`
  - simplify some callbacks now too
- `ref` -> `useRef`
  - rename variables to clarify that these are refs which are accessed via `.current`
- `componentDidMount` -> `useEffect`
- methods -> inner functions
  - also convert to async/await syntax as well
  - hoist child render functions into the main component

- also shorten some logic by using modern optional chaining syntax

See commit messages for more details

### Verification

<!-- TODO: Say how you tested your changes. -->
- Mostly no real semantic changes
- Manually tested a solid bit for `TagsInput` (as the refs gave some errors for a bit due to an accidental incorrect renaming) and a bit for `WorkflowDrawer`. Screenshots of them working post-refactor:
![Screenshot 2023-09-11 at 5 33 48 PM](https://github.com/argoproj/argo-workflows/assets/4970083/650877de-7b57-4dd8-8858-da900fb8fad8)
![Screenshot 2023-09-11 at 5 35 50 PM](https://github.com/argoproj/argo-workflows/assets/4970083/e0d974fd-afff-4d4c-82a6-63c110c34794)

### Notes for Reviewers

[Ignoring whitespace changes](https://github.com/argoproj/argo-workflows/pull/11800/files?w=1) makes it a bit easier to read. Though there are still a good amount of other refactorings
