### PR TITLE
docs: Minor update for memoization

### DIFF
--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -57,4 +57,4 @@ spec:
     * Reduce the size of the output parameters for the nodes that are being memoized.
     * Split your cache into different memoization keys and cache names so that each cache entry is small.
 1. My step isn't getting memoized, why not?
-   Ensure that you have specified at least one output on the step.
+   If you are running workflows <3.5 ensure that you have specified at least one output on the step.


### PR DESCRIPTION
Missing update to docs for memoization from #11379. 11379 allows memoization without outputs in 3.5
