### PR TITLE
docs: Fix dead link in documentation

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -56,7 +56,7 @@ The tag is substituted with the result of evaluating the tag as an expression.
 Note that any hyphenated parameter names or step names will cause a parsing error. You can reference them by
 indexing into the parameter or step map, e.g. `inputs.parameters['my-param']` or `steps['my-step'].outputs.result`.
 
-[Learn about the expression syntax](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
+[Learn about the expression syntax](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md).
 
 #### Examples
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -56,7 +56,7 @@ The tag is substituted with the result of evaluating the tag as an expression.
 Note that any hyphenated parameter names or step names will cause a parsing error. You can reference them by
 indexing into the parameter or step map, e.g. `inputs.parameters['my-param']` or `steps['my-step'].outputs.result`.
 
-[Learn about the expression syntax](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md).
+[Learn about the expression syntax](https://github.com/antonmedv/expr/blob/master/docs/language-definition.md).
 
 #### Examples
 


### PR DESCRIPTION
### Motivation

Fixed a dead link in the documentation.

### Modifications

Changed the link (the expr-lang repository has moved).