### PR TITLE
build: Remove misleading logs from crdgen.sh

### DIFF
--- a/hack/manifests/crdgen.sh
+++ b/hack/manifests/crdgen.sh
@@ -11,13 +11,12 @@ add_header() {
 controller-gen crd:maxDescLen=0 paths=./pkg/apis/... output:dir=manifests/base/crds/full
 
 find manifests/base/crds/full -name 'argoproj.io*.yaml' | while read -r file; do
-  echo "Patching ${file}"
   # remove junk fields
   go run ./hack/manifests cleancrd "$file"
   add_header "$file"
   # create minimal
   minimal="manifests/base/crds/minimal/$(basename "$file")"
-  echo "Creating ${minimal}"
+  echo "Creating minimal CRD file: ${minimal}"
   cp "$file" "$minimal"
   go run ./hack/manifests removecrdvalidation "$minimal"
 done


### PR DESCRIPTION
The current logs are misleading which may look like both the minimal and full CRDs are applied to the cluster twice:
```
Patching ...
Creating ...
```
The PR makes it less confusing.