### PR TITLE
fix(containerSet): mark container deleted when pod deleted. Fixes: #12210

### DIFF
--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -548,7 +548,7 @@ func makePodsPhase(ctx context.Context, woc *wfOperationCtx, phase apiv1.PodPhas
 func deletePods(ctx context.Context, woc *wfOperationCtx) {
 	for _, obj := range woc.controller.podInformer.GetStore().List() {
 		pod := obj.(*apiv1.Pod)
-		err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64Ptr(0)})
 		if err != nil {
 			panic(err)
 		}

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -548,7 +548,7 @@ func makePodsPhase(ctx context.Context, woc *wfOperationCtx, phase apiv1.PodPhas
 func deletePods(ctx context.Context, woc *wfOperationCtx) {
 	for _, obj := range woc.controller.podInformer.GetStore().List() {
 		pod := obj.(*apiv1.Pod)
-		err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64Ptr(0)})
+		err := woc.controller.kubeclientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 		if err != nil {
 			panic(err)
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1232,7 +1232,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) (error, bool) 
 					continue
 				}
 				if childNode.Type == wfv1.NodeTypeContainer {
-					woc.markNodeError(childNode.Name, errors.New("","container deleted"))
+					woc.markNodeError(childNode.Name, errors.New("", "container deleted"))
 				}
 			}
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1223,7 +1223,7 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) (error, bool) 
 				node.Daemoned = nil
 				woc.updated = true
 			}
-			woc.markNodePhase(node.Name, wfv1.NodeError, "pod deleted")
+			woc.markNodeError(node.Name, errors.New("", "pod deleted"))
 			// Set pod's child(container) error if pod deleted
 			for _, childNodeID := range node.Children {
 				childNode, err := woc.wf.Status.Nodes.Get(childNodeID)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10870,6 +10870,7 @@ func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 		}
 	}
 
+	// TODO: Enable use local variables in the test to avoid long wait. See https://github.com/argoproj/argo-workflows/pull/12756#discussion_r1530245007
 	// delete pod
 	time.Sleep(10 * time.Second)
 	deletePods(ctx, woc)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10803,3 +10803,91 @@ status:
 	woc.operate(ctx)
 	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
 }
+
+var wfHasContainerSet = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: lovely-rhino
+spec:
+  templates:
+    - name: init
+      dag:
+        tasks:
+          - name: A
+            template: run
+            arguments: {}
+    - name: run
+      containerSet:
+        containers:
+          - name: main
+            image: alpine:latest
+            command:
+              - /bin/sh
+            args:
+              - '-c'
+              - sleep 9000
+            resources: {}
+          - name: main2
+            image: alpine:latest
+            command:
+              - /bin/sh
+            args:
+              - '-c'
+              - sleep 9000
+            resources: {}
+  entrypoint: init
+  arguments: {}
+  ttlStrategy:
+    secondsAfterCompletion: 300
+  podGC:
+    strategy: OnPodCompletion`
+
+// TestContainerSetDoesNotStopContainerWhenPodRemoved test whether a workflow has ContainerSet error when pod removed.
+func TestContainerSetDoesNotStopContainerWhenPodRemoved(t *testing.T) {
+	_ = os.Setenv("RECENTLY_STARTED_POD_DURATION", "0")
+	cancel, controller := newController()
+	defer cancel()
+	ctx := context.Background()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+	wf := wfv1.MustUnmarshalWorkflow(wfHasContainerSet)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	assert.Nil(t, err)
+	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	assert.Nil(t, err)
+	woc := newWorkflowOperationCtx(wf, controller)
+	woc.operate(ctx)
+	pods, err := listPods(woc)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(pods.Items))
+
+	// mark pod Running
+	makePodsPhase(ctx, woc, apiv1.PodRunning)
+	woc = newWorkflowOperationCtx(woc.wf, controller)
+	woc.operate(ctx)
+	for _, node := range woc.wf.Status.Nodes {
+		if node.Type == wfv1.NodeTypePod {
+			assert.Equal(t, wfv1.NodeRunning, node.Phase)
+		}
+	}
+
+	// delete pod
+	deletePods(ctx, woc)
+	pods, err = listPods(woc)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(pods.Items))
+
+	// reconcile
+	woc = newWorkflowOperationCtx(woc.wf, controller)
+	woc.operate(ctx)
+	assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
+	for _, node := range woc.wf.Status.Nodes {
+		assert.Equal(t, wfv1.NodeError, node.Phase)
+		if node.Type == wfv1.NodeTypePod {
+			assert.Equal(t, "pod deleted", node.Message)
+		}
+		if node.Type == wfv1.NodeTypeContainer {
+			assert.Equal(t, "container deleted", node.Message)
+		}
+	}
+}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10843,8 +10843,8 @@ spec:
   podGC:
     strategy: OnPodCompletion`
 
-// TestContainerSetDoesNotStopContainerWhenPodRemoved test whether a workflow has ContainerSet error when pod removed.
-func TestContainerSetDoesNotStopContainerWhenPodRemoved(t *testing.T) {
+// TestContainerSetDeleteContainerWhenPodDeleted test whether a workflow has ContainerSet error when pod deleted.
+func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 	_ = os.Setenv("RECENTLY_STARTED_POD_DURATION", "0")
 	cancel, controller := newController()
 	defer cancel()
@@ -10890,4 +10890,5 @@ func TestContainerSetDoesNotStopContainerWhenPodRemoved(t *testing.T) {
 			assert.Equal(t, "container deleted", node.Message)
 		}
 	}
