### PR TITLE
fix(ui): use router navigation instead of page load after submit

### DIFF
--- a/ui/src/app/workflows/components/resubmit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/resubmit-workflow-panel.tsx
@@ -1,6 +1,7 @@
 import {Checkbox} from 'argo-ui';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import {Parameter, ResubmitOpts, Workflow} from '../../../models';
+import {Context} from '../../shared/context';
 import {uiUrl} from '../../shared/base';
 import {ErrorNotice} from '../../shared/components/error-notice';
 import {ParametersInput} from '../../shared/components/parameters-input';
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export function ResubmitWorkflowPanel(props: Props) {
+    const {navigation} = useContext(Context);
     const [overrideParameters, setOverrideParameters] = useState(false);
     const [workflowParameters, setWorkflowParameters] = useState<Parameter[]>(JSON.parse(JSON.stringify(props.workflow.spec.arguments.parameters || [])));
     const [memoized, setMemoized] = useState(false);
@@ -33,7 +35,7 @@ export function ResubmitWorkflowPanel(props: Props) {
             const submitted = props.isArchived
                 ? await services.workflows.resubmitArchived(props.workflow.metadata.uid, props.workflow.metadata.namespace, opts)
                 : await services.workflows.resubmit(props.workflow.metadata.name, props.workflow.metadata.namespace, opts);
-            document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`);
+            navigation.goto(uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`));
         } catch (err) {
             setError(err);
             setIsSubmitting(false);

--- a/ui/src/app/workflows/components/retry-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/retry-workflow-panel.tsx
@@ -1,6 +1,7 @@
 import {Checkbox} from 'argo-ui';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import {Parameter, RetryOpts, Workflow} from '../../../models';
+import {Context} from '../../shared/context';
 import {uiUrl} from '../../shared/base';
 import {ErrorNotice} from '../../shared/components/error-notice';
 import {ParametersInput} from '../../shared/components/parameters-input';
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export function RetryWorkflowPanel(props: Props) {
+    const {navigation} = useContext(Context);
     const [overrideParameters, setOverrideParameters] = useState(false);
     const [restartSuccessful, setRestartSuccessful] = useState(false);
     const [workflowParameters, setWorkflowParameters] = useState<Parameter[]>(JSON.parse(JSON.stringify(props.workflow.spec.arguments.parameters || [])));
@@ -37,7 +39,7 @@ export function RetryWorkflowPanel(props: Props) {
                 props.isArchived && !props.isWorkflowInCluster
                     ? await services.workflows.retryArchived(props.workflow.metadata.uid, props.workflow.metadata.namespace, opts)
                     : await services.workflows.retry(props.workflow.metadata.name, props.workflow.metadata.namespace, opts);
-            document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`);
+            navigation.goto(uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}#`)); // add # at the end to reset query params to close panel
         } catch (err) {
             setError(err);
             setIsSubmitting(false);

--- a/ui/src/app/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/app/workflows/components/submit-workflow-panel.tsx
@@ -1,6 +1,7 @@
 import {Select} from 'argo-ui';
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import {Parameter, Template} from '../../../models';
+import {Context} from '../../shared/context';
 import {uiUrl} from '../../shared/base';
 import {ErrorNotice} from '../../shared/components/error-notice';
 import {ParametersInput} from '../../shared/components/parameters-input';
@@ -26,6 +27,7 @@ const defaultTemplate: Template = {
 };
 
 export function SubmitWorkflowPanel(props: Props) {
+    const {navigation} = useContext(Context);
     const [entrypoint, setEntrypoint] = useState(workflowEntrypoint);
     const [parameters, setParameters] = useState<Parameter[]>([]);
     const [workflowParameters, setWorkflowParameters] = useState<Parameter[]>(JSON.parse(JSON.stringify(props.workflowParameters)));
@@ -55,7 +57,7 @@ export function SubmitWorkflowPanel(props: Props) {
                 ],
                 labels: labels.join(',')
             });
