### PR TITLE
fix(ui): don't show pagination warning on first page if all are displayed

### DIFF
--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -19,7 +19,8 @@ export function PaginationPanel(props: {pagination: Pagination; onChange: (pagin
                 }>
                 Next page <i className='fa fa-chevron-right' />
             </button>
-            {props.pagination.limit > 0 ? (
+            {/* if pagination is used, and we're either not on the first page, or are on the first page and have more records than the page limit */}
+            {props.pagination.limit > 0 && (props.pagination.offset || (!props.pagination.offset && props.numRecords >= props.pagination.limit)) ? (
                 <>
                     <WarningIcon /> Workflows cannot be globally sorted when paginated
                 </>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes my review comment in https://github.com/argoproj/argo-workflows/pull/11973#discussion_r1353099743
Fixes #11968 without a regression

### Motivation

<!-- TODO: Say why you made your changes. -->

- example: if you're on the first page and your pagination limit is 50 while you only have 10 total workflows, then the warning shouldn't show, as you already see all 10 workflows

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- this new logic should handle both the first page and the last page issues
  - added a comment to word it out as well, which was actually very helpful in debugging and properly writing the logic (as it's a bit convoluted)

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested manually. See https://github.com/argoproj/argo-workflows/pull/11973#discussion_r1353099743 for more details

Before:
![Screenshot 2023-10-10 at 2 01 08 PM -- before](https://github.com/argoproj/argo-workflows/assets/4970083/94d60349-9fb9-409b-ae07-34fd185e224b)

After:
![Screenshot 2023-10-10 at 2 28 04 PM -- after](https://github.com/argoproj/argo-workflows/assets/4970083/90fe757f-7fe7-46d4-9a1e-811735ebf770)
