### PR TITLE
fix: Do not reset the root node by default. Fixes #13196

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -932,6 +932,47 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		})
 }
 
+func (s *CLISuite) TestRetryWorkflowWithFailedExitHandler() {
+	var workflowName string
+	s.Given().
+		Workflow(`@testdata/retry-workflow-with-failed-exit-handler.yaml`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeFailed).
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			workflowName = metadata.Name
+			assert.Equal(t, 2, len(status.Nodes))
+		}).
+		RunCli([]string{"retry", workflowName}, func(t *testing.T, output string, err error) {
+			if assert.NoError(t, err, output) {
+				assert.Contains(t, output, "Name:")
+				assert.Contains(t, output, "Namespace:")
+			}
+		})
+
+	s.Given().
+		When().
+		WaitForWorkflow(fixtures.ToBeCompleted).
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			workflowName = metadata.Name
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
+			assert.Equal(t, 2, len(status.Nodes))
+		}).
+		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
+			return status.Name == workflowName
+		}, func(t *testing.T, status *wfv1.NodeStatus, pod *corev1.Pod) {
+			assert.Equal(t, wfv1.NodeSucceeded, status.Phase)
+		}).
+		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
+			return strings.Contains(status.Name, ".onExit")
+		}, func(t *testing.T, status *wfv1.NodeStatus, pod *corev1.Pod) {
+			assert.Equal(t, wfv1.NodeFailed, status.Phase)
+			assert.Contains(t, status.Message, "exit code 1")
+		})
+}
+
 func (s *CLISuite) TestWorkflowStop() {
 	s.Given().
 		Workflow("@smoke/basic.yaml").

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -942,7 +942,7 @@ func (s *CLISuite) TestRetryWorkflowWithFailedExitHandler() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
-			assert.Equal(t, 2, len(status.Nodes))
+			assert.Len(t, status.Nodes, 2)
 		}).
 		RunCli([]string{"retry", workflowName}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
@@ -958,7 +958,7 @@ func (s *CLISuite) TestRetryWorkflowWithFailedExitHandler() {
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
-			assert.Equal(t, 2, len(status.Nodes))
+			assert.Len(t, status.Nodes, 2)
 		}).
 		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
 			return status.Name == workflowName

--- a/test/e2e/testdata/retry-workflow-with-failed-exit-handler.yaml
+++ b/test/e2e/testdata/retry-workflow-with-failed-exit-handler.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: retry-workflow-with-failed-exit-handler
+spec:
+  entrypoint: hello
+  onExit: exit-handler
+  templates:
+  - name: hello
+    container:
+      image: alpine:3.18
+      command: [sh, -c]
+      args: ["echo hello"]
+  - name: exit-handler
+    container:
+      image: alpine:3.18
+      command: [sh, -c]
+      args: ["exit 1"]

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -989,13 +989,6 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 			// Do not allow retry of workflows with pods in Running/Pending phase
 			return nil, nil, errors.InternalErrorf("Workflow cannot be retried with node %s in %s phase", node.Name, node.Phase)
 		}
-
-		if node.Name == wf.ObjectMeta.Name {
-			log.Debugf("Reset root node: %s", node.Name)
-			newNode := node.DeepCopy()
-			newWF.Status.Nodes.Set(newNode.ID, resetNode(*newNode))
-			continue
-		}
 	}
 
 	if len(deletedNodes) > 0 {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13196 

### Motivation

Single-node workflow with failed exit handler can not be retried correctly.

### Modifications

Only reset root node when it is `FailedOrError`, remove the default reset logic.

### Verification

local test and e2e test

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
