### PR TITLE
feat: support to show inputs dir artifacts in UI

### DIFF
--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -40,6 +40,13 @@ type ArtifactServer struct {
 	artifactRepositories artifactrepositories.Interface
 }
 
+type Direction string
+
+const (
+	Outputs Direction = "outputs"
+	Inputs  Direction = "inputs"
+)
+
 func NewArtifactServer(authN auth.Gatekeeper, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive, instanceIDService instanceid.Service, artifactRepositories artifactrepositories.Interface) *ArtifactServer {
 	return newArtifactServer(authN, hydrator, wfArchive, instanceIDService, artifact.NewDriver, artifactRepositories)
 }
@@ -59,9 +66,9 @@ func (a *ArtifactServer) GetInputArtifact(w http.ResponseWriter, r *http.Request
 // single endpoint to be able to handle serving directories as well as files, both those that have been archived and those that haven't
 // Valid requests:
 //
-//	/artifact-files/{namespace}/[archived-workflows|workflows]/{id}/{nodeId}/outputs/{artifactName}
-//	/artifact-files/{namespace}/[archived-workflows|workflows]/{id}/{nodeId}/outputs/{artifactName}/{fileName}
-//	/artifact-files/{namespace}/[archived-workflows|workflows]/{id}/{nodeId}/outputs/{artifactName}/{fileDir}/.../{fileName}
+//	/artifact-files/{namespace}/[archived-workflows|workflows]/{id}/{nodeId}/[inputs|outputs]/{artifactName}
+//	/artifact-files/{namespace}/[archived-workflows|workflows]/{id}/{nodeId}/[inputs|outputs]/{artifactName}/{fileName}
+//	/artifact-files/{namespace}/[archived-workflows|workflows]/{id}/{nodeId}/[inputs|outputs]/{artifactName}/{fileDir}/.../{fileName}
 //
 // 'id' field represents 'uid' for archived workflows and 'name' for non-archived
 func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request) {
@@ -92,10 +99,10 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 	archiveDiscriminator := requestPath[archiveDiscrimIndex]
 	id := requestPath[idIndex] // if archiveDiscriminator == "archived-workflows", this represents workflow UID; if archiveDiscriminator == "workflows", this represents workflow name
 	nodeId := requestPath[nodeIdIndex]
-	direction := requestPath[directionIndex]
+	direction := Direction(requestPath[directionIndex])
 	artifactName := requestPath[artifactNameIndex]
 
-	if direction != "outputs" { // for now we just handle output artifacts
+	if direction != Outputs && direction != Inputs { // for now we handle output and input artifacts
 		a.httpBadRequestError(w)
 		return
 	}
@@ -147,7 +154,12 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	artifact, driver, err := a.getArtifactAndDriver(ctx, nodeId, artifactName, false, wf, fileName)
+	isInput := false
+	if direction == Inputs {
+		isInput = true
+	}
+
+	artifact, driver, err := a.getArtifactAndDriver(ctx, nodeId, artifactName, isInput, wf, fileName)
 	if err != nil {
 		a.serverInternalError(err, w)
 		return

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -191,6 +191,14 @@ func newServer() *ArtifactServer {
 									},
 								},
 							},
+							{
+								Name: "my-s3-artifact-directory",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									S3: &wfv1.S3Artifact{
+										Key: "my-wf/my-node-1/my-s3-artifact-directory",
+									},
+								},
+							},
 						},
 					},
 					Outputs: &wfv1.Outputs{
@@ -389,6 +397,21 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 		},
 		{
 			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-s3-artifact-directory/subdirectory/",
+			statusCode:  200,
+			isDirectory: true,
+			directoryFiles: []string{
+				"..",
+				"b.txt",
+				"c.txt",
+			},
+		},
+		{
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/inputs/my-s3-input-artifact",
+			statusCode:  200,
+			isDirectory: false,
+		},
+		{
+			path:        "/artifact-files/my-ns/workflows/my-wf/my-node-1/inputs/my-s3-artifact-directory/subdirectory/",
 			statusCode:  200,
 			isDirectory: true,
 			directoryFiles: []string{

--- a/ui/src/app/shared/services/workflow-service.test.ts
+++ b/ui/src/app/shared/services/workflow-service.test.ts
@@ -34,10 +34,10 @@ describe('workflow service', () => {
             '/artifact-files/argo/archived-workflows/test-uid/test-node/outputs/test-artifact'
         );
         expect(service.getArtifactDownloadUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-artifact', false, true)).toBe(
-            '/input-artifacts/argo/hello-world/test-node/test-artifact'
+            '/artifact-files/argo/workflows/hello-world/test-node/inputs/test-artifact'
         );
         expect(service.getArtifactDownloadUrl(workflow('hello-world', 'argo', 'test-uid'), 'test-node', 'test-artifact', true, true)).toBe(
-            '/input-artifacts-by-uid/test-uid/test-node/test-artifact'
+            '/artifact-files/argo/archived-workflows/test-uid/test-node/inputs/test-artifact'
         );
     });
 });

