### PR TITLE
fix: suppress error about unable to obtain node

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3688,25 +3688,28 @@ func (woc *wfOperationCtx) deletePDBResource(ctx context.Context) error {
 // Check if the output of this node is referenced elsewhere in the Workflow. If so, make sure to include it during
 // execution.
 func (woc *wfOperationCtx) includeScriptOutput(nodeName, boundaryID string) (bool, error) {
-	if boundaryNode, err := woc.wf.Status.Nodes.Get(boundaryID); err == nil {
-		tmplCtx, err := woc.createTemplateContext(boundaryNode.GetTemplateScope())
-		if err != nil {
-			return false, err
-		}
-		_, parentTemplate, templateStored, err := tmplCtx.ResolveTemplate(boundaryNode)
-		if err != nil {
-			return false, err
-		}
-		// A new template was stored during resolution, persist it
-		if templateStored {
-			woc.updated = true
-		}
+	if boundaryID != "" {
+		if boundaryNode, err := woc.wf.Status.Nodes.Get(boundaryID); err == nil {
+			tmplCtx, err := woc.createTemplateContext(boundaryNode.GetTemplateScope())
+			if err != nil {
+				return false, err
+			}
+			_, parentTemplate, templateStored, err := tmplCtx.ResolveTemplate(boundaryNode)
+			if err != nil {
+				return false, err
+			}
+			// A new template was stored during resolution, persist it
+			if templateStored {
+				woc.updated = true
+			}
 
-		name := getStepOrDAGTaskName(nodeName)
-		return hasOutputResultRef(name, parentTemplate), nil
-	} else {
-		woc.log.Errorf("was unable to obtain node for %s", boundaryID)
+			name := getStepOrDAGTaskName(nodeName)
+			return hasOutputResultRef(name, parentTemplate), nil
+		} else {
+			woc.log.Errorf("was unable to obtain node for %s", boundaryID)
+		}
 	}
+
 	return false, nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Relates to #11451

### Motivation

<!-- TODO: Say why you made your changes. -->

After upgrading to v3.4.11, the error log is often reported from monitoring.

```
level=error msg="was unable to obtain node for " namespace=default workflow=hello-world-jq82w
```

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

When boundaryID is empty, we don't try to get node and also don't raise any error.

### Verification

<!-- TODO: Say how you tested your changes. -->
