### PR TITLE
fix(ui): `ListWatch` should not _both_ set and depend on `nextOffset`

### DIFF
--- a/ui/src/app/shared/components/pagination-panel.tsx
+++ b/ui/src/app/shared/components/pagination-panel.tsx
@@ -39,7 +39,7 @@ export function PaginationPanel(props: {pagination: Pagination; onChange: (pagin
                         // we should not skip any by setting an offset.
                         // The offset must be initialized whenever the pagination limit is changed.
                         if (limit) {
-                            newValue.offset = '';
+                            newValue.offset = undefined;
                         }
 
                         props.onChange(newValue);

--- a/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/app/workflows/components/workflows-list/workflows-list.tsx
@@ -54,9 +54,9 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
 
     const [namespace, setNamespace] = useState(Utils.getNamespace(match.params.namespace) || '');
     const [pagination, setPagination] = useState<Pagination>(() => {
-        const savedPaginationLimit = storage.getItem('options', {}).paginationLimit || 0;
+        const savedPaginationLimit = storage.getItem('options', {}).paginationLimit || undefined;
         return {
-            offset: queryParams.get('name'),
+            offset: queryParams.get('offset') || undefined,
             limit: parseLimit(queryParams.get('limit')) || savedPaginationLimit || 50
         };
     });
@@ -155,7 +155,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
             clearSelectedWorkflows();
             listWatch.stop();
         };
-    }, [namespace, phases.toString(), labels.toString(), pagination.limit, pagination.offset, pagination.nextOffset]); // referential equality, so use values, not refs
+    }, [namespace, phases.toString(), labels.toString(), pagination.limit, pagination.offset]); // referential equality, so use values, not refs
 
     useCollectEvent('openedWorkflowList');
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12663, fixes #12626 (as well as https://github.com/argoproj/argo-workflows/issues/12025#issuecomment-1931011600 2.i, the one with the browser network tab screenshot)
Follow-up to #11891 

### Motivation

<!-- TODO: Say why you made your changes. -->

The `ListWatch` previously _both_ depended on and set `nextOffset`, which was recursive
- note that it technically _does_ depend on it since the `list` uses the whole `pagination` object, but `nextOffset` only changes within the effect or at the same time as another pagination
  - so it is safe to remove as a dep
- when pagination was enabled, this recursive dep/set would cause a duplicate request
  - in my repro, I only had one duplicate request, as after that `nextOffset` stayed consistent. would have two for each page move
    - for other folks in #12663 and #12626, this seemed to have caused an infinite loop, but I was not able to repro that specifically as `nextOffset` is constant after the duplicate
  - the quick succession of these duplicates also somehow made some of the SSEs impossible(???) to stop; even calling `listWatch.stop()` would not stop them
    - this would result in SSEs continuously growing until the browser connection limit was hit and then no new connections being allowed, halting all network activity
    - notably, I confirmed that the effect clean up and `listWatch.stop()` was occurring (through logs and other debugging), it just seemed to not close the SSE for some reason (???)
      - I have not been able to root cause that, but this fix makes that problem disappear for now at least
        - it might be an RxJS issue (notably there is some usage of deprecated functions) or a Server issue, or an SSE issue, not sure 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove `nextOffset` from the `ListWatch`'s `useEffect`'s deps array

- also fix a typo I had in the query param retrieval of `offset`
  - I had accidentally written the literal `name` instead of putting the actual name of the param, `offset`, woops 😕 

- plus consistently ensure that the pagination defaults are `undefined` everywhere, so that the `useEffect` deps do not change
  - removes more unnecessary network requests / compute / memory / etc
    - esp. with the quick succession of SSEs problem above, definitely want to limit this to only as much as is needed

### Verification

<!-- TODO: Say how you tested your changes. -->

<details> <summary> In my partial repro, the network waterfall looked like the below, with duplicate SSEs that were not always cancelled: </summary>

![Screenshot 2024-02-15 at 1 54 28 PM](https://github.com/argoproj/argo-workflows/assets/4970083/69cfe11b-55ee-4f84-ab6e-af36080b3763)

</details>

<details> <summary>After this fix, it now looked as intended, only one SSE at a time: </summary>

![Screenshot 2024-02-16 at 12 38 45 AM](https://github.com/argoproj/argo-workflows/assets/4970083/8952f731-e095-4273-80a2-dc5da871f537)

</details>


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
