### PR TITLE
fix: return failed instead of success when no container status

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1555,6 +1555,10 @@ func (woc *wfOperationCtx) inferFailedReason(pod *apiv1.Pod, tmpl *wfv1.Template
 	sort.Slice(ctrs, func(i, j int) bool { return order(ctrs[i].Name) < order(ctrs[j].Name) })
 	// Init containers have the highest preferences over other containers.
 	ctrs = append(pod.Status.InitContainerStatuses, ctrs...)
+	// When there isn't any containstatus (such as no stock in public cloud), return Failure.
+	if len(ctrs) == 0 {
+		return wfv1.NodeFailed, fmt.Sprintf("can't find failed message for pod %s namespace %s", pod.Name, pod.Namespace)
+	}
 
 	for _, ctr := range ctrs {
 


### PR DESCRIPTION
We have a product named ManagedArgoWorkflows in AlibabaCloud use eci (virtual-kubelet).
Sometimes the pod failed for some reason (no stock、timeout、schedulerFailed and more than these)，in these conditions, the pod mightly not has containerstatus/condations/messages,  and then the pod will marked success and caused mistake.

So I think we should return failed when the pod is Failed and we can't find message and status in the pod.

Maybe this problem will also occur in other public cloud platforms.