### PR TITLE
docs: change quick-start guide to use quick-start install. Fixes #12391

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -24,7 +24,7 @@ Below is an example of the install commands, ensure that you update the command 
 
 ```yaml
 kubectl create namespace argo
-kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v<<ARGO_WORKFLOWS_VERSION>>/install.yaml
+kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v<<ARGO_WORKFLOWS_VERSION>>/quick-start-minimal.yaml
 ```
 
 ### Patch argo-server authentication


### PR DESCRIPTION
The quick start guide used the regular install.yaml for installation which does not configure the default user to be a valid service account to execute a workflow. This causes any example executions to fail. However the quick-start-minimal.yaml installation does configure this and is clearly suited for this doc so switch to that.

Fixes #12391

### Verification

Redid the quick start guide with the quick-start-minimal.yaml installation and it worked.