### PR TITLE
fix(ui): parameter descriptions shouldn't disappear on input

### DIFF
--- a/ui/src/app/shared/components/parameters-input.tsx
+++ b/ui/src/app/shared/components/parameters-input.tsx
@@ -12,10 +12,11 @@ interface ParametersInputProps {
 
 export function ParametersInput(props: ParametersInputProps) {
     function onParameterChange(parameter: Parameter, value: string) {
-        props.onChange(props.parameters.map(p => ({
+        const newParameters: Parameter[] = props.parameters.map(p => ({
             ...p,
-            value: p.name === parameter.name ? value : Utils.getValueFromParameter(p),
-        })));
+            value: p.name === parameter.name ? value : Utils.getValueFromParameter(p)
+        }));
+        props.onChange(newParameters);
     }
 
     function displaySelectFieldForEnumValues(parameter: Parameter) {

--- a/ui/src/app/shared/components/parameters-input.tsx
+++ b/ui/src/app/shared/components/parameters-input.tsx
@@ -12,12 +12,10 @@ interface ParametersInputProps {
 
 export function ParametersInput(props: ParametersInputProps) {
     function onParameterChange(parameter: Parameter, value: string) {
-        const newParameters: Parameter[] = props.parameters.map(p => ({
-            name: p.name,
+        props.onChange(props.parameters.map(p => ({
+            ...p,
             value: p.name === parameter.name ? value : Utils.getValueFromParameter(p),
-            enum: p.enum
-        }));
-        props.onChange(newParameters);
+        })));
     }
 
     function displaySelectFieldForEnumValues(parameter: Parameter) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13242 

### Motivation

<!-- TODO: Say why you made your changes. -->

Per the issue, parameter tooltips/descriptions would disappear for _all_ parameters as soon as you entered any text into any _one_ of the parameter inputs. This buggy behavior would ofc make tooltips substantially less useful.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- the `map` statement missed `description` (and other parts of a `Parameter`) as it only listed a few fields and not all of them
  - use spread args to (shallow-)copy over the whole object instead, and then just overwrite the `value` as nothing else changes
    - spread makes this a lot more future-proof and less buggy, since we're not re-typing all of the unchanged fields

### Verification

<!-- TODO: Say how you tested your changes. -->

Confirmed it was working locally after typing some inputs. Screenshot:
![Screenshot 2024-06-25 at 1 22 13 AM](https://github.com/argoproj/argo-workflows/assets/4970083/935312cd-7deb-4a14-8751-ac7c31db91dd)

### Backport Notes

This is not directly backportable to 3.4 as the code has changed quite a bit (e.g. this shared component didn't exist and it used class components before). But the diff can be copy+pasted to the [equivalent section in 3.4](https://github.com/argoproj/argo-workflows/blob/89cbdb53361cbe59fbe81b887ee82722cce5de54/ui/src/app/workflows/components/submit-workflow-panel.tsx#L147) if someone wants it.

### Future Work

We might be able to further optimize this by re-using the same object when its value is unchanged (which will be the majority of cases since the whole array is modified at once). I just fixed the bug at this time




<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
