### PR TITLE
ci(retest): filter more comments to use GHA less

### DIFF
--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -1,14 +1,15 @@
 name: Detect and Trigger Retest
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 permissions:
   contents: read
 
 jobs:
   retest:
-    if: github.event.comment.author_association == 'MEMBER' && github.event.comment.body == '/retest'
+    # PR comments where a Member types "/retest" exactly
+    if: github.event.issue.pull_request && github.event.comment.author_association == 'MEMBER' && github.event.comment.body == '/retest'
     permissions:
       actions: write # for re-running failed jobs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-job-from-a-workflow-run
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to #13000

### Motivation

<!-- TODO: Say why you made your changes. -->

- they get triggerred [quite often](https://github.com/argoproj/argo-workflows/actions/workflows/retest.yaml) (for every comment), and though they only run for 2s, it would be good to filter out more of them and use less CI time

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- only run on `created` events, skip all `edited` events
  - the vast majority of `edited` events will be for unrelated comments
  - you can delete and comment again to trigger a retest instead if you had a typo

- only run on PR comments, following [GH docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only)
  - it would fail otherwise, but this prevents that scenario entirely

### Verification

<!-- TODO: Say how you tested your changes. -->


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
