### PR TITLE
docs: full copy-edit of Quick Start

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,7 +25,7 @@ Scroll down to the `Controller and Server` section and execute the `kubectl` com
 
 Below is an example of the install commands (substitute `<<ARGO_WORKFLOWS_VERSION>>` with the version number):
 
-```yaml
+```bash
 kubectl create namespace argo
 kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v<<ARGO_WORKFLOWS_VERSION>>/quick-start-minimal.yaml
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,26 +1,29 @@
 # Quick Start
 
-To see how Argo Workflows work, you can install it and run examples of simple workflows.
+To try out Argo Workflows, you can install it and run example workflows.
 
-Before you start you need a Kubernetes cluster and `kubectl` set up to be able to access that cluster. For the purposes of getting up and running, a local cluster is fine. You could consider the following local Kubernetes cluster options:
+Alternatively, if you don't want to set up a Kubernetes cluster, try the [Killercoda course](training.md#hands-on).
+
+## Prerequisites
+
+Before installing Argo, you need a Kubernetes cluster and `kubectl` configured to access it.
+For quick testing, you can use a local cluster with:
 
 * [minikube](https://minikube.sigs.k8s.io/docs/)
 * [kind](https://kind.sigs.k8s.io/)
 * [k3s](https://k3s.io/) or [k3d](https://k3d.io/)
 * [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
-Alternatively, if you want to try out Argo Workflows and don't want to set up a Kubernetes cluster, try the [Killercoda course](training.md#hands-on).
-
 !!! Warning "Development vs. Production"
-    These instructions are intended to help you get started quickly. They are not suitable for production. For production installs, please refer to [the installation documentation](installation.md).
+    These instructions are intended to help you get started quickly. They are not suitable for production.
+    For production installs, please refer to [the installation documentation](installation.md).
 
 ## Install Argo Workflows
 
-To install Argo Workflows, navigate to the [releases page](https://github.com/argoproj/argo-workflows/releases/latest) and find the release you wish to use (the latest full release is preferred).
-
+To install Argo Workflows, go to the [releases page](https://github.com/argoproj/argo-workflows/releases/latest).
 Scroll down to the `Controller and Server` section and execute the `kubectl` commands.
 
-Below is an example of the install commands, ensure that you update the command to install the correct version number:
+Below is an example of the install commands (substitute `<<ARGO_WORKFLOWS_VERSION>>` with the version number):
 
 ```yaml
 kubectl create namespace argo
@@ -39,29 +42,29 @@ You can more easily interact with Argo Workflows with the [Argo CLI](walk-throug
 argo submit -n argo --watch https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/hello-world.yaml
 ```
 
-The `--watch` flag used above will allow you to observe the workflow as it runs and the status of whether it succeeds.
-When the workflow completes, the watch on the workflow will stop.
+The `--watch` flag watches the workflow as it runs and reports whether it succeeds or not.
+When the workflow completes, the watch stops.
 
-You can list all the Workflows you have submitted by running the command below:
+You can list all submitted Workflows by running the command below:
 
 ```bash
 argo list -n argo
 ```
 
-You will notice the Workflow name has a `hello-world-` prefix followed by random characters. These characters are used
-to give Workflows unique names to help identify specific runs of a Workflow. If you submitted this Workflow again,
-the next Workflow run would have a different name.
+The Workflow name has a `hello-world-` prefix followed by random characters.
+These characters give Workflows unique names to help identify specific runs of a Workflow.
+If you submit this Workflow again, the next run will have different characters.
 
-Using the `argo get` command, you can always review the details of a Workflow run. The output for the command below will
-be the same as the information shown when you submitted the Workflow:
+You can review the details of a Workflow run using the `argo get` command.
+The output for the command below will be the same as the information shown when you submitted the Workflow:
 
 ```bash
 argo get -n argo @latest
 ```
 
-The `@latest` argument to the CLI is a shortcut to view the latest Workflow run that was executed.
+The `@latest` argument is a shortcut to view the latest Workflow run.
 
-You can also observe the logs of the Workflow run by running the following:
+You can observe the logs of the Workflow run with the following command:
 
 ```bash
 argo logs -n argo @latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/12420#discussion_r1443803712

### Motivation

<!-- TODO: Say why you made your changes. -->

Significantly simplify the wording in the Quick Start and align it to the [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/)
- this doc was quite verbose and wordy prior to these changes, and for one of the first things a user sees, it should be especially simple (the k8s style guide requires that from all docs, but this one is of particular importance)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- small functional / usability changes:
  - move Killercoda course to the top, before running k8s, not after
  - split out the "Before you start" into a "Prerequisites" section
    - now the Killercoda course is a clear alternative to the prereqs as well

- with the functional changes above and from #12560, can now make some stylistic changes
  - <details> <summary> primarily, more simple and direct, per <a href="https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language">k8s style guide <a/> </summary>
  
    - "see how [...] Workflows work" -> "try out [...] Workflows"
    - "run examples of simple workflows" -> "run example workflows"
      - also avoid the word "simple", per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-words-that-assume-a-specific-level-of-understanding)
    - "set up to be able to access that cluster" -> "configured to access it"
    - "For the purposes of getting up and running" -> "For quick testing" (this is the _quick_ start, after all)
      - also avoid the word "fine"
    - "You could consider [...] options" -> "with"
    - "find the release [...] latest full release is preferred" -> just link to latest and that's all. this is the quick-start, no need to get into version nuances
    - "allows you to observe" -> "watches"
      - also use consistent terminology: `@latest` was described as "latest", but `--watch` was described with "observes". "watch" is a simpler word and more consistent
        - another simpler word - "navigate" -> "go"
    - "are used to give" -> "give"
    - "latest run that was executed" -> "latest run"
    </details>
    
  - prefer 1 sentence per line of markdown, per [style guide](https://argo-workflows.readthedocs.io/en/latest/doc-changes/)
  - use present tense, per [k8s sytle guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-present-tense)
    - also use consistent tense within sentences
  - <details> <summary> make some small clarifications: </summary>
  
    - "will have a different name" -> "will have different characters" -- the prefix stays the same from `generateName`
    - "ensure [...] correct version number" -> "substitute [...] with the version number"
    - "run by running" -> "run with [..] command"
  
  </details>


### Verification

See [rendered markdown](https://github.com/argoproj/argo-workflows/blob/519de757fbec9eef55cd2e81c5d031e293ac0ee0/docs/quick-start.md) in this PR

### Future Work

"Submit via the CLI" could potentially be made even simpler. I need to check how k8s docs list CLI examples as "the command below" gets quite repetitive and feels redundant. The style guide does not describe example preface

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
