### PR TITLE
fix(server): improve confusing login errors

### DIFF
--- a/ui/src/app/app-router.tsx
+++ b/ui/src/app/app-router.tsx
@@ -25,6 +25,7 @@ import {ChatButton} from './shared/components/chat-button';
 import ErrorBoundary from './shared/components/error-boundary';
 import {services} from './shared/services';
 import {Utils} from './shared/utils';
+import {getCookie, AUTH_COOKIE} from './shared/cookie';
 import userinfo from './userinfo';
 import {Widgets} from './widgets/widgets';
 import workflowEventBindings from './workflow-event-bindings';
@@ -55,31 +56,41 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
     const [navBarBackgroundColor, setNavBarBackgroundColor] = useState<string>();
     const setError = (error: Error) => {
         notificationsManager.show({
-            content: 'Failed to load version/info ' + error,
+            content: 'Login failed: ' + error,
             type: NotificationType.Error
         });
     };
     Utils.onNamespaceChange = setNamespace;
+
     useEffect(() => {
         const sub = popupManager.popupProps.subscribe(setPopupProps);
         return () => sub.unsubscribe();
     }, [popupManager]);
+
     useEffect(() => {
-        services.info.getUserInfo().then(userInfo => {
-            Utils.userNamespace = userInfo.serviceAccountNamespace;
-            setNamespace(Utils.currentNamespace);
-        });
-        services.info
-            .getInfo()
-            .then(info => {
+        (async () => {
+            try {
+                const [userInfo, info, version] = await Promise.all([services.info.getUserInfo(), services.info.getInfo(), services.info.getVersion()]);
+                Utils.userNamespace = userInfo.serviceAccountNamespace;
+                setNamespace(Utils.currentNamespace);
+
                 Utils.managedNamespace = info.managedNamespace;
                 setNamespace(Utils.currentNamespace);
                 setModals(info.modals);
                 setNavBarBackgroundColor(info.navColor);
-            })
-            .then(() => services.info.getVersion())
-            .then(setVersion)
-            .catch(setError);
+
+                setVersion(version);
+            } catch (err) {
+                // don't show error if there is no cookie, that means you haven't tried logging in yet or just logged out
+                // this can also happen if SSO failed, but we have a different error for that
+                // there should also be no error in server auth mode
+                if (!getCookie(AUTH_COOKIE)) {
+                    console.debug('ignoring auth error as no cookie was present');
+                    return;
+                }
+                setError(err);
+            }
+        })();
     }, []);
 
     const namespaceSuffix = Utils.managedNamespace ? '' : '/' + namespace;

--- a/ui/src/app/login/login.tsx
+++ b/ui/src/app/login/login.tsx
@@ -3,18 +3,21 @@ import * as React from 'react';
 
 import {uiUrl, uiUrlWithParams} from '../shared/base';
 import {useCollectEvent} from '../shared/use-collect-event';
+import {setCookie, AUTH_COOKIE} from '../shared/cookie';
 
 import './login.scss';
 
 function logout() {
-    document.cookie = 'authorization=;Max-Age=0';
+    document.cookie = `${AUTH_COOKIE}=;Max-Age=0`;
     document.location.reload();
 }
