### PR TITLE
fix(server): allow passing loglevels as env vars to Server

### DIFF
--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -141,9 +141,11 @@ If your server is behind an ingress with a path (you'll be running "argo server 
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
 	if err := viper.BindPFlags(command.PersistentFlags()); err != nil {
 		log.Fatal(err)
 	}
+	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
 	command.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)

--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -138,6 +138,7 @@ If your server is behind an ingress with a path (you'll be running "argo server 
 	command.PersistentFlags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enabled verbose logging, i.e. --loglevel debug")
 
+	// set-up env vars for the CLI such that ARGO_* env vars can be used instead of flags
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -13,6 +13,7 @@ import (
 
 	eventsource "github.com/argoproj/argo-events/pkg/client/eventsource/clientset/versioned"
 	sensor "github.com/argoproj/argo-events/pkg/client/sensor/clientset/versioned"
+	"github.com/argoproj/pkg/cli"
 	"github.com/argoproj/pkg/stats"
 	log "github.com/sirupsen/logrus"
 	"github.com/skratchdot/open-golang/open"
@@ -59,6 +60,8 @@ func NewServerCommand() *cobra.Command {
 		kubeAPIQPS               float32
 		kubeAPIBurst             int
 		allowedLinkProtocol      []string
+		logLevel                 string // --loglevel
+		glogLevel                int    // --gloglevel
 		logFormat                string // --log-format
 	)
 
@@ -68,6 +71,8 @@ func NewServerCommand() *cobra.Command {
 		Example: fmt.Sprintf(`
 See %s`, help.ArgoServer),
 		RunE: func(c *cobra.Command, args []string) error {
+			cli.SetLogLevel(logLevel)
+			cmd.SetGLogLevel(glogLevel)
 			cmd.SetLogFormatter(logFormat)
 			stats.RegisterStackDumper()
 			stats.StartStatsTicker(5 * time.Minute)
@@ -233,6 +238,8 @@ See %s`, help.ArgoServer),
 	command.Flags().StringVar(&accessControlAllowOrigin, "access-control-allow-origin", "", "Set Access-Control-Allow-Origin header in HTTP responses.")
 	command.Flags().Uint64Var(&apiRateLimit, "api-rate-limit", 1000, "Set limit per IP for api ratelimiter")
 	command.Flags().StringArrayVar(&allowedLinkProtocol, "allowed-link-protocol", defaultAllowedLinkProtocol, "Allowed link protocol in configMap. Used if the allowed configMap links protocol are different from http,https. Defaults to the environment variable ALLOWED_LINK_PROTOCOL")
+	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().StringVar(&logFormat, "log-format", "text", "The formatter to use for logs. One of: text|json")
 	command.Flags().Float32Var(&kubeAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with kube-apiserver.")
 	command.Flags().IntVar(&kubeAPIBurst, "kube-api-burst", 30, "Burst to use while talking with kube-apiserver.")

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -237,6 +237,7 @@ See %s`, help.ArgoServer),
 	command.Flags().Float32Var(&kubeAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with kube-apiserver.")
 	command.Flags().IntVar(&kubeAPIBurst, "kube-api-burst", 30, "Burst to use while talking with kube-apiserver.")
 
+	// set-up env vars for the CLI such that ARGO_* env vars can be used instead of flags
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -13,7 +13,6 @@ import (
 
 	eventsource "github.com/argoproj/argo-events/pkg/client/eventsource/clientset/versioned"
 	sensor "github.com/argoproj/argo-events/pkg/client/sensor/clientset/versioned"
-	"github.com/argoproj/pkg/cli"
 	"github.com/argoproj/pkg/stats"
 	log "github.com/sirupsen/logrus"
 	"github.com/skratchdot/open-golang/open"
@@ -60,8 +59,6 @@ func NewServerCommand() *cobra.Command {
 		kubeAPIQPS               float32
 		kubeAPIBurst             int
 		allowedLinkProtocol      []string
-		logLevel                 string // --loglevel
-		glogLevel                int    // --gloglevel
 		logFormat                string // --log-format
 	)
 
@@ -71,8 +68,6 @@ func NewServerCommand() *cobra.Command {
 		Example: fmt.Sprintf(`
 See %s`, help.ArgoServer),
 		RunE: func(c *cobra.Command, args []string) error {
-			cli.SetLogLevel(logLevel)
-			cmd.SetGLogLevel(glogLevel)
 			cmd.SetLogFormatter(logFormat)
 			stats.RegisterStackDumper()
 			stats.StartStatsTicker(5 * time.Minute)
@@ -238,8 +233,6 @@ See %s`, help.ArgoServer),
 	command.Flags().StringVar(&accessControlAllowOrigin, "access-control-allow-origin", "", "Set Access-Control-Allow-Origin header in HTTP responses.")
 	command.Flags().Uint64Var(&apiRateLimit, "api-rate-limit", 1000, "Set limit per IP for api ratelimiter")
 	command.Flags().StringArrayVar(&allowedLinkProtocol, "allowed-link-protocol", defaultAllowedLinkProtocol, "Allowed link protocol in configMap. Used if the allowed configMap links protocol are different from http,https. Defaults to the environment variable ALLOWED_LINK_PROTOCOL")
-	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
-	command.Flags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.Flags().StringVar(&logFormat, "log-format", "text", "The formatter to use for logs. One of: text|json")
 	command.Flags().Float32Var(&kubeAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with kube-apiserver.")
 	command.Flags().IntVar(&kubeAPIBurst, "kube-api-burst", 30, "Burst to use while talking with kube-apiserver.")

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -240,9 +240,11 @@ See %s`, help.ArgoServer),
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
 	if err := viper.BindPFlags(command.Flags()); err != nil {
 		log.Fatal(err)
 	}
+	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
 	command.Flags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -194,9 +194,11 @@ func NewRootCommand() *cobra.Command {
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
 	if err := viper.BindPFlags(command.Flags()); err != nil {
 		log.Fatal(err)
 	}
+	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
 	command.Flags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -191,6 +191,7 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", "", "namespace that workflow-controller watches, default to the installation namespace")
 	command.Flags().BoolVar(&executorPlugins, "executor-plugins", false, "enable executor plugins")
 
+	// set-up env vars for the CLI such that ARGO_* env vars can be used instead of flags
 	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

In #11978 I noticed that `ARGO_LOGLEVEL` did not work for the Server
- `--loglevel` (and `--gloglevel`) were only set [at the parent command, `argo`](https://github.com/argoproj/argo-workflows/blob/b2e3676503999e699cd3aaca62ff7bfff64464af/cmd/argo/commands/root.go#L120), and not in [the `argo server` subcommand](https://github.com/argoproj/argo-workflows/blob/b2e3676503999e699cd3aaca62ff7bfff64464af/cmd/argo/commands/server.go#L42) itself
  - however, `viper.AutomaticEnv()` and `viper.BindPFlags(command.Flags())` does not evaluate the parent command (related https://github.com/spf13/viper/issues/646, https://github.com/spf13/viper/issues/375, https://github.com/spf13/viper/issues/801)
    - similarly, the code that actually sets the loglevels (which is in the CLI itself), would not run when an env var was used
    - hence, we have a few options:
      1. import the parent command and bind it in the child or something wacky like that
          - **EDIT**: I tried this and this crashed hard
            - trying `command.Parent().PersistentFlags()` would result in a segfault
              - tried to use `AddFlagSet` to add it in `server.go` and that crashed hard. It crashes without the `AddFlagSet`, just the `Parent().PersistentFlags()` causes it (so `viper.BindPFlags(command.Parent().PersistentFlags())` crashed too etc)
              - <details> <summary> segfault error log </summary>
                
                ```
                server: panic: runtime error: invalid memory address or nil pointer dereference
                server: [signal SIGSEGV: segmentation violation code=0x1 addr=0x188 pc=0xa3d692]
                server:
                server: goroutine 1 [running]:
                server: github.com/spf13/cobra.(*Command).PersistentFlags(0xc000169b00?)
                server:         /home/vscode/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1676 +0x12
                server: github.com/argoproj/argo-workflows/v3/cmd/argo/commands.NewServerCommand()
                server:         /home/vscode/go/src/github.com/argoproj/argo-workflows/cmd/argo/commands/server.go:240 +0xcda
                server: github.com/argoproj/argo-workflows/v3/cmd/argo/commands.NewCommand()
                server:         /home/vscode/go/src/github.com/argoproj/argo-workflows/cmd/argo/commands/root.go:100 +0x23e
                server: main.main()
                server:         /home/vscode/go/src/github.com/argoproj/argo-workflows/cmd/argo/main.go:14 +0x13
                2023/11/04 19:50:17 server: process exited 89278: exit status 2
                2023/11/04 19:50:17 server: context cancelled, stopping process
                server: exit status 2
                ```
                
                </details>
      1. try to bind env vars at the parent level
          - which may not work and would apply to _all_ subcommands, even though `viper` env vars are only used for the Controller & Server
          - parent flags and persistent flags also seem to a work a tad differently in `viper` / `cobra` per https://github.com/spf13/viper/issues/646
          - **EDIT**: this is the option I ended up going with since Option C caused a panic
      1. just add flags for loglevels inside of the `argo server` subcommand
          - this seemed by far the easiest, least complex, and least LoC
          - it is also consistent with the Controller as well
          - and we already have `--log-format` in the `argo server` subcommand as well
          - **EDIT**: this caused a panic unfortunately
            - <details> <summary> gloglevel klog flag redefinition error </summary>

              ```
              server: ./dist/argo flag redefined: log_dir
              server: panic: ./dist/argo flag redefined: log_dir
              server: 
              server: goroutine 1 [running]:
              server: flag.(*FlagSet).Var(0xc0001f8150, {0x314fe28, 0x47c1bf0}, {0x2aae917, 0x7}, {0x2b7e755, 0x52})
              server:         /usr/local/go/src/flag/flag.go:1028 +0x3a5
              server: flag.(*FlagSet).StringVar(...)
              server:         /usr/local/go/src/flag/flag.go:879
              server: k8s.io/klog/v2.InitFlags(0x4?)
              server:         /home/vscode/go/pkg/mod/k8s.io/klog/v2@v2.70.1/klog.go:424 +0x4f
              server: github.com/argoproj/argo-workflows/v3/util/cmd.SetGLogLevel(0xc00001283c?)
              server:         /home/vscode/go/src/github.com/argoproj/argo-workflows/util/cmd/glog.go:14 +0x1a
              server: github.com/argoproj/argo-workflows/v3/cmd/argo/commands.NewServerCommand.func1(0xc00022fd00?, {0x2aa9b6f?, 0x4?, 0x2aa9a8b?})
              server:         /home/vscode/go/src/github.com/argoproj/argo-workflows/cmd/argo/commands/server.go:75 +0x16f
              server: github.com/spf13/cobra.(*Command).execute(0xc0001d7800, {0x4819640, 0x0, 0x0})
              server:         /home/vscode/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x87c
              server: github.com/spf13/cobra.(*Command).ExecuteC(0xc000005200)
              server:         /home/vscode/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
              server: github.com/spf13/cobra.(*Command).Execute(0x0?)
              server:         /home/vscode/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992 +0x13
              server: main.main()
              server:         /home/vscode/go/src/github.com/argoproj/argo-workflows/cmd/argo/main.go:14 +0x18
              2023/11/04 19:42:10 server: process exited 82584: exit status 2
              server: exit status 2
              ```

              </details>
              
            - running [`cmd.SetGLogLevel`](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/util/cmd/glog.go#L13) in `server.go` would cause a panic due to a flag redefinition of `klog`
             - i.e. `SetGLogLevel` can't be called twice
             - but `cli.SetLogLevel` worked fine, so the only issue is `--gloglevel`, to be exact


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- ~added the two flags to the `argo server` subcommand next to `--log-format`~
  - ~added the same code to `RunE` that [`argo`](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/cmd/argo/commands/root.go#L128-L129) and [`workflow-controller`](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/cmd/workflow-controller/main.go#L74-L75) run when these flags are set~

**EDIT**: Option C actually did not work, so went with Option B

- so instead of hacking together some logic to get Option C to work, I just added `viper` to `root.go`, where it does capture the env vars from subcommands too
  - same `viper` logic as in other parts of the CLI (like [`server.go`](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/cmd/argo/commands/server.go#L240)), just using `command.PersistentFlags()` instead of `command.Flags()`

  - one caveat is that now env vars can be used for `loglevel`, `gloglevel`, and `verbose` for _all_ of the Argo CLI
    - nbd, IMO, but it is noteworthy to mention as a side-effect, especially when compared to Option C
  
### Verification

<!-- TODO: Say how you tested your changes. -->

  - tested by changing [this init log line](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/server/apiserver/argoserver.go#L272) to a `Debugf` instead of an `Infof` and then changing [the `ARGO_LOGLEVEL` in the kit `tasks.yaml` to `DEBUG`](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/tasks.yaml#L72) as well
    - and then checking for this in the logs:
    ```
    server: time="2023-11-04T20:12:56.151Z" level=debug msg="Argo Server started successfully on http://localhost:2746" url="http://localhost:2746"
    ```