### PR TITLE
refactor(cli): simplify counter in printer

### DIFF
--- a/util/printer/workflow-printer.go
+++ b/util/printer/workflow-printer.go
@@ -137,8 +137,7 @@ func countPendingRunningCompletedNodes(wf *wfv1.Workflow) (int, int, int) {
 	running := 0
 	completed := 0
 	for _, node := range wf.Status.Nodes {
-		tmpl := wf.GetTemplateByName(util.GetTemplateFromNode(node))
-		if tmpl == nil || !tmpl.IsPodType() {
+		if node.Type != wfv1.NodeTypePod {
 			continue
 		}
 		if node.Fulfilled() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Follow-up to https://github.com/argoproj/argo-workflows/pull/12970#discussion_r1576647976

### Motivation

<!-- TODO: Say why you made your changes. -->

Simplify and optimize some code that previously went a long way around to do an equivalent check. It also previously had a bug in that complexity and this makes it more resilient as such

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- instead of retrieving a template from the node only to check its type, we can check the type of the node directly

### Verification

<!-- TODO: Say how you tested your changes. -->

Per https://github.com/argoproj/argo-workflows/pull/12970#discussion_r1661823031:
- Semantically, the template types to node types have a conversion [in the `GetNodeType` function](https://github.com/argoproj/argo-workflows/blob/3f9b992cdddb09633ef329c13eab1823ca6e5f3e/pkg/apis/workflow/v1alpha1/workflow_types.go#L3030) (that is directly above the `IsPodType` function who's usage was removed in this PR)
- There is an [existing test](https://github.com/argoproj/argo-workflows/blob/3f9b992cdddb09633ef329c13eab1823ca6e5f3e/util/printer/workflow-printer_test.go#L87) that covers this for the `--wide` format

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
