### PR TITLE
fix: conflicting type of "workflow" logging attribute

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -261,8 +261,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	log.WithField("version", argo.GetVersion().Version).
 		WithField("defaultRequeueTime", GetRequeueTime()).
 		Info("Starting Workflow Controller")
-	log.WithField("workflow", wfWorkers).
-		WithField("workflowTtl", workflowTTLWorkers).
+	log.WithField("workflowWorkers", wfWorkers).
+		WithField("workflowTtlWorkers", workflowTTLWorkers).
 		WithField("podCleanup", podCleanupWorkers).
 		Info("Current Worker Numbers")
 


### PR DESCRIPTION
When Argo Workflows is configured to use JSON logging to simplify attributes extraction and filtering in Kibana/OpenSearch it produces attributes with conflicting types.

On start, controller will issue message "Current Worker Numbers" with attribute "workflow" equal number of workers. Which automatically mapped to "number" type in OpenSearch. Subsequent messages for actual workflows will have attribute "workflow" equals to actual workflow name. And those messages will be reject by OpenSearch with error like failed to parse field [workflow] of type [long] in document with id 'iFjDZIsBc7pTuVck5LUF'. Preview of field's value: 'okr-workflow-template-fe21b034-99wq9'.

<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
