### PR TITLE
fix: Mark non-fulfilled taskSetNodes error when agent pod failed. Fixes #12703

### DIFF
--- a/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
@@ -103,3 +103,11 @@ rules:
     - create
     - get
     - delete
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+  resourceNames:
+    - argo-workflows-agent-ca-certificates

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -1268,6 +1268,14 @@ rules:
   - create
   - get
   - delete
+- apiGroups:
+  - ""
+  resourceNames:
+  - argo-workflows-agent-ca-certificates
+  resources:
+  - secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -1268,6 +1268,14 @@ rules:
   - create
   - get
   - delete
+- apiGroups:
+  - ""
+  resourceNames:
+  - argo-workflows-agent-ca-certificates
+  resources:
+  - secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -1268,6 +1268,14 @@ rules:
   - create
   - get
   - delete
+- apiGroups:
+  - ""
+  resourceNames:
+  - argo-workflows-agent-ca-certificates
+  resources:
+  - secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -40,21 +40,21 @@ func (woc *wfOperationCtx) reconcileAgentPod(ctx context.Context) error {
 	}
 	// Check Pod is just created
 	if pod.Status.Phase != "" {
-		woc.updateAgentPodStatus(ctx, pod)
+		woc.updateAgentPodStatus(pod)
 	}
 	return nil
 }
 
-func (woc *wfOperationCtx) updateAgentPodStatus(ctx context.Context, pod *apiv1.Pod) {
+func (woc *wfOperationCtx) updateAgentPodStatus(pod *apiv1.Pod) {
 	woc.log.Info("updateAgentPodStatus")
 	newPhase, message := assessAgentPodStatus(pod)
-	if newPhase == wfv1.WorkflowFailed || newPhase == wfv1.WorkflowError {
-		woc.markWorkflowError(ctx, fmt.Errorf("agent pod failed with reason %s", message))
+	if newPhase == wfv1.NodeFailed || newPhase == wfv1.NodeError {
+		woc.markTaskSetNodesError(fmt.Errorf(`agent pod failed with reason:"%s"`, message))
 	}
 }
 
-func assessAgentPodStatus(pod *apiv1.Pod) (wfv1.WorkflowPhase, string) {
-	var newPhase wfv1.WorkflowPhase
+func assessAgentPodStatus(pod *apiv1.Pod) (wfv1.NodePhase, string) {
+	var newPhase wfv1.NodePhase
 	var message string
 	log.WithField("namespace", pod.Namespace).
 		WithField("podName", pod.Name).
@@ -63,10 +63,10 @@ func assessAgentPodStatus(pod *apiv1.Pod) (wfv1.WorkflowPhase, string) {
 	case apiv1.PodSucceeded, apiv1.PodRunning, apiv1.PodPending:
 		return "", ""
 	case apiv1.PodFailed:
-		newPhase = wfv1.WorkflowFailed
+		newPhase = wfv1.NodeFailed
 		message = pod.Status.Message
 	default:
-		newPhase = wfv1.WorkflowError
+		newPhase = wfv1.NodeError
 		message = fmt.Sprintf("Unexpected pod phase for %s: %s", pod.ObjectMeta.Name, pod.Status.Phase)
 	}
 	return newPhase, message

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -252,7 +252,9 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	if err != nil {
 		log.WithError(err).Info("Failed to create Agent pod")
 		if apierr.IsAlreadyExists(err) {
-			return created, nil
+			if existing, err := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err == nil {
+				return existing, nil
+			}
 		}
 		return nil, errors.InternalWrapError(fmt.Errorf("failed to create Agent pod. Reason: %v", err))
 	}

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -252,6 +252,7 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	if err != nil {
 		log.WithError(err).Info("Failed to create Agent pod")
 		if apierr.IsAlreadyExists(err) {
+			// get a reference to the currently existing Pod since the created pod returned before was nil.
 			if existing, err := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err == nil {
 				return existing, nil
 			}

--- a/workflow/controller/agent_test.go
+++ b/workflow/controller/agent_test.go
@@ -147,7 +147,7 @@ func TestAssessAgentPodStatus(t *testing.T) {
 			Status: apiv1.PodStatus{Phase: apiv1.PodFailed},
 		}
 		nodeStatus, msg := assessAgentPodStatus(pod1)
-		assert.Equal(t, wfv1.WorkflowFailed, nodeStatus)
+		assert.Equal(t, wfv1.NodeFailed, nodeStatus)
 		assert.Equal(t, "", msg)
 	})
 	t.Run("Running", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestAssessAgentPodStatus(t *testing.T) {
 		}
 
 		nodeStatus, msg := assessAgentPodStatus(pod1)
-		assert.Equal(t, wfv1.WorkflowPhase(""), nodeStatus)
+		assert.Equal(t, wfv1.NodePhase(""), nodeStatus)
 		assert.Equal(t, "", msg)
 	})
 	t.Run("Success", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestAssessAgentPodStatus(t *testing.T) {
 			Status: apiv1.PodStatus{Phase: apiv1.PodSucceeded},
 		}
 		nodeStatus, msg := assessAgentPodStatus(pod1)
-		assert.Equal(t, wfv1.WorkflowPhase(""), nodeStatus)
+		assert.Equal(t, wfv1.NodePhase(""), nodeStatus)
 		assert.Equal(t, "", msg)
 	})
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1126,7 +1126,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) (error, bool) 
 			return
 		}
 		if woc.isAgentPod(pod) {
-			woc.updateAgentPodStatus(ctx, pod)
+			woc.updateAgentPodStatus(pod)
 			return
 		}
 		nodeID := woc.nodeID(pod)