+	_ = os.Unsetenv("RECENTLY_STARTED_POD_DURATION")
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10845,7 +10845,6 @@ spec:
 
 // TestContainerSetDeleteContainerWhenPodDeleted test whether a workflow has ContainerSet error when pod deleted.
 func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
-	_ = os.Setenv("RECENTLY_STARTED_POD_DURATION", "0")
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
@@ -10872,6 +10871,7 @@ func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 	}
 
 	// delete pod
+	time.Sleep(1 * time.Second)
 	deletePods(ctx, woc)
 	pods, err = listPods(woc)
 	assert.Nil(t, err)
@@ -10890,5 +10890,4 @@ func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 			assert.Equal(t, "container deleted", node.Message)
 		}
 	}
-	_ = os.Unsetenv("RECENTLY_STARTED_POD_DURATION")
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10871,7 +10871,7 @@ func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 	}
 
 	// delete pod
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	deletePods(ctx, woc)
 	pods, err = listPods(woc)
 	assert.Nil(t, err)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10870,7 +10870,7 @@ func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 		}
 	}
 
-	// TODO: Enable use local variables in the test to avoid long wait. See https://github.com/argoproj/argo-workflows/pull/12756#discussion_r1530245007
+	// TODO: Refactor to use local-scoped env vars in test to avoid long wait. See https://github.com/argoproj/argo-workflows/pull/12756#discussion_r1530245007
 	// delete pod
 	time.Sleep(10 * time.Second)
 	deletePods(ctx, woc)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -10871,7 +10871,7 @@ func TestContainerSetDeleteContainerWhenPodDeleted(t *testing.T) {
 	}
 
 	// delete pod
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 	deletePods(ctx, woc)
 	pods, err = listPods(woc)
 	assert.Nil(t, err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12210 

### Motivation

Avoid incorrect judgment that dag running causes workflow hang. The fundamental reason is that when the pod is cleaned up, the container is not still displayed as running, which causes the dag to be judged as running in assessDAGPhase.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Set container node error instead of  running when pod was deleted.

### Verification

test local and e2e.

Before, pod delete but container running:
```yaml
    lovely-rhino-544408588:
      boundaryID: lovely-rhino
      children:
      - lovely-rhino-3630214831
      - lovely-rhino-1026744615
      displayName: A
      finishedAt: "2024-03-07T07:07:07Z"
      hostNodeName: kind-control-plane
      id: lovely-rhino-544408588
      message: pod deleted
      name: lovely-rhino.A
      outputs:
        artifacts:
        - name: main-logs
          s3:
            key: lovely-rhino/lovely-rhino-run-544408588/main.log
        - name: main2-logs
          s3:
            key: lovely-rhino/lovely-rhino-run-544408588/main2.log
      phase: Error
      progress: 0/1
      startedAt: "2024-03-07T07:06:34Z"
      templateName: run
      templateScope: local/lovely-rhino
      type: Pod
    lovely-rhino-1026744615:
      boundaryID: lovely-rhino-544408588
      displayName: main2
      finishedAt: null
      id: lovely-rhino-1026744615
      name: lovely-rhino.A.main2
      phase: Running
      progress: 0/1
      startedAt: "2024-03-07T07:06:34Z"
      templateName: run
      templateScope: local/lovely-rhino
      type: Container
    lovely-rhino-3630214831:
      boundaryID: lovely-rhino-544408588
      displayName: main
      finishedAt: null
      id: lovely-rhino-3630214831
      name: lovely-rhino.A.main
      phase: Running
      progress: 0/1
      startedAt: "2024-03-07T07:06:34Z"
      templateName: run
      templateScope: local/lovely-rhino
      type: Container
  phase: Running
```
After fix:
```yaml
      lovely-rhino-544408588:
        boundaryID: lovely-rhino
        children:
        - lovely-rhino-3630214831
        - lovely-rhino-1026744615
        displayName: A
        finishedAt: "2024-03-07T07:25:56Z"
        hostNodeName: kind-control-plane
        id: lovely-rhino-544408588
        message: pod deleted
        name: lovely-rhino.A
        outputs:
          artifacts:
          - name: main-logs
            s3:
              key: lovely-rhino/lovely-rhino-run-544408588/main.log
          - name: main2-logs
            s3:
              key: lovely-rhino/lovely-rhino-run-544408588/main2.log
        phase: Error
        progress: 0/1
        startedAt: "2024-03-07T07:25:32Z"
        templateName: run
        templateScope: local/lovely-rhino
        type: Pod
      lovely-rhino-1026744615:
        boundaryID: lovely-rhino-544408588
        displayName: main2
        finishedAt: "2024-03-07T07:25:56Z"
        id: lovely-rhino-1026744615
        message: container deleted
        name: lovely-rhino.A.main2
        phase: Error
        progress: 0/1
        startedAt: "2024-03-07T07:25:33Z"
        templateName: run
        templateScope: local/lovely-rhino
        type: Container
      lovely-rhino-3630214831:
        boundaryID: lovely-rhino-544408588
        displayName: main
        finishedAt: "2024-03-07T07:25:56Z"
        id: lovely-rhino-3630214831
        message: container deleted
        name: lovely-rhino.A.main
        phase: Error
        progress: 0/1
        startedAt: "2024-03-07T07:25:33Z"
        templateName: run
        templateScope: local/lovely-rhino
        type: Container
    phase: Error
```
<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
