### PR TITLE
fix(controller): set pod name version annotation when no lock

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -259,16 +259,15 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 			return
 		}
 		woc.updated = wfUpdate
-		if !acquired {
-			if !woc.releaseLocksForPendingShuttingdownWfs(ctx) {
-				woc.log.Warn("Workflow processing has been postponed due to concurrency limit")
-				phase := woc.wf.Status.Phase
-				if phase == wfv1.WorkflowUnknown {
-					phase = wfv1.WorkflowPending
-				}
-				woc.markWorkflowPhase(ctx, phase, msg)
-				return
+		if !acquired && !woc.releaseLocksForPendingShuttingdownWfs(ctx) {
+			woc.log.Warn("Workflow processing has been postponed due to concurrency limit")
+			phase := woc.wf.Status.Phase
+			if phase == wfv1.WorkflowUnknown {
+				phase = wfv1.WorkflowPending
+				setWfPodNamesAnnotation(woc.wf)
 			}
+			woc.markWorkflowPhase(ctx, phase, msg)
+			return
 		}
 	}
 
@@ -4055,16 +4054,13 @@ func (woc *wfOperationCtx) getServiceAccountTokenName(ctx context.Context, name 
 	return secrets.TokenNameForServiceAccount(account), nil
 }
 
-// setWfPodNamesAnnotation sets an annotation on a workflow with the pod naming
-// convention version
+// setWfPodNamesAnnotation sets an annotation on a workflow with the pod naming convention version
 func setWfPodNamesAnnotation(wf *wfv1.Workflow) {
-	podNameVersion := wfutil.GetPodNameVersion()
-
 	if wf.Annotations == nil {
 		wf.Annotations = map[string]string{}
 	}
 
-	wf.Annotations[common.AnnotationKeyPodNameVersion] = podNameVersion.String()
+	wf.Annotations[common.AnnotationKeyPodNameVersion] = wfutil.GetPodNameVersion().String()
 }
 
 // getChildNodeIdsAndLastRetriedNode returns child node ids and last retried node, which are marked as `NodeStatus.NodeFlag.Retried=true`.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #10178, Fixes https://github.com/argoproj/argo-workflows/pull/6982#discussion_r1574356857, Fixes https://github.com/argoproj/argo-workflows/pull/10735#discussion_r1575092505
Partly addresses https://github.com/argoproj/argo-workflows/pull/6356#discussion_r1574367137, but not entirely, as the PDB is a more complicated case. Will file a separate issue for that. **EDIT**: filed #12966 

### Motivation

<!-- TODO: Say why you made your changes. -->

- `setWfPodNamesAnnotation` was added to the `Unknown` phase check a few lines below this, but not to this line
  - these are the two places where `Unknown` is handled
  - without this, the annotation wouldn't be set if the workflow couldn't grab a lock, creating a mismatch when using synchronization

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add `setWfPodNamesAnnotation` to the other `Unknown` phase block
  - also simplify the conditional into one with an `&&` rather than nesting
    - reducing nesting reduces code complexity

- slightly simplify `setWfPodNamesAnnotation` as well

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested with the same Workflow from #12966, creating two in quick succession (one waits on the mutex lock from the other), `workflows.argoproj.io/pod-name-format: v2` annotations present in both.

Should probably add a case to `operator_concurrency_test.go`, TBD

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
