### PR TITLE
fix(devcontainer): `chown` regression for `make codegen`

### DIFF
--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -21,7 +21,8 @@ sudo apt install -y protobuf-compiler
 
 # Make sure go path is owned by vscode
 sudo chown vscode:vscode /home/vscode/go || true
-sudo chown -R vscode:vscode /home/vscode/go/src || true
+sudo chown vscode:vscode /home/vscode/go/src || true
+sudo chown vscode:vscode /home/vscode/go/src/github.com || true
 
 # download dependencies and do first-pass compile
 CI=1 kit pre-up

--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -21,6 +21,7 @@ sudo apt install -y protobuf-compiler
 
 # Make sure go path is owned by vscode
 sudo chown vscode:vscode /home/vscode/go || true
+sudo chown -R vscode:vscode /home/vscode/go/src || true
 
 # download dependencies and do first-pass compile
 CI=1 kit pre-up


### PR DESCRIPTION
https://github.com/argoproj/argo-workflows/pull/13348 removed a recursive flag from chown. I believe was done because this is slow on macintosh filesystems.

This [breaks codegen](https://cloud-native.slack.com/archives/C0510EUH90V/p1721637621193269) with
```
fatal: could not create leading directories of '/home/vscode/go/src/github.com/gogo/protobuf': Permission denied
```

This is a smaller recursive chown which fixes the issue for me.
