### PR TITLE
fix(ui): Cost Opt should only apply to live Workflows

### DIFF
--- a/docs/cost-optimisation.md
+++ b/docs/cost-optimisation.md
@@ -45,7 +45,8 @@ A workflow (and for that matter, any Kubernetes resource) will incur a cost as l
 
 The workflow controller memory and CPU needs to increase linearly with the number of pods and workflows you are currently running.
 
-You should delete workflows once they are no longer needed, or enable a [Workflow Archive](workflow-archive.md) and you can still view them after they are removed from Kubernetes.
+You should delete workflows once they are no longer needed.
+You can enable the [Workflow Archive](workflow-archive.md) to continue viewing them after they are removed from Kubernetes.
 
 Limit the total number of workflows using:
 

--- a/ui/src/models/workflows.ts
+++ b/ui/src/models/workflows.ts
@@ -548,11 +548,13 @@ export function isWorkflowInCluster(wf: Workflow): boolean {
     return !wf.metadata.labels[archivalStatus] || wf.metadata.labels[archivalStatus] === 'Pending' || wf.metadata.labels[archivalStatus] === 'Archived';
 }
 
-export function isArchivedWorkflow(wf: Workflow): boolean {
+export function isArchivedWorkflow(wf?: Workflow): boolean {
     if (!wf) {
         return false;
     }
-    return wf.metadata.labels && (wf.metadata.labels[archivalStatus] === 'Archived' || wf.metadata.labels[archivalStatus] === 'Persisted');
+
+    const labelValue = wf.metadata?.labels?.[archivalStatus];
+    return labelValue === 'Archived' || labelValue === 'Persisted';
 }
 
 export type NodeType = 'Pod' | 'Container' | 'Steps' | 'StepGroup' | 'DAG' | 'Retry' | 'Skipped' | 'TaskGroup' | 'Suspend';


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12160

### Motivation

<!-- TODO: Say why you made your changes. -->

- after the unification of the Archived + Live Workflow APIs and UIs in #11121, the `WorkflowsList`'s `CostOptimisationNudge` was not altered to account for the additional Archived Workflows
  - as such, it started showing up even for users with solid GC and archiving configurations

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- change the counting logic to skip archived workflows, which are explicitly excluded in the docs
  - using the Workflow Archive is one of [the recommendations](https://argoproj.github.io/argo-workflows/cost-optimisation/#limit-the-total-number-of-workflows-and-pods) in fact

- small code fixes/optimizations
  - improve typings
  - handle non-existent labels or metadata in `isArchivedWorkflow` func same as in `countsByCompleted` func
    - and slightly refactor / clean-up the logic with optional chaining  

- small grammar fix: comma splice in the `CostOptimisationNudge` message itself, where there is already a conjunction

- small docs clarifications and grammar fixes:
  - consistently use "the" Workflow Archive, not "a" Workflow Archive
    - there is only one and the Workflow Archive page uses "the"
  - Workflow Archive is not an "or" with deleting Workflows, it would be an "and"
    - but it is optional, so split that into a second sentence with "you can"
  - "enable [...] and you can still view them" was confusing wording as it used a conjunction (on top of the incorrect conjunction above) instead of a preposition
    - change to "enable [...] to continue viewing"


### Verification

<!-- TODO: Say how you tested your changes. -->

Tested locally by reducing the count to 10. It correctly skips the 1 archived workflow I have in the list. Screenshot:

![Screenshot 2023-11-08 at 9 10 30 PM](https://github.com/argoproj/argo-workflows/assets/4970083/f6e6928f-17e5-4867-8cad-6b044c5694d5)
