### PR TITLE
feat(ui): add history to WorkflowTemplate & ClusterWorkflowTemplate details

### DIFF
--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.scss
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.scss
@@ -1,0 +1,14 @@
+@import 'node_modules/argo-ui/src/styles/config';
+
+.workflows-cluster-template-list .workflows-list {
+  &__status {
+    max-width: 80px;
+    display: flex;
+    align-items: center;
+
+    /* checkboxes are not visible and are unused on this page */
+    &--checkbox {
+      appearance: none;
+    }
+  }
+}

--- a/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/app/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -5,16 +5,19 @@ import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 
-import {ClusterWorkflowTemplate} from '../../models';
+import * as models from '../../models';
+import {ClusterWorkflowTemplate, Workflow} from '../../models';
 import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {Loading} from '../shared/components/loading';
 import {useCollectEvent} from '../shared/use-collect-event';
+import {ZeroState} from '../shared/components/zero-state';
 import {Context} from '../shared/context';
 import {historyUrl} from '../shared/history';
 import {services} from '../shared/services';
 import {useQueryParams} from '../shared/use-query-params';
 import {Utils} from '../shared/utils';
+import {WorkflowsRow} from '../workflows/components/workflows-row/workflows-row';
 import {SubmitWorkflowPanel} from '../workflows/components/submit-workflow-panel';
 import {ClusterWorkflowTemplateEditor} from './cluster-workflow-template-editor';
 
@@ -29,6 +32,8 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
     const [namespace, setNamespace] = useState<string>();
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel') === 'true');
     const [tab, setTab] = useState<string>(queryParams.get('tab'));
+    const [workflows, setWorkflows] = useState<Workflow[]>([]);
+    const [columns, setColumns] = useState<models.Column[]>([]);
 
     const [error, setError] = useState<Error>();
     const [template, setTemplate] = useState<ClusterWorkflowTemplate>();
