### PR TITLE
fix: #13104 Addressing incorrect-integer-conversion warning flagged by CodeQL

### DIFF
--- a/util/intstr/parametrizable.go
+++ b/util/intstr/parametrizable.go
@@ -29,6 +29,11 @@ func Int32(is *intstr.IntOrString) (*int32, error) {
 	if v == nil || err != nil {
 		return nil, err
 	}
+	
+	if *v > math.MaxInt32 || *v < math.MinInt32 {
+		return nil, fmt.Errorf("integer out of range for int32: %d", *v)
+	}
+
 	i := int32(*v)
 	return &i, err
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

### Related issue

Fixes #13104

### Motivation

This issue was identified by CodeQL as part of an opensource minijam. util/intstr/parametrizable.go  was flagged as having an incorrect conversion of an integer with architecture-dependent bit size from strconv.Atoi to a lower bit size type int32 without an upper bound check on line 32.

### Modifications

Added code that checks if the value of a given integer v is within the range of a 32-bit signed integer.

### Verification
Code was tested locally.

