### PR TITLE
ci: pin all GH Actions

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: main
           fetch-depth: 0
@@ -26,7 +26,7 @@ jobs:
       - run: git tag -l 'v*'
       # avoid invoking `make` to reduce the risk of a Makefile bug failing this workflow
       - run: ./hack/changelog.sh > CHANGELOG.md
-      - uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           title: 'docs: updated CHANGELOG.md'
           commit-message: 'docs: updated CHANGELOG.md'

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -28,12 +28,12 @@ jobs:
       ui: ${{ steps.changed-files.outputs.ui_any_modified == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 50 # assume PRs are less than 50 commits
       - name: Get relevant files changed per group
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88 # v41.1.2
         with:
           files_yaml: |
             common: &common
@@ -87,6 +87,8 @@ jobs:
               - *tests
               # plus lint config
               - .golangci.yml
+              # all GH workflows / actions
+              - .github/workflows/**
               # docs files below
               - docs/**
               # generated files are covered by codegen
@@ -113,8 +115,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
           cache: true
@@ -131,8 +133,8 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
           cache: true
@@ -147,10 +149,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Build and export
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
         with:
           context: .
           tags: quay.io/argoproj/argoexec:latest
@@ -159,7 +161,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: argoexec
           path: /tmp/argoexec_image.tar
@@ -210,21 +212,21 @@ jobs:
     steps:
       - name: Install socat (needed by Kubernetes v1.25)
         run: sudo apt-get -y install socat
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
           cache: true
       - name: Install Java for the SDK
         if: ${{matrix.test == 'test-java-sdk'}}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
         with:
           java-version: '8'
           distribution: adopt
           cache: maven
       - name: Install Python for the SDK
         if: ${{matrix.test == 'test-python-sdk'}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: '3.x'
           cache: pip
@@ -243,7 +245,7 @@ jobs:
           echo "    token: xxxxxx" >> $KUBECONFIG
           until kubectl cluster-info ; do sleep 10s ; done
       - name: Download argoexec image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: argoexec
           path: /tmp
@@ -340,8 +342,8 @@ jobs:
     env:
       GOPATH: /home/runner/go
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
           cache: true
@@ -377,8 +379,8 @@ jobs:
     env:
       GOPATH: /home/runner/go
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
           cache: true
@@ -386,6 +388,9 @@ jobs:
       # if lint makes changes that are not in the PR, fail the build
       - name: Check if lint made changes not present in the PR
         run: git diff --exit-code
+      # lint GH Actions
+      - name: Ensure GH Actions are pinned to SHAs
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ba37328d4ea95eaf8b3bd6c6cef308f709a5f2ec # v3.0.3
 
   ui:
     name: UI
@@ -396,8 +401,8 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "20" # change in all GH Workflows
           cache: yarn

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # v1.6.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve PR

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,14 +19,14 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: 3.9
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '1.21'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "19"
       # Use the same make target both locally and on CI to make it easier to debug failures.
@@ -37,7 +37,7 @@ jobs:
         run: git diff --exit-code
       # Upload the site so reviewers see it.
       - name: Upload Docs Site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: docs
           path: site

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR Title's semantic conformance
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,18 +29,18 @@ jobs:
         platform: [ linux/amd64, linux/arm64 ]
         target: [ workflow-controller, argocli, argoexec ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
         with:
           version: v0.10.4
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         id: cache
         with:
           path: /tmp/.buildx-cache
@@ -49,13 +49,13 @@ jobs:
             ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.target }}-buildx-
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
 
-      - name: Docker Login
-        uses: docker/login-action@v3
+      - name: Login to Quay
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
@@ -97,15 +97,15 @@ jobs:
     if: github.repository == 'argoproj/argo-workflows'
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Docker Login
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
 
       - name: Login to Quay
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           login-server: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
@@ -147,22 +147,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-linux, build-windows ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Docker Login
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
 
       - name: Login to Quay
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           login-server: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
           cosign-release: 'v1.13.0'
 
@@ -211,13 +211,13 @@ jobs:
         target: [ workflow-controller, argocli, argoexec ]
     steps:
       - name: Docker Login
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
 
       - name: Login to Quay
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           login-server: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
@@ -245,13 +245,13 @@ jobs:
     needs: [ push-images ]
     steps:
       - name: Docker Login
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
 
       - name: Login to Quay
-        uses: Azure/docker-login@v1
+        uses: Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1
         with:
           login-server: quay.io
           username: ${{ secrets.QUAYIO_USERNAME }}
@@ -284,20 +284,20 @@ jobs:
       COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
       COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "20" # change in all GH Workflows
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.21"
       - name: Restore node packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: ui/node_modules
           key: ${{ runner.os }}-node-dep-v1-${{ hashFiles('**/yarn.lock') }}
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
           cosign-release: 'v1.13.0'
       # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
@@ -340,7 +340,7 @@ jobs:
       # If a conflict occurs (because you are not on a tag), the release will not be updated. This is a short coming
       # of this action.
       # Instead, delete the release so it is re-created.
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           prerelease: ${{ startsWith(github.ref, 'refs/tags/v0') || contains(github.ref, 'rc') }}

--- a/.github/workflows/sdks.yaml
+++ b/.github/workflows/sdks.yaml
@@ -21,7 +21,7 @@ jobs:
         - java
         - python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: make --directory sdks/${{matrix.name}} publish -B
         env:
           JAVA_SDK_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -20,9 +20,9 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Snyk to check for Go vulnerabilities
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           args: --severity-threshold=high
 
@@ -33,15 +33,15 @@ jobs:
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "20" # change in all GH Workflows
           cache: yarn
           cache-dependency-path: ui/yarn.lock
       - run: yarn --cwd ui install
       - name: Run Snyk to check for Node vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
         with:
           args: --file=ui/package.json --severity-threshold=high
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write # for commenting on a PR and editing labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # timing


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12031, "Pinned Dependencies"
- Unpinned GH Actions are about ~80% of the failures in that check right now
- Workflows equivalent of https://github.com/argoproj/argo-cd/pull/11360

### Motivation

<!-- TODO: Say why you made your changes. -->

- `git` tags are mutable, while SHAs are immutable, so SHAs are [recommended](https://github.com/ossf/scorecard/blob/8eaf0d7647a3f50d80615812c72a277fd568fb6d/docs/checks.md#pinned-dependencies) for better supply chain security
  - Note that dependabot [knows how to](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/) update both the SHA and the version comment

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions to `lint` job to ensure all actions stay pinned

- <details> <summary> Pinned all actions, as listed below, from "most trusted" to "least trusted" (zero trust all though, but potentially relevant for risk assessment purposes): </summary>

  - Published by GitHub:
    - pin `actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1` (c.f. [v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1))
    - pin `actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0` (c.f. [v5.0.0](https://github.com/actions/setup-go/releases/tag/v5.0.0))
    - pin `actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1` (c.f. [v4.0.1](https://github.com/actions/setup-node/releases/tag/v4.0.1))
    - pin `actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0` (c.f. [v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0))
    - pin `actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0` (c.f. [v4.0.0](https://github.com/actions/setup-java/releases/tag/v4.0.0))
    - pin `actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3` (c.f. [v3.3.3](https://github.com/actions/cache/releases/tag/v3.3.3))
    - pin `actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3` (c.f. [v3.1.3](https://github.com/actions/upload-artifact/releases/tag/v3.1.3))
    - pin `actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2` (c.f. [v3.0.2](https://github.com/actions/download-artifact/releases/tag/v3.0.2))
    - pin `actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0` (c.f. [v9.0.0](https://github.com/actions/stale/releases/tag/v9.0.0))
    - pin `dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # v1.6.0` (c.f. [v1.6.0](https://github.com/dependabot/fetch-metadata/releases/tag/v1.6.0))

  - Published by Docker, Azure/MSFT, then sigstore:
    - pin `docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0` (c.f. [v3.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0))
    - pin `docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0` (c.f. [v5.1.0](https://github.com/docker/build-push-action/releases/tag/v5.1.0))
    - pin `docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0` (c.f. [v3.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0))
    - pin `docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0` (c.f. [v3.0.0](https://github.com/docker/login-action/releases/tag/v3.0.0))
    - pin `Azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1.0.1` (c.f. [v1.0.1](https://github.com/Azure/docker-login/releases/tag/v1.0.1))
    - pin `sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0` (c.f. [v3.4.0](https://github.com/sigstore/cosign-installer/releases/tag/v3.4.0))

  - Published by Snyk:
    - pin `snyk/action/golang@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0` (c.f. [v0.4.0](https://github.com/snyk/actions/releases/tag/0.4.0))
    - pin `snyk/action/node@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0` (c.f. [v0.4.0](https://github.com/snyk/actions/releases/tag/0.4.0))

  - Published by third-party / indie:
    - pin `tj-actions/changed-files@cbda684547adc8c052d50711417fa61b428a9f88 # v41.1.2` (c.f. [v41.1.2](https://github.com/tj-actions/changed-files/releases/tag/v41.1.2))
    - pin `softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1` (c.f. [v1](https://github.com/softprops/action-gh-release/releases/tag/v1))
    - pin `amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f # v5.4.0` (c.f. [v5.4.0](https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.4.0))
    - pin `peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2` (c.f. [v5.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2))

</details>

### Verification

<!-- TODO: Say how you tested your changes. -->

CI passes

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
