### PR TITLE
fix(test): add a `sleep` to `TestLoadToStream`

### DIFF
--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -238,7 +238,7 @@ type WorkflowCompletionOkay bool
 
 // Wait for a workflow to meet a condition:
 // Options:
-// * `time.Duration` - change the timeout - 30s by default
+// * `time.Duration` - change the timeout - 60s by default
 // * `string` - either:
 //   - the workflow's name (not spaces)
 //   - or a new message (if it contain spaces) - default "to finish"

--- a/workflow/artifacts/common/load_to_stream_test.go
+++ b/workflow/artifacts/common/load_to_stream_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -92,6 +93,7 @@ func TestLoadToStream(t *testing.T) {
 				stream.Close()
 
 				// make sure the new file got deleted when we called stream.Close() above
+				time.Sleep(1 * time.Second) // fs race condition -- wait a bit to ensure the file has been deleted
 				filesAfter, err := os.ReadDir("/tmp/")
 				if err != nil {
 					panic(err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- it very infrequently has a test flake in it
  - have had this in my `git stash` since at least September, and only hit this a few times in those ~9 months
    - I thought it had been fixed by some other changes (#11753 in particular) for a while, but [just experienced it again](https://github.com/argoproj/argo-workflows/actions/runs/9046011165/job/24856369833) (and [twice](https://github.com/argoproj/argo-workflows/actions/runs/9248749132/job/25439502972) [more](https://github.com/argoproj/argo-workflows/actions/runs/9249013492/job/25441555518)), so nope
    
<details> <summary>Error log:</summary>

```
--- FAIL: TestLoadToStream (0.01s)
    --- FAIL: TestLoadToStream/Success (0.01s)
        load_to_stream_test.go:99: 
            	Error Trace:	/home/runner/work/argo-workflows/argo-workflows/workflow/artifacts/common/load_to_stream_test.go:99
            	Error:      	Not equal: 
            	            	expected: 25
            	            	actual  : 26
            	Test:       	TestLoadToStream/Success
```

</details>

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- also fix incorrect comment in `when.go` -- [`defaultTimeout` defaults to 60s](https://github.com/argoproj/argo-workflows/blob/0c1398ea6fa66cc77156f15a6d69c260c6b524da/test/e2e/fixtures/e2e_suite.go#L48), not 30s

### Verification

<!-- TODO: Say how you tested your changes. -->

Test passes more often

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
