### PR TITLE
fix: Add limit to number of Workflows in CronWorkflow history

### DIFF
--- a/ui/src/app/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-details.tsx
@@ -9,8 +9,6 @@ import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {openLinkWithKey} from '../shared/components/links';
 import {Loading} from '../shared/components/loading';
-import {Pagination, parseLimit} from '../shared/pagination';
-import {ScopedLocalStorage} from '../shared/scoped-local-storage';
 import {useCollectEvent} from '../shared/use-collect-event';
 import {ZeroState} from '../shared/components/zero-state';
 import {Context} from '../shared/context';
@@ -24,21 +22,12 @@ import {CronWorkflowEditor} from './cron-workflow-editor';
 import '../workflows/components/workflow-details/workflow-details.scss';
 import './cron-workflow-details.scss';
 
-const storage = new ScopedLocalStorage('ListOptions');
-
 export function CronWorkflowDetails({match, location, history}: RouteComponentProps<any>) {
     // boiler-plate
     const {navigation, notifications, popup} = useContext(Context);
     const queryParams = new URLSearchParams(location.search);
 
     const [namespace] = useState(match.params.namespace);
-    const [pagination] = useState<Pagination>(() => {
-        const savedPaginationLimit = storage.getItem('options', {}).paginationLimit || undefined;
-        return {
-            offset: queryParams.get('offset') || undefined,
-            limit: parseLimit(queryParams.get('limit')) || savedPaginationLimit || 50
-        };
-    });
     const [name] = useState(match.params.name);
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel'));
     const [tab, setTab] = useState(queryParams.get('tab'));
@@ -83,7 +72,7 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
 
     useEffect(() => {
         (async () => {
-            const workflowList = await services.workflows.list(namespace, null, [`${models.labels.cronWorkflow}=${name}`], pagination);
+            const workflowList = await services.workflows.list(namespace, null, [`${models.labels.cronWorkflow}=${name}`], {limit: 50});
             const workflowsInfo = await services.info.getInfo();
 
             setWorkflows(workflowList.items);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/12645

### Motivation

I want to avoid argo-server going OOM when there is a lot of execution history.

### Modifications

Limited the number of histories to 50.
![image](https://github.com/argoproj/argo-workflows/assets/4182311/3e845d7b-9785-49ef-9e81-9692fe557db1)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/4f5abf69-3a11-45b9-8d8f-d993310828a9)

### Verification

- [x] No completed cron workflows
- [x] Cron workflow with the number of cases exceeding the limit
- [x] Cron workflow under limit

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
