### PR TITLE
refactor(ui): consistent imports: `React.use` -> `use`

### DIFF
--- a/ui/src/app/shared/components/data-loader-dropdown.tsx
+++ b/ui/src/app/shared/components/data-loader-dropdown.tsx
@@ -1,8 +1,9 @@
 import {DataLoader, Select, SelectOption} from 'argo-ui';
 import * as React from 'react';
+import {useState} from 'react';
 
-export const DataLoaderDropdown = (props: {load: () => Promise<(string | SelectOption)[]>; onChange: (value: string) => void; placeholder?: string}) => {
-    const [selected, setSelected] = React.useState('');
+export function DataLoaderDropdown(props: {load: () => Promise<(string | SelectOption)[]>; onChange: (value: string) => void; placeholder?: string}) {
+    const [selected, setSelected] = useState('');
 
     return (
         <DataLoader load={props.load}>
@@ -19,4 +20,4 @@ export const DataLoaderDropdown = (props: {load: () => Promise<(string | SelectO
             )}
         </DataLoader>
     );
-};
+}

--- a/ui/src/app/shared/components/editors/key-value-editor.tsx
+++ b/ui/src/app/shared/components/editors/key-value-editor.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
+import {useState} from 'react';
+
 import {TextInput} from '../text-input';
 
 interface KeyValues {
     [key: string]: string;
 }
 
-export const KeyValueEditor = ({onChange, keyValues, hide}: {keyValues: KeyValues; onChange: (value: KeyValues) => void; hide?: (key: string) => boolean}) => {
-    const [name, setName] = React.useState('');
-    const [value, setValue] = React.useState('');
-    const deleteItem = (k: string) => {
+export function KeyValueEditor({onChange, keyValues, hide}: {keyValues: KeyValues; onChange: (value: KeyValues) => void; hide?: (key: string) => boolean}) {
+    const [name, setName] = useState('');
+    const [value, setValue] = useState('');
+
+    function deleteItem(k: string) {
         delete keyValues[k];
         onChange(keyValues);
-    };
-    const addItem = () => {
+    }
+    function addItem() {
         if (!name || !value) {
             return;
         }
@@ -20,7 +23,8 @@ export const KeyValueEditor = ({onChange, keyValues, hide}: {keyValues: KeyValue
         onChange(keyValues);
         setName('');
         setValue('');
-    };
+    }
+
     return (
         <>
             {Object.entries(keyValues)
@@ -57,7 +61,7 @@ export const KeyValueEditor = ({onChange, keyValues, hide}: {keyValues: KeyValue
             </div>
         </>
     );
-};
+}
 
 KeyValueEditor.defaultProps = {
     keyValues: {}

--- a/ui/src/app/shared/components/graph/graph-panel.tsx
+++ b/ui/src/app/shared/components/graph/graph-panel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {TextInput} from '../../../shared/components/text-input';
 import {ScopedLocalStorage} from '../../scoped-local-storage';
 import {FilterDropDown} from '../filter-drop-down';
@@ -40,16 +40,16 @@ interface Props {
 
 const merge = (a: {[key: string]: boolean}, b: {[key: string]: boolean}) => b && Object.assign(Object.assign({}, b), a);
 
-export const GraphPanel = (props: Props) => {
+export function GraphPanel(props: Props) {
     const storage = new ScopedLocalStorage('graph/' + props.storageScope);
-    const [nodeSize, setNodeSize] = React.useState<number>(storage.getItem('nodeSize', props.nodeSize));
-    const [horizontal, setHorizontal] = React.useState<boolean>(storage.getItem('horizontal', !!props.horizontal));
-    const [fast, setFast] = React.useState<boolean>(storage.getItem('fast', false));
-    const [nodeGenres, setNodeGenres] = React.useState<INodeSelectionMap>(storage.getItem('nodeGenres', props.nodeGenres));
-    const [nodeClassNames, setNodeClassNames] = React.useState<INodeSelectionMap>(storage.getItem('nodeClassNames', props.nodeClassNames));
-    const [nodeTags, setNodeTags] = React.useState<INodeSelectionMap>(props.nodeTags);
-    const [checkAll, setCheckAll] = React.useState<boolean>(true);
-    const [nodeSearchKeyword, setNodeSearchKeyword] = React.useState<string>('');
+    const [nodeSize, setNodeSize] = useState<number>(storage.getItem('nodeSize', props.nodeSize));
+    const [horizontal, setHorizontal] = useState<boolean>(storage.getItem('horizontal', !!props.horizontal));
+    const [fast, setFast] = useState<boolean>(storage.getItem('fast', false));
+    const [nodeGenres, setNodeGenres] = useState<INodeSelectionMap>(storage.getItem('nodeGenres', props.nodeGenres));
+    const [nodeClassNames, setNodeClassNames] = useState<INodeSelectionMap>(storage.getItem('nodeClassNames', props.nodeClassNames));
+    const [nodeTags, setNodeTags] = useState<INodeSelectionMap>(props.nodeTags);
+    const [checkAll, setCheckAll] = useState<boolean>(true);
+    const [nodeSearchKeyword, setNodeSearchKeyword] = useState<string>('');
 
     useEffect(() => storage.setItem('nodeSize', nodeSize, props.nodeSize), [nodeSize]);
     useEffect(() => storage.setItem('horizontal', horizontal, props.horizontal), [horizontal]);
@@ -68,7 +68,7 @@ export const GraphPanel = (props: Props) => {
         setCheckAll(allSelected);
     }, [nodeGenres, nodeClassNames, nodeTags]);
 
-    const visible = (id: Node) => {
+    function visible(id: Node) {
         const label = props.graph.nodes.get(id);
         // If the node matches the search string, return without considering filters
         if (nodeSearchKeyword && label.label.includes(nodeSearchKeyword)) {
@@ -87,27 +87,27 @@ export const GraphPanel = (props: Props) => {
             return false;
         }
         return true;
-    };
+    }
 
-    const checkBoxHandler = (callback: React.Dispatch<React.SetStateAction<INodeSelectionMap>>, label: string, checked: boolean) => {
+    function checkBoxHandler(callback: React.Dispatch<React.SetStateAction<INodeSelectionMap>>, label: string, checked: boolean) {
         callback(v => {
             return {
                 ...v,
                 [label]: checked
             };
         });
-    };
+    }
 
-    const getNodeMapWithAllNodesSetToValue = (nodeSelectionMap: INodeSelectionMap, value: boolean) => {
+    function getNodeMapWithAllNodesSetToValue(nodeSelectionMap: INodeSelectionMap, value: boolean) {
         return Object.keys(nodeSelectionMap).reduce((accumulatedMap, nextKey) => {
             return {
                 ...accumulatedMap,
                 [nextKey]: value
             };
         }, {});
-    };
+    }
 
-    const getIsAllSelected = (classNames: INodeSelectionMap, tags: INodeSelectionMap, genres: INodeSelectionMap) => {
+    function getIsAllSelected(classNames: INodeSelectionMap, tags: INodeSelectionMap, genres: INodeSelectionMap) {
         const nodeSelections: INodeSelectionMap = {...classNames, ...tags, ...genres};
         const totalNodeCount = Object.keys(nodeSelections).length;
 
@@ -120,22 +120,22 @@ export const GraphPanel = (props: Props) => {
         }, 0);
 
         return selectedNodeCount === totalNodeCount;
-    };
+    }
 
-    const onSelectAll = (
+    function onSelectAll(
         classNames: INodeSelectionMap,
         tags: INodeSelectionMap,
         genres: INodeSelectionMap,
         setClassNames: React.Dispatch<React.SetStateAction<INodeSelectionMap>>,
         setTags: React.Dispatch<React.SetStateAction<INodeSelectionMap>>,
         setGenres: React.Dispatch<React.SetStateAction<INodeSelectionMap>>
-    ) => {
+    ) {
         const isAllSelected = getIsAllSelected(classNames, tags, genres);
 
         setClassNames(getNodeMapWithAllNodesSetToValue(classNames, !isAllSelected));
         setTags(getNodeMapWithAllNodesSetToValue(tags, !isAllSelected));
         setGenres(getNodeMapWithAllNodesSetToValue(genres, !isAllSelected));
-    };
+    }
 
     layout(props.graph, nodeSize, horizontal, id => !visible(id), fast);
     const width = props.graph.width;
@@ -276,7 +276,7 @@ export const GraphPanel = (props: Props) => {
             </div>
         </div>
     );
-};
+}
 
 GraphPanel.defaultProps = {
     nodeSize: 64

--- a/ui/src/app/workflows/components/workflow-details/suspend-inputs.tsx
+++ b/ui/src/app/workflows/components/workflow-details/suspend-inputs.tsx
@@ -1,5 +1,7 @@
 import {Select, Tooltip} from 'argo-ui';
 import * as React from 'react';
+import {useState} from 'react';
+
 import {Parameter} from '../../../../models';
 
 interface SuspendInputProps {
@@ -9,9 +11,9 @@ interface SuspendInputProps {
 }
 
 export function SuspendInputs(props: SuspendInputProps) {
-    const [parameters, setParameters] = React.useState(props.parameters);
+    const [parameters, setParameters] = useState(props.parameters);
 
-    const setParameter = (key: string, value: string) => {
+    function setParameter(key: string, value: string) {
         props.setParameter(key, value);
         setParameters(previous => {
             return previous.map(param => {
@@ -21,9 +23,9 @@ export function SuspendInputs(props: SuspendInputProps) {
                 return param;
             });
         });
-    };
+    }
 
-    const renderSelectField = (parameter: Parameter) => {
+    function renderSelectField(parameter: Parameter) {
         return (
             <React.Fragment key={parameter.name}>
                 <br />
@@ -43,9 +45,9 @@ export function SuspendInputs(props: SuspendInputProps) {
                 />
             </React.Fragment>
         );
-    };
+    }
 
-    const renderInputField = (parameter: Parameter) => {
+    function renderInputField(parameter: Parameter) {
         return (
             <React.Fragment key={parameter.name}>
                 <br />
@@ -53,16 +55,16 @@ export function SuspendInputs(props: SuspendInputProps) {
                 <input className='argo-field' defaultValue={parameter.value || parameter.default} onChange={event => setParameter(parameter.name, event.target.value)} />
             </React.Fragment>
         );
-    };
+    }
 
-    const renderFields = (parameter: Parameter) => {
+    function renderFields(parameter: Parameter) {
         if (parameter.enum) {
             return renderSelectField(parameter);
         }
         return renderInputField(parameter);
-    };
+    }
 
-    const renderInputContentIfApplicable = () => {
+    function renderInputContentIfApplicable() {
         if (parameters.length === 0) {
             return <React.Fragment />;
         }
@@ -73,7 +75,7 @@ export function SuspendInputs(props: SuspendInputProps) {
                 <br />
             </React.Fragment>
         );
-    };
+    }
 
     return (
         <div>

--- a/ui/src/app/workflows/components/workflow-logs-viewer/full-height-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/full-height-logs-viewer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {LogsViewer} from 'argo-ui';
 import {LogsViewerProps} from 'argo-ui/src/components/logs-viewer/logs-viewer';
@@ -6,11 +7,11 @@ import {LogsViewerProps} from 'argo-ui/src/components/logs-viewer/logs-viewer';
 require('./workflow-logs-viewer.scss');
 
 export function FullHeightLogsViewer(props: LogsViewerProps) {
-    const ref = React.useRef(null);
-    const [height, setHeight] = React.useState<number>(null);
+    const ref = useRef(null);
+    const [height, setHeight] = useState<number>(null);
     const {source} = props;
 
-    React.useEffect(() => {
+    useEffect(() => {
         const parentElement = ref.current!.parentElement;
         setHeight(parentElement.getBoundingClientRect().height);
     }, [ref]);

--- a/ui/src/app/workflows/components/workflow-logs-viewer/json-logs-field-selector.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/json-logs-field-selector.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useState} from 'react';
 import {TextInput} from '../../../shared/components/text-input';
 
 export interface SelectedJsonFields {
@@ -6,9 +7,10 @@ export interface SelectedJsonFields {
 }
 
 export function JsonLogsFieldSelector({fields, onChange}: {fields: SelectedJsonFields; onChange: (v: string[]) => void}) {
-    const [inputFields, setInputFields] = React.useState(fields);
-    const [key, setKey] = React.useState('');
-    const deleteItem = (k: string) => {
+    const [inputFields, setInputFields] = useState(fields);
+    const [key, setKey] = useState('');
+
+    function deleteItem(k: string) {
         const index = inputFields.values.indexOf(k, 0);
         if (index === -1) {
             return;
@@ -16,8 +18,8 @@ export function JsonLogsFieldSelector({fields, onChange}: {fields: SelectedJsonF
         const values = inputFields.values.filter(v => v !== k);
         setInputFields({values});
         onChange(values);
-    };
-    const addItem = () => {
+    }
+    function addItem() {
         if (!key || key.trim().length === 0) {
             return;
         }
@@ -29,7 +31,7 @@ export function JsonLogsFieldSelector({fields, onChange}: {fields: SelectedJsonF
         setInputFields({values});
         setKey('');
         onChange(values);
-    };
+    }
 
     return (
         <>
@@ -54,7 +56,7 @@ export function JsonLogsFieldSelector({fields, onChange}: {fields: SelectedJsonF
                     <TextInput value={key} onChange={setKey} placeholder='jsonPayload.message' />
                 </div>
                 <div className='columns small-2'>
-                    <button onClick={() => addItem()}>
+                    <button onClick={addItem}>
                         <i className='fa fa-plus-circle' />
                     </button>
                 </div>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- a handful of files had `React.use`, while the rest had `use`
  - `use` is definitely more of the convention in the ecosystem as well 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- consistently use the same import style for `React` imports

- also use named functions instead of consts assigned to anonymous functions for better tracing
  - was changing these files anyway, might as well get that done too
  
- tiny optimization in an `onClick` event handler


### Verification

<!-- TODO: Say how you tested your changes. -->

- primarily stylistic changes outside of the tracing benefits and a tiny optimization
- partially tested manually while working on #12097 (this was just unstaged code I had lying around)