### PR TITLE
fix: shouldn't fail to run cronworkflow because previous got shutdown on its own (race condition)

### DIFF
--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -204,7 +204,12 @@ func (woc *cronWfOperationCtx) terminateOutstandingWorkflows(ctx context.Context
 		err := util.TerminateWorkflow(ctx, woc.wfClient, wfObjectRef.Name)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				woc.log.Warnf("workflow '%s' not found when trying to terminate outstanding workflows", wfObjectRef.Name)
+				woc.log.Warnf("workflow %q not found when trying to terminate outstanding workflows", wfObjectRef.Name)
+				continue
+			}
+			alreadyShutdownErr, ok := err.(util.AlreadyShutdownError)
+			if ok {
+				woc.log.Warn(alreadyShutdownErr.Error())
 				continue
 			}
 			return fmt.Errorf("error stopping workflow %s: %e", wfObjectRef.Name, err)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1110,6 +1110,15 @@ func StopWorkflow(ctx context.Context, wfClient v1alpha1.WorkflowInterface, hydr
 	return patchShutdownStrategy(ctx, wfClient, name, wfv1.ShutdownStrategyStop)
 }
 
+type AlreadyShutdownError struct {
+	workflowName string
+	namespace    string
+}
+
+func (e AlreadyShutdownError) Error() string {
+	return fmt.Sprintf("cannot shutdown a completed workflow: workflow: %q, namespace: %q", e.workflowName, e.namespace)
+}
+
 // patchShutdownStrategy patches the shutdown strategy to a workflow.
 func patchShutdownStrategy(ctx context.Context, wfClient v1alpha1.WorkflowInterface, name string, strategy wfv1.ShutdownStrategy) error {
 	patchObj := map[string]interface{}{
@@ -1128,7 +1137,7 @@ func patchShutdownStrategy(ctx context.Context, wfClient v1alpha1.WorkflowInterf
 			return !errorsutil.IsTransientErr(err), err
 		}
 		if wf.Status.Fulfilled() {
-			return true, fmt.Errorf("cannot shutdown a completed workflow")
+			return true, AlreadyShutdownError{wf.Name, wf.Namespace}
 		}
 		_, err = wfClient.Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
 		if apierr.IsConflict(err) {

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -356,10 +356,11 @@ func TestStopWorkflowByNodeName(t *testing.T) {
 
 	origWf.Status = wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded}
 	origWf.Name = "succeeded-wf"
+	origWf.Namespace = "test-namespace"
 	_, err = wfIf.Create(ctx, origWf, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	err = StopWorkflow(ctx, wfIf, hydratorfake.Noop, "succeeded-wf", "", "")
-	assert.EqualError(t, err, "cannot shutdown a completed workflow")
+	assert.EqualError(t, err, "cannot shutdown a completed workflow: workflow: \"succeeded-wf\", namespace: \"test-namespace\"")
 }
 
 // Regression test for #6478

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -356,11 +356,10 @@ func TestStopWorkflowByNodeName(t *testing.T) {
 
 	origWf.Status = wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded}
 	origWf.Name = "succeeded-wf"
-	origWf.Namespace = "test-namespace"
 	_, err = wfIf.Create(ctx, origWf, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	err = StopWorkflow(ctx, wfIf, hydratorfake.Noop, "succeeded-wf", "", "")
-	assert.EqualError(t, err, "cannot shutdown a completed workflow: workflow: \"succeeded-wf\", namespace: \"test-namespace\"")
+	assert.EqualError(t, err, "cannot shutdown a completed workflow: workflow: \"succeeded-wf\", namespace: \"\"")
 }
 
 // Regression test for #6478


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #11377 

### Motivation

If a CronWorkflow is set with a `ConcurrencyPolicy` of `ReplaceConcurrent`, the CronWorkflow Controller, when it fires, needs to first shut down any existing Workflows.

Right now there is the case in which it tries to shut down an existing Workflow, but by the time it reaches the logic to perform the shutdown, it finds that it's already been shut down. This results in an error. When the error is received by the CronWorkflow code, it does not proceed to launch the new Workflow.

### Modifications

If the Workflow was already shut down, don't consider that to be an error that prevents launching a new Workflow.


