### PR TITLE
fix: traverse nodes in BFS and remove orphan nodes when retry workflow. (Fixes #12156)

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -883,7 +883,38 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 	deletedPods := make(map[string]bool)
 	var podsToDelete []string
 	var resetParentGroupNodes []string
-	for _, node := range wf.Status.Nodes {
+
+	nodes := wf.Status.Nodes
+	// Traverse nodes in BFS.
+	var nodeQueue []string
+	if len(nodes) > 0 {
+		nodeQueue = []string{wf.ObjectMeta.Name}
+	}
+	visited := make(map[string]bool)
+	// Store parents nodes info when traverse nodes.
+	parents := make(map[string]map[string]struct{})
+	for len(nodeQueue) > 0 {
+		nodeID := nodeQueue[0]
+		nodeQueue = nodeQueue[1:]
+
+		var np *wfv1.NodeStatus
+		if np, err = nodes.Get(nodeID); err != nil {
+			log.Warnf("Traverse nodes in BFS failed due to %s", err)
+			return nil, nil, errors.Errorf(errors.CodeBadRequest, "Cannot retry a workflow: %s", err)
+		}
+		node := *np
+
+		for _, child := range node.Children {
+			if _, seen := visited[child]; !seen {
+				nodeQueue = append(nodeQueue, child)
+			}
+			if _, present := parents[child]; !present {
+				parents[child] = make(map[string]struct{})
+			}
+			parents[child][nodeID] = struct{}{}
+		}
+		visited[nodeID] = true
+
 		doForceResetNode := false
 		if _, present := nodeIDsToReset[node.ID]; present {
 			// if we are resetting this node then don't carry it across regardless of its phase
@@ -948,7 +979,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 					}
 				}
 			} else {
-				if !containsNode(resetParentGroupNodes, node.ID) {
+				if !containsNode(resetParentGroupNodes, node.ID) && !isOrphanNode(deletedNodes, parents[nodeID]) {
 					log.Debugf("Node %s remains as is", node.Name)
 					newWF.Status.Nodes.Set(node.ID, node)
 				}
@@ -1013,6 +1044,21 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 	}
 
 	return newWF, podsToDelete, nil
+}
+
+// isOrphanNode return true when all parents are deleted.
+func isOrphanNode(deletedNodes map[string]bool, parents map[string]struct{}) bool {
+	if len(parents) == 0 {
+		return false
+	}
+
+	for parent := range parents {
+		if _, ok := deletedNodes[parent]; !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 func resetNode(node wfv1.NodeStatus) wfv1.NodeStatus {

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1080,19 +1080,48 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 				StartedAt:  createdTime,
 				FinishedAt: finishedTime,
 				Nodes: map[string]wfv1.NodeStatus{
-					"failed-node":    {Name: "failed-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: wfv1.NodeFailed, Message: "failed"},
-					"succeeded-node": {Name: "succeeded-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: wfv1.NodeSucceeded, Message: "succeeded"}},
+					"my-steps": {
+						ID:         "my-steps",
+						Name:       "my-steps",
+						Type:       wfv1.NodeTypeSteps,
+						Phase:      wfv1.NodeFailed,
+						StartedAt:  createdTime,
+						FinishedAt: finishedTime,
+						Message:    "failed",
+						Children:   []string{"succeeded-node"},
+					},
+					"succeeded-node": {
+						ID:         "succeeded-node",
+						Name:       "succeeded-node",
+						StartedAt:  createdTime,
+						FinishedAt: finishedTime,
+						Phase:      wfv1.NodeSucceeded,
+						Message:    "succeeded",
+						Children:   []string{"failed-node"},
+					},
+					"failed-node": {
+						ID:         "failed-node",
+						Name:       "failed-node",
+						StartedAt:  createdTime,
+						FinishedAt: finishedTime,
+						Phase:      wfv1.NodeFailed,
+						Message:    "failed",
+					},
+				},
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
 		assert.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
 		if assert.NoError(t, err) {
+
 			assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
 			assert.Equal(t, metav1.Time{}, wf.Status.FinishedAt)
 			assert.True(t, wf.Status.StartedAt.After(createdTime.Time))
 			assert.NotContains(t, wf.Labels, common.LabelKeyCompleted)
 			assert.NotContains(t, wf.Labels, common.LabelKeyWorkflowArchivingStatus)
+
+			assert.Len(t, wf.Status.Nodes, 2)
 			for _, node := range wf.Status.Nodes {
 				switch node.Phase {
 				case wfv1.NodeSucceeded:
@@ -1118,7 +1147,7 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			Status: wfv1.WorkflowStatus{
 				Phase: wfv1.WorkflowFailed,
 				Nodes: map[string]wfv1.NodeStatus{
-					"": {Phase: wfv1.NodeFailed, Type: wfv1.NodeTypeTaskGroup}},
+					"my-dag": {Phase: wfv1.NodeFailed, Type: wfv1.NodeTypeTaskGroup, Name: "my-dag", ID: "my-dag"}},
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
@@ -1126,11 +1155,72 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
 		if assert.NoError(t, err) {
 			if assert.Len(t, wf.Status.Nodes, 1) {
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes[""].Phase)
+				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["my-dag"].Phase)
 			}
-
 		}
 	})
+	t.Run("Retry Stopped Wf With Orphan Nodes", func(t *testing.T) {
+		wfName := "retry-with-orphan-nodes"
+		wf := &wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "retry-with-orphan-nodes",
+				Labels: map[string]string{},
+			},
+			Status: wfv1.WorkflowStatus{
+				Phase: wfv1.WorkflowFailed,
+				Nodes: map[string]wfv1.NodeStatus{
+					"retry-with-orphan-nodes": {
+						ID:       wfName,
+						Name:     wfName,
+						Type:     wfv1.NodeTypeDAG,
+						Phase:    wfv1.NodeFailed,
+						Children: []string{"A"},
+					},
+					"B": {
+						ID:         "B",
+						Name:       "name-b",
+						Type:       wfv1.NodeTypeSuspend,
+						Phase:      wfv1.NodeSucceeded,
+						BoundaryID: wfName,
+						Children:   []string{"C"},
+					},
+					"C": {
+						ID:         "C",
+						Name:       "name-c",
+						Type:       wfv1.NodeTypePod,
+						Phase:      wfv1.NodeFailed,
+						BoundaryID: wfName,
+						Children:   []string{"D"},
+					},
+					"A": {
+						ID:         "A",
+						Name:       "name-a",
+						Type:       wfv1.NodeTypePod,
+						Phase:      wfv1.NodeSucceeded,
+						BoundaryID: wfName,
+						Children:   []string{"B"},
+					},
+					"D": {
+						ID:         "D",
+						Name:       "name-d",
+						Type:       wfv1.NodeTypePod,
+						Phase:      wfv1.NodeSkipped,
+						BoundaryID: wfName,
+					},
+				}},
+		}
+		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
+		assert.NoError(t, err)
+		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=suspended", nil)
+		if assert.NoError(t, err) {
+			if assert.Len(t, wf.Status.Nodes, 3) {
+				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes[wfName].Phase)
+				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["B"].Phase)
+				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["A"].Phase)
+			}
+		}
+	})
+
 	t.Run("Skipped and Suspended Nodes", func(t *testing.T) {
 		wf := &wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1140,7 +1230,8 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			Status: wfv1.WorkflowStatus{
 				Phase: wfv1.WorkflowFailed,
 				Nodes: map[string]wfv1.NodeStatus{
-					"entrypoint": {ID: "entrypoint", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup, Children: []string{"suspended", "skipped"}},
+					"wf-with-skipped-and-suspended-nodes": {ID: "wf-with-skipped-and-suspended-nodes", Type: wfv1.NodeTypeTaskGroup, Name: "wf-with-skipped-and-suspended-nodes", Phase: wfv1.NodeSucceeded, Children: []string{"entrypoint"}},
+					"entrypoint":                          {ID: "entrypoint", Name: "entrypoint", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup, Children: []string{"suspended", "skipped"}},
 					"suspended": {
 						ID:         "suspended",
 						Phase:      wfv1.NodeSucceeded,
@@ -1160,7 +1251,8 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		assert.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=suspended", nil)
 		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 3) {
+			if assert.Len(t, wf.Status.Nodes, 4) {
+				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["wf-with-skipped-and-suspended-nodes"].Phase)
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["entrypoint"].Phase)
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["suspended"].Phase)
 				assert.Equal(t, wfv1.Parameter{
@@ -1245,7 +1337,8 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			Status: wfv1.WorkflowStatus{
 				Phase: wfv1.WorkflowFailed,
 				Nodes: map[string]wfv1.NodeStatus{
-					"1": {ID: "1", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
+					"override-param-wf": {ID: "override-param-wf", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
+					"1":                 {ID: "1", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
 				}},
 		}
 		wf, _, err := FormulateRetryWorkflow(context.Background(), wf, false, "", []string{"message=modified"})
@@ -1268,7 +1361,8 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			Status: wfv1.WorkflowStatus{
 				Phase: wfv1.WorkflowFailed,
 				Nodes: map[string]wfv1.NodeStatus{
-					"1": {ID: "1", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
+					"override-param-wf": {ID: "override-param-wf", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
+					"1":                 {ID: "1", Phase: wfv1.NodeSucceeded, Type: wfv1.NodeTypeTaskGroup},
 				},
 				StoredWorkflowSpec: &wfv1.WorkflowSpec{Arguments: wfv1.Arguments{
 					Parameters: []wfv1.Parameter{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12156 

### Motivation

1.  traverse nodes in BFS.
2. remove orphan nodes when retry a workflow

<!-- TODO: Say why you made your changes. -->

### Modifications
1.  modify `FormulateRetryWorkflow` to remove orphan nodes (node `D` in example below) .
2. add root node to wf `Status.Nodes`  in unit test to make BFS works fine.

### Verification
here is an example.
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  name: retry-stopped-dag
spec:
  entrypoint: diamond
  templates:
  - name: echo
    inputs:
      parameters:
      - name: message
    container:
      image: alpine:3.7
      command: [echo, "{{inputs.parameters.message}}"]
  - name: sleep
    inputs:
      parameters:
      - name: message
    container:
      image: alpine:3.7
      command: [sleep, 36000s]
  - name: diamond
    dag:
      tasks:
      - name: A
        template: echo
        arguments:
          parameters: [{name: message, value: A}]
      - name: B
        depends: A.Succeeded
        template: echo
        arguments:
          parameters: [{name: message, value: B}]
      - name: C
        depends: B.Succeeded
        template: sleep
        arguments:
          parameters: [{name: message, value: C}]
      - name: D
        depends: C.Succeeded || C.Failed
        template: echo
        arguments:
          parameters: [{name: message, value: D}]
```

Without the fix,  stop the wf and retry,  error `Ancestor node not found` occours.
With the fix, retry works fine.

<!-- TODO: Say how you tested your changes. -->