-            document.location.href = uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`);
+            navigation.goto(uiUrl(`workflows/${submitted.metadata.namespace}/${submitted.metadata.name}`));
         } catch (err) {
             setError(err);
             setIsSubmitting(false);

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -94,9 +94,9 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
     // boiler-plate
     const {navigation, popup} = useContext(Context);
     const queryParams = new URLSearchParams(location.search);
+    const namespace = match.params.namespace;
+    const name = match.params.name;
 
-    const [namespace] = useState(match.params.namespace);
-    const [name, setName] = useState(match.params.name);
     const [tab, setTab] = useState(queryParams.get('tab') || 'workflow');
     const [uid, setUid] = useState(queryParams.get('uid') || '');
     const [nodeId, setNodeId] = useState(queryParams.get('nodeId'));
@@ -107,8 +107,8 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
     const [workflow, setWorkflow] = useState<Workflow>();
     const [links, setLinks] = useState<Link[]>();
     const [error, setError] = useState<Error>();
-    const selectedNode = workflow && workflow.status && workflow.status.nodes && workflow.status.nodes[nodeId];
-    const selectedArtifact = workflow && workflow.status && findArtifact(workflow.status, nodeId);
+    const selectedNode = workflow?.status?.nodes?.[nodeId];
+    const selectedArtifact = workflow?.status && findArtifact(workflow.status, nodeId);
     const [selectedTemplateArtifactRepo, setSelectedTemplateArtifactRepo] = useState<ArtifactRepository>();
     const isSidePanelExpanded = !!(selectedNode || selectedArtifact);
     const isSidePanelAnimating = useTransition(isSidePanelExpanded, ANIMATION_MS + ANIMATION_BUFFER_MS);
@@ -197,9 +197,7 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                             popup
                                 .confirm('Confirm', () => <DeleteCheck isWfInDB={isArchivedWorkflow(workflow)} isWfInCluster={isWorkflowInCluster(workflow)} />)
                                 .then(async yes => {
-                                    if (!yes) {
-                                        return;
-                                    }
+                                    if (!yes) return;
 
                                     const allPromises = [];
                                     if (isWorkflowInCluster(workflow)) {
@@ -224,16 +222,9 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                             setSidePanel('retry');
                         } else {
                             popup.confirm('Confirm', `Are you sure you want to ${workflowOperation.title.toLowerCase()} this workflow?`).then(yes => {
-                                if (!yes) {
-                                    return;
-                                }
+                                if (!yes) return;
 
-                                workflowOperation
-                                    .action(workflow)
-                                    .then((wf: Workflow) => {
-                                        setName(wf.metadata.name);
-                                    })
-                                    .catch(setError);
+                                workflowOperation.action(workflow).catch(setError);
                             });
                         }
                     }
@@ -481,9 +472,7 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
 
     function renderResumePopup() {
         return popup.confirm('Confirm', renderSuspendNodeOptions).then(yes => {
-            if (!yes) {
-                return;
-            }
+            if (!yes) return;
 
             updateOutputParametersForNodeIfRequired().then(resumeNode).catch(setError);
         });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

I noticed this while investigating https://github.com/argoproj/argo-workflows/issues/12868#issuecomment-2033385525, although I don't think this would fix that issue.
Also related to / similar to #12930 

### Motivation

<!-- TODO: Say why you made your changes. -->

- `document.location.href` causes the browser to load a new page which is a full page load
  - `navigation.goto` should always be used when we're routing within the single-page app (SPA)
    - this only changes the internal route so only the next component needs to render, not the entire page
      - (and user-facing `history`, same as changing the `location`)

- fix `name` and `namespace` in Workflow Details to actually change when the URL changes
  - they were previously set as `state` despite not actually being `state`, meaning they only ever received the initial URL and no further changes
    - in particular, this is required for a resubmit to work, as it re-routes to the same component (Workflow Details), but with a different URL

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use `navigation.goto` instead of assigning `document.location.href` in the submit, resubmit, and retry panels
- remove `state` for `name` and `namespace` in Workflow Details and instead always get them from the URL
- some other tiny code style optimizations in surrounding code


### Verification

<!-- TODO: Say how you tested your changes. -->

I made a few screencaptures to verify this:
1. <details><summary>Submit no longer does a full page reload</summary>

    https://github.com/argoproj/argo-workflows/assets/4970083/d3888986-c66d-4f55-a54d-579e0dd91d38

</details>

1. <details><summary>Resubmit no longer does a full page reload</summary>

    https://github.com/argoproj/argo-workflows/assets/4970083/c6059d05-3b60-48a0-8abc-2d7006d134ef

</details>

1. <details><summary>Retry no longer does a full page reload</summary>


    https://github.com/argoproj/argo-workflows/assets/4970083/c2aac826-81d2-4856-9302-792a44a16d24

    (I used a different software to record this initially, that's why it's a bit different from the other two)

</details>

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
