### PR TITLE
fix: Revert "fix: regression in memoization without outputs (#12130)"

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -351,15 +351,20 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 		return node, err
 	}
 	if outputs != nil {
+		node, err = woc.wf.GetNodeByName(nodeName)
+		if err != nil {
+			woc.log.Errorf("unable to get node by name for %s", nodeName)
+			return nil, err
+		}
 		node.Outputs = outputs
 		woc.wf.Status.Nodes.Set(node.ID, *node)
-	}
-	if node.MemoizationStatus != nil {
-		c := woc.controller.cacheFactory.GetCache(controllercache.ConfigMapCache, node.MemoizationStatus.CacheName)
-		err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
-		if err != nil {
-			woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
-			node.Phase = wfv1.NodeError
+		if node.MemoizationStatus != nil {
+			c := woc.controller.cacheFactory.GetCache(controllercache.ConfigMapCache, node.MemoizationStatus.CacheName)
+			err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
+			if err != nil {
+				woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
+				node.Phase = wfv1.NodeError
+			}
 		}
 	}
 

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -170,19 +170,21 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 	if err != nil {
 		return node, err
 	}
-
 	if outputs != nil {
+		node, err := woc.wf.GetNodeByName(nodeName)
+		if err != nil {
+			return nil, err
+		}
 		node.Outputs = outputs
 		woc.addOutputsToGlobalScope(node.Outputs)
 		woc.wf.Status.Nodes.Set(node.ID, *node)
-	}
-
-	if node.MemoizationStatus != nil {
-		c := woc.controller.cacheFactory.GetCache(controllercache.ConfigMapCache, node.MemoizationStatus.CacheName)
-		err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
-		if err != nil {
-			woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
-			node.Phase = wfv1.NodeError
+		if node.MemoizationStatus != nil {
+			c := woc.controller.cacheFactory.GetCache(controllercache.ConfigMapCache, node.MemoizationStatus.CacheName)
+			err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
+			if err != nil {
+				woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
+				node.Phase = wfv1.NodeError
+			}
 		}
 	}
 


### PR DESCRIPTION
This reverts commit c751e66050a7c16d84ecdfdfe0f7ef59d6ec84c0.

See https://github.com/argoproj/argo-workflows/issues/12165