### PR TITLE
docs: fix description of argo stop --dry-run. Fixes #10782

### DIFF
--- a/cmd/argo/commands/stop.go
+++ b/cmd/argo/commands/stop.go
@@ -72,7 +72,7 @@ func NewStopCommand() *cobra.Command {
 	command.Flags().StringVar(&stopArgs.nodeFieldSelector, "node-field-selector", "", "selector of node to stop, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
 	command.Flags().StringVarP(&stopArgs.labelSelector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&stopArgs.fieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
-	command.Flags().BoolVar(&stopArgs.dryRun, "dry-run", false, "If true, only stop the workflows that would be stopped, without stopping them.")
+	command.Flags().BoolVar(&stopArgs.dryRun, "dry-run", false, "If true, only print the workflows that would be stopped, without stopping them.")
 	return command
 }
 

--- a/docs/cli/argo_stop.md
+++ b/docs/cli/argo_stop.md
@@ -34,7 +34,7 @@ argo stop WORKFLOW WORKFLOW2... [flags]
 ### Options
 
 ```
-      --dry-run                      If true, only stop the workflows that would be stopped, without stopping them.
+      --dry-run                      If true, only print the workflows that would be stopped, without stopping them.
       --field-selector string        Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                         help for stop
       --message string               Message to add to previously running nodes


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

Updated the description of `--dry-run` flag for `argo stop` command.

<!-- Does this PR fix an issue -->

Fixes #10782

### Motivation

Improve cli commands description for clarity.

### Modifications

Updated the description of `--dry-run` flag for `argo stop` command.

### Verification

Docs update.
