### PR TITLE
ci: also skip windows unit test runs based on diff

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -126,6 +126,8 @@ jobs:
 
   tests-windows:
     name: Windows Unit Tests
+    needs: [ changed-files ]
+    if: ${{ needs.changed-files.outputs.tests == 'true' }}
     runs-on: windows-2022
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- windows unit tests (#12011) were merged shortly before my changes to skip tests (#12006) were merged
  - they are new, so they also need a conditional now

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add a `needs` and an `if` section to the `tests-windows` job, same exact one as the one in `tests`

### Verification

<!-- TODO: Say how you tested your changes. -->

no new logic here as this exact conditional is already used for the `tests` job

### Future Work

- windows tests could potentially be optimized to run on a smaller set of changed files
  - since they don't run _all_ unit tests, but only a subset of them
