### PR TITLE
fix(release): set `$DOCKER_CONFIG` if unset

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,6 +172,7 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         run: |
+          : ${DOCKER_CONFIG:=~/.docker}
           echo $(jq -c '. + { "experimental": "enabled" }' ${DOCKER_CONFIG}/config.json) > ${DOCKER_CONFIG}/config.json
 
           docker_org=$DOCKERIO_ORG


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/pull/12791#issuecomment-2155929515

### Motivation

<!-- TODO: Say why you made your changes. -->

Per the linked comment above, it seems like `Azure/docker-login` may have set this env var and so when that was changed to `docker/login-action`, this line errored out

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- set a default for `$DOCKER_CONFIG` in case it is unset
    - Per [Docker's docs](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables), the default is `~/.docker/config.json` (can also confirm locally)

### Verification

<!-- TODO: Say how you tested your changes. -->

This new line runs locally for me:
```
❯  : ${DOCKER_CONFIG:=~/.docker}; echo "$DOCKER_CONFIG"
/<redacted>/.docker
```
and `$DOCKER_CONFIG` is unset without it

But testing the entire GHA workflow is unfortunately very non-trivial 😕 

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
