### PR TITLE
fix: Mark resource && data template report-outputs-completed true

### DIFF
--- a/cmd/argoexec/commands/data.go
+++ b/cmd/argoexec/commands/data.go
@@ -24,12 +24,12 @@ func NewDataCommand() *cobra.Command {
 
 func execData(ctx context.Context) error {
 	wfExecutor := initExecutor()
-	defer wfExecutor.HandleError(ctx)
 
 	// Don't allow cancellation to impact capture of results, parameters, artifacts, or defers.
 	bgCtx := context.Background()
 	// Create a new empty (placeholder) task result with LabelKeyReportOutputsCompleted set to false.
 	wfExecutor.InitializeOutput(bgCtx)
+	defer wfExecutor.HandleError(bgCtx)
 	defer wfExecutor.FinalizeOutput(bgCtx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 
 	err := wfExecutor.Data(ctx)

--- a/cmd/argoexec/commands/data.go
+++ b/cmd/argoexec/commands/data.go
@@ -12,7 +12,7 @@ func NewDataCommand() *cobra.Command {
 		Use:   "data",
 		Short: "Process data",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx := cmd.Context()
+			ctx := context.Background()
 			err := execData(ctx)
 			if err != nil {
 				log.Fatalf("%+v", err)

--- a/cmd/argoexec/commands/data.go
+++ b/cmd/argoexec/commands/data.go
@@ -12,7 +12,7 @@ func NewDataCommand() *cobra.Command {
 		Use:   "data",
 		Short: "Process data",
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			err := execData(ctx)
 			if err != nil {
 				log.Fatalf("%+v", err)
@@ -26,9 +26,11 @@ func execData(ctx context.Context) error {
 	wfExecutor := initExecutor()
 	defer wfExecutor.HandleError(ctx)
 
+	// Don't allow cancellation to impact capture of results, parameters, artifacts, or defers.
+	bgCtx := context.Background()
 	// Create a new empty (placeholder) task result with LabelKeyReportOutputsCompleted set to false.
-	wfExecutor.InitializeOutput(ctx)
-	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
+	wfExecutor.InitializeOutput(bgCtx)
+	defer wfExecutor.FinalizeOutput(bgCtx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 
 	err := wfExecutor.Data(ctx)
 	if err != nil {

--- a/cmd/argoexec/commands/data.go
+++ b/cmd/argoexec/commands/data.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -10,11 +11,29 @@ func NewDataCommand() *cobra.Command {
 	command := cobra.Command{
 		Use:   "data",
 		Short: "Process data",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			wfExecutor := initExecutor()
-			return wfExecutor.Data(ctx)
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+			err := execData(ctx)
+			if err != nil {
+				log.Fatalf("%+v", err)
+			}
 		},
 	}
 	return &command
+}
+
+func execData(ctx context.Context) error {
+	wfExecutor := initExecutor()
+	defer wfExecutor.HandleError(ctx)
+
+	// Create a new empty (placeholder) task result with LabelKeyReportOutputsCompleted set to false.
+	wfExecutor.InitializeOutput(ctx)
+	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
+
+	err := wfExecutor.Data(ctx)
+	if err != nil {
+		wfExecutor.AddError(err)
+		return err
+	}
+	return nil
 }

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -35,7 +35,7 @@ func execResource(ctx context.Context, action string) error {
 	wfExecutor := initExecutor()
 	defer wfExecutor.HandleError(ctx)
 
-	wfExecutor.InitializeOutput(ctx)
+	//wfExecutor.InitializeOutput(ctx)
 	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 	err := wfExecutor.StageFiles()
 	if err != nil {

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -21,7 +21,7 @@ func NewResourceCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx := cmd.Context()
+			ctx := context.Background()
 			err := execResource(ctx, args[0])
 			if err != nil {
 				log.Fatalf("%+v", err)
@@ -34,6 +34,8 @@ func NewResourceCommand() *cobra.Command {
 func execResource(ctx context.Context, action string) error {
 	wfExecutor := initExecutor()
 	defer wfExecutor.HandleError(ctx)
+
+	wfExecutor.InitializeOutput(ctx)
 	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 	err := wfExecutor.StageFiles()
 	if err != nil {

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -34,15 +34,12 @@ func NewResourceCommand() *cobra.Command {
 func execResource(ctx context.Context, action string) error {
 	wfExecutor := initExecutor()
 	defer wfExecutor.HandleError(ctx)
+	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 	err := wfExecutor.StageFiles()
 	if err != nil {
 		wfExecutor.AddError(err)
 		return err
 	}
-
-	// Create a new empty (placeholder) task result with LabelKeyReportOutputsCompleted set to false.
-	wfExecutor.InitializeOutput(ctx)
-	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 
 	isDelete := action == "delete"
 	if isDelete && (wfExecutor.Template.Resource.SuccessCondition != "" || wfExecutor.Template.Resource.FailureCondition != "" || len(wfExecutor.Template.Outputs.Parameters) > 0) {

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -33,12 +33,12 @@ func NewResourceCommand() *cobra.Command {
 
 func execResource(ctx context.Context, action string) error {
 	wfExecutor := initExecutor()
-	defer wfExecutor.HandleError(ctx)
 
 	// Don't allow cancellation to impact capture of results, parameters, artifacts, or defers.
 	bgCtx := context.Background()
 
 	wfExecutor.InitializeOutput(bgCtx)
+	defer wfExecutor.HandleError(bgCtx)
 	defer wfExecutor.FinalizeOutput(bgCtx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 	err := wfExecutor.StageFiles()
 	if err != nil {

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -39,6 +39,11 @@ func execResource(ctx context.Context, action string) error {
 		wfExecutor.AddError(err)
 		return err
 	}
+
+	// Create a new empty (placeholder) task result with LabelKeyReportOutputsCompleted set to false.
+	wfExecutor.InitializeOutput(ctx)
+	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
+
 	isDelete := action == "delete"
 	if isDelete && (wfExecutor.Template.Resource.SuccessCondition != "" || wfExecutor.Template.Resource.FailureCondition != "" || len(wfExecutor.Template.Outputs.Parameters) > 0) {
 		err = fmt.Errorf("successCondition, failureCondition and outputs are not supported for delete action")

--- a/cmd/argoexec/commands/resource.go
+++ b/cmd/argoexec/commands/resource.go
@@ -21,7 +21,7 @@ func NewResourceCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			ctx := context.Background()
+			ctx := cmd.Context()
 			err := execResource(ctx, args[0])
 			if err != nil {
 				log.Fatalf("%+v", err)
@@ -35,8 +35,11 @@ func execResource(ctx context.Context, action string) error {
 	wfExecutor := initExecutor()
 	defer wfExecutor.HandleError(ctx)
 
-	//wfExecutor.InitializeOutput(ctx)
-	defer wfExecutor.FinalizeOutput(ctx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
+	// Don't allow cancellation to impact capture of results, parameters, artifacts, or defers.
+	bgCtx := context.Background()
+
+	wfExecutor.InitializeOutput(bgCtx)
+	defer wfExecutor.FinalizeOutput(bgCtx) //Ensures the LabelKeyReportOutputsCompleted is set to true.
 	err := wfExecutor.StageFiles()
 	if err != nil {
 		wfExecutor.AddError(err)

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -908,6 +908,9 @@ func (s *FunctionalSuite) TestDataTransformation() {
 			}
 			assert.NotNil(t, status.Nodes.FindByDisplayName("process-artifact(0:foo/script.py)"))
 			assert.NotNil(t, status.Nodes.FindByDisplayName("process-artifact(1:script.py)"))
+			for _, value := range status.TaskResultsCompletionStatus {
+				assert.True(t, value)
+			}
 		})
 }
 

--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -159,6 +159,9 @@ func (s *ResourceTemplateSuite) TestResourceTemplateWithOutputs() {
 					assert.Equal(t, "my-pod", parameters[1].Value.String(), "metadata.name is capture for jq")
 				}
 			}
+			for _, value := range status.TaskResultsCompletionStatus {
+				assert.True(t, value)
+			}
 		})
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
I run two example(use latest image):
 https://github.com/argoproj/argo-workflows/blob/main/test/e2e/testdata/resource-templates/outputs.yaml 
https://github.com/argoproj/argo-workflows/blob/main/test/e2e/testdata/data-transformation.yaml
I find the workflow succeed but the workflowtaskresult have two is not marked true.
The two is resource && data template. So I want to Mark resource && data report-outputs-completed true.

```
tianshuangkun@B-QGHAMD6M-2124 myworkflow % argo list
NAME                        STATUS      AGE   DURATION   PRIORITY
data-transformation-ff287   Succeeded   2h    2h         0
outputs-fww7h               Succeeded   6h    6h         0
tianshuangkun@B-QGHAMD6M-2124 myworkflow % kubectl get workflowtaskresults -o yaml | grep workflows.argoproj.io/report-outputs-completed
      workflows.argoproj.io/report-outputs-completed: "true"
      workflows.argoproj.io/report-outputs-completed: "true"
      workflows.argoproj.io/report-outputs-completed: "true"
      workflows.argoproj.io/report-outputs-completed: "true"
      workflows.argoproj.io/report-outputs-completed: "true"
      workflows.argoproj.io/report-outputs-completed: "false"
      workflows.argoproj.io/report-outputs-completed: "true"
      workflows.argoproj.io/report-outputs-completed: "false"
tianshuangkun@B-QGHAMD6M-2124 myworkflow %
```
<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
