### PR TITLE
chore(deps): bump upload and download artifact to v4

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -159,7 +159,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: argoexec
           path: /tmp/argoexec_image.tar
@@ -243,7 +243,7 @@ jobs:
           echo "    token: xxxxxx" >> $KUBECONFIG
           until kubectl cluster-info ; do sleep 10s ; done
       - name: Download argoexec image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: argoexec
           path: /tmp

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,7 +39,7 @@ jobs:
         run: git diff --exit-code
       # Upload the site so reviewers see it.
       - name: Upload Docs Site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: site


### PR DESCRIPTION
These must be bumped together.

Replaces #12374 and #12375 from dependabot
