### PR TITLE
fix: Mark `Pending` pod nodes as `Failed` when shutting down. Fixes #13210

### DIFF
--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -724,7 +724,7 @@ spec:
 			})
 			expectWorkflow(ctx, controller, "my-wf-2", func(wf *wfv1.Workflow) {
 				if assert.NotNil(t, wf) {
-					assert.Equal(t, wfv1.WorkflowSucceeded, wf.Status.Phase)
+					assert.Equal(t, wfv1.WorkflowFailed, wf.Status.Phase)
 				}
 			})
 		})
@@ -1194,9 +1194,9 @@ func TestPendingPodWhenTerminate(t *testing.T) {
 
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
+	assert.Equal(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
 	for _, node := range woc.wf.Status.Nodes {
-		assert.Equal(t, wfv1.NodeSkipped, node.Phase)
+		assert.Equal(t, wfv1.NodeFailed, node.Phase)
 	}
 }
 

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7816,7 +7816,7 @@ func TestNoPodsWhenShutdown(t *testing.T) {
 
 	node := woc.wf.Status.Nodes.FindByDisplayName("hello-world")
 	if assert.NotNil(t, node) {
-		assert.Equal(t, wfv1.NodeSkipped, node.Phase)
+		assert.Equal(t, wfv1.NodeFailed, node.Phase)
 		assert.Contains(t, node.Message, "workflow shutdown with strategy: Stop")
 	}
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -96,7 +96,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 
 	if !woc.GetShutdownStrategy().ShouldExecute(opts.onExitPod) {
 		// Do not create pods if we are shutting down
-		woc.markNodePhase(nodeName, wfv1.NodeSkipped, fmt.Sprintf("workflow shutdown with strategy: %s", woc.GetShutdownStrategy()))
+		woc.markNodePhase(nodeName, wfv1.NodeFailed, fmt.Sprintf("workflow shutdown with strategy: %s", woc.GetShutdownStrategy()))
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13210

### Motivation

see https://github.com/argoproj/argo-workflows/issues/13210#issuecomment-2175332795

### Modifications

Mark `Pending` nodes of pod type `Failed` when shutting down.

### Verification

updated UT

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
