### PR TITLE
docs: outputs from previous steps are _not_ available in hooks

### DIFF
--- a/docs/lifecyclehook.md
+++ b/docs/lifecyclehook.md
@@ -25,7 +25,7 @@ In other words, a `LifecycleHook` functions like an [exit handler](https://githu
 
 ## Unsupported conditions
 
-- [`outputs`](fields.md#outputs) are not usable since `LifecycleHook` executes during execution time and `outputs` are not produced until the step is completed. You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status variable are available there so you can still conditionally decide what to do.
+- [`outputs`](fields.md#outputs) from the step you are hooking into are available but no other outputs can be used.
 
 ## Notification use case
 


### PR DESCRIPTION
The documentation said you could use outputs from previous steps in a hook but not outputs from the current step/task. Experimentally the opposite seems to be true. See this Slack conversation for some details: https://cloud-native.slack.com/archives/C01QW9QSSSK/p1716585083642879

I'm not sure this new documentation is correct. Maybe there are situations where you can use other outputs? Also, note that the docs I updated were based on steps and in my use-case I was using a DAG.
