### PR TITLE
refactor(ui): code-split out large `xterm` dep

### DIFF
--- a/ui/src/app/api-docs/api-docs.tsx
+++ b/ui/src/app/api-docs/api-docs.tsx
@@ -1,4 +1,4 @@
-import {Page} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 
 import {uiUrl} from '../shared/base';

--- a/ui/src/app/app-router.tsx
+++ b/ui/src/app/app-router.tsx
@@ -1,5 +1,9 @@
-import {Layout, Notifications, NotificationsManager, NotificationType, Popup, PopupManager, PopupProps} from 'argo-ui';
 import * as H from 'history';
+import {Layout} from 'argo-ui/src/components/layout/layout';
+import {NotificationsManager} from 'argo-ui/src/components/notifications/notification-manager';
+import {Notifications, NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {PopupManager} from 'argo-ui/src/components/popup/popup-manager';
+import {Popup, PopupProps} from 'argo-ui/src/components/popup/popup';
 
 import * as React from 'react';
 import {useEffect, useState} from 'react';

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -1,7 +1,9 @@
-import {NavigationManager, NotificationsManager, PopupManager} from 'argo-ui';
-
 import {createBrowserHistory} from 'history';
 import * as React from 'react';
+import {NavigationManager} from 'argo-ui/src/components/navigation';
+import {NotificationsManager} from 'argo-ui/src/components/notifications/notification-manager';
+import {PopupManager} from 'argo-ui/src/components/popup/popup-manager';
+
 import {AppRouter} from './app-router';
 import {ContextApis, Provider} from './shared/context';
 

--- a/ui/src/app/app.tsx
+++ b/ui/src/app/app.tsx
@@ -4,6 +4,8 @@ import {NavigationManager} from 'argo-ui/src/components/navigation';
 import {NotificationsManager} from 'argo-ui/src/components/notifications/notification-manager';
 import {PopupManager} from 'argo-ui/src/components/popup/popup-manager';
 
+import 'argo-ui/src/styles/main.scss';
+
 import {AppRouter} from './app-router';
 import {ContextApis, Provider} from './shared/context';
 

--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -1,4 +1,4 @@
-import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import {Page} from 'argo-ui/src/components/page/page';
 import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';

--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -1,4 +1,5 @@
-import {NotificationType, Page} from 'argo-ui';
+import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {Page} from 'argo-ui/src/components/page/page';
 import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';

--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -1,5 +1,5 @@
 import {NotificationType, Page} from 'argo-ui';
-import {SlidingPanel} from 'argo-ui/src/index';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';

--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-editor.tsx
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Tabs} from 'argo-ui';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 
 import {WorkflowTemplate} from '../../models';
 import {LabelsAndAnnotationsEditor} from '../shared/components/editors/labels-and-annotations-editor';

--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-list.tsx
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-list.tsx
@@ -1,4 +1,5 @@
-import {Page, SlidingPanel} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-details.tsx
@@ -1,4 +1,4 @@
-import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import {Page} from 'argo-ui/src/components/page/page';
 import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';

--- a/ui/src/app/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-details.tsx
@@ -1,4 +1,6 @@
-import {NotificationType, Page, SlidingPanel} from 'argo-ui';
+import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';

--- a/ui/src/app/cron-workflows/cron-workflow-editor.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Tabs} from 'argo-ui';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 
 import {CronWorkflow} from '../../models';
 import {LabelsAndAnnotationsEditor} from '../shared/components/editors/labels-and-annotations-editor';

--- a/ui/src/app/cron-workflows/cron-workflow-list.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-list.tsx
@@ -1,4 +1,6 @@
-import {Page, SlidingPanel, Ticker} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
+import {Ticker} from 'argo-ui/src/components/ticker';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/cron-workflows/cron-workflow-spec-editior.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-spec-editior.tsx
@@ -1,4 +1,5 @@
-import {Checkbox, Select} from 'argo-ui';
+import {Checkbox} from 'argo-ui/src/components/checkbox';
+import {Select} from 'argo-ui/src/components/select/select';
 import * as React from 'react';
 
 import {ConcurrencyPolicy, CronWorkflowSpec} from '../../models';

