### PR TITLE
docs: remove Giscus integration

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,23 +2,11 @@
 {% block content %}
 {{ super() }}
 
-<!-- Giscus -->
-<h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+{# Footer #}
+<hr />
 
-<script src="https://giscus.app/client.js"
-        data-repo="argoproj/argo-workflows"
-        data-repo-id="MDEwOlJlcG9zaXRvcnkxMDA5ODI0NDk="
-        data-category="General"
-        data-category-id="MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMyMTA3OTY1"
-        data-mapping="pathname"
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-input-position="bottom"
-        data-theme="light"
-        data-lang="en"
-        data-loading="lazy"
-        crossorigin="anonymous"
-        async>
-</script>
+<h2>Have a question?</h2>
+
+Search on <a href="https://github.com/argoproj/argo-workflows/discussions?discussions_q=">GitHub Discussions</a> and <a href="https://argoproj.github.io/community/join-slack/">Slack</a>.
 
 {% endblock %}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/12360#issuecomment-1970762484 and a [previous Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit#heading=h.9ogkxyklinsn) about that

### Motivation

<!-- TODO: Say why you made your changes. -->

Remove Giscus as it does not work well with versioned documentation and creates inefficient, hard-to-search and hard-to-answer questions
  - Giscus creates a separate page for each version of the docs, including `release-3.4`, `release-3.5`, `latest` and `stable`  <details>
     - each of those has its own URL, and that is what Giscus uses. Translations would amplify this as well.
     - that also means the old GH Pages docs still have their own Giscus pages, but are no longer used 😕
     - this makes for lots of duplicative discussion pages, which makes it harder to search and find information as well
     - it also sometimes gets the link **wrong**, linking to a different existing discussion to a page
       - this has only been a problem I noticed since versioned docs -- Giscus attempts a fuzzy search, which can be incorrect, especially for higher level pages

</details>
       
  - Giscus doesn't exactly build up a knowledge base of questions and answers, unlike issues and regular discussions and even Slack to an extent
    - Giscus creates GH Discussions that are not "Q&A", but "General". There can also be multiple questions within a single Giscus page (which is why changing to "Q&A" would not necessarily help).
      - <details><summary>This is difficult if not impossible to organize as such. You could have 12 separate threads within one page.</summary>
      
        - this also makes search unusable -- you'll get a result for a page with 12 threads in it and have to attempt to find which thread addresses your question
          - that page also has a generic, non-specific title (the URL). In general, search and non-search pages get clogged up by these non-specific titles, which makes search far less helpful
          - you can't just scroll to the bottom and expect to see an answer there as with an issue
          - and you can't expect a highlighted answer as with "Q&A"
          - you also can't close or lock the thread for spam or once it's been sufficiently answered, because it is always ongoing for a page
        - answering can be difficult for the same reasons too, so questions just get lost into the abyss
        - some users end up seeing all these and asking questions via Giscus instead of a more efficient & searchable method as well, making this an ever compounding problem
        - (tbh, I think all of this is a larger problem with GH Discussions _in general_, but that's a bit of a separate topic)
        
      </details>
      
    - It doesn't encourage searching your questions first either, so we get duplicative questions on Giscus with some frequency. For example: https://github.com/argoproj/argo-workflows/discussions/10320#discussioncomment-6272672, https://github.com/argoproj/argo-workflows/discussions/10320#discussioncomment-7837204, https://github.com/argoproj/argo-workflows/discussions/12451#discussioncomment-8006065. We can't necessarily even mark as duplicates because they are sub-threads.
    
  - Overall, Giscus is greatly inefficient, if not actively counter-productive, and causes duplicates on duplicates
    - As user support is one of the largest uses of time in the project, that is pretty important to optimize

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- As such, remove the Giscus integration and replace with a footer suggestion to search GH Discussions and Slack, with links to each
  - Note: the GH Discussion link I used is slightly different from the default; this one searches open _and_ closed discussions - the default only searches open, but questions that have already been answered may very well be closed
  - This also roughly matches [the UI's help page](https://github.com/argoproj/argo-workflows/blob/85c88320c2f6678d26a1d468cd0ad84517ab4148/ui/src/app/help/help.tsx#L9) as well, so this improves consistency too

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes and the new footer looks as expected. Screenshots:

<details> <summary> Before: </summary>

![Screenshot 2024-06-02 at 3 34 18 PM](https://github.com/argoproj/argo-workflows/assets/4970083/f72b0fd0-2dd0-4983-95a4-4da83c897848)

</details>

<details> <summary> After: </summary>

![Screenshot 2024-06-02 at 3 33 57 PM](https://github.com/argoproj/argo-workflows/assets/4970083/17babc8d-f72e-418a-a3b8-b2ee5523df27)

</details>

### Future Work

Once this is done and backported to all versioned docs, I can slowly start to close out, organize, and lock old Giscus threads
1. Close out each discussion
1. Try to edit the initial/top comment of each Discussion with a summary listing each thread. This attempts to make them more searchable but is still not great and is _very_ tedious / requires significant manual effort (i.e. is unsustainable for maintainers if kept around)
1. Change the title to add prefix "[archived] "
  1. Attempt to make a more specific title if possible (if all threads are related to a certain topic)
1. Then try to answer any leftover questions inside of these that got lost to the abyss
1. Then lock the Discussion

Per my previous efforts in https://github.com/argoproj/argo-workflows/pull/12360#issuecomment-1970762484, there are like [~100+ of these](https://github.com/argoproj/argo-workflows/discussions?discussions_q=author%3Agiscus%5Bbot%5D+), so it will take time.


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
