### PR TITLE
fix(test): load to stream tmp file counting

### DIFF
--- a/workflow/artifacts/common/load_to_stream.go
+++ b/workflow/artifacts/common/load_to_stream.go
@@ -12,6 +12,8 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
+const loadToStreamPrefix = `wfstream-`
+
 // wrapper around os.File enables us to remove the file when it gets closed
 type selfDestructingFile struct {
 	os.File
@@ -28,7 +30,7 @@ func (w selfDestructingFile) Close() error {
 func LoadToStream(a *wfv1.Artifact, g ArtifactDriver) (io.ReadCloser, error) {
 	log.Infof("Efficient artifact streaming is not supported for type %v: see https://github.com/argoproj/argo-workflows/issues/8489",
 		reflect.TypeOf(g))
-	filename := "/tmp/" + rand.String(32)
+	filename := "/tmp/" + loadToStreamPrefix + rand.String(32)
 	if err := g.Load(a, filename); err != nil {
 		return nil, err
 	}

--- a/workflow/artifacts/common/load_to_stream_test.go
+++ b/workflow/artifacts/common/load_to_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,22 @@ func (a *fakeArtifactDriver) ListObjects(artifact *wfv1.Artifact) ([]string, err
 	return nil, fmt.Errorf("not implemented")
 }
 
+func filteredFiles(t *testing.T) ([]os.DirEntry, error) {
+	t.Helper()
+
+	filtered := make([]os.DirEntry, 0)
+	entries, err := os.ReadDir("/tmp/")
+	if err != nil {
+		return filtered, err
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), loadToStreamPrefix) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered, err
+}
+
 func TestLoadToStream(t *testing.T) {
 	tests := map[string]struct {
 		artifactDriver ArtifactDriver
@@ -80,7 +97,7 @@ func TestLoadToStream(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			// need to verify that a new file doesn't get written so check the /tmp directory ahead of time
-			filesBefore, err := os.ReadDir("/tmp/")
+			filesBefore, err := filteredFiles(t)
 			if err != nil {
 				panic(err)
 			}
@@ -92,7 +109,7 @@ func TestLoadToStream(t *testing.T) {
 				stream.Close()
 
 				// make sure the new file got deleted when we called stream.Close() above
-				filesAfter, err := os.ReadDir("/tmp/")
+				filesAfter, err := filteredFiles(t)
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
Replaces #13037 

### Motivation

This test has an infrequent flake, see #13037 

### Modifications

The current test counts files in `/tmp` and hopes there are the same number before and after the test, which is fragile

Add a prefix to the stream temporary files.
Only count files in `/tmp` which have this prefix.

### Verification

Tested locally. Tested with a file called `/tmp/wfstream-asdfasd` and extra logging in the test to show the numbers are as expected.
Tested with the `os.Remove()` removed from `selfDestructingFile.Close()` to show failure.