### PR TITLE
feat: parse exit code when Outputs is not populated

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1860,7 +1860,7 @@ func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[s
 	exitCode := "-1"
 	if lastChildNode.Outputs != nil && lastChildNode.Outputs.ExitCode != nil {
 		exitCode = *lastChildNode.Outputs.ExitCode
-	} else {
+	} else if lastChildNode.Message != nil {
 		tmpexitCode, err := extractExitCode(lastChildNode.Message)
 		if err == nil {
 			exitCode = tmpexitCode

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1860,7 +1860,7 @@ func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[s
 	exitCode := "-1"
 	if lastChildNode.Outputs != nil && lastChildNode.Outputs.ExitCode != nil {
 		exitCode = *lastChildNode.Outputs.ExitCode
-	} else if lastChildNode.Message != nil {
+	} else {
 		tmpexitCode, err := extractExitCode(lastChildNode.Message)
 		if err == nil {
 			exitCode = tmpexitCode


### PR DESCRIPTION
Relates to https://github.com/argoproj/argo-workflows/issues/12572#issuecomment-2162093707
and https://github.com/argoproj/argo-workflows/blame/465c7b6d6abd06a36165955d7fd01d9db2b6a2d4/workflow/controller/operator.go#L1621
Seems more of a workaround than addressing real root cause

cc: @tczhao @shuangkun @toyamagu-2021 