--- a/workflow/controller/operator_agent_test.go
+++ b/workflow/controller/operator_agent_test.go
@@ -2,13 +2,14 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
-	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
 var httpwf = `apiVersion: argoproj.io/v1alpha1
@@ -22,61 +23,64 @@ spec:
     - name: http
       http:
         url: https://www.google.com/
-
-`
-
-var taskSet = `apiVersion: argoproj.io/v1alpha1
-kind: WorkflowTaskSet
-metadata:
-  creationTimestamp: "2021-04-23T21:49:05Z"
-  generation: 1
-  name: hello-world
-  namespace: default
-  ownerReferences:
-  - apiVersion: argoproj.io/v1alpha1
-    kind: Workflow
-    name: hello-world
-    uid: 0b451726-8ddd-4ba3-8d69-c3b5b43e93a3
-  resourceVersion: "11581184"
-  selfLink: /apis/argoproj.io/v1alpha1/namespaces/default/workflowtasksets/hello-world
-  uid: b80385b8-8b72-4f13-af6d-f429a2cad443
-spec:
-  tasks:
-    http-template-nxvtg-1265710817:
-      http:
-        url: http://www.google.com
-
-status:
-  nodes:
-    hello-world:
-      phase: Succeed
-      outputs:
-        parameters:
-        - name: test
-          value: "welcome"
 `
 
 func TestHTTPTemplate(t *testing.T) {
-	var ts v1alpha1.WorkflowTaskSet
-	err := yaml.UnmarshalStrict([]byte(taskSet), &ts)
-	wf := v1alpha1.MustUnmarshalWorkflow(httpwf)
-	cancel, controller := newController(wf, ts)
+	wf := wfv1.MustUnmarshalWorkflow(httpwf)
+	cancel, controller := newController(wf, defaultServiceAccount)
 	defer cancel()
 
-	assert.NoError(t, err)
 	t.Run("ExecuteHTTPTemplate", func(t *testing.T) {
 		ctx := context.Background()
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
-		pods, err := controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).List(ctx, metav1.ListOptions{})
+		pod, err := controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).Get(ctx, woc.getAgentPodName(), metav1.GetOptions{})
 		assert.NoError(t, err)
-		for _, pod := range pods.Items {
-			assert.Equal(t, pod.Name, "hello-world-1340600742-agent")
-		}
-		// tss, err :=controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets(wf.Namespace).List(ctx, metav1.ListOptions{})
+		assert.NotNil(t, pod)
 		ts, err := controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets(wf.Namespace).Get(ctx, "hello-world", metav1.GetOptions{})
 		assert.NoError(t, err)
 		assert.NotNil(t, ts)
 		assert.Len(t, ts.Spec.Tasks, 1)
+
+		// simulate agent pod failure scenario
+		pod.Status.Phase = v1.PodFailed
+		pod.Status.Message = "manual termination"
+		pod, err = controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+		assert.Nil(t, err)
+		assert.Equal(t, v1.PodFailed, pod.Status.Phase)
+		woc.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
+		assert.Equal(t, `agent pod failed with reason:"manual termination"`, woc.wf.Status.Message)
+		assert.Len(t, woc.wf.Status.Nodes, 1)
+		assert.Equal(t, wfv1.NodeError, woc.wf.Status.Nodes["hello-world"].Phase)
+		assert.Equal(t, `agent pod failed with reason:"manual termination"`, woc.wf.Status.Nodes["hello-world"].Message)
+		ts, err = controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets(wf.Namespace).Get(ctx, "hello-world", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, ts)
+		assert.Empty(t, ts.Spec.Tasks)
+		assert.Empty(t, ts.Status.Nodes)
+	})
+}
+
+func TestHTTPTemplateWithoutServiceAccount(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(httpwf)
+	cancel, controller := newController(wf)
+	defer cancel()
+
+	t.Run("ExecuteHTTPTemplateWithoutServiceAccount", func(t *testing.T) {
+		ctx := context.Background()
+		woc := newWorkflowOperationCtx(wf, controller)
+		woc.operate(ctx)
+		_, err := controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).Get(ctx, woc.getAgentPodName(), metav1.GetOptions{})
+		assert.Error(t, err, fmt.Sprintf(`pods "%s" not found`, woc.getAgentPodName()))
+		ts, err := controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets(wf.Namespace).Get(ctx, "hello-world", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, ts)
+		assert.Empty(t, ts.Spec.Tasks)
+		assert.Empty(t, ts.Status.Nodes)
+		assert.Len(t, woc.wf.Status.Nodes, 1)
+		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+		assert.Equal(t, wfv1.NodeError, woc.wf.Status.Nodes["hello-world"].Phase)
+		assert.Equal(t, `create agent pod failed with reason:"failed to get token volumes: serviceaccounts "default" not found"`, woc.wf.Status.Nodes["hello-world"].Message)
 	})
 }

