### PR TITLE
fix: properly resolve exit handler inputs (fixes #12283)

### DIFF
--- a/workflow/controller/exit_handler.go
+++ b/workflow/controller/exit_handler.go
@@ -33,7 +33,7 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 			woc.log.WithField("lifeCycleHook", exitHook).Infof("Running OnExit handler")
 			onExitNodeName := common.GenerateOnExitNodeName(parentNode.Name)
 			resolvedArgs := exitHook.Arguments
-			if !resolvedArgs.IsEmpty() && outputs != nil {
+			if !resolvedArgs.IsEmpty() {
 				resolvedArgs, err = woc.resolveExitTmplArgument(exitHook.Arguments, prefix, outputs, scope)
 				if err != nil {
 					return true, nil, err
@@ -56,11 +56,13 @@ func (woc *wfOperationCtx) resolveExitTmplArgument(args wfv1.Arguments, prefix s
 	if scope == nil {
 		scope = createScope(nil)
 	}
-	for _, param := range outputs.Parameters {
-		scope.addParamToScope(fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name), param.Value.String())
-	}
-	for _, arts := range outputs.Artifacts {
-		scope.addArtifactToScope(fmt.Sprintf("%s.outputs.artifacts.%s", prefix, arts.Name), arts)
+	if outputs != nil {
+		for _, param := range outputs.Parameters {
+			scope.addParamToScope(fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name), param.Value.String())
+		}
+		for _, arts := range outputs.Artifacts {
+			scope.addArtifactToScope(fmt.Sprintf("%s.outputs.artifacts.%s", prefix, arts.Name), arts)
+		}
 	}
 
 	stepBytes, err := json.Marshal(args)

--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -999,3 +999,76 @@ status:
 	woc.operate(ctx)
 	assert.Equal(t, woc.wf.Status.Phase, wfv1.WorkflowRunning)
 }
+
+func TestStepsTemplateOnExitStatusArgument(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-tmpl-level-
+  labels:
+    test: test
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: main
+            template: echo
+            hooks:
+              exit:
+                template: hook
+                arguments:
+                  parameters:
+                    - name: status
+                      value: "{{steps.main.status}}"
+    - name: echo
+      container:
+        image: alpine:3.6
+        command: [sh, -c]
+        args: ["echo hi"]
+    - name: hook
+      inputs:
+        parameters:
+          - name: status
+      container:
+        image: alpine:3.6
+        command: [sh, -c]
+        args: ["echo {{inputs.parameters.status}}"]
+`)
+	cancel, controller := newController(wf)
+	defer cancel()
+
+	ctx := context.Background()
+	woc := newWorkflowOperationCtx(wf, controller)
+	woc.operate(ctx)
+
+	makePodsPhase(ctx, woc, apiv1.PodFailed)
+
+	woc = newWorkflowOperationCtx(woc.wf, controller)
+	woc.operate(ctx)
+
+	var hasExitNode bool
+	var exitNodeName string
+
+	for _, node := range woc.wf.Status.Nodes {
+		if node.IsExitNode() {
+			hasExitNode = true
+			exitNodeName = node.DisplayName
+			break
+		}
+	}
+
+	assert.True(t, hasExitNode)
+	assert.NotEmpty(t, exitNodeName)
+
+	hookNode := woc.wf.Status.Nodes.FindByDisplayName(exitNodeName)
+
+	if assert.NotNil(t, hookNode) {
+		assert.NotNil(t, hookNode.Inputs)
+		if assert.Len(t, hookNode.Inputs.Parameters, 1) {
+			assert.NotNil(t, hookNode.Inputs.Parameters[0].Value)
+			assert.Equal(t, hookNode.Inputs.Parameters[0].Value.String(), string(apiv1.PodFailed))
+		}
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/12283

### Motivation

Exit handlers should have access to the step status parameter.

### Modifications

I changed the logic that decides whether or not input parameters should be resolved for an exit handler.

### Verification

I wrote a test.
