### PR TITLE
refactor(ui): WorkflowsToolbar component from class to functional

### DIFF
--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -182,12 +182,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
                     ]
                 }
             }}>
-            <WorkflowsToolbar
-                selectedWorkflows={selectedWorkflows}
-                clearSelection={clearSelectedWorkflows}
-                loadWorkflows={clearSelectedWorkflows}
-                isDisabled={batchActionDisabled}
-            />
+            <WorkflowsToolbar selectedWorkflows={selectedWorkflows} clearSelection={clearSelectedWorkflows} actionsIsDisabled={batchActionDisabled} />
             <div className={`row ${selectedWorkflows.size === 0 ? '' : 'pt-60'}`}>
                 <div className='columns small-12 xlarge-2'>
                     <WorkflowsSummaryContainer workflows={filteredWorkflows} />

--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -1,7 +1,8 @@
 import {NotificationType} from 'argo-ui';
 import * as React from 'react';
+import {useContext, useMemo} from 'react';
 import {isArchivedWorkflow, isWorkflowInCluster, Workflow} from '../../../../models';
-import {Consumer, ContextApis} from '../../../shared/context';
+import {Context} from '../../../shared/context';
 import {services} from '../../../shared/services';
 import * as Actions from '../../../shared/workflow-operations-map';
 import {WorkflowOperation, WorkflowOperationAction, WorkflowOperationName} from '../../../shared/workflow-operations-map';
@@ -10,66 +11,71 @@ require('./workflows-toolbar.scss');
 
 interface WorkflowsToolbarProps {
     selectedWorkflows: Map<string, Workflow>;
-    loadWorkflows: () => void;
-    isDisabled: Actions.OperationDisabled;
+    actionsIsDisabled: Actions.OperationDisabled;
     clearSelection: () => void;
 }
 
