### PR TITLE
refactor(deps): remove `moment` dep and usage

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
         "node": ">=20"
     },
     "dependencies": {
-        "argo-ui": "git+https://github.com/argoproj/argo-ui.git#6de6bfedc0ec0625122dd5162371fc1932f8d428",
+        "argo-ui": "git+https://github.com/argoproj/argo-ui.git#54f36c723d9a0e5d3386689298cbb9c27767fa00",
         "chart.js": "^2.9.4",
         "chartjs-plugin-annotation": "^0.5.7",
         "classnames": "^2.5.1",

--- a/ui/src/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -1,7 +1,6 @@
 import {Tabs} from 'argo-ui/src/components/tabs/tabs';
 import {Ticker} from 'argo-ui/src/components/ticker';
 import {Tooltip} from 'argo-ui/src/components/tooltip/tooltip';
-import moment from 'moment';
 import * as React from 'react';
 import {useState} from 'react';
 
@@ -23,9 +22,9 @@ import {TIMESTAMP_KEYS} from '../../../shared/use-timestamp';
 
 import './workflow-node-info.scss';
 
-function nodeDuration(node: models.NodeStatus, now: moment.Moment) {
-    const endTime = node.finishedAt ? moment(node.finishedAt) : now;
-    return endTime.diff(moment(node.startedAt)) / 1000;
+function nodeDuration(node: models.NodeStatus, now: Date): number {
+    const endTime = node.finishedAt ? new Date(node.finishedAt) : now;
+    return (endTime.valueOf() - new Date(node.startedAt).valueOf()) / 1000; // ms to seconds
 }
 
 // Iterate over the node's subtree and find pod in error or fail

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2336,9 +2336,9 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-"argo-ui@git+https://github.com/argoproj/argo-ui.git#6de6bfedc0ec0625122dd5162371fc1932f8d428":
+"argo-ui@git+https://github.com/argoproj/argo-ui.git#54f36c723d9a0e5d3386689298cbb9c27767fa00":
   version "1.0.0"
-  resolved "git+https://github.com/argoproj/argo-ui.git#6de6bfedc0ec0625122dd5162371fc1932f8d428"
+  resolved "git+https://github.com/argoproj/argo-ui.git#54f36c723d9a0e5d3386689298cbb9c27767fa00"
   dependencies:
     "@fortawesome/fontawesome-free" "^6.2.1"
     "@tippy.js/react" "^3.1.1"
@@ -2346,13 +2346,12 @@ arg@^4.1.0:
     core-js "^3.32.1"
     foundation-sites "^6.4.3"
     history "^4.10.1"
-    moment "^2.29.4"
     prop-types "^15.8.1"
     react-autocomplete "1.8.1"
     react-form "^2.16.0"
     react-helmet "^6.1.0"
     react-router-dom "^4.2.2"
-    react-toastify "9.0.8"
+    react-toastify "9.0.3"
     rxjs "^7.8.1"
     typescript "^4.9.5"
     uuid "^9.0.0"
@@ -6584,7 +6583,7 @@ mkdirp@1.x:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.10.2, moment@^2.29.4, moment@^2.30.1:
+moment@^2.10.2, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
@@ -7395,10 +7394,10 @@ react-side-effect@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
   integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
-react-toastify@9.0.8:
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.8.tgz#3876c89fc6211a29027b3075010b5ec39ebe4f7e"
-  integrity sha512-EwM+teWt49HSHx+67qI08yLAW1zAsBxCXLCsUfxHYv1W7/R3ZLhrqKalh7j+kjgPna1h5LQMSMwns4tB4ww2yQ==
+react-toastify@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.3.tgz#8e6d22651c85cb584c5ebd0b5e2c3bf0d7ec06ee"
+  integrity sha512-0QZJk0SqYBxouRBGCFU3ymvjlwimRRhVH7SzqGRiVrQ001KSoUNbGKx9Yq42aoPv18n45yJzEFG82zqv3HnASg==
   dependencies:
     clsx "^1.1.1"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12059, but removing / replacing a large dep entirely.
- **EDIT**: turns out it's still used by the old version of `chart.js` in the deps, so it instead got code-split into the `Reports` page bundle, see "Notes to Reviewers" below

Follow-up to #12097 

### Motivation

<!-- TODO: Say why you made your changes. -->

`moment` has been [deprecated since Sep 2020](https://momentjs.com/docs/#/-project-status/) and recommends using native `Intl` or newer libraries that make use of native `Intl`, such as `luxon` and `day.js`
  - `moment` is also a very large dependency and hence is ripe for pruning and replacement as well

- shave off ~634KB / 260KB minified / 73KB gzipped from the main bundle by replacing ~15 LoC

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- replace all usage of `moment` with regular `Date` functions
  - `valueOf()` works the same way for `Date` and `moment`
  - `diff` doesn't exist, but it's a one-liner helper
  - `format` doesn't exist, but we can also use a simple helper for that
  
- Update `argo-ui` to latest include https://github.com/argoproj/argo-ui/pull/535. See full diff: https://github.com/argoproj/argo-ui/compare/6de6bfedc0ec0625122dd5162371fc1932f8d428...54f36c723d9a0e5d3386689298cbb9c27767fa00
  - (nearly all the changes are to Storybook, very little source code changed)

### Verification

1. `make start UI=true`
1. View a specific node of a workflow; `workflow-node-info` looks correct to me. Screenshot: <details>

     ![Screenshot 2024-10-28 at 4 15 38 PM](https://github.com/user-attachments/assets/ff9639af-551c-421c-998f-6933575439cd)

</details>

<!-- TODO: Say how you tested your changes. -->

#### Bundle Analysis 

<details><summary>before:</summary>

![before moment removal - Screenshot 2024-10-28 at 3 23 27 PM](https://github.com/user-attachments/assets/e4db386a-ec96-4937-a644-04493b4f6464)

</details>

<details><summary>after:</summary>

![after moment removal - Screenshot 2024-10-28 at 3 19 52 PM](https://github.com/user-attachments/assets/8b8241b7-18f8-48e4-bcf5-214e85fbe401)

</details>

### Notes to Reviewers

`moment` was removed as a dep in this PR from our own usage and from `argo-ui`'s usage (https://github.com/argoproj/argo-ui/pull/535), but apparently it is still [depended on by the old version of `chart.js` in the deps](https://github.com/argoproj/argo-workflows/blob/00e5fb72f18caeb1b79b935f33a4d0177b4b2d39/ui/yarn.lock#L3381), so it got code-split out to the `Reports` bundle from #12061.
- See "Future Work" below for how to improve that

### Future Work

1. [ ] Upgrade `chart.js` and `react-chartjs-2` to more modern versions with tree-shaking and no direct dependence on `moment`
    - c.f. https://react-chartjs-2-two.vercel.app/docs/chartjs-v2#upgrading-to-chartjs-v3, https://react-chartjs-2-two.vercel.app/docs/migration-to-v4, https://www.chartjs.org/docs/4.3.1/migration/v3-migration.html, https://www.chartjs.org/docs/4.3.1/migration/v4-migration.html
    - it may be worth using a smaller or simpler dep for our limited usage in the Reports page
    - The Reports page is also a prime candidate to externalize into a UI plugin https://github.com/argoproj/argo-workflows/issues/6945


<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
