### PR TITLE
fix: Automate nix updates with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "nix": {
+    "enabled": true
+  },
+  "includePaths": [
+    "**/dev/nix/flake.nix"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
   "nix": {
     "enabled": true
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #11691

### Motivation

Uses renovate to keep `/dev/nix/flake.nix` up to date, issuing PRs whenever there is an update.

### Modifications

- @terrytangyuan installed Renovate into the repo
- This PR configures renovate to only monitor the above file and to issue PRs if a change is detected.

In my test environment you can see the renovate dependency dashboard proving that it's only looking at this file and won't affect anything else:


![image](https://github.com/argoproj/argo-workflows/assets/45351296/941dfd79-77df-43ae-b954-fbe54a55e291)

### Verification

Tweaked until I was happy with the dependency dashboard locally. I have disabled the dashboard here (because it shows as another issue and will likely conflict with stalebot).
