### PR TITLE
fix: Revert #11761 to avoid argo-server performance issue

### DIFF
--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"sort"
-
 	"testing"
 	"time"
 

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -663,11 +663,11 @@ func TestMergeWithArchivedWorkflows(t *testing.T) {
 	wf3 := v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{UID: "3", CreationTimestamp: metav1.Time{Time: timeNow.Add(3 * time.Second)}}}
 	liveWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Live, wf2}}
-    archivedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Archived, wf3, wf2}}
-    expectedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Live}}
-    expectedShortWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2}}
-    assert.Equal(t, expectedWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList, 0).Items)
-    assert.Equal(t, expectedShortWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList, 2).Items)
+	archivedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Archived, wf3, wf2}}
+	expectedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Live}}
+	expectedShortWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2}}
+	assert.Equal(t, expectedWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList, 0).Items)
+	assert.Equal(t, expectedShortWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList, 2).Items)
 }
 
 func TestWatchWorkflows(t *testing.T) {

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -665,44 +665,11 @@ func TestMergeWithArchivedWorkflows(t *testing.T) {
 	wf3 := v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{UID: "3", CreationTimestamp: metav1.Time{Time: timeNow.Add(3 * time.Second)}}}
 	liveWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Live, wf2}}
-	archivedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Archived}}
-	expectedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Live}}
-	mergedWfItems := mergeWithArchivedWorkflows(liveWfList, archivedWfList).Items
-	sort.Sort(mergedWfItems)
-	assert.Equal(t, expectedWfList.Items, mergedWfItems)
-}
-
-func TestCursorPaginationByResourceVersion(t *testing.T) {
-	wf1 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1", Name: "wf1"}}
-	wf2 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2", Name: "wf2"}}
-	wf3 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "3", Name: "wf3"}}
-	wf4 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "4", Name: "wf4"}}
-	wf5 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5", Name: "wf5"}}
-	wf6 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "6", Name: "wf6"}}
-	wf7 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "7", Name: "wf7"}}
-	wf8 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "8", Name: "wf8"}}
-	wf9 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "9", Name: "wf9"}}
-	wf10 := v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "10", Name: "wf10"}}
-
-	items := []v1alpha1.Workflow{wf2, wf1, wf4, wf3, wf6, wf5, wf8, wf7, wf10, wf9}
-	wfList := &v1alpha1.WorkflowList{}
-
-	cursorPaginationByResourceVersion(items, "8", 5, wfList)
-	expectedWfList := &v1alpha1.WorkflowList{}
-	expectedWfList.Items = []v1alpha1.Workflow{wf7, wf6, wf5, wf4, wf3}
-	expectedWfList.ListMeta.Continue = "3"
-
-	assert.Equal(t, expectedWfList, wfList)
+    archivedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf1Archived, wf3, wf2}}
+    expectedWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2, wf1Live}}
+    expectedShortWfList := v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{wf3, wf2}}
+    assert.Equal(t, expectedWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList, 0).Items)
+    assert.Equal(t, expectedShortWfList.Items, mergeWithArchivedWorkflows(liveWfList, archivedWfList, 2).Items)
 }
 
 func TestWatchWorkflows(t *testing.T) {


### PR DESCRIPTION
This reverts #11761. See https://github.com/argoproj/argo-workflows/issues/12025 for context.