-function user(token: string) {
+
+function setUser(token: string) {
     const path = uiUrl('');
-    document.cookie = 'authorization=' + token + ';SameSite=Strict;path=' + path;
+    setCookie(AUTH_COOKIE, token, path);
     document.location.href = path;
 }
+
 function getRedirect(): string {
     const urlParams = new URLSearchParams(new URL(document.location.href).search);
     if (urlParams.has('redirect')) {
@@ -62,7 +65,7 @@ export function Login() {
                             <textarea id='token' cols={32} rows={8} />
                         </div>
                         <div>
-                            <button className='argo-button argo-button--base-o' onClick={() => user((document.getElementById('token') as HTMLInputElement).value)}>
+                            <button className='argo-button argo-button--base-o' onClick={() => setUser((document.getElementById('token') as HTMLInputElement).value)}>
                                 <i className='fa fa-sign-in-alt' /> Login
                             </button>
                         </div>

--- a/ui/src/app/login/login.tsx
+++ b/ui/src/app/login/login.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 
 import {uiUrl, uiUrlWithParams} from '../shared/base';
 import {useCollectEvent} from '../shared/use-collect-event';
-import {setCookie, AUTH_COOKIE} from '../shared/cookie';
+import {resetCookie, setCookie, AUTH_COOKIE} from '../shared/cookie';
 
 import './login.scss';
 
 function logout() {
-    document.cookie = `${AUTH_COOKIE}=;Max-Age=0`;
+    resetCookie(AUTH_COOKIE);
     document.location.reload();
 }
 

--- a/ui/src/app/shared/cookie.ts
+++ b/ui/src/app/shared/cookie.ts
@@ -1,13 +1,18 @@
 export const AUTH_COOKIE = 'authorization';
 
-export const getCookie = (name: string) =>
-    (
+export function getCookie(name: string) {
+    return (
         decodeURIComponent(document.cookie)
             .split(';')
             .map(x => x.trim())
             .find(x => x.startsWith(name + '=')) || ''
     ).replace(/^.*="?(.*?)"?$/, '$1');
+}
 
 export function setCookie(name: string, value: string, path: string) {
     document.cookie = name + '=' + value + ';SameSite=Strict;path=' + path;
+}
+
+export function resetCookie(name: string) {
+    document.cookie = `${name}=;Max-Age=0`;
 }

--- a/ui/src/app/shared/cookie.ts
+++ b/ui/src/app/shared/cookie.ts
@@ -1,4 +1,4 @@
-import {uiUrl} from './base';
+export const AUTH_COOKIE = 'authorization';
 
 export const getCookie = (name: string) =>
     (
@@ -8,6 +8,6 @@ export const getCookie = (name: string) =>
             .find(x => x.startsWith(name + '=')) || ''
     ).replace(/^.*="?(.*?)"?$/, '$1');
 
-export function setCookie(name: string, value: string) {
-    document.cookie = name + '=' + value + ';SameSite=Strict;path=' + uiUrl('');
+export function setCookie(name: string, value: string, path: string) {
+    document.cookie = name + '=' + value + ';SameSite=Strict;path=' + path;
 }

--- a/ui/src/app/userinfo/cli-help.tsx
+++ b/ui/src/app/userinfo/cli-help.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {createRef, useState} from 'react';
 
+import {getCookie, AUTH_COOKIE} from '../shared/cookie';
 import {Notice} from '../shared/components/notice';
 
 export function CliHelp() {
@@ -9,12 +10,7 @@ export function CliHelp() {
         .getElementsByTagName('base')[0]
         .href.toString()
         .replace(document.location.protocol + '//' + document.location.host + '/', '');
-    const argoToken = (
-        decodeURIComponent(document.cookie)
-            .split(';')
-            .map(x => x.trim())
-            .find(x => x.startsWith('authorization=')) || ''
-    ).replace(/^authorization="?(.*?)"?$/, '$1');
+    const argoToken = getCookie(AUTH_COOKIE);
 
     const text = `export ARGO_SERVER='${document.location.hostname}:${document.location.port || (argoSecure ? 443 : 80)}'
 export ARGO_HTTP1=true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #7921, Fixes #12070, Fixes #12168

### Motivation

<!-- TODO: Say why you made your changes. -->

`token not valid` errors are very confusing for non-operator end users. they also appear before you've even logged in or after you just logged out.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

#### fix(ui): don't show auth error when no cookie

- per the in-line comment, this generally means you haven't logged in yet
  - unless you're in SSO auth mode, in which case, you would've had an earlier error
  - or in Server auth mode, in which case, you wouldn't get an error in the first place
  
- if it's coming from a failed login, instead of saying "Failed to load version/info", say "Login Failed", which is a lot more concrete and understandable at a glance (that doesn't require any knowledge of API endpoints or the code)

- <details><summary>also refactor some code</summary>

  - use `getCookie` func from the previously unused `cookie` util file
  - standardize the `login` page to use the `setCookie` func as well, which effectively duplicated the logic previously
    - name the `login` func as `setUser`, which is a lot less confusing than `user`
  - also make the "authorization" cookie name a shared constant
  - use async/await for all the auth per #11740 
  </details>

#### fix(server): be more specific about validation errors

- "token not valid" is not the most helpful thing, we can say exactly what's wrong with it
  - which we do for SSO auth errors already

- **NOTE**: this technically removes the fallback to `server` auth when using it in conjunction with another one
  - you generally don't want to use `server` with anything, so that can often be a misconfiguration
    - at my last job, we didn't realize our token was incorrectly formatted until we finally set-up SSO instead of `server` for the UI (previously we had `oauth2-proxy` in front)
      - because it was silently falling back to `server` when `client` had failed
  - I might change this as it's technically breaking as such, though I think in a good way -- may make that a separate breaking change potentially

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
