### PR TITLE
fix(ui): remove "last month" default date filter mention from New Version Modal

### DIFF
--- a/ui/src/app/modals/new-version/new-version-modal.tsx
+++ b/ui/src/app/modals/new-version/new-version-modal.tsx
@@ -47,9 +47,7 @@ export const NewVersionModal = ({version, dismiss}: {version: string; dismiss: (
                     </a>
                     in the middle of the workflow
                 </li>
-                <li>
-                    Filter by date and time in the UI. <b>New default</b>: only show the past month's Workflows.
-                </li>
+                <li>Filter by date and time in the UI</li>
             </ul>
             <p>
                 <a href='https://blog.argoproj.io/what-to-expect-in-argo-workflows-v3-4-711702ad88e9?utm_source=argo-ui' target='_blank'>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

For 3.4.12+: https://github.com/argoproj/argo-workflows/issues/11851#issuecomment-1741687882
Follow-up to #11742 and #11840

### Motivation

<!-- TODO: Say why you made your changes. -->

- I removed and fixed the UI date filter in #11840
  - if that fix is going to go into 3.4.x, we should remove the "New default" notice in the New Version Modal as it no longer exists
  - I added that notice in #11742 before I fixed & removed that default, but neither of those two commits have made it into a patch release yet
    - so they can be "squashed" together and the "New default" removed as such
    
### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Remove "New default" mention from the New Version Modal for 3.4

### Verification

<!-- TODO: Say how you tested your changes. -->

Ran `yarn lint`. Otherwise this is just a simple text change to a modal