### PR TITLE
build: Add support for RISC-V

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [ linux/amd64, linux/arm64 ]
+        platform: [ linux/amd64, linux/arm64, linux/riscv64 ]
         target: [ workflow-controller, argocli, argoexec ]
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +79,13 @@ jobs:
           tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
           image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
 
+          extra_build_args=""
+          if [ $PLATFORM = "linux/riscv64" ]; then
+            extra_build_args="--build-arg BUILDER_IMAGE=riscv64/alpine:edge \
+              --build-arg UI_IMAGE=riscv64/alpine:edge \
+              --build-arg DISTROLESS_IMAGE=ghcr.io/go-riscv/distroless/static-unstable"
+          fi
+
           docker buildx build \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --cache-to "type=local,dest=/tmp/.buildx-cache" \
@@ -86,6 +93,7 @@ jobs:
             --build-arg GIT_COMMIT=$GIT_COMMIT \
             --build-arg GIT_TAG=$GIT_TAG \
             --build-arg GIT_TREE_STATE=$GIT_TREE_STATE \
+            $extra_build_args \
             --platform="${PLATFORM}" \
             --target $TARGET \
             --provenance=false \
@@ -186,11 +194,11 @@ jobs:
             image_name="${docker_org}/${target}:${tag}"
 
             if [ $target = "argoexec" ]; then
-              docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64 ${image_name}-windows
-              docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64 quay.io/${image_name}-windows
+              docker manifest create $image_name ${image_name}-linux-riscv64 ${image_name}-linux-arm64 ${image_name}-linux-amd64 ${image_name}-windows
+              docker manifest create quay.io/$image_name quay.io/${image_name}-linux-riscv64 quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64 quay.io/${image_name}-windows
             else
-              docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64
-              docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64
+              docker manifest create $image_name ${image_name}-linux-riscv64 ${image_name}-linux-arm64 ${image_name}-linux-amd64
+              docker manifest create quay.io/$image_name quay.io/${image_name}-linux-riscv64 quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64
             fi
 
             docker manifest push $image_name

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ dist/argo-linux-amd64: GOARGS = GOOS=linux GOARCH=amd64
 dist/argo-linux-arm64: GOARGS = GOOS=linux GOARCH=arm64
 dist/argo-linux-ppc64le: GOARGS = GOOS=linux GOARCH=ppc64le
 dist/argo-linux-s390x: GOARGS = GOOS=linux GOARCH=s390x
+dist/argo-linux-riscv64: GOARGS = GOOS=linux GOARCH=riscv64
 dist/argo-darwin-amd64: GOARGS = GOOS=darwin GOARCH=amd64
 dist/argo-darwin-arm64: GOARGS = GOOS=darwin GOARCH=arm64
 dist/argo-windows-amd64: GOARGS = GOOS=windows GOARCH=amd64
@@ -211,7 +212,7 @@ endif
 argocli-image:
 
 .PHONY: clis
-clis: dist/argo-linux-amd64.gz dist/argo-linux-arm64.gz dist/argo-linux-ppc64le.gz dist/argo-linux-s390x.gz dist/argo-darwin-amd64.gz dist/argo-darwin-arm64.gz dist/argo-windows-amd64.gz
+clis: dist/argo-linux-amd64.gz dist/argo-linux-arm64.gz dist/argo-linux-ppc64le.gz dist/argo-linux-s390x.gz dist/argo-linux-riscv64.gz dist/argo-darwin-amd64.gz dist/argo-darwin-arm64.gz dist/argo-windows-amd64.gz
 
 # controller
 
@@ -487,7 +488,7 @@ argosay:
 ifeq ($(DOCKER_PUSH),true)
 	cd test/e2e/images/argosay/v2 && \
 		docker buildx build \
-			--platform linux/amd64,linux/arm64 \
+			--platform linux/amd64,linux/arm64,linux/riscv64 \
 			-t argoproj/argosay:v2 \
 			--push \
 			.
@@ -504,7 +505,7 @@ argosayv1:
 ifeq ($(DOCKER_PUSH),true)
 	cd test/e2e/images/argosay/v1 && \
 		docker buildx build \
-			--platform linux/amd64,linux/arm64 \
+			--platform linux/amd64,linux/arm64,linux/riscv64 \
 			-t argoproj/argosay:v1 \
 			--push \
 			.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

This PR adds RISC-V support, by generating a CLI binary for RISC-V and container images.

### Motivation

The work is part of an ongoing effort to run [K3s on RISC-V](https://github.com/k3s-io/k3s/pull/7778). The main functionality is there, so we are now moving to higher-level services and Argo Workflows is first on the list. We expect Argo Workflows to enable us to seamlessly run workflows in a hybrid hardware environment with amd64, arm64, and riscv64 hosts. 

### Modifications

There are no code changes in this PR, just small additions and modifications in the `Makefile` and release scripts.

A binary for `riscv64` is created by adding the architecture to the `Makefile`.

The container image generation is a bit trickier, as the base images used do not currently support RISC-V. Alpine supports RISC-V in the "edge" branch and distroless has [deferred releasing RISC-V images until the Debian unstable branch is moved into stable](https://github.com/GoogleContainerTools/distroless/issues/1269) (estimated in 2025). For this reason, I turned the base image names into arguments in the `Dockerfile` and use different ones for RISC-V in `release.yaml`.

### Verification

I built container images by running the script in `release.yaml` by hand. They can be found at my organization's [Docker Hub account](https://hub.docker.com/u/carvicsforth). I then modified `install.yaml` to use these container images and tested Argo Workflows in a QEMU setup with a [RISC-V build of K3s](https://github.com/k3s-io/k3s/pull/7778). The installation manifest, as well as test workflow can be found [here](https://github.com/CARV-ICS-FORTH/kubernetes-riscv64/tree/main/argo-workflows).
