### PR TITLE
chore: make `.spelling` sorting more deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -679,7 +679,7 @@ docs-spellcheck: /usr/local/bin/mdspell
 	# check docs for spelling mistakes
 	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name upgrading.md -not -name executor_swagger.md -not -path '*/cli/*')
 	# alphabetize spelling file -- ignore first line (comment), then sort the rest case-sensitive and remove duplicates
-	$(shell cat .spelling | awk 'NR<2{ print $0; next } { print $0 | "sort" }' | uniq | tee .spelling > /dev/null)
+	$(shell cat .spelling | awk 'NR<2{ print $0; next } { print $0 | "LC_COLLATE=C sort" }' | uniq | tee .spelling > /dev/null)
 
 /usr/local/bin/markdown-link-check:
 # update this in Nix when upgrading it here


### PR DESCRIPTION
On my polish WSL2 machine sorting seems to be working a bit different than for the rest: https://github.com/argoproj/argo-workflows/pull/13368/commits/1bd4d6681c723b66074ac6ad03068aa974c42446#diff-fba04b914460eece7fe0dab2ede9808db215f0b6c859d6f34293b454b2863a86L28

This env var seems to make it consistent with what's already in the repository.
