### PR TITLE
feat: speed up resolve reference

### DIFF
--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Knetic/govaluate"
@@ -397,6 +398,15 @@ func shouldExecute(when string) (bool, error) {
 	return boolRes, nil
 }
 
+func errorFromChannel(errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	default:
+	}
+	return nil
+}
+
 // resolveReferences replaces any references to outputs of previous steps, or artifacts in the inputs
 // NOTE: by now, input parameters should have been substituted throughout the template, so we only
 // are concerned with:
@@ -414,21 +424,21 @@ func (woc *wfOperationCtx) resolveReferences(stepGroup []wfv1.WorkflowStep, scop
 		return nil, err
 	}
 
-	for i, step := range stepGroup {
+	// Resolve a Step's References and add it to newStepGroup
+	resolveStepReferences := func(i int, step wfv1.WorkflowStep, newStepGroup []wfv1.WorkflowStep) error {
 		// Step 1: replace all parameter scope references in the step
-		// TODO: improve this
 		stepBytes, err := json.Marshal(step)
 		if err != nil {
-			return nil, errors.InternalWrapError(err)
+			return errors.InternalWrapError(err)
 		}
 		newStepStr, err := template.Replace(string(stepBytes), woc.globalParams.Merge(scope.getParameters()), true)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		var newStep wfv1.WorkflowStep
 		err = json.Unmarshal([]byte(newStepStr), &newStep)
 		if err != nil {
-			return nil, errors.InternalWrapError(err)
+			return errors.InternalWrapError(err)
 		}
 
 		// If we are not executing, don't attempt to resolve any artifact references. We only check if we are executing after
@@ -441,13 +451,13 @@ func (woc *wfOperationCtx) resolveReferences(stepGroup []wfv1.WorkflowStep, scop
 			if newStep.ShouldExpand() {
 				proceed = true
 			} else {
-				return nil, err
+				return err
 			}
 		}
 		if !proceed {
 			// We can simply return this WorkflowStep; the fact that it won't execute will be reconciled later on in execution
 			newStepGroup[i] = newStep
-			continue
+			return nil
 		}
 
 		// Step 2: replace all artifact references
@@ -461,13 +471,37 @@ func (woc *wfOperationCtx) resolveReferences(stepGroup []wfv1.WorkflowStep, scop
 				if art.Optional {
 					continue
 				}
-				return nil, fmt.Errorf("unable to resolve references: %s", err)
+				return fmt.Errorf("unable to resolve references: %s", err)
 			}
 			resolvedArt.Name = art.Name
 			newStep.Arguments.Artifacts[j] = *resolvedArt
 		}
 
 		newStepGroup[i] = newStep
+		return nil
+	}
+
+	// When resolveStepReferences we can use a channel parallelStepNum to control the number of concurrencies
+	parallelStepNum := make(chan string, 500)
+	errCh := make(chan error, len(stepGroup)) // contains the error during resolveStepReferences
+	var wg sync.WaitGroup
+	for i, step := range stepGroup {
+		parallelStepNum <- step.Name
+		wg.Add(1)
+		go func(i int, step wfv1.WorkflowStep) {
+			defer wg.Done()
+			if err := resolveStepReferences(i, step, newStepGroup); err != nil {
+				woc.log.WithFields(log.Fields{"stepName": step.Name}).WithError(err).Error("Failed to resolve references")
+				errCh <- err
+			}
+			<-parallelStepNum
+		}(i, step)
+	}
+	wg.Wait()
+
+	err = errorFromChannel(errCh) // fetch the first error during resolveStepReferences
+	if err != nil {
+		return nil, fmt.Errorf("Failed to resolve references: %s", err)
 	}
 	return newStepGroup, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

I have a big and flat workflow( 2000+ ) pod, which have artifacts reference each step. I find it won’t continue running down when it run to around step 100～200. 

After investigation， I find the function "resolveReferences" is too slow. One Step Group node has 1000 step need 300s to resolveReferences and then update the Step Group succeed. After that, then the workflow can run down.  But the default time for woc.operator is 30s.  I have set MAX_OPERATION_TIME to 20 min to succeed the workflow. But I think there is a better solution.

So I want to  speed up resolve reference.

I print the step time when it change to newStepStr use "template.Replace". Maybe I will speed up the "template.Replace"  function future.
![image](https://github.com/argoproj/argo-workflows/assets/72060326/7a6db089-67bf-40cf-85b3-2ca40ff47876)
![image](https://github.com/argoproj/argo-workflows/assets/72060326/98537a5c-a6e5-453c-93ed-3bcd44c1878f)



<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->


### Beyond this PR

<!-- 
Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 

We are gauging interest in a potential system in which many companies pledge a little bit of time each to help get more people into these roles. 
See [#12229](https://github.com/argoproj/argo-workflows/issues/12229) for more information. 
If you think you or your company may be interested in getting involved, please add a comment to the issue.
-->
