### PR TITLE
fix(ui): ensure `WorkflowsRow` message is not too long

### DIFF
--- a/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
@@ -62,7 +62,8 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                         <Ticker>{() => <DurationPanel phase={wf.status.phase} duration={wfDuration(wf.status)} estimatedDuration={wf.status.estimatedDuration} />}</Ticker>
                     </div>
                     <div className='columns small-1'>{wf.status.progress || '-'}</div>
-                    <div className='columns small-2'>{wf.status.message || '-'}</div>
+                    {/* CSS has text-overflow, but sometimes it's still too long for the column for some reason, so slice it too. 180 chars are not visible on a 4k screen */}
+                    <div className='columns small-2'>{wf.status.message?.slice(0, 180) || '-'}</div>
                     <div className='columns small-1'>
                         <div className='workflows-list__labels-container'>
                             <div
@@ -99,9 +100,7 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                         <WorkflowDrawer
                             name={wf.metadata.name}
                             namespace={wf.metadata.namespace}
-                            onChange={key => {
-                                props.onChange(key);
-                            }}
+                            onChange={props.onChange}
                         />
                     )}
                 </Link>

--- a/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
@@ -94,15 +94,7 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                             </div>
                         );
                     })}
-                    {hideDrawer ? (
-                        <span />
-                    ) : (
-                        <WorkflowDrawer
-                            name={wf.metadata.name}
-                            namespace={wf.metadata.namespace}
-                            onChange={props.onChange}
-                        />
-                    )}
+                    {hideDrawer ? <span /> : <WorkflowDrawer name={wf.metadata.name} namespace={wf.metadata.namespace} onChange={props.onChange} />}
                 </Link>
             </div>
         </div>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

`WorkflowsRow` could have styling issues when the message was too long

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- cut it off at 180 chars
  - tested with browser devtools on a 4k width screen and 180 was way more than it could display anyway inside 2 columns - so this is an overshoot
- note that per comment, this does _already_ have a CSS `text-overflow`, but when the message was _very_ long, it would still go beyond the width and cause styling issues
  - so doubly cut it off with less than a line of JS
  
- also simplify `onChange` callback
  - no need to wrap in an anonymous func

### Verification

<!-- TODO: Say how you tested your changes. -->

Before, with styling issues:
![Screenshot 2023-09-29 at 11 59 55 PM -- overflow issue](https://github.com/argoproj/argo-workflows/assets/4970083/d04aa8fc-08ef-4a85-83de-59264450e632)

After, no styling issues and still properly overflows on a ~4k width screen:
![Screenshot 2023-09-29 at 11 40 57 PM -- 4k still overflows fine](https://github.com/argoproj/argo-workflows/assets/4970083/f6abc316-eae9-4715-ac1e-f1093b327dfe)

