### PR TITLE
docs(server): full copy-edit of auth mode page

### DIFF
--- a/docs/argo-server-auth-mode.md
+++ b/docs/argo-server-auth-mode.md
@@ -1,15 +1,15 @@
 # Argo Server Auth Mode
 
-You can choose which kube config the Argo Server uses:
+You can configure how the Argo Server authenticates to Kubernetes:
 
-* `server` - in hosted mode, use the kube config of service account, in local mode, use your local kube config.
-* `client` - requires clients to provide their Kubernetes bearer token and use that.
-* [`sso`](./argo-server-sso.md) - since v2.9, use single sign-on, this will use the same service account as per "server" for RBAC. We expect to change this in the future so that the OAuth claims are mapped to service accounts.
+* `server`: In [hosted mode](argo-server.md#hosted-mode), use the Server's Service Account. In [local mode](argo-server.md#local-mode), use your local kube config.
+* `client`: Use the Kubernetes [bearer token of clients](access-token.md).
+* `sso`: Use [single sign-on](argo-server-sso.md). This will use the same SA as `server` for RBAC, unless you have enabled [SSO RBAC Namespace Delegation](argo-server-sso.md#sso-rbac-namespace-delegation)
 
-The server used to start with auth mode of "server" by default, but since v3.0 it defaults to the "client".
+For v3.0 and after, the default is `client`. Prior to v3.0, it was `server`.
 
-To change the server auth mode specify the list as multiple auth-mode flags:
+To configure the Server's auth modes, use one or multiple `--auth-mode` flags. For example:
 
 ```bash
-argo server --auth-mode=sso --auth-mode=...
+argo server --auth-mode=sso --auth-mode=client
 ```

--- a/docs/argo-server-auth-mode.md
+++ b/docs/argo-server-auth-mode.md
@@ -4,7 +4,7 @@ You can configure how the Argo Server authenticates to Kubernetes:
 
 * `server`: In [hosted mode](argo-server.md#hosted-mode), use the Server's Service Account. In [local mode](argo-server.md#local-mode), use your local kube config.
 * `client`: Use the Kubernetes [bearer token of clients](access-token.md).
-* `sso`: Use [single sign-on](argo-server-sso.md). This will use the same SA as `server` for RBAC, unless you have enabled [SSO RBAC Namespace Delegation](argo-server-sso.md#sso-rbac-namespace-delegation)
+* `sso`: Use [single sign-on](argo-server-sso.md). This will use the same SA as `server` for RBAC, unless you have enabled [SSO RBAC](argo-server-sso.md#sso-rbac)
 
 For v3.0 and after, the default is `client`. Prior to v3.0, it was `server`.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

I linked to this [in Slack](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1717189187821979?thread_ts=1717176020.109829&cid=C01QW9QSSSK) recently and realized how dated it was 😬 
Also aligns with my other docs copy-edit PRs

### Motivation

<!-- TODO: Say why you made your changes. -->

- this page had some out-of-date information, had inconsistent terminology, and lacked links to several of the features it mentioned
  - it sorely needed an update

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove outdated statement about RBAC mapping
  - this feature has existed since SSO RBAC was implemented (#4198), so replace with a link to that feature

- <details><summary>terminology & consistency improvements:</summary>

  - "choose" -> "configure"
  - "which kube config" -> how to "authenticate"
    - there is no kube config in some of these cases either, so this terminology was not only inconsistent with the rest of the docs (and itself), but also very confusing
    - also that an SA generates a kube config is a k8s implementation detail that not all users are aware of. stick to a higher level description
  - consistently capitalize "Server"
  - use "v{version} and after" consistently, per #12581 
    - also mention the current default first, not the old default
      - the current has been around for years and is more important than the old one, so it should be first
    - remove the redundant SSO version references here as they are already listed in more consistent style within the linked pages
  - use code backticks consistently when referring to one of the modes and when referring to the CLI flag

</details>

- <details><summary>add links to mentioned features:</summary>

  - to hosted mode vs. local mode
  - to k8s bearer token docs
  - to SSO and NS delegation

</details>

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes

### Future Work

This page is pretty tiny, it might make sense to merge with the general Argo Server page, which links to this page, which then links back to it 😕 

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
