### PR TITLE
docs: update backported commits to https://argo-workflows.readthedocs.io/en/release-3.5

### DIFF
--- a/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
+++ b/ui/src/app/workflows/components/workflow-drawer/workflow-drawer.tsx
@@ -58,7 +58,7 @@ export function WorkflowDrawer(props: WorkflowDrawerProps) {
                                     left: (
                                         <div className='workflow-drawer__title'>
                                             RESOURCES DURATION&nbsp;
-                                            <a href='https://argoproj.github.io/argo-workflows/resource-duration/' onClick={e => e.stopPropagation()} target='_blank'>
+                                            <a href='https://argo-workflows.readthedocs.io/en/release-3.5/resource-duration/' onClick={e => e.stopPropagation()} target='_blank'>
                                                 <i className='fas fa-info-circle' />
                                             </a>
                                         </div>

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -815,7 +815,7 @@ func (we *WorkflowExecutor) InitializeOutput(ctx context.Context) {
 	}, errorsutil.IsTransientErr, func() error {
 		err := we.upsertTaskResult(ctx, wfv1.NodeResult{})
 		if apierr.IsForbidden(err) {
-			log.WithError(err).Warn("failed to patch task set, falling back to legacy/insecure pod patch, see https://argoproj.github.io/argo-workflows/workflow-rbac/")
+			log.WithError(err).Warn("failed to patch task set, falling back to legacy/insecure pod patch, see https://argo-workflows.readthedocs.io/en/release-3.5/workflow-rbac/")
 			// Only added as a backup in case LabelKeyReportOutputsCompleted could not be set
 			err = we.AddAnnotation(ctx, common.AnnotationKeyReportOutputsCompleted, "false")
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

A couple extra links in tandem with #12475; these needed converting to the new docs site as they were cherry-picked into this branch _after_ that PR without additional changes to account for the new URL
  - Note that this PR is to the [`release-3.5`](https://github.com/argoproj/argo-workflows/tree/release-3.5) branch

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Includes updated links for #12402 and #12149

### Verification

<!-- TODO: Say how you tested your changes. -->

Checked that the new URLs are correct

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
