### PR TITLE
fix(ui): use `popup.confirm` instead of browser `confirm`

### DIFF
--- a/ui/src/app/shared/workflow-operations-map.tsx
+++ b/ui/src/app/shared/workflow-operations-map.tsx
@@ -7,7 +7,7 @@ export type OperationDisabled = {
     [action in WorkflowOperationName]: boolean;
 };
 
-type WorkflowOperationName = 'RETRY' | 'RESUBMIT' | 'SUSPEND' | 'RESUME' | 'STOP' | 'TERMINATE' | 'DELETE';
+export type WorkflowOperationName = 'RETRY' | 'RESUBMIT' | 'SUSPEND' | 'RESUME' | 'STOP' | 'TERMINATE' | 'DELETE';
 
 export interface WorkflowOperation {
     title: WorkflowOperationName;

--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -1,10 +1,10 @@
 import {NotificationType} from 'argo-ui';
 import * as React from 'react';
 import {isArchivedWorkflow, isWorkflowInCluster, Workflow} from '../../../../models';
-import {Consumer} from '../../../shared/context';
+import {Consumer, ContextApis} from '../../../shared/context';
 import {services} from '../../../shared/services';
 import * as Actions from '../../../shared/workflow-operations-map';
-import {WorkflowOperation, WorkflowOperationAction} from '../../../shared/workflow-operations-map';
+import {WorkflowOperation, WorkflowOperationAction, WorkflowOperationName} from '../../../shared/workflow-operations-map';
 
 require('./workflows-toolbar.scss');
 
@@ -46,21 +46,22 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
         return this.props.selectedWorkflows.size;
     }
 
-    private performActionOnSelectedWorkflows(ctx: any, title: string, action: WorkflowOperationAction): Promise<any> {
-        let deleteArchived = false;
-        const confirmed = confirm(`Are you sure you want to ${title.toLowerCase()} all selected workflows?`);
-        if (confirmed) {
-            if (title === 'DELETE') {
-                for (const entry of this.props.selectedWorkflows) {
-                    if (isArchivedWorkflow(entry[1])) {
-                        deleteArchived = confirm('Do you also want to delete them from the Archived Workflows database?');
-                        break;
-                    }
-                }
-            }
-        } else {
+    private async performActionOnSelectedWorkflows(ctx: ContextApis, title: string, action: WorkflowOperationAction): Promise<any> {
+        const confirmed = await ctx.popup.confirm('Confirm', `Are you sure you want to ${title.toLowerCase()} all selected workflows?`);
+        if (!confirmed) {
             return Promise.resolve(false);
         }
+
+        let deleteArchived = false;
+        if (title === 'DELETE') {
+            for (const entry of this.props.selectedWorkflows) {
+                if (isArchivedWorkflow(entry[1])) {
+                    deleteArchived = await ctx.popup.confirm('Confirm', 'Do you also want to delete them from the Archived Workflows database?');
+                    break;
+                }
+            }
+        }
+
         const promises: Promise<any>[] = [];
         this.props.selectedWorkflows.forEach((wf: Workflow) => {
             if (title === 'DELETE') {
@@ -100,28 +101,29 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
         return Promise.all(promises);
     }
 
-    private renderActions(ctx: any): JSX.Element[] {
+    private renderActions(ctx: ContextApis): JSX.Element[] {
         const actionButtons = [];
         const actions: any = Actions.WorkflowOperationsMap;
-        const disabled: any = this.props.isDisabled;
-        const groupActions: WorkflowGroupAction[] = Object.keys(actions).map(actionName => {
+        const disabled = this.props.isDisabled;
+        const groupActions: WorkflowGroupAction[] = Object.keys(actions).map((actionName: WorkflowOperationName) => {
             const action = actions[actionName];
             return {
                 title: action.title,
                 iconClassName: action.iconClassName,
                 groupIsDisabled: disabled[actionName],
                 action,
-                groupAction: () => {
-                    return this.performActionOnSelectedWorkflows(ctx, action.title, action.action).then(confirmed => {
-                        if (confirmed) {
-                            this.props.clearSelection();
-                            ctx.notifications.show({
-                                content: `Performed '${action.title}' on selected workflows.`,
-                                type: NotificationType.Success
-                            });
-                            this.props.loadWorkflows();
-                        }
+                groupAction: async () => {
+                    const confirmed = await this.performActionOnSelectedWorkflows(ctx, action.title, action.action)
+                    if (!confirmed) {
+                        return
+                    }
+
+                    this.props.clearSelection();
+                    ctx.notifications.show({
+                        content: `Performed '${action.title}' on selected workflows.`,
+                        type: NotificationType.Success
                     });
+                    this.props.loadWorkflows();
                 },
                 className: action.title,
                 disabled: () => false

--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -113,9 +113,9 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
                 groupIsDisabled: disabled[actionName],
                 action,
                 groupAction: async () => {
-                    const confirmed = await this.performActionOnSelectedWorkflows(ctx, action.title, action.action)
+                    const confirmed = await this.performActionOnSelectedWorkflows(ctx, action.title, action.action);
                     if (!confirmed) {
-                        return
+                        return;
                     }
 
                     this.props.clearSelection();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #11905 
Partial fix for #11740 

### Motivation

<!-- TODO: Say why you made your changes. -->

- browser [`confirm`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) is a blocking sync method; replace with the conventional and consistently styled `popup.confirm`
  - `popup.confirm` creates an HTML modal instead
  - this was the last place in the codebase that still used browser `confirm` and not `popup.confirm`
  
- in particular, as #11905 shows, browser `confirm` was causing the browser to allow users to disable the prompt, which would make it _impossible_ to confirm
  - this is because, when there is an archived workflow, two `confirm`s would be used in a row -- one for the batch action and one for the archive delete
    - the browser detects two in a row as possible spam / abuse, and has a checkbox to disable prompts for the entire site

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- sync `confirm` -> async `popup.confirm`

- also fix various typing issues in the `WorkflowsToolbar` component while at it
  - there were several unnecessary `any`s that could use an actual type
  - not quite all of them though

- convert some syntax to use async/await as well instead of promise chains
- invert some conditionals to reduce nesting as well

### Verification

<!-- TODO: Say how you tested your changes. -->

Before, using browser API `confirm`:
![Screenshot 2023-09-30 at 12 01 48 AM -- confirm browser api](https://github.com/argoproj/argo-workflows/assets/4970083/c76287fc-9428-478c-9f8f-b6133bfe9d93)


After, using `popup.confirm` modal:
![Screenshot 2023-09-29 at 11 45 16 PM -- confirm modal](https://github.com/argoproj/argo-workflows/assets/4970083/9781691d-e9ee-4457-b0d1-93e05bc435c6)




