### PR TITLE
ci: test k8s version 1.28 and 1.30

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -215,13 +215,13 @@ jobs:
           - test: test-python-sdk
             profile: minimal
           - test: test-executor
-            install_k3s_version: v1.26.15+k3s1
+            install_k3s_version: v1.28.12+k3s1
             profile: minimal
           - test: test-corefunctional
-            install_k3s_version: v1.26.15+k3s1
+            install_k3s_version: v1.28.12+k3s1
             profile: minimal
           - test: test-functional
-            install_k3s_version: v1.26.15+k3s1
+            install_k3s_version: v1.28.12+k3s1
             profile: minimal
     steps:
       - name: Install socat (needed by Kubernetes)
@@ -247,7 +247,7 @@ jobs:
       - name: Install and start K3S
         run: |
           if ! echo "${{ matrix.install_k3s_version }}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+\+k3s1$'; then
-            export INSTALL_K3S_VERSION=v1.29.3+k3s1
+            export INSTALL_K3S_VERSION=v1.30.3+k3s1
           else
             export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
           fi

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -215,13 +215,13 @@ jobs:
           - test: test-python-sdk
             profile: minimal
           - test: test-executor
-            install_k3s_version: v1.28.12+k3s1
+            install_k3s_version: v1.28.11+k3s1
             profile: minimal
           - test: test-corefunctional
-            install_k3s_version: v1.28.12+k3s1
+            install_k3s_version: v1.28.11+k3s1
             profile: minimal
           - test: test-functional
-            install_k3s_version: v1.28.12+k3s1
+            install_k3s_version: v1.28.11+k3s1
             profile: minimal
     steps:
       - name: Install socat (needed by Kubernetes)
@@ -247,7 +247,7 @@ jobs:
       - name: Install and start K3S
         run: |
           if ! echo "${{ matrix.install_k3s_version }}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+\+k3s1$'; then
-            export INSTALL_K3S_VERSION=v1.30.3+k3s1
+            export INSTALL_K3S_VERSION=v1.30.2+k3s1
           else
             export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
           fi

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,11 +40,10 @@ Otherwise, we typically release every two weeks:
 
 ## Kubernetes Compatibility Matrix
 
-| Argo Workflows \ Kubernetes | 1.26 | 1.27 | 1.28 | 1.29 | 1.30 |
-|-----------------------|------|------|------|------|------|
-| **3.5**               | `✓` | `✓` | `✓` | `✓` | `?` |
-| **3.4**               | `✓` | `✓` | `?` | `?` | `?` |
-| **3.3**               | `?` | `?` | `?` | `?` | `?` |
+| Argo Workflows \ Kubernetes | 1.28 | 1.29 | 1.30 |
+|-----------------------------|------|------|------|
+| **3.5**                     | `✓`  | `✓`  | `✓`  |
+| **3.4**                     | `?`  | `?`  | `?`  |
 
 * `✓` Fully supported versions.
 * `?` Due to breaking changes might not work. Also, we haven't thoroughly tested against this version.
@@ -58,4 +57,4 @@ Note that Kubernetes [is backward compatible with clients](https://github.com/ku
 The caveats with newer k8s versions are possible changes to experimental APIs and unused new features.
 Argo uses stable Kubernetes APIs such as Pods and ConfigMaps; see the Controller and Server RBAC of your [installation](installation.md) for a full list.
 
-The `main` branch is currently [tested on Kubernetes 1.26](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L218) and [1.29](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L250).
+The `main` branch is currently [tested on Kubernetes 1.28](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L218) and [1.30](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L250).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

* k8s 1.26 and k8s 1.27 are eol upstream (https://kubernetes.io/releases/)
* adds test coverage for 1.30

### Modifications

* added test coverage for 1.30 and 1.28
* dropped coverage for 1.26

### Verification

e2e tests

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
