### PR TITLE
chore: Use same text for Sensors and Event Source

### DIFF
--- a/ui/src/app/event-sources/components/event-source-list/event-source-list.tsx
+++ b/ui/src/app/event-sources/components/event-source-list/event-source-list.tsx
@@ -151,7 +151,7 @@ export const EventSourceList = ({match, location, history}: RouteComponentProps<
                         ))}
                     </div>
                     <Footnote>
-                        <a onClick={() => navigation.goto(uiUrl('event-flow/' + namespace))}>Show events-flow page</a>
+                        <a onClick={() => navigation.goto(uiUrl('event-flow/' + namespace))}>Show event-flow page</a>
                     </Footnote>
                 </>
             )}


### PR DESCRIPTION
Making sure that the highlighted section shows the same text for the Sensors page and the Event Source page (being 'Show event-flow page):
![image](https://github.com/argoproj/argo-workflows/assets/22411346/544a6479-5d63-4ae1-9668-25e0ef9b3a83)
![image](https://github.com/argoproj/argo-workflows/assets/22411346/b1636c6c-7ada-40a0-812c-18634077c559)
