### PR TITLE
fix: Allow termination of workflow to update on exit handler nodes. fixes #13052

### DIFF
--- a/test/e2e/functional/workflow-exit-handler-sleep.yaml
+++ b/test/e2e/functional/workflow-exit-handler-sleep.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: workflow-exit-handler-sleep
+spec:
+  entrypoint: argosay-template
+  onExit: exit-handler
+  templates:
+  - name: argosay-template
+    container:
+      image: argoproj/argosay:v2
+      args: ["echo", "hello-world"]
+  - name: sleep
+    container:
+      image: argoproj/argosay:v2
+      args: ["sleep", "600"]
+  - name: exit-handler
+    steps:
+      - - name: exit-handler-task
+          template: sleep


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13052

### Motivation

I have created a workflow with an exit handler. When the exit-handler was running I terminated the workflow. I expected all exit handler nodes to be in the "Failed" phase after termination. However, the "StepGroup" and "Steps" type nodes were still in the "Running" phase. After the event was received the `onExitHandler` template was never executed due to `woc.GetShutdownStrategy().ShouldExecute(true) ` being part of the `if`. This means that it blocks the execute template which updates the node status. 

### Modifications

1.  Remove the `woc.GetShutdownStrategy().ShouldExecute(true)` from `if`
2. Allow `executeTemplate` on the exitNode only if the exit node exists, or if `woc.GetShutdownStrategy().ShouldExecute(true)`

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

I added an `e2e` test based on the workflow reported on the issue. Apart from that I tested locally to deploy and terminate similar workflows.

And with the provided workflow on the issue
<img width="1151" alt="image" src="https://github.com/argoproj/argo-workflows/assets/18004241/c7fba8da-a1f7-41c2-af6a-98e7934857e7">



```
│     workflow-terminate-on-exit-handler-3305888909:                                                                 │
│       Boundary ID:  workflow-terminate-on-exit-handler-626459641                                                   │
│       Children:                                                                                                    │
│         workflow-terminate-on-exit-handler-2937772702                                                              │
│       Display Name:  [0]                                                                                           │
│       Finished At:   2024-05-31T07:30:39Z                                                                          │
│       Id:            workflow-terminate-on-exit-handler-3305888909                                                 │
│       Message:       workflow shutdown with strategy:  Terminate                                                   │
│       Name:          workflow-terminate-on-exit-handler.onExit[0]                                                  │
│       Node Flag:                                                                                                   │
│       Phase:           Failed                                                                                      │
│       Progress:        0/1                                                                                         │
│       Started At:      2024-05-31T07:30:38Z                                                                        │
│       Template Scope:  local/workflow-terminate-on-exit-handler                                                    │
│       Type:            StepGroup                                                                                   │
│     workflow-terminate-on-exit-handler-626459641:                                                                  │
│       Children:                                                                                                    │
│         workflow-terminate-on-exit-handler-3305888909                                                              │
│       Display Name:  workflow-terminate-on-exit-handler.onExit                                                     │
│       Finished At:   2024-05-31T07:30:39Z                                                                          │
│       Id:            workflow-terminate-on-exit-handler-626459641                                                  │
│       Message:       workflow shutdown with strategy:  Terminate                                                   │
│       Name:          workflow-terminate-on-exit-handler.onExit                                                     │
│       Node Flag:                                                                                                   │
│         Hooked:  true                                                                                              │
│       Outbound Nodes:                                                                                              │
│         workflow-terminate-on-exit-handler-2937772702                                                              │
│       Phase:           Failed                                                                                      │
│       Progress:        0/1                                                                                         │
│       Started At:      2024-05-31T07:30:38Z                                                                        │
│       Template Name:   exit-handler                                                                                │
│       Template Scope:  local/workflow-terminate-on-exit-handler                                                    │
│       Type:            Steps
```

I also tested workflows with dag instead of `steps`.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
