### PR TITLE
fix: use GetTemplateFromNode to determine template name

### DIFF
--- a/cmd/argo/commands/cp.go
+++ b/cmd/argo/commands/cp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient"
 	workflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow"
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	wfutil "github.com/argoproj/argo-workflows/v3/workflow/util"
 )
 
 func NewCpCommand() *cobra.Command {
@@ -82,7 +83,7 @@ func NewCpCommand() *cobra.Command {
 				if nodeInfo == nil {
 					return fmt.Errorf("could not get node status for node ID %s", artifact.NodeID)
 				}
-				customPath = strings.Replace(customPath, "{templateName}", nodeInfo.TemplateName, 1)
+				customPath = strings.Replace(customPath, "{templateName}", wfutil.GetTemplateFromNode(*nodeInfo), 1)
 				customPath = strings.Replace(customPath, "{namespace}", namespace, 1)
 				customPath = strings.Replace(customPath, "{workflowName}", workflowName, 1)
 				customPath = strings.Replace(customPath, "{nodeId}", artifact.NodeID, 1)

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -93,7 +93,7 @@ func (t *Then) ExpectWorkflowNode(selector func(status wfv1.NodeStatus) bool, f 
 					ObjectMeta: *metadata,
 				}
 				version := util.GetWorkflowPodNameVersion(wf)
-				podName := util.GeneratePodName(t.wf.Name, n.Name, n.TemplateName, n.ID, version)
+				podName := util.GeneratePodName(t.wf.Name, n.Name, util.GetTemplateFromNode(*n), n.ID, version)
 
 				var err error
 				ctx := context.Background()

--- a/util/printer/workflow-printer.go
+++ b/util/printer/workflow-printer.go
@@ -137,7 +137,7 @@ func countPendingRunningCompletedNodes(wf *wfv1.Workflow) (int, int, int) {
 	running := 0
 	completed := 0
 	for _, node := range wf.Status.Nodes {
-		tmpl := wf.GetTemplateByName(node.TemplateName)
+		tmpl := wf.GetTemplateByName(util.GetTemplateFromNode(node))
 		if tmpl == nil || !tmpl.IsPodType() {
 			continue
 		}

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -179,10 +179,7 @@ func (woc *wfOperationCtx) processArtifactGCStrategy(ctx context.Context, strate
 			woc.log.Errorf("Was unable to obtain node for %s", artifactSearchResult.NodeID)
 			return fmt.Errorf("can't process Artifact GC Strategy %s: node ID %q not found in Status??", strategy, artifactSearchResult.NodeID)
 		}
-		templateName := node.TemplateName
-		if templateName == "" && node.GetTemplateRef() != nil {
-			templateName = node.GetTemplateRef().Template
-		}
+		templateName := util.GetTemplateFromNode(*node)
 		if templateName == "" {
 			return fmt.Errorf("can't process Artifact GC Strategy %s: node %+v has an unnamed template", strategy, node)
 		}

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -114,7 +114,7 @@ func (woc *wfOperationCtx) killDaemonedChildren(nodeID string) {
 		if !childNode.IsDaemoned() {
 			continue
 		}
-		podName := util.GeneratePodName(woc.wf.Name, childNode.Name, childNode.TemplateName, childNode.ID, util.GetWorkflowPodNameVersion(woc.wf))
+		podName := util.GeneratePodName(woc.wf.Name, childNode.Name, util.GetTemplateFromNode(childNode), childNode.ID, util.GetWorkflowPodNameVersion(woc.wf))
 		woc.controller.queuePodForCleanup(woc.wf.Namespace, podName, terminateContainers)
 		childNode.Phase = wfv1.NodeSucceeded
 		childNode.Daemoned = nil

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2437,7 +2437,7 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) (*wfv1.Templat
 		}
 		return tmpl, nil
 	}
-	return woc.wf.GetTemplateByName(wfutil.GetTemplateFromNode(*node)), nil
+	return woc.wf.GetTemplateByName(node.TemplateName), nil
 }
 
 func (woc *wfOperationCtx) markWorkflowRunning(ctx context.Context) {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -405,9 +405,9 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 				failedNodeStatus{
 					DisplayName:  node.DisplayName,
 					Message:      node.Message,
-					TemplateName: node.TemplateName,
+					TemplateName: wfutil.GetTemplateFromNode(node),
 					Phase:        string(node.Phase),
-					PodName:      wfutil.GeneratePodName(woc.wf.Name, node.Name, node.TemplateName, node.ID, wfutil.GetPodNameVersion()),
+					PodName:      wfutil.GeneratePodName(woc.wf.Name, node.Name, wfutil.GetTemplateFromNode(node), node.ID, wfutil.GetPodNameVersion()),
 					FinishedAt:   node.FinishedAt,
 				})
 		}
@@ -1338,7 +1338,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 			new.Phase = wfv1.NodeSucceeded
 		} else {
 			new.Phase, new.Message = woc.inferFailedReason(pod, tmpl)
-			woc.log.WithField("displayName", old.DisplayName).WithField("templateName", old.TemplateName).
+			woc.log.WithField("displayName", old.DisplayName).WithField("templateName", wfutil.GetTemplateFromNode(*old)).
 				WithField("pod", pod.Name).Infof("Pod failed: %s", new.Message)
 		}
 		new.Daemoned = nil
