### PR TITLE
docs: "beyond this issue" section should be hidden in issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.md
@@ -16,10 +16,10 @@ When would you use this?
 **Message from the maintainers**:
 
 Love this enhancement proposal? Give it a 👍. We prioritise the proposals with the most 👍.
+<!-- 
 
 **Beyond this issue**:
 
-<!-- 
 Are you a contributor? If not, have you thought about it? 
 
 Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,10 +37,9 @@ Fixes #TODO
 
 <!-- TODO: Say how you tested your changes. -->
 
-
+<!-- 
 ### Beyond this PR
 
-<!-- 
 Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 
 
 Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 


### PR DESCRIPTION
This section is only for people who are creating the issue to see.