### PR TITLE
fix: Remove overriding executionDeadline with maxDurationDeadline. Fixes #13044

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1004,11 +1004,7 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 			if err != nil {
 				return nil, false, err
 			}
-			firstChildNode, err := woc.wf.Status.Nodes.Get(childNodeIds[0])
-			if err != nil {
-				return nil, false, err
-			}
-			maxDurationDeadline = firstChildNode.StartedAt.Add(maxDuration)
+			maxDurationDeadline = lastChildNode.FinishedAt.Add(maxDuration)
 			if time.Now().After(maxDurationDeadline) {
 				woc.log.Infoln("Max duration limit exceeded. Failing...")
 				return woc.markNodePhase(node.Name, lastChildNode.Phase, "Max duration limit exceeded"), true, nil
@@ -1049,9 +1045,6 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 			retryMessage := fmt.Sprintf("Backoff for %s", humanize.Duration(timeToWait))
 			return woc.markNodePhase(node.Name, node.Phase, retryMessage), false, nil
 		}
-
-		woc.log.WithField("node", node.Name).Infof("node has maxDuration set, setting executionDeadline to: %s", humanize.Timestamp(maxDurationDeadline))
-		opts.executionDeadline = maxDurationDeadline
 
 		node = woc.markNodePhase(node.Name, node.Phase, "")
 	}


### PR DESCRIPTION
Fixes #13044

### Motivation
I've noticed that the `maxDurationDeadline` calculation process is unusual and this value is overriding `executionDeadline`.

For example, with the following workflow, it waits for 120 seconds and exits with error code 10:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: retry-sample-
spec:
  activeDeadlineSeconds: 3600
  entrypoint: retry-example
  templates:
    - name: retry-example
      retryStrategy:
        limit: 2
        backoff:
          duration: 10s
          factor: 2
          maxDuration: 3m
      container:
        image: alpine
        command: [sh, -c]
        args: ["sleep 120; exit 10"]
```

But, when the first attempt fails, the second node's container has a deadline within 1 minute, and it is killed by its wait container.

The latest Argo workflow follows this timeline (not exact times, for easier understanding):
```
0s: firstChildNode started (deadline = 3600s)
120s: firstChildNode finished and exited with an error
  (deadline = firstChildNode.StartedAt + backoff.maxDuration = 180s)
130s: Waited for 10 seconds(backoff duration) & secondChildNode started (deadline: 50 seconds left)
180s: Deadline exceeded, wait container kills main container
```

### Modifications
1. The maxDurationDeadline was calculated by adding `maxDuration` to firstChildNode's startTime.
  * Changed to calculate `maxDurationDeadline` with `lastChildNode`'s `finishedTime`.
2. `executionDeadline` was overridden by `maxDurationDeadline`.
  * Removed this override.

### Verifications
I've tested with the above workflow, and it is working as expected.