### PR TITLE
build: fix GH Codespaces building indefinitely

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
     "--add-host=mysql:127.0.0.1",
     "--add-host=azurite:127.0.0.1"
   ],
-  "onCreateCommand": ".devcontainer/pre-build.sh",
+  "postCreateCommand": ".devcontainer/pre-build.sh",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/go/src/github.com/argoproj/argo-workflows,type=bind",
   "workspaceFolder": "/home/vscode/go/src/github.com/argoproj/argo-workflows",
   "remoteEnv": {

--- a/.spelling
+++ b/.spelling
@@ -35,6 +35,7 @@ ArgoLabs
 Artifactory
 BlackRock
 Breitgand
+Codespaces
 Couler
 ClusterRoleBinding
 CRD

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -2,7 +2,7 @@
 
 You have two options:
 
-1. Use the [Dev Container](#development-container). This takes about 7 minutes. This can be used with VSCode or with the `devcontainer` CLI.
+1. Use the [Dev Container](#development-container). This takes about 7 minutes. This can be used with VSCode, the `devcontainer` CLI, or GitHub Codespaces.
 1. Install the [requirements](#requirements) on your computer manually. This takes about 1 hour.
 
 ## Development Container
@@ -13,10 +13,9 @@ You can use the development container in a few different ways:
 
 1. [Visual Studio Code](https://code.visualstudio.com/) with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Open your `argo-workflows` folder in VSCode and it should offer to use the development container automatically. VSCode will allow you to forward ports to allow your external browser to access the running components.
 1. [`devcontainer` CLI](https://github.com/devcontainers/cli). Once installed, go to your `argo-workflows` folder and run `devcontainer up --workspace-folder .` followed by `devcontainer exec --workspace-folder . /bin/bash` to get a shell where you can build the code. You can use any editor outside the container to edit code; any changes will be mirrored inside the container. Due to a limitation of the CLI, only port 8080 (the Web UI) will be exposed for you to access if you run this way. Other services are usable from the shell inside.
+1. [GitHub Codespaces](https://github.com/codespaces). You can start editing as soon as VSCode is open, though you may want to wait for `pre-build.sh` to finish installing dependencies, building binaries, and setting up the cluster before running any commands in the terminal. Once you start running services (see next steps below), you can click on the "PORTS" tab in the VSCode terminal to see all forwarded ports. You can open the Web UI in a new tab from there.
 
 Once you have entered the container, continue to [Developing Locally](#developing-locally).
-
-`Github Codespaces` is known not to work at this time.
 
 Note:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #11423

### Motivation

<!-- TODO: Say why you made your changes. -->

Make contributing easier for many users and those without too powerful local specs! Lots of folks have wanted to use it in issues and on Slack, so hopefully this should be a big help! 🙂  

- Codespaces would run indefinitely on the `onCreateCommand` and never finish (seemingly due to `kit`? https://github.com/kitproj/kit/issues/44)
  - also it would just eat up CPU hours on Codespaces, even if you closed the tab and turned off your computer
    - had to manually go into Codespaces settings and turn it off after GH sent me an email that I used 24 CPU hours overnight while I was asleep 🫠


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use [`postCreateCommand`](https://containers.dev/implementors/json_reference/#lifecycle-scripts) instead of `onCreateCommand`
  - `postCreateCommand` runs asynchronously _after_ the container is started, unlike `onCreateCommand`
  - this finished fine in my Codespace
   - this also lets you access the codespace very quickly as `pre-build.sh` is running async!
   
- add GH Codespaces instructions to the developer docs (not exactly "running locally" though... 🤔 I believe you can connect a local VSCode editor to it though)
  - link to GH Codespaces
  - warn about async `pre-build.sh` -- can start editing, but may want to hold off running commands
    - (unless you know what you're doing -- you don't _necessarily_ need to wait for everything to be ready for every command, but will want that for any testing or building)
  - instruct on how to use forwarded ports
  
- remove old warning about Codespaces not working!

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes

Ran it myself and got a Codespace running successfully! Screenshots:

Editor and Terminal with `kit` running, `pre-build.sh` complete and things are ready ("Finished configuring codespace" message at the bottom right):
![Screenshot 2023-10-10 at 6 02 04 PM](https://github.com/argoproj/argo-workflows/assets/4970083/0d61ff92-84c7-49c8-b284-0dac6e17a1aa)

Ports tab:
![Screenshot 2023-10-10 at 6 01 50 PM](https://github.com/argoproj/argo-workflows/assets/4970083/5e81f022-4d3d-4e10-a9f7-42cc6ab6d357)

UI open in a new tab connected to the codespace:
![Screenshot 2023-10-10 at 5 58 00 PM -- CODESPACES IS WORKING!!](https://github.com/argoproj/argo-workflows/assets/4970083/0d0d40ab-41e7-48c2-b2f3-6dc12acee5ad)