### PR TITLE
fix(ui): display Bitbucket Server event source icon in event flow. Fixes #13386

### DIFF
--- a/ui/src/app/event-flow/icons.ts
+++ b/ui/src/app/event-flow/icons.ts
@@ -14,6 +14,7 @@ export const icons: {[type: string]: Icon} = {
     awsLambdaTrigger: compute,
     argoWorkflowTrigger: 'stream',
     azureEventsHubEventSource: storage,
+    bitbucketserverEventSource: git,
     calendarEventSource: 'clock',
     collapsed: 'ellipsis-h',
     conditions: 'filter',

--- a/ui/src/models/event-source.ts
+++ b/ui/src/models/event-source.ts
@@ -6,6 +6,7 @@ export interface EventSource {
     spec: {
         amqp?: {[key: string]: {}};
         azureEventsHub?: {[key: string]: {}};
+        bitbucketserver?: {[key: string]: {}};
         calendar?: {[key: string]: {}};
         emitter?: {[key: string]: {}};
         file?: {[key: string]: {}};
@@ -52,6 +53,7 @@ export type EventSourceWatchEvent = kubernetes.WatchEvent<EventSource>;
 export const EventSourceTypes = [
     'amqp',
     'azureEventsHub',
+    'bitbucketserver',
     'calendar',
     'emitter',
     'file',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13386 

### References
References argoproj/argo-events#1927

### Motivation

Add support for displaying Bitbucket Server event source icon in the Argo event flow UI.

### Modifications

Added icon support for Bitbucket Server event source.
<img width="642" alt="image" src="https://github.com/user-attachments/assets/38228355-451d-4d29-8b48-928bda87d526">


### Verification

- Tested the UI to ensure the Bitbucket Server event source icon is displayed correctly.
- Built the Docker image and applied it to my k8s cluster to verify.
- Attached screenshots for UI changes.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
