### PR TITLE
test: Manual Retry (CLI) Failed Workflow

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -866,6 +866,20 @@ func (s *CLISuite) TestWorkflowRetry() {
 		})
 }
 
+func (s *CLISuite) TestWorkflowRetryFailedWorkflow() {
+	failFirstPassSecondWorkflowWhen := s.Given().
+		Workflow("@testdata/fail-first-pass-second.yaml").
+		When()
+
+	failFirstPassSecondWorkflowWhen.
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeFailed).
+		RunCli([]string{"retry", "-l", "workflows.argoproj.io/workflow=fail-first-pass-second-workflow", "--namespace=argo"}, func(t *testing.T, output string, err error) {
+			assert.NoError(t, err, output)
+		}).
+		WaitForWorkflow(fixtures.ToBeSucceeded)
+}
+
 func (s *CLISuite) TestWorkflowRetryNestedDag() {
 	s.Given().
 		Workflow("@testdata/retry-nested-dag-test.yaml").

--- a/test/e2e/testdata/fail-first-pass-second.yaml
+++ b/test/e2e/testdata/fail-first-pass-second.yaml
@@ -1,0 +1,37 @@
+metadata:
+  name: fail-first-pass-second-workflow
+  labels:
+    workflows.argoproj.io/workflow: "fail-first-pass-second-workflow"
+spec:
+  entrypoint: main
+  volumeClaimTemplates:
+    - metadata:
+        name: artifacts
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 0.1Gi
+  templates:
+    - name: main
+      container:
+        name: main
+        image: 'argoproj/argosay:v2'
+        volumeMounts:
+          - name: artifacts
+            mountPath: /tmp
+        command: [sh, -c]
+        args:
+          - |
+            if [ -s /tmp/artifact.txt ]
+            then
+              echo "Successfully retried failing workflow."
+              exit 0
+            else
+              echo "test artifact" > /tmp/artifact.txt
+              exit 1
+            fi
+      outputs:
+        artifacts:
+          - name: artifact
+            path: /tmp/artifact.txt

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -761,7 +761,6 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 			return
 		}
 		if !apierr.IsConflict(err) {
-			woc.persistWorkflowConflictErr(ctx, wfClient, err)
 			return
 		}
 		woc.log.Info("Re-applying updates on latest version and retrying update")
@@ -853,16 +852,6 @@ func (woc *wfOperationCtx) persistWorkflowSizeLimitErr(ctx context.Context, wfCl
 	_, err = wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
 	if err != nil {
 		woc.log.Warnf("Error updating workflow with size error: %v", err)
-	}
-}
-
-// persistWorkflowConflictErr will fail the workflow with an error when there is a conflict in updating it.
-func (woc *wfOperationCtx) persistWorkflowConflictErr(ctx context.Context, wfClient v1alpha1.WorkflowInterface, err error) {
-	woc.wf = woc.orig.DeepCopy()
-	woc.markWorkflowError(ctx, err)
-	_, err = wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
-	if err != nil {
-		woc.log.Warnf("Error updating workflow with conflict error: %v", err)
 	}
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -761,6 +761,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 			return
 		}
 		if !apierr.IsConflict(err) {
+			woc.persistWorkflowConflictErr(ctx, wfClient, err)
 			return
 		}
 		woc.log.Info("Re-applying updates on latest version and retrying update")
@@ -852,6 +853,16 @@ func (woc *wfOperationCtx) persistWorkflowSizeLimitErr(ctx context.Context, wfCl
 	_, err = wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
 	if err != nil {
 		woc.log.Warnf("Error updating workflow with size error: %v", err)
+	}
+}
+
+// persistWorkflowConflictErr will fail the workflow with an error when there is a conflict in updating it.
+func (woc *wfOperationCtx) persistWorkflowConflictErr(ctx context.Context, wfClient v1alpha1.WorkflowInterface, err error) {
+	woc.wf = woc.orig.DeepCopy()
+	woc.markWorkflowError(ctx, err)
+	_, err = wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
+	if err != nil {
+		woc.log.Warnf("Error updating workflow with conflict error: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

~As part of my investigation and testing for https://github.com/argoproj/argo-workflows/pull/12574, I noticed that workflow update conflicts did not result in the workflow being marked as errored. I believe workflows should be marked as errored upon an update conflict. Additionally, marking workflows with conflicting updates as errored makes it easier to test the issue described in #12574.~

**Edit:** 
As Joibel pointed out, I was mistaken in marking the workflow as errored upon conflict. I didn't notice the `!` infront of `apierr.IsConflict()`, so I interpreted it wrong.

I think the test is still useful.

### Modifications

~Added `persistWorkflowConflictErr(ctx, wfClient, err)` and a call to it in `persistUpdates`~

### Verification

Added test for manual workflow retry (in attempt to reproduce the issue described in #12574). This test is unable to reproduce the issue, though it is still a useful test.

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
