### PR TITLE
docs: add hint for limiting the number of wfs

### DIFF
--- a/docs/cost-optimisation.md
+++ b/docs/cost-optimisation.md
@@ -52,6 +52,7 @@ Limit the total number of workflows using:
 * Active Deadline Seconds - terminate running workflows that do not complete in a set time. This will make sure workflows do not run forever.
 * [Workflow TTL Strategy](fields.md#ttlstrategy) - delete completed workflows after a set time.
 * [Pod GC](fields.md#podgc) - delete completed pods. By default, Pods are not deleted.
+* [`CronWorkflow`'s history limit](cron-workflows.md#cronworkflow-options) - delete completed/failed workflows which exceed the limit.
 
 Example
 

--- a/docs/cost-optimisation.md
+++ b/docs/cost-optimisation.md
@@ -52,7 +52,7 @@ Limit the total number of workflows using:
 * Active Deadline Seconds - terminate running workflows that do not complete in a set time. This will make sure workflows do not run forever.
 * [Workflow TTL Strategy](fields.md#ttlstrategy) - delete completed workflows after a set time.
 * [Pod GC](fields.md#podgc) - delete completed pods. By default, Pods are not deleted.
-* [`CronWorkflow`'s history limit](cron-workflows.md#cronworkflow-options) - delete completed/failed workflows which exceed the limit.
+* [`CronWorkflow` history limits](cron-workflows.md#cronworkflow-options) - delete successful or failed workflows which exceed the limit.
 
 Example
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

As platform owner we have enabled [Workflow Archive](https://argoproj.github.io/argo-workflows/workflow-archive/) in our company.
On the other hand, some developer set their CronWorkflow's history limits too large and caused a flood of (completed) pods and workflows, then as a result memory consumption of workflow-controller and other some controllers increased.

I took some times to identify the root cause is CronWorkflow's history limits (are too large, and large limit is not necessary ), so I'd like to suggest to refer that in cost-optimisation.md.

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
