### PR TITLE
refactor(ui): code-split gigantic Monaco Editor dep

### DIFF
--- a/ui/src/app/apidocs/components/apiDocs.tsx
+++ b/ui/src/app/apidocs/components/apiDocs.tsx
@@ -17,8 +17,8 @@ export const ApiDocs = () => {
 
 // lazy load SwaggerUI as it is infrequently used and imports very large components (which can be split into a separate bundle)
 const LazySwaggerUI = React.lazy(() => {
-    import('swagger-ui-react/swagger-ui.css');
-    return import('swagger-ui-react');
+    import(/* webpackChunkName: "swagger-ui-react-css" */ 'swagger-ui-react/swagger-ui.css');
+    return import(/* webpackChunkName: "swagger-ui-react" */ 'swagger-ui-react');
 });
 
 function SuspenseSwaggerUI(props: any) {

--- a/ui/src/app/reports/components/report-container.tsx
+++ b/ui/src/app/reports/components/report-container.tsx
@@ -9,7 +9,7 @@ export const ReportsContainer = (props: RouteComponentProps<any>) => (
 );
 
 // lazy load Reports as it is infrequently used and imports large Chart components (which can be split into a separate bundle)
-const LazyReports = React.lazy(() => import('./reports'));
+const LazyReports = React.lazy(() => import(/* webpackChunkName: "reports" */ './reports'));
 
 function SuspenseReports(props: RouteComponentProps<any>) {
     return (

--- a/ui/src/app/shared/components/object-editor/object-editor.tsx
+++ b/ui/src/app/shared/components/object-editor/object-editor.tsx
@@ -44,7 +44,7 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
 
     useEffect(() => {
         if (!type || lang !== 'json') {
-            return
+            return;
         }
 
         (async () => {

--- a/ui/src/app/shared/components/object-editor/object-editor.tsx
+++ b/ui/src/app/shared/components/object-editor/object-editor.tsx
@@ -1,12 +1,13 @@
-import {languages} from 'monaco-editor/esm/vs/editor/editor.api';
 import * as React from 'react';
-import {createRef, useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import MonacoEditor from 'react-monaco-editor';
+
 import {uiUrl} from '../../base';
 import {ScopedLocalStorage} from '../../scoped-local-storage';
 import {Button} from '../button';
 import {parse, stringify} from '../object-parser';
 import {PhaseIcon} from '../phase-icon';
+import {SuspenseMonacoEditor} from '../suspense-monaco-editor';
 
 interface Props<T> {
     type?: string;
@@ -22,11 +23,16 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
     const [error, setError] = useState<Error>();
     const [lang, setLang] = useState<string>(storage.getItem('lang', defaultLang));
     const [text, setText] = useState<string>(stringify(value, lang));
+    const editor = useRef<MonacoEditor>(null);
 
     useEffect(() => storage.setItem('lang', lang, defaultLang), [lang]);
     useEffect(() => setText(stringify(value, lang)), [value]);
     useEffect(() => setText(stringify(parse(text), lang)), [lang]);
     useEffect(() => {
+        if (!editor.current) {
+            return;
+        }
+
         // we ONLY want to change the text, if the normalized version has changed, this prevents white-space changes
         // from resulting in a significant change
         const editorText = stringify(parse(editor.current.editor.getValue()), lang);
@@ -34,36 +40,42 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
         if (text !== editorText || lang !== editorLang) {
             editor.current.editor.setValue(stringify(parse(text), lang));
         }
-    }, [text, lang]);
+    }, [editor, text, lang]);
 
     useEffect(() => {
-        if (type && lang === 'json') {
-            const uri = uiUrl('assets/jsonschema/schema.json');
-            fetch(uri)
-                .then(res => res.json())
-                .then(swagger => {
-                    // adds auto-completion to JSON only
-                    languages.json.jsonDefaults.setDiagnosticsOptions({
-                        validate: true,
-                        schemas: [
-                            {
-                                uri,
-                                fileMatch: ['*'],
-                                schema: {
-                                    $id: 'http://workflows.argoproj.io/' + type + '.json',
-                                    $ref: '#/definitions/' + type,
-                                    $schema: 'http://json-schema.org/draft-07/schema',
-                                    definitions: swagger.definitions
-                                }
-                            }
-                        ]
-                    });
-                })
-                .catch(setError);
+        if (!type || lang !== 'json') {
+            return
         }
+
+        (async () => {
+            const uri = uiUrl('assets/jsonschema/schema.json');
+            try {
+                const res = await fetch(uri);
+                const swagger = await res.json();
+                // lazy load this, otherwise all of monaco-editor gets imported into the main bundle
+                const languages = (await import('monaco-editor/esm/vs/editor/editor.api')).languages;
+                // adds auto-completion to JSON only
+                languages.json.jsonDefaults.setDiagnosticsOptions({
+                    validate: true,
+                    schemas: [
+                        {
+                            uri,
+                            fileMatch: ['*'],
+                            schema: {
+                                $id: 'http://workflows.argoproj.io/' + type + '.json',
+                                $ref: '#/definitions/' + type,
+                                $schema: 'http://json-schema.org/draft-07/schema',
+                                definitions: swagger.definitions
+                            }
+                        }
+                    ]
+                });
+            } catch (err) {
+                setError(err);
+            }
+        })();
     }, [lang, type]);
 
-    const editor = createRef<MonacoEditor>();
     // this calculation is rough, it is probably hard to work for for every case, essentially it is:
     // some pixels above and below for buttons, plus a bit of a buffer/padding
     const height = Math.max(600, window.innerHeight * 0.9 - 250);
@@ -100,7 +112,7 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
                 {buttons}
             </div>
             <div>
-                <MonacoEditor
+                <SuspenseMonacoEditor
                     ref={editor}
                     key='editor'
                     defaultValue={text}

--- a/ui/src/app/shared/components/object-editor/object-editor.tsx
+++ b/ui/src/app/shared/components/object-editor/object-editor.tsx
@@ -53,7 +53,7 @@ export const ObjectEditor = <T extends any>({type, value, buttons, onChange}: Pr
                 const res = await fetch(uri);
                 const swagger = await res.json();
                 // lazy load this, otherwise all of monaco-editor gets imported into the main bundle
-                const languages = (await import('monaco-editor/esm/vs/editor/editor.api')).languages;
+                const languages = (await import(/* webpackChunkName: "monaco-editor" */ 'monaco-editor/esm/vs/editor/editor.api')).languages;
                 // adds auto-completion to JSON only
                 languages.json.jsonDefaults.setDiagnosticsOptions({
                     validate: true,

--- a/ui/src/app/shared/components/suspense-monaco-editor.tsx
+++ b/ui/src/app/shared/components/suspense-monaco-editor.tsx
@@ -6,7 +6,7 @@ import {Loading} from './loading';
 
 // lazy load Monaco Editor as it is a gigantic component (which can be split into a separate bundle)
 const LazyMonacoEditor = React.lazy(() => {
-  return import('react-monaco-editor');
+    return import(/* webpackChunkName: "react-monaco-editor" */ 'react-monaco-editor');
 });
 
 // workaround, react-monaco-editor's own default no-op seems to fail when lazy loaded, causing a crash when unmounted
@@ -14,9 +14,9 @@ const LazyMonacoEditor = React.lazy(() => {
 const noop = () => {}; // tslint:disable-line:no-empty
 
 export const SuspenseMonacoEditor = React.forwardRef(function InnerMonacoEditor(props: MonacoEditorProps, ref: React.MutableRefObject<MonacoEditor>) {
-  return (
-      <React.Suspense fallback={<Loading />}>
-          <LazyMonacoEditor ref={ref} editorWillUnmount={noop} {...props} />
-      </React.Suspense>
-  );
+    return (
+        <React.Suspense fallback={<Loading />}>
+            <LazyMonacoEditor ref={ref} editorWillUnmount={noop} {...props} />
+        </React.Suspense>
+    );
 });

--- a/ui/src/app/shared/components/suspense-monaco-editor.tsx
+++ b/ui/src/app/shared/components/suspense-monaco-editor.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import {MonacoEditorProps} from 'react-monaco-editor';
+import MonacoEditor from 'react-monaco-editor';
+
+import {Loading} from './loading';
+
+// lazy load Monaco Editor as it is a gigantic component (which can be split into a separate bundle)
+const LazyMonacoEditor = React.lazy(() => {
+  return import('react-monaco-editor');
+});
+
+// workaround, react-monaco-editor's own default no-op seems to fail when lazy loaded, causing a crash when unmounted
+// react-monaco-editor's default no-op: https://github.com/react-monaco-editor/react-monaco-editor/blob/7e5a4938cd328bf95ebc1288967f2037c6023b5a/src/editor.tsx#L184
+const noop = () => {}; // tslint:disable-line:no-empty
+
+export const SuspenseMonacoEditor = React.forwardRef(function InnerMonacoEditor(props: MonacoEditorProps, ref: React.MutableRefObject<MonacoEditor>) {
+  return (
+      <React.Suspense fallback={<Loading />}>
+          <LazyMonacoEditor ref={ref} editorWillUnmount={noop} {...props} />
+      </React.Suspense>
+  );
+});

--- a/ui/src/app/workflows/components/workflow-details/artifact-panel.tsx
+++ b/ui/src/app/workflows/components/workflow-details/artifact-panel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import MonacoEditor from 'react-monaco-editor';
+
 import {Artifact, ArtifactRepository, execSpec, Workflow} from '../../../../models';
 import {artifactKey, artifactURN} from '../../../shared/artifacts';
 import ErrorBoundary from '../../../shared/components/error-boundary';
@@ -8,6 +8,7 @@ import {ErrorNotice} from '../../../shared/components/error-notice';
 import {FirstTimeUserPanel} from '../../../shared/components/first-time-user-panel';
 import {GiveFeedbackLink} from '../../../shared/components/give-feedback-link';
 import {LinkButton} from '../../../shared/components/link-button';
+import {SuspenseMonacoEditor} from '../../../shared/components/suspense-monaco-editor';
 import {useCollectEvent} from '../../../shared/components/use-collect-event';
 import {services} from '../../../shared/services';
 import requests from '../../../shared/services/requests';
@@ -82,7 +83,7 @@ export function ArtifactPanel({
                         ) : show ? (
                             <ViewBox>
                                 {object ? (
-                                    <MonacoEditor
+                                    <SuspenseMonacoEditor
                                         value={object}
                                         language='json'
                                         height='500px'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12059 -- this is the largest improvement by a wide margin, though still a little bit left to do
Partial fix for #11740 

### Motivation

<!-- TODO: Say why you made your changes. -->

- shave off 7.72MB / 3MB minified / 762KB gzipped from main bundle
  - main bundle itself is now only 5.11MB / 2.81MB minified / 553KB gzipped
    - i.e. the _entire_ main bundle is smaller than the Monaco bundle 😮 😬

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- wrap `react-monaco-editor` into a lazy loaded component
  - with some tiny gimmicks to it per in-line comments

- in `ObjectEditor`, asynchronously import `languages` as well in one of its effects
  - otherwise all of `monaco-editor` gets imported, per in-line comment
  - also rewrite that effect to use modern async/await instead of promise chains
    - which ends up a good bit simpler than what it would be with a promise chain with the new async import on top of the async fetch etc
    - and invert a conditional as well to reduce nesting / code complexity

- also refactor `ObjectEditor` a bit to correctly use `useRef` instead of `createRef`
  - `createRef` is for legacy class-based components, while `useRef` is for hooks-based functional components

- add [`webpackChunkName` magic comment](https://webpack.js.org/api/module-methods/#webpackchunkname) for clearer names for all of the dynamic imports
  - note that sub-chunks (like `Chart.js`, which is a chunk of `reports`) can't be directly named
    - [`output.chunkFilename`](https://webpack.js.org/configuration/output/#outputchunkfilename) is how it's typically configured, but you can't [access](https://webpack.js.org/configuration/output/#template-strings) the unresolved import name in that
      - `[name]` is equivalent to `[id]` in this case; I tried
      
### Verification

<!-- TODO: Say how you tested your changes. -->

Tested locally, editor seems to work fine in the UI:
![Screenshot 2023-11-04 at 11 40 43 PM](https://github.com/argoproj/argo-workflows/assets/4970083/7825ff4d-882e-4c98-afd7-415808611206)

#### Bundle verification

Full bundle, `monaco-editor` now split out:
![Screenshot 2023-11-05 at 12 27 22 AM - split monaco](https://github.com/argoproj/argo-workflows/assets/4970083/14ce6a78-1618-4cea-9c1f-cfc437c9edae)

Size of remaining main bundle:
![Screenshot 2023-11-05 at 12 28 05 AM - main wo monaco](https://github.com/argoproj/argo-workflows/assets/4970083/9c1c5e23-acd7-46f4-a078-a8805dcfa163)


