### PR TITLE
feat: Support authentication via Shared Access Signatures (SAS) for Azure artifacts (Fixes #10297) 

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -166,7 +166,7 @@ artifacts:
       key: path/in/bucket
       # serviceAccountKeySecret is a secret selector.
       # It references the k8s secret named 'my-gcs-credentials'.
-      # This secret is expected to have have the key 'serviceAccountKey',
+      # This secret is expected to have the key 'serviceAccountKey',
       # containing the base64 encoded credentials
       # to the bucket.
       #
@@ -277,7 +277,7 @@ data:
       bucket: $mybucket
       # accessKeySecret and secretKeySecret are secret selectors.
       # It references the k8s secret named 'bucket-workflow-artifect-credentials'.
-      # This secret is expected to have have the keys 'accessKey'
+      # This secret is expected to have the keys 'accessKey'
       # and 'secretKey', containing the base64 encoded credentials
       # to the bucket.
       accessKeySecret:
@@ -340,107 +340,117 @@ data:
 
 ## Configuring Azure Blob Storage
 
-Create an Azure Storage account and a container within that account. There are a number of
+Create an Azure Storage account and a container within that account. There are several
 ways to accomplish this, including the [Azure Portal](https://portal.azure.com) or the
 [CLI](https://docs.microsoft.com/en-us/cli/azure/).
 
-There are two ways to allow argo to authenticate it's access to your Azure storage account.
+There are multiple ways to allow Argo to authenticate its access to your Azure storage account.
+The preferred method is via [Azure managed identities](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity).
+If a managed identity has been assigned to the machines running the workflow then `useSDKCreds` can be set to true in the workflow yaml.
+If `useSDKCreds` is set to `true`, then the `accountKeySecret` value is not
+used and authentication with Azure will be attempted using
+[`DefaultAzureCredential`](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication).
+
+```yaml
+artifacts:
+  - name: message
+    path: /tmp/message
+    azure:
+      endpoint: https://mystorageaccountname.blob.core.windows.net
+      container: my-container-name
+      blob: path/in/container
+      # If a managed identity has been assigned to the machines running the
+      # workflow (e.g., https://docs.microsoft.com/en-us/azure/aks/use-managed-identity)
+      # then useSDKCreds should be set to true. The accountKeySecret is not required
+      # and will not be used in this case.
+      useSDKCreds: true  
+```
+
+In addition to managed identities, Argo workflows also support authentication using access keys and SAS tokens.
 
 ### Using Azure access keys
 
 1. Retrieve the blob service endpoint for the storage account. For example:
 
-   ```bash
-   az storage account show -n mystorageaccountname --query 'primaryEndpoints.blob' -otsv
-   ```
+    ```bash
+    az storage account show -n mystorageaccountname --query 'primaryEndpoints.blob' -otsv
+    ```
 
 2. Retrieve the access key for the storage account. For example:
 
-   ```bash
-   az storage account keys list -n mystorageaccountname --query '[0].value' -otsv
-   ```
+    ```bash
+    az storage account keys list -n mystorageaccountname --query '[0].value' -otsv
+    ```
 
-3. Create a kubernetes secret to hold the storage account key. For example:
+3. Create a Kubernetes secret to hold the storage account key. For example:
 
-   ```bash
-   kubectl create secret generic my-azure-storage-credentials \
-     --from-literal "account-access-key=$(az storage account keys list -n mystorageaccountname --query '[0].value' -otsv)"
-   ```
+    ```bash
+    kubectl create secret generic my-azure-storage-credentials \
+      --from-literal "account-access-key=$(az storage account keys list -n mystorageaccountname --query '[0].value' -otsv)"
+    ```
 
-4. Configure `azure` artifact as following in the yaml.
+4. Configure `azure` artifact as follows in the yaml.
 
-```yaml
-artifacts:
-  - name: message
-    path: /tmp/message
-    azure:
-      endpoint: https://mystorageaccountname.blob.core.windows.net
-      container: my-container-name
-      blob: path/in/container
-      # accountKeySecret is a secret selector.
-      # It references the k8s secret named 'my-azure-storage-credentials'.
-      # This secret is expected to have have the key 'account-access-key',
-      # containing the base64 encoded credentials to the storage account.
-      #
-      # If a managed identity has been assigned to the machines running the
-      # workflow (e.g., https://docs.microsoft.com/en-us/azure/aks/use-managed-identity)
-      # then accountKeySecret is not needed, and useSDKCreds should be
-      # set to true instead:
-      # useSDKCreds: true
-      accountKeySecret:
-        name: my-azure-storage-credentials
-        key: account-access-key     
-```
+    ```yaml
+    artifacts:
+      - name: message
+        path: /tmp/message
+        azure:
+          endpoint: https://mystorageaccountname.blob.core.windows.net
+          container: my-container-name
+          blob: path/in/container
+          # accountKeySecret is a secret selector.
+          # It references the k8s secret named 'my-azure-storage-credentials'.
+          # This secret is expected to have the key 'account-access-key',
+          # containing the base64 encoded credentials to the storage account.
+          accountKeySecret:
+            name: my-azure-storage-credentials
+            key: account-access-key     
+    ```
 
-If `useSDKCreds` is set to `true`, then the `accountKeySecret` value is not
-used and authentication with Azure will be attempted using a
-[`DefaultAzureCredential`](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication)
-instead.
-
-### Using Azure Shares Access Signatures (SAS)
+### Using Azure Shared Access Signatures (SAS)
 
 If you do not wish to use an access key, you may also use a [shared access signature (SAS)](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json).
 Create an Azure Storage account and a container within that account.
-There are a number of ways to accomplish this, including the [Azure Portal](https://portal.azure.com) or the [CLI](https://docs.microsoft.com/en-us/cli/azure/).
+There are several ways to accomplish this, including the [Azure Portal](https://portal.azure.com) or the [CLI](https://docs.microsoft.com/en-us/cli/azure/).
 
 1. Retrieve the blob service endpoint for the storage account. For example:
 
-   ```bash
-   az storage account show -n mystorageaccountname --query 'primaryEndpoints.blob' -otsv
-   ```
+    ```bash
+    az storage account show -n mystorageaccountname --query 'primaryEndpoints.blob' -otsv
+    ```
 
-2. Retrieve the shares access signature for the storage account. For example:
+2. Retrieve the shared access signature for the storage account. For example:
 
-   ```bash
-   az storage container generate-sas --account-name <storage-account> --name <container> --permissions acdlrw --expiry <date-time> --auth-mode key
-   ```
+    ```bash
+    az storage container generate-sas --account-name <storage-account> --name <container> --permissions acdlrw --expiry <date-time> --auth-mode key
+    ```
 
-3. Create a kubernetes secret to hold the storage account key. For example:
+3. Create a Kubernetes secret to hold the storage account key. For example:
 
-   ```bash
-   kubectl create secret generic my-azure-storage-credentials \
-     --from-literal "sas=$(az storage container generate-sas --account-name <storage-account> --name <container> --permissions acdlrw --expiry <date-time> --auth-mode key)"
-   ```
+    ```bash
+    kubectl create secret generic my-azure-storage-credentials \
+      --from-literal "sas=$(az storage container generate-sas --account-name <storage-account> --name <container> --permissions acdlrw --expiry <date-time> --auth-mode key)"
+    ```
 
-4. Configure `azure` artifact as following in the yaml.
+4. Configure `azure` artifact as follows in the yaml.
 
-```yaml
-artifacts:
-  - name: message
-    path: /tmp/message
-    azure:
-      endpoint: https://mystorageaccountname.blob.core.windows.net
-      container: my-container-name
-      blob: path/in/container
-      # accountKeySecret is a secret selector.
-      # It references the k8s secret named 'my-azure-storage-credentials'.
-      # This secret is expected to have have the key 'sas',
-      # containing the base64 encoded shared access signature to the storage account.
-
-      accountKeySecret:
-        name: my-azure-storage-credentials
-        key: sas
-```
+    ```yaml
+    artifacts:
+      - name: message
+        path: /tmp/message
+        azure:
+          endpoint: https://mystorageaccountname.blob.core.windows.net
+          container: my-container-name
+          blob: path/in/container
+          # accountKeySecret is a secret selector.
+          # It references the k8s secret named 'my-azure-storage-credentials'.
+          # This secret is expected to have the key 'sas',
+          # containing the base64 encoded shared access signature to the storage account.
+          accountKeySecret:
+            name: my-azure-storage-credentials
+            key: sas
+    ```
 
 ## Configure the Default Artifact Repository
 

--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -344,6 +344,10 @@ Create an Azure Storage account and a container within that account. There are a
 ways to accomplish this, including the [Azure Portal](https://portal.azure.com) or the
 [CLI](https://docs.microsoft.com/en-us/cli/azure/).
 
+There are two ways to allow argo to authenticate it's access to your Azure storage account.
+
+### Using Azure access keys
+
 1. Retrieve the blob service endpoint for the storage account. For example:
 
    ```bash
@@ -393,7 +397,7 @@ used and authentication with Azure will be attempted using a
 [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication)
 instead.
 
-## Configuring Azure Blob Storage with SAS 
+### Using Azure Shares Access Signatures (SAS)
 
 If you do not wish to use an access key, you may also use a [shared access signature (SAS)](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json).
 Create an Azure Storage account and a container within that account.

--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -396,9 +396,8 @@ instead.
 ## Configuring Azure Blob Storage with SAS 
 
 If you do not wish to use an access key, you may also use a [shared access signature (SAS)](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json).
-Create an Azure Storage account and a container within that account. There are a number of
-ways to accomplish this, including the [Azure Portal](https://portal.azure.com) or the
-[CLI](https://docs.microsoft.com/en-us/cli/azure/).
+Create an Azure Storage account and a container within that account.
+There are a number of ways to accomplish this, including the [Azure Portal](https://portal.azure.com) or the [CLI](https://docs.microsoft.com/en-us/cli/azure/).
 
 1. Retrieve the blob service endpoint for the storage account. For example:
 

--- a/examples/input-artifact-azure.yaml
+++ b/examples/input-artifact-azure.yaml
@@ -28,7 +28,7 @@ spec:
           blob: path/in/container
           # accountKeySecret is a secret selector. It references the k8s secret named
           # 'my-azure-credentials'. This secret is expected to have the key
-          # 'accountKey', containing the Azure Storage account name and access key.
+          # 'accountKey', containing the Azure Storage account access key or a SAS token.
           accountKeySecret:
             name: my-azure-credentials
             key: accountKey

--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -61,6 +62,14 @@ func (azblobDriver *ArtifactDriver) newAzureContainerClient() (*container.Client
 		if azblobDriver.AccountKey == "" {
 			return nil, fmt.Errorf("accountKey secret is required for Azure Blob Storage if useSDKCreds is false")
 		}
+
+		if isSASAccountKey(azblobDriver.AccountKey) {
+			log.Infof("Provided account key is a SAS token. Using no-credential client.")
+			serviceURL := fmt.Sprintf("%s?%s", containerUrl.String(), azblobDriver.AccountKey)
+			containerClient, err := container.NewClientWithNoCredential(serviceURL, nil)
+			return containerClient, err
+		}
+
 		accountName, err := determineAccountName(containerUrl)
 		if err != nil {
 			return nil, err
@@ -88,6 +97,15 @@ func determineAccountName(containerUrl *url.URL) (string, error) {
 		parts := strings.Split(hostname, ".")
 		return parts[0], nil
 	}
+}
+
+// isSASAccountKey determines whether the account key provided is a SAS token instead of a
+// storage account key. A SAS token is a string of query parameters that is appended to the
+// URL of the storage account. This function looks for the presence of a query parameter in
+// the string and returns true if found.
+func isSASAccountKey(accountKey string) bool {
+	re := regexp.MustCompile(`(\?|\&)([^=]+)\=([^&]+)`)
+	return re.MatchString(accountKey)
 }
 
 // Load downloads artifacts from Azure Blob Storage

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -82,3 +82,25 @@ func TestArtifactDriver_DownloadDirectory_Subdir(t *testing.T) {
 	assert.NoError(t, err)
 	assert.FileExists(t, filepath.Join(dstDir, "dir", "subdir", "file-in-subdir.txt"))
 }
+
+func TestIsSASAccountKey(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		accountKey string
+		expected   bool
+	}{
+		// Valid SAS tokens
+		{"?sv=2019-12-12&ss=b&srt=sco&sp=rwdlacupx&se=2021-12-12T00:00:00Z&st=2021-01-01T00:00:00Z&spr=https&sig=signature", true},
+		{"?sv=2020-08-04&ss=b&srt=sco&sp=rwdlacupx&se=2022-12-12T00:00:00Z&st=2021-01-01T00:00:00Z&spr=https&sig=signature", true},
+		// Invalid SAS tokens
+		{"Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", false},
+		{"invalid-sas-token", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.accountKey, func(t *testing.T) {
+			result := isSASAccountKey(tc.accountKey)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -52,7 +52,7 @@ func TestDetermineAccountName(t *testing.T) {
 }
 
 func TestArtifactDriver_WithServiceKey_DownloadDirectory_Subdir(t *testing.T) {
-	// t.Skipf("This test needs azurite. docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite:latest azurite-blob")
+	t.Skipf("This test needs azurite. docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite:latest azurite-blob")
 
 	driver := ArtifactDriver{
 		AccountKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", // default azurite key
@@ -74,7 +74,7 @@ func TestArtifactDriver_WithServiceKey_DownloadDirectory_Subdir(t *testing.T) {
 }
 
 func TestArtifactDriver_WithSASToken_DownloadDirectory_Subdir(t *testing.T) {
-	// t.Skipf("This test needs azurite. docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite:latest azurite-blob")
+	t.Skipf("This test needs azurite. docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite:latest azurite-blob")
 
 	driver := ArtifactDriver{
 		AccountKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==", // default azurite key


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #10297

### Motivation

Currently, argo-workflows support Azure blob storage artifacts by authentication only via Access Keys. Azure, however, also supports auth via [Shared Access Signatures (SAS)](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json).
This PR adds support for authentication via SAS.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

To avoid spec changes, we re-use `spec.name.inputs.name.azure.accountKeySecret` to hold either an access key or SAS token. A new `isSASAccountKey` method checks whether the provided secret contains an access key or a SAS token. Since SAS tokens are nothing but URL query parameters, a simple regex can identify a SAS token. Once identified, we use the SAS token to initialize a `NewClientWithNoCredential` client instead of the `NewClientWithSharedKeyCredential` which will continue to be used for regular access keys.

### Verification

<!-- TODO: Say how you tested your changes. -->
Tests have been added to `workflow/artifacts/azure/azure_test.go` to check both the `isSASAccountKey` as well as the correct functioning of `NewClientWithNoCredential` via azurite.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
