### PR TITLE
fix: workflows that are retrying should not be deleted (Fixes #12636)

### DIFF
--- a/workflow/gccontroller/gc_controller.go
+++ b/workflow/gccontroller/gc_controller.go
@@ -211,9 +211,22 @@ func (c *Controller) deleteWorkflow(ctx context.Context, key string) error {
 	// It should be impossible for a workflow to have been queue without a valid key.
 	namespace, name, _ := cache.SplitMetaNamespaceKey(key)
 
+	// Double check that this workflow is still completed. If it were retried, it may be running again (c.f. https://github.com/argoproj/argo-workflows/issues/12636)
+	obj, exists, err := c.wfInformer.GetStore().GetByKey(key)
+	if err != nil {
+		return nil
+	}
+	if exists {
+		un, ok := obj.(*unstructured.Unstructured)
+		if ok && !common.IsDone(un) {
+			log.Infof("Workflow '%s' is not completed due to a retry operation, ignore deletion", key)
+			return nil
+		}
+	}
+
 	// Any workflow that was queued must need deleting, therefore we do not check the expiry again.
 	log.Infof("Deleting garbage collected workflow '%s'", key)
-	err := c.wfclientset.ArgoprojV1alpha1().Workflows(namespace).Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: commonutil.GetDeletePropagation()})
+	err = c.wfclientset.ArgoprojV1alpha1().Workflows(namespace).Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: commonutil.GetDeletePropagation()})
 	if err != nil {
 		if apierr.IsNotFound(err) {
 			log.Infof("Workflow already deleted '%s'", key)


### PR DESCRIPTION
<!--
### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12636 

### Motivation

try to fix #12636 

### Modifications

modify `gc_controller.go` to ignore deletion for workflow not completed due to a retry operation

### Verification

test workflow file `fix-12636.yaml`: 
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: fix-12636-
spec:
  entrypoint: main
  ttlStrategy:
    secondsAfterFailure: 30
  arguments:
    parameters:
    - name: fail
      value: 'true'
  templates:
  - name: main
    dag:
      tasks:
      - name: A
        template: first-fail
        arguments:
          parameters:
          - name: fail
            value: "{{workflow.parameters.fail}}"
      - name: B
        depends: "A"
        template: echo

  - name: first-fail
    inputs:
      parameters:
        - name: fail
    container:
      image: alpine:latest
      imagePullPolicy: IfNotPresent
      command: [sh, -c]
      args: 
      - |
        set -e
        if [ "{{inputs.parameters.fail}}" == "true" ]; then
          echo "Failing"
          exit 1
        fi
        echo "Succeeded"
  - name: echo
    container:
      image: alpine:latest
      imagePullPolicy: IfNotPresent
      command: [sh, -c]
      args:
      - |
        set -e
        echo "sleep 120s"
        sleep 120
        echo "finished"
```

-  Submit test workflow: `argo submit fix-12636.yaml`, assuming name is `fix-12636-dvw4d`
-  Node A is expected to fail.
-  Retry workflow immediately and pass parameters to ensure node A succeeds.: `argo retry fix-12636-dvw4d -p fail=false`
-  Workflows can run successfully without being mistakenly deleted (in the unpatched version, workflows could be erroneously deleted during execution).
