### PR TITLE
feat: new k8s request duration histogram metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -233,6 +233,20 @@ A counter of the number of API requests sent to the Kubernetes API.
 | `verb`        | The verb of the request, such as `Get` or `List`                   |
 | `status_code` | The HTTP status code of the response                               |
 
+This metric is calculable from `k8s_request_duration`, and it is suggested you just collect that metric instead.
+
+#### `k8s_request_duration`
+
+A histogram recording how long each type of request took.
+
+| attribute     | explanation                                                        |
+|---------------|--------------------------------------------------------------------|
+| `kind`        | The kubernetes `kind` involved in the request such as `configmaps` |
+| `verb`        | The verb of the request, such as `Get` or `List`                   |
+| `status_code` | The HTTP status code of the response                               |
+
+This is contains all the information contained in `k8s_request_total` along with timings.
+
 #### `is_leader`
 
 A gauge indicating if this Controller is the [leader](high-availability.md#workflow-controller).

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -26,6 +26,7 @@ These notes explain the differences in using the Prometheus `/metrics` endpoint 
 The following are new metrics:
 
 * `is_leader`
+* `k8s_request_duration`
 * `queue_duration`
 * `queue_longest_running`
 * `queue_retries`


### PR DESCRIPTION
This is a new metric which is a superset of the k8s_request_total
metric. The old metric is retained for backwards compatibility.

A common issue with workflows is that it stresses the kubernetes
API. Using this metric you can get insights into how long each type of
request is taking which should enable optimizations to help alleviate
problems in this area.

The new metric has the same attributes/labels of `kind`, `verb` and
`status_code` but now emits them with a time duration for each type of
response.

Note to reviewers: this is now a standlone commit