### PR TITLE
fix(ui): `ClipboardText` tooltip properly positioned

### DIFF
--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.scss
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.scss
@@ -16,6 +16,7 @@
         line-height: 24px;
         display: inline-block;
         vertical-align: middle;
+        overflow-x: auto !important; // override `.workflow-details__atribute-grid pre` selector
     }
 
     &__artifact-details span {
@@ -61,7 +62,7 @@
         span {
             color: $argo-color-teal-5;
         }
-        
+
         i {
             float: right;
             font-size: 1.5em;

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -69,7 +69,7 @@ interface Props {
 const AttributeRow = (attr: {title: string; value: any}) => (
     <React.Fragment key={attr.title}>
         <div>{attr.title}</div>
-        <div style={{overflow: 'auto hidden'}}>{attr.value}</div>
+        <div>{attr.value}</div>
     </React.Fragment>
 );
 const AttributeRows = (props: {attributes: {title: string; value: any}[]}) => (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- it seems that with the [new version of `tippy`](https://github.com/argoproj/argo-ui/pull/297) (which was pulled in as part of #11585) the `overflow` property made it show up directly above the text (in the z direction)
  - this meant that you could not click on the clipboard to copy because it would cover the icon 😕

This was found by a user and noted [on Slack](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1696440502865469). I then reproduced this myself, see below screenshot with incorrect positioning:
![Screenshot 2023-10-04 at 5 13 33 PM -- clipboard before](https://github.com/argoproj/argo-workflows/assets/4970083/3c8a32b0-49cf-48d5-a0c3-a57dd9cc8446)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- the original PR #8947 that added `overflow` here was for horizontal scrolling for multi-line args in code blocks (`<pre>` elements)
  - so I moved the `overflow` into the `pre` element's `class` more specifically and made it specific for the `x` direction
    - note that these code block elements do not have a clipboard button to copy their text

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested locally with a few different variations, see screenshots below.

Single-line clipboard tooltip positioned correctly:
![Screenshot 2023-10-04 at 5 34 25 PM -- clipboard one-line](https://github.com/argoproj/argo-workflows/assets/4970083/ae8824df-18c1-415f-98ef-f2e933dde406)

Multi-line clipboard tooltip positioned correctly:
![Screenshot 2023-10-04 at 5 06 11 PM -- clipboard multi-line](https://github.com/argoproj/argo-workflows/assets/4970083/e9535b76-6243-4cd1-aa55-ccd8a6da169e)

Horizontal overflow on code blocks still works:
![Screenshot 2023-10-04 at 5 07 16 PM -- overflow horizontal still works](https://github.com/argoproj/argo-workflows/assets/4970083/54818471-ac6b-4948-9b99-af4964ca90f7)

Horizontal overflow on multi-line code blocks still works:
![Screenshot 2023-10-04 at 5 11 23 PM -- horizontal scroll multi-line](https://github.com/argoproj/argo-workflows/assets/4970083/63b0ea12-afa6-43ff-861c-99cddc36de18)


