### PR TITLE
feat!: enable Prometheus TLS by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -260,7 +260,7 @@ type MetricsConfig struct {
 	Port int `json:"port,omitempty"`
 	// IgnoreErrors is a flag that instructs prometheus to ignore metric emission errors
 	IgnoreErrors bool `json:"ignoreErrors,omitempty"`
-	// Secure is a flag that starts the metrics servers using TLS
+	// Secure is a flag that starts the metrics servers using TLS, defaults to true
 	Secure *bool `json:"secure,omitempty"`
 }
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,8 +68,8 @@ metricsConfig: |
   # IgnoreErrors is a flag that instructs prometheus to ignore metric emission errors. Default is "false"
   ignoreErrors: false
 
-  # Use a self-signed cert for TLS
-  secure: false
+  # Use a self-signed cert for TLS, default true
+  secure: true
 ```
 
 The metric names emitted by this mechanism are prefixed with `argo_workflows_`.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,7 +68,8 @@ metricsConfig: |
   # IgnoreErrors is a flag that instructs prometheus to ignore metric emission errors. Default is "false"
   ignoreErrors: false
 
-  # Use a self-signed cert for TLS, default true
+  # Use a self-signed cert for TLS
+  # >= 3.6: default true
   secure: true
 ```
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -52,7 +52,6 @@ Custom metrics, as defined by a workflow, could be defined as one type (say coun
 #### TLS
 
 The Prometheus `/metrics` endpoint now has TLS enabled by default.
-
 To disable this set `metricsConfig.secure` to `false`.
 
 ## Upgrading to v3.5

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -49,6 +49,12 @@ Custom metrics, as defined by a workflow, could be defined as one type (say coun
 
 `metricsTTL` for histogram metrics is not functional as opentelemetry doesn't allow deletion of metrics. This is faked via asynchronous meters for the other metric types.
 
+#### TLS
+
+The Prometheus `/metrics` endpoint now has TLS enabled by default.
+
+To disable this set `metricsConfig.secure` to `false`.
+
 ## Upgrading to v3.5
 
 There are no known breaking changes in this release.

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -225,8 +225,8 @@ data:
     metricsTTL: "10m"
     # IgnoreErrors is a flag that instructs prometheus to ignore metric emission errors. Default is "false"
     ignoreErrors: false
-    # Use a self-signed cert for TLS, default false
-    secure: false
+    # Use a self-signed cert for TLS, default true
+    secure: true
 
     # DEPRECATED: Legacy metrics are now removed, this field is ignored
     disableLegacy: false

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -225,7 +225,8 @@ data:
     metricsTTL: "10m"
     # IgnoreErrors is a flag that instructs prometheus to ignore metric emission errors. Default is "false"
     ignoreErrors: false
-    # Use a self-signed cert for TLS, default true
+    # Use a self-signed cert for TLS
+    # >= 3.6: default true
     secure: true
 
     # DEPRECATED: Legacy metrics are now removed, this field is ignored

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
 )
 
-const baseUrlMetrics = "http://localhost:9090/metrics"
+const baseUrlMetrics = "https://localhost:9090/metrics"
 
 // ensure basic HTTP functionality works,
 // testing behaviour really is a non-goal

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1359,8 +1359,8 @@ func (wfc *WorkflowController) getMetricsServerConfig() *metrics.Config {
 		Port:         wfc.Config.MetricsConfig.Port,
 		TTL:          time.Duration(wfc.Config.MetricsConfig.MetricsTTL),
 		IgnoreErrors: wfc.Config.MetricsConfig.IgnoreErrors,
-		// Default to false until v3.5
-		Secure: wfc.Config.MetricsConfig.GetSecure(false),
+		// Enable by default in 3.6
+		Secure: wfc.Config.MetricsConfig.GetSecure(true),
 	}
 	return &metricsConfig
 }

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1359,8 +1359,7 @@ func (wfc *WorkflowController) getMetricsServerConfig() *metrics.Config {
 		Port:         wfc.Config.MetricsConfig.Port,
 		TTL:          time.Duration(wfc.Config.MetricsConfig.MetricsTTL),
 		IgnoreErrors: wfc.Config.MetricsConfig.IgnoreErrors,
-		// Enable by default in 3.6
-		Secure: wfc.Config.MetricsConfig.GetSecure(true),
+		Secure:       wfc.Config.MetricsConfig.GetSecure(true),
 	}
 	return &metricsConfig
 }


### PR DESCRIPTION
This appears to [have been slated for 3.5](https://github.com/argoproj/argo-workflows/blob/0322579ac813f345562f384ed6203a7f45faa484/workflow/controller/controller.go#L1361) but it didn't happen.

Note to reviewers: this is part of a stack of reviews for metrics changes. Please don't merge until the rest of the stack is also ready.

Signed-off-by: Alan Clucas <alan@clucas.org>