### PR TITLE
fix: consistently set executor log options 

### DIFF
--- a/util/cmd/glog.go
+++ b/util/cmd/glog.go
@@ -16,10 +16,6 @@ func SetGLogLevel(glogLevel int) {
 	_ = flag.Set("v", strconv.Itoa(glogLevel))
 }
 
-func GetGLogLevel() int {
-	verbosity, err := strconv.Atoi(flag.Lookup("v").Value.String())
-	if err != nil {
-		return 0
-	}
-	return verbosity
+func GetGLogLevel() string {
+	return flag.Lookup("v").Value.String()
 }

--- a/util/cmd/glog.go
+++ b/util/cmd/glog.go
@@ -15,3 +15,11 @@ func SetGLogLevel(glogLevel int) {
 	_ = flag.Set("logtostderr", "true")
 	_ = flag.Set("v", strconv.Itoa(glogLevel))
 }
+
+func GetGLogLevel() int {
+	verbosity, err := strconv.Atoi(flag.Lookup("v").Value.String())
+	if err != nil {
+		return 0
+	}
+	return verbosity
+}

--- a/util/cmd/glog.go
+++ b/util/cmd/glog.go
@@ -17,5 +17,9 @@ func SetGLogLevel(glogLevel int) {
 }
 
 func GetGLogLevel() string {
-	return flag.Lookup("v").Value.String()
+	f := flag.Lookup("v")
+	if f == nil {
+		return ""
+	}
+	return f.Value.String()
 }

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -191,11 +191,11 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	// the `init` container populates the shared empty-dir volume with tokens
 	agentInitCtr := agentCtrTemplate.DeepCopy()
 	agentInitCtr.Name = common.InitContainerName
-	agentInitCtr.Args = []string{"agent", "init", "--loglevel", getExecutorLogLevel()}
+	agentInitCtr.Args = append([]string{"agent", "init"}, woc.getExecutorLogOpts()...)
 	// the `main` container runs the actual work
 	agentMainCtr := agentCtrTemplate.DeepCopy()
 	agentMainCtr.Name = common.MainContainerName
-	agentMainCtr.Args = []string{"agent", "main", "--loglevel", getExecutorLogLevel()}
+	agentMainCtr.Args = append([]string{"agent", "main"}, woc.getExecutorLogOpts()...)
 
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -438,7 +438,7 @@ func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv
 					Name:            common.MainContainerName,
 					Image:           woc.controller.executorImage(),
 					ImagePullPolicy: woc.controller.executorImagePullPolicy(),
-					Args:            []string{"artifact", "delete", "--loglevel", getExecutorLogLevel()},
+					Args:            append([]string{"artifact", "delete"}, woc.getExecutorLogOpts()...),
 					Env: []corev1.EnvVar{
 						{Name: common.EnvVarArtifactGCPodHash, Value: woc.artifactGCPodLabel(podName)},
 					},

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3397,7 +3397,7 @@ func (woc *wfOperationCtx) executeResource(ctx context.Context, nodeName string,
 	}
 
 	mainCtr := woc.newExecContainer(common.MainContainerName, tmpl)
-	mainCtr.Command = append([]string{"argoexec", "resource"}, woc.getExecutorLogOpts()...)
+	mainCtr.Command = append([]string{"argoexec", "resource", tmpl.Resource.Action}, woc.getExecutorLogOpts()...)
 	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*mainCtr}, tmpl, &createWorkflowPodOpts{onExitPod: opts.onExitTemplate, executionDeadline: opts.executionDeadline})
 	if err != nil {
 		return woc.requeueIfTransientErr(err, node.Name)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3397,7 +3397,7 @@ func (woc *wfOperationCtx) executeResource(ctx context.Context, nodeName string,
 	}
 
 	mainCtr := woc.newExecContainer(common.MainContainerName, tmpl)
-	mainCtr.Command = []string{"argoexec", "resource", tmpl.Resource.Action}
+	mainCtr.Command = append([]string{"argoexec", "resource"}, woc.getExecutorLogOpts()...)
 	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*mainCtr}, tmpl, &createWorkflowPodOpts{onExitPod: opts.onExitTemplate, executionDeadline: opts.executionDeadline})
 	if err != nil {
 		return woc.requeueIfTransientErr(err, node.Name)
@@ -3420,7 +3420,7 @@ func (woc *wfOperationCtx) executeData(ctx context.Context, nodeName string, tem
 	}
 
 	mainCtr := woc.newExecContainer(common.MainContainerName, tmpl)
-	mainCtr.Command = []string{"argoexec", "data", string(dataTemplate)}
+	mainCtr.Command = append([]string{"argoexec", "data", string(dataTemplate)}, woc.getExecutorLogOpts()...)
 	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*mainCtr}, tmpl, &createWorkflowPodOpts{onExitPod: opts.onExitTemplate, executionDeadline: opts.executionDeadline, includeScriptOutput: true})
 	if err != nil {
 		return woc.requeueIfTransientErr(err, node.Name)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3433,7 +3433,8 @@ func TestResolveIOPathPlaceholders(t *testing.T) {
 	assert.NotEmpty(t, pods.Items, "pod was not created successfully")
 
 	assert.Equal(t, append(append([]string{"/var/run/argo/argoexec", "emissary"}, woc.getExecutorLogOpts()...),
-		"--", "sh", "-c", "head -n 3 <\"/inputs/text/data\" | tee \"/outputs/text/data\" | wc -l > \"/outputs/actual-lines-count/data\""), pods.Items[0].Spec.Containers[1].Command)
+		"--", "sh", "-c", "head -n 3 <\"/inputs/text/data\" | tee \"/outputs/text/data\" | wc -l > \"/outputs/actual-lines-count/data\"",
+	), pods.Items[0].Spec.Containers[1].Command)
 }
 
 var outputValuePlaceholders = `

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -3432,11 +3432,8 @@ func TestResolveIOPathPlaceholders(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, pods.Items, "pod was not created successfully")
 
-	assert.Equal(t, []string{
-		"/var/run/argo/argoexec", "emissary",
-		"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-		"--", "sh", "-c", "head -n 3 <\"/inputs/text/data\" | tee \"/outputs/text/data\" | wc -l > \"/outputs/actual-lines-count/data\"",
-	}, pods.Items[0].Spec.Containers[1].Command)
+	assert.Equal(t, append(append([]string{"/var/run/argo/argoexec", "emissary"}, woc.getExecutorLogOpts()...),
+		"--", "sh", "-c", "head -n 3 <\"/inputs/text/data\" | tee \"/outputs/text/data\" | wc -l > \"/outputs/actual-lines-count/data\""), pods.Items[0].Spec.Containers[1].Command)
 }
 
 var outputValuePlaceholders = `

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -608,7 +608,12 @@ func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) *apiv1.Containe
 }
 
 func (woc *wfOperationCtx) getExecutorLogOpts() []string {
-	return []string{"--loglevel", log.GetLevel().String(), "--log-format", woc.controller.executorLogFormat(), "--gloglevel", cmdutil.GetGLogLevel()}
+	logOpts := []string{"--loglevel", log.GetLevel().String(), "--log-format", woc.controller.executorLogFormat()}
+	gLogLevel := cmdutil.GetGLogLevel()
+	if gLogLevel == nil {
+		return logOpts
+	}
+	return append(logOpts, "--gloglevel", cmdutil.GetGLogLevel())
 }
 
 func (woc *wfOperationCtx) createEnvVars() []apiv1.EnvVar {

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -608,12 +608,7 @@ func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) *apiv1.Containe
 }
 
 func (woc *wfOperationCtx) getExecutorLogOpts() []string {
-	logOpts := []string{"--loglevel", log.GetLevel().String(), "--log-format", woc.controller.executorLogFormat()}
-	gLogLevel := cmdutil.GetGLogLevel()
-	if gLogLevel == "" {
-		return logOpts
-	}
-	return append(logOpts, "--gloglevel", cmdutil.GetGLogLevel())
+	return []string{"--loglevel", log.GetLevel().String(), "--log-format", woc.controller.executorLogFormat(), "--gloglevel", cmdutil.GetGLogLevel()}
 }
 
 func (woc *wfOperationCtx) createEnvVars() []apiv1.EnvVar {

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -610,7 +610,7 @@ func (woc *wfOperationCtx) newWaitContainer(tmpl *wfv1.Template) *apiv1.Containe
 func (woc *wfOperationCtx) getExecutorLogOpts() []string {
 	logOpts := []string{"--loglevel", log.GetLevel().String(), "--log-format", woc.controller.executorLogFormat()}
 	gLogLevel := cmdutil.GetGLogLevel()
-	if gLogLevel == nil {
+	if gLogLevel == "" {
 		return logOpts
 	}
 	return append(logOpts, "--gloglevel", cmdutil.GetGLogLevel())

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -397,7 +397,8 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 					c.Args = x.Cmd
 				}
 			}
-			c.Command = append(append(append([]string{common.VarRunArgoPath + "/argoexec", "emissary"}, woc.getExecutorLogOpts()...), "--"), c.Command...)
+			execCmd := append(append([]string{common.VarRunArgoPath + "/argoexec", "emissary"}, woc.getExecutorLogOpts()...), "--")
+			c.Command = append(execCmd, c.Command...)
 		}
 		if c.Image == woc.controller.executorImage() {
 			// mount tmp dir to wait container

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -648,6 +648,8 @@ func Test_createWorkflowPod_containerName(t *testing.T) {
 	assert.Equal(t, common.MainContainerName, pod.Spec.Containers[1].Name)
 }
 
+var emissaryCmd = []string{"/var/run/argo/argoexec", "emissary"}
+
 func Test_createWorkflowPod_emissary(t *testing.T) {
 	t.Run("NoCommand", func(t *testing.T) {
 		woc := newWoc()
@@ -658,26 +660,20 @@ func Test_createWorkflowPod_emissary(t *testing.T) {
 		woc := newWoc()
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Command: []string{"foo"}}}, &wfv1.Template{}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
-			"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-			"--", "foo"}, pod.Spec.Containers[1].Command)
+		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "foo"), pod.Spec.Containers[1].Command)
 	})
 	t.Run("NoCommandWithImageIndex", func(t *testing.T) {
 		woc := newWoc()
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Image: "my-image"}}, &wfv1.Template{}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
-			"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-			"--", "my-entrypoint"}, pod.Spec.Containers[1].Command)
+		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "my-entrypoint"), pod.Spec.Containers[1].Command)
 		assert.Equal(t, []string{"my-cmd"}, pod.Spec.Containers[1].Args)
 	})
 	t.Run("NoCommandWithArgsWithImageIndex", func(t *testing.T) {
 		woc := newWoc()
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Image: "my-image", Args: []string{"foo"}}}, &wfv1.Template{}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
-			"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-			"--", "my-entrypoint"}, pod.Spec.Containers[1].Command)
+		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "my-entrypoint"), pod.Spec.Containers[1].Command)
 		assert.Equal(t, []string{"foo"}, pod.Spec.Containers[1].Args)
 	})
 	t.Run("CommandFromPodSpecPatch", func(t *testing.T) {
@@ -691,9 +687,7 @@ func Test_createWorkflowPod_emissary(t *testing.T) {
 		require.NoError(t, err)
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Command: []string{"foo"}}}, &wfv1.Template{PodSpecPatch: string(podSpecPatch)}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
-			"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-			"--", "bar"}, pod.Spec.Containers[1].Command)
+		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "bar"), pod.Spec.Containers[1].Command)
 	})
 }
 
