### PR TITLE
build: parallelize `Makefile` jobs by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ USE_NIX := false
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
+# parallelize jobs by number of CPUs available
+NPROCS = $(shell nproc || printf 1)
+MAKEFLAGS += -j$(NPROCS)
+
 BUILD_DATE            := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 # copied verbatim to release.yaml
 GIT_COMMIT            := $(shell git rev-parse HEAD || echo unknown)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- optimize some of the `make` jobs by parallelizing them by default when possible
  - this way you don't have to specify, for instance, `make start -j4 UI=true` etc

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- `-j` flags allows it to start more processes
  - e.g. `-j4` means it can start 4

- use `nprocs` to get number of available CPUs

### Verification

<!-- TODO: Say how you tested your changes. -->

Used the `Makefile` with this unstaged change for a few PRs, confirmed some things ran in parallel
- the logs are interleaved for parallel jobs by default, so fairly simple to tell

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
