### PR TITLE
refactor: simplify `getPodName` and make consistent with back-end

### DIFF
--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,4 +1,6 @@
-import {Inputs, MemoizationStatus, NodePhase, NodeStatus, NodeType, Outputs, RetryStrategy} from '../../models';
+import {NodeStatus, Workflow} from '../../models';
+import {ANNOTATION_KEY_POD_NAME_VERSION} from './annotations';
+
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
 describe('pod names', () => {
@@ -9,9 +11,6 @@ describe('pod names', () => {
     });
 
     // note: the below is intended to be equivalent to the server-side Go code in workflow/util/pod_name_test.go
-    const nodeName = 'nodename';
-    const nodeID = '1';
-
     const shortWfName = 'wfname';
     const shortTemplateName = 'templatename';
 
@@ -29,58 +28,44 @@ describe('pod names', () => {
     });
 
     test('getPodName', () => {
-        const v1podName = nodeID;
-        const v2podName = `${shortWfName}-${shortTemplateName}-${createFNVHash(nodeName)}`;
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, POD_NAME_V2)).toEqual(v2podName);
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, POD_NAME_V1)).toEqual(v1podName);
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, '')).toEqual(v2podName);
-        expect(getPodName(shortWfName, nodeName, shortTemplateName, nodeID, undefined)).toEqual(v2podName);
+        const node = {
+            name: 'nodename',
+            id: '1',
+            templateName: shortTemplateName
+        } as unknown as NodeStatus;
+        const wf = {
+            metadata: {
+                name: shortWfName,
+                annotations: {
+                    [ANNOTATION_KEY_POD_NAME_VERSION]: POD_NAME_V1
+                }
+            }
+        } as unknown as Workflow;
 
