### PR TITLE
fix: workflow stuck in running state when using activeDeadlineSeconds on template level. Fixes: #12329

### DIFF
--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -4,15 +4,19 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
 type WorkflowSuite struct {
@@ -82,6 +86,101 @@ spec:
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+		})
+}
+
+func (s *WorkflowSuite) TestWorkflowFailedWhenAllPodSetFailedFromPending() {
+	(s.Given().Workflow(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: active-deadline-fanout-template-level-
+  namespace: argo
+spec:
+  entrypoint: entrypoint
+  templates:
+  - name: entrypoint
+    steps:
+    - - name: fanout
+        template: echo
+        arguments:
+          parameters:
+            - name: item
+              value: "{{item}}"
+        withItems:
+          - 1
+          - 2
+          - 3
+          - 4
+  - name: echo
+    inputs:
+      parameters:
+        - name: item
+    container:
+      image: centos:latest
+      imagePullPolicy: Always
+      command:
+        - sh
+        - '-c'
+      args:
+        - echo
+        - 'workflow number {{inputs.parameters.item}}'
+        - sleep
+        - '20'
+    activeDeadlineSeconds: 2 # defined on template level, not workflow level !
+`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeFailed, time.Minute*11).
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
+			for _, node := range status.Nodes {
+				if node.Type == wfv1.NodeTypePod {
+					assert.Equal(t, wfv1.NodeFailed, node.Phase)
+					assert.Contains(t, node.Message, "Pod was active on the node longer than the specified deadline")
+				}
+			}
+		}).
+		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
+			return strings.Contains(status.Name, "fanout(0:1)")
+		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
+					assert.NotNil(t, c.State.Waiting)
+					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+				}
+			}
+		}).
+		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
+			return strings.Contains(status.Name, "fanout(1:2)")
+		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
+					assert.NotNil(t, c.State.Waiting)
+					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+				}
+			}
+		})).
+		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
+			return strings.Contains(status.Name, "fanout(2:3)")
+		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
+					assert.NotNil(t, c.State.Waiting)
+					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+				}
+			}
+		}).
+		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
+			return strings.Contains(status.Name, "fanout(3:4)")
+		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
+					assert.NotNil(t, c.State.Waiting)
+					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+				}
+			}
 		})
 }
 

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -149,6 +149,7 @@ spec:
 				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
 					assert.NotNil(t, c.State.Waiting)
 					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+					assert.Nil(t, c.State.Running)
 				}
 			}
 		}).
@@ -159,6 +160,7 @@ spec:
 				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
 					assert.NotNil(t, c.State.Waiting)
 					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+					assert.Nil(t, c.State.Running)
 				}
 			}
 		})).
@@ -169,6 +171,7 @@ spec:
 				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
 					assert.NotNil(t, c.State.Waiting)
 					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+					assert.Nil(t, c.State.Running)
 				}
 			}
 		}).
@@ -179,6 +182,7 @@ spec:
 				if c.Name == common.WaitContainerName && c.State.Terminated == nil {
 					assert.NotNil(t, c.State.Waiting)
 					assert.Contains(t, c.State.Waiting.Reason, "PodInitializing")
+					assert.Nil(t, c.State.Running)
 				}
 			}
 		})

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1447,7 +1447,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 	// We cannot fail the node until the wait container is finished (unless any init container has failed or wait contain is still Pending) because it may be busy saving outputs, and these
 	// would not get captured successfully.
 	for _, c := range pod.Status.ContainerStatuses {
-		if (c.Name == common.WaitContainerName && c.State.Terminated == nil && c.State.Waiting == nil && new.Phase.Completed()) && !initContainerFailed {
+		if (c.Name == common.WaitContainerName && c.State.Terminated == nil && c.State.Running != nil && new.Phase.Completed()) && !initContainerFailed {
 			woc.log.WithField("new.phase", new.Phase).Info("leaving phase un-changed: wait container is not yet terminated ")
 			new.Phase = old.Phase
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1441,7 +1441,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		}
 	}
 
-	// We cannot fail the node until the wait container is finished (unless wait contain is still Pending) because it may be busy saving outputs, and these
+	// We cannot fail the node if the wait container is still running because it may be busy saving outputs, and these
 	// would not get captured successfully.
 	for _, c := range pod.Status.ContainerStatuses {
 		if c.Name == common.WaitContainerName && c.State.Running != nil && new.Phase.Completed() {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1433,21 +1433,18 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		new.Outputs.ExitCode = pointer.StringPtr(fmt.Sprint(*exitCode))
 	}
 
-	// If the init container failed, we should mark the node as failed.
-	var initContainerFailed bool
 	for _, c := range pod.Status.InitContainerStatuses {
 		if c.State.Terminated != nil && int(c.State.Terminated.ExitCode) != 0 {
 			new.Phase = wfv1.NodeFailed
-			initContainerFailed = true
 			woc.log.WithField("new.phase", new.Phase).Info("marking node as failed since init container has non-zero exit code")
 			break
 		}
 	}
 
-	// We cannot fail the node until the wait container is finished (unless any init container has failed or wait contain is still Pending) because it may be busy saving outputs, and these
+	// We cannot fail the node until the wait container is finished (unless wait contain is still Pending) because it may be busy saving outputs, and these
 	// would not get captured successfully.
 	for _, c := range pod.Status.ContainerStatuses {
-		if (c.Name == common.WaitContainerName && c.State.Terminated == nil && c.State.Running != nil && new.Phase.Completed()) && !initContainerFailed {
+		if c.Name == common.WaitContainerName && c.State.Running != nil && new.Phase.Completed() {
 			woc.log.WithField("new.phase", new.Phase).Info("leaving phase un-changed: wait container is not yet terminated ")
 			new.Phase = old.Phase
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1444,7 +1444,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		}
 	}
 
-	// We cannot fail the node until the wait container is finished (unless any init container has failed or wait contain is not Pending) because it may be busy saving outputs, and these
+	// We cannot fail the node until the wait container is finished (unless any init container has failed or wait contain is still Pending) because it may be busy saving outputs, and these
 	// would not get captured successfully.
 	for _, c := range pod.Status.ContainerStatuses {
 		if (c.Name == common.WaitContainerName && c.State.Terminated == nil && c.State.Waiting == nil && new.Phase.Completed()) && !initContainerFailed {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1444,10 +1444,10 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		}
 	}
 
-	// We cannot fail the node until the wait container is finished (unless any init container has failed) because it may be busy saving outputs, and these
+	// We cannot fail the node until the wait container is finished (unless any init container has failed or wait contain is not Pending) because it may be busy saving outputs, and these
 	// would not get captured successfully.
 	for _, c := range pod.Status.ContainerStatuses {
-		if (c.Name == common.WaitContainerName && c.State.Terminated == nil && new.Phase.Completed()) && !initContainerFailed {
+		if (c.Name == common.WaitContainerName && c.State.Terminated == nil && c.State.Waiting == nil && new.Phase.Completed()) && !initContainerFailed {
 			woc.log.WithField("new.phase", new.Phase).Info("leaving phase un-changed: wait container is not yet terminated ")
 			new.Phase = old.Phase
 		}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1588,6 +1588,32 @@ func TestAssessNodeStatus(t *testing.T) {
 		node: &wfv1.NodeStatus{TemplateName: templateName},
 		want: wfv1.NodeFailed,
 	}, {
+		name: "pod failed - wait container waiting but pod was set failed",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				InitContainerStatuses: []apiv1.ContainerStatus{
+					{
+						Name:  common.InitContainerName,
+						State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}},
+					},
+				},
+				ContainerStatuses: []apiv1.ContainerStatus{
+					{
+						Name:  common.WaitContainerName,
+						State: apiv1.ContainerState{Terminated: nil, Waiting: &apiv1.ContainerStateWaiting{Reason: "PodInitializing"}},
+					},
+					{
+						Name:  common.MainContainerName,
+						State: apiv1.ContainerState{Terminated: nil},
+					},
+				},
+				Message: "failed since wait contain waiting",
+				Phase:   apiv1.PodFailed,
+			},
+		},
+		node: &wfv1.NodeStatus{TemplateName: templateName},
+		want: wfv1.NodeFailed,
+	}, {
 		name: "pod running",
 		pod: &apiv1.Pod{
 			Status: apiv1.PodStatus{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes: #12329   
Root cause is when pod set faied from pending, because wait container's Terminated is nil, So this node is reset to pending and causing workflow stuck.

### Motivation

<!-- TODO: Say why you made your changes. -->
Let workflow Failed when activeDeadlineSeconds exceed.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Set pod Failed when pod set Failed from Pending. (Let workflow failed)

### Verification

<!-- TODO: Say how you tested your changes. -->
Local test and add some unit test and e2e
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
