### PR TITLE
fix(cli): restore `--field-selector` for archive commands. Fixes #13223

### DIFF
--- a/cmd/argo/commands/archive/list.go
+++ b/cmd/argo/commands/archive/list.go
@@ -18,7 +18,8 @@ import (
 
 func NewListCommand() *cobra.Command {
 	var (
-		selector  string
+		label     string
+		fields    string
 		output    string
 		chunkSize int64
 	)
@@ -30,20 +31,22 @@ func NewListCommand() *cobra.Command {
 			serviceClient, err := apiClient.NewArchivedWorkflowServiceClient()
 			errors.CheckError(err)
 			namespace := client.Namespace()
-			workflows, err := listArchivedWorkflows(ctx, serviceClient, namespace, selector, chunkSize)
+			workflows, err := listArchivedWorkflows(ctx, serviceClient, namespace, fields, label, chunkSize)
 			errors.CheckError(err)
 			err = printer.PrintWorkflows(workflows, os.Stdout, printer.PrintOpts{Output: output, Namespace: true, UID: true})
 			errors.CheckError(err)
 		},
 	}
 	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
-	command.Flags().StringVarP(&selector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	command.Flags().StringVarP(&label, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	command.Flags().StringVar(&fields, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	command.Flags().Int64VarP(&chunkSize, "chunk-size", "", 0, "Return large lists in chunks rather than all at once. Pass 0 to disable.")
 	return command
 }
 
-func listArchivedWorkflows(ctx context.Context, serviceClient workflowarchivepkg.ArchivedWorkflowServiceClient, namespace string, labelSelector string, chunkSize int64) (wfv1.Workflows, error) {
+func listArchivedWorkflows(ctx context.Context, serviceClient workflowarchivepkg.ArchivedWorkflowServiceClient, namespace string, fieldSelector string, labelSelector string, chunkSize int64) (wfv1.Workflows, error) {
 	listOpts := &metav1.ListOptions{
+		FieldSelector: fieldSelector,
 		LabelSelector: labelSelector,
 		Limit:         chunkSize,
 	}

--- a/cmd/argo/commands/archive/resubmit.go
+++ b/cmd/argo/commands/archive/resubmit.go
@@ -102,7 +102,7 @@ func resubmitArchivedWorkflows(ctx context.Context, archiveServiceClient workflo
 	)
 
 	if resubmitOpts.hasSelector() {
-		wfs, err = listArchivedWorkflows(ctx, archiveServiceClient, resubmitOpts.fieldSelector, resubmitOpts.labelSelector, 0)
+		wfs, err = listArchivedWorkflows(ctx, archiveServiceClient, resubmitOpts.namespace, resubmitOpts.fieldSelector, resubmitOpts.labelSelector, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/argo/commands/archive/retry.go
+++ b/cmd/argo/commands/archive/retry.go
@@ -107,7 +107,7 @@ func retryArchivedWorkflows(ctx context.Context, archiveServiceClient workflowar
 	}
 	var wfs wfv1.Workflows
 	if retryOpts.hasSelector() {
-		wfs, err = listArchivedWorkflows(ctx, archiveServiceClient, retryOpts.fieldSelector, retryOpts.labelSelector, 0)
+		wfs, err = listArchivedWorkflows(ctx, archiveServiceClient, retryOpts.namespace, retryOpts.fieldSelector, retryOpts.labelSelector, 0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!-- Does this PR fix an issue -->

Fixes #13223

### Motivation
field-selector option isn't applied for the retry and resubmit archive commands

### Modifications
- restore `FieldSelector` option for `listArchivedWorkflows` client function 
- fix call of `listArchivedWorkflows` for retry and resubmit archive commands
- add support of `field-selector` for list command

### Verification

<!-- TODO: Say how you tested your changes. -->


