### PR TITLE
ci: use `chore(deps)` prefix for dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     labels:
       - type/dependencies
       - go
+    commit-message:
+      prefix: chore(deps)
 
   - package-ecosystem: "npm"
     directory: "/ui"
@@ -31,6 +33,9 @@ updates:
     labels:
       - type/dependencies
       - javascript
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
 
   # build / CI dependencies
   - package-ecosystem: "pip"
@@ -43,6 +48,8 @@ updates:
     labels:
       - type/dependencies
       - python
+    commit-message:
+      prefix: chore(deps)
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -58,3 +65,5 @@ updates:
     labels:
       - type/dependencies
       - github_actions
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Dependabot's recent automated security updates (#12878, #12879, #12880)  (enabled after https://github.com/argoproj/argo-workflows/pull/12763#issuecomment-1986755883) used the `build(deps)` prefix instead of `chore(deps)`
  - note that I changed all their PR titles manually, but their commits still say `build(deps)` and most were auto-merged before I could change the title).

This matches the prefix we normally use for dependency updates (#12850, #12860, etc)
  - also this matches what dependabot was previously doing for non-security updates (#12512, #12507, etc), not sure why it used `build(deps)` for security updates (??)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Add `commit-message.prefix: chore(deps)` to all `package-ecosystem`s in `dependabot.yml`
  - dependabot auto-adds `: ` after the prefix
  - Add `commit-message.prefix-development: chore(deps-dev)` to `package-ecosystem: npm` (not supported for `github-actions` or `gomod`)
    - Matches previous dependabot non-security updates, such as #12511, #12510, #12509, etc

### Verification

Matches the GH Docs in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
