### PR TITLE
fix!: Only get executor plugins in workflow namespace. Fixes #12708

### DIFF
--- a/docs/executor_plugins.md
+++ b/docs/executor_plugins.md
@@ -204,12 +204,7 @@ You'll see the workflow complete successfully.
 
 ### Discovery
 
-When a workflow is run, plugins are loaded from:
-
-* The workflow's namespace.
-* The Argo installation namespace (typically `argo`).
-
-If two plugins have the same name, only the one in the workflow's namespace is loaded.
+When a workflow is run, plugins are only loaded from the workflow's namespace.
 
 ### Secrets
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12708

### Motivation

<!-- TODO: Say why you made your changes. -->
Controller plugins are loaded by default, so controller service account will be accessed if `AutomountServiceAccountToken` is true, which cause the bug in #12708 .

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
Only load plugins in user‘s workflow namespace.

### Verification

<!-- TODO: Say how you tested your changes. -->
local test

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
