### PR TITLE
build: simplify release notes as cross-platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,7 +757,7 @@ pre-commit: codegen lint docs
 # release
 
 release-notes: /dev/null
-	version=$(VERSION) envsubst < hack/release-notes.md > release-notes
+	version=$(VERSION) envsubst '$$version' < hack/release-notes.md > release-notes
 
 .PHONY: checksums
 checksums:

--- a/hack/release-notes.md
+++ b/hack/release-notes.md
@@ -12,43 +12,28 @@ Check the [upgrading guide](https://argo-workflows.readthedocs.io/en/latest/upgr
 
 ### CLI
 
-#### Mac
+#### Mac / Linux
 
 Available via `curl`
 
 ```bash
+# Detect OS
+ARGO_OS="darwin"
+if [[ uname -s != "Darwin" ]]; then
+  ARGO_OS="linux"
+fi
+
 # Download the binary
-curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${version}/argo-darwin-amd64.gz
+curl -sLO "https://github.com/argoproj/argo-workflows/releases/download/$version/argo-$ARGO_OS-amd64.gz"
 
 # Unzip
-gunzip argo-darwin-amd64.gz
+gunzip "argo-$ARGO_OS-amd64.gz"
 
 # Make binary executable
-chmod +x argo-darwin-amd64
+chmod +x "argo-$ARGO_OS-amd64"
 
 # Move binary to path
-mv ./argo-darwin-amd64 /usr/local/bin/argo
-
-# Test installation
-argo version
-```
-
-#### Linux
-
-Available via `curl`
-
-```bash
-# Download the binary
-curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${version}/argo-linux-amd64.gz
-
-# Unzip
-gunzip argo-linux-amd64.gz
-
-# Make binary executable
-chmod +x argo-linux-amd64
-
-# Move binary to path
-mv ./argo-linux-amd64 /usr/local/bin/argo
+mv "./argo-$ARGO_OS-amd64" /usr/local/bin/argo
 
 # Test installation
 argo version
@@ -58,5 +43,5 @@ argo version
 
 ```bash
 kubectl create namespace argo
-kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/${version}/install.yaml
+kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/$version/install.yaml
 ```


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- simplifies and consolidates the release notes for each version


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- detect OS in the first command and use as env var

- slightly modify `make release-notes` target to handle this properly
  - only replace `$version` and not `$ARGO_OS`

### Verification

<!-- TODO: Say how you tested your changes. -->

1. Ran `make release-notes` and checked that it only substituted `$version`
1. Ran the script on both my macOS laptop and my Linux devcontainer

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
