### PR TITLE
fix(controller): re-use `node` variables instead of re-retrieving them

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -271,13 +271,13 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			task := dagCtx.GetTask(taskName)
 			scope, err := woc.buildLocalScopeFromTask(dagCtx, task)
 			if err != nil {
-				woc.markNodeError(nodeName, err)
+				node = woc.markNodeError(nodeName, err)
 				return node, err
 			}
 			scope.addParamToScope(fmt.Sprintf("tasks.%s.status", task.Name), string(taskNode.Phase))
 			_, err = woc.executeTmplLifeCycleHook(ctx, scope, dagCtx.GetTask(taskName).Hooks, taskNode, dagCtx.boundaryID, dagCtx.tmplCtx, "tasks."+taskName)
 			if err != nil {
-				woc.markNodeError(nodeName, err)
+				node = woc.markNodeError(nodeName, err)
 				return node, err
 			}
 			if taskNode.Fulfilled() {
@@ -306,7 +306,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 		return node, nil
 	case wfv1.NodeError, wfv1.NodeFailed:
 		woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, node)
-		woc.markNodePhase(nodeName, dagPhase)
+		node = woc.markNodePhase(nodeName, dagPhase)
 		return node, nil
 	}
 
@@ -363,7 +363,8 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 	}
 
 	woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, node)
-	return woc.markNodePhase(nodeName, wfv1.NodeSucceeded), nil
+	node = woc.markNodePhase(nodeName, wfv1.NodeSucceeded)
+	return node, nil
 }
 
 func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext, targetTasks []string, node *wfv1.NodeStatus) {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -224,18 +224,12 @@ func (d *dagContext) assessDAGPhase(targetTasks []string, nodes wfv1.Nodes, isSh
 }
 
 func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmplCtx *templateresolution.Context, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
-
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
 		node = woc.initializeExecutableNode(nodeName, wfv1.NodeTypeDAG, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodeRunning, opts.nodeFlag)
 	}
 
 	defer func() {
-		node, err := woc.wf.Status.Nodes.Get(node.ID)
-		if err != nil {
-			// CRITICAL ERROR IF THIS BRANCH IS REACHED -> PANIC
-			panic(fmt.Sprintf("expected node for %s due to preceded initializeExecutableNode but couldn't find it", node.ID))
-		}
 		if node.Fulfilled() {
 			woc.killDaemonedChildren(node.ID)
 		}
@@ -277,13 +271,13 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			task := dagCtx.GetTask(taskName)
 			scope, err := woc.buildLocalScopeFromTask(dagCtx, task)
 			if err != nil {
-				woc.markNodeError(node.Name, err)
+				woc.markNodeError(nodeName, err)
 				return node, err
 			}
 			scope.addParamToScope(fmt.Sprintf("tasks.%s.status", task.Name), string(taskNode.Phase))
 			_, err = woc.executeTmplLifeCycleHook(ctx, scope, dagCtx.GetTask(taskName).Hooks, taskNode, dagCtx.boundaryID, dagCtx.tmplCtx, "tasks."+taskName)
 			if err != nil {
-				woc.markNodeError(node.Name, err)
+				woc.markNodeError(nodeName, err)
 				return node, err
 			}
 			if taskNode.Fulfilled() {
@@ -311,11 +305,8 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 	case wfv1.NodeRunning:
 		return node, nil
 	case wfv1.NodeError, wfv1.NodeFailed:
-		err = woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, nodeName)
-		if err != nil {
-			return nil, err
-		}
-		_ = woc.markNodePhase(nodeName, dagPhase)
+		woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, node)
+		woc.markNodePhase(nodeName, dagPhase)
 		return node, nil
 	}
 
@@ -367,18 +358,15 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 		err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
 		if err != nil {
 			woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
-			node.Phase = wfv1.NodeError
+			woc.markNodeError(nodeName, err)
 		}
 	}
 
-	err = woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, nodeName)
-	if err != nil {
-		return nil, err
-	}
+	woc.updateOutboundNodesForTargetTasks(dagCtx, targetTasks, node)
 	return woc.markNodePhase(nodeName, wfv1.NodeSucceeded), nil
 }
 
