### PR TITLE
fix: use same date filter in the UI and CLI

### DIFF
--- a/cmd/argo/commands/delete.go
+++ b/cmd/argo/commands/delete.go
@@ -37,7 +37,7 @@ func NewDeleteCommand() *cobra.Command {
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			hasFilterFlag := all || allNamespaces || flags.completed || flags.resubmitted || flags.prefix != "" ||
-				flags.labels != "" || flags.fields != "" || flags.finishedAfter != "" || len(flags.status) > 0
+				flags.labels != "" || flags.fields != "" || flags.finishedBefore != "" || len(flags.status) > 0
 
 			if len(args) == 0 && !hasFilterFlag {
 				cmd.HelpFunc()(cmd, args)
@@ -90,7 +90,7 @@ func NewDeleteCommand() *cobra.Command {
 	command.Flags().StringVar(&flags.prefix, "prefix", "", "Delete workflows by prefix")
 	command.Flags().StringVarP(&flags.labels, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&flags.fields, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
-	command.Flags().StringVar(&flags.finishedAfter, "older", "", "Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
+	command.Flags().StringVar(&flags.finishedBefore, "older", "", "Delete completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
 	command.Flags().StringSliceVar(&flags.status, "status", []string{}, "Delete by status (comma separated)")
 	command.Flags().Int64VarP(&flags.chunkSize, "query-chunk-size", "", 0, "Run the list query in chunks (deletes will still be executed individually)")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Do not delete the workflow, only print what would happen")

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -22,19 +22,19 @@ import (
 )
 
 type listFlags struct {
-	namespace     string
-	status        []string
-	completed     bool
-	running       bool
-	resubmitted   bool
-	prefix        string
-	output        string
-	createdSince  string
+	namespace      string
+	status         []string
+	completed      bool
+	running        bool
+	resubmitted    bool
+	prefix         string
+	output         string
+	createdSince   string
 	finishedBefore string
-	chunkSize     int64
-	noHeaders     bool
-	labels        string
-	fields        string
+	chunkSize      int64
+	noHeaders      bool
+	labels         string
+	fields         string
 }
 
 var (

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -30,7 +30,7 @@ type listFlags struct {
 	prefix        string
 	output        string
 	createdSince  string
-	finishedAfter string
+	finishedBefore string
 	chunkSize     int64
 	noHeaders     bool
 	labels        string
@@ -82,7 +82,7 @@ func NewListCommand() *cobra.Command {
 	}
 	command.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "Show workflows from all namespaces")
 	command.Flags().StringVar(&listArgs.prefix, "prefix", "", "Filter workflows by prefix")
-	command.Flags().StringVar(&listArgs.finishedAfter, "older", "", "List completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
+	command.Flags().StringVar(&listArgs.finishedBefore, "older", "", "List completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)")
 	command.Flags().StringSliceVar(&listArgs.status, "status", []string{}, "Filter by status (comma separated)")
 	command.Flags().BoolVar(&listArgs.completed, "completed", false, "Show completed workflows. Mutually exclusive with --running.")
 	command.Flags().BoolVar(&listArgs.running, "running", false, "Show running workflows. Mutually exclusive with --completed.")
@@ -146,10 +146,10 @@ func listWorkflows(ctx context.Context, serviceClient workflowpkg.WorkflowServic
 		Filter(func(wf wfv1.Workflow) bool {
 			return strings.HasPrefix(wf.ObjectMeta.Name, flags.prefix)
 		})
-	if flags.createdSince != "" && flags.finishedAfter != "" {
+	if flags.createdSince != "" && flags.finishedBefore != "" {
 		startTime, err := argotime.ParseSince(flags.createdSince)
 		errors.CheckError(err)
-		endTime, err := argotime.ParseSince(flags.finishedAfter)
+		endTime, err := argotime.ParseSince(flags.finishedBefore)
 		errors.CheckError(err)
 		workflows = workflows.Filter(wfv1.WorkflowRanBetween(*startTime, *endTime))
 	} else {
@@ -158,8 +158,8 @@ func listWorkflows(ctx context.Context, serviceClient workflowpkg.WorkflowServic
 			errors.CheckError(err)
 			workflows = workflows.Filter(wfv1.WorkflowCreatedAfter(*t))
 		}
-		if flags.finishedAfter != "" {
-			t, err := argotime.ParseSince(flags.finishedAfter)
+		if flags.finishedBefore != "" {
+			t, err := argotime.ParseSince(flags.finishedBefore)
 			errors.CheckError(err)
 			workflows = workflows.Filter(wfv1.WorkflowFinishedBefore(*t))
 		}

--- a/cmd/argo/commands/list_test.go
+++ b/cmd/argo/commands/list_test.go
@@ -71,7 +71,7 @@ func Test_listWorkflows(t *testing.T) {
 		}
 	})
 	t.Run("Older", func(t *testing.T) {
-		workflows, err := list(&metav1.ListOptions{}, listFlags{finishedAfter: "1h"})
+		workflows, err := list(&metav1.ListOptions{}, listFlags{finishedBefore: "1h"})
 		if assert.NoError(t, err) {
 			assert.Len(t, workflows, 1)
 		}

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -128,13 +128,13 @@ export const Utils = {
         namePattern?: string;
         phases?: Array<string>;
         labels?: Array<string>;
-        minStartedAt?: Date;
-        maxStartedAt?: Date;
+        createdAfter?: Date;
+        finishedBefore?: Date;
         pagination?: Pagination;
         resourceVersion?: string;
     }) {
         const queryParams: string[] = [];
-        const fieldSelector = this.fieldSelectorParams(filter.namespace, filter.name, filter.minStartedAt, filter.maxStartedAt);
+        const fieldSelector = this.fieldSelectorParams(filter.namespace, filter.name, filter.createdAfter, filter.finishedBefore);
         if (fieldSelector.length > 0) {
             queryParams.push(`listOptions.fieldSelector=${fieldSelector}`);
         }
@@ -162,7 +162,7 @@ export const Utils = {
         return queryParams;
     },
 
-    fieldSelectorParams(namespace?: string, name?: string, minStartedAt?: Date, maxStartedAt?: Date) {
+    fieldSelectorParams(namespace?: string, name?: string, createdAfter?: Date, finishedBefore?: Date) {
         let fieldSelector = '';
         if (namespace) {
             fieldSelector += 'metadata.namespace=' + namespace + ',';
@@ -170,14 +170,14 @@ export const Utils = {
         if (name) {
             fieldSelector += 'metadata.name=' + name + ',';
         }
-        if (minStartedAt) {
-            fieldSelector += 'spec.startedAt>' + minStartedAt.toISOString() + ',';
+        if (createdAfter) {
+            fieldSelector += 'metadata.creationTimestamp>' + createdAfter.toISOString() + ',';
         }
-        if (maxStartedAt) {
-            fieldSelector += 'spec.startedAt<' + maxStartedAt.toISOString() + ',';
+        if (finishedBefore) {
+            fieldSelector += 'spec.finishedAt<' + finishedBefore.toISOString() + ',';
         }
         if (fieldSelector.endsWith(',')) {
-            fieldSelector = fieldSelector.substr(0, fieldSelector.length - 1);
+            fieldSelector = fieldSelector.substring(0, fieldSelector.length - 1);
         }
         return fieldSelector;
     },

--- a/ui/src/app/workflows/components/workflow-filters/workflow-filters.tsx
+++ b/ui/src/app/workflows/components/workflow-filters/workflow-filters.tsx
@@ -17,9 +17,9 @@ interface WorkflowFilterProps {
     phaseItems: WorkflowPhase[];
     selectedPhases: WorkflowPhase[];
     selectedLabels: string[];
-    minStartedAt?: Date;
-    maxStartedAt?: Date;
-    onChange: (namespace: string, selectedPhases: WorkflowPhase[], labels: string[], minStartedAt: Date, maxStartedAt: Date) => void;
+    createdAfter?: Date;
+    finishedBefore?: Date;
+    onChange: (namespace: string, selectedPhases: WorkflowPhase[], labels: string[], createdAfter: Date, finishedBefore: Date) => void;
 }
 
 export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
@@ -44,7 +44,7 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                         <NamespaceFilter
                             value={this.props.namespace}
                             onChange={ns => {
-                                this.props.onChange(ns, this.props.selectedPhases, this.props.selectedLabels, this.props.minStartedAt, this.props.maxStartedAt);
+                                this.props.onChange(ns, this.props.selectedPhases, this.props.selectedLabels, this.props.createdAfter, this.props.finishedBefore);
                             }}
                         />
                     </div>
@@ -55,7 +55,7 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                             autocomplete={this.labelSuggestion}
                             tags={this.props.selectedLabels}
                             onChange={tags => {
-                                this.props.onChange(this.props.namespace, this.props.selectedPhases, tags, this.props.minStartedAt, this.props.maxStartedAt);
+                                this.props.onChange(this.props.namespace, this.props.selectedPhases, tags, this.props.createdAfter, this.props.finishedBefore);
                             }}
                         />
                     </div>
@@ -87,8 +87,8 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                                     this.props.namespace,
                                     selected.map(x => x as WorkflowPhase),
                                     this.props.selectedLabels,
-                                    this.props.minStartedAt,
-                                    this.props.maxStartedAt
+                                    this.props.createdAfter,
+                                    this.props.finishedBefore
                                 );
                             }}
                             items={this.getPhaseItems(this.props.workflows)}
@@ -96,12 +96,12 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                         />
                     </div>
                     <div className='columns small-5 xlarge-12'>
-                        <p className='wf-filters-container__title'>Started Time</p>
+                        <p className='wf-filters-container__title'>Created Since</p>
                         <div className='wf-filters-container__content'>
                             <DatePicker
-                                selected={this.props.minStartedAt}
+                                selected={this.props.createdAfter}
                                 onChange={date => {
-                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, date, this.props.maxStartedAt);
+                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, date, this.props.finishedBefore);
                                 }}
                                 placeholderText='From'
                                 dateFormat='dd MMM yyyy'
@@ -110,16 +110,17 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                             />
                             <a
                                 onClick={() => {
-                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, undefined, this.props.maxStartedAt);
+                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, undefined, this.props.finishedBefore);
                                 }}>
                                 <i className='fa fa-times-circle' />
                             </a>
                         </div>
+                        <p className='wf-filters-container__title'>Finished Before</p>
                         <div className='wf-filters-container__content'>
                             <DatePicker
-                                selected={this.props.maxStartedAt}
+                                selected={this.props.finishedBefore}
                                 onChange={date => {
-                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, this.props.minStartedAt, date);
+                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, this.props.createdAfter, date);
                                 }}
                                 placeholderText='To'
                                 dateFormat='dd MMM yyyy'
@@ -128,7 +129,7 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
                             />
                             <a
                                 onClick={() => {
-                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, this.props.minStartedAt, undefined);
+                                    this.props.onChange(this.props.namespace, this.props.selectedPhases, this.props.selectedLabels, this.props.createdAfter, undefined);
                                 }}>
                                 <i className='fa fa-times-circle' />
                             </a>
@@ -140,7 +141,7 @@ export class WorkflowFilters extends React.Component<WorkflowFilterProps, {}> {
     }
 
     private setLabel(name: string, value: string) {
-        this.props.onChange(this.props.namespace, this.props.selectedPhases, [name.concat('=' + value)], this.props.minStartedAt, this.props.maxStartedAt);
+        this.props.onChange(this.props.namespace, this.props.selectedPhases, [name.concat('=' + value)], this.props.createdAfter, this.props.finishedBefore);
     }
 
     private getPhaseItems(workflows: models.Workflow[]) {

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -228,7 +228,7 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
         const finishedDate: Date = new Date(finishedAt);
 
         // check for undefined date filters as well
-        // intended to be equivalent to back-end logic: https://github.com/argoproj/argo-workflows/blob/f5e31f8f36b32883087f783cb1227490bbe36bbd/pkg/apis/workflow/v1alpha1/workflow_types.go#L222
+        // equivalent to back-end logic: https://github.com/argoproj/argo-workflows/blob/f5e31f8f36b32883087f783cb1227490bbe36bbd/pkg/apis/workflow/v1alpha1/workflow_types.go#L222
         if (createdAfter && finishedBefore) {
             return createdDate > createdAfter && finishedAt && finishedDate < finishedBefore;
         } else if (createdAfter && !finishedBefore) {

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -2,7 +2,7 @@ import {Page, SlidingPanel} from 'argo-ui';
 import * as React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import * as models from '../../../../models';
-import {labels, NODE_PHASE, Workflow, WorkflowPhase, WorkflowPhases} from '../../../../models';
+import {labels, Workflow, WorkflowPhase, WorkflowPhases} from '../../../../models';
 import {uiUrl} from '../../../shared/base';
 
 import {BasePage} from '../../../shared/components/base-page';
@@ -33,8 +33,8 @@ interface State {
     pagination: Pagination;
     selectedPhases: WorkflowPhase[];
     selectedLabels: string[];
-    minStartedAt?: Date;
-    maxStartedAt?: Date;
+    createdAfter?: Date;
+    finishedBefore?: Date;
     selectedWorkflows: Map<string, models.Workflow>;
     workflows?: Workflow[];
     resourceVersion?: string;
@@ -118,8 +118,6 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
             namespace: Utils.getNamespace(this.props.match.params.namespace) || '',
             selectedPhases: phaseQueryParam.length > 0 ? (phaseQueryParam as WorkflowPhase[]) : savedOptions.selectedPhases,
             selectedLabels: labelQueryParam.length > 0 ? (labelQueryParam as string[]) : savedOptions.selectedLabels,
-            minStartedAt: this.lastMonth(),
-            maxStartedAt: this.nextDay(),
             selectedWorkflows: new Map<string, models.Workflow>(),
             batchActionDisabled: {...allBatchActionsEnabled},
             links: [],
@@ -137,8 +135,8 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                 this.state.namespace,
                 this.state.selectedPhases,
                 this.state.selectedLabels,
-                this.state.minStartedAt,
-                this.state.maxStartedAt,
+                this.state.createdAfter,
+                this.state.finishedBefore,
                 this.state.pagination
             );
         });
@@ -183,7 +181,7 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                             clearSelection={() => this.setState({selectedWorkflows: new Map<string, models.Workflow>()})}
                             loadWorkflows={() => {
                                 this.setState({selectedWorkflows: new Map<string, models.Workflow>()});
-                                this.changeFilters(this.state.namespace, this.state.selectedPhases, this.state.selectedLabels, this.state.minStartedAt, this.state.maxStartedAt, {
+                                this.changeFilters(this.state.namespace, this.state.selectedPhases, this.state.selectedLabels, this.state.createdAfter, this.state.finishedBefore, {
                                     limit: this.state.pagination.limit
                                 });
                             }}
@@ -199,10 +197,10 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                                         phaseItems={WorkflowPhases}
                                         selectedPhases={this.state.selectedPhases}
                                         selectedLabels={this.state.selectedLabels}
-                                        minStartedAt={this.state.minStartedAt}
-                                        maxStartedAt={this.state.maxStartedAt}
-                                        onChange={(namespace, selectedPhases, selectedLabels, minStartedAt, maxStartedAt) =>
-                                            this.changeFilters(namespace, selectedPhases, selectedLabels, minStartedAt, maxStartedAt, {limit: this.state.pagination.limit})
+                                        createdAfter={this.state.createdAfter}
+                                        finishedBefore={this.state.finishedBefore}
+                                        onChange={(namespace, selectedPhases, selectedLabels, createdAfter, finishedBefore) =>
+                                            this.changeFilters(namespace, selectedPhases, selectedLabels, createdAfter, finishedBefore, {limit: this.state.pagination.limit})
                                         }
                                     />
                                 </div>
@@ -223,49 +221,33 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
         );
     }
 
-    private lastMonth() {
-        const dt = new Date();
-        dt.setMonth(dt.getMonth() - 1);
-        dt.setHours(0, 0, 0, 0);
-        return dt;
-    }
-
-    private nextDay() {
-        const dt = new Date();
-        dt.setDate(dt.getDate() + 1);
-        dt.setHours(0, 0, 0, 0);
-        return dt;
-    }
-
-    private nullSafeTimeFilter(minStartedAt: Date, maxStartedAt: Date, startedStr: string, isPending: boolean): boolean {
-        // looser check for startedStr is intentional to also check for undefined
-        if (startedStr == null) {
-            // return true if isPending
-            // else false
-            return isPending;
-        }
-        const started: Date = new Date(startedStr);
+    private nullSafeTimeFilter(createdAfter: Date, finishedBefore: Date, w: Workflow): boolean {
+        const createdAt = w.metadata.creationTimestamp; // this should always be defined
+        const finishedAt = w.status.finishedAt; // this can be undefined
+        const createdDate: Date = new Date(createdAt);
+        const finishedDate: Date = new Date(finishedAt);
 
         // check for undefined date filters as well
-        if (minStartedAt && maxStartedAt) {
-            return started > minStartedAt && started < maxStartedAt;
-        } else if (minStartedAt && !maxStartedAt) {
-            return started > minStartedAt;
-        } else if (!minStartedAt && maxStartedAt) {
-            return started < maxStartedAt;
+        // intended to be equivalent to back-end logic: https://github.com/argoproj/argo-workflows/blob/f5e31f8f36b32883087f783cb1227490bbe36bbd/pkg/apis/workflow/v1alpha1/workflow_types.go#L222
+        if (createdAfter && finishedBefore) {
+            return createdDate > createdAfter && finishedAt && finishedDate < finishedBefore;
+        } else if (createdAfter && !finishedBefore) {
+            return createdDate > createdAfter;
+        } else if (!createdAfter && finishedBefore) {
+            return finishedAt && finishedDate < finishedBefore;
         } else {
             return true;
         }
     }
 
-    private fetchWorkflows(namespace: string, selectedPhases: WorkflowPhase[], selectedLabels: string[], minStartedAt: Date, maxStartedAt: Date, pagination: Pagination): void {
+    private fetchWorkflows(namespace: string, selectedPhases: WorkflowPhase[], selectedLabels: string[], createdAfter: Date, finishedBefore: Date, pagination: Pagination): void {
         if (this.listWatch) {
             this.listWatch.stop();
         }
         this.listWatch = new ListWatch(
             () =>
                 services.workflows.list(namespace, selectedPhases, selectedLabels, pagination).then(x => {
-                    x.items = x.items?.filter(w => this.nullSafeTimeFilter(minStartedAt, maxStartedAt, w.status.startedAt, w.status.phase === NODE_PHASE.PENDING));
+                    x.items = x.items?.filter(w => this.nullSafeTimeFilter(createdAfter, finishedBefore, w));
                     return x;
                 }),
             (resourceVersion: string) => services.workflows.watchFields({namespace, phases: selectedPhases, labels: selectedLabels, resourceVersion}),
@@ -277,8 +259,8 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                         pagination: {offset: pagination.offset, limit: pagination.limit, nextOffset: metadata.continue},
                         selectedPhases,
                         selectedLabels,
-                        minStartedAt,
-                        maxStartedAt,
+                        createdAfter,
+                        finishedBefore,
                         selectedWorkflows: new Map<string, models.Workflow>()
                     },
                     this.saveHistory
@@ -291,8 +273,8 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
         this.listWatch.start();
     }
 
-    private changeFilters(namespace: string, selectedPhases: WorkflowPhase[], selectedLabels: string[], minStartedAt: Date, maxStartedAt: Date, pagination: Pagination) {
-        this.fetchWorkflows(namespace, selectedPhases, selectedLabels, minStartedAt, maxStartedAt, pagination);
+    private changeFilters(namespace: string, selectedPhases: WorkflowPhase[], selectedLabels: string[], createdAfter: Date, finishedBefore: Date, pagination: Pagination) {
+        this.fetchWorkflows(namespace, selectedPhases, selectedLabels, createdAfter, finishedBefore, pagination);
     }
 
     private saveHistory() {
@@ -399,8 +381,8 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                                                 this.state.namespace,
                                                 this.state.selectedPhases,
                                                 newTags,
-                                                this.state.minStartedAt,
-                                                this.state.maxStartedAt,
+                                                this.state.createdAfter,
+                                                this.state.finishedBefore,
                                                 this.state.pagination
                                             );
                                         }}
@@ -427,8 +409,8 @@ export class WorkflowsList extends BasePage<RouteComponentProps<any>, State> {
                                     this.state.namespace,
                                     this.state.selectedPhases,
                                     this.state.selectedLabels,
-                                    this.state.minStartedAt,
-                                    this.state.maxStartedAt,
+                                    this.state.createdAfter,
+                                    this.state.finishedBefore,
                                     pagination
                                 )
                             }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #9696 (hopefully final fix for that -- this is not a partial fix, but a holistic fix), fixes #11671
Follow-up to #11792

### Motivation

<!-- TODO: Say why you made your changes. -->

Bring the UX of the CLI and the UI together and reduce a solid amount of user confusion about this

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- UI should check against `metadata.creationTimestamp` and `status.finishedAt`, same as the CLI, not `status.startedAt`
  - rename `minStartedAt` -> `createdAfter` and `maxStartedAt` -> `finishedBefore`
  - modify `nullSafeTimeFilter` to use the same logic as the Go back-end
- remove the default 1 month filter on the UI
  - it was different from the CLI, buggy, and caused confusion for users
  - the date filter is also [entirely](https://github.com/argoproj/argo-workflows/pull/8596#discussion_r864319508) [client-side](https://github.com/argoproj/argo-workflows/blob/caedd0ff7ade8211039f3dc858f74cd4eb2b1818/ui/src/app/workflows/components/workflows-list/workflows-list.tsx#L268), so the UI was just not showing Workflows it had already retrieved from the API
  - remove no longer needed date modification code as well
- add "Created Since" and "Finished Before" as titles to the UI date filters
  - matches the CLI as well

- fix CLI's internal name for `finished` to `finishedBefore`
  - it quite literally checks for [`.Before`](https://github.com/argoproj/argo-workflows/blob/f5e31f8f36b32883087f783cb1227490bbe36bbd/pkg/apis/workflow/v1alpha1/workflow_types.go#L230), and the flag (`--older`) and flag description are correct as well, so it was just named incorrectly


- also replace unrelated [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) usage of `string.substr` with `string.substring`

### Verification

<!-- TODO: Say how you tested your changes. -->

Manually tested locally:

- No date filters (now default):
![Screenshot 2023-09-18 at 8 39 07 PM -- no dates default](https://github.com/argoproj/argo-workflows/assets/4970083/8af8d973-a631-4c7a-b692-3df0beaccb3d)
- Finished Before filter:
![Screenshot 2023-09-18 at 8 48 56 PM -- only finished before filter](https://github.com/argoproj/argo-workflows/assets/4970083/0182073f-aeb6-4722-960b-259f681e6046)
- Both date filters:
![Screenshot 2023-09-18 at 8 50 21 PM -- both filters](https://github.com/argoproj/argo-workflows/assets/4970083/bad24a3b-3ec5-443a-a53b-b76df67da496)
