### PR TITLE
fix: Task result comparison is incorrect, leading to inconsistent comparison results.

### DIFF
--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -90,7 +90,7 @@ func (woc *wfOperationCtx) taskResultReconciliation() {
 		if result.Progress.IsValid() {
 			newNode.Progress = result.Progress
 		}
-		if !reflect.DeepEqual(&old, newNode) {
+		if !reflect.DeepEqual(old, newNode) {
 			woc.log.
 				WithField("nodeID", nodeID).
 				Info("task-result changed")


### PR DESCRIPTION
### Motivation

https://github.com/argoproj/argo-workflows/blob/66e64c86b9b7d24e2b1d181bf49722319b07c461/workflow/controller/taskresult.go#L93
The variable `old` is `*NodeStatus` since #11451, so `&old` and `newNode` is always not equal now.

### Modifications

use `old` instead of `&old`

### Verification

local test

Workflow Demo:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  name: workflow-sleep
spec:
  entrypoint: sleep
  templates:
  - name: sleep
    container:
      image: alpine:3.18
      command: [sh, -c]
      args: ["sleep 600"]`
```

Controller log:
```
INFO[2024-06-18T14:28:57.179Z] Processing workflow                           Phase= ResourceVersion=765095 namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.190Z] resolved artifact repository                  artifactRepositoryRef="argo/#"
INFO[2024-06-18T14:28:57.190Z] Task-result reconciliation                    namespace=argo numObjs=0 workflow=workflow-sleep
INFO[2024-06-18T14:28:57.190Z] Updated phase  -> Running                     namespace=argo workflow=workflow-sleep
WARN[2024-06-18T14:28:57.190Z] Node was nil, will be initialized as type Skipped  namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.191Z] was unable to obtain node for , letting display name to be nodeName  namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.191Z] Pod node workflow-sleep initialized Pending   namespace=argo workflow=workflow-sleep
WARN[2024-06-18T14:28:57.191Z] couldn't get boundaryTemplate through nodeName workflow-sleep  namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.218Z] Created pod: workflow-sleep (workflow-sleep)  namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.218Z] TaskSet Reconciliation                        namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.218Z] reconcileAgentPod                             namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:57.218Z] Workflow to be dehydrated                     Workflow Size=797
INFO[2024-06-18T14:28:57.233Z] Workflow update successful                    namespace=argo phase=Running resourceVersion=765101 workflow=workflow-sleep
INFO[2024-06-18T14:28:58.179Z] Processing workflow                           Phase=Running ResourceVersion=765101 namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:58.181Z] Task-result reconciliation                    namespace=argo numObjs=0 workflow=workflow-sleep
INFO[2024-06-18T14:28:58.181Z] node changed                                  namespace=argo new.message=PodInitializing new.phase=Pending new.progress=0/1 nodeID=workflow-sleep old.message= old.phase=Pending old.progress=0/1 workflow=workflow-sleep
INFO[2024-06-18T14:28:58.181Z] TaskSet Reconciliation                        namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:58.181Z] reconcileAgentPod                             namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:58.181Z] Workflow to be dehydrated                     Workflow Size=1052
INFO[2024-06-18T14:28:58.197Z] Workflow update successful                    namespace=argo phase=Running resourceVersion=765105 workflow=workflow-sleep
INFO[2024-06-18T14:28:59.199Z] Processing workflow                           Phase=Running ResourceVersion=765105 namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:59.200Z] Task-result reconciliation                    namespace=argo numObjs=1 workflow=workflow-sleep
INFO[2024-06-18T14:28:59.200Z] node unchanged                                namespace=argo nodeID=workflow-sleep workflow=workflow-sleep
INFO[2024-06-18T14:28:59.200Z] TaskSet Reconciliation                        namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:28:59.200Z] reconcileAgentPod                             namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:29:00.461Z] Processing workflow                           Phase=Running ResourceVersion=765105 namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:29:00.462Z] Task-result reconciliation                    namespace=argo numObjs=1 workflow=workflow-sleep
INFO[2024-06-18T14:29:00.462Z] node changed                                  namespace=argo new.message= new.phase=Running new.progress=0/1 nodeID=workflow-sleep old.message=PodInitializing old.phase=Pending old.progress=0/1 workflow=workflow-sleep
INFO[2024-06-18T14:29:00.462Z] TaskSet Reconciliation                        namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:29:00.462Z] reconcileAgentPod                             namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:29:00.462Z] Workflow to be dehydrated                     Workflow Size=1057
INFO[2024-06-18T14:29:00.478Z] Workflow update successful                    namespace=argo phase=Running resourceVersion=765116 workflow=workflow-sleep
INFO[2024-06-18T14:29:01.479Z] Processing workflow                           Phase=Running ResourceVersion=765116 namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:29:01.480Z] Task-result reconciliation                    namespace=argo numObjs=1 workflow=workflow-sleep
INFO[2024-06-18T14:29:01.480Z] node unchanged                                namespace=argo nodeID=workflow-sleep workflow=workflow-sleep
INFO[2024-06-18T14:29:01.480Z] TaskSet Reconciliation                        namespace=argo workflow=workflow-sleep
INFO[2024-06-18T14:29:01.480Z] reconcileAgentPod                             namespace=argo workflow=workflow-sleep
```
Logs like `task-result changed` does not appear again.
`ResourceVersion` in logs like `Workflow update successful` is different.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
