### PR TITLE
docs(quick-start): consolidate UI & port-forward sections

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -27,25 +27,13 @@ kubectl create namespace argo
 kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v<<ARGO_WORKFLOWS_VERSION>>/quick-start-minimal.yaml
 ```
 
-### Port-forward the UI
-
-Open a port-forward so you can access the UI:
-
-```bash
-kubectl -n argo port-forward deployment/argo-server 2746:2746
-```
-
-This will serve the UI on <https://localhost:2746>. Due to the self-signed certificate, you will receive a TLS error which you will need to manually approve.
-
-> Pay close attention to the URI. It uses `https` and not `http`. Navigating to `http://localhost:2746` results in a server-side error that breaks the port forwarding.
-
 ## Install the Argo Workflows CLI
 
 You can more easily interact with Argo Workflows with the [Argo CLI](walk-through/argo-cli.md).
 
-## Submitting an example workflow
+## Submit an example workflow
 
-### Submit an example workflow (CLI)
+### Submit via the CLI
 
 ```bash
 argo submit -n argo --watch https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/hello-world.yaml
@@ -79,16 +67,16 @@ You can also observe the logs of the Workflow run by running the following:
 argo logs -n argo @latest
 ```
 
-### Submit an example workflow (GUI)
+### Submit via the UI
 
-* Open a port-forward so you can access the UI:
+1. Forward the Server's port to access the UI:
 
-```bash
-kubectl -n argo port-forward service/argo-server 2746:2746
-```
+    ```bash
+    kubectl -n argo port-forward service/argo-server 2746:2746
+    ```
 
-* Navigate your browser to <https://localhost:2746>.
-
-* Click `+ Submit New Workflow` and then `Edit using full workflow options`
-
-* You can find an example workflow already in the text field. Press `+ Create` to start the workflow.
+1. Navigate your browser to <https://localhost:2746>.
+    * **Note**: The URL uses `https` and not `http`. Navigating to `http` will result in a server-side error.
+    * Due to the self-signed certificate, you will receive a TLS error which you will need to manually approve.
+1. Click `+ Submit New Workflow` and then `Edit using full workflow options`
+1. You can find an example workflow already in the text field. Press `+ Create` to start the workflow.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- these sections list the same thing and are duplicative, so combine them / remove one
  - leave the submitting example one as that's specifically written to show the UI vs. the CLI
  - having the `port-forward` part when using the CLI doesn't make sense since you don't need it for the CLI

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- combine the `port-forward` section with the UI submit example section

- <details><summary>also fix some docs issues in this section</summary>

  - grammar issues:
    - "Submitting" -> "Submit" -- use present tense, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-present-tense)
      - also, the CLI and UI subsections had "Submit" but the top-level had "Submitting", which is inconsistent grammar
    - "port-forward" is a k8s verb, not a noun, so "Open a port-forward" is grammatically incorrect
      - replace with "Forward the Server's port"

  - markdown issues:
    - UI directions should be an ordered list, not unordered, since they are in-order
      - the `port-forward` command should be inside of the list, not outside
    - the `http` vs. `https` note isn't a quotation and so shouldn't be in a blockquote
      - if anything we could use a `!!! note`, but now that it's within a list, I think that would take up too much space isn't necessary

  - style issues:
    - "GUI" -> "UI", which is how it is referred to elsewhere, including 1 line below the "GUI" text
    - "an example workflow" -> "via the UI/CLI" -- the `h2` is already "Submit an example workflow" and should not be duplicated
    - be more direct in the `https` note, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
    - prefer 1 sentence per line of markdown, per [style guide](https://argo-workflows.readthedocs.io/en/release-3.5/doc-changes/)

  </details>

### Verification

<!-- TODO: Say how you tested your changes. -->

1. `mkdocs build` passes
1. Looks as expected
    - Before: 
![Screenshot 2024-01-21 at 10 02 42 PM](https://github.com/argoproj/argo-workflows/assets/4970083/9b49c2ee-d693-43fe-86cc-bfbbc0976c63)

    - After:
![Screenshot 2024-01-21 at 10 06 33 PM](https://github.com/argoproj/argo-workflows/assets/4970083/1946587a-770b-4f65-b27e-2a23f6de88df)


<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
