### PR TITLE
fix(docs): Update buildkit example

### DIFF
--- a/examples/buildkit-template.yaml
+++ b/examples/buildkit-template.yaml
@@ -35,7 +35,7 @@ spec:
       - name: repo
         value: https://github.com/argoproj/argo-workflows
       - name: branch
-        value: master
+        value: main
       - name: path
         value: test/e2e/images/argosay/v2
       - name: image
@@ -62,13 +62,6 @@ spec:
                   value: "{{workflow.parameters.repo}}"
                 - name: branch
                   value: "{{workflow.parameters.branch}}"
-          - name: build
-            template: build
-            arguments:
-              parameters:
-                - name: path
-                  value: "{{workflow.parameters.path}}"
-            depends: "clone"
           - name: image
             template: image
             arguments:
@@ -77,7 +70,7 @@ spec:
                   value: "{{workflow.parameters.path}}"
                 - name: image
                   value: "{{workflow.parameters.image}}"
-            depends: "build"
+            depends: "clone"
     - name: clone
       inputs:
         parameters:
@@ -100,28 +93,6 @@ spec:
           - --single-branch
           - "{{inputs.parameters.repo}}"
           - .
-    - name: build
-      inputs:
-        parameters:
-          - name: path
-      container:
-        image: golang:1.13
-        volumeMounts:
-          - mountPath: /work
-            name: work
-        workingDir: /work/{{inputs.parameters.path}}
-        env:
-          # Because this is not a Gomodule, we must turn modules off.
-          - name: GO111MODULE
-            value: "off"
-        command:
-          - go
-        args:
-          - build
-          - -v
-          - -o
-          - argosay
-          - ./...
     - name: image
       inputs:
         parameters:


### PR DESCRIPTION
### Motivation

There are two issues with the buildkit example: 1) The default branch is `master` but the argo-workflows repo only has `main` 2) The build task refers to a go project that no longer exists in this repo.

### Modifications

* Updated the default branch for the example to `main`
* Removed the `build` step entirely from the example

If preferred, I could modify the build step to use the example go project from that example workflow instead.

### Verification

Ran the workflow from my local Argo workflows instance after setting up the Docker credentials as noted by the example.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->