### PR TITLE
feat(ci): Add retest workflow. Fixes #12864

### DIFF
--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -1,0 +1,24 @@
+name: Detect and Trigger Retest
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  retest:
+    if: github.event.comment.author_association == 'MEMBER' && github.event.comment.body == '/retest'
+    permissions:
+      actions: write # for re-running failed jobs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-job-from-a-workflow-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed jobs for this PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          SHA_REF=$(gh api "/repos/$REPO/pulls/$PR_NUMBER/commits" | jq -r '.[].sha' | tail -n 1)
+          RUN_ID=$(gh api "repos/$REPO/actions/workflows/ci-build.yaml/runs?per_page=1&event=pull_request&head_sha=$SHA_REF" | jq -r '.workflow_runs[] | .id)
+          gh api --method POST repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12864 

### Motivation

Due to flaky tests, it would be nice to allow `Members` to re-run failing workflows.

### Modifications

Extend github workflows with `retest.yaml`. It adds a new workflow run which is triggered on `issue_comment:[created,edited]`. It requires the comment to contain exactly the `/retest`. It will execute a sequence of API calls to fetch the latest SHA, the latest run ID and trigger the rerun of the failed jobs.

Note: If the workflow doesn't contain any failed jobs it will fail.

### Verification

Used a forked repository https://github.com/miltalex/argo-workflows . Merged the new workflow on `main` branch and opened PRs (https://github.com/miltalex/argo-workflows/pull/1 , https://github.com/miltalex/argo-workflows/pull/2 , https://github.com/miltalex/argo-workflows/pull/3) in order to:

- [x] Test new comment `/retest` &rarr; Trigger failed jobs
- [x] Test edit comment  to `retest` &rarr;  Retest workflow is skipped
- [x] Test edit comment to `/retest` &rarr; Trigger failed jobs
- [x] Test new comment without `/retest` &rarr;  Retest workflow is skipped
- [x] Test new comment with `/retest` and no failing jobs &rarr;  Retest workflow failed due to no failing jobs.


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
