### PR TITLE
fix: find correct retry node when using `templateRef`. Fixes: #12633

### DIFF
--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -15,12 +15,23 @@ type RetryTweak = func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, pod *
 func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
 	boundaryID := nodes[nodeID].BoundaryID
 	boundaryNode := nodes[boundaryID]
-	templateName := boundaryNode.TemplateName
-	for _, node := range nodes {
-		if node.Type == wfv1.NodeTypeRetry && node.TemplateName == templateName {
-			return &node
+	if boundaryNode.TemplateName != "" {
+		templateName := boundaryNode.TemplateName
+		for _, node := range nodes {
+			if node.Type == wfv1.NodeTypeRetry && node.TemplateName == templateName {
+				return &node
+			}
 		}
 	}
+	if boundaryNode.TemplateRef != nil {
+		templateRef := boundaryNode.TemplateRef
+		for _, node := range nodes {
+			if node.Type == wfv1.NodeTypeRetry && node.TemplateRef != nil && node.TemplateRef.Name == templateRef.Name && node.TemplateRef.Template == templateRef.Template {
+				return &node
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/workflow/controller/retry_tweak_test.go
+++ b/workflow/controller/retry_tweak_test.go
@@ -59,6 +59,24 @@ func TestFindRetryNode(t *testing.T) {
 			Children:     []string{},
 			TemplateName: "tmpl2",
 		},
+		"E1": wfv1.NodeStatus{
+			ID:         "E1",
+			Type:       wfv1.NodeTypeRetry,
+			Phase:      wfv1.NodeRunning,
+			BoundaryID: "A1",
+			Children:   []string{},
+			TemplateRef: &wfv1.TemplateRef{
+				Name: "tmpl1",
+			},
+		},
+		"E2": wfv1.NodeStatus{
+			ID:           "E2",
+			Type:         wfv1.NodeTypePod,
+			Phase:        wfv1.NodeRunning,
+			BoundaryID:   "E1",
+			Children:     []string{},
+			TemplateName: "tmpl2",
+		},
 	}
 	t.Run("Expect to find retry node", func(t *testing.T) {
 		node := allNodes["B2"]
@@ -67,5 +85,9 @@ func TestFindRetryNode(t *testing.T) {
 	t.Run("Expect to get nil", func(t *testing.T) {
 		a := FindRetryNode(allNodes, "A1")
 		assert.Nil(t, a)
+	})
+	t.Run("Expect to find retry node has TemplateRef", func(t *testing.T) {
+		node := allNodes["E1"]
+		assert.Equal(t, FindRetryNode(allNodes, "E2"), &node)
 	})
 }

--- a/workflow/controller/retry_tweak_test.go
+++ b/workflow/controller/retry_tweak_test.go
@@ -66,7 +66,8 @@ func TestFindRetryNode(t *testing.T) {
 			BoundaryID: "A1",
 			Children:   []string{},
 			TemplateRef: &wfv1.TemplateRef{
-				Name: "tmpl1",
+				Name:     "tmpl1",
+				Template: "tmpl3",
 			},
 		},
 		"E2": wfv1.NodeStatus{


### PR DESCRIPTION
The root cause is pod have `retryStrategy`, the boundaryNode didn't have template (use `templateRef`), so when find retryNode,  probabilistically found others and cause `"failed to get a template"`.


Some info help review:
Failed workflow(find the wrong retry node):
![image](https://github.com/argoproj/argo-workflows/assets/72060326/d7cd09b2-766f-4b61-95e0-03d7cb901916)
Succeed worklfow:
![image](https://github.com/argoproj/argo-workflows/assets/72060326/7da2eb34-08e4-40ba-90a9-e9b1f32f216d)

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes: #12633

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
