### PR TITLE
fix: retry S3 on RequestError. Fixes #9914

### DIFF
--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -10,7 +10,7 @@ import (
 // s3TransientErrorCodes is a list of S3 error codes that are transient (retryable)
 // Reference: https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102
 var s3TransientErrorCodes = []string{
-	"InternalError",
+	"RequestError",
 	"RequestTimeout",
 	"Throttling",
 	"ThrottlingException",

--- a/workflow/artifacts/s3/errors_test.go
+++ b/workflow/artifacts/s3/errors_test.go
@@ -19,4 +19,7 @@ func TestIsTransientOSSErr(t *testing.T) {
 
 	nonOSSErr := errors.New("UnseenError")
 	assert.False(t, isTransientS3Err(nonOSSErr))
+
+	requestErr := minio.ErrorResponse{Code: "RequestError"}
+	assert.True(t, isTransientS3Err(requestErr))
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #9914

### Motivation

Artifact uploads are retried when failing due to transient error, but not with error code `"RequestError"` e.g. in the case of TLS handshake timeout. The error code `"RequestError"` should be marked as transient.

### Modifications

In `s3TransientErrorCodes`, I changed one of the duplicate `"InternalError"` array items to `"RequestError"`. I suspect the duplication may have been made by mistake.

This also aligns with the source referenced in the preceding comment i.e. [retry.go from minio-go](https://github.com/minio/minio-go/blob/92fe50d14294782d96402deb861d442992038109/retry.go#L90-L102).

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

The specific timeout issue very hard to test, as it is transient, but I added an assertion to `TestIsTransientOSSErr` to make sure that the error code is marked as transient.
