### PR TITLE
chore: remove legacy go build tags

### DIFF
--- a/hack/docs/fields.go
+++ b/hack/docs/fields.go
@@ -1,5 +1,4 @@
 //go:build !fields
-// +build !fields
 
 package main
 

--- a/hack/docs/null_fields.go
+++ b/hack/docs/null_fields.go
@@ -1,5 +1,4 @@
 //go:build fields
-// +build fields
 
 package main
 

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1,5 +1,4 @@
 //go:build api
-// +build api
 
 package e2e
 

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -1,5 +1,4 @@
 //go:build executor
-// +build executor
 
 package e2e
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1,5 +1,4 @@
 //go:build cli
-// +build cli
 
 package e2e
 

--- a/test/e2e/cluster_workflow_template_test.go
+++ b/test/e2e/cluster_workflow_template_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -1,5 +1,4 @@
 //go:build cron
-// +build cron
 
 package e2e
 

--- a/test/e2e/daemon_pod_test.go
+++ b/test/e2e/daemon_pod_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/estimated_duration_test.go
+++ b/test/e2e/estimated_duration_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -1,5 +1,4 @@
 //go:build plugins
-// +build plugins
 
 package e2e
 

--- a/test/e2e/expr_lang.go
+++ b/test/e2e/expr_lang.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/failed_main_test.go
+++ b/test/e2e/failed_main_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -1,5 +1,4 @@
 //go:build corefunctional
-// +build corefunctional
 
 package e2e
 

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/http_artifacts_test.go
+++ b/test/e2e/http_artifacts_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/invalid_command_test.go
+++ b/test/e2e/invalid_command_test.go
@@ -1,5 +1,4 @@
 //go:build executor
-// +build executor
 
 package e2e
 

--- a/test/e2e/malformed_resources_test.go
+++ b/test/e2e/malformed_resources_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -1,5 +1,4 @@
 //go:build api
-// +build api
 
 package e2e
 

--- a/test/e2e/pod_cleanup_test.go
+++ b/test/e2e/pod_cleanup_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/progress_test.go
+++ b/test/e2e/progress_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -1,5 +1,4 @@
 //go:build executor
-// +build executor
 
 package e2e
 

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/run_as_not_root_test.go
+++ b/test/e2e/run_as_not_root_test.go
@@ -1,5 +1,4 @@
 //go:build executor
-// +build executor
 
 package e2e
 

--- a/test/e2e/semaphore_test.go
+++ b/test/e2e/semaphore_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/signals_test.go
+++ b/test/e2e/signals_test.go
@@ -1,5 +1,4 @@
 //go:build executor
-// +build executor
 
 package e2e
 

--- a/test/e2e/workflow_configmap_substitution_test.go
+++ b/test/e2e/workflow_configmap_substitution_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/workflow_inputs_orverridable_test.go
+++ b/test/e2e/workflow_inputs_orverridable_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/workflow_template_test.go
+++ b/test/e2e/workflow_template_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 


### PR DESCRIPTION
Since [go 1.18](https://go.dev/doc/go1.18) `go fix` will remove the `// +build` lines from code as it is superseded by `//go:build`.

Two autogenerated files still have these in and I cannot see a way to prevent the generators recreating them, but otherwise this is just a tidy up. I considered automating a `go fix` run in CI, but that's hindered by this.

