### PR TITLE
fix(build): bump golang to 1.21.12 in builder image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.21-alpine3.18 as builder
+FROM golang:1.21-alpine3.19 as builder
 
 RUN apk update && apk add --no-cache \
     git \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Motivation

The following CVEs were found in the argoexec image:

- [CVE-2024-24790](https://security-tracker.debian.org/tracker/CVE-2024-24790)
- [CVE-2024-24789](https://security-tracker.debian.org/tracker/CVE-2024-24789)

### Modifications

Bumped up golang image version to [golang:1.21-alpine3.19](https://hub.docker.com/layers/library/golang/1.21-alpine3.19/images/sha256-ce2562ac25fe59995a4f6d92d8d8b762e5f2facd0c09ca539a75a3e32ab24ce4), which uses go 1.21.12, in the builder image.


### Verification

Build passed, and the CVEs were resolved from the image.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
