### PR TITLE
feat: Allow users to selectively retry specific failed nodes . Fixes …

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -961,7 +961,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 				continue
 			} else {
 				// If restartSuccessful flag is unset and nodeFieldSelector is set, retry the failed node specified by nodeFieldSelector
-				if !restartSuccessful {
+				if !restartSuccessful && len(nodeFieldSelector) > 0 {
 					if _, present := nodeIDsToReset[node.ID]; !present {
 						newWF.Status.Nodes.Set(node.ID, node)
 						// Skip the current iteration and move to the next node


### PR DESCRIPTION
Fixes #12543 

### Motivation

Allow users to selectively retry specific failed nodes instead of retrying all failed nodes at once.


### Modifications

Removed the restriction that required the simultaneous use of `--node-field-selector` and `--restart-successful`. Now, using `--node-field-selector` alone allows for individual retries of specific failed nodes, instead of retrying all failures.

### Verification
![image](https://github.com/argoproj/argo-workflows/assets/8521943/860f70b8-cd0d-482d-8bd7-5f4f38f89998)

_--node-field-selector can be used independently._
`./dist/argo retry fail-24ptx --node-field-selector name=fail-24ptx.BB -v `

_Regressively used in combination._
`./dist/argo retry fail-mz9c4 --restart-successful --node-field-selector name=fail-mz9c4.A`


