### PR TITLE
fix(server): don't return `undefined` SA NS

### DIFF
--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -48,15 +48,15 @@ func ClaimSetFor(restConfig *rest.Config) (*types.Claims, error) {
 		return nil, fmt.Errorf("failed to unmarshal bearer token's JWT payload: %w", err)
 	}
 
-	// attempt to derive ServiceAccount and ServiceAccountNamespace from Subject
+	// attempt to derive SA name and namespace from Subject
 	// "system:serviceaccount:argo:jenkins" -> "argo", "jenkins"
 	// note that the SA name can have a colon in it, although the rest cannot
 	parts = strings.SplitN(claims.Subject, ":", 4)
 	if len(parts) < 4 {
 		return claims, nil
 	}
-	claims.ServiceAccountName = parts[2]
-	claims.ServiceAccountNamespace = parts[3]
+	claims.ServiceAccountNamespace = parts[2]
+	claims.ServiceAccountName = parts[3]
 
 	return claims, nil
 }

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -17,32 +17,46 @@ func ClaimSetFor(restConfig *rest.Config) (*types.Claims, error) {
 	username := restConfig.Username
 	if username != "" {
 		return &types.Claims{Claims: jwt.Claims{Subject: username}}, nil
-	} else if restConfig.BearerToken != "" || restConfig.BearerTokenFile != "" {
-		bearerToken := restConfig.BearerToken
-		if bearerToken == "" {
-			// should only ever be used for service accounts
-			data, err := os.ReadFile(restConfig.BearerTokenFile)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read bearer token file: %w", err)
-			}
-			bearerToken = string(data)
-		}
-		parts := strings.SplitN(bearerToken, ".", 3)
-		if len(parts) != 3 {
-			return nil, fmt.Errorf("expected bearer token to be a JWT and therefore have 3 dot-delimited parts")
-		}
-		payload := parts[1]
-		data, err := base64.RawStdEncoding.DecodeString(payload)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode bearer token's JWT payload: %w", err)
-		}
-		claims := &types.Claims{}
-		err = json.Unmarshal(data, &claims)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal bearer token's JWT payload: %w", err)
-		}
-		return claims, nil
-	} else {
+	}
+	if restConfig.BearerToken == "" && restConfig.BearerTokenFile == "" {
 		return nil, nil
 	}
+
+	bearerToken := restConfig.BearerToken
+	if bearerToken == "" {
+		// should only ever be used for service accounts
+		data, err := os.ReadFile(restConfig.BearerTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read bearer token file: %w", err)
+		}
+		bearerToken = string(data)
+	}
+
+	parts := strings.SplitN(bearerToken, ".", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("expected bearer token to be a JWT and therefore have 3 dot-delimited parts")
+	}
+	payload := parts[1]
+	data, err := base64.RawStdEncoding.DecodeString(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode bearer token's JWT payload: %w", err)
+	}
+
+	claims := &types.Claims{}
+	err = json.Unmarshal(data, &claims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal bearer token's JWT payload: %w", err)
+	}
+
+	// attempt to derive ServiceAccount and ServiceAccountNamespace from Subject
+	// "system:serviceaccount:argo:jenkins" -> "argo", "jenkins"
+	// note that the SA name can have a colon in it, although the rest cannot
+	parts = strings.SplitN(claims.Subject, ":", 4)
+	if len(parts) < 4 {
+		return claims, nil
+	}
+	claims.ServiceAccountName = parts[2]
+	claims.ServiceAccountNamespace = parts[3]
+
+	return claims, nil
 }

--- a/server/auth/serviceaccount/claims_test.go
+++ b/server/auth/serviceaccount/claims_test.go
@@ -5,11 +5,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
 )
 
-// sub = 1234567890
+const sub = 1234567890
 const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" //nolint:gosec
+
+const sub2 = "system:serviceaccount:argo:jenkins"
+const saName2 = "jenkins"
+const saNs2 = "argo"
+const iss2 = "https://kubernetes.default.svc.cluster.local"
+const token2 = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5dVprMUl0VHZkTXFpLWc4dVQwVkV1Y05UZ21XXzJvZjNuZi1iZkpfVW8ifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJrM3MiXSwiZXhwIjoxNzIwNzYzNjgyLCJpYXQiOjE3MjA3NjAwODIsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJhcmdvIiwic2VydmljZWFjY291bnQiOnsibmFtZSI6ImplbmtpbnMiLCJ1aWQiOiIyMGNjYzBjNS00NmNjLTQ3MjctYmUxMi1iZWY0ZTQ0ZTkxMjYifX0sIm5iZiI6MTcyMDc2MDA4Miwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmFyZ286amVua2lucyJ9.k0SKX4yKga70R12ScI-mSpEWbwdRtlphxXB-drHNyxPyzz2fpur29ZzdcjE8-TlZE2fQrrV-MaqMBWqaD0TWsld0ILBYRYFOcIwuUOX8s611vqmpDejTT6oAroBEd4WSduP9WoxMsiN82EdDvDJeMpNpq8i-Nz8nYgfWe2VkqV_oYCenWKe9JC3QL1TOxdkqer2qgflGnIpTzSVf7y47vmdlqsS9GPbdXyCg4MdcyDnLgY2VoVQnymD22uTG3Ugp3dO3zhaS-puHMPDOa-_EbAn2MsqETrA8H8iKal-z4sx-R6MxN8fdBrrIkWZLZZD4i_EhBS5paFTNcXXq0-T90w" //nolint:gosec
 
 func TestClaimSetFor(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
@@ -19,10 +26,11 @@ func TestClaimSetFor(t *testing.T) {
 		}
 	})
 	t.Run("Basic", func(t *testing.T) {
-		claims, err := ClaimSetFor(&rest.Config{Username: "my-username"})
+		const username = "my-username"
+		claims, err := ClaimSetFor(&rest.Config{Username: username})
 		if assert.NoError(t, err) {
 			assert.Empty(t, claims.Issuer)
-			assert.Equal(t, "my-username", claims.Subject)
+			assert.Equal(t, username, claims.Subject)
 		}
 	})
 	t.Run("BadBearerToken", func(t *testing.T) {
@@ -33,7 +41,7 @@ func TestClaimSetFor(t *testing.T) {
 		claims, err := ClaimSetFor(&rest.Config{BearerToken: token})
 		if assert.NoError(t, err) {
 			assert.Empty(t, claims.Issuer)
-			assert.Equal(t, "1234567890", claims.Subject)
+			assert.Equal(t, sub, claims.Subject)
 		}
 	})
 
@@ -48,7 +56,16 @@ func TestClaimSetFor(t *testing.T) {
 		claims, err := ClaimSetFor(&rest.Config{BearerTokenFile: tmp.Name()})
 		if assert.NoError(t, err) {
 			assert.Empty(t, claims.Issuer)
-			assert.Equal(t, "1234567890", claims.Subject)
+			assert.Equal(t, sub, claims.Subject)
 		}
+	})
+
+	t.Run("BearerToken with SA details", func(t *testing.T) {
+		claims, err := ClaimSetFor(&rest.Config{BearerToken: token2})
+		require.NoError(t, err)
+		assert.Equal(t, iss2, claims.Issuer)
+		assert.Equal(t, sub2, claims.Subject)
+		assert.Equal(t, saName2, claims.ServiceAccountName)
+		assert.Equal(t, saNs2, claims.ServiceAccountNamespace)
 	})
 }

