### PR TITLE
docs: add Releases to Sustainability hours

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -200,6 +200,7 @@ shortcodes
 stateful
 stderr
 triaged
+triaging
 un-reconciled
 v1
 v1.0

--- a/.spelling
+++ b/.spelling
@@ -200,7 +200,6 @@ shortcodes
 stateful
 stderr
 triaged
-triaging
 un-reconciled
 v1
 v1.0

--- a/community/sustainability_effort.md
+++ b/community/sustainability_effort.md
@@ -22,7 +22,7 @@ Participants are expected to try to advance in roles.
 There are different expectations depending on the role:
 - Member and non-member: should average a minimum of 6 hours per week of either [authoring PRs](../docs/CONTRIBUTING.md#authoring-prs) or performing any activities listed above in the ["Where is help needed?"](#where-is-help-needed) section (where permissions allow)
   - Note that more time is required in this role in order to learn the codebase and processes to make sufficient progress
-- Reviewer and above: should average a minimum of 2 hours per week performing any activities listed above in ["Where is help needed?"](#where-is-help-needed) section, where permissions allow
+- Reviewer and above: should average a minimum of 2 hours per week performing any activities listed above in ["Where is help needed?"](#where-is-help-needed) section (where permissions allow)
   - Highest priority is to ensure that all PRs labeled `prioritized-review` [have an Assignee](#reviewing-prs)
 
 Note that the hours per week listed above is an average over time; it's fine to have weeks of no activity so long as the average meets expectations.

--- a/community/sustainability_effort.md
+++ b/community/sustainability_effort.md
@@ -11,6 +11,7 @@ Help is needed for:
 * [triaging](../docs/CONTRIBUTING.md#triaging-bugs) new bugs by prioritizing them with `P0`, `P1`, `P2`, and `P3` labels
 * responding to questions in [Github Discussions](https://github.com/argoproj/argo-workflows/discussions)
 * responding to questions in [CNCF Slack](https://argoproj.github.io/community/join-slack) in the `#argo-workflows` and `#argo-wf-contributors` channels 
+* performing releases
 
 ## Commitment
 
@@ -19,9 +20,9 @@ Any code contributor in a designated role or with an open Membership request can
 
 Participants are expected to try to advance in roles.
 There are different expectations depending on the role:
-- Member and non-member: should average a minimum of 6 hours per week of either [authoring PRs](../docs/CONTRIBUTING.md#authoring-prs) or performing any activities listed above in the ["Where is help needed?"](#where-is-help-needed) section
+- Member and non-member: should average a minimum of 6 hours per week of either [authoring PRs](../docs/CONTRIBUTING.md#authoring-prs) or performing any activities listed above in the ["Where is help needed?"](#where-is-help-needed) section, where permissions allow
   - Note that more time is required in this role in order to learn the codebase and processes to make sufficient progress
-- Reviewer and above: should average a minimum of 2 hours per week performing any activities listed above in ["Where is help needed?"](#where-is-help-needed) section 
+- Reviewer and above: should average a minimum of 2 hours per week performing any activities listed above in ["Where is help needed?"](#where-is-help-needed) section, where permissions allow
   - Highest priority is to ensure that all PRs labeled `prioritized-review` [have an Assignee](#reviewing-prs)
 
 Note that the hours per week listed above is an average over time; it's fine to have weeks of no activity so long as the average meets expectations.

--- a/community/sustainability_effort.md
+++ b/community/sustainability_effort.md
@@ -20,7 +20,7 @@ Any code contributor in a designated role or with an open Membership request can
 
 Participants are expected to try to advance in roles.
 There are different expectations depending on the role:
-- Member and non-member: should average a minimum of 6 hours per week of either [authoring PRs](../docs/CONTRIBUTING.md#authoring-prs) or performing any activities listed above in the ["Where is help needed?"](#where-is-help-needed) section, where permissions allow
+- Member and non-member: should average a minimum of 6 hours per week of either [authoring PRs](../docs/CONTRIBUTING.md#authoring-prs) or performing any activities listed above in the ["Where is help needed?"](#where-is-help-needed) section (where permissions allow)
   - Note that more time is required in this role in order to learn the codebase and processes to make sufficient progress
 - Reviewer and above: should average a minimum of 2 hours per week performing any activities listed above in ["Where is help needed?"](#where-is-help-needed) section, where permissions allow
   - Highest priority is to ensure that all PRs labeled `prioritized-review` [have an Assignee](#reviewing-prs)

--- a/community/sustainability_effort.md
+++ b/community/sustainability_effort.md
@@ -11,7 +11,7 @@ Help is needed for:
 * [triaging](../docs/CONTRIBUTING.md#triaging-bugs) new bugs by prioritizing them with `P0`, `P1`, `P2`, and `P3` labels
 * responding to questions in [Github Discussions](https://github.com/argoproj/argo-workflows/discussions)
 * responding to questions in [CNCF Slack](https://argoproj.github.io/community/join-slack) in the `#argo-workflows` and `#argo-wf-contributors` channels 
-* performing releases
+* releasing new versions
 
 ## Commitment
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -111,6 +111,7 @@ If you are a Reviewer or below, then once you have approved a PR, request a revi
 #### Triaging Bugs
 
 New bugs need to be triaged to identify the highest priority ones.
+Any members can perform triaging.
 
 Apply the labels `P0`, `P1`, `P2`, and `P3`, where `P0` is highest priority and needs immediate attention, followed by `P1`, `P2`, and then `P3`.
 If there's a new `P0` bug, notify the [`#argo-wf-contributors`](https://cloud-native.slack.com/archives/C0510EUH90V) Slack channel.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -111,7 +111,7 @@ If you are a Reviewer or below, then once you have approved a PR, request a revi
 #### Triaging Bugs
 
 New bugs need to be triaged to identify the highest priority ones.
-Any members can perform triaging.
+Any Member can triage bugs.
 
 Apply the labels `P0`, `P1`, `P2`, and `P3`, where `P0` is highest priority and needs immediate attention, followed by `P1`, `P2`, and then `P3`.
 If there's a new `P0` bug, notify the [`#argo-wf-contributors`](https://cloud-native.slack.com/archives/C0510EUH90V) Slack channel.


### PR DESCRIPTION
### Motivation

Would like to add time spent on releases to officially count as Sustainability hours.

