### PR TITLE
feat: Fall back to retrieve logs from live pods

### DIFF
--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -252,6 +252,7 @@ export const WorkflowsService = {
 
     getContainerLogs(workflow: Workflow, podName: string, nodeId: string, container: string, grep: string, archived: boolean): Observable<LogEntry> {
         const getLogsFromArtifact = () => this.getContainerLogsFromArtifact(workflow, nodeId, container, grep, archived);
+        const getLogsFromCluster = () => this.getContainerLogsFromCluster(workflow, podName, container, grep);
 
         // If our workflow is archived, don't even bother inspecting the cluster for logs since it's likely
         // that the Workflow and associated pods have been deleted
@@ -263,9 +264,9 @@ export const WorkflowsService = {
         return from(this.isWorkflowNodePendingOrRunning(workflow, nodeId)).pipe(
             switchMap(isPendingOrRunning => {
                 if (!isPendingOrRunning && hasArtifactLogs(workflow, nodeId, container) && container === 'main') {
-                    return getLogsFromArtifact();
+                    return getLogsFromArtifact().pipe(catchError(getLogsFromCluster));
                 }
-                return this.getContainerLogsFromCluster(workflow, podName, container, grep).pipe(catchError(getLogsFromArtifact));
+                return getLogsFromCluster().pipe(catchError(getLogsFromArtifact));
             })
         );
     },


### PR DESCRIPTION
Today, if the Argo server fails to pull archived logs, it won’t use pod logs even if the pod still exists on the cluster. This means that in cases where the final upload fails due to streaming errors (or if the user’s SA does not have RBAC access to the artifact creds), Argo server will not display any logs for the workflow step after failing to retrieve archived logs even if the pod and its logs still exist on the cluster.

This PR adds a fallback to retrieve logs from live pods in those cases.