### PR TITLE
fix: Global Artifact Passing. Fixes #12554

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1051,12 +1051,20 @@ func (s *ArgoServerSuite) TestArtifactServerArchivedStoppedWorkflow() {
 			nodeID = status.Nodes.FindByDisplayName("create-artifact").ID
 		})
 
-	s.Run("GetArtifactByNodeID", func() {
-		s.e().GET("/artifact-files/argo/archived-workflows/{uid}/{nodeID}/outputs/artifact-creator", uid, nodeID).
+	s.Run("GetLocalArtifactByNodeID", func() {
+		s.e().GET("/artifact-files/argo/archived-workflows/{uid}/{nodeID}/outputs/local-artifact", uid, nodeID).
 			Expect().
 			Status(200).
 			Body().
 			Contains("testing")
+	})
+
+	s.Run("GetGlobalArtifactByNodeID", func() {
+		s.e().GET("/artifact-files/argo/archived-workflows/{uid}/{nodeID}/outputs/global-artifact", uid, nodeID).
+			Expect().
+			Status(200).
+			Body().
+			Contains("testing global")
 	})
 }
 

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -238,7 +238,7 @@ func (s *ArtifactsSuite) TestDeleteWorkflow() {
 
 	when.WaitForWorkflowDeletion()
 
-	when = when.RemoveFinalizers(false)
+	when.RemoveFinalizers(false)
 }
 
 func (s *ArtifactsSuite) TestArtifactGC() {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -4,9 +4,11 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -58,6 +60,68 @@ func (s *ArtifactsSuite) TestArtifactPassing() {
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded)
+}
+
+type expectedArtifact struct {
+	key                   string
+	bucketName            string
+	value 	              string
+}
+
+func (s *ArtifactsSuite) TestGlobalArtifactPassing() {
+	for _, tt := range []struct {
+		workflowFile string
+		expectedArtifact expectedArtifact
+	}{
+		{
+			workflowFile: "@testdata/global-artifact-passing.yaml",
+			expectedArtifact: expectedArtifact{
+				key: "globalArtifact",
+				bucketName: "my-bucket-3",
+				value: "01",
+			},
+		},
+		{
+			workflowFile: "@testdata/complex-global-artifact-passing.yaml",
+			expectedArtifact: expectedArtifact{
+				key: "finalTestUpdate",
+				bucketName: "my-bucket-3",
+				value: "Updated testUpdate",
+			},
+		},
+	} {
+		then := s.Given().
+		Workflow(tt.workflowFile).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded, time.Minute*2).
+		Then().
+		ExpectWorkflow(func(t *testing.T, objectMeta *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			// Check the global artifact value and see if it equals the expected value.
+			c, err := minio.New("localhost:9000", &minio.Options{
+				Creds: credentials.NewStaticV4("admin", "password", ""),
+			})
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			object, err := c.GetObject(context.Background(), tt.expectedArtifact.bucketName, tt.expectedArtifact.key, minio.GetObjectOptions{})
+			if err != nil {
+				t.Error(err)
+			}
+
+			buf := new(bytes.Buffer)
+			buf.ReadFrom(object)
+			newStr := buf.String()
+
+			assert.Equal(t, tt.expectedArtifact.value, newStr)
+		})
+
+		then.
+			When().
+			RemoveFinalizers(false)
+	}
 }
 
 type artifactState struct {
@@ -155,6 +219,26 @@ func (s *ArtifactsSuite) TestStoppedWorkflow() {
 		// Remove the finalizers so the workflow gets deleted in case the test failed.
 		when.RemoveFinalizers(false)
 	}
+}
+
+func (s *ArtifactsSuite) TestDeleteWorkflow() {
+	when := s.Given().
+		Workflow("@testdata/artifactgc/artgc-dag-wf-self-delete.yaml").
+		When().
+		SubmitWorkflow()
+
+	then := when.
+		WaitForWorkflow(fixtures.ToBeCompleted).
+		Then().
+		ExpectWorkflow(func(t *testing.T, objectMeta *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Contains(t, objectMeta.Finalizers, common.FinalizerArtifactGC)
+		})
+
+	when = then.When()
+
+	when.WaitForWorkflowDeletion()
+
+	when = when.RemoveFinalizers(false)
 }
 
 func (s *ArtifactsSuite) TestArtifactGC() {

--- a/test/e2e/testdata/artifact-workflow-stopped.yaml
+++ b/test/e2e/testdata/artifact-workflow-stopped.yaml
@@ -45,7 +45,7 @@ spec:
             while [ $x -le 60 ]
             do
               sleep 1
-              if [ -f "/mnt/vol/test.txt" ]; then
+              if [ -f "/mnt/vol/test.txt" ] && [ -f "/mnt/vol/globaltest.txt" ]; then
                 echo "Artifact found in shared volume"
                 break
               fi
@@ -73,6 +73,7 @@ spec:
         args:
           - |
             echo 'testing' > /mnt/vol/test.txt
+            echo 'testing global' > /mnt/vol/globaltest.txt
             echo "Artifact saved to /mnt/vol/test.txt"
             echo "Pretending to continue to do work."
             ls /mnt
@@ -82,10 +83,26 @@ spec:
             done
       outputs:
         artifacts:
-          - name: artifact-creator
+          - name: local-artifact
             path: /mnt/vol/test.txt
             s3:
-              key: artifact-creator
+              key: local-artifact
+              bucket: my-bucket-3
+              endpoint: minio:9000
+              insecure: true
+              accessKeySecret:
+                name: my-minio-cred
+                key: accesskey
+              secretKeySecret:
+                name: my-minio-cred
+                key: secretkey
+            archive:
+              none: {}
+          - name: global-artifact
+            globalName: global-artifact-global-name
+            path: /mnt/vol/globaltest.txt
+            s3:
+              key: global-artifact
               bucket: my-bucket-3
               endpoint: minio:9000
               insecure: true

--- a/test/e2e/testdata/artifactgc/artgc-dag-wf-self-delete.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-dag-wf-self-delete.yaml
@@ -1,0 +1,99 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: artgc-dag-wf-self-delete-
+spec:
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+      workflows.argoproj.io/workflow: "artgc-dag-wf-self-delete"
+  podGC:
+    strategy: OnPodCompletion
+  artifactGC:
+    serviceAccountName: default
+    strategy: OnWorkflowDeletion
+  entrypoint: artgc-dag-wf-self-delete-main
+  serviceAccountName: argo
+  executor:
+    serviceAccountName: default
+  volumeClaimTemplates:
+    - metadata:
+        name: artifacts
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
+  templates:
+    - name: artgc-dag-wf-self-delete-main
+      dag:
+        tasks:
+          - name: create-artifact
+            template: artgc-dag-artifact-creator
+          - name: delay-delete-workflow
+            template: artgc-dag-delay-delete
+            dependencies: [create-artifact]
+          - name: delete-workflow
+            template: artgc-dag-workflow-deleter
+            dependencies: [delay-delete-workflow]
+    - name: artgc-dag-delay-delete
+      container:
+        image: alpine:latest
+        volumeMounts:
+          - name: artifacts
+            mountPath: /mnt/vol
+        command: [sh, -c]
+        args:
+          - |
+            echo "Delaying workflow delete"
+            ls /mnt
+            x=0
+            while [ $x -le 60 ]
+            do
+              sleep 1
+              if [ -f "/mnt/vol/test.txt" ]; then
+                echo "Artifacts found in shared volume"
+                break
+              fi
+              x=$(( $x + 1 ))
+            done
+    - name: artgc-dag-workflow-deleter
+      container:
+        image: argoproj/argocli:latest
+        args: 
+          - delete
+          - -l
+          - workflows.argoproj.io/workflow=artgc-dag-wf-self-delete
+          - --namespace=argo
+          - --loglevel=debug
+    - name: artgc-dag-artifact-creator
+      metadata:
+        labels:
+          template: "artgc-dag-artifact-creator"
+      container:
+        image: alpine:latest
+        volumeMounts:
+          - name: artifacts
+            mountPath: /mnt/vol
+        command: [sh, -c]
+        args:
+          - |
+            echo 'testing' > /mnt/vol/test.txt
+            echo "Artifact saved to /mnt/vol/test.txt"
+      outputs:
+        artifacts:
+          - name: artifact
+            path: /mnt/vol/test.txt
+            s3:
+              key: artifact
+              bucket: my-bucket-3
+              endpoint: minio:9000
+              insecure: true
+              accessKeySecret:
+                name: my-minio-cred
+                key: accesskey
+              secretKeySecret:
+                name: my-minio-cred
+                key: secretkey
+            artifactGC:
+              strategy: OnWorkflowDeletion

--- a/test/e2e/testdata/complex-global-artifact-passing.yaml
+++ b/test/e2e/testdata/complex-global-artifact-passing.yaml
@@ -1,0 +1,205 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: global-artifact-passing-
+spec:
+  entrypoint: test-root
+  templates:
+  - inputs: {}
+    metadata: {}
+    name: test-root
+    outputs: {}
+    steps:
+    - - arguments: {}
+        name: create-global-artifacts
+        template: create-global-artifacts
+    - - arguments:
+          artifacts:
+          - from: '{{workflow.outputs.artifacts.testInput}}'
+            name: testInput
+          - from: '{{workflow.outputs.artifacts.testUpdate}}'
+            name: testUpdate
+        name: nested-workflow-entrypoint
+        template: main
+    - - arguments:
+          artifacts:
+          - from: '{{workflow.outputs.artifacts.testUpload}}'
+            name: testUpload
+        name: upload-testupload-step
+        template: upload-testupload
+    - - arguments:
+          artifacts:
+          - from: '{{workflow.outputs.artifacts.testUpdate}}'
+            name: testUpdate
+        name: upload-testupdate-step
+        template: upload-testupdate
+
+  - inputs: {}
+    metadata: {}
+    name: main
+    outputs: {}
+    steps:
+    - - arguments:
+          artifacts:
+          - from: '{{workflow.outputs.artifacts.testInput}}'
+            name: input
+        name: cp
+        template: cp
+    - - arguments:
+          artifacts:
+          - from: '{{workflow.outputs.artifacts.testUpdate}}'
+            name: input-parameters
+        name: generate-testupdate-update
+        template: generate-testupdate-update
+    - - arguments:
+          artifacts:
+          - from: '{{steps.cp.outputs.artifacts.upload}}'
+            name: testUpload
+        name: output-testupload
+        template: output-testupload
+    - - arguments:
+          artifacts:
+          - from: '{{steps.generate-testupdate-update.outputs.artifacts.updated-testupdate}}'
+            name: testUpdate
+        name: output-testupdate
+        template: output-testupdate
+
+
+
+  - container:
+      image: alpine:3.7
+      command: [sh, -c]
+      args: ["sleep 1; echo -n 'test input' > /testInput.txt; echo -n 'test update' > /testUpdate.txt"]
+    name: create-global-artifacts
+    outputs:
+      artifacts:
+      - globalName: testInput
+        name: testInput
+        path: /testInput.txt
+        archive:
+          none: {}
+      - globalName: testUpdate
+        name: testUpdate
+        path: /testUpdate.txt
+        archive:
+          none: {}
+
+
+
+  - container:
+      command: [sh, -c]
+      args: ["sleep 1; cp /input.txt /upload.txt"]
+      image: alpine:3.7
+      name: ""
+      resources: {}
+    inputs:
+      artifacts:
+      - name: input
+        path: /input.txt
+    metadata: {}
+    name: cp
+    outputs:
+      artifacts:
+      - name: upload
+        path: /upload.txt
+
+  - container:
+      command: [sh, -c]
+      args: ["sleep 1; echo -n 'Updated testUpdate' > /updated-testUpdate.txt"]
+      image: alpine:3.18.4
+    metadata: {}
+    name: generate-testupdate-update
+    outputs:
+      artifacts:
+      - name: updated-testupdate
+        path: /updated-testUpdate.txt
+        archive:
+          none: {}
+
+  - container:
+      command: [sh, -c]
+      args: ["sleep 1"]
+      image: alpine:3.18.4
+      name: ""
+      resources: {}
+    inputs:
+      artifacts:
+      - name: testUpload
+        path: /testUpload.txt
+    metadata: {}
+    name: output-testupload
+    outputs:
+      artifacts:
+      - globalName: testUpload
+        name: testUpload
+        path: /testUpload.txt
+
+  - container:
+      image: alpine:3.18.4
+      command: [sh, -c]
+      args: ["sleep 1"]
+      name: ""
+      resources: {}
+    inputs:
+      artifacts:
+      - name: testUpdate
+        path: /testUpdate.txt
+    metadata: {}
+    name: output-testupdate
+    outputs:
+      artifacts:
+      - globalName: testUpdate
+        name: testUpdate
+        path: /testUpdate.txt
+
+
+
+  - container:
+      command: [sh, -c]
+      args: ["sleep 1; cat /upload/testUpload; cat /upload/testUpload.txt > /upload/testUpload.txt"]
+      image: alpine:3.18.4
+      name: ""
+      resources: {}
+    inputs:
+      artifacts:
+      - name: testUpload
+        path: /upload/testUpload.txt
+    metadata: {}
+    name: upload-testupload
+    outputs:
+      artifacts:
+      - globalName: uploadresult
+        name: uploadresult
+        path: /upload/testUpload.txt
+
+  - container:
+      command: [sh, -c]
+      args: ["sleep 1; cat /upload/testUpdate.txt"]
+      image: alpine:3.18.4
+      name: ""
+      resources: {}
+    inputs:
+      artifacts:
+      - name: testUpdate
+        path: /upload/testUpdate.txt
+    metadata: {}
+    name: upload-testupdate
+    outputs:
+      artifacts:
+        - name: finalTestUpdate
+          path: /upload/testUpdate.txt
+          archive:
+            none: {}
+          s3:
+            key: finalTestUpdate
+            bucket: my-bucket-3
+            endpoint: minio:9000
+            insecure: true
+            accessKeySecret:
+              name: my-minio-cred
+              key: accesskey
+            secretKeySecret:
+              name: my-minio-cred
+              key: secretkey
+          artifactGC:
+            strategy: OnWorkflowDeletion

--- a/test/e2e/testdata/global-artifact-passing.yaml
+++ b/test/e2e/testdata/global-artifact-passing.yaml
@@ -1,0 +1,92 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: global-artifact-passing-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      outputs: {}
+      steps:
+        - - name: create-global-artifact
+            template: create-global-artifact
+        - - name: add-0
+            template: add-to-global-artifact
+            arguments:
+              artifacts:
+                - name: input
+                  from: '{{workflow.outputs.artifacts.globalArtifact}}'
+              parameters:
+                - name: value
+                  value: '0'
+        - - name: add-1
+            template: add-to-global-artifact
+            arguments:
+              artifacts:
+                - name: input
+                  from: '{{workflow.outputs.artifacts.globalArtifact}}'
+              parameters:
+                - name: value
+                  value: '1'
+        - - name: save-artifact
+            template: save-artifact
+            arguments:
+              artifacts:
+                - name: input
+                  from: '{{workflow.outputs.artifacts.globalArtifact}}'
+    - name: create-global-artifact
+      container:
+        image: argoproj/argosay:v2
+        command: [sh, -c]
+        args: ["touch /tmp/artifact.txt"]
+      outputs:
+        artifacts:
+          - globalName: globalArtifact
+            name: artifact
+            path: /tmp/artifact.txt
+            archive:
+              none: {}
+    - name: add-to-global-artifact
+      inputs:
+        parameters:
+          - name: value
+        artifacts:
+          - name: input
+            path: /tmp/artifact.txt
+      outputs:
+        artifacts:
+          - globalName: globalArtifact
+            name: artifact
+            path: /tmp/artifact.txt
+            archive:
+              none: {}
+      container:
+        image: argoproj/argosay:v2
+        command: [sh, -c]
+        args: ["echo -n {{inputs.parameters.value}} >> /tmp/artifact.txt"]
+    - name: save-artifact
+      container:
+        image: argoproj/argosay:v2
+      inputs:
+        artifacts:
+          - name: input
+            path: /tmp/artifact.txt
+      outputs:
+        artifacts:
+          - name: globalArtifact
+            path: /tmp/artifact.txt
+            archive:
+              none: {}
+            s3:
+              key: globalArtifact
+              bucket: my-bucket-3
+              endpoint: minio:9000
+              insecure: true
+              accessKeySecret:
+                name: my-minio-cred
+                key: accesskey
+              secretKeySecret:
+                name: my-minio-cred
+                key: secretkey
+            artifactGC:
+              strategy: OnWorkflowDeletion

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -86,11 +86,6 @@ func (woc *wfOperationCtx) taskResultReconciliation() {
 			if old.Outputs != nil && newNode.Outputs.ExitCode == nil { // prevent overwriting of ExitCode
 				newNode.Outputs.ExitCode = old.Outputs.ExitCode
 			}
-			// Add outputs to global scope here to ensure that they are reflected in archive.
-			// We check that reconciliation is complete first since we don't want to break workflows that depend on global outputs.
-			if woc.checkReconciliationComplete() {
-				woc.addOutputsToGlobalScope(newNode.Outputs)
-			}
 		}
 		if result.Progress.IsValid() {
 			newNode.Progress = result.Progress

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -87,7 +87,10 @@ func (woc *wfOperationCtx) taskResultReconciliation() {
 				newNode.Outputs.ExitCode = old.Outputs.ExitCode
 			}
 			// Add outputs to global scope here to ensure that they are reflected in archive.
-			woc.addOutputsToGlobalScope(newNode.Outputs)
+			// We check that reconciliation is complete first since we don't want to break workflows that depend on global outputs.
+			if woc.checkReconciliationComplete() {
+				woc.addOutputsToGlobalScope(newNode.Outputs)
+			}
 		}
 		if result.Progress.IsValid() {
 			newNode.Progress = result.Progress


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12554

### Motivation

An issue with global artifact passing was introduced in https://github.com/argoproj/argo-workflows/pull/12402.

### Modifications

The fix is to protect the call to `addOutputsToGlobalScope()` in `taskResultReconciliation` with `checkReconciliationComplete()`. This allows reconciliation to promote outputs to the global scope, but only when the workflow is complete.

This ensures that artifacts make it into the archive, while also ensuring that the order of global artifact availability in the workflow isn't disrupted.

### Verification

Added multiple global artifact passing tests. Notably, `complex-global-artifact-passing.yaml` would frequently (but not always) fail before the fix made in this PR.
