### PR TITLE
fix(ui): show correct podGC message for deleteDelayDuration. Fixes: #12395

### DIFF
--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -299,7 +299,6 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
                     <>
                         <WarningIcon /> Your pod GC settings will delete pods and their logs {execSpec(workflow).podGC.deleteDelayDuration ? `after ${execSpec(workflow).podGC.deleteDelayDuration}` : "immediately"} on completion.
                     </>
-                )}
                 )}{' '}
                 Logs may not appear for pods that are deleted.{' '}
                 {podName ? (

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -297,7 +297,8 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
                 )}
                 {execSpec(workflow).podGC && (
                     <>
-                        <WarningIcon /> Your pod GC settings will delete pods and their logs {execSpec(workflow).podGC.deleteDelayDuration ? `after ${execSpec(workflow).podGC.deleteDelayDuration}` : "immediately"} on completion.
+                        <WarningIcon /> Your pod GC settings will delete pods and their logs{' '}
+                        {execSpec(workflow).podGC.deleteDelayDuration ? `after ${execSpec(workflow).podGC.deleteDelayDuration}` : 'immediately'} on completion.
                     </>
                 )}{' '}
                 Logs may not appear for pods that are deleted.{' '}

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -295,15 +295,11 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
                         <a href={services.workflows.getArtifactLogsPath(workflow, podNamesToNodeIDs.get(podName), selectedContainer, archived)}>logs from the artifacts</a>.
                     </>
                 )}
-                {execSpec(workflow).podGC && !execSpec(workflow).podGC.deleteDelayDuration && (
+                {execSpec(workflow).podGC && (
                     <>
-                        <WarningIcon /> Your pod GC settings will delete pods and their logs immediately on completion.
+                        <WarningIcon /> Your pod GC settings will delete pods and their logs {execSpec(workflow).podGC.deleteDelayDuration ? "after ${execSpec(workflow).podGC.deleteDelayDuration}" : "immediately"} on completion.
                     </>
                 )}
-                {execSpec(workflow).podGC && execSpec(workflow).podGC.deleteDelayDuration && (
-                    <>
-                        <WarningIcon /> Your pod GC settings will delete pods and their logs after {execSpec(workflow).podGC.deleteDelayDuration} on completion.
-                    </>
                 )}{' '}
                 Logs may not appear for pods that are deleted.{' '}
                 {podName ? (

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -295,9 +295,14 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
                         <a href={services.workflows.getArtifactLogsPath(workflow, podNamesToNodeIDs.get(podName), selectedContainer, archived)}>logs from the artifacts</a>.
                     </>
                 )}
-                {execSpec(workflow).podGC && (
+                {execSpec(workflow).podGC && !execSpec(workflow).podGC.deleteDelayDuration && (
                     <>
                         <WarningIcon /> Your pod GC settings will delete pods and their logs immediately on completion.
+                    </>
+                )}
+                {execSpec(workflow).podGC && execSpec(workflow).podGC.deleteDelayDuration && (
+                    <>
+                        <WarningIcon /> Your pod GC settings will delete pods and their logs after {execSpec(workflow).podGC.deleteDelayDuration} on completion.
                     </>
                 )}{' '}
                 Logs may not appear for pods that are deleted.{' '}

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -297,7 +297,7 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
                 )}
                 {execSpec(workflow).podGC && (
                     <>
-                        <WarningIcon /> Your pod GC settings will delete pods and their logs {execSpec(workflow).podGC.deleteDelayDuration ? "after ${execSpec(workflow).podGC.deleteDelayDuration}" : "immediately"} on completion.
+                        <WarningIcon /> Your pod GC settings will delete pods and their logs {execSpec(workflow).podGC.deleteDelayDuration ? `after ${execSpec(workflow).podGC.deleteDelayDuration}` : "immediately"} on completion.
                     </>
                 )}
                 )}{' '}

--- a/ui/src/models/workflows.ts
+++ b/ui/src/models/workflows.ts
@@ -825,6 +825,7 @@ export interface WorkflowSpec {
      */
     podGC?: {
         strategy?: string;
+        deleteDelayDuration?: string;
     };
     /**
      * SecurityContext holds pod-level security attributes and common container settings.


### PR DESCRIPTION
Fixes: #12395

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->
Show correct message on UI when podGC is enabled with deleteDelayDuration.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

Local test:
no deleteDelayDuration:
![image](https://github.com/argoproj/argo-workflows/assets/72060326/63f5ea26-32ba-4373-87ac-934ad6a282b1)
with deleteDelayDuration:
![image](https://github.com/argoproj/argo-workflows/assets/72060326/70752c8a-b15a-421b-8cc6-9410b1851f22)



<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
