### PR TITLE
fix: inline template loops should receive more than the first item. Fixes: #12594

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -3420,14 +3420,14 @@ func (wf *Workflow) SetStoredTemplate(scope ResourceScope, resourceName string, 
 }
 
 // SetStoredInlineTemplate stores a inline template in stored templates of the workflow.
-func (wf *Workflow) SetStoredInlineTemplate(scope ResourceScope, resourceName string, tmpl *Template) (bool, error) {
+func (wf *Workflow) SetStoredInlineTemplate(scope ResourceScope, resourceName string, tmpl *Template) error {
 	// Store inline templates in steps.
 	for _, steps := range tmpl.Steps {
 		for _, step := range steps.Steps {
 			if step.GetTemplate() != nil {
 				_, err := wf.SetStoredTemplate(scope, resourceName, &step, step.GetTemplate())
 				if err != nil {
-					return false, nil
+					return err
 				}
 			}
 		}
@@ -3438,13 +3438,13 @@ func (wf *Workflow) SetStoredInlineTemplate(scope ResourceScope, resourceName st
 			if task.GetTemplate() != nil {
 				_, err := wf.SetStoredTemplate(scope, resourceName, &task, task.GetTemplate())
 				if err != nil {
-					return false, nil
+					return err
 				}
 			}
 		}
 	}
 
-	return true, nil
+	return nil
 }
 
 // resolveTemplateReference resolves the stored template name of a given template holder on the template scope and determines

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -3419,6 +3419,34 @@ func (wf *Workflow) SetStoredTemplate(scope ResourceScope, resourceName string, 
 	return false, nil
 }
 
+// SetStoredInlineTemplate stores a inline template in stored templates of the workflow.
+func (wf *Workflow) SetStoredInlineTemplate(scope ResourceScope, resourceName string, tmpl *Template) (bool, error) {
+	// Store inline templates in steps.
+	for _, steps := range tmpl.Steps {
+		for _, step := range steps.Steps {
+			if step.GetTemplate() != nil {
+				_, err := wf.SetStoredTemplate(scope, resourceName, &step, step.GetTemplate())
+				if err != nil {
+					return false, nil
+				}
+			}
+		}
+	}
+	// Store inline templates in DAG tasks.
+	if tmpl.DAG != nil {
+		for _, task := range tmpl.DAG.Tasks {
+			if task.GetTemplate() != nil {
+				_, err := wf.SetStoredTemplate(scope, resourceName, &task, task.GetTemplate())
+				if err != nil {
+					return false, nil
+				}
+			}
+		}
+	}
+
+	return true, nil
+}
+
 // resolveTemplateReference resolves the stored template name of a given template holder on the template scope and determines
 // if it should be stored
 func resolveTemplateReference(callerScope ResourceScope, resourceName string, caller TemplateReferenceHolder) (string, bool) {

--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -213,7 +213,7 @@ func (ctx *Context) resolveTemplateImpl(tmplHolder wfv1.TemplateReferenceHolder)
 			}
 			storedInline, err := ctx.workflow.SetStoredInlineTemplate(scope, resourceName, newTmpl)
 			if err != nil {
-				log.Errorf("Failed to store the inline template: %v", err)
+				ctx.log.Errorf("Failed to store the inline template: %v", err)
 			}
 			if storedInline {
 				ctx.log.Debug("Stored the inline template")

--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -211,12 +211,9 @@ func (ctx *Context) resolveTemplateImpl(tmplHolder wfv1.TemplateReferenceHolder)
 				ctx.log.Debug("Stored the template")
 				templateStored = true
 			}
-			storedInline, err := ctx.workflow.SetStoredInlineTemplate(scope, resourceName, newTmpl)
+			err = ctx.workflow.SetStoredInlineTemplate(scope, resourceName, newTmpl)
 			if err != nil {
 				ctx.log.Errorf("Failed to store the inline template: %v", err)
-			}
-			if storedInline {
-				ctx.log.Debug("Stored the inline template")
 			}
 		}
 		tmpl = newTmpl

--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -211,6 +211,13 @@ func (ctx *Context) resolveTemplateImpl(tmplHolder wfv1.TemplateReferenceHolder)
 				ctx.log.Debug("Stored the template")
 				templateStored = true
 			}
+			storedInline, err := ctx.workflow.SetStoredInlineTemplate(scope, resourceName, newTmpl)
+			if err != nil {
+				log.Errorf("Failed to store the inline template: %v", err)
+			}
+			if storedInline {
+				ctx.log.Debug("Stored the inline template")
+			}
 		}
 		tmpl = newTmpl
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12594

I find the root cause is first inline template was store，So the next one in the loop is taken first.

### Motivation

<!-- TODO: Say why you made your changes. -->
I want the inline templates to be stored before being parsed so that each loop gets the correct template instead of the first one that was parsed.

### Modifications

<!-- TODO: Say what changes you made. -->
When storing a template, if it also has an inline template, store it to avoid being parsed.
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!-- 
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project? 

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 

-->