@@ -747,9 +741,7 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		assert.Equal(t, "tmp-dir-argo", wait.VolumeMounts[1].Name)
 		assert.Equal(t, "var-run-argo", wait.VolumeMounts[2].Name)
 		main := containers[1]
-		assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
-			"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-			"--", "cowsay"}, main.Command)
+		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "cowsay"), main.Command)
 		require.Len(t, main.VolumeMounts, 2)
 		assert.Equal(t, "volume-name", main.VolumeMounts[0].Name)
 		assert.Equal(t, "var-run-argo", main.VolumeMounts[1].Name)

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -660,20 +660,23 @@ func Test_createWorkflowPod_emissary(t *testing.T) {
 		woc := newWoc()
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Command: []string{"foo"}}}, &wfv1.Template{}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "foo"), pod.Spec.Containers[1].Command)
+		cmd := append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "foo")
+		assert.Equal(t, cmd, pod.Spec.Containers[1].Command)
 	})
 	t.Run("NoCommandWithImageIndex", func(t *testing.T) {
 		woc := newWoc()
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Image: "my-image"}}, &wfv1.Template{}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "my-entrypoint"), pod.Spec.Containers[1].Command)
+		cmd := append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "my-entrypoint")
+		assert.Equal(t, cmd, pod.Spec.Containers[1].Command)
 		assert.Equal(t, []string{"my-cmd"}, pod.Spec.Containers[1].Args)
 	})
 	t.Run("NoCommandWithArgsWithImageIndex", func(t *testing.T) {
 		woc := newWoc()
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Image: "my-image", Args: []string{"foo"}}}, &wfv1.Template{}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "my-entrypoint"), pod.Spec.Containers[1].Command)
+		cmd := append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "my-entrypoint")
+		assert.Equal(t, cmd, pod.Spec.Containers[1].Command)
 		assert.Equal(t, []string{"foo"}, pod.Spec.Containers[1].Args)
 	})
 	t.Run("CommandFromPodSpecPatch", func(t *testing.T) {
@@ -687,7 +690,8 @@ func Test_createWorkflowPod_emissary(t *testing.T) {
 		require.NoError(t, err)
 		pod, err := woc.createWorkflowPod(context.Background(), "", []apiv1.Container{{Command: []string{"foo"}}}, &wfv1.Template{PodSpecPatch: string(podSpecPatch)}, &createWorkflowPodOpts{})
 		require.NoError(t, err)
-		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "bar"), pod.Spec.Containers[1].Command)
+		cmd := append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "bar")
+		assert.Equal(t, cmd, pod.Spec.Containers[1].Command)
 	})
 }
 
