### PR TITLE
fix(ui): default to `main` container name in event source logs API call

### DIFF
--- a/ui/src/app/shared/services/event-source-service.ts
+++ b/ui/src/app/shared/services/event-source-service.ts
@@ -33,8 +33,8 @@ export const EventSourceService = {
         return requests.loadEventSource(`api/v1/stream/event-sources/${namespace}`).pipe(map(line => line && (JSON.parse(line).result as EventSourceWatchEvent)));
     },
 
-    eventSourcesLogs(namespace: string, name = '', eventSourceType = '', eventName = '', grep = '', tailLines = -1) {
-        const params = ['podLogOptions.follow=true'];
+    eventSourcesLogs(namespace: string, name = '', eventSourceType = '', eventName = '', grep = '', tailLines = -1, container = 'main') {
+        const params = ['podLogOptions.follow=true', `podLogOptions.container=${container}`];
         if (name) {
             params.push('name=' + name);
         }


### PR DESCRIPTION
fixes argoproj#12938