### PR TITLE
fix: don't fail workflow if PDB creation fails

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -283,15 +283,15 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	}
 
 	if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
-		woc.markWorkflowRunning(ctx)
-		setWfPodNamesAnnotation(woc.wf)
-
 		err := woc.createPDBResource(ctx)
 		if err != nil {
-			msg := fmt.Sprintf("Unable to create PDB resource for workflow, %s error: %s", woc.wf.Name, err)
-			woc.markWorkflowFailed(ctx, msg)
+			woc.log.WithError(err).WithField("workflow", woc.wf.Name).Error("PDB creation failed")
+			woc.requeue()
 			return
 		}
+
+		woc.markWorkflowRunning(ctx)
+		setWfPodNamesAnnotation(woc.wf)
 
 		woc.workflowDeadline = woc.getWorkflowDeadline()
 


### PR DESCRIPTION
### Motivation

It is likely that a busy kubernetes API will fail to create a PDB occasionally. This results in the whole workflow being marked as failed, when this is most likely something that will succeed on retry.

### Modifications

PDB creation only happens to workflows in state Unknown, so delay marking the workflow is running until after we know if PDB creation has succeeded.

If PDB creation fails then requeue the workflow and log the failure.

### Verification

Modified `createPDBResource()` to mostly fail (1 in 20 succeeded). Submitted multiple simultaneous copies of [examples/default-pdb-support.yaml](../blob/main/examples/default-pdb-support.yaml) modified for a longer sleep, and ensured they:
* All started eventually
* All started with their PDB having been created

This isn't suitable for a regression test that I can think of without hooking createPDBResource.

### Design

I don't like having to reorder code to make this work.
Ideally the workflow controller would act like an operator, formulating a list of k8s objects that should exist, and then reconcile that with what actually exists in an independent reconciler later. This is too big a change for this bug fix.