-        const name = getPodName(longWfName, nodeName, longTemplateName, nodeID, POD_NAME_V2);
+        const v1podName = node.id;
+        const v2podName = `${shortWfName}-${shortTemplateName}-${createFNVHash(node.name)}`;
+
+        expect(getPodName(wf, node)).toEqual(v1podName);
+        wf.metadata.annotations[ANNOTATION_KEY_POD_NAME_VERSION] = POD_NAME_V2;
+        expect(getPodName(wf, node)).toEqual(v2podName);
+        wf.metadata.annotations[ANNOTATION_KEY_POD_NAME_VERSION] = '';
+        expect(getPodName(wf, node)).toEqual(v2podName);
+        delete wf.metadata.annotations;
+        expect(getPodName(wf, node)).toEqual(v2podName);
+
+        wf.metadata.name = longWfName;
+        node.templateName = longTemplateName;
+        const name = getPodName(wf, node);
         expect(name.length).toEqual(maxK8sResourceNameLength);
     });
 
     test('getTemplateNameFromNode', () => {
         // case: no template ref or template name
         // expect fallback to empty string
-        const nodeType: NodeType = 'Pod';
-        const nodePhase: NodePhase = 'Succeeded';
-        const retryStrategy: RetryStrategy = {};
-        const outputs: Outputs = {};
-        const inputs: Inputs = {};
-        const memoizationStatus: MemoizationStatus = {
-            hit: false,
-            key: 'key',
-            cacheName: 'cache'
-        };
-
-        const node: NodeStatus = {
-            id: 'patch-processing-pipeline-ksp78-1623891970',
-            name: 'patch-processing-pipeline-ksp78.retriable-map-authoring-initializer',
-            displayName: 'retriable-map-authoring-initializer',
-            type: nodeType,
-            templateScope: 'local/',
-            phase: nodePhase,
-            boundaryID: '',
-            message: '',
-            startedAt: '',
-            finishedAt: '',
-            podIP: '',
-            daemoned: false,
-            retryStrategy,
-            outputs,
-            children: [],
-            outboundNodes: [],
-            templateName: '',
-            inputs,
-            hostNodeName: '',
-            memoizationStatus
-        };
-
+        const node = {} as unknown as NodeStatus;
         expect(getTemplateNameFromNode(node)).toEqual('');
 
         // case: template ref defined but no template name defined
-        // expect to return templateRef.template
         node.templateRef = {
             name: 'test-template-name',
             template: 'test-template-template'
@@ -88,7 +73,6 @@ describe('pod names', () => {
         expect(getTemplateNameFromNode(node)).toEqual(node.templateRef.template);
 
         // case: template name defined
-        // expect to return templateName
         node.templateName = 'test-template';
         expect(getTemplateNameFromNode(node)).toEqual(node.templateName);
     });

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -52,14 +52,6 @@ function createFNVHash(input: string): number {
 }
 
 function getTemplateNameFromNode(node: NodeStatus): string {
-    if (node.templateName && node.templateName !== '') {
-        return node.templateName;
-    }
-
     // fall back to v1 pod names if no templateName or templateRef defined
-    if (node?.templateRef === undefined || node?.templateRef.template === '') {
-        return '';
-    }
-
-    return node.templateRef.template;
+    return node.templateName || node.templateRef?.template || '';
 }

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -6,6 +6,7 @@ export const POD_NAME_V2 = 'v2';
 
 export const maxK8sResourceNameLength = 253;
 export const k8sNamingHashLength = 10;
+const maxPrefixLength = maxK8sResourceNameLength - k8sNamingHashLength;
 
 // getPodName returns a deterministic pod name
 // In case templateName is not defined or that version is explicitly set to  POD_NAME_V1, it will return the nodeID (v1)
@@ -29,9 +30,7 @@ export function getPodName(workflow: Workflow, node: NodeStatus): string {
     return node.id;
 };
 
-function ensurePodNamePrefixLength(prefix: string): string {
-    const maxPrefixLength = maxK8sResourceNameLength - k8sNamingHashLength;
-
+export function ensurePodNamePrefixLength(prefix: string): string {
     if (prefix.length > maxPrefixLength - 1) {
         return prefix.substring(0, maxPrefixLength - 1);
     }
@@ -39,7 +38,7 @@ function ensurePodNamePrefixLength(prefix: string): string {
     return prefix;
 }
 
-function createFNVHash(input: string): number {
+export function createFNVHash(input: string): number {
     let hashint = 2166136261;
 
     for (let i = 0; i < input.length; i++) {
@@ -51,7 +50,7 @@ function createFNVHash(input: string): number {
     return hashint >>> 0;
 }
 
-function getTemplateNameFromNode(node: NodeStatus): string {
+export function getTemplateNameFromNode(node: NodeStatus): string {
     // fall back to v1 pod names if no templateName or templateRef defined
     return node.templateName || node.templateRef?.template || '';
 }

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -32,7 +32,7 @@ export function getPodName(workflow: Workflow, node: NodeStatus): string {
 
     const hash = createFNVHash(node.name);
     return `${prefix}-${hash}`;
-};
+}
 
 export function ensurePodNamePrefixLength(prefix: string): string {
     if (prefix.length > maxPrefixLength - 1) {

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import {useContext, useEffect, useRef, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 
-import {archivalStatus, ArtifactRepository, execSpec, isArchivedWorkflow, isWorkflowInCluster, Link, NodeStatus, Parameter, Workflow} from '../../../../models';
+import {archivalStatus, ArtifactRepository, execSpec, isArchivedWorkflow, isWorkflowInCluster, Link, Parameter, Workflow} from '../../../../models';
 import {artifactRepoHasLocation, findArtifact} from '../../../shared/artifacts';
 import {uiUrl} from '../../../shared/base';
 import {CostOptimisationNudge} from '../../../shared/components/cost-optimisation-nudge';

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -477,15 +477,7 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
         });
     }
 
-    function ensurePodName(wf: Workflow, node: NodeStatus): string {
-        if (workflow && node) {
-            return getPodName(wf, node);
-        }
-
-        return node.id;
-    }
-
-    const podName = ensurePodName(workflow, selectedNode);
+    const podName = workflow && selectedNode ? getPodName(workflow, selectedNode) : nodeId;
 
     const archived = isArchivedWorkflow(workflow);
 

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -5,7 +5,6 @@ import {useContext, useEffect, useRef, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {archivalStatus, ArtifactRepository, execSpec, isArchivedWorkflow, isWorkflowInCluster, Link, NodeStatus, Parameter, Workflow} from '../../../../models';
-import {ANNOTATION_KEY_POD_NAME_VERSION} from '../../../shared/annotations';
 import {artifactRepoHasLocation, findArtifact} from '../../../shared/artifacts';
 import {uiUrl} from '../../../shared/base';
 import {CostOptimisationNudge} from '../../../shared/components/cost-optimisation-nudge';
@@ -17,7 +16,7 @@ import {useCollectEvent} from '../../../shared/use-collect-event';
 import {hasArtifactGCError, hasWarningConditionBadge} from '../../../shared/conditions-panel';
 import {Context} from '../../../shared/context';
 import {historyUrl} from '../../../shared/history';
-import {getPodName, getTemplateNameFromNode} from '../../../shared/pod-name';
+import {getPodName} from '../../../shared/pod-name';
 import {RetryWatch} from '../../../shared/retry-watch';
 import {services} from '../../../shared/services';
 import {getResolvedTemplates} from '../../../shared/template-resolution';
@@ -478,18 +477,15 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
         });
     }
 
-    function ensurePodName(wf: Workflow, node: NodeStatus, nodeID: string): string {
+    function ensurePodName(wf: Workflow, node: NodeStatus): string {
         if (workflow && node) {
-            const annotations = workflow.metadata.annotations || {};
-            const version = annotations[ANNOTATION_KEY_POD_NAME_VERSION];
-            const templateName = getTemplateNameFromNode(node);
-            return getPodName(wf.metadata.name, node.name, templateName, node.id, version);
+            return getPodName(wf, node);
         }
 
-        return nodeID;
+        return node.id;
     }
 
-    const podName = ensurePodName(workflow, selectedNode, nodeId);
+    const podName = ensurePodName(workflow, selectedNode);
 
     const archived = isArchivedWorkflow(workflow);
 

--- a/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/app/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -6,14 +6,13 @@ import {Observable} from 'rxjs';
 import {map, publishReplay, refCount} from 'rxjs/operators';
 import * as models from '../../../../models';
 import {execSpec} from '../../../../models';
-import {ANNOTATION_KEY_POD_NAME_VERSION} from '../../../shared/annotations';
 import {Button} from '../../../shared/components/button';
 import {ErrorNotice} from '../../../shared/components/error-notice';
 import {InfoIcon, WarningIcon} from '../../../shared/components/fa-icons';
 import {Links} from '../../../shared/components/links';
 import {Context} from '../../../shared/context';
 import {useLocalStorage} from '../../../shared/use-local-storage';
-import {getPodName, getTemplateNameFromNode} from '../../../shared/pod-name';
+import {getPodName} from '../../../shared/pod-name';
 import {ScopedLocalStorage} from '../../../shared/scoped-local-storage';
 import {services} from '../../../shared/services';
 import {FullHeightLogsViewer} from './full-height-logs-viewer';
@@ -157,9 +156,6 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
         return () => clearTimeout(x);
     }, [logFilter]);
 
-    const annotations = workflow.metadata.annotations || {};
-    const podNameVersion = annotations[ANNOTATION_KEY_POD_NAME_VERSION];
-
     // map pod names to corresponding node IDs
     const podNamesToNodeIDs = new Map<string, string>();
     const podNames = [{value: '', label: 'All'}].concat(
@@ -167,8 +163,7 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
             .filter(x => x.type === 'Pod')
             .map(targetNode => {
                 const {name, id, displayName} = targetNode;
-                const templateName = getTemplateNameFromNode(targetNode);
-                const targetPodName = getPodName(workflow.metadata.name, name, templateName, id, podNameVersion);
+                const targetPodName = getPodName(workflow, targetNode);
                 podNamesToNodeIDs.set(targetPodName, id);
                 return {value: targetPodName, label: (displayName || name) + ' (' + targetPodName + ')'};
             })

--- a/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/app/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -5,7 +5,6 @@ import {useState} from 'react';
 
 import * as models from '../../../../models';
 import {Artifact, NodeStatus, Workflow} from '../../../../models';
-import {ANNOTATION_KEY_POD_NAME_VERSION} from '../../../shared/annotations';
 import {Button} from '../../../shared/components/button';
 import {ClipboardText} from '../../../shared/components/clipboard-text';
 import {DurationPanel} from '../../../shared/components/duration-panel';
@@ -13,7 +12,7 @@ import {InlineTable} from '../../../shared/components/inline-table/inline-table'
 import {Links} from '../../../shared/components/links';
 import {Phase} from '../../../shared/components/phase';
 import {Timestamp} from '../../../shared/components/timestamp';
-import {getPodName, getTemplateNameFromNode} from '../../../shared/pod-name';
+import {getPodName} from '../../../shared/pod-name';
 import {ResourcesDuration} from '../../../shared/resources-duration';
 import {services} from '../../../shared/services';
 import {getResolvedTemplates} from '../../../shared/template-resolution';
@@ -100,12 +99,7 @@ function DisplayWorkflowTime(props: {date: Date | string | number}) {
 
 function WorkflowNodeSummary(props: Props) {
     const {workflow, node} = props;
-
-    const annotations = workflow.metadata.annotations || {};
-    const version = annotations[ANNOTATION_KEY_POD_NAME_VERSION];
-    const templateName = getTemplateNameFromNode(node);
-
-    const podName = getPodName(workflow.metadata.name, node.name, templateName, node.id, version);
+    const podName = getPodName(workflow, node);
 
     const attributes = [
         {title: 'NAME', value: <ClipboardText text={props.node.name} />},

--- a/workflow/util/pod_name.go
+++ b/workflow/util/pod_name.go
@@ -13,6 +13,7 @@ import (
 const (
 	maxK8sResourceNameLength = 253
 	k8sNamingHashLength      = 10
+	maxPrefixLength          = maxK8sResourceNameLength - k8sNamingHashLength
 )
 
 // PodNameVersion stores which type of pod names should be used.
@@ -70,8 +71,6 @@ func GeneratePodName(workflowName, nodeName, templateName, nodeID string, versio
 }
 
 func ensurePodNamePrefixLength(prefix string) string {
-	maxPrefixLength := maxK8sResourceNameLength - k8sNamingHashLength
-
 	if len(prefix) > maxPrefixLength-1 {
 		return prefix[0 : maxPrefixLength-1]
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/pull/6982#discussion_r1574359684, Fixes https://github.com/argoproj/argo-workflows/pull/9168#discussion_r1574264448

### Motivation

<!-- TODO: Say why you made your changes. -->

Simplify `getPodName` as it required lots of args that could be retrieved from the existing Workflow and Node. Simplify surrounding code as well

Make it more consistent to the back-end as well, particularly after #12928.
  - It seems to have diverged unintentionally within the same PR per https://github.com/argoproj/argo-workflows/pull/6982#discussion_r1574359684 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- simplify calls to `getPodName` to only require the Workflow and Node as args
   - the rest can be derived from them, so we can remove all the duplicate, extraneous logic from all callers
     - `workflow-details.tsx` was particularly simplified as a result, a whole function was replaced with a one-liner
   - also make `getPodName` in the UI more closely match `GeneratePodName` on the back-end

- adjust `pod-name.test.ts` to match the modified args
  - also heavily simplify one of the test suites to cast some types instead of creating an unnecessary structure

- <details><summary>simplify other parts of <code>pod-name.ts</code></summary>
  
    - simplify `getTemplateNameFromNode` to a one-liner that's easier to read and reads like the comment too
      - JS has [truthiness](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), so `if (node.templateName)` checks for `undefined`, `''`, and others
      - `node?.` is not necessary per https://github.com/argoproj/argo-workflows/pull/9168#discussion_r1574264448, and we can invert the conditional to `if (node.templateRef?.template)`
      - put it all together and you get a one-liner
      
    - slightly optimize `ensurePodNamePrefixLength` by moving the static calculation of `maxPrefixLength` into the module scope and outside the function scope
      - it does not change per function invocation
      - do the same on the back-end too in `pod_name.go`
      
    - use named functions for better tracing compared to `const` variables assigned to anonymous functions, same as #12062 et al
    
</details>


### Verification

<!-- TODO: Say how you tested your changes. -->

Existing tests pass

Also tested manually with the Workflow from #12895. <details><summary> Screenshot: </summary>

![Screenshot 2024-04-22 at 12 17 24 PM](https://github.com/argoproj/argo-workflows/assets/4970083/c578c14a-2284-4555-89f9-a1398629f2e8)

</details>

### Notes to Reviewers

It's easier to read each commit independently than it is to read the PR as a whole, that's why I split them that way

### Future Work

1. `pod-name.ts` should only be `export`ing `getPodName`. the rest is not used anywhere except for the tests
    - The tests need a good bit of adjustment for this though, so for now, I left them as-is to show they still pass
1. The back-end's `GeneratePodName` can similarly be simplified, but it requires a lot more refactoring of functions of up the chain
    - partial workflow information, partial node information, etc gets passed down through a few layers of the call stack

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
