### PR TITLE
test: add test for missing child node

### DIFF
--- a/test/e2e/functional/missing-steps.yaml
+++ b/test/e2e/functional/missing-steps.yaml
@@ -1,0 +1,72 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: missing-steps
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - arguments:
+          parameters:
+          - name: script
+            value: |
+              echo hello
+        name: step1
+        template: work
+    - - arguments:
+          parameters:
+          - name: script
+            value: |
+              echo world
+        name: step2
+        template: work
+  - name: work
+    inputs:
+      parameters:
+        - name: script
+        - name: outputArtifactResultFilePath
+          default: /tmp/output
+      artifacts:
+        - name: inputFile
+          optional: true
+    outputs:
+      parameters:
+        - name: result
+          valueFrom:
+            parameter: '{{steps.execute-script.outputs.result}}'
+      artifacts:
+        - name: resultFile
+          optional: true
+          from: '{{steps.execute-script.outputs.artifacts.resultFile}}'
+    steps:
+      - - name: execute-script
+          template: execute-target-script
+          arguments:
+            parameters:
+              - name: script
+                value: '{{inputs.parameters.script}}'
+              - name: outputArtifactResultFilePath
+                value: '{{inputs.parameters.outputArtifactResultFilePath}}'
+            artifacts:
+              - name: inputFile
+                from: '{{inputs.artifacts.inputFile}}'
+  - name: execute-target-script
+    inputs:
+      parameters:
+        - name: script
+        - name: outputArtifactResultFilePath
+          default: /tmp/output
+      artifacts:
+        - name: inputFile
+          optional: true
+          path: /tmp/inputFile
+    outputs:
+      artifacts:
+        - name: resultFile
+          optional: true
+          path: '{{inputs.parameters.outputArtifactResultFilePath}}'
+    script:
+      command: [ 'bash' ]
+      image: 'argoproj/argosay:v2'
+      source: '{{inputs.parameters.script}}'

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1200,3 +1200,17 @@ func (s *FunctionalSuite) TestEntrypointName() {
 		})
 
 }
+
+func (s *FunctionalSuite) TestMissingStepsInUI() {
+	s.Given().
+		Workflow(`@functional/missing-steps.yaml`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectWorkflowNode(wfv1.NodeWithName(`missing-steps[0].step1[0].execute-script`), func(t *testing.T, n *wfv1.NodeStatus, _ *apiv1.Pod) {
+			assert.NotNil(t, n)
+			assert.NotNil(t, n.Children)
+			assert.Equal(t, 1, len(n.Children))
+		})
+}


### PR DESCRIPTION
This test is providing a regression test for #12165. As promised in #12203.

It verifies that a child link is correctly made in the case of a step with outputs.

### Verification

This test fails if #12203 is reverted.