### PR TITLE
fix(build): bump golang to 1.21.12 in builder image to fix CVEs in release-3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.21-alpine3.18 as builder
+FROM golang:1.21-alpine3.19 as builder
 
 RUN apk update && apk add --no-cache \
     git \


### PR DESCRIPTION
Port #13311 to [release-3.4](https://github.com/argoproj/argo-workflows/tree/release-3.4).