### PR TITLE
docs: Clarify maxDuration behavior when used with activeDeadlineSeconds. Fixes #13044

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -4438,7 +4438,7 @@
           "description": "Factor is a factor to multiply the base duration after each failed retry"
         },
         "maxDuration": {
-          "description": "MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy",
+          "description": "MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.",
           "type": "string"
         }
       },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8397,7 +8397,7 @@
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
         },
         "maxDuration": {
-          "description": "MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy",
+          "description": "MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.",
           "type": "string"
         }
       }

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -463,7 +463,10 @@ the ReadOnly setting in VolumeMounts.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | duration | string| `string` |  | | Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h") |  |
 | factor | [IntOrString](#int-or-string)| `IntOrString` |  | |  |  |
-| maxDuration | string| `string` |  | | MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy |  |
+| maxDuration | string| `string` |  | | MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy.
+It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds.
+However, when the workflow fails, the pod's deadline is then overridden by maxDuration.
+This ensures that the workflow does not exceed the specified maximum duration when retries are involved. |  |
 
 
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2333,7 +2333,7 @@ Backoff is a backoff strategy to use within retryStrategy
 |:----------:|:----------:|---------------|
 |`duration`|`string`|Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")|
 |`factor`|[`IntOrString`](#intorstring)|Factor is a factor to multiply the base duration after each failed retry|
-|`maxDuration`|`string`|MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy|
+|`maxDuration`|`string`|MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.|
 
 ## Mutex
 

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -328,7 +328,10 @@ message Backoff {
   // Factor is a factor to multiply the base duration after each failed retry
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString factor = 2;
 
-  // MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy
+  // MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy.
+  // It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds.
+  // However, when the workflow fails, the pod's deadline is then overridden by maxDuration.
+  // This ensures that the workflow does not exceed the specified maximum duration when retries are involved.
   optional string maxDuration = 3;
 }
 

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -1412,7 +1412,7 @@ func schema_pkg_apis_workflow_v1alpha1_Backoff(ref common.ReferenceCallback) com
 					},
 					"maxDuration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy",
+							Description: "MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2014,7 +2014,10 @@ type Backoff struct {
 	Duration string `json:"duration,omitempty" protobuf:"varint,1,opt,name=duration"`
 	// Factor is a factor to multiply the base duration after each failed retry
 	Factor *intstr.IntOrString `json:"factor,omitempty" protobuf:"varint,2,opt,name=factor"`
-	// MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy
+	// MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy.
+	// It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds.
+	// However, when the workflow fails, the pod's deadline is then overridden by maxDuration.
+	// This ensures that the workflow does not exceed the specified maximum duration when retries are involved.
 	MaxDuration string `json:"maxDuration,omitempty" protobuf:"varint,3,opt,name=maxDuration"`
 }
 

--- a/pkg/plugins/executor/swagger.yml
+++ b/pkg/plugins/executor/swagger.yml
@@ -365,8 +365,11 @@ definitions:
       factor:
         $ref: '#/definitions/IntOrString'
       maxDuration:
-        description: MaxDuration is the maximum amount of time allowed for a workflow
-          in the backoff strategy
+        description: |-
+          MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy.
+          It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds.
+          However, when the workflow fails, the pod's deadline is then overridden by maxDuration.
+          This ensures that the workflow does not exceed the specified maximum duration when retries are involved.
         type: string
     type: object
   BasicAuth:

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1Backoff.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1Backoff.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **duration** | **String** | Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \&quot;2m\&quot;, \&quot;1h\&quot;) |  [optional]
 **factor** | **String** |  |  [optional]
-**maxDuration** | **String** | MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy |  [optional]
+**maxDuration** | **String** | MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod&#39;s deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod&#39;s deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved. |  [optional]
 
 
 

--- a/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_backoff.py
+++ b/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_backoff.py
@@ -140,7 +140,7 @@ class IoArgoprojWorkflowV1alpha1Backoff(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             duration (str): Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\"). [optional]  # noqa: E501
             factor (str): [optional]  # noqa: E501
-            max_duration (str): MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. [optional]  # noqa: E501
+            max_duration (str): MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -224,7 +224,7 @@ class IoArgoprojWorkflowV1alpha1Backoff(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             duration (str): Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \"2m\", \"1h\"). [optional]  # noqa: E501
             factor (str): [optional]  # noqa: E501
-            max_duration (str): MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. [optional]  # noqa: E501
+            max_duration (str): MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1Backoff.md
+++ b/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1Backoff.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **duration** | **str** | Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. \&quot;2m\&quot;, \&quot;1h\&quot;) | [optional] 
 **factor** | **str** |  | [optional] 
-**max_duration** | **str** | MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy | [optional] 
+**max_duration** | **str** | MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod&#39;s deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod&#39;s deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved. | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION
Fixes #13044 

### Motivation
The current documentation for `maxDuration` in the Argo workflow is unclear and potentially misleading, particularly when used in conjunction with `activeDeadlineSeconds`.
The description does not accurately reflect the behavior observed in the code, where the pod's deadline set by `activeDeadlineSeconds` is overridden by `maxDuration` upon workflow failure.
https://github.com/argoproj/argo-workflows/blob/a1db80aedf9344fd74d7e381b4337fb8fb7e244b/workflow/controller/operator.go#L1053-L1054

This can lead to confusion for users trying to understand how these two parameters interact.
The updated documentation aims to clarify this behavior, ensuring that users have a precise understanding of how `maxDuration` and `activeDeadlineSeconds` work together in the context of workflow retries and backoff strategies.

### Modifications
Updated comments in `pkg/apis/workflow/v1alpha1/workflow_types.go` and run `make pre-commit -B`.

### Verification
`make docs` passed.