### PR TITLE
feat: enable configuration of temporality in opentelemetry metrics

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -205,6 +205,7 @@ sandboxed
 shortcodes
 stateful
 stderr
+temporality
 triaged
 un-reconciled
 v1

--- a/config/config.go
+++ b/config/config.go
@@ -269,9 +269,9 @@ type MetricsConfig struct {
 	IgnoreErrors bool `json:"ignoreErrors,omitempty"`
 	// Secure is a flag that starts the metrics servers using TLS, defaults to true
 	Secure *bool `json:"secure,omitempty"`
-	// Temporality configures the temporality of the opentelemetry metrics.
-	// Valid values are Cumulative and Delta, defaulting to cumulative.
-	// This has no effect on prometheus metrics, which are always cumulative
+	// Temporality of the OpenTelemetry metrics.
+	// Enum of Cumulative or Delta, defaulting to Cumulative.
+	// No effect on Prometheus metrics, which are always Cumulative.
 	Temporality MetricsTemporality `json:"temporality,omitempty"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -245,6 +245,13 @@ type MySQLConfig struct {
 	Options map[string]string `json:"options,omitempty"`
 }
 
+type MetricsTemporality string
+
+const (
+	MetricsTemporalityCumulative MetricsTemporality = "Cumulative"
+	MetricsTemporalityDelta      MetricsTemporality = "Delta"
+)
+
 // MetricsConfig defines a config for a metrics server
 type MetricsConfig struct {
 	// Enabled controls metric emission. Default is true, set "enabled: false" to turn off
@@ -262,6 +269,10 @@ type MetricsConfig struct {
 	IgnoreErrors bool `json:"ignoreErrors,omitempty"`
 	// Secure is a flag that starts the metrics servers using TLS, defaults to true
 	Secure *bool `json:"secure,omitempty"`
+	// Temporality configures the temporality of the opentelemetry metrics.
+	// Valid values are Cumulative and Delta, defaulting to cumulative.
+	// This has no effect on prometheus metrics, which are always cumulative
+	Temporality MetricsTemporality `json:"temporality,omitempty"`
 }
 
 func (mc MetricsConfig) GetSecure(defaultValue bool) bool {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -50,7 +50,7 @@ receivers:
 
 You can use the [OpenTelemetry operator](https://opentelemetry.io/docs/kubernetes/operator/) to setup the collector and instrument the workflow-controller.
 
-You can configure the temporality of OpenTelemetry metrics in the [Workflow Controller ConfigMap](workflow-controller-configmap.md).
+You can configure the [temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) of OpenTelemetry metrics in the [Workflow Controller ConfigMap](workflow-controller-configmap.md).
 
 ```yaml
 metricsConfig: |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,7 +54,7 @@ You can configure the [temporality](https://opentelemetry.io/docs/specs/otel/met
 
 ```yaml
 metricsConfig: |
-  # Which temporality to use for opentelemetry, defaults to Cumulative
+  # >= 3.6. Which temporality to use for OpenTelemetry. Default is "Cumulative"
   temporality: Delta
 ```
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -36,7 +36,7 @@ It will not be enabled if left blank, unlike some other implementations.
 
 You can configure the protocol using the environment variables documented in [standard environment variables](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/).
 
-The [configuration option](#common) in the controller ConfigMap `metricsTTL` affects the OpenTelemetry behavior, but the other parameters do not.
+The [configuration options](#common) in the controller ConfigMap `metricsTTL` and `temporality` affect the OpenTelemetry behavior, but the other parameters do not.
 
 To use the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) you can configure it
 
@@ -49,6 +49,14 @@ receivers:
 ```
 
 You can use the [OpenTelemetry operator](https://opentelemetry.io/docs/kubernetes/operator/) to setup the collector and instrument the workflow-controller.
+
+You can adjust temporality of the OpenTelemetry metrics configuration by changing values in the [Workflow Controller Config Map](workflow-controller-configmap.md).
+
+```yaml
+metricsConfig: |
+  # Which temporality to use for opentelemetry, defaults to Cumulative
+  temporality: Delta
+```
 
 ### Prometheus scraping
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -50,7 +50,7 @@ receivers:
 
 You can use the [OpenTelemetry operator](https://opentelemetry.io/docs/kubernetes/operator/) to setup the collector and instrument the workflow-controller.
 
-You can adjust temporality of the OpenTelemetry metrics configuration by changing values in the [Workflow Controller Config Map](workflow-controller-configmap.md).
+You can configure the temporality of OpenTelemetry metrics in the [Workflow Controller ConfigMap](workflow-controller-configmap.md).
 
 ```yaml
 metricsConfig: |

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -228,6 +228,8 @@ data:
     # Use a self-signed cert for TLS
     # >= 3.6: default true
     secure: true
+    # Which temporality to use for opentelemetry, defaults to Cumulative
+    temporality: Delta
 
     # DEPRECATED: Legacy metrics are now removed, this field is ignored
     disableLegacy: false

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -228,7 +228,7 @@ data:
     # Use a self-signed cert for TLS
     # >= 3.6: default true
     secure: true
-    # Which temporality to use for opentelemetry, defaults to Cumulative
+    # >= 3.6. Which temporality to use for OpenTelemetry. Default is "Cumulative"
     temporality: Delta
 
     # DEPRECATED: Legacy metrics are now removed, this field is ignored

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1360,6 +1360,7 @@ func (wfc *WorkflowController) getMetricsServerConfig() *metrics.Config {
 		TTL:          time.Duration(wfc.Config.MetricsConfig.MetricsTTL),
 		IgnoreErrors: wfc.Config.MetricsConfig.IgnoreErrors,
 		Secure:       wfc.Config.MetricsConfig.GetSecure(true),
+		Temporality:  wfc.Config.MetricsConfig.Temporality,
 	}
 	return &metricsConfig
 }


### PR DESCRIPTION
Implemented because of https://github.com/argoproj/argo-workflows/issues/12589#issuecomment-2174216603

Some backends (e.g. prometheus) only support cumulative temporality while others (e.g. dynatrace) only support delta metrics.

It is possible to configure an opentelemetry collector between argo workflow controller and the backend to convert cumulative metrics into delta metrics but it has some limits (e.g. when controller is restarted or when it is scaled up).

This commit enables the choice of temporality for OpenTelemetry

Temporality is always cumulative by definition in Prometheus

Note to reviewers: this is part of a stack of reviews for metrics changes. Please don't merge until the rest of the stack is also ready.

Signed-off-by: Alan Clucas <alan@clucas.org>