### PR TITLE
chore: use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -67,16 +68,16 @@ func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
 		return newOfflineClient(opts.OfflineFiles)
 	}
 	if opts.ArgoServerOpts.URL != "" && opts.InstanceID != "" {
-		return nil, nil, fmt.Errorf("cannot use instance ID with Argo Server")
+		return nil, nil, errors.New("cannot use instance ID with Argo Server")
 	}
 	if opts.ArgoServerOpts.HTTP1 {
 		if opts.AuthSupplier == nil {
-			return nil, nil, fmt.Errorf("AuthSupplier cannot be empty when connecting to Argo Server")
+			return nil, nil, errors.New("AuthSupplier cannot be empty when connecting to Argo Server")
 		}
 		return newHTTP1Client(opts.ArgoServerOpts.GetURL(), opts.AuthSupplier(), opts.ArgoServerOpts.InsecureSkipVerify, opts.ArgoServerOpts.Headers, opts.ArgoServerOpts.HTTP1Client)
 	} else if opts.ArgoServerOpts.URL != "" {
 		if opts.AuthSupplier == nil {
-			return nil, nil, fmt.Errorf("AuthSupplier cannot be empty when connecting to Argo Server")
+			return nil, nil, errors.New("AuthSupplier cannot be empty when connecting to Argo Server")
 		}
 		return newArgoServerClient(opts.ArgoServerOpts, opts.AuthSupplier())
 	} else {

--- a/pkg/apiclient/offline-client.go
+++ b/pkg/apiclient/offline-client.go
@@ -2,6 +2,7 @@ package apiclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
@@ -36,7 +37,7 @@ type offlineClient struct {
 	namespacedWorkflowTemplateGetterMap offlineWorkflowTemplateGetterMap
 }
 
-var OfflineErr = fmt.Errorf("not supported when you are in offline mode")
+var OfflineErr = errors.New("not supported when you are in offline mode")
 
 var _ Client = &offlineClient{}
 

--- a/pkg/plugins/spec/plugin_types.go
+++ b/pkg/plugins/spec/plugin_types.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -33,16 +34,16 @@ type Sidecar struct {
 func (s Sidecar) Validate() error {
 	c := s.Container
 	if len(c.Ports) < 1 {
-		return fmt.Errorf("at least one port is mandatory")
+		return errors.New("at least one port is mandatory")
 	}
 	if c.Resources.Requests == nil {
-		return fmt.Errorf("resources requests are mandatory")
+		return errors.New("resources requests are mandatory")
 	}
 	if c.Resources.Limits == nil {
-		return fmt.Errorf("resources limits are mandatory")
+		return errors.New("resources limits are mandatory")
 	}
 	if c.SecurityContext == nil {
-		return fmt.Errorf("security context is mandatory")
+		return errors.New("security context is mandatory")
 	}
 	return nil
 }


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters will much better