--- a/server/auth/serviceaccount/claims_test.go
+++ b/server/auth/serviceaccount/claims_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const sub = 1234567890
+const sub = "1234567890"
 const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" //nolint:gosec
 
 const sub2 = "system:serviceaccount:argo:jenkins"

--- a/ui/src/app/app-router.tsx
+++ b/ui/src/app/app-router.tsx
@@ -82,7 +82,7 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
             .catch(setError);
     }, []);
 
-    const namespaceSuffix = Utils.managedNamespace ? '' : '/' + namespace;
+    const namespaceSuffix = Utils.managedNamespace ? '' : '/' + (namespace || '');
     return (
         <>
             {popupProps && <Popup {...popupProps} />}

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -84,9 +84,10 @@ export const Utils = {
 
     fixLocalStorageString(x: string): string {
         // empty string is valid, so we cannot use `truthy`
-        if (x !== null && x !== 'null' && x !== 'undefined') {
-            return x;
+        if (x == null || x == 'null' || x == 'undefined') {
+            return undefined; // explicitly return undefined
         }
+        return x;
     },
 
     // TODO: some of these utils should probably be moved to context
@@ -105,12 +106,7 @@ export const Utils = {
     },
 
     get currentNamespace() {
-        // we always prefer the managed namespace
-        if (localStorage.getItem(currentNamespaceKey) === null) {
-            return this.userNamespace || this.managedNamespace;
-        } else {
-            return this.fixLocalStorageString(localStorage.getItem(currentNamespaceKey));
-        }
+        return this.fixLocalStorageString(localStorage.getItem(currentNamespaceKey)) ?? (this.userNamespace || this.managedNamespace);
     },
 
     // return a namespace, favoring managed namespace when set


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12658, for which the root cause also resulted in confusion in #13316
Follow-up to #9008

### Motivation

<!-- TODO: Say why you made your changes. -->

- previously, in client auth mode, no SA name or ns was listed, causing `userNamespace` to be `undefined`
  - and that would cause `currentNamespace` to be set as the string literal `"undefined"`

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- derive the SA name and namespace from the `subject` at the end of `claims.go`
  - invert the conditional as well for less nesting and complexity, similar to other refactors of mine

- add some defensive code to the UI as well, so that in case of `undefined` (which should be substantially rarer now), don't set the namespace in the URL to literally "undefined" <details>

  - invert `fixLocalStorageString` conditional because it very confusingly would _implicitly_ return `undefined` before
    - and catch the case of this returning `undefined` in `currentNamespace`
      - use the `??` nullish coaelscing operator to handle null or undefined but not empty string etc (unlike truthy)
        - (this operator may not have existed at the time the original code was written)
      - also remove the incorrect comment here

</details>

### Verification

<!-- TODO: Say how you tested your changes. -->

- Added unit tests
- <details><summary>Manually tested and got this correct result in the UI:</summary>

    ![Screenshot 2024-07-13 at 7 09 05 PM](https://github.com/user-attachments/assets/2455f78e-fd3b-4ef1-aefe-772c3808eb72)

    - As well as this correct `localStorage` item: ![Screenshot 2024-07-13 at 7 09 39 PM](https://github.com/user-attachments/assets/828c9bb2-2929-472e-a808-502ffd85c0f3)
    
    **EDIT**: woops I accidentally flipped these, fixed per [below comment](https://github.com/argoproj/argo-workflows/pull/13347#issuecomment-2229726424)
    
</details>

### Notes to Reviewers

- ["Hide whitespace" view](https://github.com/argoproj/argo-workflows/pull/13347/files?diff=unified&w=1) shows the `claims.go` diff as much smaller.

- This works for SA-based and token-based auth for `client` auth mode as well as `server` auth mode. During local dev though, `server` auth mode runs with local kubeconfig, which in the default k3s set-up, actually uses a client cert for auth. This has no `bearerToken` or similar to pull out. I could not figure out a way to pull out claims from that via `client-go` and there may not be a way of doing so.
  - This case is very rare for users though, so this PR should still fix 99% of the issue

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
