### PR TITLE
build(ui): code-split `ApiDocs` and `Reports` components

### DIFF
--- a/ui/src/app/apidocs/components/apiDocs.tsx
+++ b/ui/src/app/apidocs/components/apiDocs.tsx
@@ -1,8 +1,7 @@
 import {Page} from 'argo-ui';
 import * as React from 'react';
-import SwaggerUI from 'swagger-ui-react';
-import 'swagger-ui-react/swagger-ui.css';
 import {uiUrl} from '../../shared/base';
+import {Loading} from '../../shared/components/loading';
 import {useCollectEvent} from '../../shared/components/use-collect-event';
 
 export const ApiDocs = () => {
@@ -10,8 +9,22 @@ export const ApiDocs = () => {
     return (
         <Page title='Swagger'>
             <div className='argo-container'>
-                <SwaggerUI url={uiUrl('assets/openapi-spec/swagger.json')} defaultModelExpandDepth={0} />
+                <SuspenseSwaggerUI url={uiUrl('assets/openapi-spec/swagger.json')} defaultModelExpandDepth={0} />
             </div>
         </Page>
     );
 };
+
+// lazy load SwaggerUI as it is infrequently used and imports very large components (which can be split into a separate bundle)
+const LazySwaggerUI = React.lazy(() => {
+    import('swagger-ui-react/swagger-ui.css');
+    return import('swagger-ui-react');
+});
+
+function SuspenseSwaggerUI(props: any) {
+    return (
+        <React.Suspense fallback={<Loading />}>
+            <LazySwaggerUI {...props} />
+        </React.Suspense>
+    );
+}

--- a/ui/src/app/cron-workflows/components/pretty-schedule.tsx
+++ b/ui/src/app/cron-workflows/components/pretty-schedule.tsx
@@ -1,7 +1,7 @@
-import React = require('react');
-import {WarningIcon} from '../../shared/components/fa-icons';
+import x from 'cronstrue';
+import * as React from 'react';
 
-const x = require('cronstrue');
+import {WarningIcon} from '../../shared/components/fa-icons';
 
 /*
     https://github.com/bradymholt/cRonstrue
@@ -12,7 +12,7 @@ const x = require('cronstrue');
     sometime it'll not work as expected. Therefore, we must let the user know about this.
  */
 
-export const PrettySchedule = ({schedule}: {schedule: string}) => {
+export function PrettySchedule({schedule}: {schedule: string}) {
     try {
         if (schedule.split(' ').length >= 6) {
             throw new Error('cron schedules must consist of 5 values only');
@@ -26,4 +26,4 @@ export const PrettySchedule = ({schedule}: {schedule: string}) => {
             </span>
         );
     }
-};
+}

--- a/ui/src/app/cron-workflows/components/schedule-validator.tsx
+++ b/ui/src/app/cron-workflows/components/schedule-validator.tsx
@@ -1,9 +1,9 @@
-import React = require('react');
+import x from 'cronstrue';
+import * as React from 'react';
+
 import {SuccessIcon, WarningIcon} from '../../shared/components/fa-icons';
 
-const x = require('cronstrue');
-
-export const ScheduleValidator = ({schedule}: {schedule: string}) => {
+export function ScheduleValidator({schedule}: {schedule: string}) {
     try {
         if (schedule.split(' ').length >= 6) {
             throw new Error('cron schedules must consist of 5 values only');
@@ -20,4 +20,4 @@ export const ScheduleValidator = ({schedule}: {schedule: string}) => {
             </span>
         );
     }
-};
+}

--- a/ui/src/app/event-flow/components/event-flow-details/event-flow-page.tsx
+++ b/ui/src/app/event-flow/components/event-flow-details/event-flow-page.tsx
@@ -1,6 +1,6 @@
 import {Page, SlidingPanel, Tabs} from 'argo-ui';
 import {useContext, useEffect, useState} from 'react';
-import React = require('react');
+import * as React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {Observable} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
@@ -34,7 +34,7 @@ import {ID} from './id';
 
 require('./event-flow-page.scss');
 
-export const EventFlowPage = ({history, location, match}: RouteComponentProps<any>) => {
+export function EventFlowPage({history, location, match}: RouteComponentProps<any>) {
     // boiler-plate
     const {navigation} = useContext(Context);
     const queryParams = new URLSearchParams(location.search);
@@ -355,4 +355,4 @@ export const EventFlowPage = ({history, location, match}: RouteComponentProps<an
             </SlidingPanel>
         </Page>
     );
-};
+}

--- a/ui/src/app/reports/components/report-container.tsx
+++ b/ui/src/app/reports/components/report-container.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import {Route, RouteComponentProps, Switch} from 'react-router';
-import {Reports} from './reports';
+import {Loading} from '../../shared/components/loading';
 
 export const ReportsContainer = (props: RouteComponentProps<any>) => (
     <Switch>
-        <Route exact={true} path={`${props.match.path}/:namespace?`} component={Reports} />
+        <Route exact={true} path={`${props.match.path}/:namespace?`} component={SuspenseReports} />
     </Switch>
 );
+
+// lazy load Reports as it is infrequently used and imports large Chart components (which can be split into a separate bundle)
+const LazyReports = React.lazy(() => import('./reports'));
+
+function SuspenseReports(props: RouteComponentProps<any>) {
+    return (
+        <React.Suspense fallback={<Loading />}>
+            <LazyReports {...props} />
+        </React.Suspense>
+    );
+}

--- a/ui/src/app/reports/components/reports.tsx
+++ b/ui/src/app/reports/components/reports.tsx
@@ -131,3 +131,5 @@ export function Reports({match, location, history}: RouteComponentProps<any>) {
         </Page>
     );
 }
+
+export default Reports;

--- a/ui/src/app/shared/components/chat-button.tsx
+++ b/ui/src/app/shared/components/chat-button.tsx
@@ -1,9 +1,9 @@
-import React = require('react');
+import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {Link} from '../../../models';
 import {services} from '../services';
 
-export const ChatButton = () => {
+export function ChatButton() {
     const [link, setLink] = useState<Link>();
 
     useEffect(() => {
@@ -27,4 +27,4 @@ export const ChatButton = () => {
             </a>
         </div>
     );
-};
+}

--- a/ui/src/app/shared/components/links.tsx
+++ b/ui/src/app/shared/components/links.tsx
@@ -1,6 +1,6 @@
 import {ObjectMeta} from 'argo-ui/src/models/kubernetes';
 import {useEffect, useState} from 'react';
-import React = require('react');
+import * as React from 'react';
 import {Link, Workflow} from '../../../models';
 import {services} from '../services';
 import {Button} from './button';

--- a/ui/src/app/shared/components/object-parser.ts
+++ b/ui/src/app/shared/components/object-parser.ts
@@ -1,4 +1,4 @@
-import jsyaml = require('js-yaml');
+import jsyaml from 'js-yaml';
 
 export function parse<T>(value: string) {
     if (value.startsWith('{')) {

--- a/ui/src/app/shared/cron.tsx
+++ b/ui/src/app/shared/cron.tsx
@@ -1,4 +1,4 @@
-import parser = require('cron-parser');
+import parser from 'cron-parser';
 
 export function getNextScheduledTime(schedule: string, tz: string): Date {
     let out: Date;

--- a/ui/src/app/tsconfig.json
+++ b/ui/src/app/tsconfig.json
@@ -3,7 +3,8 @@
         "outDir": "./../../dist/app",
         "sourceMap": true,
         "noImplicitAny": true,
-        "module": "commonjs",
+        "module": "ES2020", // must be ES2020+ for dynamic imports: https://github.com/Microsoft/TypeScript/issues/16675, https://github.com/webpack/webpack/issues/5703#issuecomment-357512412
+        "moduleResolution": "node",
         "esModuleInterop": true,
         "target": "es5",
         "jsx": "react",

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 
 import {Autocomplete} from 'argo-ui';
-import moment = require('moment-timezone');
+import moment from 'moment-timezone';
 import {Observable} from 'rxjs';
 import {map, publishReplay, refCount} from 'rxjs/operators';
 import * as models from '../../../../models';


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12059
  - still more code splitting that can be done

### Motivation

<!-- TODO: Say why you made your changes. -->

- `swagger-ui-react` was one of the biggest dependencies and only used on the infrequently used `/apiDocs` page
  - and it was the sole importer of large dependencies like `dompurify`, `immutable`, `redux`, etc
  - shave off ~2MB / 826KB minified / 250KB gzipped from the main bundle
- `charts.js` was also one of the bigger deps and similarly only used on the infrequently used `/reports` page
  - shave off ~525KB / 190KB minified / 60KB gzipped from the main bundle

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use `React.lazy` to lazy load them with dynamic imports
  - and `React.Suspense` to add a fallback etc
  - see https://react.dev/reference/react/lazy and https://webpack.js.org/guides/code-splitting/#dynamic-imports
    - also https://v5.reactrouter.com/web/guides/code-splitting, though it's a bit dated now (`lazy` and `Suspense` are built-in now, no need to use `loadable-components`)

- make some small upgrades to support dynamic importing
  - per in-line code comments, `ES2020`+ `module` format is required for dynamic imports (otherwise they get transpiled to regular, synchronous `require`s) (c.f. https://github.com/Microsoft/TypeScript/issues/16675, https://github.com/webpack/webpack/issues/5703#issuecomment-357512412)
    - note that Argo CD [already uses this](https://github.com/argoproj/argo-cd/blob/973565e194c094d163d2fd0873364d0e36951806/ui/src/app/tsconfig.json#L6)
    - this new module format did require updating some legacy code that used the [`import x = require('x')` syntax](https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require)
      - update it to use what are nowadays just regular ESM imports
      - remaining `require` usage is all for CSS/SCSS and a handful of packages that have no types (or at least that we haven't imported an `@types/` package for)
        - those should be converted in the future too, but nbd right now
      - there are some new TS/Webpack warnings that pop up as a result of this new module format
        - they're warnings, so not causing any errors just yet -- they should be worked on in the future though
        - seemingly all of these are for exports of types -- they should be moved to the [newer `export type` syntax](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)
          - problematically, updating to `export type` seems to cause errors in legacy `tslint`... so we may be blocked until that is swapped out for `eslint`
  - add a `default` `export` to `Reports` because this is (still) currently required for lazy loading

- minor stylistic changes while at it
  - consts assigned to anonymous functions -> named functions for better tracing
  - new line between external imports and internal imports for consistency

### Verification

<!-- TODO: Say how you tested your changes. -->

See screenshots bundle analysis after this code splitting was added below:
![Screenshot 2023-10-21 at 3 14 45 PM -- after code-split apiDocs and Reports](https://github.com/argoproj/argo-workflows/assets/4970083/3cceeee4-5813-483f-be83-082645dfacf9)
![Screenshot 2023-10-21 at 3 10 22 PM -- after code-split apiDocs and Reports](https://github.com/argoproj/argo-workflows/assets/4970083/28edbd19-6f94-4042-aada-f5d3763a669c)

Tested locally and worked without issues.
I barely even noticed the lazy load as it took less than a second for it to appear, and I was specifically paying attention for it. Results may vary ofc, esp since locally the network is ofc much faster, but per #12059 I still think this is well worth the tiny trade-off given how rarely used these pages are. 

### Future Work

There's still more to code-split per #12059
- these two were particularly quick as they were their own pages and isolated to a single module
- `monaco-editor` would be good to do next; I didn't do it as part of this because it requires more granular changes to two different components/modules -- need to take some more time with that