-func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext, targetTasks []string, nodeName string) error {
+func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext, targetTasks []string, node ) {
 	// set the outbound nodes from the target tasks
 	outbound := make([]string, 0)
 	for _, depName := range targetTasks {
@@ -390,15 +378,9 @@ func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext,
 		outboundNodeIDs := woc.getOutboundNodes(depNode.ID)
 		outbound = append(outbound, outboundNodeIDs...)
 	}
-	node, err := woc.wf.GetNodeByName(nodeName)
-	if err != nil {
-		woc.log.Warnf("was unable to obtain node by name for %s", nodeName)
-		return err
-	}
 	node.OutboundNodes = outbound
 	woc.wf.Status.Nodes.Set(node.ID, *node)
 	woc.log.Infof("Outbound nodes of %s set to %s", node.ID, outbound)
-	return nil
 }
 
 // executeDAGTask traverses and executes the upward chain of dependencies of a task
@@ -593,10 +575,10 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 			case ErrParallelismReached:
 			case ErrMaxDepthExceeded:
 			case ErrTimeout:
-				_ = woc.markNodePhase(taskNodeName, wfv1.NodeFailed, err.Error())
+				woc.markNodePhase(taskNodeName, wfv1.NodeFailed, err.Error())
 				return
 			default:
-				_ = woc.markNodeError(taskNodeName, fmt.Errorf("task '%s' errored: %v", taskNodeName, err))
+				woc.markNodeError(taskNodeName, fmt.Errorf("task '%s' errored: %v", taskNodeName, err))
 				return
 			}
 		}

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -366,7 +366,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 	return woc.markNodePhase(nodeName, wfv1.NodeSucceeded), nil
 }
 
