### PR TITLE
fix(hack): various fixes & improvements to cherry-pick script

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,10 +9,10 @@ to work well with our versioned website.
 Then get a list of commits you may want to cherry-pick:
 
 ```bash
-./hack/cherry-pick.sh release-3.3 "fix" true
-./hack/cherry-pick.sh release-3.3 "chore(deps)" true
-./hack/cherry-pick.sh release-3.3 "build" true
-./hack/cherry-pick.sh release-3.3 "ci" true
+./hack/cherry-pick.sh release-3.3 "fix"
+./hack/cherry-pick.sh release-3.3 "chore(deps)"
+./hack/cherry-pick.sh release-3.3 "build"
+./hack/cherry-pick.sh release-3.3 "ci"
 ```
 
 To automatically cherry-pick, run the following:

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -32,7 +32,7 @@ prs "$base" main
 diff "/tmp/$br" /tmp/main | grep "^> " | cut -c 3- > /tmp/prs
 
 # print all the commits that need cherry-picking
-git log --oneline --grep "${commitGrepPattern}" "$base...main" | while read -r m; do
+git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while read -r m; do
   if [[ "$dryRun" == "true" ]]; then
     grep -q "$(echo "$m" | prNo)" /tmp/prs && echo "$m"
   else

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -38,7 +38,7 @@ diff "/tmp/$branch" /tmp/main | grep "^> " | cut -c 3- > /tmp/prs
 
 # print all the commits that need cherry-picking
 git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while read -r m; do
-  if grep -q "$(echo "$m" | getPRNum)" /tmp/prs ; then
+  if grep -q -v "$(echo "$m" | getPRNum)" /tmp/prs ; then
     continue
   fi
 

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -49,7 +49,7 @@ git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while rea
 
   commit=${m:0:9}
   echo "cherry-picking: $commit"
-  if ! git cherry-pick "$commit" -x ; then
+  if ! git cherry-pick "$commit" -x -Xpatience ; then
     echo "failed to cherry-pick $commit"
     git cherry-pick --abort
   fi

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -33,10 +33,13 @@ diff "/tmp/$br" /tmp/main | grep "^> " | cut -c 3- > /tmp/prs
 
 # print all the commits that need cherry-picking
 git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while read -r m; do
+  if grep -q "$(echo "$m" | prNo)" /tmp/prs ; then
+    continue
+  fi
   if [[ "$dryRun" == "true" ]]; then
-    grep -q "$(echo "$m" | prNo)" /tmp/prs && echo "$m"
+    echo "$m"
   else
-    commit=$(grep -q "$(echo "$m" | prNo)" /tmp/prs && echo "${m:0:9}")
+    commit=${m:0:9}
     echo "cherry-picking: $commit"
     if ! git cherry-pick "$commit"; then
       echo "failed to cherry-pick $commit"

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -8,6 +8,13 @@ commitPrefix="$2" # prefix to use to filter commits, e.g. fix, chore(deps), buil
 # Otherwise, cherry-pick the commits to the specified branch.
 dryRun="${3:-"true"}"
 
+# unfortunately, cherry-picking to another branch is not possible, so error out if not on the branch (c.f. https://stackoverflow.com/q/13878904/3431180)
+curr_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$curr_branch" != "$branch" ]]; then
+  echo "Current branch is '$curr_branch', but trying to cherry-pick to branch '$branch'. You must have branch '$branch' checked out in order to cherry-pick"
+  exit 1
+fi
+
 commitGrepPattern="^${commitPrefix}(*.*)*:.*(#"
 
 # find the branch point

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -42,7 +42,7 @@ git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while rea
 
   commit=${m:0:9}
   echo "cherry-picking: $commit"
-  if ! git cherry-pick "$commit" ; then
+  if ! git cherry-pick "$commit -x" ; then
     echo "failed to cherry-pick $commit"
     git cherry-pick --abort
   fi

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -49,7 +49,7 @@ git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while rea
 
   commit=${m:0:9}
   echo "cherry-picking: $commit"
-  if ! git cherry-pick "$commit -x" ; then
+  if ! git cherry-pick "$commit" -x ; then
     echo "failed to cherry-pick $commit"
     git cherry-pick --abort
   fi

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eu
-# See docs/releasing.md for instructions.
+# See ../docs/releasing.md for instructions.
 
-br="$1" # branch name, e.g. release-3.3
+branch="$1" # branch name, e.g. release-3.3
 commitPrefix="$2" # prefix to use to filter commits, e.g. fix, chore(deps), build, ci
 # If dryRun is unset or `true`, only print the list of commits to be cherry-picked.
 # Otherwise, cherry-pick the commits to the specified branch.
@@ -11,39 +11,39 @@ dryRun="${3:-"true"}"
 commitGrepPattern="^${commitPrefix}(*.*)*:.*(#"
 
 # find the branch point
