### PR TITLE
fix(ui): faulty `setInterval` -> `setTimeout` in clipboard

### DIFF
--- a/ui/src/app/shared/components/clipboard-text.tsx
+++ b/ui/src/app/shared/components/clipboard-text.tsx
@@ -2,8 +2,8 @@ import {Tooltip} from 'argo-ui';
 import * as React from 'react';
 import {useState} from 'react';
 
-export const ClipboardText = ({text}: {text: string}) => {
-    const [justClicked, setJustClicked] = useState<boolean>(false);
+export function ClipboardText({text}: {text: string}) {
+    const [justClicked, setJustClicked] = useState(false);
 
     if (!text) {
         return <></>;
@@ -20,11 +20,11 @@ export const ClipboardText = ({text}: {text: string}) => {
                         onClick={() => {
                             setJustClicked(true);
                             navigator.clipboard.writeText(text);
-                            setInterval(() => setJustClicked(false), 2000);
+                            setTimeout(() => setJustClicked(false), 2000);
                         }}
                     />
                 </a>
             </Tooltip>
         </>
     );
-};
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

`setInterval` is incorrect in this context, it should be `setTimeout`
- this is a tiny optimization
- I just stumbled upon this while looking at tooltip usage. Also _unrelated_ to the [recent Slack thread](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1696440502865469), I happened to already be looking at tooltips after a [different thread](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1695922722824439) from last week.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- [`setInterval`](https://developer.mozilla.org/en-US/docs/Web/API/setInterval) is for calling a function on an interval, i.e. once every 2s
  - it also requires clean-up with [`clearInterval`](https://developer.mozilla.org/en-US/docs/Web/API/clearInterval), which this component does not do
  - whereas [`setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) calls a function once after a timeout, i.e. after 2s
    - that is the correct behavior here -- to close the tooltip 2s after it was copied, not to continuously close it every 2s
    
- also convert anonymous function to named function for better traceability etc

### Verification

<!-- TODO: Say how you tested your changes. -->

simple semantic change