### PR TITLE
fix(resource): catch fatal `kubectl` errors

### DIFF
--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -173,7 +173,7 @@ func (s *ResourceTemplateSuite) TestResourceTemplateFailed() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 		})
 }
 

--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -165,6 +165,18 @@ func (s *ResourceTemplateSuite) TestResourceTemplateWithOutputs() {
 		})
 }
 
+func (s *ResourceTemplateSuite) TestResourceTemplateFailed() {
+	s.Given().
+		Workflow("@testdata/resource-templates/failed.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+		})
+}
+
 func TestResourceTemplateSuite(t *testing.T) {
 	suite.Run(t, new(ResourceTemplateSuite))
 }

--- a/test/e2e/testdata/resource-templates/failed.yaml
+++ b/test/e2e/testdata/resource-templates/failed.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: failed-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    resource:
+      action: patch
+      successCondition: status.phase == Failed # intentional failure
+      manifest: |
+        apiVersion: v1
+        # kind: Pod -- missing this causes an error
+        metadata:
+          name: {{pod.name}}
+          annotations:
+            foo: bar

--- a/test/e2e/testdata/resource-templates/failed.yaml
+++ b/test/e2e/testdata/resource-templates/failed.yaml
@@ -8,7 +8,6 @@ spec:
   - name: main
     resource:
       action: patch
-      successCondition: status.phase == Failed # intentional failure
       manifest: |
         apiVersion: v1
         # kind: Pod -- missing this causes an error

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -372,13 +372,14 @@ func runKubectl(args ...string) ([]byte, error) {
 		os.Args = osArgs
 	}()
 
-	var buf bytes.Buffer
 	var err error
 	// catch `os.Exit(1)` from kubectl
 	kubectlutil.BehaviorOnFatal(func(msg string, code int) {
 		log.Info("fatal error: %s", msg)
 		err = errors.New(string(code), msg)
 	})
+
+	var buf bytes.Buffer
 	if err = kubectlcmd.NewKubectlCommand(kubectlcmd.KubectlOptions{
 		Arguments: args,
 		// TODO(vadasambar): use `DefaultConfigFlags` variable from upstream

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -375,7 +375,7 @@ func runKubectl(args ...string) ([]byte, error) {
 	var fatalErr error
 	// catch `os.Exit(1)` from kubectl
 	kubectlutil.BehaviorOnFatal(func(msg string, code int) {
-		fatalErr = errors.New(errors.CodeBadRequest, msg)
+		fatalErr = errors.New(fmt.Sprint(code), msg)
 	})
 
 	var buf bytes.Buffer


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13299 using the simpler/non-breaking change I outlined in https://github.com/argoproj/argo-workflows/issues/13299#issuecomment-2211119337
- Technically a follow-up to #12544

### Motivation

<!-- TODO: Say why you made your changes. -->

- `kubectl` will `os.Exit(1)` upon error, meaning it won't run through all our error handling code, resulting in a stuck Workflow
  - as the respective `workflowtaskresult` will never be marked as complete (or errored etc)

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- use the same method that `kubectl`'s [own tests do](https://github.com/kubernetes/kubectl/blob/68dbd0767a9175dd30eb9dc8687ba5167c678c9b/pkg/cmd/explain/explain_test.go#L217), customizing the error with `BehaviorOnFatal`

### Verification

<!-- TODO: Say how you tested your changes. -->

I tested this worked while testing #13317 (where I hit the bug _a lot_ while testing) and it does work:
```
kubectl get workflow
NAME                        STATUS      AGE     MESSAGE
k8s-patch-basic-ndrs8       Failed      22s     Error (exit code 1): no more retries error: unable to decode "/tmp/manifest.yaml": Object 'Kind' is missing in '{"apiVersion":"v1","metadata":{"annotations":{"foo":"bar"},"name":"k8s-patch-basic-ndrs8"}}'
```

~but:~
1. ~This should have a negative E2E test case, confirming that the failure behavior doesn't get stuck in `Running`~ **EDIT**: Added
1. ~The error is coming out very generic, less helpful than it used to be from the `kubectl` error. Not sure why, maybe error wrapping:~ <details>

    ```
    time="2024-07-07T18:44:57.662Z" level=error msg="executor error: unexpected end of JSON input"
    time="2024-07-07T18:44:57.667Z" level=fatal msg="unexpected end of JSON input"
    ```

     **EDIT**: this was because I [didn't quite return the fatal error from the callback](https://github.com/argoproj/argo-workflows/pull/13321/commits/c630f941e9af69122b2757500ccc73cea757bde4) since the `err` value I used originally was overwritten. Fixed now.
     
   </details>

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
