### PR TITLE
docs: elaborate on k8s compatibility

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -164,6 +164,7 @@ instantiators
 jenkins
 k3d
 k3s
+k8s
 k8s-jobs
 kube
 kube-apiserver

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -53,6 +53,10 @@ Otherwise, we typically release every two weeks:
 
 ### Notes on Compatibility
 
-Argo versions may be compatible with newer and older versions than what it is listed but only three minor versions are supported per Argo release unless otherwise noted.
+Argo versions may be compatible with newer and older Kubernetes versions (indicated by `?`), but only three minor versions are actively tested against unless otherwise noted.
 
-The main branch of `Argo Workflows` is currently tested on `Kubernetes` 1.29.
+Note that Kubernetes [is backward compatible with clients](https://github.com/kubernetes/client-go/tree/aa7909e7d7c0661792ba21b9e882f3cd6ad0ce53?tab=readme-ov-file#compatibility-client-go---kubernetes-clusters), so newer k8s versions are generally supported.
+The caveats with newer k8s versions are possible changes to experimental APIs and unused new features.
+Argo uses stable Kubernetes APIs such as Pods and ConfigMaps; see the Controller and Server RBAC of your [installation](installation.md) for a full list.
+
+The `main` branch is currently [tested on Kubernetes 1.26](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L218) and [1.29](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L250).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -53,7 +53,7 @@ Otherwise, we typically release every two weeks:
 
 ### Notes on Compatibility
 
-Argo versions may be compatible with newer and older Kubernetes versions (indicated by `?`), but only three minor versions are actively tested against unless otherwise noted.
+Argo versions may be compatible with newer and older Kubernetes versions (indicated by `?`), but only three minor versions are tested unless otherwise noted.
 
 Note that Kubernetes [is backward compatible with clients](https://github.com/kubernetes/client-go/tree/aa7909e7d7c0661792ba21b9e882f3cd6ad0ce53?tab=readme-ov-file#compatibility-client-go---kubernetes-clusters), so newer k8s versions are generally supported.
 The caveats with newer k8s versions are possible changes to experimental APIs and unused new features.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

- this has been asked about by users several times [on](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1716901715484439) [Slack](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1717050469207059?thread_ts=1716901715.484439&cid=C01QW9QSSSK)
  - as well as at least once on GitHub: #12695

- I also asked about our k8s upgrade policy in [a Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit#heading=h.eb9qvqsmpwns) and [the contributors Slack](https://cloud-native.slack.com/archives/C0510EUH90V/p1712081347503639)
  - and I clarified later in [the thread](https://cloud-native.slack.com/archives/C0510EUH90V/p1713383168753329?thread_ts=1712081347.503639&cid=C0510EUH90V) about k8s's guarantees and `client-go`'s matrix, etc

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- this PR is effectively equivalent to my clarifications on Slack: specify that k8s is backward compatible with all clients and link to `client-go`'s docs

- also link to the CI tests for concrete references on k8s version testing

- minor wording improvements, simplifying some sentences as well as specifying Argo version vs k8s version to clear up ambiguous wording
- reference k8s and Argo consistently (the docs do not use `Argo Workflows` or `Kubernetes` anywhere else)


### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes

### Notes to Reviewers

- **NOTE**: this will need to be modified when backported -- since we have versioned docs now (#11390), those should reference their own branch (i.e. `release-3.5`, `release-3.4`) and that branch's tests
  - this is important since currently the earlier versions of docs say that "the main branch is tested on" even though they are referring to their own branch now and not `main` anymore
  - I can handle backporting that myself once merged


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
