### PR TITLE
feat: speed up retry archived workflow

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -186,7 +186,7 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (*argoServer, error
 	}, nil
 }
 
-var backoff = wait.Backoff{
+var Backoff = wait.Backoff{
 	Steps:    5,
 	Duration: 500 * time.Millisecond,
 	Factor:   1.0,
@@ -237,7 +237,7 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	var conn net.Listener
 	var listerErr error
 	address := fmt.Sprintf(":%d", port)
-	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+	err = wait.ExponentialBackoff(Backoff, func() (bool, error) {
 		conn, listerErr = net.Listen("tcp", address)
 		if listerErr != nil {
 			log.WithError(err).Warn("failed to listen")

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -186,7 +186,7 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (*argoServer, error
 	}, nil
 }
 
-var Backoff = wait.Backoff{
+var backoff = wait.Backoff{
 	Steps:    5,
 	Duration: 500 * time.Millisecond,
 	Factor:   1.0,
@@ -237,7 +237,7 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	var conn net.Listener
 	var listerErr error
 	address := fmt.Sprintf(":%d", port)
-	err = wait.ExponentialBackoff(Backoff, func() (bool, error) {
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
 		conn, listerErr = net.Listen("tcp", address)
 		if listerErr != nil {
 			log.WithError(err).Warn("failed to listen")

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -371,15 +371,6 @@ func (s *workflowServer) DeleteWorkflow(ctx context.Context, req *workflowpkg.Wo
 	return &workflowpkg.WorkflowDeleteResponse{}, nil
 }
 
-func errorFromChannel(errCh <-chan error) error {
-	select {
-	case err := <-errCh:
-		return err
-	default:
-	}
-	return nil
-}
-
 func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.WorkflowRetryRequest) (*wfv1.Workflow, error) {
 	wfClient := auth.GetWfClient(ctx)
 	kubeClient := auth.GetKubeClient(ctx)
@@ -420,7 +411,7 @@ func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.Wor
 	}
 	wg.Wait()
 
-	err = errorFromChannel(errCh)
+	err = util.ErrorFromChannel(errCh)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -4,19 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"sort"
+
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
-	"sort"
-	"sync"
-	"time"
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	"github.com/argoproj/argo-workflows/v3/persist/sqldb"
@@ -397,37 +394,7 @@ func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.Wor
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
 
-	var backoff = wait.Backoff{
-		Steps:    5,
-		Duration: 500 * time.Millisecond,
-		Factor:   1.0,
-		Jitter:   0.1,
-	}
-
-	errCh := make(chan error, len(podsToDelete))
-	var wg sync.WaitGroup
-	parallelPodNum := make(chan string, 500)
-	for _, podName := range podsToDelete {
-		log.WithFields(log.Fields{"podDeleted": podName}).Info("Deleting pod")
-		wg.Add(1)
-		go func(podName string) {
-			err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-				err := kubeClient.CoreV1().Pods(wf.Namespace).Delete(ctx, podName, metav1.DeleteOptions{})
-				if err != nil && !apierr.IsNotFound(err) {
-					klog.Errorf("Failed to delete pod %s: %v", podName, err)
-					return false, nil
-				}
-				return true, nil
-			})
-			if err != nil {
-				errCh <- err
-			}
-			<-parallelPodNum
-		}(podName)
-	}
-	wg.Wait()
-
-	err = util.ErrorFromChannel(errCh)
+	err = util.DeletePodsInParallel(ctx, podsToDelete, kubeClient, wf.Namespace)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -3,8 +3,6 @@ package workflowarchive
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 	"os"
 	"regexp"
 	"sort"
@@ -12,6 +10,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1321,3 +1321,12 @@ func FindWaitCtrIndex(pod *apiv1.Pod) (int, error) {
 	}
 	return waitCtrIndex, nil
 }
+
+func ErrorFromChannel(errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	default:
+	}
+	return nil
+}


### PR DESCRIPTION
https://github.com/argoproj/argo-workflows/pull/12419 
Since I accelerated the deletion of pods during retry workflow, it works well and is much faster. I want to speed up the retry archived workflow too.


<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->
Speed up retry archived workflow. Let a large archived workflow (more than 8000 pods) can be successfully retryed within 1 minute.

### Modifications

<!-- TODO: Say what changes you made. -->
Clean up failed nodes in parallel.
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
e2e test.
<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
