### PR TITLE
fix: when key not present assume NodeRunning. Fixes 11843

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -157,7 +157,9 @@ func (d *dagContext) assessDAGPhase(targetTasks []string, nodes wfv1.Nodes, isSh
 
 		node, err := nodes.Get(curr.nodeId)
 		if err != nil {
-			return "", err
+			// this is okay, this means that
+			// we are still running
+			return wfv1.NodeRunning, nil
 		}
 		// We need to store the current branchPhase to remember the last completed phase in this branch so that we can apply it to omitted nodes
 		branchPhase := curr.phase


### PR DESCRIPTION
Fixes #11843

When a node is not present in the nodes map, this implies that the DAG is still running. 
We errored out which is what causes #11843, this fixes that by assuming NodeRunning. 

## Verification

Tested on the workflow posted in #11843 