### PR TITLE
docs: consolidate expression links

### DIFF
--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -83,7 +83,7 @@ metadata:
     # Must evaluate to a boolean.
     # If you want an account to be the default to use, this rule can be "true".
     # Details of the expression language are available in
-    # https://github.com/expr-lang/expr/blob/master/docs/language-definition.md.
+    # https://expr-lang.org/docs/language-definition.
     workflows.argoproj.io/rbac-rule: "'admin' in groups"
     # The precedence is used to determine which service account to use whe
     # Precedence is an integer. It may be negative. If omitted, it defaults to "0".

--- a/docs/data-sourcing-and-transformation.md
+++ b/docs/data-sourcing-and-transformation.md
@@ -53,6 +53,6 @@ A `data` template must always contain a `source`. Current available sources:
 
 A `data` template may contain any number of transformations (or zero). The transformations will be applied serially in order. Current available transformations:
 
-* `expression`: an [`expr`](https://github.com/expr-lang/expr) expression. See language definition [here](https://github.com/expr-lang/expr/blob/master/docs/Language-Definition.md). When defining `expr` expressions Argo will pass the available data to the environment as a variable called `data` (see example above).
+* `expression`: an [expression](variables.md#expression). The data is accessible in the `data` variable (see example above).
 
     We understand that the `expression` transformation is limited. We intend to greatly expand the functionality of this template with our community's feedback. Please see the link at the top of this document to submit ideas or use cases for this feature.

--- a/docs/events.md
+++ b/docs/events.md
@@ -150,13 +150,11 @@ requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/
 
 ## Event Expression Syntax and the Event Expression Environment
 
-**Event expressions** are expressions that are evaluated over the **event expression environment**.
+**Event expressions** are [expressions](variables.md#expression) that are evaluated over the **event expression environment**.
 
 ### Expression Syntax
 
 Because the endpoint accepts any JSON data, it is the user's responsibility to write a suitable expression to correctly filter the events they are interested in. Therefore, DO NOT assume the existence of any fields, and guard against them using a nil check.
-
-[Learn more about expression syntax](https://github.com/expr-lang/expr).
 
 ### Expression Environment
 

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -85,9 +85,8 @@ spec:
 
 > v3.2 and after
 
-You can also use `expression` to control retries. The `expression` field
-accepts an [expr](https://github.com/expr-lang/expr) expression and has
-access to the following variables:
+You can also use `expression` to control retries.
+This is an [expression](variables.md#expression) with access to the following variables:
 
 - `lastRetry.exitCode`: The exit code of the last retry, or "-1" if not available
 - `lastRetry.status`: The phase of the last retry: Error, Failed

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -56,7 +56,7 @@ The tag is substituted with the result of evaluating the tag as an expression.
 Note that any hyphenated parameter names or step names will cause a parsing error. You can reference them by
 indexing into the parameter or step map, e.g. `inputs.parameters['my-param']` or `steps['my-step'].outputs.result`.
 
-[Learn about the expression syntax](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md).
+[Learn more about the expression syntax](https://expr-lang.org/docs/language-definition).
 
 #### Examples
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/12469#discussion_r1443145079 and https://github.com/argoproj/argo-workflows/pull/12573#discussion_r1471449979

### Motivation

<!-- TODO: Say why you made your changes. -->

- most of these should go to the definition in Argo's own docs in `variables.md#expression`
- use https://expr-lang.org/docs/language-definition instead of GH as it has nicer UX

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- change internal docs references to expressions to go to `variables.md#expression`, the internal docs definition of it
- change external references to go to https://expr-lang.org/docs/language-definition

- while at it, make some small docs changes in the same place
  - more simple and direct, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
    - some of these, especially the `data` one, were incredibly overly verbose and have been greatly simplified
  - use present tense, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-present-tense)
  - prefer 1 sentence per line, per [style guide](https://argo-workflows.readthedocs.io/en/release-3.5/doc-changes/)

### Verification

<!-- TODO: Say how you tested your changes. -->

1. `make docs` passes

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
