### PR TITLE
fix: nodeAntiAffinity is not working as expected when boundaryID is empty. Fixes: #9193

### DIFF
--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -210,6 +210,11 @@ var (
 			return node.Type == wfv1.NodeTypePod && node.Phase == wfv1.NodeRunning
 		}), "to have running pod"
 	}
+	ToHaveFailedPod Condition = func(wf *wfv1.Workflow) (bool, string) {
+		return wf.Status.Nodes.Any(func(node wfv1.NodeStatus) bool {
+			return node.Type == wfv1.NodeTypePod && node.Phase == wfv1.NodeFailed
+		}), "to have failed pod"
+	}
 )
 
 // `ToBeDone` replaces `ToFinish` which also makes sure the workflow is both complete not pending archiving.

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -218,10 +218,17 @@ spec:
 		WaitForWorkflow(time.Second * 90).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowPhase("Failed"), status.Phase)
-			nodeStatus := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(0)")
-			nodeStatusRetry := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(1)")
-			assert.NotEqual(t, nodeStatus.HostNodeName, nodeStatusRetry.HostNodeName)
+			if status.Phase == wfv1.WorkflowFailed {
+				nodeStatus := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(0)")
+				nodeStatusRetry := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(1)")
+				assert.NotEqual(t, nodeStatus.HostNodeName, nodeStatusRetry.HostNodeName)
+			}
+			if status.Phase == wfv1.WorkflowRunning {
+				nodeStatus := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(0)")
+				nodeStatusRetry := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(1)")
+				assert.Contains(t, nodeStatusRetry.Message, "1 node(s) didn't match Pod's node affinity/selector")
+				assert.NotEqual(t, nodeStatus.HostNodeName, nodeStatusRetry.HostNodeName)
+			}
 		})
 }
 

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -215,7 +215,8 @@ spec:
 `).
 		When().
 		SubmitWorkflow().
-		WaitForWorkflow(time.Second * 30).
+		WaitForWorkflow(fixtures.ToHaveFailedPod).
+		Wait(5 * time.Second).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			if status.Phase == wfv1.WorkflowFailed {

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -194,6 +194,37 @@ spec:
 	})
 }
 
+func (s *RetryTestSuite) TestRetryNodeAntiAffinity() {
+	s.Given().
+		Workflow(`
+metadata:
+  name: test-nodeantiaffinity-strategy
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: '1'
+        retryPolicy: "Always"
+        affinity:
+          nodeAntiAffinity: {}
+      container:
+          name: main
+          image: 'argoproj/argosay:v2'
+          args: [ exit, "1" ]
+`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(time.Second * 90).
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowPhase("Failed"), status.Phase)
+			nodeStatus := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(0)")
+			nodeStatusRetry := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(1)")
+			assert.NotEqual(t, nodeStatus.HostNodeName, nodeStatusRetry.HostNodeName)
+		})
+}
+
 func TestRetrySuite(t *testing.T) {
 	suite.Run(t, new(RetryTestSuite))
 }

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -215,7 +215,7 @@ spec:
 `).
 		When().
 		SubmitWorkflow().
