### PR TITLE
feat: delete pods in parallel to speed up retryworkflow

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -370,6 +371,15 @@ func (s *workflowServer) DeleteWorkflow(ctx context.Context, req *workflowpkg.Wo
 	return &workflowpkg.WorkflowDeleteResponse{}, nil
 }
 
+func errorFromChannel(errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	default:
+	}
+	return nil
+}
+
 func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.WorkflowRetryRequest) (*wfv1.Workflow, error) {
 	wfClient := auth.GetWfClient(ctx)
 	kubeClient := auth.GetKubeClient(ctx)
@@ -394,12 +404,25 @@ func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.Wor
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
 
+	errCh := make(chan error, len(podsToDelete))
+	var wg sync.WaitGroup
+	wg.Add(len(podsToDelete))
 	for _, podName := range podsToDelete {
 		log.WithFields(log.Fields{"podDeleted": podName}).Info("Deleting pod")
-		err := kubeClient.CoreV1().Pods(wf.Namespace).Delete(ctx, podName, metav1.DeleteOptions{})
-		if err != nil && !apierr.IsNotFound(err) {
-			return nil, sutils.ToStatusError(err, codes.Internal)
-		}
+		go func(podName string) {
+			defer wg.Done()
+			err := kubeClient.CoreV1().Pods(wf.Namespace).Delete(ctx, podName, metav1.DeleteOptions{})
+			if err != nil && !apierr.IsNotFound(err) {
+				errCh <- err
+				return
+			}
+		}(podName)
+	}
+	wg.Wait()
+
+	err = errorFromChannel(errCh)
+	if err != nil {
+		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
 
 	err = s.hydrator.Dehydrate(wf)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

I have a big worklfow. When it failed and retry, it will be slowly. Latency increases with the number of pods. Always letting my automated system（interact with argo server use https) time out.

```
time="2023-12-26T13:02:01.560Z" level=info duration=1m18.730806898s method=PUT path=/api/v1/workflows/default/catch-workflow-8c48s/retry size=194 status=409
```

I found that the main time spent was deleting pods. 

```
time="2023-12-26T13:02:00.126Z" level=info msg="Deleting pod" podDeleted=catch-workflow-8c48s-read-ligands-from-vswdb-op-bmvou-9dzxr-2538960512
time="2023-12-26T13:02:00.328Z" level=info msg="Deleting pod" podDeleted=catch-workflow-8c48s-read-ligands-from-vswdb-op-bmvou-9dzxr-2824246174
time="2023-12-26T13:02:00.527Z" level=info msg="Deleting pod" podDeleted=catch-workflow-8c48s-read-ligands-from-vswdb-op-bmvou-9dzxr-3817503941
time="2023-12-26T13:02:00.731Z" level=info msg="Deleting pod" podDeleted=catch-workflow-8c48s-read-ligands-from-vswdb-op-bmvou-9dzxr-1699455227
time="2023-12-26T13:02:00.925Z" level=info msg="Deleting pod" podDeleted=catch-workflow-8c48s-read-ligands-from-vswdb-op-bmvou-9dzxr-4168132452
time="2023-12-26T13:02:01.133Z" level=info msg="Deleting pod" podDeleted=catch-workflow-8c48s-read-ligands-from-vswdb-op-bmvou-9dzxr-1982889595
```

So I want make deleting pods parallel.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 

We are gauging interest in a potential system in which many companies pledge a little bit of time each to help get more people into these roles. 
See [#12229](https://github.com/argoproj/argo-workflows/issues/12229) for more information. 
If you think you or your company may be interested in getting involved, please add a comment to the issue.
-->
