### PR TITLE
feat(cli): Add `--no-color` support to `argo lint`. Fixes #12913

### DIFF
--- a/cmd/argo/commands/lint.go
+++ b/cmd/argo/commands/lint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/lint"
 	wf "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 )
@@ -48,6 +49,7 @@ func NewLintCommand() *cobra.Command {
 	command.Flags().StringVarP(&output, "output", "o", "pretty", "Linting results output format. One of: pretty|simple")
 	command.Flags().BoolVar(&strict, "strict", true, "Perform strict workflow validation")
 	command.Flags().BoolVar(&offline, "offline", false, "perform offline linting. For resources referencing other resources, the references will be resolved from the provided args")
+	command.Flags().BoolVar(&common.NoColor, "no-color", false, "Disable colorized output")
 
 	return command
 }

--- a/cmd/argo/lint/formatter_pretty.go
+++ b/cmd/argo/lint/formatter_pretty.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/TwiN/go-color"
+
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 )
 
 const (
@@ -14,6 +16,7 @@ const (
 type formatterPretty struct{}
 
 func (f formatterPretty) Format(l *LintResult) string {
+	setColorize()
 	if !l.Linted {
 		return ""
 	}
@@ -34,6 +37,7 @@ func (f formatterPretty) Format(l *LintResult) string {
 }
 
 func (f formatterPretty) Summarize(l *LintResults) string {
+	setColorize()
 	if l.Success {
 		return fmt.Sprintf("%s no linting errors found!\n", color.Ize(color.Green, "✔"))
 	}
@@ -48,4 +52,8 @@ func (f formatterPretty) Summarize(l *LintResults) string {
 	}
 
 	return fmt.Sprintln(color.Ize(color.Red, fmt.Sprintf("✖ %d linting errors found!", totErr)))
+}
+
+func setColorize() {
+	color.Toggle(!common.NoColor)
 }

--- a/cmd/argo/lint/formatter_pretty_test.go
+++ b/cmd/argo/lint/formatter_pretty_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/TwiN/go-color"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 )
 
 func TestPrettySummarize(t *testing.T) {
@@ -51,6 +53,70 @@ func TestPrettyFormat(t *testing.T) {
 			Linted: true,
 		})
 		expected := "\x1b[4mtest2\x1b[0m:\n   \x1b[31m✖\x1b[0m some error\n\n"
+		assert.Equal(t, expected, msg)
+	})
+
+	t.Run("NotLinted", func(t *testing.T) {
+		msg := formatterPretty{}.Format(&LintResult{
+			File:   "test3",
+			Linted: false,
+		})
+		expected := ""
+		assert.Equal(t, expected, msg)
+	})
+}
+
+func TestPrettySummarizeWithColorDisabled(t *testing.T) {
+	common.NoColor = true
+	defer func() {
+		common.NoColor = false
+	}()
+
+	t.Run("Success", func(t *testing.T) {
+		msg := formatterPretty{}.Summarize(&LintResults{
+			Success: true,
+		})
+		expected := "✔ no linting errors found!\n"
+		assert.Equal(t, expected, msg)
+	})
+	t.Run("Nothing linted", func(t *testing.T) {
+		msg := formatterPretty{}.Summarize(&LintResults{
+			anythingLinted: false,
+			Success:        false,
+		})
+		expected := "✖ found nothing to lint in the specified paths, failing...\n"
+		assert.Equal(t, expected, msg)
+	})
+}
+
+func TestPrettyFormatWithColorDisabled(t *testing.T) {
+	common.NoColor = true
+	defer func() {
+		common.NoColor = false
+	}()
+
+	t.Run("Multiple", func(t *testing.T) {
+		msg := formatterPretty{}.Format(&LintResult{
+			File: "test1",
+			Errs: []error{
+				fmt.Errorf("some error"),
+				fmt.Errorf("some error2"),
+			},
+			Linted: true,
+		})
+		expected := "test1:\n   ✖ some error\n   ✖ some error2\n\n"
+		assert.Equal(t, expected, msg)
+	})
+
+	t.Run("One", func(t *testing.T) {
+		msg := formatterPretty{}.Format(&LintResult{
+			File: "test2",
+			Errs: []error{
+				fmt.Errorf("some error"),
+			},
+			Linted: true,
+		})
+		expected := "test2:\n   ✖ some error\n\n"
 		assert.Equal(t, expected, msg)
 	})
 

--- a/docs/cli/argo_lint.md
+++ b/docs/cli/argo_lint.md
@@ -24,6 +24,7 @@ argo lint FILE... [flags]
 ```
   -h, --help            help for lint
       --kinds strings   Which kinds will be linted. Can be: workflows|workflowtemplates|cronworkflows|clusterworkflowtemplates (default [all])
+      --no-color        Disable colorized output
       --offline         perform offline linting. For resources referencing other resources, the references will be resolved from the provided args
   -o, --output string   Linting results output format. One of: pretty|simple (default "pretty")
       --strict          Perform strict workflow validation (default true)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12913 

### Motivation

Visibility would be improved in cases where you capture the output, and include it in a GitHub comment on a Pull Request.

### Modifications

Extend `argo lint` with the `--no-color` flag. When used the flag will disable the colors output by setting [`color.Toggle(false)`](https://github.com/TwiN/go-color/tree/v1.4.1?tab=readme-ov-file#disabling-colors). Apart from that extended unit tests to cover the changes

### Verification

- [x] Disable colors in `Format` func
- [x] Disable colors in `Summarize` func


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
