### PR TITLE
fix: return correct error information when use ternary expression. Fixes: #12317

### DIFF
--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -160,7 +160,7 @@ func resolveExpression(expression string, env map[string]interface{}, allowUnres
 	// it allows for errors that are obviously
 	// not failed reference checks to also pass
 	if err != nil && !allowUnresolved {
-		return expression, fmt.Errorf("failed to evaluate expression: %w", err)
+		log.WithError(err).Debug("failed to evaluate expression: %w", err)
 	}
 	result, err := expr.Run(program, env)
 	if (err != nil || result == nil) && allowUnresolved {

--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -24,14 +24,14 @@ func expressionReplace(w io.Writer, expression string, env map[string]interface{
 	if isTernaryExpression(expression) {
 		splits := strings.SplitN(expression, "?", 2)
 		cond := splits[0]
-		result, err := runExpression(cond, env, allowUnresolved)
+		result, err := resolveExpression(cond, env, allowUnresolved)
 		if err != nil {
 			return w.Write([]byte(fmt.Sprintf("{{%s%s}}", kindExpression, expression)))
 		}
 		expression = fmt.Sprintf("%s?%s", result, splits[1])
 	}
 
-	result, err := runExpression(expression, env, allowUnresolved)
+	result, err := resolveExpression(expression, env, allowUnresolved)
 	if err != nil {
 		return w.Write([]byte(fmt.Sprintf("{{%s%s}}", kindExpression, expression)))
 	}
@@ -126,7 +126,7 @@ func isTernaryExpression(expression string) bool {
 	return false
 }
 
-func runExpression(expression string, env map[string]interface{}, allowUnresolved bool) (string, error) {
+func resolveExpression(expression string, env map[string]interface{}, allowUnresolved bool) (string, error) {
 	var unmarshalledExpression string
 	err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, expression)), &unmarshalledExpression)
 	if err != nil && allowUnresolved {

--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -174,5 +174,5 @@ func resolveExpression(expression string, env map[string]interface{}, allowUnres
 	if result == nil {
 		return expression, fmt.Errorf("failed to evaluate expression %q", expression)
 	}
-	return fmt.Sprintf("%s", result), nil
+	return fmt.Sprintf("%v", result), nil
 }

--- a/util/template/template.go
+++ b/util/template/template.go
@@ -2,8 +2,9 @@ package template
 
 import (
 	"bytes"
-	"github.com/valyala/fasttemplate"
 	"io"
+
+	"github.com/valyala/fasttemplate"
 
 	exprenv "github.com/argoproj/argo-workflows/v3/util/expr/env"
 )

--- a/util/template/template.go
+++ b/util/template/template.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"io"
+	"strings"
 
 	"github.com/valyala/fasttemplate"
 
@@ -37,6 +38,10 @@ func (t *impl) Replace(replaceMap map[string]string, allowUnresolved bool) (stri
 		switch kind {
 		case kindExpression:
 			env := exprenv.GetFuncMap(EnvMap(replaceMap))
+			if isTernaryExpression(expression) {
+				cond := strings.SplitN(expression, "?", 2)
+				expressionReplace(w, expression, env, allowUnresolved)
+			}
 			return expressionReplace(w, expression, env, allowUnresolved)
 		default:
 			return simpleReplace(w, tag, replaceMap, allowUnresolved)

--- a/util/template/template.go
+++ b/util/template/template.go
@@ -2,10 +2,8 @@ package template
 
 import (
 	"bytes"
-	"io"
-	"strings"
-
 	"github.com/valyala/fasttemplate"
+	"io"
 
 	exprenv "github.com/argoproj/argo-workflows/v3/util/expr/env"
 )
@@ -38,10 +36,6 @@ func (t *impl) Replace(replaceMap map[string]string, allowUnresolved bool) (stri
 		switch kind {
 		case kindExpression:
 			env := exprenv.GetFuncMap(EnvMap(replaceMap))
-			if isTernaryExpression(expression) {
-				cond := strings.SplitN(expression, "?", 2)
-				expressionReplace(w, expression, env, allowUnresolved)
-			}
 			return expressionReplace(w, expression, env, allowUnresolved)
 		default:
 			return simpleReplace(w, tag, replaceMap, allowUnresolved)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes: #12317 

### Motivation

<!-- TODO: Say why you made your changes. -->
Return correct error information to help customers locate the problem

### Modifications

<!-- TODO: Say what changes you made. -->
When parsing an expression, if an "interface conversion" error is encountered, return an error instead of ignoring it.
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
e2e tests
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
