### PR TITLE
fix: better error messages for file:// in git artifacts (Fixes #12152)

### DIFF
--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 
 	"k8s.io/client-go/util/homedir"
@@ -167,6 +168,14 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 				SingleBranch: true,
 			}))
 		})
+	})
+	t.Run("UnsupportedFileScheme", func(t *testing.T) {
+		t.Setenv("PATH", "") // make sure git executable not in path
+		driver := &ArtifactDriver{}
+		repo := "file://DOES_NOT_MATTER"
+		err := load(driver, &wfv1.GitArtifact{Repo: repo})
+		assert.ErrorIs(t, err, exec.ErrNotFound)
+		assert.ErrorContains(t, err, "but using file:// scheme requires a git executable, which is not installed by default in argo workflows executor images")
 	})
 }
 


### PR DESCRIPTION
Fixes #12152 by checking whether the clone error is an `exec.NotFoundError` at some place in its tree and then generating a more informative error message.

<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Motivation

I saw very unintuitive error messages when using a malformed SCP-like git repo URL. I thought I needed to install git in the image specified at the step's `container.image` because the error message wasn't clear. I think it's better if the error messages state what is going on more clearly.

### Modifications

Add an `errors.Is` check for the exec error encountered when `go-git` attempts to call out to the `git` executable for `file://` repos. Ask for forgiveness, not permission.

Since the exec error is not at the top of the error tree, I used `errors.Is` and slightly modified the `switch` statement by wrapping it in an `if err != nil`, a stylistic choice. Viewing the diff without whitespace changes makes the semantic changes more obvious. I'm not particularly attached to the exact wording of the error message or how I detect the error condition so changes to this are very welcome.

### Verification

A test has been added to ensure this specific error is returned when using a `file://` url. The test uses [`t.Setenv`](https://beta.pkg.go.dev/testing@master#T.Setenv) to clear the path to ensure that no git executable is ever found. This cleans up after itself (restoring the old value of `PATH`), but it is not safe to use in parallel and will panic if it is used in those circumstances.
