### PR TITLE
docs: full copy-edit of enhanced `depends` page

### DIFF
--- a/docs/enhanced-depends-logic.md
+++ b/docs/enhanced-depends-logic.md
@@ -2,8 +2,8 @@
 
 > v2.9 and after
 
-Enhanced `depends` improves on [the `dependencies` field](walk-through/dag.md) by allowing you to specify which _result_ of a task to depend on.
-For example, you may only want to run a task if its dependent task succeeded.
+Enhanced `depends` improves on [the `dependencies` field](walk-through/dag.md) by specifying which _result_ of a task to depend on.
+For example, to only run a task if its dependent task succeeded.
 
 ## Depends
 

--- a/docs/enhanced-depends-logic.md
+++ b/docs/enhanced-depends-logic.md
@@ -9,8 +9,8 @@ For example, to only run a task if its dependent task succeeded.
 
 You can use the `depends` field to specify dependent tasks, their results, and boolean logic between them.
 
-Its value is a `string` with expression-like syntax with operands having the form `<task-name>.<task-result>`, such as `task-1.Succeeded`, `task-2.Failed`, `task-3.Daemoned`.
-The available task results are:
+You use operands of the form `<task-name>.<task-result>`, such as `task-1.Succeeded`, `task-2.Failed`, `task-3.Daemoned`.
+Available task results are:
 
 |  Task Result | Description |
 |:------------:|-------------|

--- a/docs/enhanced-depends-logic.md
+++ b/docs/enhanced-depends-logic.md
@@ -2,35 +2,26 @@
 
 > v2.9 and after
 
-## Introduction
-
-Previous to version 2.8, the only way to specify dependencies in DAG templates was to use the `dependencies` field and
-specify a list of other tasks the current task depends on. This syntax was limiting because it does not allow the user to
-specify which _result_ of the task to depend on. For example, a task may only be relevant to run if the dependent task
-succeeded (or failed, etc.).
+Enhanced `depends` improves on [the `dependencies` field](walk-through/dag.md) by allowing you to specify which _result_ of a task to depend on.
+For example, you may only want to run a task if its dependent task succeeded.
 
 ## Depends
 
-To remedy this, there exists a new field called `depends`, which allows users to specify dependent tasks, their statuses,
-as well as any complex boolean logic. The field is a `string` field and the syntax is expression-like with operands having
-form `<task-name>.<task-result>`. Examples include `task-1.Succeeded`, `task-2.Failed`, `task-3.Daemoned`. The full list of
-available task results is as follows:
+You can use the `depends` field to specify dependent tasks, their results, and boolean logic between them.
 
-|  Task Result | Description    | Meaning |
-|:------------:|----------------|---------|
-| `.Succeeded` | Task Succeeded | Task finished with no error |
-| `.Failed` | Task Failed | Task exited with a non-0 exit code |
-| `.Errored` | Task Errored | Task had an error other than a non-0 exit code |
-| `.Skipped` | Task Skipped | Task was skipped |
-| `.Omitted` | Task Omitted | Task was omitted |
-| `.Daemoned` | Task is Daemoned and is not Pending | |
+Its value is a `string` with expression-like syntax with operands having the form `<task-name>.<task-result>`, such as `task-1.Succeeded`, `task-2.Failed`, `task-3.Daemoned`.
+The available task results are:
 
-A tasks is considered `Skipped` if its `when` condition evaluates to false. On the other hand, if a task doesn't run
-because its `depends` evaluated to false it is `Omitted`.
+|  Task Result | Description |
+|:------------:|-------------|
+| `.Succeeded` | Task finished with no error |
+| `.Failed`    | Task exited with a non-0 exit code |
+| `.Errored`   | Task had an error other than a non-0 exit code |
+| `.Skipped`   | Task's `when` condition evaluated to `false` |
+| `.Omitted`   | Task's `depends` condition evaluated to `false` |
+| `.Daemoned`  | Task is Daemoned and is not Pending |
 
-For convenience, an omitted task result is equivalent to `(task.Succeeded || task.Skipped || task.Daemoned)`.
-
-For example:
+For compatibility with `dependencies`, an unspecified result is equivalent to `(task.Succeeded || task.Skipped || task.Daemoned)`. For example:
 
 ```yaml
 depends: "task || task-2.Failed"
@@ -42,20 +33,19 @@ is equivalent to:
 depends: (task.Succeeded || task.Skipped || task.Daemoned) || task-2.Failed
 ```
 
-Full boolean logic is also available. Operators include:
+You can use boolean logic with the operators:
 
 * `&&`
 * `||`
 * `!`
 
- Example:
+Example:
 
 ```yaml
 depends: "(task-2.Succeeded || task-2.Skipped) && !task-3.Failed"
 ```
 
