### PR TITLE
[agent-go-#L35/11898] - Example added to agent.go for NewAgentInitCom…

### DIFF
--- a/cmd/argoexec/commands/agent.go
+++ b/cmd/argoexec/commands/agent.go
@@ -35,7 +35,7 @@ func NewAgentInitCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "Initialize a new agent workflow",
-		Example: `# Initialize a workflow:
+		Example: `# Initialize a workflow for new agent:
 
 	argo init my-wf
 			  

--- a/cmd/argoexec/commands/agent.go
+++ b/cmd/argoexec/commands/agent.go
@@ -33,7 +33,40 @@ func NewAgentCommand() *cobra.Command {
 
 func NewAgentInitCommand() *cobra.Command {
 	return &cobra.Command{
-		Use: "init",
+		Use:   "init",
+		Short: "Initialize a new agent workflow",
+		Example: `# Initialize a workflow:
+
+	argo init my-wf
+			  
+# Init multiple workflows:
+			  
+	argo init my-wf my-other-wf my-third-wf
+			  
+# Init multiple workflows by label selector:
+			  
+	argo init -l workflows.argoproj.io/test=true
+			  
+# Init multiple workflows by field selector:
+			  
+	argo init --field-selector metadata.namespace=argo
+		  
+# Init and wait for completion:
+			  
+	argo init --wait my-wf.yaml
+			  
+# Init and watch until completion:
+			  
+	argo init --watch my-wf.yaml
+			  
+# Init and tail logs until completion:
+			  
+	argo init --log my-wf.yaml
+		  
+# Init the latest workflow:
+			  
+	argo init @latest
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, name := range getPluginNames() {
 				filename := tokenFilename(name)


### PR DESCRIPTION
<!-- Does this PR fix an issue -->
Yes

Fixes #11898 

### Motivation

I have added the --help-output for agent.go file in which a function called NewAgentInitCommand() returns a cobra command and initiates a workflow.

### Modifications
I have added the example output for the **NewAgentInitCommand()**

### Verification
While running the argo init cobra command. I verified the changes example is coming.
