### PR TITLE
docs: Fix incorrect link in edit button

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Argo Workflows - The workflow engine for Kubernetes
 repo_url: https://github.com/argoproj/argo-workflows
+edit_uri: https://github.com/argoproj/argo-workflows/edit/main/docs
 strict: true
 theme:
   name: material


### PR DESCRIPTION
Currently, when click "edit" on any of the docs page from the website, it will direct you to a 404 page since it uses hard-coded "master" branch. This PR fixes that by changing it to "main" branch URL instead.