### PR TITLE
fix: show pagination warning on all pages (fixes #11968)

### DIFF
--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -19,7 +19,7 @@ export function PaginationPanel(props: {pagination: Pagination; onChange: (pagin
                 }>
                 Next page <i className='fa fa-chevron-right' />
             </button>
-            {props.pagination.limit > 0 && props.pagination.limit <= props.numRecords ? (
+            {props.pagination.limit > 0 ? (
                 <>
                     <WarningIcon /> Workflows cannot be globally sorted when paginated
                 </>


### PR DESCRIPTION
When limiting the number of visible records in the workflow page, the pagination warning is now shown on all pages (not depending on the number of records on that page).

Fixes #11968 
