### PR TITLE
fix: terminate workflow should not get throttled Fixes #12778

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -834,7 +834,7 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 
 	woc := newWorkflowOperationCtx(wf, wfc)
 
-	if !wfc.throttler.Admit(key.(string)) {
+	if !(woc.GetShutdownStrategy().Enabled() && woc.GetShutdownStrategy() == wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key.(string)) {
 		log.WithField("key", key).Info("Workflow processing has been postponed due to max parallelism limit")
 		if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
 			woc.markWorkflowPhase(ctx, wfv1.WorkflowPending, "Workflow processing has been postponed because too many workflows are already running")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12778 

### Motivation

<!-- TODO: Say why you made your changes. -->

To prevent cronworkflow from queueing up pending workflows when
- reached parallelism limit 
- concurrenpolicy-replace already update the spec of the pending workflow to `shutdown: terminated`

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Allow workflow in the queue to be processed (operated) regardless of parallelism limit.

We have scenarios
- reach parallelism limit, terminate running workflow (no issue)
- reach parallelism limit, terminate pending workflow (we should not block the queue from processing these workflow, just like semaphore doesn't block the queue from processing pending workflow that got terminated https://github.com/argoproj/argo-workflows/blob/5b3909b9567a5c6fc4fef81ac0785cfddbffb291/workflow/controller/operator.go#L528)

### Verification

<!-- TODO: Say how you tested your changes. -->

Add test,
test fail
Add code change
test succeed

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
