### PR TITLE
docs: correct link to k8s docs for manually creating Secrets

### DIFF
--- a/docs/manually-create-secrets.md
+++ b/docs/manually-create-secrets.md
@@ -1,16 +1,15 @@
-# Kubernetes Secrets
+# Service Account Secrets
 
 As of Kubernetes v1.24, secrets are no longer automatically created for service accounts.
 
-You must create a secret
-manually: [Find out how to create these yourself manually](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token)
-.
+You must [create a secret manually](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount).
 
-You must make the secret discoverable. You have two options:
+You must also make the secret discoverable.
+You have two options:
 
 ## Option 1 - Discovery By Name
 
-Name your secret `${serviceAccountName}.service-account-token`.
+Name your secret `${serviceAccountName}.service-account-token`:
 
 ```yaml
 apiVersion: v1
@@ -22,7 +21,7 @@ metadata:
 type: kubernetes.io/service-account-token
 ```
 
-This option is simpler than option 2, as you can combine creating the secret with making it discoverable by name.
+This option is simpler than option 2, as you can create the secret and make it discoverable by name at the same time.
 
 ## Option 2 - Discovery By Annotation
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- the [old link](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token)'s anchor/subheading is no longer correct, update it to the [correct current one](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-long-lived-api-token-for-a-serviceaccount)

Stumbled upon this while responding to a user [on Slack](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1697738676287909?thread_ts=1697735798.105029&cid=C01QW9QSSSK)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Updated link

- while at it, make some small copy-edits:
  - rename the top heading from "Kubernetes Secrets" to "Service Account Secrets" - this page is not about all secrets, but specifically SA secrets
    - NOTE: I did not change the actual link to this page ("Manually create Secrets") as we don't have redirects set-up for the docs yet (see also https://github.com/argoproj/argo-workflows/issues/11390#issuecomment-1705657040)
  - in-line the link to the k8s docs instead of duplicating text
    - see also k8s style guide for [links](https://kubernetes.io/docs/contribute/style/style-guide/#links) and [simple and direct language](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
  - prefer 1 sentence per line of markdown for prose
  - consistently use a colon to end a sentence which has an example immediately after it
    - before it either had a period or a colon
  - reword the "combine creating the secret with" to use simpler language, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
    - this is slightly longer but I think "at the same time" is much simpler to understand compared to "combine creating [...] with", especially for foreign speakers. the tense is simpler as well
      - tbh I got a tad confused by the word "combine" before too as I thought that meant with `kustomize` or something in a more technical fashion

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes