### PR TITLE
chore(deps): upgrade `actions/cache` and `create-pull-request` to Node v20

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -26,7 +26,7 @@ jobs:
       - run: git tag -l 'v*'
       # avoid invoking `make` to reduce the risk of a Makefile bug failing this workflow
       - run: ./hack/changelog.sh > CHANGELOG.md
-      - uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+      - uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # v6.0.1
         with:
           title: 'docs: updated CHANGELOG.md'
           commit-message: 'docs: updated CHANGELOG.md'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           version: v0.10.4
 
       - name: Cache Docker layers
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         id: cache
         with:
           path: /tmp/.buildx-cache
@@ -292,7 +292,7 @@ jobs:
         with:
           go-version: "1.21"
       - name: Restore node packages cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: ui/node_modules
           key: ${{ runner.os }}-node-dep-v1-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

<details> <summary>Both of these were giving warnings in GH Actions runs during <a href="https://github.com/argoproj/argo-workflows/issues/11997#issuecomment-1972029716">the 3.5.5 release</a> </summary>

  - [`release.yaml` run](https://github.com/argoproj/argo-workflows/actions/runs/8102509236)
    - > Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
    - Screenshot for posterity: ![Screenshot 2024-03-09 at 3 30 43 AM](https://github.com/argoproj/argo-workflows/assets/4970083/2ac0a51c-5fc1-4edb-a826-c7d34adc1a5d)
    
  - [`changelog.yaml` run](https://github.com/argoproj/argo-workflows/actions/runs/8102509233)
    - > Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: peter-evans/create-pull-request@v5. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
    - Screenshot for posterity:  ![Screenshot 2024-03-09 at 3 31 26 AM](https://github.com/argoproj/argo-workflows/assets/4970083/10904ae9-35e8-4a5e-b5da-6cbb8a2cb7b9)


</details>

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- `actions/cache` [v4](https://github.com/actions/cache/releases/tag/v4.0.0) updated to Node 20
  - no other breaking changes
  - used latest [v4.0.1](https://github.com/actions/cache/releases/tag/v4.0.1) (v3.3.3 -> v4.0.1)

- `peter-evans/create-pull-request` [v6](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.0) updated to Node 20
  - other breaking changes do not affect our usage:
    - we don't use `push-to-fork`
    - the `author` and `committer` changes are to the automated bot and just make it more accurate
  - used latest [v6.0.1](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.1) (v5.0.2 -> v6.0.1)

### Verification

<!-- TODO: Say how you tested your changes. -->

This only runs during releases, so a bit hard to test 😕 

### Future Work

A few more actions need updating as well, but they have some blockers that need resolving:
1. `actions/upload-artifact` and `actions/download-artifact` blocked by intermittent failures: #12455 
1. `Azure/docker-login` has no update / seems unmaintained in general: https://github.com/Azure/docker-login/pull/64
    - should probably switch all these to `docker/login-action` which we already use in the very same file; they _should_ work on Windows too since actions are all Node-based

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
