### PR TITLE
fix: wrong values are assigned to input parameters of workflowtemplat…

### DIFF
--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -36,6 +36,8 @@ func MergeTo(patch, target *wfv1.Workflow) error {
 	if err != nil {
 		return err
 	}
+
+	target.Spec = wfv1.WorkflowSpec{}
 	err = json.Unmarshal(mergedWfByte, target)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12314

We should unmarshal mergedWfByte to a new workflowspec instead of the basis of the original. 

### Motivation

<!-- TODO: Say why you made your changes. -->

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
I hava add a ut and test it e2e.
<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 

We are gauging interest in a potential system in which many companies pledge a little bit of time each to help get more people into these roles. 
See [#12229](https://github.com/argoproj/argo-workflows/issues/12229) for more information. 
If you think you or your company may be interested in getting involved, please add a comment to the issue.
-->
