### PR TITLE
ci: ensure least privilege permissions for GHA tokens

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -5,6 +5,7 @@ on:
     tags:
       - v*
       - "!v0.0.0"
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -9,8 +9,8 @@ jobs:
   review:
     if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'argoproj/argo-workflows'}}
     permissions:
-      pull-requests: write
-      contents: write
+      pull-requests: write # for approving a PR
+      contents: write # for enabling auto-merge on a PR
     runs-on: ubuntu-latest
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,11 +13,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for publishing the docs to GH Pages
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   title-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12031, Token Permissions

### Motivation

<!-- TODO: Say why you made your changes. -->

- This is an [OpenSSF Scorecard check](https://github.com/ossf/scorecard/blob/8eaf0d7647a3f50d80615812c72a277fd568fb6d/docs/checks.md#token-permissions): Token Permissions
  - Not many changes required, but the ones made ensure that if a new GHA Job is added to an existing GHA Workflow, it will only have read-only permissions unless explicitly specified in the GHA Job itself

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Basically follow the OpenSSF Scorecard directions

- default to `permissions.contents: read` for read-only permissions for a GHA Workflow
  - this was missing from `pr.yaml` and was `write` for `docs.yaml`
- only add needed permissions per specific GHA Job
  - move the `permissions.contents: write` for `docs.yaml` into the `docs:` Job

- also add comments for why all permissions are needed

### Verification

<!-- TODO: Say how you tested your changes. -->

- `pr.yaml` still successfully runs on this PR
- `docs.yaml` has no real semantic changes since there was only 1 GHA job there anyway