### PR TITLE
fix: Fixed mutex with withSequence in http template broken. Fixes #12018

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2993,6 +2993,8 @@ func (tmpl *Template) GetNodeType() NodeType {
 		return NodeTypeSteps
 	case TemplateTypeSuspend:
 		return NodeTypeSuspend
+	case TemplateTypeHTTP:
+		return NodeTypeHTTP
 	case TemplateTypePlugin:
 		return NodeTypePlugin
 	}

--- a/workflow/controller/http_template.go
+++ b/workflow/controller/http_template.go
@@ -8,6 +8,8 @@ func (woc *wfOperationCtx) executeHTTPTemplate(nodeName string, templateScope st
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
 		node = woc.initializeExecutableNode(nodeName, wfv1.NodeTypeHTTP, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag)
+	}
+	if !node.Fulfilled() {
 		woc.taskSet[node.ID] = *tmpl
 	}
 	return node


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12018 

### Motivation

Fixes `synchronization` of `mutex` not working with http template.
Currently any http template will not work when you use with mutex.
(`withSequence` doesn't matter, however)

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

When running the issue's example, you can see the error directly in UI.

![스크린샷 2023-11-11 오전 4 44 18](https://github.com/argoproj/argo-workflows/assets/20155452/4f6c00f0-4611-42fd-af0e-9e8729fa1043)

The first node(`call-endpoint(0:0)`)  is good, but the second (`call-endpoint(1:1)`) is not shown and so the workflow is on infinite pending.

Reason:
Mutex is handled in [executeTemplate](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/workflow/controller/operator.go#L1786) of `operator.go`.

But there are two problems when using mutex with http template.

1. **Unavailable to get node type of HTTP by [wfutil.GetNodeType(processedTmpl)](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/workflow/controller/operator.go#L1882C51-L1882C84).** 

- You can see [GetNodeType](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/pkg/apis/workflow/v1alpha1/workflow_types.go#L2983) doesn't have type mapping of `TemplateTypeHTTP`. This is omitted.
- This makes you see the weird empty space in UI instead of the proper node.

  
2. **[executeHTTPTemplate](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/workflow/controller/operator.go#L2090C14-L2090C33) is not dealing with the node performed case.** 
- Currently it only checks [GetNodeByName](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/workflow/controller/http_template.go#L8) which is not well working with the [mutex's node initialization](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/workflow/controller/operator.go#L1882)
- This makes even when number 1 problem is solved, the later node not running and running infinite workflow.

I solve this issue by adding the omitted case of number 1's problem, and executing the HTTP template with checking fulfilled node. `Checking fulfilled node` is the exactly same way using in [executePluginTemplate](https://github.com/shmruin/argo-workflows/blob/873bacbafc4da79df15e0da728501ad925eef4fc/workflow/controller/plugin_template.go#L15).

### Verification

<!-- TODO: Say how you tested your changes. -->
![스크린샷 2023-11-11 오전 4 41 54](https://github.com/argoproj/argo-workflows/assets/20155452/cd56a3d4-3e3c-4651-bfa1-29c0543e9f1e)

Fix the two things above.

All nodes works correctly as well as the synchronization of mutex.

You can test this by running the example below.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: http-wf-test-mutex
spec:
  entrypoint: main
  templates:
    - name: main
      steps:
        - - name: call-endpoint
            template: call-endpoint
            withSequence:
              count: "2"
    - name: call-endpoint
      synchronization:
        mutex:
          name: test
      http:
        url: "https://api.github.com/users/hadley/repos"
        successCondition: "response.statusCode == 200"
```

