### PR TITLE
fix(cron): `schedules` with `timezone`

### DIFF
--- a/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
@@ -174,7 +174,7 @@ func (c *CronWorkflowSpec) getSchedules(withTimezone bool) []string {
 			if withTimezone {
 				schedule = c.withTimezone(schedule)
 			}
-			schedules[i] = c.withTimezone(schedule)
+			schedules[i] = schedule
 		}
 	}
 	return schedules

--- a/pkg/apis/workflow/v1alpha1/cron_workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/cron_workflow_types_test.go
@@ -16,16 +16,21 @@ func TestCronWorkflowStatus_HasActiveUID(t *testing.T) {
 	assert.False(t, cwfStatus.HasActiveUID("foo"))
 }
 
-func TestCronWorkflowSpec_GetScheduleString(t *testing.T) {
+func TestCronWorkflowSpec_GetScheduleStrings(t *testing.T) {
 	cwfSpec := CronWorkflowSpec{
 		Timezone: "",
 		Schedule: "* * * * *",
 	}
 
+	assert.Equal(t, []string{"* * * * *"}, cwfSpec.GetSchedules())
+	assert.Equal(t, []string{"* * * * *"}, cwfSpec.GetSchedulesWithTimezone())
 	assert.Equal(t, "* * * * *", cwfSpec.GetScheduleString())
 
 	cwfSpec.Timezone = "America/Los_Angeles"
+	assert.Equal(t, []string{"* * * * *"}, cwfSpec.GetSchedules())
+	assert.Equal(t, []string{"CRON_TZ=America/Los_Angeles * * * * *"}, cwfSpec.GetSchedulesWithTimezone())
 	assert.Equal(t, "CRON_TZ=America/Los_Angeles * * * * *", cwfSpec.GetScheduleString())
+
 	cwfSpec = CronWorkflowSpec{
 		Timezone:  "",
 		Schedules: []string{"* * * * *", "0 * * * *"},
@@ -33,5 +38,7 @@ func TestCronWorkflowSpec_GetScheduleString(t *testing.T) {
 	assert.Equal(t, "* * * * *,0 * * * *", cwfSpec.GetScheduleString())
 
 	cwfSpec.Timezone = "America/Los_Angeles"
+	assert.Equal(t, []string{"* * * * *", "0 * * * *"}, cwfSpec.GetSchedules())
+	assert.Equal(t, []string{"CRON_TZ=America/Los_Angeles * * * * *", "CRON_TZ=America/Los_Angeles 0 * * * *"}, cwfSpec.GetSchedulesWithTimezone())
 	assert.Equal(t, "CRON_TZ=America/Los_Angeles * * * * *,CRON_TZ=America/Los_Angeles 0 * * * *", cwfSpec.GetScheduleString())
 }

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -220,7 +220,7 @@ kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic-allow
   labels:
-    
+
 spec:
   schedule: "* * * * *"
   concurrencyPolicy: "Allow"
@@ -425,6 +425,42 @@ spec:
 				assert.Equal(t, int64(1), cronWf.Status.Failed)
 				assert.Equal(t, wfv1.StoppedPhase, cronWf.Status.Phase)
 				assert.Equal(t, "true", cronWf.Labels[common.LabelKeyCronWorkflowCompleted])
+			})
+	})
+	s.Run("TestMultipleWithTimezone", func() {
+		s.T().Parallel()
+		s.Given().
+			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-multiple-with-timezone
+spec:
+  schedules:
+    - "* * * * *"
+    - "0 1 * * *"
+  timezone: "America/Los_Angeles"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowSpec:
+    metadata:
+      labels:
+        workflows.argoproj.io/test: "true"
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2`).
+			When().
+			CreateCronWorkflow().
+			Wait(1 * time.Minute).
+			Then().
+			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+				assert.Equal(t, cronWf.Spec.GetScheduleString(), cronWf.GetLatestSchedule())
+				assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
 			})
 	})
 }


### PR DESCRIPTION
### Motivation

Using `schedules` with a timezone specified does not work. The cron schedule given to the cron backend includes the CRON_TZ=zone string and should not.

### Modifications

The actual fix is one line to correctly honor the timezone flag on `getSchedules` so that it doesn't double append when that flag is set, nor single append when it is not. GetSchedules() would return an invalid cron string resulting in the error:

```
could not schedule CronWorkflow" cronWorkflow=argo/go-forward error="expected exactly 5 fields, found 6: [CRON_TZ=America/Los_Angeles 30 2 * * *]
```

### Verification

Added some more unit tests to check this behaves as expected, and a smoke e2e test.

I have to say, the original set of tests for #12616 looked like it really should cover this, so I was surprised when nothing broke when I made the change and it took a while to work out what was going wrong.

### Target branches

Just `main`, do not try to backport.
