### PR TITLE
fix: Set initial progress from pod metadata if exists. Fixes #13057

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1421,6 +1421,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 		new.PodIP = pod.Status.PodIP
 	}
 
+	// If `AnnotationKeyReportOutputsCompleted` is set, it means RBAC prevented WorkflowTaskResult from being written.
 	if x, ok := pod.Annotations[common.AnnotationKeyReportOutputsCompleted]; ok {
 		woc.log.Warn("workflow uses legacy/insecure pod patch, see https://argo-workflows.readthedocs.io/en/latest/workflow-rbac/")
 		resultName := woc.nodeID(pod)
@@ -1430,6 +1431,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 			woc.wf.Status.MarkTaskResultIncomplete(resultName)
 		}
 
+		// Get node outputs from pod annotations instead if RBAC prevented WorkflowTaskResult from being written.
 		if x, ok = pod.Annotations[common.AnnotationKeyOutputs]; ok {
 			if new.Outputs == nil {
 				new.Outputs = &wfv1.Outputs{}
@@ -1440,6 +1442,7 @@ func (woc *wfOperationCtx) assessNodeStatus(pod *apiv1.Pod, old *wfv1.NodeStatus
 			}
 		}
 
+		// Get node progress from pod annotations instead if RBAC prevented WorkflowTaskResult from being written.
 		if x, ok = pod.Annotations[common.AnnotationKeyProgress]; ok {
 			if p, ok := wfv1.ParseProgress(x); ok {
 				new.Progress = p

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -258,6 +258,18 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	woc.addSchedulingConstraints(pod, wfSpec, tmpl, nodeName)
 	woc.addMetadata(pod, tmpl)
 
+	// Set initial progress from pod metadata if exists.
+	if x, ok := pod.ObjectMeta.Annotations[common.AnnotationKeyProgress]; ok {
+		if p, ok := wfv1.ParseProgress(x); ok {
+			node, err := woc.wf.Status.Nodes.Get(nodeID)
+			if err != nil {
+				woc.log.Panicf("was unable to obtain node for %s", nodeID)
+			}
+			node.Progress = p
+			woc.wf.Status.Nodes.Set(nodeID, *node)
+		}
+	}
+
 	err = addVolumeReferences(pod, woc.volumes, tmpl, woc.wf.Status.PersistentVolumeClaims)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13057

### Motivation

Self reporting progress does not work when `workflows.argoproj.io/progress` is set.

### Modifications

1. Set initial progress from pod metadata if exists before `podReconciliation`.
2. Prevent the node's existing progress from being overwritten with the initial progress in pod metadata: only override it when workflow uses legacy/insecure pod patch.

### Verification

Local test and UT.
Workflow demo:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: progress-
spec:
  entrypoint: main
  templates:
    - name: main
      dag:
        tasks:
          - name: progress
            template: progress
    - name: progress
      metadata:
        annotations:
          workflows.argoproj.io/progress: 0/100
      container:
        image: alpine
        imagePullPolicy: IfNotPresent
        command: [ "/bin/sh", "-c" ]
        args:
          - |
            for i in `seq 1 10`; do sleep 10; echo "$(($i*10))"'/100' > $ARGO_PROGRESS_FILE; done
```
<img width="1373" src="https://github.com/argoproj/argo-workflows/assets/18543532/cf733af3-caa9-484c-9628-905582eb94a9">
<img width="1342" src="https://github.com/argoproj/argo-workflows/assets/18543532/ffbc3021-a8d9-4ed5-87b8-f185fd9a7679">


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
