### PR TITLE
ci: E2E_ENV_FACTOR to 2 because TestParallel is very flaky

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -64,6 +64,7 @@ jobs:
     timeout-minutes: 30
     env:
       KUBECONFIG: /home/runner/.kubeconfig
+      E2E_ENV_FACTOR: 2
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Partial Fixes #10807 

### Motivation

* `TestParallel` is flaky (It takes ~11sec although the test requires < 10s)
   * https://github.com/argoproj/argo-workflows/blob/1a83117b1d45d3c52e8f5ea08c5929b5a4b45e6c/test/e2e/agent_test.go#L67
* Jobs
   * https://github.com/argoproj/argo-workflows/actions/runs/6410678697/job/17404702303?pr=11945
   * https://github.com/argoproj/argo-workflows/actions/runs/6440659448?pr=11839

### Modifications

* Change `E2E_ENV_FACTOR` to 2 (default is 1)
  * https://github.com/argoproj/argo-workflows/blob/1a83117b1d45d3c52e8f5ea08c5929b5a4b45e6c/test/e2e/fixtures/e2e_suite.go#L41-L42

### Verification


