### PR TITLE
fix: OnExit node can retry when retry a workflow (#13184)

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -938,7 +938,7 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
-			assert.Equal(t, 7, len(status.Nodes))
+			assert.Equal(t, 8, len(status.Nodes))
 		}).
 		RunCli([]string{"retry", workflowName}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
@@ -954,7 +954,7 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
-			assert.Equal(t, 7, len(status.Nodes))
+			assert.Equal(t, 8, len(status.Nodes))
 		}).
 		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".success")

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -938,7 +938,7 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
-			assert.Equal(t, 8, len(status.Nodes))
+			assert.Equal(t, 10, len(status.Nodes))
 		}).
 		RunCli([]string{"retry", workflowName}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
@@ -954,7 +954,7 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
-			assert.Equal(t, 8, len(status.Nodes))
+			assert.Equal(t, 10, len(status.Nodes))
 		}).
 		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".success")

--- a/test/e2e/testdata/retry-workflow-with-continueon.yaml
+++ b/test/e2e/testdata/retry-workflow-with-continueon.yaml
@@ -20,7 +20,7 @@ spec:
                   value: 0
           - name: failure
             template: node-to-exit
-            dependencies: [success]
+            dependencies: [ success ]
             onExit: on-exit
             arguments:
               parameters:
@@ -28,7 +28,7 @@ spec:
                   value: 1
           - name: task-after-failure
             template: node-to-exit
-            dependencies: [failure]
+            dependencies: [ failure ]
             arguments:
               parameters:
                 - name: exitCode
@@ -37,14 +37,14 @@ spec:
             template: node-to-exit
             continueOn:
               failed: true
-            dependencies: [success]
+            dependencies: [ success ]
             arguments:
               parameters:
                 - name: exitCode
                   value: 2
           - name: task-after-continue
             template: node-to-exit
-            dependencies: [continue]
+            dependencies: [ continue ]
             arguments:
               parameters:
                 - name: exitCode
@@ -59,6 +59,11 @@ spec:
         command: [ sh, "-c", "exit {{inputs.parameters.exitCode}}" ]
 
     - name: on-exit
+      steps:
+        - - name: alarm
+            template: alarm
+
+    - name: alarm
       container:
         image: alpine:3.7
         command: [ sh, "-c", "exit 0" ]

--- a/test/e2e/testdata/retry-workflow-with-continueon.yaml
+++ b/test/e2e/testdata/retry-workflow-with-continueon.yaml
@@ -21,6 +21,7 @@ spec:
           - name: failure
             template: node-to-exit
             dependencies: [success]
+            onExit: on-exit
             arguments:
               parameters:
                 - name: exitCode
@@ -56,3 +57,8 @@ spec:
       container:
         image: alpine:3.7
         command: [ sh, "-c", "exit {{inputs.parameters.exitCode}}" ]
+
+    - name: on-exit
+      container:
+        image: alpine:3.7
+        command: [ sh, "-c", "exit 0" ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13184 

### Motivation

fix retry logic

### Modifications

1.  function `FormulateRetryWorkflow` in `workflow/util/util.go` file
2.  function `isDescendantNodeSucceeded` in `workflow/util/util.go` file

### Verification
OnExit node and its parent can be retried when a workflow is retried
yaml: `test/e2e/testdata/retry-workflow-with-continueon.yaml`
1. do retrying
<img width="391" alt="image" src="https://github.com/argoproj/argo-workflows/assets/17411006/aedf9dfe-ef86-4da8-b15a-b9879a86a5f7">

2. done
<img width="217" alt="image" src="https://github.com/argoproj/argo-workflows/assets/17411006/50153630-fb73-4284-b3b0-3f4b46ef3543">

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
