### PR TITLE
ci: show all container logs during failure debug

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -328,9 +328,9 @@ jobs:
           set -eux
           kubectl get pods -l workflows.argoproj.io/workflow
           kubectl describe pods -l workflows.argoproj.io/workflow
-      - name: Failure debug - Wait container logs
+      - name: Failure debug - Workflow Pod logs
         if: ${{ failure() }}
-        run: kubectl logs -c wait -l workflows.argoproj.io/workflow --prefix
+        run: kubectl logs --all-containers -l workflows.argoproj.io/workflow --prefix
 
   # workaround for status checks -- check this one job instead of each individual E2E job in the matrix
   # this allows us to skip the entire matrix when it doesn't need to run while still having accurate status checks


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Resolves the lack of logs in CI in https://github.com/argoproj/argo-workflows/pull/13317#issuecomment-2212008467

### Motivation

<!-- TODO: Say why you made your changes. -->

- previously it would only show the `wait` container, but some template types, like `resource`, don't have a `wait` container
- and showing all container logs could be helpful in general; e.g. seeing why `main` or `init` or some other attached container failed

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- change from `-c wait` to `--all-containers`

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested the command locally and got output that roughly looks like this:
```
[pod/synchronization-wf-level-qkx7f/wait] time="2024-04-23T02:16:08.206Z" level=debug msg="Patch workflowtaskresults 200"
[pod/synchronization-wf-level-qkx7f/main] time="2024-04-23T02:16:06.953Z" level=info msg="capturing logs" argo=true
```

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
