### PR TITLE
fix: remove completed taskset status before update workflow. Fixes: #12832

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -747,7 +747,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		}
 	}
 
-	// Remove completed taskset status before mark worklfow completed.
+	// Remove completed taskset status before mark workflow completed.
 	err = woc.removeCompletedTaskSetStatus(ctx)
 	if err != nil {
 		woc.log.WithError(err).Warn("error updating taskset")

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -747,7 +747,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		}
 	}
 
-	// Remove completed taskset status before mark workflow completed.
+	// Remove completed taskset status before update workflow.
 	err = woc.removeCompletedTaskSetStatus(ctx)
 	if err != nil {
 		woc.log.WithError(err).Warn("error updating taskset")

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -747,6 +747,12 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		}
 	}
 
+	// Remove completed taskset status before mark worklfow completed.
+	err = woc.removeCompletedTaskSetStatus(ctx)
+	if err != nil {
+		woc.log.WithError(err).Warn("error updating taskset")
+	}
+
 	wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
 	if err != nil {
 		woc.log.Warnf("Error updating workflow: %v %s", err, apierr.ReasonForError(err))
@@ -792,12 +798,6 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		}
 	case "false":
 		time.Sleep(1 * time.Second)
-	}
-
-	err = woc.removeCompletedTaskSetStatus(ctx)
-
-	if err != nil {
-		woc.log.WithError(err).Warn("error updating taskset")
 	}
 
 	// Make sure the workflow completed.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

remove completed taskset status before update worklfow.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12832 

### Motivation

<!-- TODO: Say why you made your changes. -->
We should mark all tasksets complete before mark workflow completed.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