-In the case that you're depending on a task that uses `withItems`, you can depend on
-whether any of the item tasks are successful or all have failed using `.AnySucceeded` and `.AllFailed`, for example:
+If you depend on a task that uses `withItems`, you can use `.AnySucceeded` and `.AllFailed`. For example:
 
 ```yaml
 depends: "task-1.AnySucceeded || task-2.AllFailed"
@@ -63,9 +53,9 @@ depends: "task-1.AnySucceeded || task-2.AllFailed"
 
 ## Compatibility with `dependencies` and `dag.task.continueOn`
 
-This feature is fully compatible with `dependencies` and conversion is easy.
+You cannot use both `dependencies` and `depends` in the same task group.
 
-To convert simply join your `dependencies` with `&&`:
+To convert from `dependencies` to `depends`, join your array into a string with `&&`. For example:
 
 ```yaml
 dependencies: ["A", "B", "C"]
@@ -77,5 +67,4 @@ is equivalent to:
 depends: "A && B && C"
 ```
 
-Because of the added control found in `depends`, the `dag.task.continueOn` is not available when using it. Furthermore,
-it is not possible to use both `dependencies` and `depends` in the same task group.
+`dag.task.continueOn` is not available when using `depends`; instead you can specify `.Failed`.

--- a/docs/enhanced-depends-logic.md
+++ b/docs/enhanced-depends-logic.md
@@ -17,9 +17,9 @@ Available task results are:
 | `.Succeeded` | Task finished with no error |
 | `.Failed`    | Task exited with a non-0 exit code |
 | `.Errored`   | Task had an error other than a non-0 exit code |
-| `.Skipped`   | Task's `when` condition evaluated to `false` |
+| `.Skipped`   | Task's [`when`](walk-through/conditionals.md) condition evaluated to `false` |
 | `.Omitted`   | Task's `depends` condition evaluated to `false` |
-| `.Daemoned`  | Task is Daemoned and is not Pending |
+| `.Daemoned`  | Task is [daemoned](walk-through/daemon-containers.md) and is not `Pending` |
 
 For compatibility with `dependencies`, an unspecified result is equivalent to `(task.Succeeded || task.Skipped || task.Daemoned)`. For example:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/13087#pullrequestreview-2084423364 and my other full page copy-edits of docs
Fixes https://github.com/argoproj/argo-workflows/discussions/8693#discussioncomment-5076751
Addresses the first question of #10363 as well


### Motivation

<!-- TODO: Say why you made your changes. -->

Heavily simplify the page, elaborate on some details, and use consistent, up-to-date style

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

larger style changes:
- heavily simplify several sentences and paragraphs, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language) <details>
  - remove unnecessary "Introduction" section -- just introduce it
    - describe how `depends` improves on `dependencies`, instead of explaining the history and limitations
      - same description, but substantially more concise and no longer dated
  - remove some redundant short descriptions like "or failed" that are described better and in more detail almost immediately after
  - simplify the task result table by combining "Description" and "Meaning"
    - previously "Description" was redundant, repeating the result
    
 </details>

- remove dated statements like "new" etc, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-statements-that-will-soon-be-out-of-date) <details>
  - Also, "Previous to version 2.8" has a grammatical error, seems incorrect (directly above says `v2.9`), and is not consistent with our existing versioning usage (c.f. #12581), which is the `> v2.9 and after` that already exists above
  
</details>

- "the user" -> "you", per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#address-the-reader-as-you) <details>
  - similarly, use active voice, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-active-voice)
  - and use a more consistent tense as well
  
</details>

- consistently use "results"; do not use "status" sometimes to mean the same thing -- inconsistency is confusing
  - similarly, use the word "unspecified" instead of "omitted" when referring to a task with no result specified -- `.Omitted` is an existing term here already
    - elaborate why this exists; it's not just for convenience, it's for compat with `dependencies`

- elaborate why `continueOn` is not available either; it can be substituted by `.Failed` in `depends`

<details><summary>smaller style modifications:</summary>

- remove modifiers like "easy", per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-words-that-assume-a-specific-level-of-understanding)
  - similarly remove modifiers like "complex" and "full"; those modifiers felt misleading given that the boolean logic only has 3 operators
- remove Latin abbreviations like "etc", per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-latin-phrases)
- prefer 1 sentence per line of markdown, per [style guide](https://argo-workflows.readthedocs.io/en/release-3.5/doc-changes/)

</details>

### Verification

<!-- TODO: Say how you tested your changes. -->

1. `make docs` passes
1. See [rendered markdown](https://github.com/argoproj/argo-workflows/blob/0680bc5db4f73f1122f513eb71c73705a6cac211/docs/enhanced-depends-logic.md)

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
