### PR TITLE
ci: increase sleep time for very flaky hook test

### DIFF
--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -147,12 +147,13 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
+        args: ["/bin/sleep 2; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, status.Progress, v1alpha1.Progress("6/6"))
 			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 		return strings.Contains(status.Name, "step-1.hooks.succeed")

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -260,12 +260,13 @@ spec:
       container:
         image: argoproj/argosay:v2
         command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
+        args: ["/bin/sleep 2; /argosay"]
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, status.Progress, v1alpha1.Progress("6/6"))
 			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 		return strings.Contains(status.Name, "step-1.hooks.succeed")


### PR DESCRIPTION
Signed-off-by: toyamagu-2021 <toyamagu2021@gmail.com>

<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #10807

### Motivation

* Address to https://github.com/argoproj/argo-workflows/issues/10807#issuecomment-1728685887
* Increase sleep time to give enough time to trigger the running hook
* Add `Progress` assertion to understood problem
