### PR TITLE
fix: Enable realtime metric gc after its workflow is completed. Fixes #12790

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1095,7 +1095,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 		DeleteFunc: func(obj interface{}) {
 			wf, ok := obj.(*unstructured.Unstructured)
 			if ok { // maybe cache.DeletedFinalStateUnknown
-				wfc.metrics.StopRealtimeMetricsForKey(string(wf.GetUID()))
+				wfc.metrics.DeleteRealtimeMetricsForKey(string(wf.GetUID()))
 			}
 		},
 	})

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -802,6 +802,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 
 	// Make sure the workflow completed.
 	if woc.wf.Status.Fulfilled() {
+		woc.controller.metrics.StopRealtimeMetricsForKey(string(woc.wf.GetUID()))
 		if err := woc.deleteTaskResults(ctx); err != nil {
 			woc.log.WithError(err).Warn("failed to delete task-results")
 		}

--- a/workflow/metrics/server.go
+++ b/workflow/metrics/server.go
@@ -139,7 +139,12 @@ func (m *Metrics) garbageCollector(ctx context.Context) {
 		case <-ticker.C:
 			for key, metric := range m.customMetrics {
 				if time.Since(metric.lastUpdated) > m.metricsConfig.TTL {
-					delete(m.customMetrics, key)
+					switch {
+					case metric.realtime && metric.completed:
+						delete(m.customMetrics, key)
+					case !metric.realtime:
+						delete(m.customMetrics, key)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #12790 

### Motivation

Realtime metrics may be cleaned up, even if the workflow is still running.

### Modifications

Adding two boolean value: `realtime` and `complete` in metric to indicate whether the metric is realtime type and whether it is completed.
Enable realtime metric gc only after its workflow is completed.

### Verification

local test and UT

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
