### PR TITLE
test: test framework ExpectWorkflowNode should fail when no node

### DIFF
--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -104,10 +104,11 @@ func (t *Then) ExpectWorkflowNode(selector func(status wfv1.NodeStatus) bool, f 
 					p = nil // i did not expect to need to nil the pod, but here we are
 				}
 			}
+			f(tt, n, p)
 		} else {
 			_, _ = fmt.Println("Did not find node")
+			t.t.Error("Did not find expected node")
 		}
-		f(tt, n, p)
 	})
 }
 


### PR DESCRIPTION
By the name of ExpectWorkflowNode I believed that if the node it was selecting for didn't exist the thing wouldn't call f() and would error out.

So I've made it do that.

### Verification

Existing users of the test framework (the tests) pass