--- a/ui/src/app/event-flow/event-flow-page.tsx
+++ b/ui/src/app/event-flow/event-flow-page.tsx
@@ -1,4 +1,6 @@
-import {Page, SlidingPanel, Tabs} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 import {useContext, useEffect, useState} from 'react';
 import * as React from 'react';
 import {RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/event-sources/event-source-details.tsx
+++ b/ui/src/app/event-sources/event-source-details.tsx
@@ -1,4 +1,4 @@
-import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import {Page} from 'argo-ui/src/components/page/page';
 import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import {Tabs} from 'argo-ui/src/components/tabs/tabs';

--- a/ui/src/app/event-sources/event-source-details.tsx
+++ b/ui/src/app/event-sources/event-source-details.tsx
@@ -1,5 +1,7 @@
-import {NotificationType, Page} from 'argo-ui';
-import {SlidingPanel, Tabs} from 'argo-ui/src/index';
+import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';

--- a/ui/src/app/event-sources/event-source-editor.tsx
+++ b/ui/src/app/event-sources/event-source-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Tabs} from 'argo-ui';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 
 import {EventSource} from '../../models';
 import {MetadataEditor} from '../shared/components/editors/metadata-editor';

--- a/ui/src/app/event-sources/event-source-list.tsx
+++ b/ui/src/app/event-sources/event-source-list.tsx
@@ -1,4 +1,6 @@
-import {Page, SlidingPanel, Tabs} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 import classNames from 'classnames';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';

--- a/ui/src/app/help/help.tsx
+++ b/ui/src/app/help/help.tsx
@@ -1,4 +1,4 @@
-import {Page} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 
 import {uiUrl} from '../shared/base';

--- a/ui/src/app/login/login.tsx
+++ b/ui/src/app/login/login.tsx
@@ -1,4 +1,4 @@
-import {Page} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 
 import {uiUrl, uiUrlWithParams} from '../shared/base';

--- a/ui/src/app/plugins/plugin-list.tsx
+++ b/ui/src/app/plugins/plugin-list.tsx
@@ -1,4 +1,4 @@
-import {Page} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/reports/reports.tsx
+++ b/ui/src/app/reports/reports.tsx
@@ -1,4 +1,4 @@
-import {Page} from 'argo-ui/src/index';
+import {Page} from 'argo-ui/src/components/page/page';
 import {ChartOptions} from 'chart.js';
 import 'chartjs-plugin-annotation';
 import * as React from 'react';

--- a/ui/src/app/sensors/sensor-details.tsx
+++ b/ui/src/app/sensors/sensor-details.tsx
@@ -1,4 +1,4 @@
-import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';

--- a/ui/src/app/sensors/sensor-details.tsx
+++ b/ui/src/app/sensors/sensor-details.tsx
@@ -1,4 +1,5 @@
-import {NotificationType, Page} from 'argo-ui';
+import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';

--- a/ui/src/app/sensors/sensor-editor.tsx
+++ b/ui/src/app/sensors/sensor-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Tabs} from 'argo-ui';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 
 import {Sensor} from '../../models';
 import {MetadataEditor} from '../shared/components/editors/metadata-editor';

--- a/ui/src/app/sensors/sensor-list.tsx
+++ b/ui/src/app/sensors/sensor-list.tsx
@@ -1,4 +1,5 @@
-import {Page, SlidingPanel} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import classNames from 'classnames';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';

--- a/ui/src/app/sensors/sensor-side-panel.tsx
+++ b/ui/src/app/sensors/sensor-side-panel.tsx
@@ -1,6 +1,8 @@
-import {SlidingPanel, Tabs} from 'argo-ui';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 import * as React from 'react';
 import {useState} from 'react';
+
 import {Sensor} from '../../models';
 import {Node} from '../shared/components/graph/types';
 import {EventsPanel} from '../workflows/components/events-panel';

--- a/ui/src/app/shared/components/checkbox-filter/checkbox-filter.tsx
+++ b/ui/src/app/shared/components/checkbox-filter/checkbox-filter.tsx
@@ -1,4 +1,4 @@
-import {Checkbox} from 'argo-ui';
+import {Checkbox} from 'argo-ui/src/components/checkbox';
 import * as React from 'react';
 
 import './checkbox-filter.scss';

--- a/ui/src/app/shared/components/clipboard-text.tsx
+++ b/ui/src/app/shared/components/clipboard-text.tsx
@@ -1,4 +1,4 @@
-import {Tooltip} from 'argo-ui';
+import {Tooltip} from 'argo-ui/src/components/tooltip/tooltip';
 import * as React from 'react';
 import {useState} from 'react';
 

