### PR TITLE
ci(deps): fix auto deduplication of `yarn.lock` for Dependabot PRs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -416,14 +416,17 @@ jobs:
       - run: yarn --cwd ui lint
       - run: yarn --cwd ui deduplicate
       # Deduplicate UI deps for dependabot PRs
-      - if: github.actor == 'dependabot[bot]'
+      - name: Commit deduplicated yarn.lock for Dependabot PRs
+        if: github.actor == 'dependabot[bot]'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add ui/yarn.lock
-          git commit -s -m 'chore: deduplicate yarn.lock'
+          git commit -s --alow-empty -m 'chore: deduplicate yarn.lock'
           git push
-      - run: git diff --exit-code
+      # if lint or deduplicate make changes that are not in the PR, fail the build
+      - name: Check if lint & deduplicate made changes not present in the PR
+        run: git diff --exit-code
       # check to see if it'll start (but not if it'll render)
       - run: yarn --cwd ui start &
       - run: until curl http://localhost:8080 > /dev/null ; do sleep 10s ; done


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/pull/12880#issuecomment-2036064662, https://github.com/argoproj/argo-workflows/pull/12234#discussion_r1550796719

### Motivation

<!-- TODO: Say why you made your changes. -->

- previously the deduplication commit would fail if there were no changes, so add `--allow-empty` to the commit as a quick fix


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add `--allow-empty` to the `git commit` for deduplicated Dependabot PRs
- also add `name`s to these steps for clarity (per https://github.com/argoproj/argo-workflows/pull/12880#issuecomment-2036064662, following #11752)

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested this locally and it worked and exited cleanly (exit code `0`):
```sh
git add ui/yarn.lock
git commit -s --alow-empty -m 'chore: deduplicate yarn.lock'
```

### Future Work

Optimize this by adding a conditional to not even try to commit if there are no changes to the `yarn.lock`

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