@@ -63,7 +68,11 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
     useEffect(() => {
         (async () => {
             try {
+                const workflowList = await services.workflows.list('', null, [`${models.labels.clusterWorkflowTemplate}=${name}`], {limit: 50});
                 const info = await services.info.getInfo();
+
+                setWorkflows(workflowList.items);
+                setColumns(info.columns);
                 setNamespace(Utils.getNamespaceWithDefault(info.managedNamespace));
                 setError(null);
             } catch (err) {
@@ -74,6 +83,53 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
 
     useCollectEvent('openedClusterWorkflowTemplateDetails');
 
+    const getItems = () => {
+        const items = [
+            {
+                title: 'Submit',
+                iconClassName: 'fa fa-plus',
+                disabled: edited,
+                action: () => setSidePanel(true)
+            },
+            {
+                title: 'Update',
+                iconClassName: 'fa fa-save',
+                disabled: !edited,
+                action: () => {
+                    services.clusterWorkflowTemplate
+                        .update(template, name)
+                        .then(setTemplate)
+                        .then(() =>
+                            notifications.show({
+                                content: 'Updated',
+                                type: NotificationType.Success
+                            })
+                        )
+                        .then(() => setError(null))
+                        .then(() => setEdited(false))
+                        .catch(setError);
+                }
+            },
+            {
+                title: 'Delete',
+                iconClassName: 'fa fa-trash',
+                action: () => {
+                    popup.confirm('confirm', 'Are you sure you want to delete this cluster workflow template?').then(yes => {
+                        if (yes) {
+                            services.clusterWorkflowTemplate
+                                .delete(name)
+                                .then(() => navigation.goto(uiUrl('cluster-workflow-templates')))
+                                .then(() => setError(null))
+                                .catch(setError);
+                        }
+                    });
+                }
+            }
+        ];
+
+        return items;
+    };
+
     return (
         <Page
             title='Cluster Workflow Template Details'
@@ -83,70 +139,67 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
                     {title: name, path: uiUrl('cluster-workflow-templates/' + name)}
                 ],
                 actionMenu: {
-                    items: [
-                        {
-                            title: 'Submit',
-                            iconClassName: 'fa fa-plus',
-                            disabled: edited,
-                            action: () => setSidePanel(true)
-                        },
-                        {
-                            title: 'Update',
-                            iconClassName: 'fa fa-save',
-                            disabled: !edited,
-                            action: () => {
-                                services.clusterWorkflowTemplate
-                                    .update(template, name)
-                                    .then(setTemplate)
-                                    .then(() =>
-                                        notifications.show({
-                                            content: 'Updated',
-                                            type: NotificationType.Success
-                                        })
-                                    )
-                                    .then(() => setError(null))
-                                    .then(() => setEdited(false))
-                                    .catch(setError);
-                            }
-                        },
-                        {
-                            title: 'Delete',
-                            iconClassName: 'fa fa-trash',
-                            action: () => {
-                                popup.confirm('confirm', 'Are you sure you want to delete this cluster workflow template?').then(yes => {
-                                    if (yes) {
-                                        services.clusterWorkflowTemplate
-                                            .delete(name)
-                                            .then(() => navigation.goto(uiUrl('cluster-workflow-templates')))
-                                            .then(() => setError(null))
-                                            .catch(setError);
-                                    }
-                                });
-                            }
-                        }
-                    ]
+                    items: getItems()
                 }
             }}>
             <>
-                <ErrorNotice error={error} />
-                {!template ? (
-                    <Loading />
-                ) : (
-                    <ClusterWorkflowTemplateEditor template={template} onChange={setTemplate} onError={setError} onTabSelected={setTab} selectedTabKey={tab} />
+                <>
+                    <ErrorNotice error={error} />
+                    {!template ? (
+                        <Loading />
+                    ) : (
+                        <ClusterWorkflowTemplateEditor template={template} onChange={setTemplate} onError={setError} onTabSelected={setTab} selectedTabKey={tab} />
+                    )}
+                </>
+                {template && (
+                    <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isMiddle={true}>
+                        <SubmitWorkflowPanel
+                            kind='ClusterWorkflowTemplate'
+                            namespace={namespace}
+                            name={template.metadata.name}
+                            entrypoint={template.spec.entrypoint}
+                            templates={template.spec.templates || []}
+                            workflowParameters={template.spec.arguments.parameters || []}
+                        />
+                    </SlidingPanel>
                 )}
+                <>
+                    <ErrorNotice error={error} />
+                    {!workflows ? (
+                        <ZeroState title='No completed cluster workflow templates'>
+                            <p> You can create new cluster workflow templates here or using the CLI. </p>
+                        </ZeroState>
+                    ) : (
+                        <div className='argo-table-list workflows-cluster-template-list'>
+                            <div className='row argo-table-list__head'>
+                                <div className='columns small-1 workflows-list__status' />
+                                <div className='row small-11'>
+                                    <div className='columns small-2'>NAME</div>
+                                    <div className='columns small-1'>NAMESPACE</div>
+                                    <div className='columns small-1'>STARTED</div>
+                                    <div className='columns small-1'>FINISHED</div>
+                                    <div className='columns small-1'>DURATION</div>
+                                    <div className='columns small-1'>PROGRESS</div>
+                                    <div className='columns small-2'>MESSAGE</div>
+                                    <div className='columns small-1'>DETAILS</div>
+                                    <div className='columns small-1'>ARCHIVED</div>
+                                    {(columns || []).map(col => {
+                                        return (
+                                            <div className='columns small-1' key={col.key}>
+                                                {col.name}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                            {/* checkboxes are not visible and are unused on this page */}
+                            {workflows.map(wf => {
+                                return <WorkflowsRow workflow={wf} key={wf.metadata.uid} checked={false} columns={columns} onChange={null} select={null} />;
+                            })}
+                        </div>
+                    )}
+                </>
             </>
-            {template && (
-                <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel(null)} isMiddle={true}>
-                    <SubmitWorkflowPanel
-                        kind='ClusterWorkflowTemplate'
-                        namespace={namespace}
-                        name={template.metadata.name}
-                        entrypoint={template.spec.entrypoint}
-                        templates={template.spec.templates || []}
-                        workflowParameters={template.spec.arguments.parameters || []}
-                    />
-                </SlidingPanel>
-            )}
         </Page>
     );
 }

--- a/ui/src/app/workflow-templates/workflow-template-details.scss
+++ b/ui/src/app/workflow-templates/workflow-template-details.scss
@@ -1,0 +1,14 @@
+@import 'node_modules/argo-ui/src/styles/config';
+
+.workflows-template-list .workflows-list {
+  &__status {
+    max-width: 80px;
+    display: flex;
+    align-items: center;
+
+    /* checkboxes are not visible and are unused on this page */
+    &--checkbox {
+      appearance: none;
+    }
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13282

### Motivation

As indicated in the Issue, it is inconvenient that the history is not visible in the WorkflowTemplate details.
CronWorkflow can see it, so I would like to see consistency.

### Modifications

#### WorkflowTemplate

![image](https://github.com/argoproj/argo-workflows/assets/4182311/6a13b580-c98a-4b1e-bf86-217df9218596)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/6ede2f6e-204c-49be-8606-405825ba94d9)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/2361a570-ea84-496a-bcf9-b71f151ea58d)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/aac46c44-d91a-4587-9713-16a4ece3375d)

<details>
<summary>No history</summary>

![image](https://github.com/argoproj/argo-workflows/assets/4182311/3a792ce4-e29b-4b82-93cb-2e85874ae375)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/375e172b-9932-4f3d-beb1-d9f3979377f8)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/2307d5b6-5a30-4ead-9306-bdd993d48a95)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/6b687076-83f0-4109-9e0a-c17948ef80ff)
</details>

#### ClusterWorkflowTemplate

![image](https://github.com/argoproj/argo-workflows/assets/4182311/90d4f14e-4587-4ea2-aaf7-19b43af26010)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/b5b3e600-f83f-49a1-95ba-7383c5c533b9)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/28c309bd-0d26-4c39-b9b4-80c4b1d16102)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/7297a988-6c52-498a-a123-ac59e3d0fb70)


<details>
<summary>No history</summary>

![image](https://github.com/argoproj/argo-workflows/assets/4182311/f4defbca-43fe-49d2-b0a3-158a91953829)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/79495c4c-920a-44b3-a747-e71ec2fa11b2)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/23c0419f-5fa8-4f47-8ac3-90e3bfd8077e)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/bedc4272-d4e1-4efa-81bd-9b6f7961bfa4)
</details>

### Verification

- [x] no data
- [x] Only the relevant Workflow is displayed in the execution history, even if there are multiple WorkflowTemplates.
- [x] Displayed with no problem even with multiple data.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
