### PR TITLE
fix(ui): Use proper podname for containersets. Fixes #13038

### DIFF
--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -3,7 +3,6 @@ import {ANNOTATION_KEY_POD_NAME_VERSION} from './annotations';
 
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
 
-
 describe('pod names', () => {
     test('createFNVHash', () => {
         expect(createFNVHash('hello')).toEqual(1335831723);

--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,7 +1,17 @@
 import {NodeStatus, Workflow} from '../../models';
 import {ANNOTATION_KEY_POD_NAME_VERSION} from './annotations';
 
-import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
+import {
+    createFNVHash,
+    ensurePodNamePrefixLength,
+    getPodName,
+    getTemplateNameFromNode,
+    k8sNamingHashLength,
+    maxK8sResourceNameLength,
+    POD_NAME_V1,
+    POD_NAME_V2,
+    getNodeIdFromNodeName
+} from './pod-name';
 
 describe('pod names', () => {
     test('createFNVHash', () => {
@@ -75,5 +85,15 @@ describe('pod names', () => {
         // case: template name defined
         node.templateName = 'test-template';
         expect(getTemplateNameFromNode(node)).toEqual(node.templateName);
+    });
+
+    test('getNodeIdFromNodeName', () => {
+        const wf = {
+            metadata: {
+                name: 'outputs-result-5cffb'
+            }
+        } as unknown as Workflow;
+        expect(getNodeIdFromNodeName(wf, 'outputs-result-5cffb.a.main')).toEqual('outputs-result-5cffb-534491738');
+        expect(getNodeIdFromNodeName(wf, 'outputs-result-5cffb.b')).toEqual('outputs-result-5cffb-3597813194');
     });
 });

--- a/ui/src/app/shared/pod-name.test.ts
+++ b/ui/src/app/shared/pod-name.test.ts
@@ -1,17 +1,8 @@
 import {NodeStatus, Workflow} from '../../models';
 import {ANNOTATION_KEY_POD_NAME_VERSION} from './annotations';
 
-import {
-    createFNVHash,
-    ensurePodNamePrefixLength,
-    getPodName,
-    getTemplateNameFromNode,
-    k8sNamingHashLength,
-    maxK8sResourceNameLength,
-    POD_NAME_V1,
-    POD_NAME_V2,
-    getNodeIdFromNodeName
-} from './pod-name';
+import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
+
 
 describe('pod names', () => {
     test('createFNVHash', () => {
@@ -62,6 +53,7 @@ describe('pod names', () => {
         expect(getPodName(wf, node)).toEqual(v2podName);
         delete wf.metadata.annotations;
         expect(getPodName(wf, node)).toEqual(v2podName);
+        expect(getPodName(wf, {...node, name: node.name + '.mycontainername', type: 'Container'})).toEqual(v2podName); // containerSet node check
 
         wf.metadata.name = longWfName;
         node.templateName = longTemplateName;
@@ -85,15 +77,5 @@ describe('pod names', () => {
         // case: template name defined
         node.templateName = 'test-template';
         expect(getTemplateNameFromNode(node)).toEqual(node.templateName);
-    });
-
-    test('getNodeIdFromNodeName', () => {
-        const wf = {
-            metadata: {
-                name: 'outputs-result-5cffb'
-            }
-        } as unknown as Workflow;
-        expect(getNodeIdFromNodeName(wf, 'outputs-result-5cffb.a.main')).toEqual('outputs-result-5cffb-534491738');
-        expect(getNodeIdFromNodeName(wf, 'outputs-result-5cffb.b')).toEqual('outputs-result-5cffb-3597813194');
     });
 });

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -11,7 +11,7 @@ const maxPrefixLength = maxK8sResourceNameLength - k8sNamingHashLength;
 // getPodName returns a deterministic pod name
 // In case templateName is not defined or that version is explicitly set to  POD_NAME_V1, it will return the nodeID (v1)
 // In other cases it will return a combination of workflow name, template name, and a hash (v2)
-// note: this is intended to be equivalent to the server-side Go code in workflow/util/pod_name.go
+// note: this is intended to be equivalent to the server-side Go code in workflow/util/pod_name.go#GeneratePodName
 export function getPodName(workflow: Workflow, node: NodeStatus): string {
     const version = workflow.metadata?.annotations?.[ANNOTATION_KEY_POD_NAME_VERSION];
     if (version === POD_NAME_V1) {
@@ -19,7 +19,10 @@ export function getPodName(workflow: Workflow, node: NodeStatus): string {
     }
 
     const workflowName = workflow.metadata.name;
-    if (workflowName === node.name) {
+    // convert containerSet node name to its corresponding pod node name by removing the ".<containerName>" postfix
+    // this part is from workflow/controller/container_set_template.go#executeContainerSet; the inverse never happens in the back-end, so is unique to the front-end
+    const podNodeName = node.type == 'Container' ? node.name.replace(/\.[^/.]+$/, '') : node.name;
+    if (workflowName === podNodeName) {
         return workflowName;
     }
 
@@ -30,7 +33,7 @@ export function getPodName(workflow: Workflow, node: NodeStatus): string {
     }
     prefix = ensurePodNamePrefixLength(prefix);
 
-    const hash = createFNVHash(node.name);
+    const hash = createFNVHash(podNodeName);
     return `${prefix}-${hash}`;
 }
 
@@ -57,15 +60,4 @@ export function createFNVHash(input: string): number {
 export function getTemplateNameFromNode(node: NodeStatus): string {
     // fall back to v1 pod names if no templateName or templateRef defined
     return node.templateName || node.templateRef?.template || '';
-}
-
-// Calculates the node id from a node name.
-// note: this is intended to be equivalent to the server-side Go code in pkg/apis/workflow/v1alpha1/workflow_types.go
-export function getNodeIdFromNodeName(workflow: Workflow, nodeName: string): string {
-    if (workflow.metadata.name === nodeName) {
-        return workflow.metadata.name;
-    }
-
-    const hash = createFNVHash(nodeName);
-    return `${workflow.metadata.name}-${hash}`;
 }

--- a/ui/src/app/shared/pod-name.ts
+++ b/ui/src/app/shared/pod-name.ts
@@ -58,3 +58,14 @@ export function getTemplateNameFromNode(node: NodeStatus): string {
     // fall back to v1 pod names if no templateName or templateRef defined
     return node.templateName || node.templateRef?.template || '';
 }
+
+// Calculates the node id from a node name.
+// note: this is intended to be equivalent to the server-side Go code in pkg/apis/workflow/v1alpha1/workflow_types.go
+export function getNodeIdFromNodeName(workflow: Workflow, nodeName: string): string {
+    if (workflow.metadata.name === nodeName) {
+        return workflow.metadata.name;
+    }
+
+    const hash = createFNVHash(nodeName);
+    return `${workflow.metadata.name}-${hash}`;
+}

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -17,7 +17,7 @@ import {useCollectEvent} from '../../../shared/use-collect-event';
 import {hasArtifactGCError, hasWarningConditionBadge} from '../../../shared/conditions-panel';
 import {Context} from '../../../shared/context';
 import {historyUrl} from '../../../shared/history';
-import {getPodName, getNodeIdFromNodeName} from '../../../shared/pod-name';
+import {getPodName} from '../../../shared/pod-name';
 import {RetryWatch} from '../../../shared/retry-watch';
 import {services} from '../../../shared/services';
 import {getResolvedTemplates} from '../../../shared/template-resolution';
@@ -472,15 +472,7 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
         });
     }
 
-    const podName = (() => {
-        if (workflow && selectedNode?.type === 'Container') {
-            // A containerset node name can be converted to its corresponding pod node name by removing the postfix
-            const podNodeName = selectedNode.name.replace(/\.[^/.]+$/, '');
-            const podNode = workflow.status.nodes[getNodeIdFromNodeName(workflow, podNodeName)];
-            return getPodName(workflow, podNode);
-        } else if (workflow && selectedNode) return getPodName(workflow, selectedNode);
-        else return nodeId;
-    })();
+    const podName = workflow && selectedNode ? getPodName(workflow, selectedNode) : nodeId;
 
     const archived = isArchivedWorkflow(workflow);
 

--- a/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/app/workflows/components/workflow-details/workflow-details.tsx
@@ -17,7 +17,7 @@ import {useCollectEvent} from '../../../shared/use-collect-event';
 import {hasArtifactGCError, hasWarningConditionBadge} from '../../../shared/conditions-panel';
 import {Context} from '../../../shared/context';
 import {historyUrl} from '../../../shared/history';
-import {getPodName} from '../../../shared/pod-name';
+import {getPodName, getNodeIdFromNodeName} from '../../../shared/pod-name';
 import {RetryWatch} from '../../../shared/retry-watch';
 import {services} from '../../../shared/services';
 import {getResolvedTemplates} from '../../../shared/template-resolution';
@@ -472,7 +472,15 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
         });
     }
 
-    const podName = workflow && selectedNode ? getPodName(workflow, selectedNode) : nodeId;
+    const podName = (() => {
+        if (workflow && selectedNode?.type === 'Container') {
+            // A containerset node name can be converted to its corresponding pod node name by removing the postfix
+            const podNodeName = selectedNode.name.replace(/\.[^/.]+$/, '');
+            const podNode = workflow.status.nodes[getNodeIdFromNodeName(workflow, podNodeName)];
+            return getPodName(workflow, podNode);
+        } else if (workflow && selectedNode) return getPodName(workflow, selectedNode);
+        else return nodeId;
+    })();
 
     const archived = isArchivedWorkflow(workflow);
 


### PR DESCRIPTION
Fixes #13038 
### Motivation

Containerset nodes currently do not retrieve their logs in the UI. This is due to the podname calculation failing, which makes the request to the backend incorrect. This fix will hopefully become obsolete when https://github.com/argoproj/argo-workflows/issues/12528 is fixed, but until then this should do the trick.

### Modifications

Uses a better podname when the node type is `Container`.
![image](https://github.com/argoproj/argo-workflows/assets/123898174/b441ce75-420d-416b-a839-1cca9b1ad983)
![image](https://github.com/argoproj/argo-workflows/assets/123898174/258c8097-aa1e-4c1f-ba3e-df8cc3588d69)


### Verification

Tried a few different containerset templates to verify the fix, and a few none-containetset templates to verify that there is no regression. 