### PR TITLE
fix(windows): prevent infinite run. Fixes #11810

### DIFF
--- a/workflow/executor/os-specific/command.go
+++ b/workflow/executor/os-specific/command.go
@@ -3,27 +3,12 @@ package os_specific
 import (
 	"io"
 	"os"
-	"os/exec"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/term"
 )
 
 var logger = log.WithField("argo", true)
-
-func simpleStart(cmd *exec.Cmd) (func(), error) {
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	closer := func() {
-		cmd.WaitDelay = 100 * time.Millisecond
-		_ = cmd.Wait()
-	}
-
-	return closer, nil
-}
 
 func isTerminal(stdin io.Reader) bool {
 	f, ok := stdin.(*os.File)

--- a/workflow/executor/os-specific/command_unix.go
+++ b/workflow/executor/os-specific/command_unix.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 	"golang.org/x/term"
@@ -84,6 +85,19 @@ func StartCommand(cmd *exec.Cmd) (func(), error) {
 		_ = term.Restore(int(stdin.Fd()), oldState)
 		_ = ptmx.Close()
 		origCloser()
+	}
+
+	return closer, nil
+}
+
+func simpleStart(cmd *exec.Cmd) (func(), error) {
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	closer := func() {
+		cmd.WaitDelay = 100 * time.Millisecond
+		_ = cmd.Wait()
 	}
 
 	return closer, nil

--- a/workflow/executor/os-specific/command_windows.go
+++ b/workflow/executor/os-specific/command_windows.go
@@ -15,3 +15,14 @@ func StartCommand(cmd *exec.Cmd) (func(), error) {
 	}
 	return simpleStart(cmd)
 }
+
+func simpleStart(cmd *exec.Cmd) (func(), error) {
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	closer := func() {
+	}
+
+	return closer, nil
+}


### PR DESCRIPTION
windows based workflows already call .Wait() in signal_windows.go, calling it twice will result in not exiting at all.

Unix based workflows prevent that by releasing the process early on and checking exit code of all running processes.

Windows workflows don't do this and without knowing in-depth how windows processes work, I didn't find a way to achieve a similar "wait for all processes" syscall.

Fixes #11810

### Motivation

The windows-only bug got introduced with PR #11368 but wasn't catched because seemingly windows tests aren't run automatically. 

### Modifications

`simpleStart` is now os specific code and does not attach a WaitDelay nor a Wait to the closer function. 

### Verification

Ran the changed code locally and ran the windows emissary command tests locally which now run through again. 
