### PR TITLE
fix(ui): remove accidentally rendered semi-colon

### DIFF
--- a/ui/src/app/cron-workflows/components/cron-workflow-details/cron-workflow-details.tsx
+++ b/ui/src/app/cron-workflows/components/cron-workflow-details/cron-workflow-details.tsx
@@ -6,6 +6,7 @@ import * as models from '../../../../models';
 import {CronWorkflow, Link, Workflow} from '../../../../models';
 import {uiUrl} from '../../../shared/base';
 import {ErrorNotice} from '../../../shared/components/error-notice';
+import {openLinkWithKey} from '../../../shared/components/links';
 import {Loading} from '../../../shared/components/loading';
 import {useCollectEvent} from '../../../shared/components/use-collect-event';
 import {ZeroState} from '../../../shared/components/zero-state';
@@ -20,7 +21,7 @@ import {CronWorkflowEditor} from '../cron-workflow-editor';
 require('../../../workflows/components/workflow-details/workflow-details.scss');
 require('./cron-workflow-details.scss');
 
-export const CronWorkflowDetails = ({match, location, history}: RouteComponentProps<any>) => {
+export function CronWorkflowDetails({match, location, history}: RouteComponentProps<any>) {
     // boiler-plate
     const {navigation, notifications, popup} = useContext(Context);
     const queryParams = new URLSearchParams(location.search);
@@ -107,14 +108,6 @@ export const CronWorkflowDetails = ({match, location, history}: RouteComponentPr
                   disabled: !cronWorkflow || !cronWorkflow.spec.suspend || edited
               };
 
-    const openLink = (link: Link) => {
-        if ((window.event as MouseEvent).ctrlKey || (window.event as MouseEvent).metaKey) {
-            window.open(link.url, '_blank');
-        } else {
-            document.location.href = link.url;
-        }
-    };
-
     const getItems = () => {
         const items = [
             {
@@ -193,7 +186,7 @@ export const CronWorkflowDetails = ({match, location, history}: RouteComponentPr
             items.push({
                 title: templateLink.name,
                 iconClassName: icon,
-                action: () => openLink(templateLink)
+                action: () => openLinkWithKey(templateLink.url)
             });
         }
 
@@ -262,4 +255,4 @@ export const CronWorkflowDetails = ({match, location, history}: RouteComponentPr
             </>
         </Page>
     );
-};
+}

--- a/ui/src/app/reports/components/reports.tsx
+++ b/ui/src/app/reports/components/reports.tsx
@@ -87,7 +87,7 @@ export function Reports({match, location, history}: RouteComponentProps<any>) {
                     <ReportFilters namespace={namespace} labels={labels} onChange={onChange} />
                 </div>
                 <div className='columns small-12 xlarge-10'>
-                    <ErrorNotice error={error} />;
+                    <ErrorNotice error={error} />
                     {!charts ? (
                         <ZeroState title='Workflow Report'>
                             <p>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/pull/11794#discussion_r1367772045

### Motivation

<!-- TODO: Say why you made your changes. -->

- when I refactored the `Reports` component in #11794, I accidentally left in the semi-colon from a copy+paste

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove the accidentally rendered semi-colon

- also make some tiny optimizations while at it
  - consolidate `CronWorkflowDetails`'s `openLink` function to also use `openLinkWithKey`
    - yay no duplication!
    - all the link behavior is now in one place, especially with this slightly complex function
  - refactor const assigned to anonymous func -> named function for better tracing

### Verification

<!-- TODO: Say how you tested your changes. -->

tested locally, can confirm there is no semi-colon now 😅 