### PR TITLE
refactor: rendering workflow list after perfoming action button in WorkflowToolBar 

### DIFF
--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -80,6 +80,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
     const [workflows, setWorkflows] = useState<Workflow[]>();
     const [links, setLinks] = useState<models.Link[]>([]);
     const [columns, setColumns] = useState<models.Column[]>([]);
+    const [performed, setPerformed] = useState(false);
     const [error, setError] = useState<Error>();
 
     const batchActionDisabled = useMemo<Actions.OperationDisabled>(() => {
@@ -97,6 +98,10 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
 
     function clearSelectedWorkflows() {
         setSelectedWorkflows(new Map<string, models.Workflow>());
+    }
+
+    function loadPerformedWorkflows() {
+        setPerformed(!performed);
     }
 
     function getSidePanel() {
@@ -155,7 +160,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
             clearSelectedWorkflows();
             listWatch.stop();
         };
-    }, [namespace, phases.toString(), labels.toString(), pagination.limit, pagination.offset, pagination.nextOffset]); // referential equality, so use values, not refs
+    }, [namespace, phases.toString(), labels.toString(), pagination.limit, pagination.offset, pagination.nextOffset, performed]); // referential equality, so use values, not refs
 
     useCollectEvent('openedWorkflowList');
 
@@ -185,7 +190,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
             <WorkflowsToolbar
                 selectedWorkflows={selectedWorkflows}
                 clearSelection={clearSelectedWorkflows}
-                loadWorkflows={clearSelectedWorkflows}
+                loadWorkflows={loadPerformedWorkflows}
                 isDisabled={batchActionDisabled}
             />
             <div className={`row ${selectedWorkflows.size === 0 ? '' : 'pt-60'}`}>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow up to #11891 

### Motivation

While refactoring `WorkflowsToolBar` to fucntional components, I found that `Workflow List` wasn't rendering after performing selected workflows by clicking the action button in `WorkflowsToolBar`, It was redering by clicking workflows page button. 

Example, below
![image](https://github.com/argoproj/argo-workflows/assets/63052097/681412a4-e7f3-480b-a449-c5ad72ab39a1) click the delete button in `WorkflowsToolBar`, you can see `workflow list` is not rendering while notification shows. 

### Modifications

- Add to `performed` state as boolean type
- Add `performed` as dependency array in `useEffect` that rendering workflowList 
- convert `loadWorkflows` function values `clearSelectedWorkflows` -> `loadPerformedWorkflows`. It update `performed` state. 

### Verification

![image](https://github.com/argoproj/argo-workflows/assets/63052097/110343b7-ec4d-484d-b352-e878c123ac98)
- workflows list in the initial state

![image](https://github.com/argoproj/argo-workflows/assets/63052097/1a931b7d-677c-43eb-90b9-609b28148b5d)
- workflow list after `DELETE` button  

![image](https://github.com/argoproj/argo-workflows/assets/63052097/3df769e8-6a6c-4a33-a172-77734651a1d3)
- workflow list after  `RESUBMIT` button