--- a/ui/src/app/shared/services/workflows-service.ts
+++ b/ui/src/app/shared/services/workflows-service.ts
@@ -280,14 +280,8 @@ export const WorkflowsService = {
     },
 
     artifactPath(workflow: Workflow, nodeId: string, artifactName: string, archived: boolean, isInput: boolean) {
-        if (!isInput) {
-            return `artifact-files/${workflow.metadata.namespace}/${archived ? 'archived-workflows' : 'workflows'}/${
-                archived ? workflow.metadata.uid : workflow.metadata.name
-            }/${nodeId}/outputs/${artifactName}`;
-        } else if (archived) {
-            return `input-artifacts-by-uid/${workflow.metadata.uid}/${nodeId}/${encodeURIComponent(artifactName)}`;
-        } else {
-            return `input-artifacts/${workflow.metadata.namespace}/${workflow.metadata.name}/${nodeId}/${encodeURIComponent(artifactName)}`;
-        }
+        return `artifact-files/${workflow.metadata.namespace}/${archived ? 'archived-workflows' : 'workflows'}/${
+            archived ? workflow.metadata.uid : workflow.metadata.name
+        }/${nodeId}/${isInput ? 'inputs' : 'outputs'}/${artifactName}`;
     }
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
I want to set inputs artifacts which is dir type in UI.
The example is:
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: artifactory-artifact-
spec:
  entrypoint: artifact-example
  templates:
  - name: artifact-example
    steps:
    - - name: generate-artifact
        template: whalesay
    - - name: consume-artifact
        template: print-message
        arguments:
          artifacts:
          - name: message
            from: "{{steps.generate-artifact.outputs.artifacts.hello-art}}"
          - name: log
            from: "{{steps.generate-artifact.outputs.artifacts.log}}"

  - name: whalesay
    inputs:
      artifacts:
      - archive:
          none: {}
        name: danger
        oss:
          key: aaaaa/store/artifactory-artifact-647sm/log
        path: /tmp
    container:
      image: docker/whalesay:latest
      command: [sh, -c]
      args: ["cowsay hello world | tee /tmp/hello_world.txt && cowsay hello world | tee /tmp/hello_world2.txt"]
    outputs:
      artifacts:
      - name: hello-art
        path: /tmp
      - archive:
          none: {}
        name: log
        oss:
          key: aaaaa/store/{{workflow.name}}/log
        path: /tmp

  - name: print-message
    inputs:
      artifacts:
      - name: message
        path: /tmp/message
      - name: log
        path: /tmp/inputs/artifacts/logs
    container:
      image: alpine:latest
      command: [sh, -c]
      args: ["ls /tmp/message && ls /tmp/inputs/artifacts/logs"]
```
The UI is when I click inputs artifacts which is a dir:
![image](https://github.com/argoproj/argo-workflows/assets/72060326/c11b0e90-e909-4e06-b036-700c530e3f6f)

![image](https://github.com/argoproj/argo-workflows/assets/72060326/16fc9720-62c5-4b5e-b522-0476aed8d2e8)

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->


### Beyond this PR

<!-- 
Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 

We are gauging interest in a potential system in which many companies pledge a little bit of time each to help get more people into these roles. 
See [#12229](https://github.com/argoproj/argo-workflows/issues/12229) for more information. 
If you think you or your company may be interested in getting involved, please add a comment to the issue.
-->
