### PR TITLE
build(docs): don't install NPM global deps if they're already installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,7 +678,7 @@ docs/cli/argo.md: $(CLI_PKGS) go.sum server/static/files.go hack/cli/main.go
 /usr/local/bin/mdspell:
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	npm i -g markdown-spellcheck@1.3.1
+	npm list -g markdown-spellcheck@1.3.1 > /dev/null || npm i -g markdown-spellcheck@1.3.1
 endif
 
 .PHONY: docs-spellcheck
@@ -689,7 +689,7 @@ docs-spellcheck: /usr/local/bin/mdspell
 /usr/local/bin/markdown-link-check:
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	npm i -g markdown-link-check@3.11.1
+	npm list -g markdown-link-check@3.11.1 > /dev/null || npm i -g markdown-link-check@3.11.1
 endif
 
 .PHONY: docs-linkcheck
@@ -700,7 +700,7 @@ docs-linkcheck: /usr/local/bin/markdown-link-check
 /usr/local/bin/markdownlint:
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	npm i -g markdownlint-cli@0.33.0
+	npm list -g markdownlint-cli@0.33.0 > /dev/null || npm i -g markdownlint-cli@0.33.0
 endif
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Only install NPM global deps if they're not already installed
- previously the `make` commands would unconditionally install these global deps, which was unnecessary & inefficient the vast majority of the time
  - it would reinstall these every single time I ran these commands

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use `npm list -g` to check if they're installed first
  - this exits with error code 1 if it doesn't exist

- note: that was the purpose of the `/usr/local/bin/` part in the `Makefile`, but this is not universally installed in the same place
  - can run `npm prefix -g` and concat `/bin/` to that to get the path to your global installs
    - on my Mac with versioned node (using [`rtx`](https://github.com/jdx/rtx)), the path is: `/Users/<my-user>/.local/share/rtx/installs/node/20.6.0/bin/`
    - in the `devcontainer` with versioned node (uses `nvm`), the path is: `/usr/local/share/nvm/versions/node/v20.5.1/bin`

### Verification

<!-- TODO: Say how you tested your changes. -->

1. Manually ran the commands with the dependency, confirmed it skipped the install
1. Manually ran the commands without the dependency, confirmed it performed the install

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
