### PR TITLE
ci: disable non-security dependabot updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     - dependency-name: k8s.io/*
     - dependency-name: github.com/grpc-ecosystem/*
     - dependency-name: google.golang.org/grpc
+    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
+    - dependency-name: "*"
+      update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
@@ -20,6 +23,9 @@ updates:
       # temporarily ignore until https://github.com/actions/download-artifact/issues/249 is resolved
       - dependency-name: "actions/download-artifact"
       - dependency-name: "actions/upload-artifact"
+      # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
+      - dependency-name: "*"
+        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
 
   - package-ecosystem: "npm"
     directory: "/ui"
@@ -31,4 +37,7 @@ updates:
       - dependency-name: style-loader
       - dependency-name: react-router-dom
       - dependency-name: "@types/react-router-dom"
+      # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
+      - dependency-name: "*"
+        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,8 @@ updates:
       - dependency-name: k8s.io/*
       - dependency-name: github.com/grpc-ecosystem/*
       - dependency-name: google.golang.org/grpc
-      # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
-      - dependency-name: "*"
-        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
-    open-pull-requests-limit: 10
+    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -23,9 +21,8 @@ updates:
       # temporarily ignore until https://github.com/actions/download-artifact/issues/249 is resolved
       - dependency-name: "actions/download-artifact"
       - dependency-name: "actions/upload-artifact"
-      # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
-      - dependency-name: "*"
-        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
+    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directory: "/ui"
@@ -37,7 +34,5 @@ updates:
       - dependency-name: style-loader
       - dependency-name: react-router-dom
       - dependency-name: "@types/react-router-dom"
-      # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
-      - dependency-name: "*"
-        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
-    open-pull-requests-limit: 10
+    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,12 @@ updates:
       interval: "weekly"
       day: "saturday"
     ignore:
-    - dependency-name: k8s.io/*
-    - dependency-name: github.com/grpc-ecosystem/*
-    - dependency-name: google.golang.org/grpc
-    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
-    - dependency-name: "*"
-      update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
+      - dependency-name: k8s.io/*
+      - dependency-name: github.com/grpc-ecosystem/*
+      - dependency-name: google.golang.org/grpc
+      # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore
+      - dependency-name: "*"
+        update-types: [version-update:semver-major, version-update:semver-minor, version-update:semver-patch]
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

As discussed in a [previous Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit#heading=h.k1l4irxjo6vc) and last month [on Slack](https://cloud-native.slack.com/archives/C0510EUH90V/p1701289310482799?thread_ts=1701102825.624669&cid=C0510EUH90V).

### Motivation

<!-- TODO: Say why you made your changes. -->

- most of the automated updates from dependabot cause a lot of noise and use up CI time, without adding much
  - most often are small patch updates that don't affect our usage of deps
  - some can also cause a lot of breakage when they pass CI but break something in a way that doesn't have an automated test (or has a test flake)
    - examples in this repo include #12454, #10648, #9041, #8839 etc
  - some can also cause lots of merge conflicts with other manual dependency updates
    - examples in this repo include https://github.com/argoproj/argo-workflows/pull/12516#issuecomment-1890821682, https://github.com/argoproj/argo-workflows/pull/12097#issuecomment-1793787408, https://github.com/argoproj/argo-workflows/pull/11637#issuecomment-1696380931, etc

- instead of unnecessary automated updates, we can just manually update deps when needed (when we need a feature or patch) and set a reminder every 6 months to check in
  - IMO, I think this would actually end up as less work than monitoring all the dependabot updates

- Note that this intentionally _does not_ impact security updates. Security updates will still happen automatically
  - per the [linked docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit):
     > This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.
    - that is why I specifically used this configuration

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Set `open-pull-requests-limit: 0` in `dependabot.yml` for all our currently specified package ecosystems

#### minor style modification

- `gomod` section had 0 space while the rest had 2 space indentation
  - now all are 2 space consistently

### Verification

<!-- TODO: Say how you tested your changes. -->

GH has no way to actually test this, but this is something I previously implemented in other repos that I have maintained ([example](https://github.com/jaredpalmer/tsdx/blob/2d7981b00b2bf7363a3eeff44ff5ff698ba58c8c/.github/dependabot.yml#L53)).

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
