### PR TITLE
chore(deps): upgrade `mkdocs-material` from 8.2.6 to 9.x

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==8.2.6
-mkdocs-redirects==1.2.1
+mkdocs-material==9.*
+mkdocs-redirects==1.*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #12031, "Vulnerabilities"

### Motivation

<!-- TODO: Say why you made your changes. -->

- [8.2.6](https://github.com/squidfunk/mkdocs-material/releases/tag/8.2.6) is 2 years old now
  - and there hasn't been an 8.x release since [9.0.0](https://github.com/squidfunk/mkdocs-material/releases/tag/9.0.0) was released 1.5 years ago
  - in particular, there are some CVEs in transitive deps of `mkdocs-material` now (such as `urllib3` CVEs: [GHSA-g4mx-q9vg-27p4](https://github.com/urllib3/urllib3/security/advisories/GHSA-g4mx-q9vg-27p4), [GHSA-hmv2-79q8-fv6g](https://github.com/advisories/GHSA-hmv2-79q8-fv6g), [GHSA-v845-jxx5-vc9f](https://github.com/advisories/GHSA-v845-jxx5-vc9f), etc)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- make the upgrade to 9.x in `docs/requirements.txt`
  - none of the removals in 9.0.0 affect our usage
  - main noticeable changes I can see are some CSS improvements

- also remove fixed dep pins in `docs/requirements.txt` and use a range
  - ideally we should use [`poetry`](https://github.com/python-poetry/poetry/) or similar and create a lockfile, but that's a separate topic with many more changes required -- this PR is focused on the upgrade

### Verification

1. `make docs`
1. `open site/index.html`
1. <details><summary>Took a look around, all seemed well to me. Mermaid plugin works, Field Reference with <code>md_in_html</code> works, admonitions work</summary>

    - Screenshot of how admonitions look like now (compare to https://github.com/argoproj/argo-workflows/pull/12809#issuecomment-2036237459): 
![Screenshot 2024-04-05 at 1 02 05 AM](https://github.com/argoproj/argo-workflows/assets/4970083/15c6c5d8-8f2e-441c-a83c-62bf266d6e2a)

</details>

### Notes to Reviewers

- Dependabot didn't update this, I think that might have been because of either (or all of):
    - the fixed dep with no range 
    - that there were no patches within the `mkdocs-material` 8.x range
    - no lockfile to independently update `urllib3` etc without touching `mkdocs-material`

### Future Work

Add `poetry` or `Pipfile` config and a lockfile


<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
