### PR TITLE
fix: don't necessarily include all artifacts from templates in node outputs

### DIFF
--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -57,16 +57,17 @@ func waitContainer(ctx context.Context) error {
 	}
 
 	// Saving output artifacts
-	err = wfExecutor.SaveArtifacts(bgCtx)
+	artifacts, err := wfExecutor.SaveArtifacts(bgCtx)
 	if err != nil {
 		wfExecutor.AddError(err)
 	}
 
 	// Save log artifacts
 	logArtifacts := wfExecutor.SaveLogs(bgCtx)
+	artifacts = append(artifacts, logArtifacts...)
 
 	// Try to upsert TaskResult. If it fails, we will try to update the Pod's Annotations
-	err = wfExecutor.ReportOutputs(bgCtx, logArtifacts)
+	err = wfExecutor.ReportOutputs(bgCtx, artifacts)
 	if err != nil {
 		wfExecutor.AddError(err)
 	}

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -148,7 +148,7 @@ type artifactDerivedKey struct {
 
 func (al *s3Location) getS3Key(wf *wfv1.Workflow) (string, error) {
 	if al.specifiedKey == "" && al.derivedKey == nil {
-		panic(fmt.Sprintf("invalid artifactLocation: %+v, must have knownKey or derivedKey set", al))
+		panic(fmt.Sprintf("invalid artifactLocation: %+v, must have specifiedKey or derivedKey set", al))
 	}
 
 	if al.specifiedKey != "" {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -407,8 +407,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 		when.
 			DeleteWorkflow().
 			WaitForWorkflowDeletion()
-
-		when.Then().ExpectWorkflowDeleted()
+			Then().
+			ExpectWorkflowDeleted()
 
 		when = when.RemoveFinalizers(false) // just in case - if the above test failed we need to forcibly remove the finalizer for Artifact GC
 

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -137,11 +137,11 @@ type artifactState struct {
 type s3Location struct {
 	bucketName string
 	// specify one of these two:
-	specifiedKey string      // exact key is known
-	derivedKey   *derivedKey // exact key needs to be derived
+	specifiedKey string              // exact key is known
+	derivedKey   *artifactDerivedKey // exact key needs to be derived
 }
 
-type derivedKey struct {
+type artifactDerivedKey struct {
 	templateName string
 	artifactName string
 }
@@ -386,7 +386,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        false, // artifact not being present causes Workflow to fail
 			expectedGCPodsOnWFCompletion: 0,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket", derivedKey: &derivedKey{templateName: "artifact-written", artifactName: "present"}}, false, true},
+				artifactState{s3Location{bucketName: "my-bucket", derivedKey: &artifactDerivedKey{templateName: "artifact-written", artifactName: "present"}}, false, true},
 			},
 		},
 	} {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -147,7 +147,6 @@ type artifactDerivedKey struct {
 }
 
 func (al *s3Location) getS3Key(wf *wfv1.Workflow) (string, error) {
-
 	if al.specifiedKey == "" && al.derivedKey == nil {
 		panic(fmt.Sprintf("invalid artifactLocation: %+v, must have knownKey or derivedKey set", al))
 	}

--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -58,6 +58,10 @@ func (w *When) SubmitWorkflow() *When {
 	return w
 }
 
+func (w *When) GetWorkflow() *wfv1.Workflow {
+	return w.wf
+}
+
 func label(obj metav1.Object) {
 	labels := obj.GetLabels()
 	if labels == nil {

--- a/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: testing-artifact-not-present-
+  generateName: artgc-artifact-not-written-
 spec:
   entrypoint: entrypoint
   artifactGC:

--- a/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
@@ -11,8 +11,23 @@ spec:
   templates:
     - name: entrypoint
       steps:
+      - - name: artifact-written
+          template: artifact-written
       - - name: artifact-not-written
           template: artifact-not-written
+    - name: artifact-written
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            echo "something" > /tmp/present
+      outputs:
+        artifacts:
+          - name: present
+            path: /tmp/present
     - name: artifact-not-written
       container:
         image: argoproj/argosay:v2

--- a/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
@@ -21,7 +21,7 @@ spec:
           - -c
         args:
           - |
-            echo "not writing anything"
+            echo "intentionally not writing anything to disk"
       outputs:
         artifacts:
           - name: notpresent

--- a/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
@@ -11,9 +11,9 @@ spec:
   templates:
     - name: entrypoint
       steps:
-      - - name: on-deletion
-          template: on-deletion
-    - name: on-deletion
+      - - name: artifact-not-written
+          template: artifact-not-written
+    - name: artifact-not-written
       container:
         image: argoproj/argosay:v2
         command:

--- a/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-artifact-not-written.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: testing-artifact-not-present-
+spec:
+  entrypoint: entrypoint
+  artifactGC:
+    strategy: OnWorkflowDeletion
+  podGC:
+    strategy: ""
+  templates:
+    - name: entrypoint
+      steps:
+      - - name: on-deletion
+          template: on-deletion
+    - name: on-deletion
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            echo "not writing anything"
+      outputs:
+        artifacts:
+          - name: notpresent
+            path: /tmp/notpresent

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -291,26 +291,27 @@ func (we *WorkflowExecutor) StageFiles() error {
 }
 
 // SaveArtifacts uploads artifacts to the archive location
-func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) error {
+func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, error) {
+	artifacts := wfv1.Artifacts{}
 	if len(we.Template.Outputs.Artifacts) == 0 {
 		log.Infof("No output artifacts")
-		return nil
+		return artifacts, nil
 	}
 
 	log.Infof("Saving output artifacts")
 	err := os.MkdirAll(tempOutArtDir, os.ModePerm)
 	if err != nil {
-		return argoerrs.InternalWrapError(err)
+		return artifacts, argoerrs.InternalWrapError(err)
 	}
 
 	for i, art := range we.Template.Outputs.Artifacts {
 		err := we.saveArtifact(ctx, common.MainContainerName, &art)
 		if err != nil {
-			return err
+			return artifacts, err
 		}
-		we.Template.Outputs.Artifacts[i] = art
+		artifacts = append(artifacts, art)
 	}
-	return nil
+	return artifacts, nil
 }
 
 func (we *WorkflowExecutor) saveArtifact(ctx context.Context, containerName string, art *wfv1.Artifact) error {
@@ -832,9 +833,9 @@ func (we *WorkflowExecutor) InitializeOutput(ctx context.Context) {
 }
 
 // ReportOutputs updates the WorkflowTaskResult (or falls back to annotate the Pod)
-func (we *WorkflowExecutor) ReportOutputs(ctx context.Context, logArtifacts []wfv1.Artifact) error {
+func (we *WorkflowExecutor) ReportOutputs(ctx context.Context, artifacts []wfv1.Artifact) error {
 	outputs := we.Template.Outputs.DeepCopy()
-	outputs.Artifacts = append(outputs.Artifacts, logArtifacts...)
+	outputs.Artifacts = artifacts
 	return we.reportResult(ctx, wfv1.NodeResult{Outputs: outputs})
 }
 

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -304,7 +304,7 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 		return artifacts, argoerrs.InternalWrapError(err)
 	}
 
-	for i, art := range we.Template.Outputs.Artifacts {
+	for _, art := range we.Template.Outputs.Artifacts {
 		err := we.saveArtifact(ctx, common.MainContainerName, &art)
 		if err != nil {
 			return artifacts, err

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -481,7 +481,7 @@ func TestSaveArtifacts(t *testing.T) {
 
 	for _, tt := range tests {
 		ctx := context.Background()
-		err := tt.workflowExecutor.SaveArtifacts(ctx)
+		_, err := tt.workflowExecutor.SaveArtifacts(ctx)
 		if err != nil {
 			assert.Equal(t, tt.expectError, true)
 			continue


### PR DESCRIPTION

The fact that it's being listed in the NodeStatus is causing ArtifactGC to attempt to delete it (and fail doing so).

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes: #12845 

### Motivation

If an Artifact file didn't get written, it shouldn't be in the outputs for the TaskResult (and thus the Outputs for the Node) just because it was listed as an Artifact in the Workflow.

### Modifications

Only if the Artifact file is successfully written does the wait container include it as one of the Output Artifacts in its `WorkflowTaskResult`. The Workflow Controller uses that `WorkflowTaskResult` information to populate the `NodeStatus` of the Workflow. This is the information that ArtifactGC uses to determine what needs to be deleted. 

### Verification

The person who submitted the Issue [tested](https://github.com/argoproj/argo-workflows/discussions/12845#discussioncomment-9616341) the image I made, and it repeatedly worked to solve his issue of ArtifactGC failing. (Note it also prevented his other artifacts from getting deleted, because the failed deletion preempted the other deletions from being attempted (as @agilgur5 [pointed out](https://github.com/argoproj/argo-workflows/discussions/12845#discussioncomment-9598353), this could be another improvement, to continue the deletion process independent of failure)).

I did start to create an e2e test for this issue. But it seems that with minio, I can't repeat the same failure using the "main" branch. It seems that attempting to delete an artifact which doesn't exist doesn't result in a failure for some reason.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
