### PR TITLE
feat: don't add configmap volumemounts in wait container(#13089)

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -1063,6 +1063,16 @@ func addOutputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.Template) {
 			if util.IsWindowsUNCPath(mnt.MountPath, tmpl) {
 				continue
 			}
+			isConfigMapVolume := false
+			for _, vol := range pod.Spec.Volumes {
+				if vol.Name == mnt.Name && vol.ConfigMap != nil {
+					isConfigMapVolume = true
+					break
+				}
+			}
+			if isConfigMapVolume {
+				continue
+			}
 			mnt.MountPath = filepath.Join(common.ExecutorMainFilesystemDir, mnt.MountPath)
 			// ReadOnly is needed to be false for overlapping volume mounts
 			mnt.ReadOnly = false


### PR DESCRIPTION
Fixes point 2 of https://github.com/argoproj/argo-workflows/issues/13089