### PR TITLE
ci(deps): remove auto `yarn-deduplicate` on dependabot PRs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -415,15 +415,6 @@ jobs:
       - run: yarn --cwd ui test
       - run: yarn --cwd ui lint
       - run: yarn --cwd ui deduplicate
-      # Deduplicate UI deps for dependabot PRs
-      - name: Commit deduplicated yarn.lock for Dependabot PRs
-        if: github.actor == 'dependabot[bot]'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add ui/yarn.lock
-          git commit -s --allow-empty -m 'chore: deduplicate yarn.lock'
-          git push
       # if lint or deduplicate make changes that are not in the PR, fail the build
       - name: Check if lint & deduplicate made changes not present in the PR
         run: git diff --exit-code


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Reverts #12234, per my comments in https://github.com/argoproj/argo-workflows/pull/12234#discussion_r1552636495 as well as testing in my fork https://github.com/agilgur5/argo-workflows/pull/3#issuecomment-2038818809

### Motivation

<!-- TODO: Say why you made your changes. -->

- ultimately, it would produce PRs that would not be mergeable as [checks do not run on commits `push`ed via GH Actions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)
  - so it was fundamentally unworkable and hadn't been tested properly (note the missing "Verification" in the PR)

- I do not know a good solution or workaround to this, but as it doesn't work, it should be removed
  - If we find something workable in the future, it can be added then once it's had extensive testing
  - Ideally, this should be fixed upstream in dependabot itself https://github.com/dependabot/dependabot-core/issues/5830


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Remove the `yarn.lock` deduplication step in `ci-build.yaml`'s UI GHA job

### Verification

<!-- TODO: Say how you tested your changes. -->

It was working before #12234

### Notes to Reviewers

Dependabot PRs with duplicate deps would fail to pass CI before #12234. This will happen again and those _will_ need manual fixing. There's currently no workaround I know of if #12234 is fundamentally not doable.
That being said, since #12487, this should happen significantly less often, as only security updates are done, which are often only patch bumps that don't create duplicate deps. 

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