-		WaitForWorkflow(time.Second * 90).
+		WaitForWorkflow(time.Second * 30).
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			if status.Phase == wfv1.WorkflowFailed {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7575,6 +7575,112 @@ func TestRetryOnDiffHost(t *testing.T) {
 	assert.Equal(t, sourceNodeSelectorRequirement, targetNodeSelectorRequirement)
 }
 
+var nodeAntiAffinityWorkflow = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: retry-fail
+spec:
+  entrypoint: retry-fail
+  templates:
+  - name: retry-fail
+    retryStrategy:
+      limit: 2
+      retryPolicy: "Always"
+      affinity:
+        nodeAntiAffinity: {}
+    script:
+      image: python:alpine3.6
+      command: [python]
+      source: |
+        import random
+        import time
+        random.seed(time.time())
+        i = random.randint(1, 10)
+        print(i)
+        exit(i)
+`
+
+func TestRetryOnNodeAntiAffinity(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(nodeAntiAffinityWorkflow)
+	cancel, controller := newController(wf)
+	defer cancel()
+
+	ctx := context.Background()
+	woc := newWorkflowOperationCtx(wf, controller)
+	woc.operate(ctx)
+
+	pods, err := listPods(woc)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(pods.Items))
+
+	// First retry
+	pod := pods.Items[0]
+	pod.Spec.NodeName = "node0"
+	_, err = controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace()).Update(ctx, &pod, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	makePodsPhase(ctx, woc, apiv1.PodFailed)
+	woc.operate(ctx)
+
+	node := woc.wf.Status.Nodes.FindByDisplayName("retry-fail(0)")
+	if assert.NotNil(t, node) {
+		assert.Equal(t, wfv1.NodeFailed, node.Phase)
+		assert.Equal(t, "node0", node.HostNodeName)
+	}
+
+	pods, err = listPods(woc)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(pods.Items))
+
+	var podRetry1 apiv1.Pod
+	for _, p := range pods.Items {
+		if p.Name != pod.GetName() {
+			podRetry1 = p
+		}
+	}
+
+	hostSelector := "kubernetes.io/hostname"
+	targetNodeSelectorRequirement := podRetry1.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
+	sourceNodeSelectorRequirement := apiv1.NodeSelectorRequirement{
+		Key:      hostSelector,
+		Operator: apiv1.NodeSelectorOpNotIn,
+		Values:   []string{node.HostNodeName},
+	}
+	assert.Equal(t, sourceNodeSelectorRequirement, targetNodeSelectorRequirement)
+
+	// Second retry
+	podRetry1.Spec.NodeName = "node1"
+	_, err = controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace()).Update(ctx, &podRetry1, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	makePodsPhase(ctx, woc, apiv1.PodFailed)
+	woc.operate(ctx)
+
+	node1 := woc.wf.Status.Nodes.FindByDisplayName("retry-fail(1)")
+	if assert.NotNil(t, node) {
+		assert.Equal(t, wfv1.NodeFailed, node1.Phase)
+		assert.Equal(t, "node1", node1.HostNodeName)
+	}
+
+	pods, err = listPods(woc)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(pods.Items))
+
+	var podRetry2 apiv1.Pod
+	for _, p := range pods.Items {
+		if p.Name != pod.GetName() && p.Name != podRetry1.GetName() {
+			podRetry2 = p
+		}
+	}
+
+	targetNodeSelectorRequirement = podRetry2.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
+	sourceNodeSelectorRequirement = apiv1.NodeSelectorRequirement{
+		Key:      hostSelector,
+		Operator: apiv1.NodeSelectorOpNotIn,
+		Values:   []string{node1.HostNodeName, node.HostNodeName},
+	}
+	assert.Equal(t, sourceNodeSelectorRequirement, targetNodeSelectorRequirement)
+}
+
 var noPodsWhenShutdown = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7593,12 +7593,7 @@ spec:
       image: python:alpine3.6
       command: [python]
       source: |
-        import random
-        import time
-        random.seed(time.time())
-        i = random.randint(1, 10)
-        print(i)
-        exit(i)
+        exit(1)
 `
 
 func TestRetryOnNodeAntiAffinity(t *testing.T) {

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -17,13 +17,14 @@ func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
 	boundaryNode := nodes[boundaryID]
 	templateName := boundaryNode.TemplateName
 	for _, node := range nodes {
-		if boundaryID == "" && node.Type == wfv1.NodeTypeRetry && node.HasChild(nodeID) {
-			return &node
+		if node.Type != wfv1.NodeTypeRetry {
+			continue
 		}
-		if node.Type == wfv1.NodeTypeRetry && node.TemplateName == templateName {
+		if boundaryID == "" && node.HasChild(nodeID) {
 			return &node
-		}
-		if boundaryNode.TemplateRef != nil && node.Type == wfv1.NodeTypeRetry && node.TemplateRef != nil && node.TemplateRef.Name == boundaryNode.TemplateRef.Name && node.TemplateRef.Template == boundaryNode.TemplateRef.Template {
+		} else if node.TemplateName == templateName {
+			return &node
+		} else if boundaryNode.TemplateRef != nil && node.TemplateRef != nil && node.TemplateRef.Name == boundaryNode.TemplateRef.Name && node.TemplateRef.Template == boundaryNode.TemplateRef.Template {
 			return &node
 		}
 	}

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -22,7 +22,7 @@ func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
 		}
 		if boundaryID == "" && node.HasChild(nodeID) {
 			return &node
-		} else if node.TemplateName == templateName {
+		} else if boundaryNode.TemplateName != "" && node.TemplateName == templateName {
 			return &node
 		} else if boundaryNode.TemplateRef != nil && node.TemplateRef != nil && node.TemplateRef.Name == boundaryNode.TemplateRef.Name && node.TemplateRef.Template == boundaryNode.TemplateRef.Template {
 			return &node

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -14,6 +14,13 @@ type RetryTweak = func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, pod *
 // FindRetryNode locates the closes retry node ancestor to nodeID
 func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
 	boundaryID := nodes[nodeID].BoundaryID
+	if boundaryID == "" {
+		for _, node := range nodes {
+			if node.Type == wfv1.NodeTypeRetry && node.HasChild(nodeID) {
+				return &node
+			}
+		}
+	}
 	boundaryNode := nodes[boundaryID]
 	if boundaryNode.TemplateName != "" {
 		templateName := boundaryNode.TemplateName

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -15,14 +15,13 @@ type RetryTweak = func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, pod *
 func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
 	boundaryID := nodes[nodeID].BoundaryID
 	boundaryNode := nodes[boundaryID]
-	templateName := boundaryNode.TemplateName
 	for _, node := range nodes {
 		if node.Type != wfv1.NodeTypeRetry {
 			continue
 		}
 		if boundaryID == "" && node.HasChild(nodeID) {
 			return &node
-		} else if boundaryNode.TemplateName != "" && node.TemplateName == templateName {
+		} else if boundaryNode.TemplateName != "" && node.TemplateName == boundaryNode.TemplateName {
 			return &node
 		} else if boundaryNode.TemplateRef != nil && node.TemplateRef != nil && node.TemplateRef.Name == boundaryNode.TemplateRef.Name && node.TemplateRef.Template == boundaryNode.TemplateRef.Template {
 			return &node

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -14,31 +14,19 @@ type RetryTweak = func(retryStrategy wfv1.RetryStrategy, nodes wfv1.Nodes, pod *
 // FindRetryNode locates the closes retry node ancestor to nodeID
 func FindRetryNode(nodes wfv1.Nodes, nodeID string) *wfv1.NodeStatus {
 	boundaryID := nodes[nodeID].BoundaryID
-	if boundaryID == "" {
-		for _, node := range nodes {
-			if node.Type == wfv1.NodeTypeRetry && node.HasChild(nodeID) {
-				return &node
-			}
-		}
-	}
 	boundaryNode := nodes[boundaryID]
-	if boundaryNode.TemplateName != "" {
-		templateName := boundaryNode.TemplateName
-		for _, node := range nodes {
-			if node.Type == wfv1.NodeTypeRetry && node.TemplateName == templateName {
-				return &node
-			}
+	templateName := boundaryNode.TemplateName
+	for _, node := range nodes {
+		if boundaryID == "" && node.Type == wfv1.NodeTypeRetry && node.HasChild(nodeID) {
+			return &node
+		}
+		if node.Type == wfv1.NodeTypeRetry && node.TemplateName == templateName {
+			return &node
+		}
+		if boundaryNode.TemplateRef != nil && node.Type == wfv1.NodeTypeRetry && node.TemplateRef != nil && node.TemplateRef.Name == boundaryNode.TemplateRef.Name && node.TemplateRef.Template == boundaryNode.TemplateRef.Template {
+			return &node
 		}
 	}
-	if boundaryNode.TemplateRef != nil {
-		templateRef := boundaryNode.TemplateRef
-		for _, node := range nodes {
-			if node.Type == wfv1.NodeTypeRetry && node.TemplateRef != nil && node.TemplateRef.Name == templateRef.Name && node.TemplateRef.Template == templateRef.Template {
-				return &node
-			}
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #9193

### Motivation

<!-- TODO: Say why you made your changes. -->

The root cause is the workflow's boundaryID is empty. So did't find the retry node to fetch the HostNodeName. 
So I want to find the retry node and fetch the HostNodeName as the new pod‘s nodeAntiAffinity.

### Modifications

<!-- TODO: Say what changes you made. -->
Find the correct retrynode when boundaryID is empty.
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
e2e tests  and ut
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
