### PR TITLE
ci: temporal workaround for flakiness of TestStopBehavior

### DIFF
--- a/test/e2e/functional/stop-terminate.yaml
+++ b/test/e2e/functional/stop-terminate.yaml
@@ -11,7 +11,7 @@ spec:
         tasks:
           - name: A
             template: echo
-            onExit: exit
+            onExit: exit-template
 
     - name: echo
       container:
@@ -19,6 +19,14 @@ spec:
         command: [ sleep ]
         args: [ "999" ]
 
+    # This sleep value is only a temporal workaround ensuring template-level hooks finish faster.
+    # See https://github.com/argoproj/argo-workflows/issues/11880
     - name: exit
+      container:
+        image: argoproj/argosay:v1
+        command: [ sleep ]
+        args: [ "4" ]
+
+    - name: exit-template
       container:
         image: argoproj/argosay:v1


### PR DESCRIPTION
Signed-off-by: toyamagu2021@gmail.com <toyamagu2021@gmail.com>

<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Relates #11880
Partial fix for #10807 

### Motivation

* Fix flaky test `TestStopBehavior`

### Modifications

* Ensure workflow-level hook is finished after template-level hook is finished.

### Verification

