### PR TITLE
fix(ui): missing `uiUrl` in `ArchivedWorkflowsList`

### DIFF
--- a/ui/src/app/archived-workflows/components/archived-workflow-list/archived-workflow-list.tsx
+++ b/ui/src/app/archived-workflows/components/archived-workflow-list/archived-workflow-list.tsx
@@ -80,7 +80,7 @@ export class ArchivedWorkflowList extends BasePage<RouteComponentProps<any>, Sta
     public componentDidUpdate(): void {
         if (this.state.deep === true && this.state.workflows && this.state.workflows.length === 1) {
             const workflow = this.state.workflows[0];
-            const url = '/archived-workflows/' + workflow.metadata.namespace + '/' + (workflow.metadata.uid || '');
+            const url = uiUrl('/archived-workflows/' + workflow.metadata.namespace + '/' + (workflow.metadata.uid || ''));
             this.props.history.push(url);
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/9764#issuecomment-1728735583

### Motivation

<!-- TODO: Say why you made your changes. -->

- `BASE_HREF` was not handled in a few places and Archived Workflows specifically was missed as it was removed in the 3.5 release
  - this PR is to the 3.4.x branch

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add `uiUrl` to the one missing place in an Archived Workflows component
  - didn't find any other missing ones for Archived Workflows (searched for `/archived-workflows/`)

### Verification

<!-- TODO: Say how you tested your changes. -->

### Notes for Reviewers

~I added this to the `release-3.4.13` branch as there is no 3.4.14 branch yet. We'll want to modify the branch base once that exists.~ **EDIT**: updated to 3.4.14 release branch
I might suggest having a running `3.4.x` (etc) branch in order to have an ongoing branch, and then just tag patches off of that
