### PR TITLE
fix: make sure Finalizers has chance to be removed. Fixes: #12836

### DIFF
--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -347,6 +347,7 @@ func (w *When) WaitForWorkflowList(listOptions metav1.ListOptions, condition fun
 				return w
 			}
 		}
+		time.Sleep(time.Second)
 	}
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"math"
 	"os"
 	"reflect"
@@ -805,6 +806,10 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		if err := woc.deleteTaskResults(ctx); err != nil {
 			woc.log.WithError(err).Warn("failed to delete task-results")
 		}
+	}
+	// If FinalizerArtifactGC exists, requeue to make sure artifact GC can execute.
+	if woc.wf.Status.Fulfilled() && slices.Contains(wf.GetFinalizers(), common.FinalizerArtifactGC) {
+		woc.requeue()
 	}
 
 	// It is important that we *never* label pods as completed until we successfully updated the workflow

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -808,7 +808,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 	}
 	// If Finalizer exists, requeue to make sure Finalizer can be removed.
 	if woc.wf.Status.Fulfilled() && len(wf.GetFinalizers()) > 0 {
-		woc.requeue()
+		woc.requeueAfter(5 * time.Second)
 	}
 
 	// It is important that we *never* label pods as completed until we successfully updated the workflow

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"math"
 	"os"
 	"reflect"

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -807,7 +807,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		}
 	}
 	// If Finalizer exists, requeue to make sure Finalizer can be removed.
-	if len(wf.GetFinalizers()) > 0 {
+	if woc.wf.Status.Fulfilled() && len(wf.GetFinalizers()) > 0 {
 		woc.requeue()
 	}
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/exp/slices"
+
 	"math"
 	"os"
 	"reflect"
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/argoproj/argo-workflows/v3/util/secrets"
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/argoproj/argo-workflows/v3/util/secrets"
 
 	"github.com/argoproj/pkg/humanize"
@@ -808,8 +806,8 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 			woc.log.WithError(err).Warn("failed to delete task-results")
 		}
 	}
-	// If FinalizerArtifactGC exists, requeue to make sure artifact GC can execute.
-	if woc.wf.Status.Fulfilled() && slices.Contains(wf.GetFinalizers(), common.FinalizerArtifactGC) {
+	// If Finalizer exists, requeue to make sure Finalizer can be removed.
+	if len(wf.GetFinalizers()) > 0 {
 		woc.requeue()
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Fixes: #12836 

When the cluster pressure is high or execution is slow, `TestStoppedWorkflow` often fail. 
Because artifacts gc didn't execute.

It should be that after the last Failed, the controller has no chance to execute this workflow again.
<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
