### PR TITLE
docs(faq): add note about `pods` `patch` error

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,8 +21,8 @@ Is there an RBAC error?
 
 [Learn more about workflow RBAC](workflow-rbac.md)
 
-## Return "unknown (get pods)" error
+## `cannot patch resource "pods" in API group ""` error
 
 You're probably getting a permission denied error because your RBAC is not configured.
 
-[Learn more about workflow RBAC](workflow-rbac.md) and [even more details](https://blog.argoproj.io/demystifying-argo-workflowss-kubernetes-rbac-7a1406d446fc)
+[Learn more about workflow RBAC](workflow-rbac.md)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- questions about `pods` `patch` errors are probably the most common questions we field on Slack & GH Issues + Discussions, especially by beginners
  - <details> <summary>links: </summary> 
  
      #12783, #12391, #12398, https://github.com/argoproj/argo-workflows/discussions/12767#discussioncomment-9211165, https://github.com/argoproj/argo-workflows/discussions/9476#discussioncomment-3515577, https://github.com/argoproj/argo-workflows/discussions/9476#discussioncomment-6809834, https://github.com/argoproj/argo-workflows/discussions/9478#discussioncomment-3515727, https://github.com/argoproj/argo-workflows/discussions/10552#discussioncomment-5270259, https://github.com/argoproj/argo-workflows/discussions/10570#discussioncomment-5269662, https://github.com/argoproj/argo-workflows/discussions/9963#discussioncomment-4051285, Slack [1](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1711108679910959), [2](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1711017086385639), [3](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1710244748098179), [4](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1696181792402239?thread_ts=1696169932.593369&cid=C01QW9QSSSK), [5](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1690822604887149?thread_ts=1690759339.827699&cid=C01QW9QSSSK), etc, etc, etc 
  
  </details>

  - so I think this deserves a spot on the FAQ
  - users also often only see the error and miss the preceding log that this is a fallback when `workflowtaskresults` RBAC is not available
    - so they end up searching the `pod` `patch` error instead, which isn't written about in the docs -- hence this PR

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- replace the previous note about "unknown (get pods)", which was removed in v3.3.1 in #8133
  - also remove [the blog link](https://blog.argoproj.io/demystifying-argo-workflowss-kubernetes-rbac-7a1406d446fc) as it has dated RBAC which could be very confusing to users
    - I also left a comment on the blog post clarifying that it's dated: https://medium.com/@agilgur5/note-that-this-blog-post-is-from-oct-2020-cf4cb541915d

### Verification

`make docs` passes

### Future Work

We may want to modify this or add to it in the next minor when #12976 lands. I would probably suggest adding a second error message similar to the `"token not valid"` error message above, which has old variants and new variants

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
