### PR TITLE
fix(ui): properly get archive logs when no node was chosen

### DIFF
--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -586,7 +586,7 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                         <WorkflowLogsViewer
                             workflow={workflow}
                             initialPodName={podName}
-                            nodeId={parsedSidePanel.nodeId}
+                            initialNodeId={parsedSidePanel.nodeId}
                             container={parsedSidePanel.container}
                             archived={isArchivedWorkflow(workflow)}
                         />

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -174,7 +174,7 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
             })
     );
 
-    // default to the node id of of the pod
+    // default to the node id of the pod
     const nodeId = initialNodeId || podNamesToNodeIDs.get(podName);
     const node = workflow.status.nodes[nodeId];
     const templates = execSpec(workflow).templates.filter(t => !node || t.name === node.templateName);

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -25,7 +25,7 @@ const timezones = Intl.supportedValuesOf('timeZone');
 
 interface WorkflowLogsViewerProps {
     workflow: models.Workflow;
-    nodeId?: string;
+    initialNodeId?: string;
     initialPodName: string;
     container: string;
     archived: boolean;
@@ -74,7 +74,7 @@ function parseAndTransform(formattedString: string, timeZone: string) {
     }
 }
 
-export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container, archived}: WorkflowLogsViewerProps) {
+export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, container, archived}: WorkflowLogsViewerProps) {
     const storage = new ScopedLocalStorage('workflow-logs-viewer');
     const storedJsonFields = storage.getItem('jsonFields', {
         values: []
@@ -162,7 +162,6 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
 
     // map pod names to corresponding node IDs
     const podNamesToNodeIDs = new Map<string, string>();
-
     const podNames = [{value: '', label: 'All'}].concat(
         Object.values(workflow.status.nodes || {})
             .filter(x => x.type === 'Pod')
@@ -175,6 +174,8 @@ export function WorkflowLogsViewer({workflow, nodeId, initialPodName, container,
             })
     );
 
+    // default to the node id of of the pod
+    const nodeId = initialNodeId || podNamesToNodeIDs.get(podName);
     const node = workflow.status.nodes[nodeId];
     const templates = execSpec(workflow).templates.filter(t => !node || t.name === node.templateName);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12590, Fixes #12759
- Partially replaces #12591 with a root cause fix (that I wrote & pushed [myself](https://github.com/argoproj/argo-workflows/pull/12591#discussion_r1562071827) to the PR) and without an additional feature, so that this can be properly backported to 3.4.x and 3.5.x

Follow-up to #9464

### Motivation

<!-- TODO: Say why you made your changes. -->

- a node doesn't have to be clicked on in the UI to get logs, you can also click on the top-level logs button
  - in this case, there is no nodeId, but we can infer/derive one based on the Pod chosen in the drop-down

- a nodeId is required for archive logs, so this fixes archive logs when no node was chosen
  - which is a bug / regression that seems to stem from the `POD_NAMES=v2` change

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use the `podNamesToNodeIDs` map from #9464 to derive a `nodeId`

### Verification

<!-- TODO: Say how you tested your changes. -->

Manually tested that clicking the top-level logs button and then choosing a pod name gets logs for both archive and non-archive. Screenshot below, note that the URL has no `nodeId` in it as a node was not clicked

![Screenshot 2024-04-13 at 2 03 05 PM](https://github.com/argoproj/argo-workflows/assets/4970083/190f58b7-2f39-4767-8a8a-78482f90ec1c)

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
