### PR TITLE
chore: remove unused pods/exec role

### DIFF
--- a/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
+++ b/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
@@ -22,7 +22,6 @@ rules:
       - ""
     resources:
       - pods
-      - pods/exec
       - pods/log
     verbs:
       - get

--- a/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
+++ b/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
@@ -7,7 +7,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   verbs:
   - create
   - get

--- a/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -22,7 +22,6 @@ rules:
       - ""
     resources:
       - pods
-      - pods/exec
       - pods/log
     verbs:
       - get

--- a/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -15,7 +15,6 @@ rules:
       - ""
     resources:
       - pods
-      - pods/exec
     verbs:
       - create
       - get

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -1172,7 +1172,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   verbs:
   - create
   - get
@@ -1308,7 +1307,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   - pods/log
   verbs:
   - get

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -1172,7 +1172,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   verbs:
   - create
   - get
@@ -1308,7 +1307,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   - pods/log
   verbs:
   - get

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -1172,7 +1172,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   verbs:
   - create
   - get
@@ -1308,7 +1307,6 @@ rules:
   - ""
   resources:
   - pods
-  - pods/exec
   - pods/log
   verbs:
   - get


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13307

### Motivation

<!-- TODO: Say why you made your changes. -->

`pods/exec` was used for [legacy executors](https://github.com/argoproj/argo-workflows/blob/release-3.3/docs/workflow-executors.md) (e.g. k8sapi),
these legacy executors are removed since v3.4.0, thus removing the role
(we are currently using [emissary executor](https://argo-workflows.readthedocs.io/en/latest/workflow-executors/#emissary-emissary))

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
