### PR TITLE
fix: add timeout for executor signal

### DIFF
--- a/workflow/signal/signal.go
+++ b/workflow/signal/signal.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,8 @@ func ExecPodContainerAndGetOutput(ctx context.Context, restConfig *rest.Config, 
 	if err != nil {
 		return err
 	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
 	stdout, stderr, err := common.GetExecutorOutput(ctx, x)
 	log.
 		WithField("namespace", namespace).

--- a/workflow/signal/signal.go
+++ b/workflow/signal/signal.go
@@ -50,6 +50,7 @@ func ExecPodContainerAndGetOutput(ctx context.Context, restConfig *rest.Config, 
 	if err != nil {
 		return err
 	}
+	// workaround for when exec does not properly return: https://github.com/kubernetes/kubernetes/pull/103177
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	stdout, stderr, err := common.GetExecutorOutput(ctx, x)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

<!-- Does this PR fix an issue -->

Fixes #13011

### Motivation

### Modifications

I added a context timeout to prevent spdy from blocking for a long time 
