### PR TITLE
test: Fix invalid parameter reference in TestInvalidNameParameterSubstitution

### DIFF
--- a/test/e2e/workflow_configmap_substitution_test.go
+++ b/test/e2e/workflow_configmap_substitution_test.go
@@ -128,7 +128,7 @@ spec:
       - name: message
         valueFrom:
           configMapKeyRef:
-            name: '{{ workflow.parameters.cm-name}'
+            name: '{{ workflow.parameters.cm-name }}'
             key: msg
     container:
       image: argoproj/argosay:v2


### PR DESCRIPTION
See https://github.com/argoproj/argo-workflows/pull/11781#issuecomment-1712437382

```
=== RUN   TestConfigMapKeySelectorSubstitutionSuite/TestInvalidNameParameterSubstitution
Submitting workflow  workflow-template-configmapkeyselector-wf-
Waiting 1m0s for workflow metadata.name=workflow-template-configmapkeyselector-wf-m2hkg
 ✖ workflow-template-configmapkeyselector-wf-m2hkg Workflow 0s      invalid spec: templates.whalesay: failed to resolve {{ workflow.parameters.cm-name}","key":"msg"}}

    workflow_configmap_substitution_test.go:141: condition never and cannot be met because the workflow is done
=== FAIL: WorkflowConfigMapSelectorSubstitutionSuite/TestInvalidNameParameterSubstitution
FAIL	github.com/argoproj/argo-workflows/v3/test/e2e	872.118s
```