### PR TITLE
fix: setBucketLifecycleRule error in OSS Artifact Driver.  Fixes #12925

### DIFF
--- a/workflow/artifacts/oss/oss.go
+++ b/workflow/artifacts/oss/oss.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aliyun/credentials-go/credentials"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -202,7 +201,9 @@ func (ossDriver *ArtifactDriver) Save(path string, outputArtifact *wfv1.Artifact
 			objectName := outputArtifact.OSS.Key
 			if outputArtifact.OSS.LifecycleRule != nil {
 				err = setBucketLifecycleRule(osscli, outputArtifact.OSS)
-				return !isTransientOSSErr(err), err
+				if err != nil {
+					return !isTransientOSSErr(err), err
+				}
 			}
 			if isDir {
 				if err = putDirectory(bucket, objectName, path); err != nil {
@@ -315,33 +316,32 @@ func setBucketLifecycleRule(client *oss.Client, ossArtifact *wfv1.OSSArtifact) e
 		return fmt.Errorf("markInfrequentAccessAfterDays cannot be large than markDeletionAfterDays")
 	}
 
-	// Set expiration rule.
-	expirationRule := oss.BuildLifecycleRuleByDays("expiration-rule", ossArtifact.Key, true, markInfrequentAccessAfterDays)
-	// Automatically delete the expired delete tag so we don't have to manage it ourselves.
+	// Delete the current version objects after a period of time.
+	// If BucketVersioning is enbaled, the objects will turn to non-current version.
 	expiration := oss.LifecycleExpiration{
-		ExpiredObjectDeleteMarker: pointer.Bool(true),
+		Days: markDeletionAfterDays,
 	}
 	// Convert to Infrequent Access (IA) storage type for objects that are expired after a period of time.
-	versionTransition := oss.LifecycleVersionTransition{
-		NoncurrentDays: markInfrequentAccessAfterDays,
-		StorageClass:   oss.StorageIA,
+	transition := oss.LifecycleTransition{
+		Days:         markInfrequentAccessAfterDays,
+		StorageClass: oss.StorageIA,
 	}
-	// Mark deletion after a period of time.
-	versionExpiration := oss.LifecycleVersionExpiration{
-		NoncurrentDays: markDeletionAfterDays,
+	// Delete the aborted uploaded parts after a period of time.
+	abortMultipartUpload := oss.LifecycleAbortMultipartUpload{
+		Days: markDeletionAfterDays,
 	}
-	versionTransitionRule := oss.LifecycleRule{
-		ID:                    "version-transition-rule",
-		Prefix:                ossArtifact.Key,
-		Status:                string(oss.VersionEnabled),
-		Expiration:            &expiration,
-		NonVersionExpiration:  &versionExpiration,
-		NonVersionTransitions: []oss.LifecycleVersionTransition{versionTransition},
+
+	rule := oss.LifecycleRule{
+		ID:                   "argo-workflows-rule",
+		Prefix:               ossArtifact.Key,
+		Status:               string(oss.VersionEnabled),
+		Expiration:           &expiration,
+		Transitions:          []oss.LifecycleTransition{transition},
+		AbortMultipartUpload: &abortMultipartUpload,
 	}
 
 	// Set lifecycle rules to the bucket.
-	rules := []oss.LifecycleRule{expirationRule, versionTransitionRule}
-	err := client.SetBucketLifecycle(ossArtifact.Bucket, rules)
+	err := client.SetBucketLifecycle(ossArtifact.Bucket, []oss.LifecycleRule{rule})
 	return err
 }
 

--- a/workflow/artifacts/oss/oss.go
+++ b/workflow/artifacts/oss/oss.go
@@ -1,6 +1,7 @@
 package oss
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"math"
@@ -331,8 +332,9 @@ func setBucketLifecycleRule(client *oss.Client, ossArtifact *wfv1.OSSArtifact) e
 		Days: markDeletionAfterDays,
 	}
 
+	keySha := fmt.Sprintf("%x", sha256.Sum256([]byte(ossArtifact.Key)))
 	rule := oss.LifecycleRule{
-		ID:                   "argo-workflows-rule",
+		ID:                   keySha,
 		Prefix:               ossArtifact.Key,
 		Status:               string(oss.VersionEnabled),
 		Expiration:           &expiration,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12925

### Motivation

<!-- TODO: Say why you made your changes. -->
OSS does not support to set different rules at a time for a same prefix and that's why I received a 400 error. And more details added in related issue.
```
time="2024-04-09T16:04:23.147Z" level=info msg="Save artifact" artifactName=out duration=1.270302632s error="oss: service returned error: StatusCode=400, ErrorCode=InvalidRequest, ErrorMessage=\"Found same prefix in different rules\", RequestId=6615670711BF5732361C11E2, Ec=0014-00000085" key=argo-workflows/test/lifecycletime="2024-04-09T16:04:23.147Z" level=error msg="executor error: oss: service returned error: StatusCode=400, ErrorCode=InvalidRequest, ErrorMessage=\"Found same prefix in different rules\", RequestId=6615670711BF5732361C11E2, Ec=0014-00000085"
```

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

LifecycleRule modified to:
- Set Transitions with MarkInfrequentAccessAfterDays (Objects will be converted to IA)
- Set Expiration with MarkDeletionAfterDays. (Objects will be deleted if Versioning is disabled, or changed to non-current version or else)
- Set AbortMultipartUpload with MarkDeletionAfterDays also. (Aborted Uploaded Parts will be deleted)


### Verification

<!-- TODO: Say how you tested your changes. -->
Please test with workflow
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: set-lifecycle-
spec:
  entrypoint: main
  templates:
    - name: main
      metadata:
        annotations:
          k8s.aliyun.com/eci-extra-ephemeral-storage: "5Gi"
          k8s.aliyun.com/eci-use-specs : "ecs.g7.xlarge"
      container:
        image: alpine:latest
        command:
          - sh
          - -c
        args:
          - |
            mkdir -p /out
            dd if=/dev/random of=/out/lifecycle.txt bs=2M count=1024
            echo "created files!"
      outputs:
        artifacts:
          - name: out
            path: /out/lifecycle.txt
            oss:
              endpoint: http://oss-cn-zhangjiakou-internal.aliyuncs.com
              bucket: my-argo-workflow
              key: argo-workflows/test/lifecycle
              accessKeySecret:
                name: my-argo-workflow-credentials
                key: accessKey
              secretKeySecret:
                name: my-argo-workflow-credentials
                key: secretKey
              lifecycleRule:
                markInfrequentAccessAfterDays: 1
                markDeletionAfterDays: 3
```
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
