### PR TITLE
ci(deps): group Dependabot updates by devDeps vs prod deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,14 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    # split devDeps and prod deps as typically only prod deps need security backports
+    groups:
+      devDeps:
+        applies-to: security-updates
+        dependency-type: "development"
+      deps:
+        applies-to: security-updates
+        dependency-type: "production"
     ignore:
       - dependency-name: raw-loader
       - dependency-name: style-loader


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/12887#issuecomment-2038223808 part 2

### Motivation

<!-- TODO: Say why you made your changes. -->

- generally, security updates for prod deps should be backported, while devDeps are not strictly necessary
  - so splitting these is helpful for cherry-picking, especially if there might be conflicts (which may be more likely with devDeps and build chain changes)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add two `groups` to NPM (the only one where have a devDeps/prod deps split) to split `devDeps` and `deps`

### Verification

- Followed the docs https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
  - note that `applies-to` is necessary as it defaults to `version-updates` per the docs
    - I thought it would default to _both_, but they seem to be mutually exclusive in `applies-to`? we don't use `version-updates` in any case though (per #12487)

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
