### PR TITLE
docs(cli): add `stdin` example for `argo submit`. Relates to #926

### DIFF
--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -51,6 +51,10 @@ func NewSubmitCommand() *cobra.Command {
 # Submit a single workflow from an existing resource
 
   argo submit --from cronwf/my-cron-wf
+
+# Submit multiple workflows from stdin:
+
+  cat my-wf.yaml | argo submit -
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			if cmd.Flag("priority").Changed {

--- a/docs/cli/argo_submit.md
+++ b/docs/cli/argo_submit.md
@@ -32,7 +32,7 @@ argo submit [FILE... | --from `kind/name] [flags]
 # Submit multiple workflows from stdin:
 
   cat my-wf.yaml | argo submit -
-  
+
 ```
 
 ### Options

--- a/docs/cli/argo_submit.md
+++ b/docs/cli/argo_submit.md
@@ -29,6 +29,10 @@ argo submit [FILE... | --from `kind/name] [flags]
 
   argo submit --from cronwf/my-cron-wf
 
+# Submit multiple workflows from stdin:
+
+  cat my-wf.yaml | argo submit -
+  
 ```
 
 ### Options


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Supplements #926

### Motivation

The initial implementation neglected to include an example in the documentation.

### Modifications

Adds a simple example to the https://argo-workflows.readthedocs.io/en/latest/cli/argo_submit/ docs

```
# Submit multiple workflows from stdin:

  cat my-wf.yaml | argo submit -
```

### Verification

N/A

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