@@ -741,7 +745,8 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		assert.Equal(t, "tmp-dir-argo", wait.VolumeMounts[1].Name)
 		assert.Equal(t, "var-run-argo", wait.VolumeMounts[2].Name)
 		main := containers[1]
-		assert.Equal(t, append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "cowsay"), main.Command)
+		cmd := append(append(emissaryCmd, woc.getExecutorLogOpts()...), "--", "cowsay")
+		assert.Equal(t, cmd, main.Command)
 		require.Len(t, main.VolumeMounts, 2)
 		assert.Equal(t, "volume-name", main.VolumeMounts[0].Name)
 		assert.Equal(t, "var-run-argo", main.VolumeMounts[1].Name)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12788, Fixes https://github.com/argoproj/argo-workflows/pull/12929#discussion_r1572707894

### Motivation

<!-- TODO: Say why you made your changes. -->

- loglevel, gloglevel, and log format were inconsistently set around the codebase for executor containers
  - meaning that some had partial settings and some had no settings, depending on the command run etc

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- for all commands, including `emissary`, `agent`, `resource`, and `data`
  - set loglevel, gloglevel, and log format

- replace `getExecutorLogLevel` helper with `getExecutorLogOpts` helper
- add a helper in `util/cmd/glog.go` to get the gloglevel

### Verification

<!-- TODO: Say how you tested your changes. -->

Existing tests pass

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
