### PR TITLE
feat: allow custom http client and use ctx for http1 apiclient. Fixes #12827

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -73,7 +73,7 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 		if opts.AuthSupplier == nil {
 			return nil, nil, fmt.Errorf("AuthSupplier cannot be empty when connecting to Argo Server")
 		}
-		return newHTTP1Client(opts.ArgoServerOpts.GetURL(), opts.AuthSupplier(), opts.ArgoServerOpts.InsecureSkipVerify, opts.ArgoServerOpts.Headers)
+		return newHTTP1Client(opts.ArgoServerOpts.GetURL(), opts.AuthSupplier(), opts.ArgoServerOpts.InsecureSkipVerify, opts.ArgoServerOpts.Headers, opts.ArgoServerOpts.HTTP1Client)
 	} else if opts.ArgoServerOpts.URL != "" {
 		if opts.AuthSupplier == nil {
 			return nil, nil, fmt.Errorf("AuthSupplier cannot be empty when connecting to Argo Server")

--- a/pkg/apiclient/argo-server-opts.go
+++ b/pkg/apiclient/argo-server-opts.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"fmt"
+	"net/http"
 )
 
 type ArgoServerOpts struct {
@@ -12,8 +13,10 @@ type ArgoServerOpts struct {
 	Secure             bool
 	InsecureSkipVerify bool
 	// whether or not to use HTTP1
-	HTTP1   bool
-	Headers []string
+	HTTP1 bool
+	// use custom http client
+	HTTP1Client *http.Client
+	Headers     []string
 }
 
 func (o ArgoServerOpts) GetURL() string {

--- a/pkg/apiclient/http1-client.go
+++ b/pkg/apiclient/http1-client.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
 	cronworkflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/cronworkflow"
@@ -40,6 +41,6 @@ func (h httpClient) NewInfoServiceClient() (infopkg.InfoServiceClient, error) {
 	return http1.InfoServiceClient(h), nil
 }
 
-func newHTTP1Client(baseUrl string, auth string, insecureSkipVerify bool, headers []string) (context.Context, Client, error) {
-	return context.Background(), httpClient(http1.NewFacade(baseUrl, auth, insecureSkipVerify, headers)), nil
+func newHTTP1Client(baseUrl string, auth string, insecureSkipVerify bool, headers []string, customHttpClient *http.Client) (context.Context, Client, error) {
+	return context.Background(), httpClient(http1.NewFacade(baseUrl, auth, insecureSkipVerify, headers, customHttpClient)), nil
 }

--- a/pkg/apiclient/http1/archived-workflows-service-client.go
+++ b/pkg/apiclient/http1/archived-workflows-service-client.go
@@ -12,47 +12,47 @@ import (
 
 type ArchivedWorkflowsServiceClient = Facade
 
-func (h ArchivedWorkflowsServiceClient) ListArchivedWorkflows(_ context.Context, in *workflowarchivepkg.ListArchivedWorkflowsRequest, _ ...grpc.CallOption) (*wfv1.WorkflowList, error) {
+func (h ArchivedWorkflowsServiceClient) ListArchivedWorkflows(ctx context.Context, in *workflowarchivepkg.ListArchivedWorkflowsRequest, _ ...grpc.CallOption) (*wfv1.WorkflowList, error) {
 	out := &wfv1.WorkflowList{}
-	return out, h.Get(in, out, "/api/v1/archived-workflows")
+	return out, h.Get(ctx, in, out, "/api/v1/archived-workflows")
 }
 
-func (h ArchivedWorkflowsServiceClient) GetArchivedWorkflow(_ context.Context, in *workflowarchivepkg.GetArchivedWorkflowRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h ArchivedWorkflowsServiceClient) GetArchivedWorkflow(ctx context.Context, in *workflowarchivepkg.GetArchivedWorkflowRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Get(in, out, "/api/v1/archived-workflows/{uid}")
+	return out, h.Get(ctx, in, out, "/api/v1/archived-workflows/{uid}")
 }
 
-func (h ArchivedWorkflowsServiceClient) DeleteArchivedWorkflow(_ context.Context, in *workflowarchivepkg.DeleteArchivedWorkflowRequest, _ ...grpc.CallOption) (*workflowarchivepkg.ArchivedWorkflowDeletedResponse, error) {
+func (h ArchivedWorkflowsServiceClient) DeleteArchivedWorkflow(ctx context.Context, in *workflowarchivepkg.DeleteArchivedWorkflowRequest, _ ...grpc.CallOption) (*workflowarchivepkg.ArchivedWorkflowDeletedResponse, error) {
 	out := &workflowarchivepkg.ArchivedWorkflowDeletedResponse{}
-	return out, h.Delete(in, out, "/api/v1/archived-workflows/{uid}")
+	return out, h.Delete(ctx, in, out, "/api/v1/archived-workflows/{uid}")
 }
 
-func (h ArchivedWorkflowsServiceClient) DeleteClusterWorkflowTemplate(_ context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateDeleteRequest, _ ...grpc.CallOption) (*clusterworkflowtemplate.ClusterWorkflowTemplateDeleteResponse, error) {
+func (h ArchivedWorkflowsServiceClient) DeleteClusterWorkflowTemplate(ctx context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateDeleteRequest, _ ...grpc.CallOption) (*clusterworkflowtemplate.ClusterWorkflowTemplateDeleteResponse, error) {
 	out := &clusterworkflowtemplate.ClusterWorkflowTemplateDeleteResponse{}
-	return out, h.Delete(in, out, "/api/v1/cluster-workflow-templates/{name}")
+	return out, h.Delete(ctx, in, out, "/api/v1/cluster-workflow-templates/{name}")
 }
 
-func (h ArchivedWorkflowsServiceClient) LintClusterWorkflowTemplate(_ context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateLintRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
+func (h ArchivedWorkflowsServiceClient) LintClusterWorkflowTemplate(ctx context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateLintRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
 	out := &wfv1.ClusterWorkflowTemplate{}
-	return out, h.Post(in, out, "/api/v1/cluster-workflow-templates/lint")
+	return out, h.Post(ctx, in, out, "/api/v1/cluster-workflow-templates/lint")
 }
 
-func (h ArchivedWorkflowsServiceClient) ListArchivedWorkflowLabelKeys(_ context.Context, in *workflowarchivepkg.ListArchivedWorkflowLabelKeysRequest, _ ...grpc.CallOption) (*wfv1.LabelKeys, error) {
+func (h ArchivedWorkflowsServiceClient) ListArchivedWorkflowLabelKeys(ctx context.Context, in *workflowarchivepkg.ListArchivedWorkflowLabelKeysRequest, _ ...grpc.CallOption) (*wfv1.LabelKeys, error) {
 	out := &wfv1.LabelKeys{}
-	return out, h.Get(in, out, "/api/v1/archived-workflows-label-keys")
+	return out, h.Get(ctx, in, out, "/api/v1/archived-workflows-label-keys")
 }
 
-func (h ArchivedWorkflowsServiceClient) ListArchivedWorkflowLabelValues(_ context.Context, in *workflowarchivepkg.ListArchivedWorkflowLabelValuesRequest, _ ...grpc.CallOption) (*wfv1.LabelValues, error) {
+func (h ArchivedWorkflowsServiceClient) ListArchivedWorkflowLabelValues(ctx context.Context, in *workflowarchivepkg.ListArchivedWorkflowLabelValuesRequest, _ ...grpc.CallOption) (*wfv1.LabelValues, error) {
 	out := &wfv1.LabelValues{}
-	return out, h.Get(in, out, "/api/v1/archived-workflows-label-values")
+	return out, h.Get(ctx, in, out, "/api/v1/archived-workflows-label-values")
 }
 
-func (h ArchivedWorkflowsServiceClient) RetryArchivedWorkflow(_ context.Context, in *workflowarchivepkg.RetryArchivedWorkflowRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h ArchivedWorkflowsServiceClient) RetryArchivedWorkflow(ctx context.Context, in *workflowarchivepkg.RetryArchivedWorkflowRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/archived-workflows/{uid}/retry")
+	return out, h.Put(ctx, in, out, "/api/v1/archived-workflows/{uid}/retry")
 }
 
-func (h ArchivedWorkflowsServiceClient) ResubmitArchivedWorkflow(_ context.Context, in *workflowarchivepkg.ResubmitArchivedWorkflowRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h ArchivedWorkflowsServiceClient) ResubmitArchivedWorkflow(ctx context.Context, in *workflowarchivepkg.ResubmitArchivedWorkflowRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/archived-workflows/{uid}/resubmit")
+	return out, h.Put(ctx, in, out, "/api/v1/archived-workflows/{uid}/resubmit")
 }

--- a/pkg/apiclient/http1/cluster-workflow-template-service-client.go
+++ b/pkg/apiclient/http1/cluster-workflow-template-service-client.go
@@ -11,22 +11,22 @@ import (
 
 type ClusterWorkflowTemplateServiceClient = Facade
 
-func (h ClusterWorkflowTemplateServiceClient) CreateClusterWorkflowTemplate(_ context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateCreateRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
+func (h ClusterWorkflowTemplateServiceClient) CreateClusterWorkflowTemplate(ctx context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateCreateRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
 	out := &wfv1.ClusterWorkflowTemplate{}
-	return out, h.Post(in, out, "/api/v1/cluster-workflow-templates")
+	return out, h.Post(ctx, in, out, "/api/v1/cluster-workflow-templates")
 }
 
-func (h ClusterWorkflowTemplateServiceClient) GetClusterWorkflowTemplate(_ context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateGetRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
+func (h ClusterWorkflowTemplateServiceClient) GetClusterWorkflowTemplate(ctx context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateGetRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
 	out := &wfv1.ClusterWorkflowTemplate{}
-	return out, h.Get(in, out, "/api/v1/cluster-workflow-templates/{name}")
+	return out, h.Get(ctx, in, out, "/api/v1/cluster-workflow-templates/{name}")
 }
 
-func (h ClusterWorkflowTemplateServiceClient) ListClusterWorkflowTemplates(_ context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateListRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplateList, error) {
+func (h ClusterWorkflowTemplateServiceClient) ListClusterWorkflowTemplates(ctx context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateListRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplateList, error) {
 	out := &wfv1.ClusterWorkflowTemplateList{}
-	return out, h.Get(in, out, "/api/v1/cluster-workflow-templates")
+	return out, h.Get(ctx, in, out, "/api/v1/cluster-workflow-templates")
 }
 
-func (h ClusterWorkflowTemplateServiceClient) UpdateClusterWorkflowTemplate(_ context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateUpdateRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
+func (h ClusterWorkflowTemplateServiceClient) UpdateClusterWorkflowTemplate(ctx context.Context, in *clusterworkflowtemplate.ClusterWorkflowTemplateUpdateRequest, _ ...grpc.CallOption) (*wfv1.ClusterWorkflowTemplate, error) {
 	out := &wfv1.ClusterWorkflowTemplate{}
-	return out, h.Put(in, out, "/api/v1/cluster-workflow-templates/{name}")
+	return out, h.Put(ctx, in, out, "/api/v1/cluster-workflow-templates/{name}")
 }

--- a/pkg/apiclient/http1/cron-workflow-service-client.go
+++ b/pkg/apiclient/http1/cron-workflow-service-client.go
@@ -11,42 +11,42 @@ import (
 
 type CronWorkflowServiceClient = Facade
 
-func (h CronWorkflowServiceClient) LintCronWorkflow(_ context.Context, in *cronworkflowpkg.LintCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
+func (h CronWorkflowServiceClient) LintCronWorkflow(ctx context.Context, in *cronworkflowpkg.LintCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
 	out := &wfv1.CronWorkflow{}
-	return out, h.Post(in, out, "/api/v1/cron-workflows/{namespace}/lint")
+	return out, h.Post(ctx, in, out, "/api/v1/cron-workflows/{namespace}/lint")
 }
 
-func (h CronWorkflowServiceClient) CreateCronWorkflow(_ context.Context, in *cronworkflowpkg.CreateCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
+func (h CronWorkflowServiceClient) CreateCronWorkflow(ctx context.Context, in *cronworkflowpkg.CreateCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
 	out := &wfv1.CronWorkflow{}
-	return out, h.Post(in, out, "/api/v1/cron-workflows/{namespace}")
+	return out, h.Post(ctx, in, out, "/api/v1/cron-workflows/{namespace}")
 }
 
-func (h CronWorkflowServiceClient) ListCronWorkflows(_ context.Context, in *cronworkflowpkg.ListCronWorkflowsRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflowList, error) {
+func (h CronWorkflowServiceClient) ListCronWorkflows(ctx context.Context, in *cronworkflowpkg.ListCronWorkflowsRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflowList, error) {
 	out := &wfv1.CronWorkflowList{}
-	return out, h.Get(in, out, "/api/v1/cron-workflows/{namespace}")
+	return out, h.Get(ctx, in, out, "/api/v1/cron-workflows/{namespace}")
 }
 
-func (h CronWorkflowServiceClient) GetCronWorkflow(_ context.Context, in *cronworkflowpkg.GetCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
+func (h CronWorkflowServiceClient) GetCronWorkflow(ctx context.Context, in *cronworkflowpkg.GetCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
 	out := &wfv1.CronWorkflow{}
-	return out, h.Get(in, out, "/api/v1/cron-workflows/{namespace}/{name}")
+	return out, h.Get(ctx, in, out, "/api/v1/cron-workflows/{namespace}/{name}")
 }
 
-func (h CronWorkflowServiceClient) UpdateCronWorkflow(_ context.Context, in *cronworkflowpkg.UpdateCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
+func (h CronWorkflowServiceClient) UpdateCronWorkflow(ctx context.Context, in *cronworkflowpkg.UpdateCronWorkflowRequest, _ ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
 	out := &wfv1.CronWorkflow{}
-	return out, h.Put(in, out, "/api/v1/cron-workflows/{namespace}/{name}")
+	return out, h.Put(ctx, in, out, "/api/v1/cron-workflows/{namespace}/{name}")
 }
 
 func (h Facade) ResumeCronWorkflow(ctx context.Context, in *cronworkflowpkg.CronWorkflowResumeRequest, opts ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
 	out := &wfv1.CronWorkflow{}
-	return out, h.Put(in, out, "/api/v1/cron-workflows/{namespace}/{name}/resume")
+	return out, h.Put(ctx, in, out, "/api/v1/cron-workflows/{namespace}/{name}/resume")
 }
 
 func (h Facade) SuspendCronWorkflow(ctx context.Context, in *cronworkflowpkg.CronWorkflowSuspendRequest, opts ...grpc.CallOption) (*wfv1.CronWorkflow, error) {
 	out := &wfv1.CronWorkflow{}
-	return out, h.Put(in, out, "/api/v1/cron-workflows/{namespace}/{name}/suspend")
+	return out, h.Put(ctx, in, out, "/api/v1/cron-workflows/{namespace}/{name}/suspend")
 }
 
-func (h CronWorkflowServiceClient) DeleteCronWorkflow(_ context.Context, in *cronworkflowpkg.DeleteCronWorkflowRequest, _ ...grpc.CallOption) (*cronworkflowpkg.CronWorkflowDeletedResponse, error) {
+func (h CronWorkflowServiceClient) DeleteCronWorkflow(ctx context.Context, in *cronworkflowpkg.DeleteCronWorkflowRequest, _ ...grpc.CallOption) (*cronworkflowpkg.CronWorkflowDeletedResponse, error) {
 	out := &cronworkflowpkg.CronWorkflowDeletedResponse{}
-	return out, h.Delete(in, out, "/api/v1/cron-workflows/{namespace}/{name}")
+	return out, h.Delete(ctx, in, out, "/api/v1/cron-workflows/{namespace}/{name}")
 }

--- a/pkg/apiclient/http1/facade.go
+++ b/pkg/apiclient/http1/facade.go
@@ -3,6 +3,7 @@ package http1
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -25,35 +26,36 @@ type Facade struct {
 	authorization      string
 	insecureSkipVerify bool
 	headers            []string
+	httpClient         *http.Client
 }
 
-func NewFacade(baseUrl, authorization string, insecureSkipVerify bool, headers []string) Facade {
-	return Facade{baseUrl, authorization, insecureSkipVerify, headers}
+func NewFacade(baseUrl, authorization string, insecureSkipVerify bool, headers []string, httpClient *http.Client) Facade {
+	return Facade{baseUrl, authorization, insecureSkipVerify, headers, httpClient}
 }
 
-func (h Facade) Get(in, out interface{}, path string) error {
-	return h.do(in, out, "GET", path)
+func (h Facade) Get(ctx context.Context, in, out interface{}, path string) error {
+	return h.do(ctx, in, out, "GET", path)
 }
 
-func (h Facade) Put(in, out interface{}, path string) error {
-	return h.do(in, out, "PUT", path)
+func (h Facade) Put(ctx context.Context, in, out interface{}, path string) error {
+	return h.do(ctx, in, out, "PUT", path)
 }
 
-func (h Facade) Post(in, out interface{}, path string) error {
-	return h.do(in, out, "POST", path)
+func (h Facade) Post(ctx context.Context, in, out interface{}, path string) error {
+	return h.do(ctx, in, out, "POST", path)
 }
 
-func (h Facade) Delete(in, out interface{}, path string) error {
-	return h.do(in, out, "DELETE", path)
+func (h Facade) Delete(ctx context.Context, in, out interface{}, path string) error {
+	return h.do(ctx, in, out, "DELETE", path)
 }
 
-func (h Facade) EventStreamReader(in interface{}, path string) (*bufio.Reader, error) {
+func (h Facade) EventStreamReader(ctx context.Context, in interface{}, path string) (*bufio.Reader, error) {
 	method := "GET"
 	u, err := h.url(method, path, in)
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -65,12 +67,15 @@ func (h Facade) EventStreamReader(in interface{}, path string) (*bufio.Reader, e
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Authorization", h.authorization)
 	log.Debugf("curl -H 'Accept: text/event-stream' -H 'Authorization: ******' '%v'", u)
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: h.insecureSkipVerify,
+	client := h.httpClient
+	if h.httpClient == nil {
+		client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: h.insecureSkipVerify,
+				},
 			},
-		},
+		}
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -84,7 +89,7 @@ func (h Facade) EventStreamReader(in interface{}, path string) (*bufio.Reader, e
 	return bufio.NewReader(resp.Body), nil
 }
 
-func (h Facade) do(in interface{}, out interface{}, method string, path string) error {
+func (h Facade) do(ctx context.Context, in interface{}, out interface{}, method string, path string) error {
 	var data []byte
 	if method != "GET" {
 		var err error
@@ -97,7 +102,7 @@ func (h Facade) do(in interface{}, out interface{}, method string, path string) 
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(method, u.String(), bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -108,13 +113,16 @@ func (h Facade) do(in interface{}, out interface{}, method string, path string) 
 	req.Header = headers
 	req.Header.Set("Authorization", h.authorization)
 	log.Debugf("curl -X %s -H 'Authorization: ******' -d '%s' '%v'", method, string(data), u)
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: h.insecureSkipVerify,
+	client := h.httpClient
+	if h.httpClient == nil {
+		client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: h.insecureSkipVerify,
+				},
+				DisableKeepAlives: true,
 			},
-			DisableKeepAlives: true,
-		},
+		}
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/apiclient/http1/info-service-client.go
+++ b/pkg/apiclient/http1/info-service-client.go
@@ -11,22 +11,22 @@ import (
 
 type InfoServiceClient = Facade
 
-func (h InfoServiceClient) GetInfo(_ context.Context, in *infopkg.GetInfoRequest, _ ...grpc.CallOption) (*infopkg.InfoResponse, error) {
+func (h InfoServiceClient) GetInfo(ctx context.Context, in *infopkg.GetInfoRequest, _ ...grpc.CallOption) (*infopkg.InfoResponse, error) {
 	out := &infopkg.InfoResponse{}
-	return out, h.Get(in, out, "/api/v1/info")
+	return out, h.Get(ctx, in, out, "/api/v1/info")
 }
 
-func (h InfoServiceClient) GetVersion(_ context.Context, in *infopkg.GetVersionRequest, _ ...grpc.CallOption) (*wfv1.Version, error) {
+func (h InfoServiceClient) GetVersion(ctx context.Context, in *infopkg.GetVersionRequest, _ ...grpc.CallOption) (*wfv1.Version, error) {
 	out := &wfv1.Version{}
-	return out, h.Get(in, out, "/api/v1/version")
+	return out, h.Get(ctx, in, out, "/api/v1/version")
 }
 
-func (h InfoServiceClient) GetUserInfo(_ context.Context, in *infopkg.GetUserInfoRequest, _ ...grpc.CallOption) (*infopkg.GetUserInfoResponse, error) {
+func (h InfoServiceClient) GetUserInfo(ctx context.Context, in *infopkg.GetUserInfoRequest, _ ...grpc.CallOption) (*infopkg.GetUserInfoResponse, error) {
 	out := &infopkg.GetUserInfoResponse{}
-	return out, h.Get(in, out, "/api/v1/userinfo")
+	return out, h.Get(ctx, in, out, "/api/v1/userinfo")
 }
 
-func (h InfoServiceClient) CollectEvent(_ context.Context, in *infopkg.CollectEventRequest, _ ...grpc.CallOption) (*infopkg.CollectEventResponse, error) {
+func (h InfoServiceClient) CollectEvent(ctx context.Context, in *infopkg.CollectEventRequest, _ ...grpc.CallOption) (*infopkg.CollectEventResponse, error) {
 	out := &infopkg.CollectEventResponse{}
-	return out, h.Post(in, out, "/api/v1/tracking/event")
+	return out, h.Post(ctx, in, out, "/api/v1/tracking/event")
 }

--- a/pkg/apiclient/http1/workflow-service-client.go
+++ b/pkg/apiclient/http1/workflow-service-client.go
@@ -11,23 +11,23 @@ import (
 
 type WorkflowServiceClient = Facade
 
-func (h WorkflowServiceClient) CreateWorkflow(_ context.Context, in *workflowpkg.WorkflowCreateRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) CreateWorkflow(ctx context.Context, in *workflowpkg.WorkflowCreateRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Post(in, out, "/api/v1/workflows/{namespace}")
+	return out, h.Post(ctx, in, out, "/api/v1/workflows/{namespace}")
 }
 
-func (h WorkflowServiceClient) GetWorkflow(_ context.Context, in *workflowpkg.WorkflowGetRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) GetWorkflow(ctx context.Context, in *workflowpkg.WorkflowGetRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Get(in, out, "/api/v1/workflows/{namespace}/{name}")
+	return out, h.Get(ctx, in, out, "/api/v1/workflows/{namespace}/{name}")
 }
 
-func (h WorkflowServiceClient) ListWorkflows(_ context.Context, in *workflowpkg.WorkflowListRequest, _ ...grpc.CallOption) (*wfv1.WorkflowList, error) {
+func (h WorkflowServiceClient) ListWorkflows(ctx context.Context, in *workflowpkg.WorkflowListRequest, _ ...grpc.CallOption) (*wfv1.WorkflowList, error) {
 	out := &wfv1.WorkflowList{}
-	return out, h.Get(in, out, "/api/v1/workflows/{namespace}")
+	return out, h.Get(ctx, in, out, "/api/v1/workflows/{namespace}")
 }
 
 func (h WorkflowServiceClient) WatchWorkflows(ctx context.Context, in *workflowpkg.WatchWorkflowsRequest, _ ...grpc.CallOption) (workflowpkg.WorkflowService_WatchWorkflowsClient, error) {
-	reader, err := h.EventStreamReader(in, "/api/v1/workflow-events/{namespace}")
+	reader, err := h.EventStreamReader(ctx, in, "/api/v1/workflow-events/{namespace}")
 	if err != nil {
 		return nil, err
 	}
@@ -35,60 +35,60 @@ func (h WorkflowServiceClient) WatchWorkflows(ctx context.Context, in *workflowp
 }
 
 func (h WorkflowServiceClient) WatchEvents(ctx context.Context, in *workflowpkg.WatchEventsRequest, _ ...grpc.CallOption) (workflowpkg.WorkflowService_WatchEventsClient, error) {
-	reader, err := h.EventStreamReader(in, "/api/v1/stream/events/{namespace}")
+	reader, err := h.EventStreamReader(ctx, in, "/api/v1/stream/events/{namespace}")
 	if err != nil {
 		return nil, err
 	}
 	return eventWatchClient{serverSentEventsClient{ctx, reader}}, nil
 }
 
-func (h WorkflowServiceClient) DeleteWorkflow(_ context.Context, in *workflowpkg.WorkflowDeleteRequest, _ ...grpc.CallOption) (*workflowpkg.WorkflowDeleteResponse, error) {
+func (h WorkflowServiceClient) DeleteWorkflow(ctx context.Context, in *workflowpkg.WorkflowDeleteRequest, _ ...grpc.CallOption) (*workflowpkg.WorkflowDeleteResponse, error) {
 	out := &workflowpkg.WorkflowDeleteResponse{}
-	return out, h.Delete(in, out, "/api/v1/workflows/{namespace}/{name}")
+	return out, h.Delete(ctx, in, out, "/api/v1/workflows/{namespace}/{name}")
 }
 
-func (h WorkflowServiceClient) RetryWorkflow(_ context.Context, in *workflowpkg.WorkflowRetryRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) RetryWorkflow(ctx context.Context, in *workflowpkg.WorkflowRetryRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/retry")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/retry")
 }
 
-func (h WorkflowServiceClient) ResubmitWorkflow(_ context.Context, in *workflowpkg.WorkflowResubmitRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) ResubmitWorkflow(ctx context.Context, in *workflowpkg.WorkflowResubmitRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/resubmit")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/resubmit")
 }
 
-func (h WorkflowServiceClient) ResumeWorkflow(_ context.Context, in *workflowpkg.WorkflowResumeRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) ResumeWorkflow(ctx context.Context, in *workflowpkg.WorkflowResumeRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/resume")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/resume")
 }
 
-func (h WorkflowServiceClient) SuspendWorkflow(_ context.Context, in *workflowpkg.WorkflowSuspendRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) SuspendWorkflow(ctx context.Context, in *workflowpkg.WorkflowSuspendRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/suspend")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/suspend")
 }
 
-func (h WorkflowServiceClient) TerminateWorkflow(_ context.Context, in *workflowpkg.WorkflowTerminateRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) TerminateWorkflow(ctx context.Context, in *workflowpkg.WorkflowTerminateRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/terminate")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/terminate")
 }
 
-func (h WorkflowServiceClient) StopWorkflow(_ context.Context, in *workflowpkg.WorkflowStopRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) StopWorkflow(ctx context.Context, in *workflowpkg.WorkflowStopRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/stop")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/stop")
 }
 
-func (h WorkflowServiceClient) SetWorkflow(_ context.Context, in *workflowpkg.WorkflowSetRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) SetWorkflow(ctx context.Context, in *workflowpkg.WorkflowSetRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Put(in, out, "/api/v1/workflows/{namespace}/{name}/set")
+	return out, h.Put(ctx, in, out, "/api/v1/workflows/{namespace}/{name}/set")
 }
 
-func (h WorkflowServiceClient) LintWorkflow(_ context.Context, in *workflowpkg.WorkflowLintRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) LintWorkflow(ctx context.Context, in *workflowpkg.WorkflowLintRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Post(in, out, "/api/v1/workflows/{namespace}/lint")
+	return out, h.Post(ctx, in, out, "/api/v1/workflows/{namespace}/lint")
 }
 
 func (h WorkflowServiceClient) PodLogs(ctx context.Context, in *workflowpkg.WorkflowLogRequest, _ ...grpc.CallOption) (workflowpkg.WorkflowService_PodLogsClient, error) {
-	reader, err := h.EventStreamReader(in, "/api/v1/workflows/{namespace}/{name}/{podName}/log")
+	reader, err := h.EventStreamReader(ctx, in, "/api/v1/workflows/{namespace}/{name}/{podName}/log")
 	if err != nil {
 		return nil, err
 	}
@@ -96,14 +96,14 @@ func (h WorkflowServiceClient) PodLogs(ctx context.Context, in *workflowpkg.Work
 }
 
 func (h WorkflowServiceClient) WorkflowLogs(ctx context.Context, in *workflowpkg.WorkflowLogRequest, _ ...grpc.CallOption) (workflowpkg.WorkflowService_WorkflowLogsClient, error) {
-	reader, err := h.EventStreamReader(in, "/api/v1/workflows/{namespace}/{name}/log")
+	reader, err := h.EventStreamReader(ctx, in, "/api/v1/workflows/{namespace}/{name}/log")
 	if err != nil {
 		return nil, err
 	}
 	return &podLogsClient{serverSentEventsClient{ctx, reader}}, nil
 }
 
-func (h WorkflowServiceClient) SubmitWorkflow(_ context.Context, in *workflowpkg.WorkflowSubmitRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
+func (h WorkflowServiceClient) SubmitWorkflow(ctx context.Context, in *workflowpkg.WorkflowSubmitRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
 	out := &wfv1.Workflow{}
-	return out, h.Post(in, out, "/api/v1/workflows/{namespace}/submit")
+	return out, h.Post(ctx, in, out, "/api/v1/workflows/{namespace}/submit")
 }

--- a/pkg/apiclient/http1/workflow-template-service-client.go
+++ b/pkg/apiclient/http1/workflow-template-service-client.go
@@ -11,32 +11,32 @@ import (
 
 type WorkflowTemplateServiceClient = Facade
 
-func (h WorkflowTemplateServiceClient) CreateWorkflowTemplate(_ context.Context, in *workflowtemplatepkg.WorkflowTemplateCreateRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
+func (h WorkflowTemplateServiceClient) CreateWorkflowTemplate(ctx context.Context, in *workflowtemplatepkg.WorkflowTemplateCreateRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
 	out := &wfv1.WorkflowTemplate{}
-	return out, h.Post(in, out, "/api/v1/workflow-templates/{namespace}")
+	return out, h.Post(ctx, in, out, "/api/v1/workflow-templates/{namespace}")
 }
 
-func (h WorkflowTemplateServiceClient) GetWorkflowTemplate(_ context.Context, in *workflowtemplatepkg.WorkflowTemplateGetRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
+func (h WorkflowTemplateServiceClient) GetWorkflowTemplate(ctx context.Context, in *workflowtemplatepkg.WorkflowTemplateGetRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
 	out := &wfv1.WorkflowTemplate{}
-	return out, h.Get(in, out, "/api/v1/workflow-templates/{namespace}/{name}")
+	return out, h.Get(ctx, in, out, "/api/v1/workflow-templates/{namespace}/{name}")
 }
 
-func (h WorkflowTemplateServiceClient) ListWorkflowTemplates(_ context.Context, in *workflowtemplatepkg.WorkflowTemplateListRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplateList, error) {
+func (h WorkflowTemplateServiceClient) ListWorkflowTemplates(ctx context.Context, in *workflowtemplatepkg.WorkflowTemplateListRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplateList, error) {
 	out := &wfv1.WorkflowTemplateList{}
-	return out, h.Get(in, out, "/api/v1/workflow-templates/{namespace}")
+	return out, h.Get(ctx, in, out, "/api/v1/workflow-templates/{namespace}")
 }
 
-func (h WorkflowTemplateServiceClient) UpdateWorkflowTemplate(_ context.Context, in *workflowtemplatepkg.WorkflowTemplateUpdateRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
+func (h WorkflowTemplateServiceClient) UpdateWorkflowTemplate(ctx context.Context, in *workflowtemplatepkg.WorkflowTemplateUpdateRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
 	out := &wfv1.WorkflowTemplate{}
-	return out, h.Put(in, out, "/api/v1/workflow-templates/{namespace}/{name}")
+	return out, h.Put(ctx, in, out, "/api/v1/workflow-templates/{namespace}/{name}")
 }
 
-func (h WorkflowTemplateServiceClient) DeleteWorkflowTemplate(_ context.Context, in *workflowtemplatepkg.WorkflowTemplateDeleteRequest, _ ...grpc.CallOption) (*workflowtemplatepkg.WorkflowTemplateDeleteResponse, error) {
+func (h WorkflowTemplateServiceClient) DeleteWorkflowTemplate(ctx context.Context, in *workflowtemplatepkg.WorkflowTemplateDeleteRequest, _ ...grpc.CallOption) (*workflowtemplatepkg.WorkflowTemplateDeleteResponse, error) {
 	out := &workflowtemplatepkg.WorkflowTemplateDeleteResponse{}
-	return out, h.Delete(in, out, "/api/v1/workflow-templates/{namespace}/{name}")
+	return out, h.Delete(ctx, in, out, "/api/v1/workflow-templates/{namespace}/{name}")
 }
 
-func (h WorkflowTemplateServiceClient) LintWorkflowTemplate(_ context.Context, in *workflowtemplatepkg.WorkflowTemplateLintRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
+func (h WorkflowTemplateServiceClient) LintWorkflowTemplate(ctx context.Context, in *workflowtemplatepkg.WorkflowTemplateLintRequest, _ ...grpc.CallOption) (*wfv1.WorkflowTemplate, error) {
 	out := &wfv1.WorkflowTemplate{}
-	return out, h.Post(in, out, "/api/v1/workflow-templates/{namespace}/lint")
+	return out, h.Post(ctx, in, out, "/api/v1/workflow-templates/{namespace}/lint")
 }


### PR DESCRIPTION


the current implementation does not suite our usecase because the http Fascade interface does not take proxy url we have to use proxy for cross network calls for argo server

so we might as well just allow a fully configured http client to be passed in - this allows more flexible configurations of the HTTP1 client via custom roundtripper

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12827 

### Motivation

- Allow more flexible configuration for the http1 workflow apiclient so that caller can inject runtime headers (e.g. per-request tracing id) or use a http proxy via roundtripper
- Include the context for the request to argo server so that timeouts can be configured by the caller 

### Modifications

- Add configuration option for `HTTP1Client`
- Have `Facade` use the custom http client if provided
- Use `NewRequestWithContext` to include context from caller
- Update `do` to accept context from caller
- Update service clients to use context, `_ context.Context` -> `ctx context.Context`, and pass that do `Facade`

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
