### PR TITLE
fix: allow withItems when hooks are involved

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -72,7 +72,7 @@ spec:
         value: bar
   workflowMetadata:
     labelsFrom:
-      my-label: 
+      my-label:
         expression: workflow.parameters.foo
   entrypoint: main
   templates:
@@ -654,7 +654,7 @@ spec:
         parameters:
         - name: message
       container:
-        image: argoproj/argosay:v2 
+        image: argoproj/argosay:v2
         command: [cowsay]
         args: ["{{inputs.parameters.message}}"]
 `).
@@ -1334,4 +1334,12 @@ func (s *FunctionalSuite) TestMissingStepsInUI() {
 			assert.NotNil(t, n.Children)
 			assert.Equal(t, 1, len(n.Children))
 		})
+}
+
+func (s *FunctionalSuite) TestWithItemsWithHooks() {
+	s.Given().
+		Workflow("@smoke/with-items-with-hooks.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded)
 }

--- a/test/e2e/smoke/with-items-with-hooks.yaml
+++ b/test/e2e/smoke/with-items-with-hooks.yaml
@@ -1,0 +1,76 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  namespace: argo
+  generateName: with-items-dag-error-
+spec:
+  podMetadata:
+    labels:
+      parent-workflow:  '{{workflow.name}}'
+  podGC:
+    strategy: OnPodCompletion
+  templates:
+    - name: hook-template
+      inputs:
+        parameters:
+          - name: 'foo'
+      script:
+        image: >-
+          alpine:3.17.3
+        command:
+          - sh
+        source: >-
+          echo "I am a hook {{inputs.parameters.foo}}"
+    - name: run-sim-template
+      inputs:
+        parameters:
+          - name: fanoutValue
+      script:
+        image: >-
+          alpine:3.17.3
+        command:
+          - sh
+        source: >-
+          echo $FANOUT_VALUE
+        env:
+          - name: FANOUT_VALUE
+            value: '{{inputs.parameters.fanoutValue}}'
+    - name: run-sim-steps-template
+      inputs:
+        parameters:
+          - name: fanoutValue
+      steps:
+        - - name: run-sim
+            arguments:
+              parameters:
+                - name: fanoutValue
+                  value: '{{inputs.parameters.fanoutValue}}'
+            template: run-sim-template
+    - name: main
+      dag:
+        tasks:
+          - name: run-sim
+            arguments:
+              parameters:
+                - name: fanoutValue
+                  value: '{{item}}'
+            template: run-sim-steps-template
+            withItems:
+              - 1
+              - 2
+              - 3
+            hooks:
+              exit:
+                template: hook-template
+                arguments:
+                  parameters:
+                    - name: foo
+                      value: bar
+              running:
+                template: hook-template
+                arguments:
+                  parameters:
+                    - name: foo
+                      value: bar
+                expression: tasks["run-sim"].status == "Running"
+  entrypoint: main

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3071,6 +3071,15 @@ func (woc *wfOperationCtx) processAggregateNodeOutputs(scope *wfScope, prefix st
 	if len(childNodes) == 0 {
 		return nil
 	}
+	// Some of the children may be hooks, only keep those that aren't
+	nodeIdx := 0
+	for i := range childNodes {
+		if childNodes[i].NodeFlag == nil || !childNodes[i].NodeFlag.Hooked {
+			childNodes[nodeIdx] = childNodes[i]
+			nodeIdx++
+		}
+	}
+	childNodes = childNodes[:nodeIdx]
 	// need to sort the child node list so that the order of outputs are preserved
 	sort.Sort(loopNodes(childNodes))
 	paramList := make([]map[string]string, 0)


### PR DESCRIPTION
processAggregateNodeOutputs expects all children to be withItems children, but when there are hooks involved, this is not true. It uses `DisplayName` in an evil way to order the children, but the hooks don't fit it's idea of how displayName should look, so it will panic. I don't attempt to address this evil.

Instead I've opted filter the children in place to make it work.

Fixes #12279 

### Verification

Functional test included.
