### PR TITLE
docs: Add notes on release branch to work with versioned docs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -218,6 +218,7 @@ v3.3.
 v3.4
 v3.4.
 v3.5
+versioned
 validator
 versioning
 webHDFS

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,6 +3,8 @@
 ## Cherry-Picking Fixes
 
 ✋ Before you start, make sure you have created a release branch (e.g. `release-3.3`) and it's passing CI.
+Please make sure all patch releases (e.g. `v3.3.5`) should be released from its associated minor release branch (e.g. `release-3.3`)
+to work well with our setup for versioned documentation website.
 
 Then get a list of commits you may want to cherry-pick:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,8 +3,8 @@
 ## Cherry-Picking Fixes
 
 ✋ Before you start, make sure you have created a release branch (e.g. `release-3.3`) and it's passing CI.
-Please make sure all patch releases (e.g. `v3.3.5`) should be released from its associated minor release branch (e.g. `release-3.3`)
-to work well with our setup for versioned documentation website.
+Please make sure that all patch releases (e.g. `v3.3.5`) should be released from their associated minor release branches (e.g. `release-3.3`)
+to work well with our versioned website.
 
 Then get a list of commits you may want to cherry-pick:
 


### PR DESCRIPTION
Per our previous discussions, this would avoid any manual sync with release branches. cc @jmeridth @agilgur5 

Also cc @sarabala1979 who will be doing the upcoming patch releases.