### PR TITLE
fix: correct pod names for inline templates. Fixes #12895

### DIFF
--- a/workflow/util/pod_name.go
+++ b/workflow/util/pod_name.go
@@ -57,7 +57,7 @@ func GeneratePodName(workflowName, nodeName, templateName, nodeID string, versio
 	}
 
 	prefix := workflowName
-	if !strings.Contains(nodeName, ".inline") {
+	if !strings.Contains(nodeName, ".inline") && templateName != "" {
 		prefix = fmt.Sprintf("%s-%s", workflowName, templateName)
 	}
 	prefix = ensurePodNamePrefixLength(prefix)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12895

### Motivation

<!-- TODO: Say why you made your changes. -->
https://github.com/argoproj/argo-workflows/blob/87a2041ba7507c15070a3855b924c1075c50c268/workflow/util/pod_name.go#L60
```
inline-cant-show-errors-9ptb9--3016472844   0/2     Error       0               25h
inline-cant-show-errors-9ptb9--3942528235   0/2     Completed   0               25h
```
Incorrect pod names of inline templates will lead to empty UI logs problem.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
Test with the workflow mentioned in issue, got result like image post below:
![image](https://github.com/argoproj/argo-workflows/assets/83764662/80b2858f-228a-44c3-9bc1-06a5e8af2d08)


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
