### PR TITLE
fix(ui): try retrieving live workflow first then archived

### DIFF
--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -388,6 +388,8 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                 const wf = await services.workflows.get(namespace, name);
                 setUid(wf.metadata.uid);
                 setWorkflow(wf);
+                setError(null);
+                return;
             } catch (err) {
                 if (err.status !== 404 && uid === '') {
                     setError(err);
@@ -397,6 +399,8 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                 try {
                     const archivedWf = await services.workflows.getArchived(namespace, uid);
                     setWorkflow(archivedWf);
+                    setError(null);
+                    return;
                 } catch (archiveErr) {
                     if (archiveErr.status === 500 && archiveErr.response.body.message === 'getting archived workflows not supported') {
                         setError(err);

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -384,33 +384,26 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
     // Get workflow
     useEffect(() => {
         (async () => {
-            let archivedWf: Workflow;
-            if (uid !== '') {
-                try {
-                    archivedWf = await services.workflows.getArchived(namespace, uid);
-                    setError(null);
-                } catch (err) {
-                    if (err.status !== 404) {
-                        setError(err);
-                    }
-                }
-            }
-
             try {
                 const wf = await services.workflows.get(namespace, name);
-                setError(null);
-                // If we find live workflow which has same uid, we use live workflow.
-                if (!archivedWf || archivedWf.metadata.uid === wf.metadata.uid) {
-                    setWorkflow(wf);
-                    setUid(wf.metadata.uid);
-                } else {
-                    setWorkflow(archivedWf);
-                }
+                setUid(wf.metadata.uid);
+                setWorkflow(wf);
             } catch (err) {
-                if (archivedWf) {
-                    setWorkflow(archivedWf);
-                } else {
+                if (err.status !== 404 && uid === '') {
                     setError(err);
+                    return;
+                }
+
+                try {
+                    const archivedWf = await services.workflows.getArchived(namespace, uid);
+                    setWorkflow(archivedWf);
+                } catch (archiveErr) {
+                    if (archiveErr.status === 500 && archiveErr.response.body.message === 'getting archived workflows not supported') {
+                        setError(err);
+                        return;
+                    }
+
+                    setError(archiveErr);
                 }
             }
         })();


### PR DESCRIPTION
Retrieving an archived workflow is the fallback now.

Related Slack thread: https://cloud-native.slack.com/archives/C01QW9QSSSK/p1710600357875049\?thread_ts\=1710510295.856659\&cid\=C01QW9QSSSK

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/12814

### Motivation

Currently an error appears when loading a workflow because archived workflows are not enabled and the ui tries to get the archived workflow first. 

### Modifications

Changed the order in which workflows are retrieved from the back end.

### Verification

None, not sure how to verify at the moment.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
