### PR TITLE
fix: fix mergeWithArchivedWorkflows test data to match expected

### DIFF
--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -3,6 +3,9 @@ package workflow
 import (
 	"context"
 	"fmt"
+
+	"sort"
+
 	"testing"
 	"time"
 
@@ -663,8 +666,10 @@ func TestMergeWithArchivedWorkflows(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{UID: "3", CreationTimestamp: metav1.Time{Time: timeNow.Add(3 * time.Second)}}}
 	liveWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Live, wf2}}
 	archivedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Archived}}
-	expectedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Live, wf2, wf3}}
-	assert.Equal(t, expectedWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList).Items)
+	expectedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Live}}
+	mergedWfItems := mergeWithArchivedWorkflows(liveWfList, archivedWfList).Items
+	sort.Sort(mergedWfItems)
+	assert.Equal(t, expectedWfList.Items, mergedWfItems)
 }
 
 func TestCursorPaginationByResourceVersion(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #11815

### Motivation

https://github.com/argoproj/argo-workflows/actions/runs/6166062084/job/16734921912

<!-- TODO: Say why you made your changes. -->

### Modifications

The mergeWithArchivedWorkflows test data was modified to match expected.

Since mergeWithArchivedWorkflows does not return sorted within the function, sort.Sort() was used for testing to match expected.

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

![image](https://github.com/argoproj/argo-workflows/assets/29159013/9b049750-ad0d-4945-9f3c-cac1e71a8fb7)