-func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext, targetTasks []string, node ) {
+func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(dagCtx *dagContext, targetTasks []string, node *wfv1.NodeStatus) {
 	// set the outbound nodes from the target tasks
 	outbound := make([]string, 0)
 	for _, depName := range targetTasks {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -358,7 +358,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 		err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
 		if err != nil {
 			woc.log.WithFields(log.Fields{"nodeID": node.ID}).WithError(err).Error("Failed to save node outputs to cache")
-			woc.markNodeError(nodeName, err)
+			node.Phase = wfv1.NodeError
 		}
 	}
 

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -44,12 +44,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 	}
 
 	defer func() {
-		nodePhase, err := woc.wf.Status.Nodes.GetPhase(node.ID)
-		if err != nil {
-			woc.log.Fatalf("was unable to obtain nodePhase for %s", node.ID)
-			panic(fmt.Sprintf("unable to obtain nodePhase for %s", node.ID))
-		}
-		if nodePhase.Fulfilled() {
+		if node.Phase.Fulfilled() {
 			woc.killDaemonedChildren(node.ID)
 		}
 	}()

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -190,7 +190,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 }
 
 // updateOutboundNodes set the outbound nodes from the last step group
-func (woc *wfOperationCtx) updateOutboundNodes(node, tmpl *wfv1.Template) {
+func (woc *wfOperationCtx) updateOutboundNodes(node *wfv1.NodeStatus, tmpl *wfv1.Template) {
 	outbound := make([]string, 0)
 
 	// Find the last, initialized stepgroup node

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -70,9 +70,9 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 		{
 			sgNode, err := woc.wf.GetNodeByName(sgNodeName)
 			if err != nil {
-				_ = woc.initializeNode(sgNodeName, wfv1.NodeTypeStepGroup, stepTemplateScope, &wfv1.WorkflowStep{}, stepsCtx.boundaryID, wfv1.NodeRunning, &wfv1.NodeFlag{})
+				woc.initializeNode(sgNodeName, wfv1.NodeTypeStepGroup, stepTemplateScope, &wfv1.WorkflowStep{}, stepsCtx.boundaryID, wfv1.NodeRunning, &wfv1.NodeFlag{})
 			} else if !sgNode.Fulfilled() {
-				_ = woc.markNodePhase(sgNodeName, wfv1.NodeRunning)
+				woc.markNodePhase(sgNodeName, wfv1.NodeRunning)
 			}
 		}
 		// The following will connect the step group node to its parents.
@@ -119,9 +119,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 		if sgNode.FailedOrError() {
 			failMessage := fmt.Sprintf("step group %s was unsuccessful: %s", sgNode.ID, sgNode.Message)
 			woc.log.Info(failMessage)
-			if err = woc.updateOutboundNodes(nodeName, tmpl); err != nil {
-				return nil, err
-			}
+			woc.updateOutboundNodes(node, tmpl)
 			return woc.markNodePhase(nodeName, wfv1.NodeFailed, sgNode.Message), nil
 		}
 
@@ -163,10 +161,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 		}
 	}
 
-	err = woc.updateOutboundNodes(nodeName, tmpl)
-	if err != nil {
-		return nil, err
-	}
+	woc.updateOutboundNodes(node, tmpl)
 	// If this template has outputs from any of its steps, copy them to this node here
 	outputs, err := getTemplateOutputsFromScope(tmpl, stepsCtx.scope)
 	if err != nil {
@@ -195,36 +190,32 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 }
 
 // updateOutboundNodes set the outbound nodes from the last step group
-func (woc *wfOperationCtx) updateOutboundNodes(nodeName string, tmpl *wfv1.Template) error {
+func (woc *wfOperationCtx) updateOutboundNodes(node, tmpl *wfv1.Template) {
 	outbound := make([]string, 0)
+
 	// Find the last, initialized stepgroup node
 	var lastSGNode *wfv1.NodeStatus
-	var err error
 	for i := len(tmpl.Steps) - 1; i >= 0; i-- {
-		var sgNode *wfv1.NodeStatus
-		sgNode, err = woc.wf.GetNodeByName(fmt.Sprintf("%s[%d]", nodeName, i))
+		sgNode, err := woc.wf.GetNodeByName(fmt.Sprintf("%s[%d]", node.name, i))
 		if err == nil {
 			lastSGNode = sgNode
 			break
 		}
 	}
 	if lastSGNode == nil {
-		woc.log.Warnf("node '%s' had no initialized StepGroup nodes", nodeName)
-		return err
+		woc.log.Warnf("node '%s' had no initialized StepGroup nodes", node.name)
+		return
 	}
+
 	for _, childID := range lastSGNode.Children {
 		outboundNodeIDs := woc.getOutboundNodes(childID)
 		woc.log.Infof("Outbound nodes of %s is %s", childID, outboundNodeIDs)
 		outbound = append(outbound, outboundNodeIDs...)
 	}
-	node, err := woc.wf.GetNodeByName(nodeName)
-	if err != nil {
-		return err
-	}
+
 	woc.log.Infof("Outbound nodes of %s is %s", node.ID, outbound)
 	node.OutboundNodes = outbound
 	woc.wf.Status.Nodes.Set(node.ID, *node)
-	return nil
 }
 
 // executeStepGroup examines a list of parallel steps and executes them in parallel.
@@ -290,10 +281,10 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 			case ErrParallelismReached:
 			case ErrMaxDepthExceeded:
 			case ErrTimeout:
-				return woc.markNodePhase(node.Name, wfv1.NodeFailed, err.Error()), nil
+				return woc.markNodePhase(sgNodeName, wfv1.NodeFailed, err.Error()), nil
 			default:
 				woc.addChildNode(sgNodeName, childNodeName)
-				return woc.markNodeError(node.Name, fmt.Errorf("step group deemed errored due to child %s error: %w", childNodeName, err)), nil
+				return woc.markNodeError(sgNodeName, fmt.Errorf("step group deemed errored due to child %s error: %w", childNodeName, err)), nil
 			}
 		}
 		if childNode != nil {
@@ -302,10 +293,6 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		}
 	}
 
