### PR TITLE
docs: specify where `activeDeadlineSeconds` can be set

### DIFF
--- a/docs/walk-through/timeouts.md
+++ b/docs/walk-through/timeouts.md
@@ -1,9 +1,26 @@
 # Timeouts
 
-To limit the elapsed time for a workflow, you can set the variable `activeDeadlineSeconds`.
+You can use the field `activeDeadlineSeconds` to limit the elapsed time for a workflow:
 
 ```yaml
-# To enforce a timeout for a container template, specify a value for activeDeadlineSeconds.
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: timeouts-
+spec:
+  activeDeadlineSeconds: 10 # terminate workflow after 10 seconds
+  entrypoint: sleep
+  templates:
+  - name: sleep
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo sleeping for 1m; sleep 60; echo done"]
+```
+
+You can limit the elapsed time for a specific template as well:
+
+```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -12,9 +29,9 @@ spec:
   entrypoint: sleep
   templates:
   - name: sleep
+    activeDeadlineSeconds: 10 # terminate container template after 10 seconds
     container:
       image: alpine:latest
       command: [sh, -c]
       args: ["echo sleeping for 1m; sleep 60; echo done"]
-    activeDeadlineSeconds: 10           # terminate container template after 10 seconds
 ```


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Small follow-up to https://github.com/argoproj/argo-workflows/discussions/11940#discussioncomment-7187258, where I realized the "Timeout" page did not specify that the `activeDeadlineSeconds` field can be set in two different places: [Workflow-level](https://argoproj.github.io/argo-workflows/fields/#workflowspec) _and_ [template-level](https://argoproj.github.io/argo-workflows/fields/#template)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- show an example of both -- same example, just `activeDeadlineSeconds` in two different places
  - move the field up a bit so it's more visible as well

- also [use active voice](https://kubernetes.io/docs/contribute/style/style-guide/#use-active-voice), per k8s style guide

### Verification

<!-- TODO: Say how you tested your changes. -->

n/a, docs change