### PR TITLE
feat: enable configuration of individual metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -245,6 +245,17 @@ type MySQLConfig struct {
 	Options map[string]string `json:"options,omitempty"`
 }
 
+// MetricModifier are modifiers for an individual named metric to change their behaviour
+type MetricModifier struct {
+	// Disabled disables the emission of this metric completely
+	Disabled bool `json:"disabled,omitempty"`
+	// DisabledAttributes lists labels for this metric to remove that attributes to save on cardinality
+	DisabledAttributes []string `json:"disabledAttributes"`
+	// HistogramBuckets allow configuring of the buckets used in a histogram
+	// Has no effect on non-histogram buckets
+	HistogramBuckets []float64 `json:"histogramBuckets,omitempty"`
+}
+
 type MetricsTemporality string
 
 const (
@@ -269,6 +280,8 @@ type MetricsConfig struct {
 	IgnoreErrors bool `json:"ignoreErrors,omitempty"`
 	// Secure is a flag that starts the metrics servers using TLS, defaults to true
 	Secure *bool `json:"secure,omitempty"`
+	// Modifiers configure metrics by name
+	Modifiers map[string]MetricModifier `json:"modifiers,omitempty"`
 	// Temporality of the OpenTelemetry metrics.
 	// Enum of Cumulative or Delta, defaulting to Cumulative.
 	// No effect on Prometheus metrics, which are always Cumulative.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,6 +30,16 @@ The following are new metrics:
 * `queue_retries`
 * `queue_unfinished_work`
 
+and can be disabled with
+
+```yaml
+metricsConfig: |
+  modifiers:
+    build_info:
+      disable: true
+...
+```
+
 #### Renamed metrics
 
 If you are using these metrics in your recording rules, dashboards, or alerts, you will need to update their names after the upgrade:

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -228,6 +228,15 @@ data:
     # Use a self-signed cert for TLS
     # >= 3.6: default true
     secure: true
+    # Options for configuring individual metrics
+    options:
+      pod_missing:
+        disable: true
+      cronworkflows_triggered_total:
+        disabledAttributes:
+          - name
+      k8s_request_duration:
+        histogramBuckets: [ 1.0, 2.0, 10.0 ]
     # >= 3.6. Which temporality to use for OpenTelemetry. Default is "Cumulative"
     temporality: Delta
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1352,6 +1352,14 @@ func (wfc *WorkflowController) getMaxStackDepth() int {
 
 func (wfc *WorkflowController) getMetricsServerConfig() *metrics.Config {
 	// Metrics config
+	modifiers := make(map[string]metrics.Modifier)
+	for name, modifier := range wfc.Config.MetricsConfig.Modifiers {
+		modifiers[name] = metrics.Modifier{
+			Disabled:           modifier.Disabled,
+			DisabledAttributes: modifier.DisabledAttributes,
+			HistogramBuckets:   modifier.HistogramBuckets,
+		}
+	}
 
 	metricsConfig := metrics.Config{
 		Enabled:      wfc.Config.MetricsConfig.Enabled == nil || *wfc.Config.MetricsConfig.Enabled,
@@ -1360,6 +1368,7 @@ func (wfc *WorkflowController) getMetricsServerConfig() *metrics.Config {
 		TTL:          time.Duration(wfc.Config.MetricsConfig.MetricsTTL),
 		IgnoreErrors: wfc.Config.MetricsConfig.IgnoreErrors,
 		Secure:       wfc.Config.MetricsConfig.GetSecure(true),
+		Modifiers:    modifiers,
 		Temporality:  wfc.Config.MetricsConfig.Temporality,
 	}
 	return &metricsConfig

--- a/workflow/metrics/instrument.go
+++ b/workflow/metrics/instrument.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"sort"
 
 	"go.opentelemetry.io/otel/metric"
 
@@ -145,5 +146,12 @@ func (m *Metrics) createInstrument(instType instrumentType, name, desc, unit str
 }
 
 func (m *Metrics) buckets(name string, defaultBuckets []float64) []float64 {
+	if opts, ok := m.config.Modifiers[name]; ok {
+		if len(opts.HistogramBuckets) > 0 {
+			buckets := opts.HistogramBuckets
+			sort.Float64s(buckets)
+			return buckets
+		}
+	}
 	return defaultBuckets
 }

--- a/workflow/metrics/metrics.go
+++ b/workflow/metrics/metrics.go
@@ -27,6 +27,7 @@ type Config struct {
 	TTL          time.Duration
 	IgnoreErrors bool
 	Secure       bool
+	Modifiers    map[string]Modifier
 	Temporality  wfconfig.MetricsTemporality
 }
 
@@ -72,6 +73,7 @@ func New(ctx context.Context, serviceName string, config *Config, callbacks Call
 		options = append(options, metricsdk.WithReader(promExporter))
 	}
 	options = append(options, extraOpts...)
+	options = append(options, view(config))
 
 	provider := metricsdk.NewMeterProvider(options...)
 	otel.SetMeterProvider(provider)

--- a/workflow/metrics/modifiers.go
+++ b/workflow/metrics/modifiers.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	metricsdk "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// Modifier holds options to change the behaviour for a single metric
+type Modifier struct {
+	Disabled           bool
+	DisabledAttributes []string
+	HistogramBuckets   []float64
+}
+
+// Create an opentelemetry 'view' which disables whole metrics or aggregates across labels
+func view(config *Config) metricsdk.Option {
+	views := make([]metricsdk.View, 0)
+	for metric, modifier := range config.Modifiers {
+		if modifier.Disabled {
+			views = append(views, metricsdk.NewView(metricsdk.Instrument{Name: metric},
+				metricsdk.Stream{Aggregation: metricsdk.AggregationDrop{}}))
+		} else if len(modifier.DisabledAttributes) > 0 {
+			keys := make([]attribute.Key, len(modifier.DisabledAttributes))
+			for i, key := range modifier.DisabledAttributes {
+				keys[i] = attribute.Key(key)
+			}
+			views = append(views, metricsdk.NewView(metricsdk.Instrument{Name: metric},
+				metricsdk.Stream{AttributeFilter: attribute.NewDenyKeysFilter(keys...)}))
+		}
+	}
+	return metricsdk.WithView(views...)
+}

--- a/workflow/metrics/modifiers_test.go
+++ b/workflow/metrics/modifiers_test.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestViewDisable(t *testing.T) {
+	// Same metric as TestMetrics, but disabled by a view
+	m, te, err := createTestMetrics(&Config{
+		Modifiers: map[string]Modifier{
+			nameOperationDuration: {
+				Disabled: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	m.OperationCompleted(m.ctx, 5)
+	attribs := attribute.NewSet()
+	_, err = te.GetFloat64HistogramData(nameOperationDuration, &attribs)
+	require.Error(t, err)
+}
+
+func TestViewDisabledAttributes(t *testing.T) {
+	// Disable the error cause label
+	m, te, err := createTestMetrics(&Config{
+		Modifiers: map[string]Modifier{
+			nameErrorCount: {
+				DisabledAttributes: []string{labelErrorCause},
+			},
+		},
+	})
+	require.NoError(t, err)
+	// Submit a couple of errors
+	m.OperationPanic(context.Background())
+	m.CronWorkflowSubmissionError(context.Background())
+	// See if we can find this with the attributes, we should not be able to
+	attribsFail := attribute.NewSet(attribute.String(labelErrorCause, string(ErrorCauseOperationPanic)))
+	_, err = te.GetInt64CounterValue(nameErrorCount, &attribsFail)
+	require.Error(t, err)
+	// Find a sum of all error types
+	attribsSuccess := attribute.NewSet()
+	val, err := te.GetInt64CounterValue(nameErrorCount, &attribsSuccess)
+	require.NoError(t, err)
+	// Sum of the two submitted errors is 2
+	assert.Equal(t, int64(2), val)
+}
+
+func TestViewHistogramBuckets(t *testing.T) {
+	// Same metric as TestMetrics, but buckets changed
+	bounds := []float64{1.0, 3.0, 5.0, 10.0}
+	m, te, err := createTestMetrics(&Config{
+		Modifiers: map[string]Modifier{
+			nameOperationDuration: {
+				HistogramBuckets: bounds,
+			},
+		},
+	})
+	require.NoError(t, err)
+	m.OperationCompleted(m.ctx, 5)
+	attribs := attribute.NewSet()
+	val, err := te.GetFloat64HistogramData(nameOperationDuration, &attribs)
+	require.NoError(t, err)
+	assert.Equal(t, bounds, val.Bounds)
+	assert.Equal(t, []uint64{0, 0, 1, 0, 0}, val.BucketCounts)
+}


### PR DESCRIPTION
Allows removal of metrics, removal of attributes (labels), and reconfiguration of histogram buckets for all metrics using `modifiers` in the workflow-controller-configmap.

Implemented using opentelemetry views, these modifiers work for Prometheus metrics also

Note to reviewers: this is part of a stack of reviews for metrics changes. Please don't merge until the rest of the stack is also ready.

Signed-off-by: Alan Clucas <alan@clucas.org>