### PR TITLE
fix(resources): improve ressource accounting. Fixes #12468

### DIFF
--- a/util/resource/duration_test.go
+++ b/util/resource/duration_test.go
@@ -44,7 +44,7 @@ func TestDurationForPod(t *testing.T) {
 			corev1.ResourceCPU:    wfv1.NewResourceDuration(2 * time.Minute),
 			corev1.ResourceMemory: wfv1.NewResourceDuration(1 * time.Minute),
 		}},
-		{"ContainerWithCPURequest", &corev1.Pod{
+		{"ContainerWithGPULimit", &corev1.Pod{
 			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("2000m"),

--- a/util/resource/summary.go
+++ b/util/resource/summary.go
@@ -28,9 +28,14 @@ func (ss Summaries) Duration() wfv1.ResourcesDuration {
 	// Add container states.
 	d := wfv1.ResourcesDuration{}
 	for _, s := range ss {
+		// age is converted to seconds, otherwise the multiplication below is very likely to overflow
 		age := int64(s.age().Seconds())
 		for n, q := range s.ResourceList {
-			d = d.Add(wfv1.ResourcesDuration{n: wfv1.NewResourceDuration(time.Duration(q.Value() * age / wfv1.ResourceQuantityDenominator(n).Value() * int64(time.Second)))})
+			d = d.Add(wfv1.ResourcesDuration{
+				n: wfv1.NewResourceDuration(time.Duration(
+					q.MilliValue()*age/wfv1.ResourceQuantityDenominator(n).MilliValue(),
+				) * time.Second),
+			})
 		}
 	}
 	return d


### PR DESCRIPTION
Fixes #12468

### Motivation

Fix cpu ressources consumption estimation.

### Modifications

Change the use of the `.Values()` function (which rounds ressources up to an integer) to `.MilliValues()` which is more accurate for CPU resources, which can be fractional.
The `MilliValues()` documentation mentions that this function may overflow, but the return value is stored in an int64, so the overflow will happen if a container requests more than 9*10^(15) of a ressource. I assume this should be fine for a while.

### Verification

Tested by submitting the workflow attached to the issue this PR fixes. The result is now what is expected:
```
      resourcesDuration:
        cpu: 63
        memory: 101
```
