### PR TITLE
fix: ensure workflow wait for onExit hook for DAG template (#11880)

### DIFF
--- a/test/e2e/functional/stop-terminate.yaml
+++ b/test/e2e/functional/stop-terminate.yaml
@@ -19,14 +19,13 @@ spec:
         command: [ sleep ]
         args: [ "999" ]
 
-    # This sleep value is only a temporal workaround ensuring template-level hooks finish faster.
-    # See https://github.com/argoproj/argo-workflows/issues/11880
     - name: exit
       container:
         image: argoproj/argosay:v1
-        command: [ sleep ]
-        args: [ "4" ]
-
+   
+    # We should sleep finite time to ensure workflow controller wait for DAG onExit template to complete.
     - name: exit-template
       container:
         image: argoproj/argosay:v1
+        command: [ sleep ]
+        args: [ "5" ]


### PR DESCRIPTION
Signed-off-by: toyamagu2021@gmail.com <toyamagu2021@gmail.com>

Fixes #11880

### Motivation

* Ensure workflow wait for onExit hook for DAG template
* #11493 introduces a feature that none of DAG task waits for a hook after shutdown is started.
* But workflows should wait for all onExit hooks completed as commented in https://github.com/argoproj/argo-workflows/issues/11880#issuecomment-1864097420

### Modifications

* Wait for onExit hook even if a shutdown process is started.
* Logic is almost same as steps one
  * https://github.com/argoproj/argo-workflows/blob/6ca4d506eb23cb02e7c8cf21700509d0ff4a2c19/workflow/controller/steps.go#L328-L341

### Verification

* E2E tests
* Fixes #11880
  * ![image](https://github.com/argoproj/argo-workflows/assets/83329336/39913b93-cdbc-49ee-95c2-52153f343c86)

