### PR TITLE
docs(sso): clarify Dex `staticClients` ID for `argo-cd/values.yaml` block

### DIFF
--- a/docs/argo-server-sso-argocd.md
+++ b/docs/argo-server-sso-argocd.md
@@ -126,6 +126,7 @@ data:
        config:
          dex.config: |
            staticClients:
+           # This is the OIDC client ID in plaintext
            - id: argo-workflows-sso
              name: Argo Workflow
              redirectURIs:


### PR DESCRIPTION
### Motivation

Fixing wordings for SSO with ArgoCD for client_id

### Modifications

Add a comment in argo-cd/values.yaml in documentation to reflect that `client_id` should be the actual OIDC client-id received from OIDC provider and it should be in plain-text format.
This info was missing earlier.



