### PR TITLE
ci: add Stale Action for specifically labeled issues and PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,41 @@
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # once a day at 2am
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for commenting on an issue and editing labels
+      pull-requests: write # for commenting on a PR and editing labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # timing
+          days-before-stale: 14 # 2 weeks of inactivity
+          days-before-close: 14 # 2 more weeks of inactivity
+          # labels to watch for, add, and remove
+          only-labels: 'more information needed' # only mark issues/PRs as stale if they have this label
+          labels-to-remove-when-unstale: 'more information needed' # remove label when unstale -- should be manually added back if information is insufficient
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          # automated messages to issue/PR authors
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had recent activity and needs more information.
+            It will be closed if no further activity occurs.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had recent activity and needs further changes.
+            It will be closed if no further activity occurs.
+          close-issue-message: >
+            This issue has been closed due to inactivity and lack of information.
+            If you still encounter this issue, please add the requested information and re-open.
+          close-pr-message:
+            This PR has been closed due to inactivity and lack of changes.
+            If you would like to still work on this PR, please address the review comments and re-open.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -120,7 +120,16 @@ Any bugs with 3-4 "👍" reactions should be labeled at least `P2`.
 Bugs can be [sorted by "👍"](https://github.com/argoproj/argo-workflows/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Abug).
 
 If the issue is determined to be a user error and not a bug, remove the `bug` label (and the `regression` label, if applicable) and replace it with the `support` label.
-If more information is needed from the author to diagnose the issue, then apply the `more-information-needed` label.
+If more information is needed from the author to diagnose the issue, then apply the `more information needed` label.
+
+##### Staleness
+
+Only issues and PRs that have the [`more information needed` label](https://github.com/argoproj/argo-workflows/labels/more%20information%20needed) will be considered for staleness.
+
+If the author does not respond timely to a request for more information, the issue or PR will be automatically marked with the `stale` label and a bot message.
+Subsequently, if there is still no response, it will be automatically closed as "not planned".
+
+See the [Stale Action configuration](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/stale.yaml) for more details.
 
 ## Sustainability Effort
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/11836#issuecomment-1766672575, a [Slack thread](https://cloud-native.slack.com/archives/C0510EUH90V/p1702069651909869) last month, and a [previous Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit)

### Motivation

<!-- TODO: Say why you made your changes. -->

- as previously discussed, use the stale action in a much more limited fashion than the previous (deprecated) stale bot
  - only run on issues and PRs labeled with `more information needed`

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- configured similarly (but not entirely the same) to the previous Stale bot that was removed in #11836
- add a small section on staleness to the Contributing docs under issue triage

### Verification

<!-- TODO: Say how you tested your changes. -->

- n/a on the action as it runs in CI on a schedule with a very specific config.
  - this action is already used [in the `argo-ui` repo](https://github.com/argoproj/argo-ui/blob/c65a9520366b0c0cf0ac585618d029e60041a94d/.github/workflows/stale.yml) and it does work as configured
- `make docs-spellcheck` passes on the new contributing docs section

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
