### PR TITLE
docs: Remove old version pin in README

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -11,7 +11,7 @@ Python >= 3.6
 If you'd like to install the official releases of the SDK on PyPI, please run the following:
 
 ```sh
-pip install argo-workflows==6.3.0rc2
+pip install argo-workflows
 ```
 
 Otherwise, you can install the latest development version of the SDK via the following:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12364 

### Motivation

I tried installing the version in the README before realizing it was very old and could not be used to follow other parts of the documentation

### Modifications

It's a README change.

### Verification

I ran the command in the README

### Beyond this PR

<!-- 
Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 

We are gauging interest in a potential system in which many companies pledge a little bit of time each to help get more people into these roles. 
See [#12229](https://github.com/argoproj/argo-workflows/issues/12229) for more information. 
If you think you or your company may be interested in getting involved, please add a comment to the issue.
-->
