### PR TITLE
fix(ui): `package.json#license` should be Apache

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
     "name": "argo-workflows-ui",
     "version": "1.0.0",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "files": [
         "src"
     ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Same as https://github.com/argoproj/argo-ui/pull/555, similar to https://github.com/argoproj/argo-cd/commit/b1b5ce211eedfb9354f7661b23b60469f9b103d7

### Motivation

<!-- TODO: Say why you made your changes. -->

- it was listed as `MIT` for some reason (copy+paste?), while Argo uses Apache, including this repo's own `LICENSE` file
  - also CNCF uses Apache

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

fix `package.json#license` field

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
