### PR TITLE
docs: full copy-edit of `environment-variables.md`

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,10 +1,10 @@
 # Environment Variables
 
-This document outlines the set of environment variables that can be used to customize the behavior at different
-levels.
+This document outlines environment variables that can be used to customize behavior.
 
-⚠️ Environment variables are typically added to test out experimental features and should not be used by
-most users. Environment variables may be removed at any time.
+!!! Warning
+    Environment variables are typically added to test out experimental features and should not be used by most users.
+    Environment variables may be removed at any time.
 
 ## Controller
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -30,7 +30,6 @@ most users. Environment variables may be removed at any time.
 | `DISABLE_MAX_RECURSION`                  | `bool`              | `false`                                                                                     | Set to true to disable the recursion preventer, which will stop a workflow running which has called into a child template 100 times                                                                                                                                      |
 | `EXPRESSION_TEMPLATES`                   | `bool`              | `true`                                                                                      | Escape hatch to disable expression templates.                                                                                                                                                                                                                            |
 | `EVENT_AGGREGATION_WITH_ANNOTATIONS`     | `bool`              | `false`                                                                                     | Whether event annotations will be used when aggregating events.                                                                                                                                                                                                          |
-| `GRPC_MESSAGE_SIZE`                      | `string`            | Use different GRPC Max message size for Argo server deployment (supporting huge workflows). |
 | `GZIP_IMPLEMENTATION`                    | `string`            | `PGZip`                                                                                     | The implementation of compression/decompression. Currently only "`PGZip`" and "`GZip`" are supported.                                                                                                                                                                    |
 | `INFORMER_WRITE_BACK`                    | `bool`              | `true`                                                                                      | Whether to write back to informer instead of catching up.                                                                                                                                                                                                                |
 | `HEALTHZ_AGE`                            | `time.Duration`     | `5m`                                                                                        | How old a un-reconciled workflow is to report unhealthy.                                                                                                                                                                                                                 |
@@ -54,7 +53,7 @@ most users. Environment variables may be removed at any time.
 | `WORKFLOW_GC_PERIOD`                     | `time.Duration`     | `5m`                                                                                        | The periodicity for GC of workflows.                                                                                                                                                                                                                                     |
 | `SEMAPHORE_NOTIFY_DELAY`                 | `time.Duration`     | `1s`                                                                                        | Tuning Delay when notifying semaphore waiters about availability in the semaphore                                                                                                                                                                                        |
 
-CLI parameters of the Server and Controller can be specified as environment variables with the `ARGO_` prefix.
+CLI parameters of the Controller can be specified as environment variables with the `ARGO_` prefix.
 For example:
 
 ```bash
@@ -65,34 +64,6 @@ Can be expressed as:
 
 ```bash
 ARGO_MANAGED_NAMESPACE=argo workflow-controller
-```
-
-You can set environment variables for the Server Deployment's container spec like the following:
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: argo-server
-spec:
-  selector:
-    matchLabels:
-      app: argo-server
-  template:
-    metadata:
-      labels:
-        app: argo-server
-    spec:
-      containers:
-        - args:
-            - server
-          image: argoproj/argocli:latest
-          name: argo-server
-          env:
-            - name: GRPC_MESSAGE_SIZE
-              value: "209715200"
-          ports:
-          # ...
 ```
 
 You can set environment variables for the Controller Deployment's container spec like the following:
@@ -153,3 +124,45 @@ data:
 | `FEEDBACK_MODAL`                           | `bool`   | `true`  | Show this modal.                                                                                                        |
 | `NEW_VERSION_MODAL`                        | `bool`   | `true`  | Show this modal.                                                                                                        |
 | `POD_NAMES`                                | `string` | `v2`    | Whether to have pod names contain the template name (v2) or be the node id (v1) - should be set the same for Controller |