-base=$(git merge-base "$br" main)
+base=$(git merge-base "$branch" main)
 
 # extract the PRs from stdin
-prNo() {
-  set -eu
+getPRNum() {
   cat | sed "s|.*(\(#[0-9]*\))|\1|"
 }
 
 # list the PRs on each branch
-prs() {
-  set -eu
-  git log --format="%s" --grep "${commitGrepPattern}" "$1...$2" | prNo | sort > "/tmp/$2"
+getPRs() {
+  git log --format="%s" --grep "${commitGrepPattern}" "$1...$2" | getPRNum | sort > "/tmp/$2"
 }
 
-prs "$base" "$br"
-prs "$base" main
+getPRs "$base" "$branch"
+getPRs "$base" main
 
 # find PRs added to main
-diff "/tmp/$br" /tmp/main | grep "^> " | cut -c 3- > /tmp/prs
+diff "/tmp/$branch" /tmp/main | grep "^> " | cut -c 3- > /tmp/prs
 
 # print all the commits that need cherry-picking
 git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while read -r m; do
-  if grep -q "$(echo "$m" | prNo)" /tmp/prs ; then
+  if grep -q "$(echo "$m" | getPRNum)" /tmp/prs ; then
     continue
   fi
+
   if [[ "$dryRun" == "true" ]]; then
     echo "$m"
-  else
-    commit=${m:0:9}
-    echo "cherry-picking: $commit"
-    if ! git cherry-pick "$commit"; then
-      echo "failed to cherry-pick $commit"
-      git cherry-pick --abort
-    fi
+    continue
+  fi
+
+  commit=${m:0:9}
+  echo "cherry-picking: $commit"
+  if ! git cherry-pick "$commit" ; then
+    echo "failed to cherry-pick $commit"
+    git cherry-pick --abort
   fi
 done

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -38,7 +38,7 @@ diff "/tmp/$branch" /tmp/main | grep "^> " | cut -c 3- > /tmp/prs
 
 # print all the commits that need cherry-picking
 git log --oneline --grep "${commitGrepPattern}" "$base...main" | tac | while read -r m; do
-  if grep -q -v "$(echo "$m" | getPRNum)" /tmp/prs ; then
+  if ! grep -q "$(echo "$m" | getPRNum)" /tmp/prs ; then
     continue
   fi
 

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -4,9 +4,9 @@ set -eu
 
 br="$1" # branch name, e.g. release-3.3
 commitPrefix="$2" # prefix to use to filter commits, e.g. fix, chore(deps), build, ci
-# whether this is dry-run. If set to `true`, this script will only print out the list
-# of commits. Otherwise, this script will automatically cherry-pick the commits to the branch.
-dryRun="$3"
+# If dryRun is unset or `true`, only print the list of commits to be cherry-picked.
+# Otherwise, cherry-pick the commits to the specified branch.
+dryRun="${3:-"true"}"
 
 commitGrepPattern="^${commitPrefix}(*.*)*:.*(#"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

As Isitha and I now have Approver permissions and were working on the release rotation per #12592, we both used the script and both found some issues, one of which was mentioned in https://github.com/argoproj/argo-workflows/issues/11997#issuecomment-1970241749

Fix a few bugs in the script and make it more ergonomic

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

#### bugfixes

- error out when the current branch that is checked out is not equivalent to the branch we're doing a cherry-pick on, as you can't cherry-pick onto other branches (see also this [SO question](https://stackoverflow.com/q/13878904/3431180))
- correctly order the commits in reverse chronological order -- the commits should be cherry-picked in the same order they were added
  - add a simple `tac` (reverse `cat`) to achieve this
- like the dry-run, commits that aren't going to be cherry-picked should be skipped
  - previously this would error out with no error message, which was _very_ confusing

#### misc improvements

- enable dry-run by default, for safety and simplicity (the arg is now optional)
- add flags to [`git cherry-pick`](https://git-scm.com/docs/git-cherry-pick)
  - use [`-Xpatience`](https://git-scm.com/docs/git-cherry-pick#Documentation/git-cherry-pick.txt--Xltoptiongt) to run the slower [`patience` diff strategy](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-algorithmpatienceminimalhistogrammyers) for hopefully less merge conflicts
  - use [`-x`](https://git-scm.com/docs/git-cherry-pick#Documentation/git-cherry-pick.txt--x) to add "(cherry picked from commit ...)"
    - this flag is very useful for posterity for backports as it creates a backlink to the original commit

- <details> <summary> other improvements: </summary>
  
  - remove redundant `set -eu` -- this only needs to be set once in the script
  - rename variables and functions to be more explicit etc
    - e.g. use conventional `get*` functions
  - reduce nesting by removing the `else`

</details>

### Verification

Run `./hack/cherry-pick.sh release-3.5 fix` in a few variations
- on a different branch
- with and without dry run

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
