### PR TITLE
DRAFT fix!: dag use specified dependency as parent

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -494,15 +494,12 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 			// Otherwise, add all outbound nodes of our dependencies as parents to this node
 			for _, depName := range taskDependencies {
 				depNode := dagCtx.getTaskNode(depName)
-				outboundNodeIDs := woc.getOutboundNodes(depNode.ID)
-				for _, outNodeID := range outboundNodeIDs {
-					nodeName, err := woc.wf.Status.Nodes.GetName(outNodeID)
-					if err != nil {
-						woc.log.Errorf("was unable to obtain node for %s", outNodeID)
-						return
-					}
-					woc.addChildNode(nodeName, taskNodeName)
+				nodeName, err := woc.wf.Status.Nodes.GetName(depNode.ID)
+				if err != nil {
+					woc.log.Errorf("was unable to obtain node for %s", depNode.ID)
+					return
 				}
+				woc.addChildNode(nodeName, taskNodeName)
 			}
 		}
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3147,9 +3147,10 @@ func (woc *wfOperationCtx) processAggregateNodeOutputs(scope *wfScope, prefix st
 		return nil
 	}
 	// Some of the children may be hooks, only keep those that aren't
+	// keep children that's a sub task/step
 	nodeIdx := 0
 	for i := range childNodes {
-		if childNodes[i].NodeFlag == nil || !childNodes[i].NodeFlag.Hooked {
+		if (childNodes[i].NodeFlag == nil || !childNodes[i].NodeFlag.Hooked) && strings.Contains(childNodes[i].DisplayName, "(") {
 			childNodes[nodeIdx] = childNodes[i]
 			nodeIdx++
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->



<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12997

approach 1, connect dag nodes to the specified dependency instead of the deepest childnode of the dependency
breaking change, potentially affects many other area of the dag code

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
