### PR TITLE
fix: update MinIO Helm URL

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -30,7 +30,7 @@ You can install MinIO into your cluster via Helm.
 First, [install `helm`](https://helm.sh/docs/intro/install/). Then, install MinIO with the below commands:
 
 ```bash
-helm repo add minio https://helm.min.io/ # official minio Helm charts
+helm repo add minio https://charts.min.io/ # official minio Helm charts
 helm repo update
 helm install argo-artifacts minio/minio --set service.type=LoadBalancer --set fullnameOverride=argo-artifacts
 ```


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

Fixes #TODO

### Motivation

MinIO changed the URL from https://helm.min.io/ to https://charts.min.io/ as per https://github.com/minio/minio/tree/master/helm/minio

### Modifications

Changed installation example URL from https://helm.min.io/ to https://charts.min.io/

### Verification

Ran the command with the new URL and it works.

