### PR TITLE
docs: Add notes on issue assignment in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Bugs can be [sorted by "👍"](https://github.com/argoproj/argo-workflows/issues
 If the issue is determined to be a user error and not a bug, remove the `bug` label (and the `regression` label, if applicable) and replace it with the `support` label.
 If more information is needed from the author to diagnose the issue, then apply the `more information needed` label.
 
-Please only assign issues to regular contributors and maintainers.
+Please only assign issues to regular contributors and maintainers. New contributors are encouraged to work on a PR directly without being assigned.
 
 ##### Staleness
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -123,6 +123,8 @@ Bugs can be [sorted by "👍"](https://github.com/argoproj/argo-workflows/issues
 If the issue is determined to be a user error and not a bug, remove the `bug` label (and the `regression` label, if applicable) and replace it with the `support` label.
 If more information is needed from the author to diagnose the issue, then apply the `more information needed` label.
 
+Please only assign issues to regular contributors and maintainers.
+
 ##### Staleness
 
 Only issues and PRs that have the [`more information needed` label](https://github.com/argoproj/argo-workflows/labels/more%20information%20needed) will be considered for staleness.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Bugs can be [sorted by "👍"](https://github.com/argoproj/argo-workflows/issues
 If the issue is determined to be a user error and not a bug, remove the `bug` label (and the `regression` label, if applicable) and replace it with the `support` label.
 If more information is needed from the author to diagnose the issue, then apply the `more information needed` label.
 
-Please only assign issues to regular contributors and maintainers. New contributors are encouraged to work on a PR directly without being assigned.
+Please only assign issues to members. New contributors are encouraged to work on a PR directly without being assigned.
 
 ##### Staleness
 


### PR DESCRIPTION
There have been many cases where new contributors asked to get assigned but never worked on it and these issues were kept getting re-assigned. We should consider only assign issues to regular contributors and maintainers going forward. For new contributors, they can just work on a PR directly without being assigned.