### PR TITLE
fix(cli): `argo lint` with strict should report case-sensitive errors. Fixes #13006

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -294,7 +294,7 @@ require (
 	k8s.io/component-helpers v0.26.15 // indirect
 	k8s.io/metrics v0.26.15 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect
-	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1111,7 +1111,7 @@ func (s *CLISuite) TestTemplateCommands() {
 		s.Given().RunCli([]string{"template", "lint", "testdata/workflow-templates"}, func(t *testing.T, output string, err error) {
 			assert.Error(t, err)
 			assert.Contains(t, output, "invalid-workflowtemplate.yaml")
-			assert.Contains(t, output, `unknown field "entrypoints"`)
+			assert.Contains(t, output, `unknown field "spec.entrypoints"`)
 			assert.Contains(t, output, "linting errors found!")
 		})
 	})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13006

## Motivation

Currently, when linting a `CronWorkflow` definition file, `argo lint` fails to detect keys with incorrect capitalization. This oversight can lead to unexpected behavior when applying these definitions using `kubectl`. Prior to this fix, `argo cron create` would ignore capitalization issues and proceed with the provided values, creating an inconsistency between `kubectl` and `argo cron create` behaviors.

By addressing this issue, we aim to:

1. Enhance the linting process to catch capitalization errors early in the development cycle.
2. Align the behavior of `argo cron create/argo submit` with `kubectl`, ensuring both tools report errors for incorrectly capitalized fields.
3. Streamline the workflow creation process by providing consistent feedback across different Argo and Kubernetes tools.

This change will help prevent potential errors by catching and reporting capitalization issues uniformly across all relevant tools.

## Modifications

To address this issue, we've made the following change:

Modified the strict path of the linting process to utilize the `sigs.k8s.io/json` library for unmarshaling.
   - This library provides case-sensitive unmarshaling in strict mode.
   - Fields with incorrect capitalization (e.g., "schedUle" instead of "schedule") will now be unmarshaled as-is.
   - The strict mode will then report these incorrectly capitalized fields as errors using the `k8s.io/apimachinery/pkg/runtime` library.

This change ensures that `argo lint` will now flag incorrectly capitalized fields when strict mode is enabled, providing developers with immediate feedback on potential issues in their workflow definitions. It also aligns the behavior of `argo lint` and `argo cron create/argo submit` with `kubectl`, creating a consistent experience across these tools.

## Verification

To validate the effectiveness of this fix, I have extended the test suite with two new unit tests:

1. A test case for strict mode enabled, verifying that capitalization errors are correctly reported.
2. A test case for strict mode disabled, ensuring that the existing behavior remains unchanged.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
