### PR TITLE
feat: improve SSE buffering between argo server and client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	google.golang.org/api v0.138.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230803162519-f966b187b2e5
 	google.golang.org/grpc v1.57.0
+	google.golang.org/protobuf v1.31.0
 	gopkg.in/go-playground/webhooks.v5 v5.17.0
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1181,6 +1181,7 @@ func (s *ArgoServerSuite) stream(url string, f func(t *testing.T, line string) (
 	}()
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "no", resp.Header.Get("X-Accel-Buffering"))
 	if t.Failed() {
 		t.FailNow()
 	}


### PR DESCRIPTION
Add Header "X-Accel-Buffering: no" to argo server responses to improve buffering between argo server and client

I tried to reuse the options of `gwmux` instead of copy-pasting them. Maybe you have an idea to make this code DRYier?

<!-- markdownlint-disable MD041 -->

Fixes #11848

### Motivation

Users that uses argo-workflows behind a Nginx Ingress Controller may be unable to access pages that uses SSE. This is because by default Nginx buffers the requests.

Some users cannot disable proxy_buffering, or for some users this does not work at all. Let's ease the deployment of argo-workflows for these users by adding the header `X-Accel-Buffering`.

### Verification

Manually deployed on a Kubernetes cluster. Without the change, SSE does not work. With, it works.