### PR TITLE
fix: Fixed running multiple workflows with mutex and memo concurrently is broken

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1956,6 +1956,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	if node != nil {
 		fulfilledNode := woc.handleNodeFulfilled(nodeName, node, processedTmpl)
 		if fulfilledNode != nil {
+			woc.controller.syncManager.Release(woc.wf, node.ID, processedTmpl.Synchronization)
 			return fulfilledNode, nil
 		}
 		// Memoized nodes don't have StartedAt.


### PR DESCRIPTION
Fixes #11853

### Motivation

When running multiple workflows with mutex synchronization and cache at the same time, there is an issue that mutex key is not released.

The first workflow will run correctly and release the keys, but the second workflow's 1st step will run but it does not release the key.

So this results in infinite pending nodes (like second workflow's 2nd or later nodes) as described in the issue.

### Modifications

Omitting releasing lock in [fulfilled node check after memo](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1958) in `executeTemplate` makes this problem.

When checking fulfilled node, this also should release any locks that this node have.

In `executeTemplate`,  lock is released at [first](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1834) of the function  or after running the details (like [this](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L2103C26-L2103C26) or [this](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L2097))

However, if memoization exists, node is returned as a short-cut, so currently releasing lock only depends on the [first](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1834).
Though most nodes go through `executeTemplate` multiple times by their state, Omitting releasing lock in [fulfilled node check after memo](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1958) surley makes the  problem.

Like this issue, when running multiple nodes concurrently, second workflow's first node is not `fulfilled` but cache is hit, so it pass the [first](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1834) and [fulfilled node check after memo](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1958) does not release the lock. so the later nodes cannot get the lock forever.

I just fix this issue by adding omitted releasing lock to [fulfilled node check after memo](https://github.com/argoproj/argo-workflows/blob/35e4b1700d09bf9359f31ec73f1b08061cfd4b58/workflow/controller/operator.go#L1958)

### Verification
![image](https://github.com/argoproj/argo-workflows/assets/20155452/4c0a8d72-25f7-469d-b921-e2993534c375)

Simply can test this changes works by running the workflow below few times concurrently.

The fist workflows cache hit is 'NO' and 'YES' and seconds workflows cache hit is all 'YES' with no error as expected.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: example-steps-
spec:
  entrypoint: main

  templates:
    - name: main
      steps:
        - - name: job-1
            template: sleep
            arguments:
              parameters:
                - name: sleep_duration
                  value: 30
          - name: job-2
            template: sleep
            arguments:
              parameters:
                - name: sleep_duration
                  value: 15

    - name: sleep
      synchronization:
        mutex:
          name: mutex-example-steps-simple
      inputs:
        parameters:
          - name: sleep_duration
      script:
        image: alpine:latest
        command: [/bin/sh]
        source: |
          echo "Sleeping for {{ inputs.parameters.sleep_duration }}"
          sleep {{ inputs.parameters.sleep_duration }}
      memoize:
        key: "memo-key-5"
        cache:
          configMap:
            name: cache-example-steps-simple
```