### PR TITLE
refactor(ui): use `import type` syntax where possible

### DIFF
--- a/ui/src/app/shared/components/suspense-monaco-editor.tsx
+++ b/ui/src/app/shared/components/suspense-monaco-editor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {MonacoEditorProps} from 'react-monaco-editor';
-import MonacoEditor from 'react-monaco-editor';
+import type {MonacoEditorProps} from 'react-monaco-editor';
+import type MonacoEditor from 'react-monaco-editor';
 
 import {Loading} from './loading';
 

--- a/ui/src/app/shared/workflow-operations-map.tsx
+++ b/ui/src/app/shared/workflow-operations-map.tsx
@@ -1,4 +1,4 @@
-import {NodePhase, Workflow} from '../../models';
+import type {NodePhase, Workflow} from '../../models';
 import {services} from './services';
 import {WorkflowDeleteResponse} from './services/responses';
 import {Utils} from './utils';

--- a/ui/src/app/widgets/workflow-status-badge.tsx
+++ b/ui/src/app/widgets/workflow-status-badge.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 
-import {NodePhase} from '../../models';
+import type {NodePhase} from '../../models';
 import {uiUrl} from '../shared/base';
 import {historyUrl} from '../shared/history';
 import {RetryWatch} from '../shared/retry-watch';

--- a/ui/src/models/index.ts
+++ b/ui/src/models/index.ts
@@ -6,6 +6,6 @@ export * from './workflow-templates';
 export * from './cron-workflows';
 export * from './cluster-workflow-templates';
 export * from './submit-opts';
-export {EventSource} from './event-source';
-export {Sensor, SensorList} from './sensor';
+export type {EventSource} from './event-source';
+export type {Sensor, SensorList} from './sensor';
 export {models as kubernetes} from 'argo-ui';


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Unblocks #12516
Follow-up to #12163 & #12290, which unblocked this
Follow-up to https://github.com/argoproj/argo-workflows/pull/12150#discussion_r1382510455 
Same changes can be made for #12158 and the `argo-ui` warnings introduced in #12061

### Motivation

<!-- TODO: Say why you made your changes. -->

- now that we've migrated from archived `tslint` to `eslint` and updated `prettier` from v1 to v3, we can _finally_ use this [newer TS syntax from TS 3.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)
  - this fixes a few warnings in the build as well as makes things more explicit and efficient
    - **note**: there are more warnings to fix around `export type`, but those are all from `argo-ui`'s source code and so can't be fixed from within this repo

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use `import type` syntax in a few files where it is only types that are imported

### Verification

<!-- TODO: Say how you tested your changes. -->

1. `yarn build` works fine, with a few less warnings now
2. `make start UI=true` and tested UI, esp. `monaco-editor`, all still works fine

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