--- a/workflow/controller/operator_agent_test.go
+++ b/workflow/controller/operator_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -48,6 +49,8 @@ func TestHTTPTemplate(t *testing.T) {
 		pod, err = controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, v1.PodFailed, pod.Status.Phase)
+		// sleep 1 second to wait for informer getting pod info
+		time.Sleep(time.Second)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
 		assert.Equal(t, `agent pod failed with reason:"manual termination"`, woc.wf.Status.Message)

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -34,7 +34,7 @@ func (woc *wfOperationCtx) mergePatchTaskSet(ctx context.Context, patch interfac
 func (woc *wfOperationCtx) getDeleteTaskAndNodePatch() (tasksPatch map[string]interface{}, nodesPatch map[string]interface{}) {
 	deletedNode := make(map[string]interface{})
 	for _, node := range woc.wf.Status.Nodes {
-		if (node.Type == wfv1.NodeTypeHTTP || node.Type == wfv1.NodeTypePlugin) && node.Fulfilled() {
+		if taskSetNode(node) && node.Fulfilled() {
 			deletedNode[node.ID] = nil
 		}
 	}
@@ -52,6 +52,15 @@ func (woc *wfOperationCtx) getDeleteTaskAndNodePatch() (tasksPatch map[string]in
 	}
 	return
 }
+
+func (woc *wfOperationCtx) markTaskSetNodesError(err error) {
+	for _, node := range woc.wf.Status.Nodes {
+		if taskSetNode(node) && !node.Fulfilled() {
+			woc.markNodeError(node.Name, err)
+		}
+	}
+}
+
 func taskSetNode(n wfv1.NodeStatus) bool {
 	return n.Type == wfv1.NodeTypeHTTP || n.Type == wfv1.NodeTypePlugin
 }
@@ -96,7 +105,7 @@ func (woc *wfOperationCtx) taskSetReconciliation(ctx context.Context) {
 	}
 	if err := woc.reconcileAgentPod(ctx); err != nil {
 		woc.log.WithError(err).Error("error in agent pod reconciliation")
-		woc.markWorkflowError(ctx, err)
+		woc.markTaskSetNodesError(fmt.Errorf(`create agent pod failed with reason:"%s"`, err))
 		return
 	}
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -524,6 +524,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			// workflow pod names are deterministic. We can get here if the
 			// controller fails to persist the workflow after creating the pod.
 			woc.log.Infof("Failed pod %s (%s) creation: already exists", nodeName, pod.Name)
+			// get a reference to the currently existing Pod since the created pod returned before was nil.
 			if existing, err = woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err == nil {
 				return existing, nil
 			}

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -524,7 +524,9 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			// workflow pod names are deterministic. We can get here if the
 			// controller fails to persist the workflow after creating the pod.
 			woc.log.Infof("Failed pod %s (%s) creation: already exists", nodeName, pod.Name)
-			return created, nil
+			if existing, err = woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err == nil {
+				return existing, nil
+			}
 		}
 		if errorsutil.IsTransientErr(err) {
 			return nil, err


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12703

### Motivation

<!-- TODO: Say why you made your changes. -->
1. Node status is non-fulfilled when agent pod failed.
2. `argo-cluster-role` can not get secrets `argo-workflows-agent-ca-certificates`

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
1. Mark non-fulfilled taskSetNodes error when agent pod failed.
2. add secrets `argo-workflows-agent-ca-certificates` get permission to `argo-cluster-role`

### Verification

<!-- TODO: Say how you tested your changes. -->
UT

Delete `hello-executor-plugin` serviceaccount to simulate agent pod failure scenario.
1. single step example
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: hello-
spec:
  entrypoint: main
  templates:
    - name: main
      plugin:
        hello: { }
```
```
# argo get hello-q8h7f
Name:                hello-q8h7f
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Error
Message:             create agent pod failed with reason:"serviceaccounts "hello-executor-plugin" not found"
Conditions:
 PodRunning          False
 Completed           True
Created:             Fri Mar 01 15:55:18 +0800 (53 seconds ago)
Started:             Fri Mar 01 15:55:18 +0800 (53 seconds ago)
Finished:            Fri Mar 01 15:55:19 +0800 (52 seconds ago)
Duration:            1 second
Progress:            0/1

STEP            TEMPLATE  PODNAME  DURATION  MESSAGE
 ⚠ hello-q8h7f  main                         create agent pod failed with reason:"serviceaccounts "hello-executor-plugin" not found"
```

2. parallel steps example
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: hello-
spec:
  entrypoint: main
  templates:
    - name: main
      steps:
      - - name: plugin
          template: hello-plugin
        - name: container
          template: hello-container
    - name: hello-plugin
      plugin:
        hello: {}
    - name: hello-container
      container:
        image: docker/whalesay:latest
        command: [sh, -c]
        args: ["echo hello"]
```
```
# argo get hello-dtkm9
Name:                hello-dtkm9
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Failed
Message:             child 'hello-dtkm9-3577871718' failed
Conditions:
 PodRunning          False
 Completed           True
Created:             Fri Mar 01 15:55:35 +0800 (28 seconds ago)
Started:             Fri Mar 01 15:55:35 +0800 (28 seconds ago)
Finished:            Fri Mar 01 15:55:45 +0800 (18 seconds ago)
Duration:            10 seconds
Progress:            1/2
ResourcesDuration:   0s*(1 cpu),4s*(100Mi memory)

STEP              TEMPLATE         PODNAME                                 DURATION  MESSAGE
 ✖ hello-dtkm9    main                                                               child 'hello-dtkm9-3577871718' failed
 └─┬─✔ container  hello-container  hello-dtkm9-hello-container-1541734788  7s
   └─⚠ plugin     hello-plugin                                                       create agent pod failed with reason:"serviceaccounts "hello-executor-plugin" not found"
```

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
