### PR TITLE
docs(security): add Draft GHSA option

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,10 @@ If you find a security related bug in Argo Workflows, we kindly ask you for resp
 disclosure and for giving us appropriate time to react, analyze and develop a
 fix to mitigate the found security vulnerability.
 
-Please report vulnerabilities by e-mail to the following address:
+Please report vulnerabilities by:
 
-* cncf-argo-security@lists.cncf.io
+* Opening a draft GitHub Security Advisory: https://github.com/argoproj/argo-workflows/security/advisories/new
+* Sending an e-mail to the following address: cncf-argo-security@lists.cncf.io
 
 All vulnerabilities and associated information will be treated with full confidentiality.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12745

### Motivation

<!-- TODO: Say why you made your changes. -->

- for ease of use, built-in templates, crediting, single source of truth, etc
  - built-in private fork generation for resolution is another nice feature
- as well as consistency [with CD](https://github.com/argoproj/argo-cd/blob/a4b50515381bad9d6db316d49d33efae351c6222/SECURITY.md?plain=1#L68)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Add another reporting option to the `SECURITY.md` (we already have email), which is using draft GHSAs.

### Verification

See the [rendered markdown](https://github.com/argoproj/argo-workflows/blob/7ab7f2a2c4cfdbc39148cc72f6d129f60d6453f9/SECURITY.md) in this PR

### Notes to Reviewers

**Do not merge** until Draft GHSAs are enabled by an admin, i.e. until this link works: https://github.com/argoproj/argo-workflows/security/advisories/new

For clarity and explicitness, draft GHSAs are not equivalent to CVEs. If a draft GHSA is determined to be an active vuln (as opposed to false positive etc), then a CVE can be assigned. It is just another method of private disclosure, one that keeps things consistent and in the same place as public disclosures.

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
