### PR TITLE
feat(ui): display line numbers in object-editor. Fixes #12807.

### DIFF
--- a/ui/src/app/shared/components/object-editor.tsx
+++ b/ui/src/app/shared/components/object-editor.tsx
@@ -121,7 +121,6 @@ export function ObjectEditor<T>({type, value, buttons, onChange}: Props<T>) {
                     options={{
                         readOnly: onChange === null,
                         minimap: {enabled: false},
-                        lineNumbers: 'off',
                         guides: {
                             indentation: false
                         },


### PR DESCRIPTION
### Related issue:

Fixes #12807

### Motivation

Adding support for displaying the line number would enhance the user experience, as it would aid in debugging

### Modifications

Remove `lineNumbers` key in `object-editor.tsx`.

### Verification

after changes:

<img width="1512" alt="Screenshot 2024-04-02 at 9 38 51 PM" src="https://github.com/argoproj/argo-workflows/assets/79321261/aaff42d4-8b09-47d0-ad33-8c225f6eba9d">

before changes:
<img width="1512" alt="Screenshot 2024-04-02 at 11 36 28 PM" src="https://github.com/argoproj/argo-workflows/assets/79321261/db9f2213-d5c5-4bd7-920c-a666eb0257fc">



