### PR TITLE
feat: added example support for artifact command in root.go (#11898)

### DIFF
--- a/cmd/argoexec/commands/artifact/root.go
+++ b/cmd/argoexec/commands/artifact/root.go
@@ -7,8 +7,8 @@ import (
 func NewArtifactCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "artifact",
-		Short: "Implement a new artifact",
-		Example: `# Initialize a workflow for new artifact:
+		Short: "Create a new artifact",
+		Example: `# Initialize for new artifact:
 
 	argo artifact my-wf
 			  

--- a/cmd/argoexec/commands/artifact/root.go
+++ b/cmd/argoexec/commands/artifact/root.go
@@ -6,7 +6,40 @@ import (
 
 func NewArtifactCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "artifact",
+		Use:   "artifact",
+		Short: "Implement a new artifact",
+		Example: `# Initialize a workflow for new artifact:
+
+	argo artifact my-wf
+			  
+# Artifact multiple workflows:
+			  
+	argo artifact my-wf my-other-wf my-third-wf
+			  
+# Artifact multiple workflows by label selector:
+			  
+	argo artifact -l workflows.argoproj.io/test=true
+			  
+# Artifact multiple workflows by field selector:
+			  
+	argo artifact --field-selector metadata.namespace=argo
+		  
+# Artifact and wait for completion:
+			  
+	argo artifact --wait my-wf.yaml
+			  
+# Artifact and watch until completion:
+			  
+	argo artifact --watch my-wf.yaml
+			  
+# Artifact and tail logs until completion:
+			  
+	argo artifact --log my-wf.yaml
+		  
+# Artifact the latest workflow:
+			  
+	argo artifact @latest
+`,
 	}
 	cmd.AddCommand(NewArtifactDeleteCommand())
 	return cmd


### PR DESCRIPTION
<!-- Does this PR fix an issue -->
Yes, it fixes by adding the example support for the artifact command.

Fixes #11898 

### Motivation
I have made my changes to support more detailed information when someone triggers or runs artifact cobra command.

### Verification
by running - `argo artifact my-wf`
