### PR TITLE
fix(docs): remove `workflow-controller-configmap.yaml` self reference

### DIFF
--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -1,6 +1,3 @@
-#######
-# NEW URL FOR THIS FILE: https://argo-workflows.readthedocs.io/en/latest/workflow-controller-configmap.yaml
-#######
 # This file describes the config settings available in the workflow controller configmap
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/pull/12446#discussion_r1482271109

### Motivation

<!-- TODO: Say why you made your changes. -->

- this was erroneously added to the `main` branch in https://github.com/argoproj/argo-workflows/pull/12446#discussion_r1482271109
  - it should only be on the `gh-pages` branch, for which all HTML pages redirect to ReadTheDocs now, but this YAML could not be, so we added this comment (see https://github.com/argoproj/argo-workflows/pull/12362#discussion_r1433271044)

- on the `main` branch, this is a confusing as it is a self-reference
  - https://argo-workflows.readthedocs.io/en/latest/workflow-controller-configmap.yaml currently points to itself in circular fashion

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove self-reference comment at the top of `docs/workflow-controller-configmap.yaml` on `main`

### Verification

n/a, as it's rendered raw in the docs

I double-checked that this was not present in the [`release-3.4`](https://github.com/argoproj/argo-workflows/blob/release-3.4/docs/workflow-controller-configmap.yaml#L1) and [`release-3.5`](https://github.com/argoproj/argo-workflows/blob/release-3.5/docs/workflow-controller-configmap.yaml#L1) docs, so no back-porting needed

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
