### PR TITLE
fix: don't rebuild `ui/dist/app/index.html` in `argocli-build` stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ ARG GIT_TREE_STATE
 RUN mkdir -p ui/dist
 COPY --from=argo-ui ui/dist/app ui/dist/app
 
+# Ensure in github CI that we don't attempt to rebuild this file
+RUN touch ui/dist/app/index.html
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build STATIC_FILES=true make dist/argo GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE}
 
 ####################################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,9 @@ ARG GIT_TREE_STATE
 
 RUN mkdir -p ui/dist
 COPY --from=argo-ui ui/dist/app ui/dist/app
-
-# Ensure in github CI that we don't attempt to rebuild this file
+# update timestamp so that `make` doesn't try to rebuild this -- it was already built in the previous stage
 RUN touch ui/dist/app/index.html
+
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build STATIC_FILES=true make dist/argo GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE}
 
 ####################################################################################################


### PR DESCRIPTION
The timestamps in CI are incorrect, and may result in an attempt to rebuild this file when we don't have yarn installed. So don't.

This is a problem introduced in #13018. _edit by agilgur5:_ See also [Slack thread](https://cloud-native.slack.com/archives/C0510EUH90V/p1715172548595289?thread_ts=1715163699.813329&cid=C0510EUH90V) for some debugging details on this

The timestamps don't always line up like expected when we come to check if we need to rebuild ui/dist/app/index.heml in the argocli-build step so force them fixed.

![image](https://github.com/argoproj/argo-workflows/assets/1827156/e08b707d-b470-440a-a255-9e8579eb6dc4)