-interface WorkflowGroupAction extends WorkflowOperation {
-    groupIsDisabled: boolean;
-    className: string;
-    groupAction: () => Promise<any>;
+interface WorkflowsOperation extends WorkflowOperation {
+    isDisabled: boolean;
+    workflowsAction: () => Promise<any>;
 }
 
-export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}> {
-    constructor(props: WorkflowsToolbarProps) {
-        super(props);
-    }
+export function WorkflowsToolbar(props: WorkflowsToolbarProps) {
+    const {popup, notifications} = useContext(Context);
+    const numberSelected: number = props.selectedWorkflows.size;
 
-    public render() {
-        return (
-            <Consumer>
-                {ctx => (
-                    <div className={`workflows-toolbar ${this.getNumberSelected() === 0 ? 'hidden' : ''}`}>
-                        <div className='workflows-toolbar__count'>
-                            {this.getNumberSelected() === 0 ? 'No' : this.getNumberSelected()}
-                            &nbsp;workflow{this.getNumberSelected() === 1 ? '' : 's'} selected
-                        </div>
-                        <div className='workflows-toolbar__actions'>{this.renderActions(ctx)}</div>
-                    </div>
-                )}
-            </Consumer>
-        );
-    }
+    const groupAction = useMemo<WorkflowsOperation[]>(() => {
+        const actions: any = Actions.WorkflowOperationsMap;
+        const disabled = props.actionsIsDisabled;
 
-    private getNumberSelected(): number {
-        return this.props.selectedWorkflows.size;
-    }
+        return Object.keys(actions).map((actionName: WorkflowOperationName) => {
+            const action = actions[actionName];
+            return {
+                title: action.title,
+                iconClassName: action.iconClassName,
+                isDisabled: disabled[actionName],
+                action,
+                workflowsAction: async () => {
+                    //check for action
+                    const confirmed = await popup.confirm('Confirm', `Are you sure you want to ${action.title.toLowerCase()} all selected workflows?`);
+                    if (!confirmed) {
+                        return;
+                    }
 
-    private async performActionOnSelectedWorkflows(ctx: ContextApis, title: string, action: WorkflowOperationAction): Promise<any> {
-        const confirmed = await ctx.popup.confirm('Confirm', `Are you sure you want to ${title.toLowerCase()} all selected workflows?`);
-        if (!confirmed) {
-            return Promise.resolve(false);
-        }
+                    // check for delete from archived workflows
+                    let deleteArchived = false;
+                    if (action.title === 'DELETE') {
+                        // check for delete workflows from archived workflows
+                        for (const entry of props.selectedWorkflows) {
+                            if (isArchivedWorkflow(entry[1])) {
+                                deleteArchived = await popup.confirm('Confirm', 'Do you also want to delete them from the Archived Workflows database?');
+                                break;
+                            }
+                        }
+                    }
 
-        let deleteArchived = false;
-        if (title === 'DELETE') {
-            for (const entry of this.props.selectedWorkflows) {
-                if (isArchivedWorkflow(entry[1])) {
-                    deleteArchived = await ctx.popup.confirm('Confirm', 'Do you also want to delete them from the Archived Workflows database?');
-                    break;
-                }
-            }
-        }
+                    performActionOnSelectedWorkflows(action.title, action.action, deleteArchived);
 
+                    props.clearSelection();
+                    notifications.show({
+                        content: `Performed '${action.title}' on selected workflows.`,
+                        type: NotificationType.Success
+                    });
+                },
+                disabled: () => false
+            } as WorkflowsOperation;
+        });
+    }, [props.selectedWorkflows]);
+
+    function performActionOnSelectedWorkflows(title: string, action: WorkflowOperationAction, deleteArchived: boolean): Promise<any> {
         const promises: Promise<any>[] = [];
-        this.props.selectedWorkflows.forEach((wf: Workflow) => {
+        props.selectedWorkflows.forEach((wf: Workflow) => {
             if (title === 'DELETE') {
                 // The ones without archivalStatus label or with 'Archived' labels are the live workflows.
                 if (isWorkflowInCluster(wf)) {
                     promises.push(
                         services.workflows.delete(wf.metadata.name, wf.metadata.namespace).catch(reason =>
-                            ctx.notifications.show({
+                            notifications.show({
                                 content: `Unable to delete workflow ${wf.metadata.name} in the cluster: ${reason.toString()}`,
                                 type: NotificationType.Error
                             })
@@ -79,7 +85,7 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
                 if (deleteArchived && isArchivedWorkflow(wf)) {
                     promises.push(
                         services.workflows.deleteArchived(wf.metadata.uid, wf.metadata.namespace).catch(reason =>
-                            ctx.notifications.show({
+                            notifications.show({
                                 content: `Unable to delete workflow ${wf.metadata.name} in database: ${reason.toString()}`,
                                 type: NotificationType.Error
                             })
@@ -89,8 +95,7 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
             } else {
                 promises.push(
                     action(wf).catch(reason => {
-                        this.props.loadWorkflows();
-                        ctx.notifications.show({
+                        notifications.show({
                             content: `Unable to ${title} workflow: ${reason.content.toString()}`,
                             type: NotificationType.Error
                         });
@@ -101,48 +106,28 @@ export class WorkflowsToolbar extends React.Component<WorkflowsToolbarProps, {}>
         return Promise.all(promises);
     }
 
-    private renderActions(ctx: ContextApis): JSX.Element[] {
-        const actionButtons = [];
-        const actions: any = Actions.WorkflowOperationsMap;
-        const disabled = this.props.isDisabled;
-        const groupActions: WorkflowGroupAction[] = Object.keys(actions).map((actionName: WorkflowOperationName) => {
-            const action = actions[actionName];
-            return {
-                title: action.title,
-                iconClassName: action.iconClassName,
-                groupIsDisabled: disabled[actionName],
-                action,
-                groupAction: async () => {
-                    const confirmed = await this.performActionOnSelectedWorkflows(ctx, action.title, action.action);
-                    if (!confirmed) {
-                        return;
-                    }
-
-                    this.props.clearSelection();
-                    ctx.notifications.show({
-                        content: `Performed '${action.title}' on selected workflows.`,
-                        type: NotificationType.Success
-                    });
-                    this.props.loadWorkflows();
-                },
-                className: action.title,
-                disabled: () => false
-            } as WorkflowGroupAction;
-        });
-        for (const groupAction of groupActions) {
-            actionButtons.push(
-                <button
-                    key={groupAction.title}
-                    onClick={() => {
-                        groupAction.groupAction().catch();
-                    }}
-                    className={`workflows-toolbar__actions--${groupAction.className} workflows-toolbar__actions--action`}
-                    disabled={this.getNumberSelected() === 0 || groupAction.groupIsDisabled}>
-                    <i className={groupAction.iconClassName} />
-                    &nbsp;{groupAction.title}
-                </button>
-            );
-        }
-        return actionButtons;
-    }
+    return (
+        <div className={`workflows-toolbar ${numberSelected === 0 ? 'hidden' : ''}`}>
+            <div className='workflows-toolbar__count'>
+                {numberSelected === 0 ? 'No' : numberSelected}
+                &nbsp;workflow{numberSelected === 1 ? '' : 's'} selected
+            </div>
+            <div className='workflows-toolbar__actions'>
+                {groupAction.map(action => {
+                    return (
+                        <button
+                            key={action.title}
+                            onClick={() => {
+                                action.workflowsAction().catch();
+                            }}
+                            className={`workflows-toolbar__actions--${action.title} workflows-toolbar__actions--action`}
+                            disabled={numberSelected === 0 || action.isDisabled}>
+                            <i className={action.iconClassName} />
+                            &nbsp;{action.title}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial Fixes for #9810

### Motivation

Use newer, modern functional components compatible with hooks instead of legacy class-based components

### Modifications

1. class fo functional
- `this.props` -> arguments
- methods -> inner functions

<br>

2. Delete `loadWorkflows()` from `WorkflowsToolBar` props
- Beacause `ListWatch()` update workflows when workflows was performed action

<br>

3. `getNumberSelected()` -> `WorkflowsToolbar`'s local variable `numberSelected`
- This function get the number of selected workflows from calling props. However it gets called multiple times each rendering. 
-  So, when they are updated, we can get the number of selected workflows from `numberSelected` _once_ without multiple function call.  

<br>

4. using `popup` and `notifications` with `useContext`

<br>

5. delete `renderActions`
- move rendering Action buttons element to`WorkflowsToolBar`s rendering  
- local variable
   - `actionButtons` -> delete
   - `actions` -> local variable in useMemo
   - `disabled` -> local variable in useMemo
   - `groupActions` -> variable `groupAction` in `WorkflowsToolbar`
       - using `useMemo` with dependency  `props.selectedWorkflows`

<br>

6. modify name in `WorkflowsGroupAction` and variable
- interface `WorkflowsGroupAction` -> `WorkflowsOperation`
   - Beacuse I think it is _ambiguous what 'group' means 'workflows' or 'Action'_
   - WorkflowsOperation is similar with WorkflowOperation
- `groupIsDisabled` -> `isDisabled`
  - I think _'disabled' is more related with "operation"_ not "group", 
  - _Also, `isDiabled` -> `actionIsDiabled` in `WorkflowsToolBarProps`_ 
- `className` -> delete
  - It is same `action.title`
- `groupAction` -> `workflowsAction`

<br>

7. modify function `performActionOnSelectedWorfklows`
- async/await -> delete
  - `await` keyword use in popup that check action  
  - `popup` move to `workflowsAction`  
- _This function is called only when action are performed in the selected workflow._

<br>

### Verification

Pure refactor, no real semantic changes
Tested in Local environment
- Screenshot below, Action of delete workflows
![image](https://github.com/argoproj/argo-workflows/assets/63052097/3fa1e7ca-4f73-4387-a7d2-03a0be8f61e9)
![image](https://github.com/argoproj/argo-workflows/assets/63052097/2e96a980-6bbf-44d0-8afd-ff8c43344ac0)

- Screenshot below, Action of resubmit workflows
![image](https://github.com/argoproj/argo-workflows/assets/63052097/4921dae0-ad4d-478b-9155-a87a8512dd22)
![image](https://github.com/argoproj/argo-workflows/assets/63052097/384560ef-96a3-45c0-a183-70d38eb25ff7)

- Screenshot below, action button when workflows running
![image](https://github.com/argoproj/argo-workflows/assets/63052097/199db98c-11f2-44d7-b3c3-0e27f109588d)
