### PR TITLE
chore: clarify `:latest` in bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,7 +9,7 @@ body:
       options:
         - label: I have double-checked my configuration
           required: true
-        - label: I have tested with the `:latest` image tag (i.e. `quay.io/argoproj/workflow-controller:latest`) and can confirm the issue still exists on `:latest`
+        - label: I have tested with the `:latest` image tag (i.e. `quay.io/argoproj/workflow-controller:latest`) and can confirm the issue still exists on `:latest`. If not, I have explained why, **in detail**, in my description below.
           required: true
         - label: I have searched existing issues and could not find a match for this bug
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,7 +9,7 @@ body:
       options:
         - label: I have double-checked my configuration
           required: true
-        - label: I can confirm the issue exists when I tested with `:latest`
+        - label: I have tested with the `:latest` image tag (i.e. `quay.io/argoproj/workflow-controller:latest`) and can confirm the issue still exists on `:latest`
           required: true
         - label: I have searched existing issues and could not find a match for this bug
           required: true
@@ -53,8 +53,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for submitting this issue! Are you a contributor? If not, have you thought about it? 
+        Thanks for submitting this issue! Are you a contributor? If not, have you thought about it?
 
-        Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
-        See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 
+        Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
+        See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.
 

--- a/.github/ISSUE_TEMPLATE/regression.yaml
+++ b/.github/ISSUE_TEMPLATE/regression.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I have double-checked my configuration
           required: true
-        - label: I have tested with the `:latest` image tag (i.e. `quay.io/argoproj/workflow-controller:latest`) and can confirm the issue still exists on `:latest`
+        - label: I have tested with the `:latest` image tag (i.e. `quay.io/argoproj/workflow-controller:latest`) and can confirm the issue still exists on `:latest`. If not, I have explained why, **in detail**, in my description below.
           required: true
         - label: I have searched existing issues and could not find a match for this bug
           required: true

--- a/.github/ISSUE_TEMPLATE/regression.yaml
+++ b/.github/ISSUE_TEMPLATE/regression.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I have double-checked my configuration
           required: true
-        - label: I can confirm the issue exists when I tested with `:latest`
+        - label: I have tested with the `:latest` image tag (i.e. `quay.io/argoproj/workflow-controller:latest`) and can confirm the issue still exists on `:latest`
           required: true
         - label: I have searched existing issues and could not find a match for this bug
           required: true
@@ -56,6 +56,6 @@ body:
       value: |
         Thanks for submitting this issue! Are you a contributor? If not, have you thought about it?
 
-        Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable. 
-        See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information. 
+        Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
+        See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- there have been many cases of users checking the box despite not testing `:latest`, sometimes not even testing the latest patch version
  - this is an effort to clarify that / make it more explicit what that means to hopefully reduce that occurrence
  - some recent examples of this occurrence include: https://github.com/argoproj/argo-workflows/issues/12946#issuecomment-2060000421, https://github.com/argoproj/argo-workflows/issues/12802#issuecomment-2007756351, https://github.com/argoproj/argo-workflows/issues/12949#issuecomment-2062322286
  
@Joibel and I have also briefly talked about this during Contributor Meetings

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Clarify "tested with `:latest`" by adding "image tag" and giving an example

### Verification

<!-- TODO: Say how you tested your changes. -->

the strings are valid, but otherwise n/a, this is GH specific. there is also no local preview for issue forms unfortunately: https://github.com/orgs/community/discussions/7039, https://github.com/orgs/community/discussions/4402, https://github.com/orgs/community/discussions/63402#discussioncomment-6697333, https://github.com/orgs/community/discussions/4265, etc

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
