### PR TITLE
fix: create parent folder for artifact (Fixes #12174)

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -198,6 +198,15 @@ func (we *WorkflowExecutor) LoadArtifacts(ctx context.Context) error {
 			// unbeknownst to the user.
 			log.Infof("Specified artifact path %s overlaps with volume mount at %s. Extracting to volume mount", art.Path, mnt.MountPath)
 			artPath = path.Join(common.ExecutorMainFilesystemDir, art.Path)
+
+			// Ensure parent directory exists
+			artDir, _ := filepath.Split(artPath)
+			if artDir != "" {
+				// Create any missing dirs
+				if err := os.MkdirAll(artDir, 0o700); err != nil {
+					return err
+				}
+			}
 		}
 
 		// The artifact is downloaded to a temporary location, after which we determine if


### PR DESCRIPTION
Fixes #12174

### Motivation

We're switching workflow inputs from S3 to Http. We hit a problem when the parent path of the artifact's path does not exist. E.g. when path is `/folder-does-not-exst/my-file` we get an error when `os.Create()` is called by http artifact.

S3Cli would run `os.MkDirAll("/folder-does-not-exst/", 0o700)` before writing `folder-does-not-exist/my-file`.

This pull request runs the same code S3 runs to ensure that the parent folder exists prior to writing file.

I think this is the root cause for #12174. 

Our path is `/app/extra/files/file-plain/file-plain-7415959943057166615.txt`, however the directory `/app/extra/files/file-plain` doesn't exits.

The log output from argo-exec is:

``` 
init time="2023-11-10T17:52:55.936Z" level=info msg="Downloading artifact: 3075ff64-b69f-4720-a5c9-97caae2f5bb9"                                                                                                                                                                   init time="2023-11-10T17:52:55.936Z" level=info msg="Specified artifact path /app/extra/files/file-plain/file-plain-7415959943057166615.txt overlaps with volume mount at /app/extra/files/. Extracting to volume mount"                                                           init time="2023-11-10T17:52:55.936Z" level=info msg="Load artifact" artifactName=3075ff64-b69f-4720-a5c9-97caae2f5bb9 duration="30.183µs" error="open /mainctrfs/app/extra/files/file-plain/file-plain-7415959943057166615.txt.tmp: no such file or directory" key={TRUNCATED}
init time="2023-11-10T17:52:55.936Z" level=error msg="executor error: artifact 3075ff64-b69f-4720-a5c9-97caae2f5bb9 failed to load: open /mainctrfs/app/extra/files/file-plain/file-plain-7415959943057166615.txt.tmp: no such file or directory"                                  init time="2023-11-10T17:52:55.937Z" level=info msg="Alloc=9318 TotalAlloc=14207 Sys=28285 NumGC=4 Goroutines=6"                                                                                                                                                                   init time="2023-11-10T17:52:55.937Z" level=fatal msg="artifact 3075ff64-b69f-4720-a5c9-97caae2f5bb9 failed to load: open /mainctrfs/app/extra/files/file-plain/file-plain-7415959943057166615.txt.tmp: no such file or directory"       
```

### Modifications

Added step in workflow executor to create any missing parent folders prior to loading 


### Verification

[x] Executed our failing Argo Workflow with patched argo-exec. Everything worked.