### PR TITLE
fix: ensure wftmplLifecycleHook wait for each dag task

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -322,3 +322,18 @@ func IsDone(un *unstructured.Unstructured) bool {
 		un.GetLabels()[LabelKeyCompleted] == "true" &&
 		un.GetLabels()[LabelKeyWorkflowArchivingStatus] != "Pending"
 }
+
+// Check whether child hooked nodes Fulfilled
+func CheckAllHooksFullfilled(node *wfv1.NodeStatus, nodes wfv1.Nodes) bool {
+	childs := node.Children
+	for _, id := range childs {
+		n, ok := nodes[id]
+		if !ok {
+			continue
+		}
+		if n.NodeFlag != nil && n.NodeFlag.Hooked && !n.Fulfilled() {
+			return false
+		}
+	}
+	return true
+}

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -843,18 +843,8 @@ func (d *dagContext) evaluateDependsLogic(taskName string) (bool, bool, error) {
 
 		// If the task is still running, we should not proceed.
 		depNode := d.getTaskNode(taskName)
-		if depNode == nil || !depNode.Fulfilled() {
+		if depNode == nil || !depNode.Fulfilled() || !common.CheckAllHooksFullfilled(depNode, d.wf.Status.Nodes) {
 			return false, false, nil
-		}
-
-		// If a task happens to have an onExit node, don't proceed until the onExit node is fulfilled
-		if onExitNode, err := d.wf.GetNodeByName(common.GenerateOnExitNodeName(depNode.Name)); onExitNode != nil {
-			if err != nil {
-				return false, false, err
-			}
-			if !onExitNode.Fulfilled() {
-				return false, false, nil
-			}
 		}
 
 		evalTaskName := strings.Replace(taskName, "-", "_", -1)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1770,7 +1770,7 @@ func getRetryNodeChildrenIds(node *wfv1.NodeStatus, nodes wfv1.Nodes) []string {
 		if node == nil {
 			continue
 		}
-		if strings.HasSuffix(node.Name, ".onExit") {
+		if node.NodeFlag != nil && node.NodeFlag.Hooked {
 			childrenIds = append(childrenIds, node.ID)
 		} else if len(node.Children) > 0 {
 			childrenIds = append(childrenIds, node.Children...)

--- a/workflow/controller/testdata/dag_wftmpl_hook_with_retry.yaml
+++ b/workflow/controller/testdata/dag_wftmpl_hook_with_retry.yaml
@@ -1,0 +1,52 @@
+# https://github.com/argoproj/argo-workflows/issues/12120
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-wftmpl-hook-with-retry
+  namespace: argo
+spec:
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: task
+            template: task
+            hooks:
+              failure:
+                template: exit-handler
+                expression: tasks["task"].status == "Failed"
+          - name: finish
+            template: finish
+            dependencies:
+              - task
+    - name: task
+      container:
+        name: ''
+        image: alpine:latest
+        command:
+          - sh
+          - '-c'
+        args:
+          - exit 1;
+    - name: exit-handler
+      container:
+        name: ''
+        image: alpine:latest
+        command:
+          - sh
+          - '-c'
+        args:
+          - exit 1;
+      retryStrategy:
+        limit: 1
+        retryPolicy: Always
+    - name: finish
+      container:
+        name: ''
+        image: alpine:latest
+        command:
+          - sh
+          - '-c'
+        args:
+          - echo "Finished!";
+  entrypoint: main


### PR DESCRIPTION
Signed-off-by: toyamagu-2021 <toyamagu2021@gmail.com>

<!-- Does this PR fix an issue -->

Fixes #12120

### Motivation

* Ensure WorkflowTemplateLevelLifeCycleHook wait for each dag task
* Almost same as `onExit` handler #3435

### Modifications

* Add `CheckAllHooksFullfilled` to check child hooked nodes.

### Verification

This PR resolve #12120

<details>
<summary>yaml</summary>

```yaml
spec:
  templates:
    - name: main
      inputs: {}
      outputs: {}
      metadata: {}
      dag:
        tasks:
          - name: some-task
            template: some-task
            arguments: {}
            hooks:
              failure:
                template: exit-handler
                arguments: {}
                expression: tasks["some-task"].status == "Failed"
          - name: finish
            template: finish
            arguments: {}
            dependencies:
              - some-task
    - name: some-task
      inputs: {}
      outputs: {}
      metadata: {}
      container:
        name: ''
        image: alpine:latest
        command:
          - sh
          - '-c'
        args:
          - |
            echo "Doing great things";
            echo "Failing...";
            exit 1;
        resources: {}
    - name: exit-handler
      inputs: {}
      outputs: {}
      metadata: {}
      container:
        name: ''
        image: alpine:latest
        command:
          - sh
          - '-c'
        args:
          - |
            echo "Sending updates to github";
            sleep 5;
            echo "Done!";
        resources: {}
      retryStrategy:
        limit: 1
        retryPolicy: Always
    - name: finish
      inputs: {}
      outputs: {}
      metadata: {}
      container:
        name: ''
        image: alpine:latest
        command:
          - sh
          - '-c'
        args:
          - |
            echo "Finished!";
        resources: {}
  entrypoint: main
```

</details>

* Success hook case

![image](https://github.com/argoproj/argo-workflows/assets/83329336/ab5684ff-17b5-46b4-b7e4-c303ff4835c4)

* Failed hook case

![image](https://github.com/argoproj/argo-workflows/assets/83329336/a140072f-b00f-465a-9aa9-fbef10b91bb5)
