### PR TITLE
fix: silence devcontainer `Permission denied` error. Fixes #13109

### DIFF
--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -20,7 +20,7 @@ sudo apt update
 sudo apt install -y protobuf-compiler
 
 # Make sure go path is owned by vscode
-sudo chown -R vscode:vscode /home/vscode/go
+sudo chown -R vscode:vscode /home/vscode/go || true
 
 # download dependencies and do first-pass compile
 CI=1 kit pre-up


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13109

### Motivation

`chown` command fails for some reason on `.git` folder on my mac M1

### Modifications

<!-- TODO: Say what changes you made. -->
I silenced the error by adding `|| true` on the failing command on `.devcontainer/pre-build.sh`

-> The error is probably due to a mac-specific thing. It'll be to do with how the OS has mounted that volume to the dev docker container
-> There is no gitignore-style file for devcontainers, to ignore `.git` directory
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
The impact of the change are quite small, but the process reached the end

![Screenshot 2024-05-29 at 15 16 01](https://github.com/argoproj/argo-workflows/assets/4726647/2722b2ae-bf40-4fe5-bbf7-a17c69c41098)


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
