### PR TITLE
ci: run E2E tests if `Dockerfile` changes

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -42,6 +42,7 @@ jobs:
               - tasks.yaml
             tests: &tests
               - *common
+              - Dockerfile
               - cmd/**
               - config/**
               - errors/**

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -42,7 +42,6 @@ jobs:
               - tasks.yaml
             tests: &tests
               - *common
-              - Dockerfile
               - cmd/**
               - config/**
               - errors/**
@@ -57,6 +56,7 @@ jobs:
             e2e-tests:
               - *tests
               # plus manifests and SDKs that are used in E2E tests
+              - Dockerfile
               - manifests/**
               - sdks/**
             codegen:


### PR DESCRIPTION
When the Dockerfile changes we should re-test most of the world
