### PR TITLE
docs: add FOSSA License Badge for CLOMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <!-- markdownlint-disable-next-line MD041 -->
 [![slack](https://img.shields.io/badge/slack-argoproj-brightgreen.svg?logo=slack)](https://argoproj.github.io/community/join-slack)
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3830/badge)](https://bestpractices.coreinfrastructure.org/projects/3830)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/3830/badge)](https://bestpractices.coreinfrastructure.org/projects/3830)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/argoproj/argo-workflows/badge)](https://api.securityscorecards.dev/projects/github.com/argoproj/argo-workflows)
+[![FOSSA License Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fargoproj%2Fargo-workflows.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fargoproj%2Fargo-workflows?ref=badge_shield)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/argo-workflows)](https://artifacthub.io/packages/helm/argo/argo-workflows)
 [![Twitter Follow](https://img.shields.io/twitter/follow/argoproj?style=social)](https://twitter.com/argoproj)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #9769
  - #12031 is a follow-up specific to the security scores
  
Proper version of #12023 that FOSSA made automatically on integration

### Motivation

<!-- TODO: Say why you made your changes. -->

- this is the last non-security check we need for CNCF CLOMonitor
  - after this, all the non-security checks will be at 100%

- note that while we already use Snyk, it actually does not support Go dep badges: https://support.snyk.io/hc/en-us/articles/360003997277-Badge-Support-for-Repositories (see also https://github.com/cncf/clomonitor/issues/50#issuecomment-1039557687)
  - so use FOSSA, which [Argo CD already uses](https://github.com/argoproj/argo-cd/blob/a9f03aa8ccdafc350b96ee90db054b11cad44692/README.md?plain=1#L11) and is already integrated into Argoproj

- we do also have some license checks to resolve there, I am working on those as well
  - **EDIT**: see #12033 .
  - I also configured FOSSA to ignore `bufpipe` since it is licensed, but was just missing a license in older releases.
    - and also configured FOSSA to ignore a GPL devDep `node-forge`
      - [`webpack-dev-server`'s](https://github.com/argoproj/argo-workflows/blob/5c264c094104645a4c917a9a23615424d564d1e4/ui/yarn.lock#L8328) dep `selfsigned` [uses](https://github.com/argoproj/argo-workflows/blob/5c264c094104645a4c917a9a23615424d564d1e4/ui/yarn.lock#L7184) it
        - it's a devDep, so not included in prod builds, and it's only used by `webpack-dev-server`, which is a separate process. so valid use of GPL that does not need a separate notice 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add FOSSA badge to the README

- also rename "CII Best Practices" to its new name, "OpenSSF Best Practices"

### Verification

<!-- TODO: Say how you tested your changes. -->

Markdown preview looks ok to me