### PR TITLE
fix(controller): add missing namespace index from workflow informer

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -265,6 +265,7 @@ var indexers = cache.Indexers{
 	indexes.WorkflowPhaseIndex:           indexes.MetaWorkflowPhaseIndexFunc(),
 	indexes.ConditionsIndex:              indexes.ConditionsIndexFunc,
 	indexes.UIDIndex:                     indexes.MetaUIDFunc,
+	cache.NamespaceIndex:                 cache.MetaNamespaceIndexFunc,
 }
 
 // Run starts an Workflow resource controller


### PR DESCRIPTION
<!---
### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.
--->

Due to the namespace index missing from the workflow informer the healthz endpoint could not list namespace indexes. 

Leading to the following warning message: 
```
listers.go:79] can not retrieve list of objects using index : Index with name namespace does not exist
```
Everytime the healthz endpoint is called.

This fix has been verified in our environment by building the `workflow-controller` image from scratch and deploying it. 

Related Slack thread: https://cloud-native.slack.com/archives/C01QW9QSSSK/p1707918209805259

### Fixes

Fixes healthz endpoint not being able to list namespace indexes.

### Motivation

These changes are similar to what others have done to resolve the issue.

- https://github.com/prometheus-operator/prometheus-operator/pull/1697
- https://github.com/argoproj/argo-cd/pull/2761

### Modifications

Added the namespace index to the workflow informer.

### Verification

Deployed to our environment hit the healthz endpoint with `curl http://127.0.0.1:6060/healthz` and checked for the log message. It no longer appears.