+| `GRPC_MESSAGE_SIZE`                        | `string` | `104857600` | Use different GRPC Max message size for Server (supporting huge workflows).                                         |
+
+CLI parameters of the Server can be specified as environment variables with the `ARGO_` prefix.
+For example:
+
+```bash
+argo server --managed-namespace=argo
+```
+
+Can be expressed as:
+
+```bash
+ARGO_MANAGED_NAMESPACE=argo argo server
+```
+
+You can set environment variables for the Server Deployment's container spec like the following:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-server
+spec:
+  selector:
+    matchLabels:
+      app: argo-server
+  template:
+    metadata:
+      labels:
+        app: argo-server
+    spec:
+      containers:
+        - args:
+            - server
+          image: argoproj/argocli:latest
+          name: argo-server
+          env:
+            - name: GRPC_MESSAGE_SIZE
+              value: "209715200"
+          ports:
+          # ...
+```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -54,8 +54,8 @@ most users. Environment variables may be removed at any time.
 | `WORKFLOW_GC_PERIOD`                     | `time.Duration`     | `5m`                                                                                        | The periodicity for GC of workflows.                                                                                                                                                                                                                                     |
 | `SEMAPHORE_NOTIFY_DELAY`                 | `time.Duration`     | `1s`                                                                                        | Tuning Delay when notifying semaphore waiters about availability in the semaphore                                                                                                                                                                                        |
 
-CLI parameters of the `argo-server` and `workflow-controller` can be specified as environment variables with the `ARGO_`
-prefix. For example:
+CLI parameters of the Server and Controller can be specified as environment variables with the `ARGO_` prefix.
+For example:
 
 ```bash
 workflow-controller --managed-namespace=argo
@@ -67,7 +67,7 @@ Can be expressed as:
 ARGO_MANAGED_NAMESPACE=argo workflow-controller
 ```
 
-You can set environment variable for the argo-server deployment, for example:
+You can set environment variables for the Server Deployment's container spec like the following:
 
 ```yaml
 apiVersion: apps/v1
@@ -92,12 +92,10 @@ spec:
             - name: GRPC_MESSAGE_SIZE
               value: "209715200"
           ports:
-          ..
-          ...
-          ....
+          # ...
 ```
 
-You can set the environment variables for controller in controller's container spec like the following:
+You can set environment variables for the Controller Deployment's container spec like the following:
 
 ```yaml
 apiVersion: apps/v1
@@ -131,8 +129,7 @@ spec:
 | `RESOURCE_STATE_CHECK_INTERVAL`        | `time.Duration` | `5s`    | The time interval between resource status checks against the specified success and failure conditions. |
 | `WAIT_CONTAINER_STATUS_CHECK_INTERVAL` | `time.Duration` | `5s`    | The time interval for wait container to check whether the containers have completed.                   |
 
-You can set the environment variables for executor by customizing executor container's environment variables in your
-controller's config-map like the following:
+You can set environment variables for the Executor in your [`workflow-controller-configmap`](workflow-controller-configmap.md) like the following:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

`environment-variables.md` had some inconsistencies and mistakes in it.
- I've linked to it a few times and have added relative links from other places in the docs, so would like to make sure the page is accurate etc

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

#### Accuracy fixes

- move Server env vars and examples into the Server section
  - instead of being in the Controller block
  - `GRPC_MESSAGE_SIZE` was used in the example yet wasn't in the Server's env var list
    - it was incorrectly in the Controller list, confirmed it was only used [in Server code](https://github.com/argoproj/argo-workflows/blob/a47e46208cd0029ef2e35019207d0b1ee4f85ea4/server/apiserver/argoserver.go#L119)
    - also add its previously missing default into the table
  - also comment out ellipses in code block so that the block is all valid code

#### Consistency
- consistently use 1 sentence per line

- consistently use "Server and Controller" instead of `argo-server` and `workflow-controller` (or the lowercase variants)
  - consistent with the rest of this page and the rest of the docs
  - those names are primarily referenced in the manifests

- consistently use the sentence "You can set environment variables [...] like the following"
  - there were a few variations on this before
  - consistently use "Deployment's container spec"
    - similarly a few variations before

#### Misc
- be more direct with the first line description of the document, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
- use `!!! Warning` block instead of a unicode character
  - this is more consistent with the rest of the docs and a more clear warning

- link to the `workflow-controller-configmap` when it is mentioned
  - keep references to it consistent across the docs; always use `workflow-controller-configmap`



### Verification

<!-- TODO: Say how you tested your changes. -->
`make docs` and `make codegen` pass