### PR TITLE
fix(build): `uname` handling for mac M1 arch. Fixes #13112

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -732,7 +732,7 @@ docs: /usr/local/bin/mkdocs \
 	# check environment-variables.md contains all variables mentioned in the code
 	./hack/docs/check-env-doc.sh
 	# build the docs
-	mkdocs build --strict
+	TZ=UTC mkdocs build --strict
 	# tell the user the fastest way to edit docs
 	@echo "ℹ️ If you want to preview your docs, open site/index.html. If you want to edit them with hot-reload, run 'make docs-serve' to start mkdocs on port 8000"
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,13 @@ SRC                   := $(GOPATH)/src/github.com/argoproj/argo-workflows
 # docker image publishing options
 IMAGE_NAMESPACE       ?= quay.io/argoproj
 DEV_IMAGE             ?= $(shell [ `uname -s` = Darwin ] && echo true || echo false)
-TARGET_PLATFORM := $(shell [ `uname -m` = arm64 ] && echo linux/arm64 || echo linux/amd64)
+PLATFORM ?= $(shell uname -m)
+ifeq ($(PLATFORM), x86_64)
+PLATFORM=amd64
+else ifeq ($(PLATFORM), arm)
+PLATFORM=arm64
+endif
+TARGET_PLATFORM := $(shell echo linux/${PLATFORM})
 
 # declares which cluster to import to in case it's not the default name
 K3D_CLUSTER_NAME      ?= k3s-default

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,7 @@ SRC                   := $(GOPATH)/src/github.com/argoproj/argo-workflows
 # docker image publishing options
 IMAGE_NAMESPACE       ?= quay.io/argoproj
 DEV_IMAGE             ?= $(shell [ `uname -s` = Darwin ] && echo true || echo false)
-PLATFORM ?= $(shell uname -m)
-ifeq ($(PLATFORM), x86_64)
-PLATFORM=amd64
-else ifeq ($(PLATFORM), arm)
-PLATFORM=arm64
-endif
-TARGET_PLATFORM := $(shell echo linux/${PLATFORM})
+TARGET_PLATFORM       ?= linux/$(shell go env GOARCH)
 
 # declares which cluster to import to in case it's not the default name
 K3D_CLUSTER_NAME      ?= k3s-default


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13112

### Motivation

<!-- TODO: Say why you made your changes. -->
Unable to build the project using `make start UI=true`, and fails because of my M1 arch

### Modifications

<!-- TODO: Say what changes you made. -->
I updated the `TARGET_PLATFORM` value on the Makefile to be able to also handle my arch value which is `aarch64`
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
![image](https://github.com/argoproj/argo-workflows/assets/4726647/e492ae44-3028-4351-87dc-df51c99a8754)
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
