### PR TITLE
fix: disable concurrency when downloading azure files

### DIFF
--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -170,8 +170,8 @@ func DownloadFile(containerClient *container.Client, blobName, path string) erro
 		}
 	}()
 
-	o := blob.DownloadFileOptions{Concurrency: 1} // workaround https://github.com/Azure/azure-sdk-for-go/issues/22156
-	_, err = blobClient.DownloadFile(context.TODO(), outFile, &o)
+	opts := blob.DownloadFileOptions{Concurrency: 1} // workaround for https://github.com/Azure/azure-sdk-for-go/issues/22156
+	_, err = blobClient.DownloadFile(context.TODO(), outFile, &opts)
 	return err
 }
 

--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
@@ -168,7 +170,8 @@ func DownloadFile(containerClient *container.Client, blobName, path string) erro
 		}
 	}()
 
-	_, err = blobClient.DownloadFile(context.TODO(), outFile, nil)
+	o := blob.DownloadFileOptions{Concurrency: 1} // workaround https://github.com/Azure/azure-sdk-for-go/issues/22156
+	_, err = blobClient.DownloadFile(context.TODO(), outFile, &o)
 	return err
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

workaround for https://github.com/Azure/azure-sdk-for-go/issues/22156

### Motivation

Recently [bumped](https://github.com/argoproj/argo-workflows/pull/12459) the azure sdk for go for blob storage. But it has an [issue](https://github.com/Azure/azure-sdk-for-go/issues/22156) with concurrent downloads.

### Modifications

Set concurrency when downloading artifacts/files/blobs from azure blob storage to 1 (instead of 5)

### Verification

Tested in production with a patch on 3.5.4. We [suffered](https://github.com/Azure/azure-sdk-for-go/issues/22156#issuecomment-1883653523) from this issue before (hanging workflow steps) and now not anymore.

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