-	node, err = woc.wf.GetNodeByName(sgNodeName)
-	if err != nil {
-		return nil, err
-	}
 	// Return if not all children completed
 	completed := true
 	for _, childNodeID := range node.Children {
@@ -319,7 +306,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		stepsCtx.scope.addParamToScope(fmt.Sprintf("steps.%s.status", childNode.DisplayName), string(childNode.Phase))
 		hookCompleted, err := woc.executeTmplLifeCycleHook(ctx, stepsCtx.scope, step.Hooks, childNode, stepsCtx.boundaryID, stepsCtx.tmplCtx, "steps."+step.Name)
 		if err != nil {
-			woc.markNodeError(node.Name, err)
+			woc.markNodeError(sgNodeName, err)
 		}
 		// Check all hooks are completed
 		if !hookCompleted {
@@ -353,11 +340,11 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 		if childNode.FailedOrError() && !step.ContinuesOn(childNode.Phase) {
 			failMessage := fmt.Sprintf("child '%s' failed", childNodeID)
 			woc.log.Infof("Step group node %s deemed failed: %s", node.ID, failMessage)
-			return woc.markNodePhase(node.Name, wfv1.NodeFailed, failMessage), nil
+			return woc.markNodePhase(sgNodeName, wfv1.NodeFailed, failMessage), nil
 		}
 	}
 	woc.log.Infof("Step group node %v successful", node.ID)
-	return woc.markNodePhase(node.Name, wfv1.NodeSucceeded), nil
+	return woc.markNodePhase(sgNodeName, wfv1.NodeSucceeded), nil
 }
 
 // shouldExecute evaluates a already substituted when expression to decide whether or not a step should execute

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -115,7 +115,8 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 			failMessage := fmt.Sprintf("step group %s was unsuccessful: %s", sgNode.ID, sgNode.Message)
 			woc.log.Info(failMessage)
 			woc.updateOutboundNodes(node, tmpl)
-			return woc.markNodePhase(nodeName, wfv1.NodeFailed, sgNode.Message), nil
+			node = woc.markNodePhase(nodeName, wfv1.NodeFailed, sgNode.Message)
+			return node, nil
 		}
 
 		// Add all outputs of each step in the group to the scope
@@ -181,7 +182,8 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 			node.Phase = wfv1.NodeError
 		}
 	}
-	return woc.markNodePhase(nodeName, wfv1.NodeSucceeded), nil
+	node = woc.markNodePhase(nodeName, wfv1.NodeSucceeded)
+	return node, nil
 }
 
 // updateOutboundNodes set the outbound nodes from the last step group

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -191,14 +191,14 @@ func (woc *wfOperationCtx) updateOutboundNodes(node *wfv1.NodeStatus, tmpl *wfv1
 	// Find the last, initialized stepgroup node
 	var lastSGNode *wfv1.NodeStatus
 	for i := len(tmpl.Steps) - 1; i >= 0; i-- {
-		sgNode, err := woc.wf.GetNodeByName(fmt.Sprintf("%s[%d]", node.name, i))
+		sgNode, err := woc.wf.GetNodeByName(fmt.Sprintf("%s[%d]", node.Name, i))
 		if err == nil {
 			lastSGNode = sgNode
 			break
 		}
 	}
 	if lastSGNode == nil {
-		woc.log.Warnf("node '%s' had no initialized StepGroup nodes", node.name)
+		woc.log.Warnf("node '%s' had no initialized StepGroup nodes", node.Name)
 		return
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12165 -- #12203 was the quick fix partial revert of #12130 Alan made to revert to previous behavior while I was out sick, this PR is a root cause fix of the underlying problem I discovered in ~6 year old code in https://github.com/argoproj/argo-workflows/issues/12165#issuecomment-1807244326

### Motivation

<!-- TODO: Say why you made your changes. -->

- previously, different functions would `Get` the `node` even though it was created in the same function or in a parent function
  - this would result in multiple references to the same `node` that could potentially have different versions dependent on timing
  - and in the case of `steps`, the logic actually relied on those references being the same, as when some redundant assignment logic was removed, it actually broke tracking of `outboundNodes` and `children`
    - basically the `node` could be overwritten with an old version

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use the same `node` throughout `executeSteps` and `executeDAG` and the functions they call, instead of re-retrieving it
  - also do the same for `nodeName` in a few places
  - this also removes some repetitive error checking, simplifying a few blocks and functions

- while at it, remove unused `_` assignments
- and improve a node phase set by consistently using the `markNodeError` function

### Verification

<!-- TODO: Say how you tested your changes. -->

The E2E test added in #12214 should verify this as well. I haven't yet quite tested this locally with the reproducible example from https://github.com/argoproj/argo-workflows/issues/12165#issuecomment-1807177485, that's why I had this code waiting since late Nov 😅 . Figured I'd get the code up at least in draft form

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
