### PR TITLE
feat(executor): set seccomp profile to runtimedefault

### DIFF
--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -39,8 +40,9 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 				spec := pod.Spec
 				assert.Equal(t, pointer.Bool(false), spec.AutomountServiceAccountToken)
 				assert.Equal(t, &apiv1.PodSecurityContext{
-					RunAsUser:    pointer.Int64(8737),
-					RunAsNonRoot: pointer.Bool(true),
+					RunAsUser:      pointer.Int64(8737),
+					RunAsNonRoot:   pointer.Bool(true),
+					SeccompProfile: &v1.SeccompProfile{Type: "RuntimeDefault"},
 				}, spec.SecurityContext)
 				if assert.Len(t, spec.Volumes, 4) {
 					assert.Contains(t, spec.Volumes[0].Name, "kube-api-access-")
@@ -71,7 +73,9 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 								RunAsNonRoot:             pointer.Bool(true),
 								AllowPrivilegeEscalation: pointer.Bool(false),
 								ReadOnlyRootFilesystem:   pointer.Bool(true),
+								Privileged:               pointer.Bool(false),
 								Capabilities:             &apiv1.Capabilities{Drop: []apiv1.Capability{"ALL"}},
+								SeccompProfile:           &v1.SeccompProfile{Type: "RuntimeDefault"},
 							}, agent.SecurityContext)
 						}
 					}

--- a/workflow/common/security_context.go
+++ b/workflow/common/security_context.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func MinimalCtrSC() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		Privileged:               pointer.Bool(false),
+		RunAsNonRoot:             pointer.Bool(true),
+		RunAsUser:                pointer.Int64(8737),
+		ReadOnlyRootFilesystem:   pointer.Bool(true),
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+	}
+}
+
+func MinimalPodSC() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot:   pointer.Bool(true),
+		RunAsUser:      pointer.Int64(8737),
+		SeccompProfile: &corev1.SeccompProfile{Type: "RuntimeDefault"},
+	}
+}

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -174,15 +174,7 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 		Image:           woc.controller.executorImage(),
 		ImagePullPolicy: woc.controller.executorImagePullPolicy(),
 		Env:             envVars,
-		SecurityContext: &apiv1.SecurityContext{
-			Capabilities: &apiv1.Capabilities{
-				Drop: []apiv1.Capability{"ALL"},
-			},
-			RunAsNonRoot:             pointer.Bool(true),
-			RunAsUser:                pointer.Int64(8737),
-			ReadOnlyRootFilesystem:   pointer.Bool(true),
-			AllowPrivilegeEscalation: pointer.Bool(false),
-		},
+		SecurityContext: common.MinimalCtrSC(),
 		Resources: apiv1.ResourceRequirements{
 			Requests: map[apiv1.ResourceName]resource.Quantity{
 				"cpu":    resource.MustParse("10m"),
@@ -221,12 +213,9 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 			},
 		},
 		Spec: apiv1.PodSpec{
-			RestartPolicy:    apiv1.RestartPolicyOnFailure,
-			ImagePullSecrets: woc.execWf.Spec.ImagePullSecrets,
-			SecurityContext: &apiv1.PodSecurityContext{
-				RunAsNonRoot: pointer.Bool(true),
-				RunAsUser:    pointer.Int64(8737),
-			},
+			RestartPolicy:                apiv1.RestartPolicyOnFailure,
+			ImagePullSecrets:             woc.execWf.Spec.ImagePullSecrets,
+			SecurityContext:              common.MinimalPodSC(),
 			ServiceAccountName:           serviceAccountName,
 			AutomountServiceAccountToken: pointer.Bool(false),
 			Volumes:                      podVolumes,

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -431,7 +431,8 @@ func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv
 			OwnerReferences: ownerReferences,
 		},
 		Spec: corev1.PodSpec{
-			Volumes: volumes,
+			Volumes:         volumes,
+			SecurityContext: common.MinimalPodSC(),
 			Containers: []corev1.Container{
 				{
 					Name:            common.MainContainerName,
@@ -444,14 +445,7 @@ func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv
 					// if this pod is breached by an attacker we:
 					// * prevent installation of any new packages
 					// * modification of the file-system
-					SecurityContext: &corev1.SecurityContext{
-						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-						Privileged:               pointer.Bool(false),
-						RunAsNonRoot:             pointer.Bool(true),
-						RunAsUser:                pointer.Int64(8737),
-						ReadOnlyRootFilesystem:   pointer.Bool(true),
-						AllowPrivilegeEscalation: pointer.Bool(false),
-					},
+					SecurityContext: common.MinimalCtrSC(),
 					// if this pod is breached by an attacker these limits prevent excessive CPU and memory usage
 					Resources: corev1.ResourceRequirements{
 						Limits: map[corev1.ResourceName]resource.Quantity{

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -685,14 +685,9 @@ func (woc *wfOperationCtx) newExecContainer(name string, tmpl *wfv1.Template) *a
 	}
 	// lock down resource pods by default
 	if tmpl.GetType() == wfv1.TemplateTypeResource && exec.SecurityContext == nil {
-		exec.SecurityContext = &apiv1.SecurityContext{
-			Capabilities: &apiv1.Capabilities{
-				Drop: []apiv1.Capability{"ALL"},
-			},
-			RunAsNonRoot:             pointer.Bool(true),
-			RunAsUser:                pointer.Int64(8737),
-			AllowPrivilegeEscalation: pointer.Bool(false),
-		}
+		exec.SecurityContext = common.MinimalCtrSC()
+		// TODO: always set RO FS once #10787 is fixed
+		exec.SecurityContext.ReadOnlyRootFilesystem = nil
 		if exec.Name != common.InitContainerName && exec.Name != common.WaitContainerName {
 			exec.SecurityContext.ReadOnlyRootFilesystem = pointer.Bool(true)
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation


We are using Kyverno Policies to enforce different security settings within our cluster. For example running containers as non Root.

But also to explicitly have set the SeccompProfile to RuntimeDefault. See the [official Documentation](https://kubernetes.io/docs/tutorials/security/seccomp/#create-a-pod-that-uses-the-container-runtime-default-seccomp-profile)

Currently the artifact GC is beeing blocked by our Kyverno policy. On my search for values to change the default (e.g. via Helm) i found the code I changed in this PR.

### Modifications

Explicitly Setting the Seccomp Profile to RuntimeDefault when creating the artifact GC Pod.

### Verification

The E2E tests should catch any issues, if you want me to test this locally let me know

