### PR TITLE
ci: add `mkdocs` Python deps to dependabot security updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,14 @@ updates:
     open-pull-requests-limit: 0
 
   # build / CI dependencies
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+    open-pull-requests-limit: 0
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # prod dependencies
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -9,18 +10,6 @@ updates:
       - dependency-name: k8s.io/*
       - dependency-name: github.com/grpc-ecosystem/*
       - dependency-name: google.golang.org/grpc
-    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
-    open-pull-requests-limit: 0
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "saturday"
-    ignore:
-      # temporarily ignore until https://github.com/actions/download-artifact/issues/249 is resolved
-      - dependency-name: "actions/download-artifact"
-      - dependency-name: "actions/upload-artifact"
     # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
     open-pull-requests-limit: 0
 
@@ -34,5 +23,18 @@ updates:
       - dependency-name: style-loader
       - dependency-name: react-router-dom
       - dependency-name: "@types/react-router-dom"
+    # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+    open-pull-requests-limit: 0
+
+  # build / CI dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    ignore:
+      # temporarily ignore until https://github.com/actions/download-artifact/issues/249 is resolved
+      - dependency-name: "actions/download-artifact"
+      - dependency-name: "actions/upload-artifact"
     # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
     open-pull-requests-limit: 0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to #12360 that added `docs/requirements.txt` (glad to have a proper dep file for that!)
- Follows #12487, which merge conflicted with this, so I waited to make the PR for this one (can see that the original commits were made at the same time)

### Motivation

<!-- TODO: Say why you made your changes. -->

- same as our other deps, for security updates only
  - in particular, a scenario I can see possible is if `mkdocs` has an XSS vuln or something that would impact the docs site

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Add `docs/` `pip` section to `dependabot.yml`

style: reorder dep sections
- put Go, then NPM, then docs, then GH Actions
  - i.e. the most important prod impacting deps, then build deps

### Verification

<!-- TODO: Say how you tested your changes. -->

n/a, this can only be tested after updating

### Notes to Reviewers

I was thinking about some of the NPM docs deps too, but those don't make it into prod, so I don't think they necessarily need to have security updates, but that wouldn't necessarily be bad practice to safeguard devDeps too.
- they also need a proper dep file as well, currently they're installed directly in the `Makefile` as well as in the Nix flakes.

`mkdocs` is technically _also_ a devDep, but the code it produces goes into the prod docs site, per the "Motivation" section above. So if `mkdocs` itself has a vuln, not a big issue, but if its generated code has a vuln, potentially an issue. There's no real way to distinguish between those two scenarios though, unfortunately.

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