--- a/ui/src/app/shared/components/data-loader-dropdown.tsx
+++ b/ui/src/app/shared/components/data-loader-dropdown.tsx
@@ -1,4 +1,5 @@
-import {DataLoader, Select, SelectOption} from 'argo-ui';
+import {DataLoader} from 'argo-ui/src/components/data-loader';
+import {Select, SelectOption} from 'argo-ui/src/components/select/select';
 import * as React from 'react';
 import {useState} from 'react';
 

--- a/ui/src/app/shared/components/filter-drop-down.tsx
+++ b/ui/src/app/shared/components/filter-drop-down.tsx
@@ -1,4 +1,4 @@
-import {Checkbox} from 'argo-ui';
+import {Checkbox} from 'argo-ui/src/components/checkbox';
 import classNames from 'classnames';
 import * as React from 'react';
 

--- a/ui/src/app/shared/components/input-filter.tsx
+++ b/ui/src/app/shared/components/input-filter.tsx
@@ -1,4 +1,4 @@
-import {Autocomplete} from 'argo-ui';
+import {Autocomplete} from 'argo-ui/src/components/autocomplete/autocomplete';
 import React, {useState} from 'react';
 
 interface InputProps {

--- a/ui/src/app/shared/components/links.tsx
+++ b/ui/src/app/shared/components/links.tsx
@@ -1,6 +1,7 @@
 import {ObjectMeta} from 'argo-ui/src/models/kubernetes';
 import {useEffect, useState} from 'react';
 import * as React from 'react';
+
 import {Link, Workflow} from '../../../models';
 import {services} from '../services';
 import {Button} from './button';

--- a/ui/src/app/shared/components/loading.tsx
+++ b/ui/src/app/shared/components/loading.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {MockupList} from '../../../../node_modules/argo-ui';
+import {MockupList} from 'argo-ui/src/components/mockup-list/mockup-list';
 
 export const Loading = () => (
     <div style={{margin: 20}}>

--- a/ui/src/app/shared/components/parameters-input.tsx
+++ b/ui/src/app/shared/components/parameters-input.tsx
@@ -1,4 +1,5 @@
-import {Select, Tooltip} from 'argo-ui';
+import {Select} from 'argo-ui/src/components/select/select';
+import {Tooltip} from 'argo-ui/src/components/tooltip/tooltip';
 import React from 'react';
 
 import {Parameter} from '../../../models';

--- a/ui/src/app/shared/components/tags-input/tags-input.tsx
+++ b/ui/src/app/shared/components/tags-input/tags-input.tsx
@@ -1,4 +1,4 @@
-import {Autocomplete, AutocompleteApi, AutocompleteOption} from 'argo-ui';
+import {Autocomplete, AutocompleteApi, AutocompleteOption} from 'argo-ui/src/components/autocomplete/autocomplete';
 import classNames from 'classnames';
 import * as React from 'react';
 import {useRef, useState} from 'react';

--- a/ui/src/app/shared/components/timestamp.tsx
+++ b/ui/src/app/shared/components/timestamp.tsx
@@ -1,4 +1,4 @@
-import {Ticker} from 'argo-ui';
+import {Ticker} from 'argo-ui/src/components/ticker';
 import * as React from 'react';
 
 import {ago} from '../duration';

--- a/ui/src/app/shared/context.ts
+++ b/ui/src/app/shared/context.ts
@@ -1,4 +1,4 @@
-import {AppContext as ArgoAppContext, NavigationApi, NotificationsApi, PopupApi} from 'argo-ui';
+import type {AppContext as ArgoAppContext, NavigationApi, NotificationsApi, PopupApi} from 'argo-ui';
 import {History} from 'history';
 import * as React from 'react';
 

--- a/ui/src/app/shared/context.ts
+++ b/ui/src/app/shared/context.ts
@@ -1,4 +1,7 @@
-import type {AppContext as ArgoAppContext, NavigationApi, NotificationsApi, PopupApi} from 'argo-ui';
+import type {AppContext as ArgoAppContext} from 'argo-ui/src/context';
+import type {NavigationApi} from 'argo-ui/src/components/navigation';
+import type {NotificationsApi} from 'argo-ui/src/components/notifications/notification-manager';
+import type {PopupApi} from 'argo-ui/src/components/popup/popup-manager';
 import {History} from 'history';
 import * as React from 'react';
 

--- a/ui/src/app/userinfo/user-info.tsx
+++ b/ui/src/app/userinfo/user-info.tsx
@@ -1,4 +1,4 @@
-import {Page} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 

--- a/ui/src/app/workflow-event-bindings/workflow-event-bindings.tsx
+++ b/ui/src/app/workflow-event-bindings/workflow-event-bindings.tsx
@@ -1,4 +1,5 @@
-import {Page, SlidingPanel} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/workflow-templates/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/workflow-template-details.tsx
@@ -1,4 +1,4 @@
-import type {NotificationType} from 'argo-ui/src/components/notifications/notifications'
+import {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import {Page} from 'argo-ui/src/components/page/page';
 import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';

--- a/ui/src/app/workflow-templates/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/workflow-template-details.tsx
@@ -1,5 +1,6 @@
-import {NotificationType, Page} from 'argo-ui';
-import {SlidingPanel} from 'argo-ui/src/index';
+import type {NotificationType} from 'argo-ui/src/components/notifications/notifications'
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';

--- a/ui/src/app/workflow-templates/workflow-template-editor.tsx
+++ b/ui/src/app/workflow-templates/workflow-template-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Tabs} from 'argo-ui';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 
 import {WorkflowTemplate} from '../../models';
 import {LabelsAndAnnotationsEditor} from '../shared/components/editors/labels-and-annotations-editor';

--- a/ui/src/app/workflow-templates/workflow-template-list.tsx
+++ b/ui/src/app/workflow-templates/workflow-template-list.tsx
@@ -1,4 +1,5 @@
-import {Page, SlidingPanel} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/workflows/components/resubmit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/resubmit-workflow-panel.tsx
@@ -1,5 +1,6 @@
-import {Checkbox} from 'argo-ui';
+import {Checkbox} from 'argo-ui/src/components/checkbox';
 import React, {useContext, useState} from 'react';
+
 import {Parameter, ResubmitOpts, Workflow} from '../../../models';
 import {Context} from '../../shared/context';
 import {uiUrl} from '../../shared/base';

--- a/ui/src/app/workflows/components/retry-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/retry-workflow-panel.tsx
@@ -1,5 +1,6 @@
-import {Checkbox} from 'argo-ui';
+import {Checkbox} from 'argo-ui/src/components/checkbox';
 import React, {useContext, useState} from 'react';
+
 import {Parameter, RetryOpts, Workflow} from '../../../models';
 import {Context} from '../../shared/context';
 import {uiUrl} from '../../shared/base';

--- a/ui/src/app/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/submit-workflow-panel.tsx
@@ -1,5 +1,6 @@
-import {Select} from 'argo-ui';
+import {Select} from 'argo-ui/src/components/select/select';
 import React, {useContext, useMemo, useState} from 'react';
+
 import {Parameter, Template} from '../../../models';
 import {Context} from '../../shared/context';
 import {uiUrl} from '../../shared/base';

--- a/ui/src/app/workflows/components/workflow-details/suspend-inputs.tsx
+++ b/ui/src/app/workflows/components/workflow-details/suspend-inputs.tsx
@@ -1,4 +1,5 @@
-import {Select, Tooltip} from 'argo-ui';
+import {Select} from 'argo-ui/src/components/select/select';
+import {Tooltip} from 'argo-ui/src/components/tooltip/tooltip';
 import * as React from 'react';
 import {useState} from 'react';
 

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -1,4 +1,5 @@
-import {Page, SlidingPanel} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import classNames from 'classnames';
 import * as React from 'react';
 import {useContext, useEffect, useRef, useState} from 'react';

--- a/ui/src/app/workflows/components/workflow-editor.tsx
+++ b/ui/src/app/workflows/components/workflow-editor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 
-import {Tabs} from 'argo-ui';
 import {Workflow} from '../../../models';
 import {MetadataEditor} from '../../shared/components/editors/metadata-editor';
 import {WorkflowParametersEditor} from '../../shared/components/editors/workflow-parameters-editor';

--- a/ui/src/app/workflows/components/workflow-logs-viewer/full-height-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/full-height-logs-viewer.tsx
@@ -28,7 +28,7 @@ export function FullHeightLogsViewer(props: LogsViewerProps) {
 const LazyLogsViewer = React.lazy(async () => {
     // prefetch b/c logs are commonly used
     const module = await import(/* webpackPrefetch: true, webpackChunkName: "argo-ui-logs-viewer" */ 'argo-ui/src/components/logs-viewer/logs-viewer');
-    return { default: module.LogsViewer }; // React.lazy requires a default import, so we create an intermediate module
+    return {default: module.LogsViewer}; // React.lazy requires a default import, so we create an intermediate module
 });
 
 function SuspenseLogsViewer(props: LogsViewerProps) {

--- a/ui/src/app/workflows/components/workflow-logs-viewer/full-height-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/full-height-logs-viewer.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 
-import {LogsViewer} from 'argo-ui';
-import {LogsViewerProps} from 'argo-ui/src/components/logs-viewer/logs-viewer';
+import type {LogsViewerProps} from 'argo-ui/src/components/logs-viewer/logs-viewer';
+
+import {Loading} from '../../../shared/components/loading';
 
 import './workflow-logs-viewer.scss';
 
@@ -18,7 +19,22 @@ export function FullHeightLogsViewer(props: LogsViewerProps) {
 
     return (
         <div ref={ref} style={{height}} className='log-box'>
-            {height && <LogsViewer source={source} />}
+            {height && <SuspenseLogsViewer source={source} />}
         </div>
+    );
+}
+
+// lazy load LogsViewer as it imports a large component: xterm (which can be split into a separate bundle)
+const LazyLogsViewer = React.lazy(async () => {
+    // prefetch b/c logs are commonly used
+    const module = await import(/* webpackPrefetch: true, webpackChunkName: "argo-ui-logs-viewer" */ 'argo-ui/src/components/logs-viewer/logs-viewer');
+    return { default: module.LogsViewer }; // React.lazy requires a default import, so we create an intermediate module
+});
+
+function SuspenseLogsViewer(props: LogsViewerProps) {
+    return (
+        <React.Suspense fallback={<Loading />}>
+            <LazyLogsViewer {...props} />
+        </React.Suspense>
     );
 }

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
-import {Autocomplete} from 'argo-ui';
+import {Autocomplete} from 'argo-ui/src/components/autocomplete/autocomplete';
 import {Observable} from 'rxjs';
 import {map, publishReplay, refCount} from 'rxjs/operators';
 

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -1,4 +1,7 @@
-import {Tabs, Ticker, Tooltip} from 'argo-ui';
+import {Tabs} from 'argo-ui/src/components/tabs/tabs';
+import {Ticker} from 'argo-ui/src/components/ticker';
+import {Tooltip} from 'argo-ui/src/components/tooltip/tooltip';
+
 import moment from 'moment';
 import * as React from 'react';
 import {useState} from 'react';

--- a/ui/src/app/workflows/components/workflow-panel/workflow-panel.tsx
+++ b/ui/src/app/workflows/components/workflow-panel/workflow-panel.tsx
@@ -1,5 +1,6 @@
 import {ObjectMeta} from 'argo-ui/src/models/kubernetes';
 import * as React from 'react';
+
 import {WorkflowStatus} from '../../../../models';
 import {Notice} from '../../../shared/components/notice';
 import {Phase} from '../../../shared/components/phase';

--- a/ui/src/app/workflows/components/workflow-summary-panel.tsx
+++ b/ui/src/app/workflows/components/workflow-summary-panel.tsx
@@ -1,4 +1,4 @@
-import {Ticker} from 'argo-ui';
+import {Ticker} from 'argo-ui/src/components/ticker';
 import * as React from 'react';
 
 import {labels, NODE_PHASE, Workflow} from '../../../models';

--- a/ui/src/app/workflows/components/workflow-yaml-viewer/workflow-yaml-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-yaml-viewer/workflow-yaml-viewer.tsx
@@ -1,4 +1,4 @@
-import {SlideContents} from 'argo-ui';
+import {SlideContents} from 'argo-ui/src/components/slide-contents/slide-contents';
 import * as React from 'react';
 
 import * as models from '../../../../models';

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -1,4 +1,5 @@
-import {Page, SlidingPanel} from 'argo-ui';
+import {Page} from 'argo-ui/src/components/page/page';
+import {SlidingPanel} from 'argo-ui/src/components/sliding-panel/sliding-panel';
 import * as React from 'react';
 import {useContext, useEffect, useMemo, useState} from 'react';
 import {RouteComponentProps} from 'react-router-dom';

--- a/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/app/workflows/components/workflows-row/workflows-row.tsx
@@ -1,4 +1,4 @@
-import {Ticker} from 'argo-ui/src/index';
+import {Ticker} from 'argo-ui/src/components/ticker';
 import * as React from 'react';
 import {useState} from 'react';
 import {Link} from 'react-router-dom';

--- a/ui/src/app/workflows/components/workflows-summary-container/workflows-summary-container.tsx
+++ b/ui/src/app/workflows/components/workflows-summary-container/workflows-summary-container.tsx
@@ -1,4 +1,4 @@
-import {Tooltip} from 'argo-ui';
+import {Tooltip} from 'argo-ui/src/components/tooltip/tooltip';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 

--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -1,4 +1,4 @@
-import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
+import {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import * as React from 'react';
 import {useContext, useMemo} from 'react';
 

--- a/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/app/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -1,4 +1,4 @@
-import {NotificationType} from 'argo-ui';
+import type {NotificationType} from 'argo-ui/src/components/notifications/notifications';
 import * as React from 'react';
 import {useContext, useMemo} from 'react';
 

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -8,4 +8,4 @@ export * from './cluster-workflow-templates';
 export * from './submit-opts';
 export type {EventSource} from './event-source';
 export type {Sensor, SensorList} from './sensor';
-export {models as kubernetes} from 'argo-ui';
+export * as kubernetes from 'argo-ui/src/models/kubernetes';


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12059 

### Motivation

<!-- TODO: Say why you made your changes. -->

After the past few code-splits (#12150, #12097, #12061) `xterm` was left as one of the largest deps in the main bundle
- `xterm` is only used by `argo-ui` in its `LogsViewer` component, which is only used by Workflows' `FullHeightLogsViewer` component
- shave off more than half a MB from the main bundle:
  - from `xterm` itself: ~550KB / ~380KB minified / 84KB gzipped from main bundle
  - from `argo-ui`: ~190KB / ~60KB minified / ~17KB gzipped from main bundle
    - part of this went into the `xterm` bundle though, so there is some overlap
  - main bundle itself is now only 3.26MB / 1.64MB minified / ~430KB gzipped
  
### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- lazy load `LogsViewer` within `FullHeightLogsViewer` in order to code-split it
  - add a [`webpackPrefetch`](https://webpack.js.org/guides/code-splitting/#prefetchingpreloading-modules) magic comment as logs are _very_ commonly used, at least in my experience
  
- import all `argo-ui` components individually, via `argo-ui/src/components/*`, instead of together via `argo-ui` or `argo-ui/src/index`
  - this makes tree-shaking `argo-ui` actually possible. the overall `argo-ui` import as well as each component imports styles, which are side-effects that make tree-shaking not possible
    - in particular, [this SCSS import](https://github.com/argoproj/argo-ui/blob/5ff344ac9692c14dd108468bd3c020c3c75181cb/src/components/index.ts#L1) made the main import not tree-shakeable
  - this also removed some `argo-ui` components from the bundle that are not used by Workflows

### Verification

<!-- TODO: Say how you tested your changes. -->

UI seems to work as before. Log viewing works as before. <details><summary>Screenshot: </summary>

![Screenshot 2024-05-14 at 2 41 04 PM](https://github.com/argoproj/argo-workflows/assets/4970083/6a1c8a3d-a913-43a0-a54b-f48b319436ee)

</details>

#### Bundle analysis

<details><summary>Before:</summary>

![Screenshot 2024-05-14 at 2 51 42 PM](https://github.com/argoproj/argo-workflows/assets/4970083/49d8e696-6d44-4f94-aa5d-ace06e651b34)
![Screenshot 2024-05-14 at 2 51 54 PM](https://github.com/argoproj/argo-workflows/assets/4970083/ef2dd197-07b1-43ca-9dd0-f3c8e73d4cb2)

</details>

<details><summary>After:</summary>

![Screenshot 2024-05-14 at 2 48 41 PM](https://github.com/argoproj/argo-workflows/assets/4970083/73653fe1-58c0-4332-9de1-1449496e0331)
![Screenshot 2024-05-14 at 2 49 32 PM](https://github.com/argoproj/argo-workflows/assets/4970083/29ee5525-12a6-48d0-b6ac-9fa43fde03b0)
![Screenshot 2024-05-14 at 2 49 15 PM](https://github.com/argoproj/argo-workflows/assets/4970083/041e745c-c856-4fea-ab65-be7a025d319d)

</details>


### Notes to Reviewers

1. The main change is to [`full-height-logs-viewer.tsx`](https://github.com/argoproj/argo-workflows/pull/12158/files#diff-2954852619de80fb686f957e28ae3cad3090e2a0206e58387b3dc7a273702051), the rest is just import changes

1. I thought of doing all the tree-shaking within a shim import, e.g. `./argo-ui-shim.ts`, but then anything that imports that would get everything that the shim imports (due to its CSS import side-effects). Importing components individually where they're used allows for _more_ splitting, particularly when more pages are split per #12059