@@ -2437,7 +2437,7 @@ func (woc *wfOperationCtx) GetNodeTemplate(node *wfv1.NodeStatus) (*wfv1.Templat
 		}
 		return tmpl, nil
 	}
-	return woc.wf.GetTemplateByName(node.TemplateName), nil
+	return woc.wf.GetTemplateByName(wfutil.GetTemplateFromNode(*node)), nil
 }
 
 func (woc *wfOperationCtx) markWorkflowRunning(ctx context.Context) {
@@ -2628,7 +2628,7 @@ func (woc *wfOperationCtx) getPodByNode(node *wfv1.NodeStatus) (*apiv1.Pod, erro
 		return nil, fmt.Errorf("Expected node type %s, got %s", wfv1.NodeTypePod, node.Type)
 	}
 
-	podName := woc.getPodName(node.Name, node.TemplateName)
+	podName := woc.getPodName(node.Name, wfutil.GetTemplateFromNode(*node))
 	return woc.controller.getPodFromCache(woc.wf.GetNamespace(), podName)
 }
 

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -454,7 +454,7 @@ func ResumeWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, hydrat
 func SelectorMatchesNode(selector fields.Selector, node wfv1.NodeStatus) bool {
 	nodeFields := fields.Set{
 		"displayName":  node.DisplayName,
-		"templateName": node.TemplateName,
+		"templateName": GetTemplateFromNode(node),
 		"phase":        string(node.Phase),
 		"name":         node.Name,
 		"id":           node.ID,


### PR DESCRIPTION
The way to get a template name in a `NodeStatus` is different if using template references. Not all places in the code base handle this small detail. I searched for all reads of `NodeStatus.TemplateName` field and replaced it to use the `GetTemplateFromNode` function. This will ensure that the template name is never empty and retrieved uniformly. 

There are three places in the code base that still manually handle these details: 
- https://github.com/argoproj/argo-workflows/blob/main/cmd/argo/commands/common/get.go#L488-L492
- https://github.com/argoproj/argo-workflows/blob/main/workflow/controller/retry_tweak.go#L18-L33. 
- https://github.com/argoproj/argo-workflows/pull/12970#discussion_r1576605599

If you think we should change these to also use `GetTemplateFromNode` let me know.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/12967

### Motivation

I wanted to create a link to the failed task logs pane in the UI, it requires the pod name to be correct in the workflow failures json, but in the failures json the pod name was incorrect because the template name field was empty.

### Modifications

Changed almost all references of `NodeStatus.TemplateName` to use `GetTemplateFromNode(NodeStatus.TemplateName)`.

### Verification

Ran unit tests.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
