### PR TITLE
ci: Remove coverage report for Windows tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -140,10 +140,6 @@ jobs:
       - run: go test -p 1  -covermode=atomic -coverprofile='coverage.out' $(go list ./... | select-string -Pattern 'github.com/argoproj/argo-workflows/v3/workflow/controller' , 'github.com/argoproj/argo-workflows/v3/server' -NotMatch)
         env:
           KUBECONFIG: /dev/null
-      # engineers just ignore this in PRs, so lets not even run it
-      - name: Upload coverage report
-        if: github.ref == 'refs/heads/master'
-        run: bash <(curl -s https://codecov.io/bash)
 
   argoexec-image:
     name: argoexec-image


### PR DESCRIPTION
This causes master branch to fail. We already uploaded coverage in non-Windows unit tests builds which is more correct since we skip certain tests on Windows.