### PR TITLE
fix(devcontainer): remove `-R` in `chown`

### DIFF
--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -20,7 +20,7 @@ sudo apt update
 sudo apt install -y protobuf-compiler
 
 # Make sure go path is owned by vscode
-sudo chown -R vscode:vscode /home/vscode/go || true
+sudo chown vscode:vscode /home/vscode/go || true
 
 # download dependencies and do first-pass compile
 CI=1 kit pre-up


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


Follow-up to #13111, might make the `|| true` no longer necessary as well

### Motivation

<!-- TODO: Say why you made your changes. -->

- it seems like the `-R` isn't necessary??
  - that would take very long for me to run and without it I seemed to get a fresh build working fine

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove the recursive `-R` from the `chown` command in `pre-build.sh`

### Verification

<!-- TODO: Say how you tested your changes. -->

Did a local rebuild
~Will also confirm with a fresh Codespace of this branch (it's building right now)~
- **EDIT**: Made a fresh Codespace, which built and ran `make start UI=true` successfully (and the UI, Controller, Server et al were running correctly as well)

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
