### PR TITLE
refactor: use context from `processNextPodCleanupItem`

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -98,10 +98,10 @@ func ExecPodContainer(restConfig *rest.Config, namespace string, pod string, con
 }
 
 // GetExecutorOutput returns the output of an remotecommand.Executor
-func GetExecutorOutput(exec remotecommand.Executor) (*bytes.Buffer, *bytes.Buffer, error) {
+func GetExecutorOutput(ctx context.Context, exec remotecommand.Executor) (*bytes.Buffer, *bytes.Buffer, error) {
 	var stdOut bytes.Buffer
 	var stdErr bytes.Buffer
-	err := exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
+	err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: &stdOut,
 		Stderr: &stdErr,
 		Tty:    false,

--- a/workflow/signal/signal.go
+++ b/workflow/signal/signal.go
@@ -1,6 +1,7 @@
 package signal
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -14,7 +15,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
-func SignalContainer(restConfig *rest.Config, pod *corev1.Pod, container string, s syscall.Signal) error {
+func SignalContainer(ctx context.Context, restConfig *rest.Config, pod *corev1.Pod, container string, s syscall.Signal) error {
 	command := []string{"/bin/sh", "-c", "kill -%d 1"}
 
 	// If the container has the /var/run/argo volume mounted, this it will have access to `argoexec`.
@@ -40,15 +41,15 @@ func SignalContainer(restConfig *rest.Config, pod *corev1.Pod, container string,
 		}
 	}
 
-	return ExecPodContainerAndGetOutput(restConfig, pod.Namespace, pod.Name, container, command...)
+	return ExecPodContainerAndGetOutput(ctx, restConfig, pod.Namespace, pod.Name, container, command...)
 }
 
-func ExecPodContainerAndGetOutput(restConfig *rest.Config, namespace string, pod string, container string, command ...string) error {
+func ExecPodContainerAndGetOutput(ctx context.Context, restConfig *rest.Config, namespace string, pod string, container string, command ...string) error {
 	x, err := common.ExecPodContainer(restConfig, namespace, pod, container, true, true, command...)
 	if err != nil {
 		return err
 	}
-	stdout, stderr, err := common.GetExecutorOutput(x)
+	stdout, stderr, err := common.GetExecutorOutput(ctx, x)
 	log.
 		WithField("namespace", namespace).
 		WithField("pod", pod).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation

Addresses https://github.com/argoproj/argo-workflows/pull/12847#discussion_r1543760541

### Modifications

* Use the context from processNextPodCleanupItem in GetExecutorOutput

### Verification

Existing test coverage will be sufficient 

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
