### PR TITLE
refactor(tests): testifylint automated fixes

### DIFF
--- a/cmd/argo/commands/clustertemplate/util_test.go
+++ b/cmd/argo/commands/clustertemplate/util_test.go
@@ -41,6 +41,6 @@ spec:
 func TestUnmarshalCWFT(t *testing.T) {
 	clusterwfts, err := unmarshalClusterWorkflowTemplates([]byte(cwfts), false)
 	if assert.NoError(t, err) {
-		assert.Equal(t, 2, len(clusterwfts))
+		assert.Len(t, clusterwfts, 2)
 	}
 }

--- a/cmd/argo/commands/list_test.go
+++ b/cmd/argo/commands/list_test.go
@@ -19,7 +19,7 @@ func Test_listWorkflows(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		workflows, err := listEmpty(&metav1.ListOptions{}, listFlags{})
 		if assert.NoError(t, err) {
-			assert.Len(t, workflows, 0)
+			assert.Empty(t, workflows)
 		}
 	})
 	t.Run("Nothing", func(t *testing.T) {

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -88,7 +88,7 @@ func TestLintFile(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, res.Success, false)
+	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "steps-" (Workflow): lint error`, file.Name()))
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 1)
 	wftServiceSclientMock.AssertNotCalled(t, "LintWorkflowTemplate")
@@ -119,7 +119,7 @@ func TestLintMultipleKinds(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, res.Success, false)
+	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "steps-" (Workflow): lint error`, file.Name()))
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "foo" (WorkflowTemplate): lint error`, file.Name()))
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 1)
@@ -172,7 +172,7 @@ func TestLintWithOutput(t *testing.T) {
 	mw.AssertCalled(t, "Write", []byte(expected[1]))
 	mw.AssertCalled(t, "Write", []byte(expected[2]))
 	assert.NoError(t, err)
-	assert.Equal(t, res.Success, false)
+	assert.False(t, res.Success)
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 2)
 	wftServiceSclientMock.AssertNumberOfCalls(t, "LintWorkflowTemplate", 2)
 	assert.Equal(t, strings.Join(expected, ""), res.Msg())
@@ -206,7 +206,7 @@ func TestLintStdin(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, res.Success, false)
+	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, `stdin: in "steps-" (Workflow): lint error`)
 	assert.Contains(t, res.msg, `stdin: in "foo" (WorkflowTemplate): lint error`)
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 1)
@@ -243,7 +243,7 @@ func TestLintDeviceFile(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, res.Success, false)
+	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "steps-" (Workflow): lint error`, deviceFileName))
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 1)
 	wftServiceSclientMock.AssertNotCalled(t, "LintWorkflowTemplate")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,7 @@ func TestSanitize(t *testing.T) {
 		if tt.err != "" {
 			assert.Equal(t, err.Error(), tt.err)
 		} else {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 	}
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -12,7 +12,7 @@ import (
 // TestErrorf tests the initializer of error package
 func TestErrorf(t *testing.T) {
 	err := errors.Errorf(errors.CodeInternal, "test internal")
-	assert.Equal(t, err.Error(), "test internal")
+	assert.Equal(t, "test internal", err.Error())
 }
 
 // TestWrap ensures we can wrap an error and use Cause() to retrieve the original error

--- a/pkg/apis/workflow/v1alpha1/container_set_template_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/container_set_template_types_test.go
@@ -29,7 +29,7 @@ func TestContainerSetGetRetryStrategy(t *testing.T) {
 			},
 		}
 		strategy, err := set.GetRetryStrategy()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, wait.Backoff{Steps: 100}, strategy)
 	})
 
@@ -43,7 +43,7 @@ func TestContainerSetGetRetryStrategy(t *testing.T) {
 			},
 		}
 		strategy, err := set.GetRetryStrategy()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, wait.Backoff{
 			Steps:    100,
 			Duration: time.Duration(20 * time.Second),
@@ -86,7 +86,7 @@ volumeMounts:
     mountPath: /workspace
 `
 	err := validateContainerSetTemplate(invalidContainerSetEmpty)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "containers must have at least one container")
 	}
 }
@@ -103,7 +103,7 @@ containers:
     image: argoproj/argosay:v2
 `
 	err := validateContainerSetTemplate(invalidContainerSetDuplicateNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "volumeMounts[1].mountPath '/workspace' already mounted in volumeMounts.workspace")
 	}
 }
@@ -120,7 +120,7 @@ containers:
     image: argoproj/argosay:v2
 `
 	err := validateContainerSetTemplate(invalidContainerSetDuplicateNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "containers[1].name 'a' is not unique")
 	}
 }
@@ -139,7 +139,7 @@ containers:
       - c
 `
 	err := validateContainerSetTemplate(invalidContainerSetDependencyNotFound)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "containers.b dependency 'c' not defined")
 	}
 }
@@ -160,7 +160,7 @@ containers:
       - a
 `
 	err := validateContainerSetTemplate(invalidContainerSetDependencyCycle)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "containers dependency cycle detected: b->a->b")
 	}
 }

--- a/pkg/apis/workflow/v1alpha1/item_test.go
+++ b/pkg/apis/workflow/v1alpha1/item_test.go
@@ -30,7 +30,7 @@ func TestItem(t *testing.T) {
 func runItemTest(t *testing.T, data string, expectedType Type) {
 	itm, err := ParseItem(data)
 	assert.NoError(t, err)
-	assert.Equal(t, itm.GetType(), expectedType)
+	assert.Equal(t, expectedType, itm.GetType())
 	jsonBytes, err := json.Marshal(itm)
 	assert.NoError(t, err)
 	assert.Equal(t, data, string(jsonBytes), "marshalling is symmetric")

--- a/pkg/apis/workflow/v1alpha1/marshall_test.go
+++ b/pkg/apis/workflow/v1alpha1/marshall_test.go
@@ -11,7 +11,7 @@ func TestMustUnmarshalClusterWorkflow(t *testing.T) {
 		if r := recover(); r == nil {
 			t.Fatalf("The code did not panic but should have")
 		} else {
-			assert.Equal(t, r.(string), "no text to unmarshal")
+			assert.Equal(t, "no text to unmarshal", r.(string))
 		}
 	}()
 	_ = MustUnmarshalClusterWorkflow([]byte(""))

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -32,7 +32,7 @@ func TestWorkflows(t *testing.T) {
 	})
 	t.Run("Filter", func(t *testing.T) {
 		assert.Len(t, wfs.Filter(func(wf Workflow) bool { return true }), 4)
-		assert.Len(t, wfs.Filter(func(wf Workflow) bool { return false }), 0)
+		assert.Empty(t, wfs.Filter(func(wf Workflow) bool { return false }))
 	})
 }
 
@@ -717,9 +717,9 @@ func TestNodes_Children(t *testing.T) {
 	}
 	t.Run("Found", func(t *testing.T) {
 		ret := nodes.Children("node_0")
-		assert.Equal(t, len(ret), 2)
-		assert.Equal(t, ret["node_1"].Name, "node_1")
-		assert.Equal(t, ret["node_2"].Name, "node_2")
+		assert.Len(t, ret, 2)
+		assert.Equal(t, "node_1", ret["node_1"].Name)
+		assert.Equal(t, "node_2", ret["node_2"].Name)
 	})
 	t.Run("NotFound", func(t *testing.T) {
 		assert.Empty(t, nodes.Children("node_1"))
@@ -766,9 +766,9 @@ func TestNodes_Filter(t *testing.T) {
 	})
 	t.Run("Found", func(t *testing.T) {
 		n := nodes.Filter(func(x NodeStatus) bool { return x.Phase == NodeFailed })
-		assert.Equal(t, len(n), 2)
-		assert.Equal(t, n["node_1"].ID, "node_1")
-		assert.Equal(t, n["node_3"].ID, "node_3")
+		assert.Len(t, n, 2)
+		assert.Equal(t, "node_1", n["node_1"].ID)
+		assert.Equal(t, "node_3", n["node_3"].ID)
 	})
 }
 
@@ -783,8 +783,8 @@ func TestNodes_Map(t *testing.T) {
 	})
 	t.Run("Exist", func(t *testing.T) {
 		n := nodes.Map(func(x NodeStatus) interface{} { return x.HostNodeName })
-		assert.Equal(t, n["node_1"], "host_1")
-		assert.Equal(t, n["node_2"], "host_2")
+		assert.Equal(t, "host_1", n["node_1"])
+		assert.Equal(t, "host_2", n["node_2"])
 	})
 }
 
@@ -856,11 +856,11 @@ func TestCronWorkflowConditions(t *testing.T) {
 		Status:  metav1.ConditionTrue,
 	}
 
-	assert.Len(t, cwfCond, 0)
+	assert.Empty(t, cwfCond)
 	cwfCond.UpsertCondition(cond)
 	assert.Len(t, cwfCond, 1)
 	cwfCond.RemoveCondition(ConditionTypeSubmissionError)
-	assert.Len(t, cwfCond, 0)
+	assert.Empty(t, cwfCond)
 }
 
 func TestDisplayConditions(t *testing.T) {
@@ -1045,7 +1045,7 @@ func TestWorkflow_SearchArtifacts(t *testing.T) {
 	query.NodeId = "node-foobar"
 	queriedArtifactSearchResults = wf.SearchArtifacts(query)
 	assert.Nil(t, queriedArtifactSearchResults)
-	assert.Len(t, queriedArtifactSearchResults, 0)
+	assert.Empty(t, queriedArtifactSearchResults)
 
 	// template and artifact name
 	query = NewArtifactSearchQuery()
@@ -1302,7 +1302,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, dagTmpl.Script)
 		assert.Nil(t, dagTmpl.Resource)
 		assert.Nil(t, dagTmpl.Data)
-		assert.Len(t, dagTmpl.Steps, 0)
+		assert.Empty(t, dagTmpl.Steps)
 		assert.Nil(t, dagTmpl.Container)
 		assert.Nil(t, dagTmpl.Suspend)
 	})
@@ -1314,7 +1314,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, scriptTmpl.DAG)
 		assert.Nil(t, scriptTmpl.Resource)
 		assert.Nil(t, scriptTmpl.Data)
-		assert.Len(t, scriptTmpl.Steps, 0)
+		assert.Empty(t, scriptTmpl.Steps)
 		assert.Nil(t, scriptTmpl.Container)
 		assert.Nil(t, scriptTmpl.Suspend)
 	})
@@ -1326,7 +1326,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, resourceTmpl.Script)
 		assert.Nil(t, resourceTmpl.DAG)
 		assert.Nil(t, resourceTmpl.Data)
-		assert.Len(t, resourceTmpl.Steps, 0)
+		assert.Empty(t, resourceTmpl.Steps)
 		assert.Nil(t, resourceTmpl.Container)
 		assert.Nil(t, resourceTmpl.Suspend)
 	})
@@ -1337,7 +1337,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, containerTmpl.Script)
 		assert.Nil(t, containerTmpl.DAG)
 		assert.Nil(t, containerTmpl.Data)
-		assert.Len(t, containerTmpl.Steps, 0)
+		assert.Empty(t, containerTmpl.Steps)
 		assert.Nil(t, containerTmpl.Resource)
 		assert.Nil(t, containerTmpl.Suspend)
 	})
@@ -1348,7 +1348,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, dataTmpl.Script)
 		assert.Nil(t, dataTmpl.DAG)
 		assert.Nil(t, dataTmpl.Container)
-		assert.Len(t, dataTmpl.Steps, 0)
+		assert.Empty(t, dataTmpl.Steps)
 		assert.Nil(t, dataTmpl.Resource)
 		assert.Nil(t, dataTmpl.Suspend)
 	})
@@ -1359,7 +1359,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		assert.Nil(t, suspendTmpl.Script)
 		assert.Nil(t, suspendTmpl.DAG)
 		assert.Nil(t, suspendTmpl.Container)
-		assert.Len(t, suspendTmpl.Steps, 0)
+		assert.Empty(t, suspendTmpl.Steps)
 		assert.Nil(t, suspendTmpl.Resource)
 		assert.Nil(t, suspendTmpl.Data)
 	})
@@ -1516,7 +1516,7 @@ func TestStepSpecGetExitHook(t *testing.T) {
 func TestTemplate_RetryStrategy(t *testing.T) {
 	tmpl := Template{}
 	strategy, err := tmpl.GetRetryStrategy()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, wait.Backoff{Steps: 1}, strategy)
 }
 
@@ -1540,7 +1540,7 @@ func TestGetExecSpec(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "stored-spec-template")
+	assert.Equal(t, "stored-spec-template", wf.GetExecSpec().Templates[0].Name)
 
 	wf = Workflow{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1554,11 +1554,11 @@ func TestGetExecSpec(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "spec-template")
+	assert.Equal(t, "spec-template", wf.GetExecSpec().Templates[0].Name)
 
 	wf.Status.StoredWorkflowSpec = nil
 
-	assert.Equal(t, wf.GetExecSpec().Templates[0].Name, "spec-template")
+	assert.Equal(t, "spec-template", wf.GetExecSpec().Templates[0].Name)
 }
 
 // Check that inline tasks and steps are properly recovered from the store
@@ -1633,16 +1633,16 @@ func TestInlineStore(t *testing.T) {
 			steptmpl2 := &wf.Spec.Templates[1].Steps[0].Steps[1]
 			stored, err := wf.SetStoredTemplate(scope, "dag-template", dagtmpl1, dagtmpl1.Inline)
 			assert.Equal(t, shouldStore, stored, "DAG template 1 should be stored for non local scopes")
-			assert.Nil(t, err, "SetStoredTemplate for DAG1 should not return an error")
+			assert.NoError(t, err, "SetStoredTemplate for DAG1 should not return an error")
 			stored, err = wf.SetStoredTemplate(scope, "dag-template", dagtmpl2, dagtmpl2.Inline)
 			assert.Equal(t, shouldStore, stored, "DAG template 2 should be stored for non local scopes")
-			assert.Nil(t, err, "SetStoredTemplate for DAG2 should not return an error")
+			assert.NoError(t, err, "SetStoredTemplate for DAG2 should not return an error")
 			stored, err = wf.SetStoredTemplate(scope, "step-template", steptmpl1, steptmpl1.Inline)
 			assert.Equal(t, shouldStore, stored, "Step template 1 should be stored for non local scopes")
-			assert.Nil(t, err, "SetStoredTemplate for Step 1 should not return an error")
+			assert.NoError(t, err, "SetStoredTemplate for Step 1 should not return an error")
 			stored, err = wf.SetStoredTemplate(scope, "step-template", steptmpl2, steptmpl2.Inline)
 			assert.Equal(t, shouldStore, stored, "Step template 2 should be stored for non local scopes")
-			assert.Nil(t, err, "SetStoredTemplate for Step 2 should not return an error")
+			assert.NoError(t, err, "SetStoredTemplate for Step 2 should not return an error")
 			// For cases where we can store we should be able to retrieve and check
 			if shouldStore {
 				dagretrieved1 := wf.GetStoredTemplate(scope, "dag-template", dagtmpl1)

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -151,5 +151,5 @@ func TestGetSessionExpiry(t *testing.T) {
 	config := Config{
 		SessionExpiry: metav1.Duration{Duration: 5 * time.Hour},
 	}
-	assert.Equal(t, config.GetSessionExpiry(), 5*time.Hour)
+	assert.Equal(t, 5*time.Hour, config.GetSessionExpiry())
 }

--- a/server/auth/types/claims_test.go
+++ b/server/auth/types/claims_test.go
@@ -244,7 +244,7 @@ func TestGetUserInfoGroups(t *testing.T) {
 
 		claims := &Claims{}
 		groups, err := claims.GetUserInfoGroups(httpClient, "Bearer fake", "https://fake.okta.com", "/user-info")
-		assert.Equal(t, groups, []string{"Everyone"})
-		assert.Equal(t, nil, err)
+		assert.Equal(t, []string{"Everyone"}, groups)
+		assert.NoError(t, err)
 	})
 }

--- a/server/cache/resource_cache_test.go
+++ b/server/cache/resource_cache_test.go
@@ -79,12 +79,12 @@ func TestServer_K8sUtilsCache(t *testing.T) {
 
 	t.Run("List Service Accounts in different namespaces", func(t *testing.T) {
 		sa, _ := cache.ServiceAccountLister.ServiceAccounts("ns1").List(labels.Everything())
-		assert.Equal(t, 2, len(sa))
+		assert.Len(t, sa, 2)
 		assert.True(t, checkServiceAccountExists(sa, "sa1"))
 		assert.True(t, checkServiceAccountExists(sa, "sa2"))
 
 		sa, _ = cache.ServiceAccountLister.ServiceAccounts("ns2").List(labels.Everything())
-		assert.Equal(t, 1, len(sa))
+		assert.Len(t, sa, 1)
 		assert.True(t, checkServiceAccountExists(sa, "sa3"))
 
 		secret, _ := cache.GetSecret(ctx, "ns1", "s1")

--- a/server/event/event_server_test.go
+++ b/server/event/event_server_test.go
@@ -41,7 +41,7 @@ func TestController(t *testing.T) {
 		stopCh <- struct{}{}
 		s.Run(stopCh)
 
-		assert.Len(t, s.operationQueue, 0, "all events were processed")
+		assert.Empty(t, s.operationQueue, "all events were processed")
 	})
 	t.Run("Sync", func(t *testing.T) {
 		s := newController(false)

--- a/server/info/info_server_test.go
+++ b/server/info/info_server_test.go
@@ -55,8 +55,8 @@ func Test_infoServer_GetInfo(t *testing.T) {
 		info, err := i.GetInfo(context.TODO(), nil)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "", info.ManagedNamespace)
-			assert.Equal(t, 0, len(info.Links))
-			assert.Equal(t, 0, len(info.Columns))
+			assert.Empty(t, info.Links)
+			assert.Empty(t, info.Columns)
 			assert.Equal(t, "", info.NavColor)
 		}
 	})

--- a/server/utils/errors_test.go
+++ b/server/utils/errors_test.go
@@ -62,7 +62,7 @@ func TestRecursiveStatus(t *testing.T) {
 
 func TestNilStatus(t *testing.T) {
 	newErr := ToStatusError(nil, codes.InvalidArgument)
-	assert.Equal(t, nil, newErr)
+	assert.NoError(t, newErr)
 }
 
 func TestArgoError(t *testing.T) {
@@ -96,7 +96,7 @@ func TestHTTPToStatusError(t *testing.T) {
 	t.Run("StatusOk", func(t *testing.T) {
 		code := http.StatusAccepted
 		err, ok := httpToStatusError(code, "msg")
-		assert.Equal(true, ok)
+		assert.True(ok)
 		stat := status.Convert(err)
 		assert.Equal(codes.OK, stat.Code())
 	})
@@ -104,7 +104,7 @@ func TestHTTPToStatusError(t *testing.T) {
 	t.Run("StatusOnRedirect", func(t *testing.T) {
 		code := http.StatusPermanentRedirect
 		err, ok := httpToStatusError(code, "msg")
-		assert.Equal(true, ok)
+		assert.True(ok)
 		stat := status.Convert(err)
 		assert.Equal(codes.Internal, stat.Code())
 	})
@@ -112,7 +112,7 @@ func TestHTTPToStatusError(t *testing.T) {
 	t.Run("StatusTeapot", func(t *testing.T) {
 		code := http.StatusTeapot
 		err, ok := httpToStatusError(code, "msg")
-		assert.Equal(true, ok)
+		assert.True(ok)
 		stat := status.Convert(err)
 		assert.Equal(codes.InvalidArgument, stat.Code())
 	})
@@ -121,7 +121,7 @@ func TestHTTPToStatusError(t *testing.T) {
 	t.Run("StatusInternal", func(t *testing.T) {
 		code := http.StatusVariantAlsoNegotiates
 		err, ok := httpToStatusError(code, "msg")
-		assert.Equal(true, ok)
+		assert.True(ok)
 		stat := status.Convert(err)
 		assert.Equal(codes.Internal, stat.Code())
 	})

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -732,7 +732,7 @@ func TestGetLatestWorkflow(t *testing.T) {
 	wfClient := ctx.Value(auth.WfKey).(versioned.Interface)
 	wf, err := getLatestWorkflow(ctx, wfClient, "test")
 	if assert.NoError(t, err) {
-		assert.Equal(t, wf.Name, "hello-world-9tql2-test")
+		assert.Equal(t, "hello-world-9tql2-test", wf.Name)
 	}
 }
 
@@ -765,12 +765,12 @@ func TestListWorkflow(t *testing.T) {
 	wfl, err := getWorkflowList(ctx, server, "workflows")
 	if assert.NoError(t, err) {
 		assert.NotNil(t, wfl)
-		assert.Equal(t, 4, len(wfl.Items))
+		assert.Len(t, wfl.Items, 4)
 	}
 	wfl, err = getWorkflowList(ctx, server, "test")
 	if assert.NoError(t, err) {
 		assert.NotNil(t, wfl)
-		assert.Equal(t, 2, len(wfl.Items))
+		assert.Len(t, wfl.Items, 2)
 	}
 }
 
@@ -815,7 +815,7 @@ func TestSuspendResumeWorkflow(t *testing.T) {
 	wf, err := server.SuspendWorkflow(ctx, &workflowpkg.WorkflowSuspendRequest{Name: "hello-world-9tql2-run", Namespace: "workflows"})
 	if assert.NoError(t, err) {
 		assert.NotNil(t, wf)
-		assert.Equal(t, true, *wf.Spec.Suspend)
+		assert.True(t, *wf.Spec.Suspend)
 		wf, err = server.ResumeWorkflow(ctx, &workflowpkg.WorkflowResumeRequest{Name: wf.Name, Namespace: wf.Namespace})
 		if assert.NoError(t, err) {
 			assert.NotNil(t, wf)
@@ -833,21 +833,21 @@ func TestSuspendResumeWorkflowWithNotFound(t *testing.T) {
 	}
 	wf, err := server.SuspendWorkflow(ctx, &susWfReq)
 	assert.Nil(t, wf)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	rsmWfReq := workflowpkg.WorkflowResumeRequest{
 		Name:      "hello-world-9tql2-not",
 		Namespace: "workflows",
 	}
 	wf, err = server.ResumeWorkflow(ctx, &rsmWfReq)
 	assert.Nil(t, wf)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestTerminateWorkflow(t *testing.T) {
 	server, ctx := getWorkflowServer()
 
 	wf, err := getWorkflow(ctx, server, "workflows", "hello-world-9tql2-run")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	rsmWfReq := workflowpkg.WorkflowTerminateRequest{
 		Name:      wf.Name,
 		Namespace: wf.Namespace,
@@ -855,7 +855,7 @@ func TestTerminateWorkflow(t *testing.T) {
 	wf, err = server.TerminateWorkflow(ctx, &rsmWfReq)
 	assert.NotNil(t, wf)
 	assert.Equal(t, v1alpha1.ShutdownStrategyTerminate, wf.Spec.Shutdown)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	rsmWfReq = workflowpkg.WorkflowTerminateRequest{
 		Name:      "hello-world-9tql2-not",
@@ -863,7 +863,7 @@ func TestTerminateWorkflow(t *testing.T) {
 	}
 	wf, err = server.TerminateWorkflow(ctx, &rsmWfReq)
 	assert.Nil(t, wf)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestStopWorkflow(t *testing.T) {

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -167,7 +167,7 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{FieldSelector: "metadata.name=my-name,spec.startedAt>2020-01-01T00:00:00Z,spec.startedAt<2020-01-02T00:00:00Z,ext.showRemainingItemCount=true", Limit: 1}, NamePrefix: "my-"})
 		if assert.NoError(t, err) {
 			assert.Len(t, resp.Items, 1)
-			assert.Equal(t, *resp.ListMeta.RemainingItemCount, int64(4))
+			assert.Equal(t, int64(4), *resp.ListMeta.RemainingItemCount)
 			assert.Empty(t, resp.Continue)
 		}
 		/////// Currently, for the purpose of backward compatibility, namespace is supported both as its own query parameter and as part of the field selector
@@ -245,7 +245,7 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		assert.False(t, matchLabelKeyPattern("wrong key"))
 		resp, err = w.ListArchivedWorkflowLabelValues(ctx, &workflowarchivepkg.ListArchivedWorkflowLabelValuesRequest{ListOptions: &metav1.ListOptions{LabelSelector: "my-key"}})
 		assert.NoError(t, err)
-		assert.Len(t, resp.Items, 0)
+		assert.Empty(t, resp.Items)
 	})
 	t.Run("RetryArchivedWorkflow", func(t *testing.T) {
 		_, err := w.RetryArchivedWorkflow(ctx, &workflowarchivepkg.RetryArchivedWorkflowRequest{Uid: "failed-uid"})

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -63,7 +63,7 @@ spec:
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
 			// Ensure that the workflow ran for less than 10 seconds
-			assert.True(t, status.FinishedAt.Sub(status.StartedAt.Time) < time.Duration(10*fixtures.EnvFactor)*time.Second)
+			assert.Less(t, status.FinishedAt.Sub(status.StartedAt.Time), time.Duration(10*fixtures.EnvFactor)*time.Second)
 
 			var finishedTimes []time.Time
 			var startTimes []time.Time
@@ -80,14 +80,14 @@ spec:
 					return finishedTimes[i].Before(finishedTimes[j])
 				})
 				// Everything finished with a two second tolerance window
-				assert.True(t, finishedTimes[3].Sub(finishedTimes[0]) < time.Duration(2)*time.Second)
+				assert.Less(t, finishedTimes[3].Sub(finishedTimes[0]), time.Duration(2)*time.Second)
 			}
 			if assert.Len(t, startTimes, 4) {
 				sort.Slice(startTimes, func(i, j int) bool {
 					return startTimes[i].Before(startTimes[j])
 				})
 				// Everything started with same time
-				assert.True(t, startTimes[3].Sub(startTimes[0]) == 0)
+				assert.Equal(t, time.Duration(0), startTimes[3].Sub(startTimes[0]))
 			}
 		})
 }

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -132,7 +132,7 @@ func (s *ArgoServerSuite) TestSubmitWorkflowTemplateFromGithubWebhook() {
 	s.bearerToken = ""
 
 	data, err := os.ReadFile("testdata/github-webhook-payload.json")
-	assert.NoError(s.T(), err)
+	s.NoError(err)
 
 	s.Given().
 		WorkflowTemplate(`
@@ -380,9 +380,9 @@ func (s *ArgoServerSuite) TestMultiCookieAuth() {
 func (s *ArgoServerSuite) createServiceAccount(name string) {
 	ctx := context.Background()
 	_, err := s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{})
-	assert.NoError(s.T(), err)
+	s.NoError(err)
 	secret, err := s.KubeClient.CoreV1().Secrets(fixtures.Namespace).Create(ctx, secrets.NewTokenSecret(name), metav1.CreateOptions{})
-	assert.NoError(s.T(), err)
+	s.NoError(err)
 	s.T().Cleanup(func() {
 		_ = s.KubeClient.CoreV1().Secrets(fixtures.Namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
 		_ = s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Delete(ctx, name, metav1.DeleteOptions{})
@@ -401,11 +401,11 @@ func (s *ArgoServerSuite) TestPermission() {
 	var roleName string
 	s.Run("LoadRoleYaml", func() {
 		obj, err := fixtures.LoadObject("@testdata/argo-server-test-role.yaml")
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 		role, _ := obj.(*rbacv1.Role)
 		roleName = role.Name
 		_, err = s.KubeClient.RbacV1().Roles(nsName).Create(ctx, role, metav1.CreateOptions{})
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 	})
 	defer func() {
 		_ = s.KubeClient.RbacV1().Roles(nsName).Delete(ctx, roleName, metav1.DeleteOptions{})
@@ -424,7 +424,7 @@ func (s *ArgoServerSuite) TestPermission() {
 	}
 	s.Run("CreateRoleBinding", func() {
 		_, err := s.KubeClient.RbacV1().RoleBindings(nsName).Create(ctx, roleBinding, metav1.CreateOptions{})
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 	})
 	defer func() {
 		_ = s.KubeClient.RbacV1().RoleBindings(nsName).Delete(ctx, roleBindingName, metav1.DeleteOptions{})
@@ -438,10 +438,10 @@ func (s *ArgoServerSuite) TestPermission() {
 	var goodToken string
 	s.Run("GetGoodSAToken", func() {
 		sAccount, err := s.KubeClient.CoreV1().ServiceAccounts(nsName).Get(ctx, goodSaName, metav1.GetOptions{})
-		if assert.NoError(s.T(), err) {
+		if s.NoError(err) {
 			secretName := secrets.TokenNameForServiceAccount(sAccount)
 			secret, err := s.KubeClient.CoreV1().Secrets(nsName).Get(ctx, secretName, metav1.GetOptions{})
-			assert.NoError(s.T(), err)
+			s.NoError(err)
 			goodToken = string(secret.Data["token"])
 		}
 	})
@@ -450,10 +450,10 @@ func (s *ArgoServerSuite) TestPermission() {
 	var badToken string
 	s.Run("GetBadSAToken", func() {
 		sAccount, err := s.KubeClient.CoreV1().ServiceAccounts(nsName).Get(ctx, badSaName, metav1.GetOptions{})
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 		secretName := secrets.TokenNameForServiceAccount(sAccount)
 		secret, err := s.KubeClient.CoreV1().Secrets(nsName).Get(ctx, secretName, metav1.GetOptions{})
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 		badToken = string(secret.Data["token"])
 	})
 

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -185,18 +185,18 @@ func (s *ArtifactsSuite) TestStoppedWorkflow() {
 		c, err := minio.New("localhost:9000", &minio.Options{
 			Creds: credentials.NewStaticV4("admin", "password", ""),
 		})
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 
 		// Ensure the artifacts aren't in the bucket.
 		_, err = c.StatObject(context.Background(), "my-bucket-3", "on-deletion-wf-stopped-1", minio.StatObjectOptions{})
 		if err == nil {
 			err = c.RemoveObject(context.Background(), "my-bucket-3", "on-deletion-wf-stopped-1", minio.RemoveObjectOptions{})
-			assert.NoError(s.T(), err)
+			s.NoError(err)
 		}
 		_, err = c.StatObject(context.Background(), "my-bucket-3", "on-deletion-wf-stopped-2", minio.StatObjectOptions{})
 		if err == nil {
 			err = c.RemoveObject(context.Background(), "my-bucket-3", "on-deletion-wf-stopped-2", minio.RemoveObjectOptions{})
-			assert.NoError(s.T(), err)
+			s.NoError(err)
 		}
 
 		then := s.Given().
@@ -206,10 +206,10 @@ func (s *ArtifactsSuite) TestStoppedWorkflow() {
 
 		// Assert the artifacts don't exist.
 		then.ExpectArtifactByKey("on-deletion-wf-stopped-1", "my-bucket-3", func(t *testing.T, object minio.ObjectInfo, err error) {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		})
 		then.ExpectArtifactByKey("on-deletion-wf-stopped-2", "my-bucket-3", func(t *testing.T, object minio.ObjectInfo, err error) {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		})
 
 		when := then.When().
@@ -250,10 +250,10 @@ func (s *ArtifactsSuite) TestStoppedWorkflow() {
 
 		// Assert the artifacts don't exist.
 		then.ExpectArtifactByKey("on-deletion-wf-stopped-1", "my-bucket-3", func(t *testing.T, object minio.ObjectInfo, err error) {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		})
 		then.ExpectArtifactByKey("on-deletion-wf-stopped-2", "my-bucket-3", func(t *testing.T, object minio.ObjectInfo, err error) {
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 		})
 
 		when = then.When()
@@ -438,7 +438,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			if expectedArtifact.deletedAtWFCompletion {
 				fmt.Printf("verifying artifact %s is deleted at completion time\n", artifactKey)
 				then.ExpectArtifactByKey(artifactKey, expectedArtifact.artifactLocation.bucketName, func(t *testing.T, object minio.ObjectInfo, err error) {
-					assert.NotNil(t, err)
+					assert.Error(t, err)
 				})
 			} else {
 				fmt.Printf("verifying artifact %s is not deleted at completion time\n", artifactKey)
@@ -473,7 +473,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			if expectedArtifact.deletedAtWFDeletion {
 				fmt.Printf("verifying artifact %s is deleted\n", artifactKey)
 				then.ExpectArtifactByKey(artifactKey, expectedArtifact.artifactLocation.bucketName, func(t *testing.T, object minio.ObjectInfo, err error) {
-					assert.NotNil(t, err)
+					assert.Error(t, err)
 				})
 			} else {
 				fmt.Printf("verifying artifact %s is not deleted\n", artifactKey)
@@ -520,7 +520,7 @@ spec:
 func (s *ArtifactsSuite) TestInsufficientRole() {
 	ctx := context.Background()
 	_, err := s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "artgc-role-test-sa"}}, metav1.CreateOptions{})
-	assert.NoError(s.T(), err)
+	s.NoError(err)
 	s.T().Cleanup(func() {
 		_ = s.KubeClient.CoreV1().ServiceAccounts(fixtures.Namespace).Delete(ctx, "artgc-role-test-sa", metav1.DeleteOptions{})
 	})
@@ -544,13 +544,13 @@ func (s *ArtifactsSuite) TestInsufficientRole() {
 		var workflow wfv1.Workflow
 		err = yaml.Unmarshal([]byte(insufficientRoleWorkflow), &workflow)
 		if err != nil {
-			assert.Fail(s.T(), err.Error())
+			s.Fail(err.Error())
 		}
 
 		workflow.Spec.ArtifactGC.ForceFinalizerRemoval = tt.forceFinalizerRemoval
 		modifiedWorkflow, err := yaml.Marshal(&workflow)
 		if err != nil {
-			assert.Fail(s.T(), err.Error())
+			s.Fail(err.Error())
 		}
 
 		// Submit the Workflow
@@ -583,13 +583,13 @@ func (s *ArtifactsSuite) TestInsufficientRole() {
 						failCondition = true
 					}
 				}
-				assert.Equal(t, true, failCondition)
+				assert.True(t, failCondition)
 			}).
 			ExpectWorkflow(func(t *testing.T, meta *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 				if tt.forceFinalizerRemoval {
-					assert.NotContains(s.T(), meta.Finalizers, common.FinalizerArtifactGC)
+					s.NotContains(meta.Finalizers, common.FinalizerArtifactGC)
 				} else {
-					assert.Contains(s.T(), meta.Finalizers, common.FinalizerArtifactGC)
+					s.Contains(meta.Finalizers, common.FinalizerArtifactGC)
 				}
 			}).
 			When().
@@ -744,7 +744,7 @@ spec:
 					},
 				}
 				if assert.NotNil(t, n) {
-					assert.Equal(t, n.Outputs, expectedOutputs)
+					assert.Equal(t, expectedOutputs, n.Outputs)
 				}
 			})
 	})

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -238,7 +238,7 @@ func (s *CLISuite) TestSubmitWorkflowTemplateDryRun() {
 		}).
 		Then().
 		ExpectWorkflowList(metav1.ListOptions{LabelSelector: common.LabelKeyWorkflowTemplate + "=workflow-template-whalesay-template"}, func(t *testing.T, wfList *wfv1.WorkflowList) {
-			assert.Equal(t, 0, len(wfList.Items))
+			assert.Empty(t, wfList.Items)
 		})
 }
 
@@ -256,7 +256,7 @@ func (s *CLISuite) TestSubmitWorkflowTemplateServerDryRun() {
 		}).
 		Then().
 		ExpectWorkflowList(metav1.ListOptions{LabelSelector: common.LabelKeyWorkflowTemplate + "=workflow-template-whalesay-template"}, func(t *testing.T, wfList *wfv1.WorkflowList) {
-			assert.Equal(t, 0, len(wfList.Items))
+			assert.Empty(t, wfList.Items)
 		})
 }
 
@@ -274,7 +274,7 @@ func (s *CLISuite) TestTokenArg() {
 	var goodToken string
 	s.Run("GetSAToken", func() {
 		token, err := s.GetServiceAccountToken()
-		assert.NoError(s.T(), err)
+		s.NoError(err)
 		goodToken = token
 	})
 	s.Run("ListWithGoodToken", func() {
@@ -423,7 +423,7 @@ func (s *CLISuite) TestLogProblems() {
 
 func (s *CLISuite) TestParametersFile() {
 	err := os.WriteFile("/tmp/parameters-file.yaml", []byte("message: hello"), os.ModePerm)
-	assert.NoError(s.T(), err)
+	s.NoError(err)
 	s.Given().
 		RunCli([]string{"submit", "testdata/parameters-workflow.yaml", "-l", "workflows.argoproj.io/test=true", "--parameter-file=/tmp/parameters-file.yaml"}, func(t *testing.T, output string, err error) {
 			assert.NoError(t, err)
@@ -974,7 +974,7 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
-			assert.Equal(t, 7, len(status.Nodes))
+			assert.Len(t, status.Nodes, 7)
 		}).
 		RunCli([]string{"retry", workflowName}, func(t *testing.T, output string, err error) {
 			if assert.NoError(t, err, output) {
@@ -990,12 +990,12 @@ func (s *CLISuite) TestRetryWorkflowWithContinueOn() {
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			workflowName = metadata.Name
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
-			assert.Equal(t, 7, len(status.Nodes))
+			assert.Len(t, status.Nodes, 7)
 		}).
 		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".success")
 		}, func(t *testing.T, status *wfv1.NodeStatus, pod *corev1.Pod) {
-			assert.Equal(t, 2, len(status.Children))
+			assert.Len(t, status.Children, 2)
 		})
 }
 
@@ -1284,7 +1284,7 @@ func (s *CLISuite) TestWorkflowResubmitDAGWithDependencies() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
-			assert.Equal(t, 5, len(status.Nodes))
+			assert.Len(t, status.Nodes, 5)
 		}).
 		ExpectWorkflowNode(func(status wfv1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".A")
@@ -1863,7 +1863,7 @@ func (s *CLISuite) TestArchiveLabel() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, wfv1.WorkflowSucceeded)
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
 		})
 	s.Run("ListKeys", func() {
 		s.Given().

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -207,7 +207,7 @@ spec:
 			Wait(2 * time.Minute).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, 1, len(cronWf.Status.Active))
+				assert.Len(t, cronWf.Status.Active, 1)
 				assert.True(t, cronWf.Status.LastScheduledTime.Time.Before(time.Now().Add(-1*time.Minute)))
 			})
 	})
@@ -243,7 +243,7 @@ spec:
 			Wait(2 * time.Minute).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, 2, len(cronWf.Status.Active))
+				assert.Len(t, cronWf.Status.Active, 2)
 			})
 	})
 	s.Run("TestBasicReplace", func() {
@@ -276,7 +276,7 @@ spec:
 			Wait(2*time.Minute + 20*time.Second).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, 1, len(cronWf.Status.Active))
+				assert.Len(t, cronWf.Status.Active, 1)
 				if assert.NotNil(t, cronWf.Status.LastScheduledTime) {
 					assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
 				}
@@ -313,7 +313,7 @@ spec:
 			Wait(2*time.Minute+25*time.Second).
 			Then().
 			ExpectWorkflowList(listOptions, func(t *testing.T, wfList *wfv1.WorkflowList) {
-				assert.Equal(t, 1, len(wfList.Items))
+				assert.Len(t, wfList.Items, 1)
 				assert.True(t, wfList.Items[0].Status.FinishedAt.Time.After(time.Now().Add(-1*time.Minute)))
 			})
 	})
@@ -349,7 +349,7 @@ spec:
 			Wait(2*time.Minute+25*time.Second).
 			Then().
 			ExpectWorkflowList(listOptions, func(t *testing.T, wfList *wfv1.WorkflowList) {
-				assert.Equal(t, 1, len(wfList.Items))
+				assert.Len(t, wfList.Items, 1)
 				assert.True(t, wfList.Items[0].Status.FinishedAt.Time.After(time.Now().Add(-1*time.Minute)))
 			})
 	})

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -45,9 +45,9 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 				}, spec.SecurityContext)
 				if assert.Len(t, spec.Volumes, 4) {
 					assert.Contains(t, spec.Volumes[0].Name, "kube-api-access-")
-					assert.Equal(t, spec.Volumes[1].Name, "var-run-argo")
+					assert.Equal(t, "var-run-argo", spec.Volumes[1].Name)
 					assert.Contains(t, spec.Volumes[2].Name, "kube-api-access-")
-					assert.Equal(t, spec.Volumes[3].Name, "argo-workflows-agent-ca-certificates")
+					assert.Equal(t, "argo-workflows-agent-ca-certificates", spec.Volumes[3].Name)
 				}
 				if assert.Len(t, spec.Containers, 2) {
 					{
@@ -65,7 +65,7 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 							if assert.Len(t, agent.VolumeMounts, 3) {
 								assert.Equal(t, "var-run-argo", agent.VolumeMounts[0].Name)
 								assert.Contains(t, agent.VolumeMounts[1].Name, "kube-api-access-")
-								assert.Equal(t, agent.VolumeMounts[2].Name, "argo-workflows-agent-ca-certificates")
+								assert.Equal(t, "argo-workflows-agent-ca-certificates", agent.VolumeMounts[2].Name)
 							}
 							assert.Equal(t, &apiv1.SecurityContext{
 								RunAsUser:                pointer.Int64(8737),
@@ -83,8 +83,8 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 		}).
 		ExpectWorkflowTaskSet(func(t *testing.T, wfts *wfv1.WorkflowTaskSet) {
 			assert.NotNil(t, wfts)
-			assert.Len(t, wfts.Spec.Tasks, 0)
-			assert.Len(t, wfts.Status.Nodes, 0)
+			assert.Empty(t, wfts.Spec.Tasks)
+			assert.Empty(t, wfts.Status.Nodes)
 			assert.Equal(t, "true", wfts.Labels[common.LabelKeyCompleted])
 		})
 }

--- a/test/e2e/expr_lang.go
+++ b/test/e2e/expr_lang.go
@@ -50,7 +50,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".split")

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -127,7 +127,7 @@ func (s *FunctionalSuite) TestJSONVariables() {
 		ExpectWorkflowNode(wfv1.SucceededPodNode, func(t *testing.T, n *wfv1.NodeStatus, p *apiv1.Pod) {
 			for _, c := range p.Spec.Containers {
 				if c.Name == "main" {
-					assert.Equal(t, 3, len(c.Args))
+					assert.Len(t, c.Args, 3)
 					assert.Equal(t, "myLabelValue", c.Args[0])
 					assert.Equal(t, "myAnnotationValue", c.Args[1])
 					assert.Equal(t, "myParamValue", c.Args[2])
@@ -338,7 +338,7 @@ func (s *FunctionalSuite) TestEventOnNodeFail() {
 					case "WorkflowRunning":
 					case "WorkflowNodeFailed":
 						assert.Contains(t, e.Message, "Failed node failed-step-event-")
-						assert.Equal(t, e.Annotations["workflows.argoproj.io/node-type"], "Pod")
+						assert.Equal(t, "Pod", e.Annotations["workflows.argoproj.io/node-type"])
 						assert.Contains(t, e.Annotations["workflows.argoproj.io/node-name"], "failed-step-event-")
 					case "WorkflowFailed":
 						assert.Contains(t, e.Message, "exit code 1")
@@ -742,7 +742,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflowNode(wfv1.FailedPodNode, func(t *testing.T, n *wfv1.NodeStatus, p *apiv1.Pod) {
-			assert.Equal(t, *p.Spec.ActiveDeadlineSeconds, int64(5))
+			assert.Equal(t, int64(5), *p.Spec.ActiveDeadlineSeconds)
 		})
 }
 
@@ -883,12 +883,12 @@ spec:
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflowNode(wfv1.SucceededPodNode, func(t *testing.T, n *wfv1.NodeStatus, p *apiv1.Pod) {
-			assert.Equal(t, *p.Spec.TerminationGracePeriodSeconds, int64(5))
+			assert.Equal(t, int64(5), *p.Spec.TerminationGracePeriodSeconds)
 			for _, c := range p.Spec.Containers {
 				if c.Name == "main" {
-					assert.Equal(t, c.Resources.Limits.Cpu().String(), "100m")
+					assert.Equal(t, "100m", c.Resources.Limits.Cpu().String())
 				} else if c.Name == "wait" {
-					assert.Equal(t, c.Resources.Limits.Cpu().String(), "101m")
+					assert.Equal(t, "101m", c.Resources.Limits.Cpu().String())
 				}
 			}
 		})
@@ -1344,7 +1344,7 @@ func (s *FunctionalSuite) TestMissingStepsInUI() {
 		ExpectWorkflowNode(wfv1.NodeWithName(`missing-steps[0].step1[0].execute-script`), func(t *testing.T, n *wfv1.NodeStatus, _ *apiv1.Pod) {
 			assert.NotNil(t, n)
 			assert.NotNil(t, n.Children)
-			assert.Equal(t, 1, len(n.Children))
+			assert.Len(t, n.Children, 1)
 		})
 }
 
@@ -1374,9 +1374,9 @@ func (s *FunctionalSuite) TestTerminateWorkflowWhileOnExitHandlerRunning() {
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			for _, node := range status.Nodes {
 				if node.Type == wfv1.NodeTypeStepGroup || node.Type == wfv1.NodeTypeSteps {
-					assert.Equal(t, node.Phase, wfv1.NodeFailed)
+					assert.Equal(t, wfv1.NodeFailed, node.Phase)
 				}
 			}
-			assert.Equal(t, status.Phase, wfv1.WorkflowFailed)
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 		})
 }

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -51,7 +51,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 		return strings.Contains(status.Name, ".hooks.running")
 	}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
@@ -101,7 +101,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowFailed)
+			assert.Equal(t, v1alpha1.WorkflowFailed, status.Phase)
 		}).ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 		return strings.Contains(status.Name, ".hooks.running")
 	}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
@@ -453,7 +453,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 			assert.Equal(t, status.Progress, v1alpha1.Progress("2/2"))
 			assert.Equal(t, 1, int(status.Progress.N()/status.Progress.M()))
 		}).
@@ -501,7 +501,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 			assert.Equal(t, status.Progress, v1alpha1.Progress("2/2"))
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
@@ -554,7 +554,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 			assert.Equal(t, status.Progress, v1alpha1.Progress("3/3"))
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
@@ -609,22 +609,22 @@ spec:
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowFailed)
+			assert.Equal(t, v1alpha1.WorkflowFailed, status.Phase)
 			assert.Equal(t, status.Progress, v1alpha1.Progress("2/4"))
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "test-workflow-level-hooks-with-retry.hooks.running"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
-			assert.Equal(t, true, status.NodeFlag.Hooked)
-			assert.Equal(t, false, status.NodeFlag.Retried)
+			assert.True(t, status.NodeFlag.Hooked)
+			assert.False(t, status.NodeFlag.Retried)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "test-workflow-level-hooks-with-retry.hooks.failed"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
-			assert.Equal(t, true, status.NodeFlag.Hooked)
-			assert.Equal(t, false, status.NodeFlag.Retried)
+			assert.True(t, status.NodeFlag.Hooked)
+			assert.False(t, status.NodeFlag.Retried)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "test-workflow-level-hooks-with-retry"
@@ -637,15 +637,15 @@ spec:
 			return status.Name == "test-workflow-level-hooks-with-retry(0)"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeFailed, status.Phase)
-			assert.Equal(t, false, status.NodeFlag.Hooked)
-			assert.Equal(t, true, status.NodeFlag.Retried)
+			assert.False(t, status.NodeFlag.Hooked)
+			assert.True(t, status.NodeFlag.Retried)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "test-workflow-level-hooks-with-retry(1)"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeFailed, status.Phase)
-			assert.Equal(t, false, status.NodeFlag.Hooked)
-			assert.Equal(t, true, status.NodeFlag.Retried)
+			assert.False(t, status.NodeFlag.Hooked)
+			assert.True(t, status.NodeFlag.Retried)
 		})
 }
 
@@ -753,20 +753,20 @@ spec:
 			return status.Name == "retries-with-hooks-and-artifact[0].build(0)"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Contains(t, children, status.ID)
-			assert.Equal(t, false, status.NodeFlag.Hooked)
+			assert.False(t, status.NodeFlag.Hooked)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "retries-with-hooks-and-artifact[0].build.hooks.started"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Contains(t, children, status.ID)
-			assert.Equal(t, true, status.NodeFlag.Hooked)
+			assert.True(t, status.NodeFlag.Hooked)
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
 		})).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "retries-with-hooks-and-artifact[0].build.hooks.success"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Contains(t, children, status.ID)
-			assert.Equal(t, true, status.NodeFlag.Hooked)
+			assert.True(t, status.NodeFlag.Hooked)
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -63,7 +63,7 @@ spec:
 			return status.Name == "test-retry-limit(0)"
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeFailed, status.Phase)
-			assert.Equal(t, true, status.NodeFlag.Retried)
+			assert.True(t, status.NodeFlag.Retried)
 		})
 }
 
@@ -140,7 +140,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, wfv1.WorkflowFailed)
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.Name == "workflow-template-containerset"
@@ -153,43 +153,43 @@ spec:
 		ctx := context.Background()
 		podLogOptions := &apiv1.PodLogOptions{Container: "c1"}
 		stream, err := s.KubeClient.CoreV1().Pods(ns).GetLogs(name, podLogOptions).Stream(ctx)
-		assert.Nil(s.T(), err)
+		s.NoError(err)
 		defer stream.Close()
 		logBytes, err := io.ReadAll(stream)
-		assert.Nil(s.T(), err)
+		s.NoError(err)
 		output := string(logBytes)
 		count := strings.Count(output, "capturing logs")
-		assert.Equal(s.T(), 1, count)
-		assert.Contains(s.T(), output, "hi")
+		s.Equal(1, count)
+		s.Contains(output, "hi")
 	})
 	// Command err. No retry logic is entered.
 	s.Run("ContainerLogs", func() {
 		ctx := context.Background()
 		podLogOptions := &apiv1.PodLogOptions{Container: "c2"}
 		stream, err := s.KubeClient.CoreV1().Pods(ns).GetLogs(name, podLogOptions).Stream(ctx)
-		assert.Nil(s.T(), err)
+		s.NoError(err)
 		defer stream.Close()
 		logBytes, err := io.ReadAll(stream)
-		assert.Nil(s.T(), err)
+		s.NoError(err)
 		output := string(logBytes)
 		count := strings.Count(output, "capturing logs")
-		assert.Equal(s.T(), 0, count)
-		assert.Contains(s.T(), output, "executable file not found in $PATH")
+		s.Equal(0, count)
+		s.Contains(output, "executable file not found in $PATH")
 	})
 	// Retry when err.
 	s.Run("ContainerLogs", func() {
 		ctx := context.Background()
 		podLogOptions := &apiv1.PodLogOptions{Container: "c3"}
 		stream, err := s.KubeClient.CoreV1().Pods(ns).GetLogs(name, podLogOptions).Stream(ctx)
-		assert.Nil(s.T(), err)
+		s.NoError(err)
 		defer stream.Close()
 		logBytes, err := io.ReadAll(stream)
-		assert.Nil(s.T(), err)
+		s.NoError(err)
 		output := string(logBytes)
 		count := strings.Count(output, "capturing logs")
-		assert.Equal(s.T(), 2, count)
+		s.Equal(2, count)
 		countFailureInfo := strings.Count(output, "intentional failure")
-		assert.Equal(s.T(), 2, countFailureInfo)
+		s.Equal(2, countFailureInfo)
 	})
 }
 

--- a/test/e2e/workflow_template_test.go
+++ b/test/e2e/workflow_template_test.go
@@ -48,7 +48,7 @@ spec:
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		})
 }
 
@@ -61,7 +61,7 @@ func (s *WorkflowTemplateSuite) TestSubmitWorkflowTemplateWithEnum() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		})
 }
 
@@ -74,7 +74,7 @@ func (s *WorkflowTemplateSuite) TestSubmitWorkflowTemplateWorkflowMetadataSubsti
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		})
 }
 
@@ -87,7 +87,7 @@ func (s *WorkflowTemplateSuite) TestSubmitWorkflowTemplateResourceUnquotedExpres
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		})
 }
 
@@ -100,7 +100,7 @@ func (s *WorkflowTemplateSuite) TestSubmitWorkflowTemplateWithParallelStepsRequi
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
 		ExpectPVCDeleted()
 }
@@ -121,7 +121,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeErrored).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowError)
+			assert.Equal(t, v1alpha1.WorkflowError, status.Phase)
 			assert.Contains(t, status.Message, "error in exit template execution")
 		}).
 		ExpectPVCDeleted()
@@ -143,7 +143,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowSucceeded)
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return strings.Contains(status.Name, "hooks.running")
@@ -173,7 +173,7 @@ spec:
 		WaitForWorkflow(fixtures.ToBeErrored).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowError)
+			assert.Equal(t, v1alpha1.WorkflowError, status.Phase)
 			assert.Contains(t, status.Message, "error in entry template execution")
 		}).
 		ExpectPVCDeleted()

--- a/util/slice/slice_test.go
+++ b/util/slice/slice_test.go
@@ -10,42 +10,42 @@ func TestRemoveString(t *testing.T) {
 	t.Run("RemoveEmpty", func(t *testing.T) {
 		slice := []string{}
 		newSlice := RemoveString(slice, "1")
-		assert.Equal(t, 0, len(newSlice))
+		assert.Empty(t, newSlice)
 		assert.NotContains(t, newSlice, "1")
 	})
 
 	t.Run("RemoveSingle", func(t *testing.T) {
 		slice := []string{"1"}
 		newSlice := RemoveString(slice, "3")
-		assert.Equal(t, 1, len(newSlice))
+		assert.Len(t, newSlice, 1)
 		assert.Contains(t, newSlice, "1")
 	})
 
 	t.Run("RemoveSingleWithMatch", func(t *testing.T) {
 		slice := []string{"1"}
 		newSlice := RemoveString(slice, "1")
-		assert.Equal(t, 0, len(newSlice))
+		assert.Empty(t, newSlice)
 		assert.NotContains(t, newSlice, "1")
 	})
 
 	t.Run("RemoveFirst", func(t *testing.T) {
 		slice := []string{"1", "2", "3", "4", "5", "6"}
 		newSlice := RemoveString(slice, "1")
-		assert.Equal(t, 5, len(newSlice))
+		assert.Len(t, newSlice, 5)
 		assert.NotContains(t, newSlice, "1")
 	})
 
 	t.Run("RemoveMiddle", func(t *testing.T) {
 		slice := []string{"1", "2", "3", "4", "5", "6"}
 		newSlice := RemoveString(slice, "3")
-		assert.Equal(t, 5, len(newSlice))
+		assert.Len(t, newSlice, 5)
 		assert.NotContains(t, newSlice, "3")
 	})
 
 	t.Run("RemoveLast", func(t *testing.T) {
 		slice := []string{"1", "2", "3", "4", "5", "6"}
 		newSlice := RemoveString(slice, "6")
-		assert.Equal(t, 5, len(newSlice))
+		assert.Len(t, newSlice, 5)
 		assert.NotContains(t, newSlice, "6")
 	})
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -62,7 +62,7 @@ func TestRecoverWorkflowNameFromSelectorString(t *testing.T) {
 		})
 	}
 	name := RecoverWorkflowNameFromSelectorStringIfAny("whatever=whalesay")
-	assert.Equal(t, name, "")
+	assert.Equal(t, "", name)
 	assert.NotPanics(t, func() {
 		_ = RecoverWorkflowNameFromSelectorStringIfAny("whatever")
 	})

--- a/workflow/artifacts/common/load_to_stream_test.go
+++ b/workflow/artifacts/common/load_to_stream_test.go
@@ -87,7 +87,7 @@ func TestLoadToStream(t *testing.T) {
 
 			stream, err := LoadToStream(&wfv1.Artifact{}, tc.artifactDriver)
 			if tc.errMsg == "" {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, stream)
 				stream.Close()
 
@@ -98,7 +98,7 @@ func TestLoadToStream(t *testing.T) {
 				}
 				assert.Equal(t, len(filesBefore), len(filesAfter))
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Equal(t, tc.errMsg, err.Error())
 			}
 		})

--- a/workflow/artifacts/http/http_test.go
+++ b/workflow/artifacts/http/http_test.go
@@ -129,7 +129,7 @@ func TestSaveHTTPArtifactRedirect(t *testing.T) {
 			},
 		}
 		err := driver.Save(tempFile, &art)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 }

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -229,10 +229,10 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 				},
 			})
 			if tc.errMsg == "" {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, stream)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Equal(t, tc.errMsg, err.Error())
 			}
 		})
@@ -396,7 +396,7 @@ func TestLoadS3Artifact(t *testing.T) {
 			if err != nil {
 				assert.Equal(t, tc.errMsg, err.Error())
 			} else {
-				assert.Equal(t, tc.errMsg, "")
+				assert.Equal(t, "", tc.errMsg)
 			}
 		})
 	}
@@ -530,7 +530,7 @@ func TestSaveS3Artifact(t *testing.T) {
 			if err != nil {
 				assert.Equal(t, tc.errMsg, err.Error())
 			} else {
-				assert.Equal(t, tc.errMsg, "")
+				assert.Equal(t, "", tc.errMsg)
 			}
 		})
 	}
@@ -606,10 +606,10 @@ func TestListObjects(t *testing.T) {
 					},
 				})
 			if tc.expectedSuccess {
-				assert.Nil(t, err)
-				assert.Equal(t, tc.expectedNumFiles, len(files))
+				assert.NoError(t, err)
+				assert.Len(t, files, tc.expectedNumFiles)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Equal(t, tc.expectedErrMsg, err.Error())
 			}
 		})

--- a/workflow/common/convert_test.go
+++ b/workflow/common/convert_test.go
@@ -109,7 +109,7 @@ spec:
 	assert.NoError(t, err)
 	wf = ConvertCronWorkflowToWorkflow(&cronWf)
 	if assert.Contains(t, wf.GetLabels(), LabelKeyControllerInstanceID) {
-		assert.Equal(t, wf.GetLabels()[LabelKeyControllerInstanceID], "test-controller")
+		assert.Equal(t, "test-controller", wf.GetLabels()[LabelKeyControllerInstanceID])
 	}
 
 	err = yaml.Unmarshal([]byte(cronWfInstanceIdString), &cronWf)

--- a/workflow/common/placeholder_test.go
+++ b/workflow/common/placeholder_test.go
@@ -9,7 +9,7 @@ import (
 // TestNextPlaceholder verifies dynamically-generated placeholder strings.
 func TestNextPlaceholder(t *testing.T) {
 	pg := NewPlaceholderGenerator()
-	assert.Equal(t, pg.NextPlaceholder(), "placeholder-0")
-	assert.Equal(t, pg.NextPlaceholder(), "placeholder-1")
-	assert.Equal(t, pg.NextPlaceholder(), "placeholder-2")
+	assert.Equal(t, "placeholder-0", pg.NextPlaceholder())
+	assert.Equal(t, "placeholder-1", pg.NextPlaceholder())
+	assert.Equal(t, "placeholder-2", pg.NextPlaceholder())
 }

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -147,10 +147,10 @@ func TestUnknownFieldEnforcerForWorkflowStep(t *testing.T) {
 }
 
 func TestParseObjects(t *testing.T) {
-	assert.Equal(t, 1, len(ParseObjects([]byte(validWf), false)))
+	assert.Len(t, ParseObjects([]byte(validWf), false), 1)
 
 	res := ParseObjects([]byte(invalidWf), false)
-	assert.Equal(t, 1, len(res))
+	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0].Object)
 	assert.EqualError(t, res[0].Err, "json: unknown field \"doesNotExist\"")
 
@@ -194,7 +194,7 @@ func TestIsDone(t *testing.T) {
 
 func TestSubstituteConfigMapKeyRefParam(t *testing.T) {
 	res := ParseObjects([]byte(validConfigMapRefWf), false)
-	assert.Equal(t, 1, len(res))
+	assert.Len(t, res, 1)
 
 	obj, ok := res[0].Object.(*wfv1.Workflow)
 	assert.True(t, ok)
@@ -216,7 +216,7 @@ func TestSubstituteConfigMapKeyRefParam(t *testing.T) {
 
 func TestSubstituteConfigMapKeyRefParamWithNoParamsDefined(t *testing.T) {
 	res := ParseObjects([]byte(invalidConfigMapRefWf), false)
-	assert.Equal(t, 1, len(res))
+	assert.Len(t, res, 1)
 
 	obj, ok := res[0].Object.(*wfv1.Workflow)
 	assert.True(t, ok)
@@ -262,13 +262,13 @@ func TestOverridableDefaultInputArts(t *testing.T) {
 	localParams := make(map[string]string)
 
 	newTmpl, err := ProcessArgs(&tmpl, &inputs, globalParams, localParams, false, "", nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Artifacts[0].Raw.Data, rawArt.Data)
 
 	inputs.Artifacts = []wfv1.Artifact{inputArt}
 	newTmpl, err = ProcessArgs(&tmpl, &inputs, globalParams, localParams, false, "", nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Artifacts[0].Raw.Data, inputRawArt.Data)
 }
@@ -313,12 +313,12 @@ func TestOverridableTemplateInputParamsValue(t *testing.T) {
 	localParams := make(map[string]string)
 
 	newTmpl, err := ProcessArgs(&tmpl, &valueArgs, globalParams, localParams, false, "", configMapStore)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), valueArgs.Parameters[0].Value.String())
 
 	newTmpl, err = ProcessArgs(&tmpl, &valueFromArgs, globalParams, localParams, false, "", configMapStore)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), overrideConfigMapValue)
 }
@@ -371,12 +371,12 @@ func TestOverridableTemplateInputParamsValueFrom(t *testing.T) {
 	localParams := make(map[string]string)
 
 	newTmpl, err := ProcessArgs(&tmpl, &valueArgs, globalParams, localParams, false, "", configMapStore)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), valueArgs.Parameters[0].Value.String())
 
 	newTmpl, err = ProcessArgs(&tmpl, &valueFromArgs, globalParams, localParams, false, "", configMapStore)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), overrideConfigMapValue)
 }

--- a/workflow/controller/artifact_gc_test.go
+++ b/workflow/controller/artifact_gc_test.go
@@ -348,7 +348,7 @@ func TestProcessArtifactGCStrategy(t *testing.T) {
 	woc.wf.Status.ArtifactGCStatus = &wfv1.ArtGCStatus{}
 
 	err := woc.processArtifactGCStrategy(ctx, wfv1.ArtifactGCOnWorkflowCompletion)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	wfatcs := controller.wfclientset.ArgoprojV1alpha1().WorkflowArtifactGCTasks(woc.wf.GetNamespace())
 	podcs := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace())
@@ -368,7 +368,7 @@ func TestProcessArtifactGCStrategy(t *testing.T) {
 	// and it should only consist of artifacts labeled with OnWorkflowCompletion
 
 	assert.NotNil(t, pods)
-	assert.Equal(t, 2, len((*pods).Items))
+	assert.Len(t, (*pods).Items, 2)
 	var pod1 *corev1.Pod
 	var pod2 *corev1.Pod
 	for i, pod := range (*pods).Items {
@@ -390,7 +390,7 @@ func TestProcessArtifactGCStrategy(t *testing.T) {
 	//  verify ServiceAccount and Annotations
 	//  verify that the right volume mounts get created
 	//  verify patched pod spec
-	assert.Equal(t, pod1.Spec.ServiceAccountName, "default")
+	assert.Equal(t, "default", pod1.Spec.ServiceAccountName)
 	assert.Contains(t, pod1.Annotations, "annotation-key-1")
 	assert.Equal(t, "annotation-value-1", pod1.Annotations["annotation-key-1"])
 	volumesMap1 := make(map[string]struct{})
@@ -400,7 +400,7 @@ func TestProcessArtifactGCStrategy(t *testing.T) {
 	assert.Contains(t, volumesMap1, "my-minio-cred-1")
 	assert.Contains(t, volumesMap1, "my-minio-cred-2")
 
-	assert.Equal(t, pod2.Spec.ServiceAccountName, "default")
+	assert.Equal(t, "default", pod2.Spec.ServiceAccountName)
 	assert.Contains(t, pod2.Annotations, "annotation-key-1")
 	assert.Equal(t, "annotation-value-3", pod2.Annotations["annotation-key-1"])
 	volumesMap2 := make(map[string]struct{})
@@ -422,7 +422,7 @@ func TestProcessArtifactGCStrategy(t *testing.T) {
 	// We should have on WFAT per Pod (for now until we implement the capability to have multiple)
 
 	assert.NotNil(t, wfats)
-	assert.Equal(t, 2, len((*wfats).Items))
+	assert.Len(t, (*wfats).Items, 2)
 
 	var wfat1 *wfv1.WorkflowArtifactGCTask
 	var wfat2 *wfv1.WorkflowArtifactGCTask
@@ -571,7 +571,7 @@ func TestProcessCompletedWorkflowArtifactGCTask(t *testing.T) {
 	// - Conditions
 
 	_, err := woc.processCompletedWorkflowArtifactGCTask(wfat, "OnWorkflowCompletion")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	for _, expectedArtifact := range []struct {
 		nodeName     string
@@ -715,7 +715,7 @@ func TestWorkflowHasArtifactGC(t *testing.T) {
 
 			hasArtifact := woc.HasArtifactGC()
 
-			assert.Equal(t, hasArtifact, tt.expectedResult)
+			assert.Equal(t, tt.expectedResult, hasArtifact)
 		})
 	}
 

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -577,7 +577,7 @@ func TestAddingWorkflowDefaultValueIfValueNotExist(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, defaultWorkflowSpec.Spec.HostNetwork, &ans)
 		assert.NotEqual(t, defaultWorkflowSpec, wfv1.MustUnmarshalWorkflow(helloWorldWf))
-		assert.Equal(t, *defaultWorkflowSpec.Spec.HostNetwork, true)
+		assert.True(t, *defaultWorkflowSpec.Spec.HostNetwork)
 	})
 }
 
@@ -586,14 +586,14 @@ func TestAddingWorkflowDefaultComplex(t *testing.T) {
 	defer cancel()
 	workflow := wfv1.MustUnmarshalWorkflow(testDefaultWf)
 	var ten int32 = 10
-	assert.Equal(t, workflow.Spec.Entrypoint, "whalesay")
+	assert.Equal(t, "whalesay", workflow.Spec.Entrypoint)
 	assert.Nil(t, workflow.Spec.TTLStrategy)
 	assert.Contains(t, workflow.Labels, "foo")
 	err := controller.setWorkflowDefaults(workflow)
 	assert.NoError(t, err)
 	assert.NotEqual(t, workflow, wfv1.MustUnmarshalWorkflow(testDefaultWf))
-	assert.Equal(t, workflow.Spec.Entrypoint, "whalesay")
-	assert.Equal(t, workflow.Spec.ServiceAccountName, "whalesay")
+	assert.Equal(t, "whalesay", workflow.Spec.Entrypoint)
+	assert.Equal(t, "whalesay", workflow.Spec.ServiceAccountName)
 	assert.Equal(t, *workflow.Spec.TTLStrategy.SecondsAfterFailure, ten)
 	assert.Contains(t, workflow.Labels, "foo")
 	assert.Contains(t, workflow.Labels, "label")
@@ -609,8 +609,8 @@ func TestAddingWorkflowDefaultComplexTwo(t *testing.T) {
 	err := controller.setWorkflowDefaults(workflow)
 	assert.NoError(t, err)
 	assert.NotEqual(t, workflow, wfv1.MustUnmarshalWorkflow(testDefaultWfTTL))
-	assert.Equal(t, workflow.Spec.Entrypoint, "whalesay")
-	assert.Equal(t, workflow.Spec.ServiceAccountName, "whalesay")
+	assert.Equal(t, "whalesay", workflow.Spec.Entrypoint)
+	assert.Equal(t, "whalesay", workflow.Spec.ServiceAccountName)
 	assert.Equal(t, *workflow.Spec.TTLStrategy.SecondsAfterCompletion, five)
 	assert.Equal(t, *workflow.Spec.TTLStrategy.SecondsAfterFailure, ten)
 	assert.NotContains(t, workflow.Labels, "foo")
@@ -835,7 +835,7 @@ func TestInvalidWorkflowMetadata(t *testing.T) {
 	defer cancel()
 	woc := newWorkflowOperationCtx(wf, controller)
 	err := woc.setExecWorkflow(context.Background())
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "invalid label value")
 	}
 
@@ -844,7 +844,7 @@ func TestInvalidWorkflowMetadata(t *testing.T) {
 	defer cancel()
 	woc = newWorkflowOperationCtx(wf, controller)
 	err = woc.setExecWorkflow(context.Background())
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "invalid label value")
 	}
 }
@@ -1176,7 +1176,7 @@ spec:
 	assert.Equal(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
 	pods, err := listPods(woc)
 	assert.NoError(t, err)
-	assert.Len(t, pods.Items, 0)
+	assert.Empty(t, pods.Items)
 }
 
 func TestPendingPodWhenTerminate(t *testing.T) {
@@ -1230,13 +1230,13 @@ func TestWorkflowWithLongArguments(t *testing.T) {
 
 	cms, err := controller.kubeclientset.CoreV1().ConfigMaps(woc.wf.ObjectMeta.Namespace).List(ctx, metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + woc.wf.ObjectMeta.Name})
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(cms.Items))
+	assert.Len(t, cms.Items, 1)
 	assert.Contains(t, cms.Items[0].Data, common.EnvVarTemplate)
 
 	podcs := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace())
 	pods, err := podcs.List(ctx, metav1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(pods.Items))
+	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
 	found := false
 	for _, vol := range pod.Spec.Volumes {

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -104,9 +104,9 @@ func TestSingleDependency(t *testing.T) {
 
 		ctx := context.Background()
 		wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		woc := newWorkflowOperationCtx(wf, controller)
 
 		woc.operate(ctx)

--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -751,7 +751,7 @@ func TestWorkflowOnExitHttpReconciliation(t *testing.T) {
 
 	taskSets, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets("").List(ctx, v1.ListOptions{})
 	if assert.NoError(t, err) {
-		assert.Len(t, taskSets.Items, 0)
+		assert.Empty(t, taskSets.Items)
 	}
 	woc.operate(ctx)
 
@@ -853,7 +853,7 @@ func TestWorkflowOnExitStepsHttpReconciliation(t *testing.T) {
 
 	taskSets, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets("").List(ctx, v1.ListOptions{})
 	if assert.NoError(t, err) {
-		assert.Len(t, taskSets.Items, 0)
+		assert.Empty(t, taskSets.Items)
 	}
 
 	woc.operate(ctx)
@@ -998,10 +998,10 @@ status:
 
 	taskSets, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets("").List(ctx, v1.ListOptions{})
 	if assert.NoError(t, err) {
-		assert.Len(t, taskSets.Items, 0)
+		assert.Empty(t, taskSets.Items)
 	}
 	woc.operate(ctx)
-	assert.Equal(t, woc.wf.Status.Phase, wfv1.WorkflowRunning)
+	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 }
 
 func TestStepsTemplateOnExitStatusArgument(t *testing.T) {

--- a/workflow/controller/inline_test.go
+++ b/workflow/controller/inline_test.go
@@ -167,8 +167,8 @@ func TestCallTemplateWithInlineSteps(t *testing.T) {
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
 	pods, err := listPods(woc)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(pods.Items))
+	assert.NoError(t, err)
+	assert.Len(t, pods.Items, 4)
 	count := 0
 	for _, pod := range pods.Items {
 		nodeName := pod.Annotations["workflows.argoproj.io/node-name"]
@@ -183,10 +183,10 @@ func TestCallTemplateWithInlineSteps(t *testing.T) {
 	assert.Equal(t, 2, count)
 	for name, storedTemplate := range woc.wf.Status.StoredTemplates {
 		if strings.Contains(name, "inline-a") {
-			assert.Equal(t, storedTemplate.Container.Args[0], "{{ inputs.parameters.arg }} a")
+			assert.Equal(t, "{{ inputs.parameters.arg }} a", storedTemplate.Container.Args[0])
 		}
 		if strings.Contains(name, "inline-b") {
-			assert.Equal(t, storedTemplate.Container.Args[0], "{{ inputs.parameters.arg }} b")
+			assert.Equal(t, "{{ inputs.parameters.arg }} b", storedTemplate.Container.Args[0])
 		}
 	}
 }
@@ -269,8 +269,8 @@ func TestCallTemplateWithInlineDAG(t *testing.T) {
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
 	pods, err := listPods(woc)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(pods.Items))
+	assert.NoError(t, err)
+	assert.Len(t, pods.Items, 4)
 	count := 0
 	for _, pod := range pods.Items {
 		nodeName := pod.Annotations["workflows.argoproj.io/node-name"]
@@ -285,10 +285,10 @@ func TestCallTemplateWithInlineDAG(t *testing.T) {
 	assert.Equal(t, 2, count)
 	for name, storedTemplate := range woc.wf.Status.StoredTemplates {
 		if strings.Contains(name, "inline-a") {
-			assert.Equal(t, storedTemplate.Container.Args[0], "{{ inputs.parameters.arg }} a")
+			assert.Equal(t, "{{ inputs.parameters.arg }} a", storedTemplate.Container.Args[0])
 		}
 		if strings.Contains(name, "inline-b") {
-			assert.Equal(t, storedTemplate.Container.Args[0], "{{ inputs.parameters.arg }} b")
+			assert.Equal(t, "{{ inputs.parameters.arg }} b", storedTemplate.Container.Args[0])
 		}
 	}
 }

--- a/workflow/controller/operator_agent_test.go
+++ b/workflow/controller/operator_agent_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -47,7 +46,7 @@ func TestHTTPTemplate(t *testing.T) {
 		pod.Status.Phase = v1.PodFailed
 		pod.Status.Message = "manual termination"
 		pod, err = controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, v1.PodFailed, pod.Status.Phase)
 		// sleep 1 second to wait for informer getting pod info
 		time.Sleep(time.Second)
@@ -75,7 +74,7 @@ func TestHTTPTemplateWithoutServiceAccount(t *testing.T) {
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		_, err := controller.kubeclientset.CoreV1().Pods(woc.wf.Namespace).Get(ctx, woc.getAgentPodName(), metav1.GetOptions{})
-		assert.Error(t, err, fmt.Sprintf(`pods "%s" not found`, woc.getAgentPodName()))
+		assert.Error(t, err, `pods "%s" not found`, woc.getAgentPodName())
 		ts, err := controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets(wf.Namespace).Get(ctx, "hello-world", metav1.GetOptions{})
 		assert.NoError(t, err)
 		assert.NotNil(t, ts)

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -180,7 +180,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 		woc.operate(ctx)
 		assert.NotNil(t, woc.wf.Status.Synchronization)
 		assert.NotNil(t, woc.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc.wf.Status.Synchronization.Semaphore.Holding, 1)
 
 		for _, node := range woc.wf.Status.Nodes {
 			assert.Equal(t, wfv1.NodePending, node.Phase)
@@ -215,7 +215,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 		woc_two.operate(ctx)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc_two.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc_two.wf.Status.Synchronization.Semaphore.Holding, 1)
 	})
 }
 
@@ -241,7 +241,7 @@ func TestSemaphoreScriptTmplLevel(t *testing.T) {
 		woc.operate(ctx)
 		assert.NotNil(t, woc.wf.Status.Synchronization)
 		assert.NotNil(t, woc.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc.wf.Status.Synchronization.Semaphore.Holding, 1)
 
 		for _, node := range woc.wf.Status.Nodes {
 			assert.Equal(t, wfv1.NodePending, node.Phase)
@@ -275,7 +275,7 @@ func TestSemaphoreScriptTmplLevel(t *testing.T) {
 		woc_two.operate(ctx)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc_two.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc_two.wf.Status.Synchronization.Semaphore.Holding, 1)
 	})
 }
 
@@ -302,7 +302,7 @@ func TestSemaphoreScriptConfigMapInDifferentNamespace(t *testing.T) {
 		woc.operate(ctx)
 		assert.NotNil(t, woc.wf.Status.Synchronization)
 		assert.NotNil(t, woc.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc.wf.Status.Synchronization.Semaphore.Holding, 1)
 
 		for _, node := range woc.wf.Status.Nodes {
 			assert.Equal(t, wfv1.NodePending, node.Phase)
@@ -337,7 +337,7 @@ func TestSemaphoreScriptConfigMapInDifferentNamespace(t *testing.T) {
 		woc_two.operate(ctx)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc_two.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc_two.wf.Status.Synchronization.Semaphore.Holding, 1)
 	})
 }
 
@@ -363,7 +363,7 @@ func TestSemaphoreResourceTmplLevel(t *testing.T) {
 		woc.operate(ctx)
 		assert.NotNil(t, woc.wf.Status.Synchronization)
 		assert.NotNil(t, woc.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc.wf.Status.Synchronization.Semaphore.Holding, 1)
 
 		for _, node := range woc.wf.Status.Nodes {
 			assert.Equal(t, wfv1.NodePending, node.Phase)
@@ -398,7 +398,7 @@ func TestSemaphoreResourceTmplLevel(t *testing.T) {
 		woc_two.operate(ctx)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization)
 		assert.NotNil(t, woc_two.wf.Status.Synchronization.Semaphore)
-		assert.Equal(t, 1, len(woc_two.wf.Status.Synchronization.Semaphore.Holding))
+		assert.Len(t, woc_two.wf.Status.Synchronization.Semaphore.Holding, 1)
 	})
 }
 
@@ -901,7 +901,7 @@ func TestSynchronizationWithStepRetry(t *testing.T) {
 		woc.operate(ctx)
 		for _, n := range woc.wf.Status.Nodes {
 			if n.Name == "[0].step1(0)" {
-				assert.Equal(n.Phase, wfv1.NodePending)
+				assert.Equal(wfv1.NodePending, n.Phase)
 			}
 		}
 		// Updating Pod state
@@ -910,17 +910,17 @@ func TestSynchronizationWithStepRetry(t *testing.T) {
 		woc.operate(ctx)
 		for _, n := range woc.wf.Status.Nodes {
 			if n.Name == "[0].step1(0)" {
-				assert.Equal(n.Phase, wfv1.NodeRunning)
+				assert.Equal(wfv1.NodeRunning, n.Phase)
 			}
 		}
 		makePodsPhase(ctx, woc, apiv1.PodFailed)
 		woc.operate(ctx)
 		for _, n := range woc.wf.Status.Nodes {
 			if n.Name == "[0].step1(0)" {
-				assert.Equal(n.Phase, wfv1.NodeFailed)
+				assert.Equal(wfv1.NodeFailed, n.Phase)
 			}
 			if n.Name == "[0].step1(1)" {
-				assert.Equal(n.Phase, wfv1.NodePending)
+				assert.Equal(wfv1.NodePending, n.Phase)
 			}
 		}
 	})
@@ -963,7 +963,7 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		woc.operate(ctx)
 		assert.NotNil(t, woc.wf.Status.Synchronization)
 		assert.NotNil(t, woc.wf.Status.Synchronization.Mutex)
-		assert.Equal(t, 1, len(woc.wf.Status.Synchronization.Mutex.Holding))
+		assert.Len(t, woc.wf.Status.Synchronization.Mutex.Holding, 1)
 
 		// Create the second workflow and try to acquire the lock, which should not be available.
 		wfTwo := wf.DeepCopy()
@@ -1007,7 +1007,7 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		woc.operate(ctx)
 		assert.NotNil(t, woc.wf.Status.Synchronization)
 		assert.NotNil(t, woc.wf.Status.Synchronization.Mutex)
-		assert.Equal(t, 1, len(woc.wf.Status.Synchronization.Mutex.Holding))
+		assert.Len(t, woc.wf.Status.Synchronization.Mutex.Holding, 1)
 
 		// Create the second workflow and try to acquire the lock, which should not be available.
 		wfTwo := wf.DeepCopy()
@@ -1036,7 +1036,7 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		assert.Equal(t, wfv1.WorkflowPending, wocTwo.execWf.Status.Phase)
 		assert.NotNil(t, wocTwo.wf.Status.Synchronization)
 		assert.NotNil(t, wocTwo.wf.Status.Synchronization.Mutex)
-		assert.Equal(t, 1, len(wocTwo.wf.Status.Synchronization.Mutex.Waiting))
+		assert.Len(t, wocTwo.wf.Status.Synchronization.Mutex.Waiting, 1)
 
 		// Mark the first workflow as succeeded
 		woc.wf.Status.Phase = wfv1.WorkflowSucceeded

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -531,7 +531,7 @@ func TestWFTWithVol(t *testing.T) {
 	woc.operate(ctx)
 	pvc, err = controller.kubeclientset.CoreV1().PersistentVolumeClaims("default").List(ctx, metav1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Len(t, pvc.Items, 0)
+	assert.Empty(t, pvc.Items)
 }
 
 const wfTmp = `
@@ -621,7 +621,7 @@ func TestWorkflowTemplateWithDynamicRef(t *testing.T) {
 	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 	pods, err := listPods(woc)
 	assert.NoError(t, err)
-	assert.True(t, len(pods.Items) > 0, "pod was not created successfully")
+	assert.NotEmpty(t, pods.Items, "pod was not created successfully")
 	pod := pods.Items[0]
 	assert.Contains(t, pod.Name, "hello-world")
 	assert.Equal(t, "docker/whalesay", pod.Spec.Containers[1].Image)

--- a/workflow/controller/taskset_test.go
+++ b/workflow/controller/taskset_test.go
@@ -305,8 +305,8 @@ status:
 			assert.NotNil(t, ts)
 			assert.Equal(t, ts.Name, wf.Name)
 			assert.Equal(t, ts.Namespace, wf.Namespace)
-			assert.Len(t, ts.Spec.Tasks, 0)
-			assert.Len(t, ts.Status.Nodes, 0)
+			assert.Empty(t, ts.Spec.Tasks)
+			assert.Empty(t, ts.Status.Nodes)
 		}
 
 	})

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -198,7 +198,7 @@ func TestWFLevelServiceAccount(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, pod.Spec.ServiceAccountName, "foo")
+	assert.Equal(t, "foo", pod.Spec.ServiceAccountName)
 }
 
 // TestTmplServiceAccount verifies the ability to carry forward the Template level service account name
@@ -218,7 +218,7 @@ func TestTmplServiceAccount(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, pod.Spec.ServiceAccountName, "tmpl")
+	assert.Equal(t, "tmpl", pod.Spec.ServiceAccountName)
 }
 
 // TestWFLevelAutomountServiceAccountToken verifies the ability to carry forward workflow level AutomountServiceAccountToken to Podspec.
@@ -240,7 +240,7 @@ func TestWFLevelAutomountServiceAccountToken(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, *pod.Spec.AutomountServiceAccountToken, false)
+	assert.False(t, *pod.Spec.AutomountServiceAccountToken)
 }
 
 // TestTmplLevelAutomountServiceAccountToken verifies the ability to carry forward template level AutomountServiceAccountToken to Podspec.
@@ -264,7 +264,7 @@ func TestTmplLevelAutomountServiceAccountToken(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, *pod.Spec.AutomountServiceAccountToken, false)
+	assert.False(t, *pod.Spec.AutomountServiceAccountToken)
 }
 
 // verifyServiceAccountTokenVolumeMount is a helper function to verify service account token volume in a container.
@@ -375,7 +375,7 @@ func TestImagePullSecrets(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, pod.Spec.ImagePullSecrets[0].Name, "secret-name")
+	assert.Equal(t, "secret-name", pod.Spec.ImagePullSecrets[0].Name)
 }
 
 // TestAffinity verifies the ability to carry forward affinity rules
@@ -433,7 +433,7 @@ func TestTolerations(t *testing.T) {
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
 	assert.NotNil(t, pod.Spec.Tolerations)
-	assert.Equal(t, pod.Spec.Tolerations[0].Key, "nvidia.com/gpu")
+	assert.Equal(t, "nvidia.com/gpu", pod.Spec.Tolerations[0].Key)
 }
 
 // TestMetadata verifies ability to carry forward annotations and labels
@@ -801,10 +801,10 @@ func TestVolumesPodSubstitution(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, 3, len(pod.Spec.Volumes))
+	assert.Len(t, pod.Spec.Volumes, 3)
 	assert.Equal(t, "volume-name", pod.Spec.Volumes[2].Name)
 	assert.Equal(t, "test-name", pod.Spec.Volumes[2].PersistentVolumeClaim.ClaimName)
-	assert.Equal(t, 2, len(pod.Spec.Containers[1].VolumeMounts))
+	assert.Len(t, pod.Spec.Containers[1].VolumeMounts, 2)
 	assert.Equal(t, "volume-name", pod.Spec.Containers[0].VolumeMounts[0].Name)
 }
 
@@ -889,7 +889,7 @@ func TestPriority(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, pod.Spec.PriorityClassName, "foo")
+	assert.Equal(t, "foo", pod.Spec.PriorityClassName)
 	assert.Equal(t, pod.Spec.Priority, &priority)
 }
 
@@ -906,7 +906,7 @@ func TestSchedulerName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, pod.Spec.SchedulerName, "foo")
+	assert.Equal(t, "foo", pod.Spec.SchedulerName)
 }
 
 // TestInitContainers verifies the ability to set up initContainers
@@ -961,13 +961,13 @@ func TestInitContainers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, 2, len(pod.Spec.InitContainers))
+	assert.Len(t, pod.Spec.InitContainers, 2)
 	foo := pod.Spec.InitContainers[1]
 	assert.Equal(t, "init-foo", foo.Name)
 	for _, v := range volumes {
 		assert.Contains(t, pod.Spec.Volumes, v)
 	}
-	assert.Equal(t, 3, len(foo.VolumeMounts))
+	assert.Len(t, foo.VolumeMounts, 3)
 	assert.Equal(t, "init-volume-name", foo.VolumeMounts[0].Name)
 	assert.Equal(t, "volume-name", foo.VolumeMounts[1].Name)
 	assert.Equal(t, "var-run-argo", foo.VolumeMounts[2].Name)
@@ -1026,14 +1026,14 @@ func TestSidecars(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
-	assert.Equal(t, 3, len(pod.Spec.Containers))
+	assert.Len(t, pod.Spec.Containers, 3)
 	assert.Equal(t, "wait", pod.Spec.Containers[0].Name)
 	assert.Equal(t, "main", pod.Spec.Containers[1].Name)
 	assert.Equal(t, "side-foo", pod.Spec.Containers[2].Name)
 	for _, v := range volumes {
 		assert.Contains(t, pod.Spec.Volumes, v)
 	}
-	assert.Equal(t, 3, len(pod.Spec.Containers[2].VolumeMounts))
+	assert.Len(t, pod.Spec.Containers[2].VolumeMounts, 3)
 	assert.Equal(t, "sidecar-volume-name", pod.Spec.Containers[2].VolumeMounts[0].Name)
 	assert.Equal(t, "volume-name", pod.Spec.Containers[2].VolumeMounts[1].Name)
 }
@@ -1437,7 +1437,7 @@ func TestPodSpecPatchPodName(t *testing.T) {
 		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 		pods, err := listPods(woc)
 		assert.NoError(t, err)
-		assert.True(t, len(pods.Items) > 0, "pod was not created successfully")
+		assert.NotEmpty(t, pods.Items, "pod was not created successfully")
 		template, err := getPodTemplate(&pods.Items[0])
 		assert.NoError(t, err)
 		parameterValue := template.Outputs.Parameters[0].Value
@@ -1596,12 +1596,12 @@ func TestWindowsUNCPathsAreRemoved(t *testing.T) {
 		assert.Errorf(t, err, "could not find wait ctr index")
 	}
 	for _, mnt := range pod.Spec.Containers[waitCtrIdx].VolumeMounts {
-		assert.NotEqual(t, mnt.Name, "unc")
+		assert.NotEqual(t, "unc", mnt.Name)
 	}
 	for _, initCtr := range pod.Spec.InitContainers {
 		if initCtr.Name == common.InitContainerName {
 			for _, mnt := range initCtr.VolumeMounts {
-				assert.NotEqual(t, mnt.Name, "unc")
+				assert.NotEqual(t, "unc", mnt.Name)
 			}
 		}
 	}

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -271,7 +271,7 @@ func TestScheduleTimeParam(t *testing.T) {
 	woc.Run()
 	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, wsl.Items.Len(), 1)
+	assert.Equal(t, 1, wsl.Items.Len())
 	wf := wsl.Items[0]
 	assert.NotNil(t, wf)
 	assert.Len(t, wf.GetAnnotations(), 1)
@@ -450,7 +450,7 @@ func TestMultipleSchedules(t *testing.T) {
 	woc.Run()
 	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, wsl.Items.Len(), 1)
+	assert.Equal(t, 1, wsl.Items.Len())
 	wf := wsl.Items[0]
 	assert.NotNil(t, wf)
 	assert.Len(t, wf.GetAnnotations(), 1)

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -198,7 +198,7 @@ func TestDefaultParameters(t *testing.T) {
 	ctx := context.Background()
 	err := we.SaveParameters(ctx)
 	assert.NoError(t, err)
-	assert.Equal(t, we.Template.Outputs.Parameters[0].Value.String(), "Default Value")
+	assert.Equal(t, "Default Value", we.Template.Outputs.Parameters[0].Value.String())
 }
 
 func TestDefaultParametersEmptyString(t *testing.T) {
@@ -487,10 +487,10 @@ func TestSaveArtifacts(t *testing.T) {
 		ctx := context.Background()
 		_, err := tt.workflowExecutor.SaveArtifacts(ctx)
 		if err != nil {
-			assert.Equal(t, tt.expectError, true)
+			assert.True(t, tt.expectError)
 			continue
 		}
-		assert.Equal(t, tt.expectError, false)
+		assert.False(t, tt.expectError)
 	}
 }
 
@@ -588,7 +588,7 @@ func TestReportOutputs(t *testing.T) {
 		ctx := context.Background()
 		err := we.ReportOutputs(ctx, artifacts)
 
-		assert.Equal(t, err, nil)
+		assert.NoError(t, err)
 		assert.Empty(t, we.errors)
 	})
 

--- a/workflow/gccontroller/gc_controller_test.go
+++ b/workflow/gccontroller/gc_controller_test.go
@@ -488,10 +488,10 @@ func TestTTLlExpired(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow([]byte(failedWf))
 	wf.Spec.TTLStrategy = &wfv1.TTLStrategy{SecondsAfterFailure: &ten}
 	wf.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-11 * time.Second)}
-	assert.Equal(t, true, wf.Status.Failed())
+	assert.True(t, wf.Status.Failed())
 	now := controller.clock.Now()
-	assert.Equal(t, true, now.After(wf.Status.FinishedAt.Add(time.Second*time.Duration(*wf.Spec.TTLStrategy.SecondsAfterFailure))))
-	assert.Equal(t, true, wf.Status.Failed() && wf.Spec.TTLStrategy.SecondsAfterFailure != nil)
+	assert.True(t, now.After(wf.Status.FinishedAt.Add(time.Second*time.Duration(*wf.Spec.TTLStrategy.SecondsAfterFailure))))
+	assert.True(t, wf.Status.Failed() && wf.Spec.TTLStrategy.SecondsAfterFailure != nil)
 	expiresIn, ok := controller.expiresIn(wf)
 	assert.True(t, ok)
 	assert.LessOrEqual(t, int(expiresIn), 0)

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -106,7 +106,7 @@ func TestMetricGC(t *testing.T) {
 		TTL:     1 * time.Second,
 	}
 	m := New(config, config)
-	assert.Len(t, m.customMetrics, 0)
+	assert.Empty(t, m.customMetrics)
 
 	err := m.UpsertCustomMetric("metric", "", newCounter("test", "test", nil), false)
 	if assert.NoError(t, err) {
@@ -128,7 +128,7 @@ func TestMetricGC(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	assert.Len(t, m.customMetrics, 0)
+	assert.Empty(t, m.customMetrics)
 }
 
 func TestRealtimeMetricGC(t *testing.T) {
@@ -139,7 +139,7 @@ func TestRealtimeMetricGC(t *testing.T) {
 		TTL:     1 * time.Second,
 	}
 	m := New(config, config)
-	assert.Len(t, m.customMetrics, 0)
+	assert.Empty(t, m.customMetrics)
 
 	err := m.UpsertCustomMetric("realtime_metric", "workflow-uid", newCounter("test", "test", nil), true)
 	if assert.NoError(t, err) {
@@ -175,7 +175,7 @@ func TestRealtimeMetricGC(t *testing.T) {
 		// Sleep to prevent overloading test worker CPU.
 		time.Sleep(100 * time.Millisecond)
 	}
-	assert.Len(t, m.customMetrics, 0)
+	assert.Empty(t, m.customMetrics)
 }
 
 func TestWorkflowQueueMetrics(t *testing.T) {
@@ -220,7 +220,7 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 
 	m.DeleteRealtimeMetricsForKey("123")
 	assert.Empty(t, m.workflows["123"])
-	assert.Len(t, m.customMetrics, 0)
+	assert.Empty(t, m.customMetrics)
 
 	metric, err := ConstructOrUpdateMetric(nil, &v1alpha1.Prometheus{Name: "name", Help: "hello", Gauge: &v1alpha1.Gauge{Value: "1"}})
 	assert.NoError(t, err)

--- a/workflow/metrics/work_queue_test.go
+++ b/workflow/metrics/work_queue_test.go
@@ -15,7 +15,7 @@ func TestMetricsWorkQueue(t *testing.T) {
 	}
 	m := New(config, config)
 
-	assert.Len(t, m.workersBusy, 0)
+	assert.Empty(t, m.workersBusy)
 
 	m.newWorker("test")
 	assert.Len(t, m.workersBusy, 1)

--- a/workflow/sync/mutex_test.go
+++ b/workflow/sync/mutex_test.go
@@ -122,7 +122,7 @@ func TestMutexLock(t *testing.T) {
 		wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
 		assert.NoError(t, err)
 		concurrenyMgr.Initialize(wfList.Items)
-		assert.Equal(t, 1, len(concurrenyMgr.syncLockMap))
+		assert.Len(t, concurrenyMgr.syncLockMap, 1)
 	})
 	t.Run("WfLevelMutexAcquireAndRelease", func(t *testing.T) {
 		var nextWorkflow string
@@ -176,7 +176,7 @@ func TestMutexLock(t *testing.T) {
 		concurrenyMgr.Release(wf, "", wf.Spec.Synchronization)
 		assert.Equal(t, holderKey2, nextWorkflow)
 		assert.NotNil(t, wf.Status.Synchronization)
-		assert.Equal(t, 0, len(wf.Status.Synchronization.Mutex.Holding))
+		assert.Empty(t, wf.Status.Synchronization.Mutex.Holding)
 
 		// Low priority workflow try to acquire the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
@@ -253,7 +253,7 @@ func TestMutexLock(t *testing.T) {
 		concurrenyMgr.Release(wf, "", wf.Spec.Synchronization)
 		assert.Equal(t, holderKey2, nextWorkflow)
 		assert.NotNil(t, wf.Status.Synchronization)
-		assert.Equal(t, 0, len(wf.Status.Synchronization.Mutex.Holding))
+		assert.Empty(t, wf.Status.Synchronization.Mutex.Holding)
 
 		// Low priority workflow try to acquire the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -345,7 +345,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
 		assert.NoError(t, err)
 		concurrenyMgr.Initialize(wfList.Items)
-		assert.Equal(t, 1, len(concurrenyMgr.syncLockMap))
+		assert.Len(t, concurrenyMgr.syncLockMap, 1)
 	})
 	t.Run("InitializeSynchronizationWithInvalid", func(t *testing.T) {
 		concurrenyMgr := NewLockManager(syncLimitFunc, func(key string) {
@@ -357,7 +357,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
 		assert.NoError(t, err)
 		concurrenyMgr.Initialize(wfList.Items)
-		assert.Equal(t, 0, len(concurrenyMgr.syncLockMap))
+		assert.Empty(t, concurrenyMgr.syncLockMap)
 	})
 
 	t.Run("WfLevelAcquireAndRelease", func(t *testing.T) {
@@ -412,7 +412,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		concurrenyMgr.Release(wf, "", wf.Spec.Synchronization)
 		assert.Equal(t, holderKey2, nextKey)
 		assert.NotNil(t, wf.Status.Synchronization)
-		assert.Equal(t, 0, len(wf.Status.Synchronization.Semaphore.Holding[0].Holders))
+		assert.Empty(t, wf.Status.Synchronization.Semaphore.Holding[0].Holders)
 
 		// Low priority workflow try to acquire the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
@@ -440,7 +440,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		concurrenyMgr.ReleaseAll(wf1)
 		assert.Len(t, sema.pending.items, 1)
 		concurrenyMgr.ReleaseAll(wf3)
-		assert.Len(t, sema.pending.items, 0)
+		assert.Empty(t, sema.pending.items)
 	})
 }
 
@@ -653,7 +653,7 @@ func TestMutexWfLevel(t *testing.T) {
 		concurrenyMgr.ReleaseAll(wf1)
 		assert.Len(t, mutex.pending.items, 1)
 		concurrenyMgr.ReleaseAll(wf2)
-		assert.Len(t, mutex.pending.items, 0)
+		assert.Empty(t, mutex.pending.items)
 	})
 }
 
@@ -693,10 +693,10 @@ func TestCheckWorkflowExistence(t *testing.T) {
 		assert.Len(semaphore.getCurrentHolders(), 1)
 		assert.Len(semaphore.getCurrentPending(), 1)
 		concurrenyMgr.CheckWorkflowExistence()
-		assert.Len(mutex.getCurrentHolders(), 0)
+		assert.Empty(mutex.getCurrentHolders())
 		assert.Len(mutex.getCurrentPending(), 1)
-		assert.Len(semaphore.getCurrentHolders(), 0)
-		assert.Len(semaphore.getCurrentPending(), 0)
+		assert.Empty(semaphore.getCurrentHolders())
+		assert.Empty(semaphore.getCurrentPending())
 	})
 }
 

--- a/workflow/util/merge_test.go
+++ b/workflow/util/merge_test.go
@@ -370,7 +370,7 @@ func TestJoinWfSpecs(t *testing.T) {
 	targetWf, err := JoinWorkflowSpec(&wf1.Spec, wft.GetWorkflowSpec(), &wfDefault.Spec)
 	assert.NoError(err)
 	assert.Equal(result.Spec, targetWf.Spec)
-	assert.Equal(3, len(targetWf.Spec.Templates))
+	assert.Len(targetWf.Spec.Templates, 3)
 	assert.Equal("whalesay", targetWf.Spec.Entrypoint)
 }
 
@@ -473,7 +473,7 @@ func TestMergeHooks(t *testing.T) {
 
 		err := MergeTo(patchHookWf, targetHookWf)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(targetHookWf.Spec.Hooks))
+		assert.Len(t, targetHookWf.Spec.Hooks, 2)
 		assert.Equal(t, "c", targetHookWf.Spec.Hooks[`foo`].Template)
 		assert.Equal(t, "b", targetHookWf.Spec.Hooks[`bar`].Template)
 	})
@@ -485,7 +485,7 @@ func TestMergeHooks(t *testing.T) {
 
 		err := MergeTo(patchHookWf, targetHookWf)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(targetHookWf.Spec.Hooks))
+		assert.Len(t, targetHookWf.Spec.Hooks, 2)
 		assert.Equal(t, "a", targetHookWf.Spec.Hooks[`foo`].Template)
 		assert.Equal(t, "b", targetHookWf.Spec.Hooks[`bar`].Template)
 	})

--- a/workflow/util/pod_name_v1_test.go
+++ b/workflow/util/pod_name_v1_test.go
@@ -32,7 +32,7 @@ func TestPodNameV1(t *testing.T) {
 	expected = fmt.Sprintf("%s-%s", longWfName, longTemplateName)
 	actual = ensurePodNamePrefixLength(expected)
 
-	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
+	assert.Len(t, actual, maxK8sResourceNameLength-k8sNamingHashLength-1)
 
 	name = GeneratePodName(longWfName, nodeName, longTemplateName, nodeID, PodNameV1)
 	assert.Equal(t, nodeID, name)

--- a/workflow/util/pod_name_v2_test.go
+++ b/workflow/util/pod_name_v2_test.go
@@ -42,7 +42,7 @@ func TestPodNameV2(t *testing.T) {
 	expected = fmt.Sprintf("%s-%s", longWfName, longTemplateName)
 	actual = ensurePodNamePrefixLength(expected)
 
-	assert.Equal(t, maxK8sResourceNameLength-k8sNamingHashLength-1, len(actual))
+	assert.Len(t, actual, maxK8sResourceNameLength-k8sNamingHashLength-1)
 
 	longPrefix := fmt.Sprintf("%s-%s", longWfName, longTemplateName)
 	expectedPodName = fmt.Sprintf("%s-%v", longPrefix[0:maxK8sResourceNameLength-k8sNamingHashLength-1], h.Sum32())

--- a/workflow/util/retry/retry_test.go
+++ b/workflow/util/retry/retry_test.go
@@ -64,13 +64,13 @@ func TestGetFailHosts(t *testing.T) {
 		},
 	}
 	t.Run("NotExistParent", func(t *testing.T) {
-		assert.Equal(t, GetFailHosts(nodes, "not-exist-node"), []string{})
+		assert.Equal(t, []string{}, GetFailHosts(nodes, "not-exist-node"))
 	})
 	t.Run("ParentWithoutChildrenPodTypeError", func(t *testing.T) {
-		assert.Equal(t, GetFailHosts(nodes, "n3"), []string{"hostn3"})
+		assert.Equal(t, []string{"hostn3"}, GetFailHosts(nodes, "n3"))
 	})
 	t.Run("ParentWithoutChildrenPodTypeRunning", func(t *testing.T) {
-		assert.Equal(t, GetFailHosts(nodes, "n2"), []string{})
+		assert.Equal(t, []string{}, GetFailHosts(nodes, "n2"))
 	})
 	t.Run("ParentWithChildrenFromRetryNode", func(t *testing.T) {
 		assert.ElementsMatch(t, GetFailHosts(nodes, "retry"), []string{"hostn1", "hostn3"})

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -161,8 +161,8 @@ func TestReadFromSingleorMultiplePathErrorHandling(t *testing.T) {
 				}
 			}
 			body, err := ReadFromFilePathsOrUrls(filePaths...)
-			assert.NotNil(t, err)
-			assert.Equal(t, len(body), 0)
+			assert.Error(t, err)
+			assert.Empty(t, body)
 		})
 	}
 }
@@ -665,7 +665,7 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 			assert.NotContains(t, wf.GetLabels(), common.LabelKeyCompleted)
 			assert.NotContains(t, wf.GetLabels(), common.LabelKeyWorkflowArchivingStatus)
 			assert.Contains(t, wf.GetLabels(), common.LabelKeyPreviousWorkflowName)
-			assert.Equal(t, 1, len(wf.OwnerReferences))
+			assert.Len(t, wf.OwnerReferences, 1)
 			assert.Equal(t, "test", wf.OwnerReferences[0].APIVersion)
 			assert.Equal(t, "testObj", wf.OwnerReferences[0].Name)
 		}
@@ -1365,7 +1365,7 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			if assert.Len(t, wf.Status.Nodes, 4) {
 				assert.Equal(t, wfv1.NodeFailed, wf.Status.Nodes["2"].Phase)
 				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-				assert.Equal(t, 2, len(podsToDelete))
+				assert.Len(t, podsToDelete, 2)
 			}
 		}
 	})
@@ -1394,7 +1394,7 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			if assert.Len(t, wf.Status.Nodes, 2) {
 				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
 				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["continue-on-failed-workflow-2"].Phase)
-				assert.Equal(t, 4, len(podsToDelete))
+				assert.Len(t, podsToDelete, 4)
 			}
 		}
 	})
@@ -1941,25 +1941,25 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry top individual pod node
 	wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step1", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 1)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
-	assert.Equal(t, 6, len(podsToDelete))
+	assert.Len(t, podsToDelete, 6)
 
 	// Retry top individual suspend node
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step2", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 3)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
-	assert.Equal(t, 5, len(podsToDelete))
+	assert.Len(t, podsToDelete, 5)
 
 	// Retry the starting on first DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 12, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -1974,13 +1974,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1").Phase)
-	assert.Equal(t, 3, len(podsToDelete))
+	assert.Len(t, podsToDelete, 3)
 
 	// Retry the starting on second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 12, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -1995,13 +1995,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1").Phase)
-	assert.Equal(t, 3, len(podsToDelete))
+	assert.Len(t, podsToDelete, 3)
 
 	// Retry the first individual node (suspended node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 12, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -2016,13 +2016,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1").Phase)
-	assert.Equal(t, 3, len(podsToDelete))
+	assert.Len(t, podsToDelete, 3)
 
 	// Retry the second individual node (pod node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 12, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -2038,13 +2038,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1").Phase)
 	// The suspended node remains succeeded
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1").Phase)
-	assert.Equal(t, 3, len(podsToDelete))
+	assert.Len(t, podsToDelete, 3)
 
 	// Retry the third individual node (pod node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step3", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 13, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 13)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -2061,13 +2061,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// The suspended node remains succeeded
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2").Phase)
-	assert.Equal(t, 2, len(podsToDelete))
+	assert.Len(t, podsToDelete, 2)
 
 	// Retry the last individual node (suspend node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step2", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 15, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 15)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -2085,13 +2085,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step2").Phase)
-	assert.Equal(t, 1, len(podsToDelete))
+	assert.Len(t, podsToDelete, 1)
 
 	// Retry the node that connects the two branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step4", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 16, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 16)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -2108,13 +2108,13 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step2").Phase)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step4").Phase)
-	assert.Equal(t, 1, len(podsToDelete))
+	assert.Len(t, podsToDelete, 1)
 
 	// Retry the last node (failing node)
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step5-tofail", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, 16, len(wf.Status.Nodes))
+	assert.Len(t, wf.Status.Nodes, 16)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step2").Phase)
@@ -2131,5 +2131,5 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step2").Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step4").Phase)
-	assert.Equal(t, 1, len(podsToDelete))
+	assert.Len(t, podsToDelete, 1)
 }

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -34,7 +34,7 @@ spec:
 
 func TestDAGCycle(t *testing.T) {
 	err := validate(dagCycle)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "cycle")
 	}
 }
@@ -63,7 +63,7 @@ spec:
 
 func TestAnyWithoutExpandingTask(t *testing.T) {
 	err := validate(dagAnyWithoutExpandingTask)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "does not contain any items")
 	}
 }
@@ -85,7 +85,7 @@ spec:
 
 func TestDAGUndefinedTemplate(t *testing.T) {
 	err := validate(dagUndefinedTemplate)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "undefined")
 	}
 }
@@ -310,14 +310,14 @@ spec:
 
 func TestDAGVariableResolution(t *testing.T) {
 	err := validate(dagUnresolvedVar)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.A.outputs.parameters.unresolvable}}")
 	}
 	err = validate(dagResolvedVar)
 	assert.NoError(t, err)
 
 	err = validate(dagResolvedVarNotAncestor)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "templates.unresolved.tasks.C missing dependency 'B' for parameter 'message'")
 	}
 
@@ -620,12 +620,12 @@ func TestDAGStatusReference(t *testing.T) {
 
 	err = validate(dagStatusNoFutureReferenceSimple)
 	// Can't reference the status of steps that have not run yet
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
 	}
 	err = validate(dagStatusNoFutureReferenceWhenFutureReferenceHasChild)
 	// Can't reference the status of steps that have not run yet, even if the referenced steps have children
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
 	}
 
@@ -635,7 +635,7 @@ func TestDAGStatusReference(t *testing.T) {
 	err = validate(dagStatusOnlyDirectAncestors)
 	// Can't reference steps that are not direct ancestors of node
 	// Here Node E references the status of Node B, even though it is not its descendent
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
 	}
 }
@@ -672,7 +672,7 @@ spec:
 
 func TestDAGNonExistantTarget(t *testing.T) {
 	err := validate(dagNonexistantTarget)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "target 'DOESNTEXIST' is not defined")
 	}
 }
@@ -747,7 +747,7 @@ spec:
 
 func TestDAGTargetMissingInputParam(t *testing.T) {
 	err := validate(dagTargetMissingInputParam)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 var dagDependsAndDependencies = `
@@ -862,7 +862,7 @@ spec:
 
 func TestDAGDependsDigit(t *testing.T) {
 	err := validate(dagDependsDigit)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 	}
 }
@@ -916,7 +916,7 @@ spec:
 
 func TestDAGDependenciesDigit(t *testing.T) {
 	err := validate(dagDependenciesDigit)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 	}
 }
@@ -1074,7 +1074,7 @@ spec:
 
 func TestDAGMissingParamValueInTask(t *testing.T) {
 	err := validate(dagMissingParamValueInTask)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), ".valueFrom only allows: default, configMapKeyRef and supplied")
 	}
 }
@@ -1139,7 +1139,7 @@ spec:
 
 func TestFailDAGArgParamValueFromPathInTask(t *testing.T) {
 	err := validate(failDagArgParamValueFromPathInTask)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "valueFrom only allows: default, configMapKeyRef and supplied")
 	}
 }

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -124,15 +124,15 @@ spec:
 
 func TestDuplicateOrEmptyNames(t *testing.T) {
 	err := validate(dupTemplateNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "not unique")
 	}
 	err = validate(dupInputNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "not unique")
 	}
 	err = validate(emptyName)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "name is required")
 	}
 }
@@ -203,15 +203,15 @@ spec:
 
 func TestUnresolved(t *testing.T) {
 	err := validate(unresolvedInput)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve")
 	}
 	err = validate(unresolvedStepInput)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve")
 	}
 	err = validate(unresolvedOutput)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve")
 	}
 }
@@ -397,7 +397,7 @@ spec:
 func TestStepStatusReferenceNoFutureReference(t *testing.T) {
 	err := validate(stepStatusReferencesNoFutureReference)
 	// Can't reference the status of steps that have not run yet
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{steps.two.status}}")
 	}
 }
@@ -501,7 +501,7 @@ spec:
 
 func TestParamWithoutValue(t *testing.T) {
 	err := validate(paramWithoutValue)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "not supplied")
 	}
 }
@@ -662,7 +662,7 @@ spec:
 
 func TestInvalidTemplateName(t *testing.T) {
 	err := validate(invalidTemplateNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
@@ -689,7 +689,7 @@ spec:
 
 func TestInvalidArgParamName(t *testing.T) {
 	err := validate(invalidArgParamNames)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 var invalidArgArtNames = `
@@ -720,7 +720,7 @@ spec:
 
 func TestInvalidArgArtName(t *testing.T) {
 	err := validate(invalidArgArtNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
@@ -767,7 +767,7 @@ spec:
 
 func TestInvalidStepName(t *testing.T) {
 	err := validate(invalidStepNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
@@ -793,7 +793,7 @@ spec:
 
 func TestInvalidInputParamName(t *testing.T) {
 	err := validate(invalidInputParamNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
@@ -845,7 +845,7 @@ spec:
 
 func TestInvalidInputArtName(t *testing.T) {
 	err := validate(invalidInputArtNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
@@ -871,7 +871,7 @@ spec:
 
 func TestInvalidOutputArtName(t *testing.T) {
 	err := validate(invalidOutputArtNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 }
@@ -986,23 +986,23 @@ spec:
 
 func TestInvalidOutputParam(t *testing.T) {
 	err := validate(invalidOutputParamNames)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), invalidErr)
 	}
 	err = validate(invalidOutputMissingValueFrom)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "does not have valueFrom or value specified")
 	}
 	err = validate(invalidOutputMultipleValueFrom)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "multiple valueFrom")
 	}
 	err = validate(invalidOutputIncompatibleValueFromPath)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), ".path must be specified for Container templates")
 	}
 	err = validate(invalidOutputIncompatibleValueFromParam)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), ".parameter or expression must be specified for Steps templates")
 	}
 }
@@ -1031,7 +1031,7 @@ spec:
 
 func TestMultipleTemplateTypes(t *testing.T) {
 	err := validate(multipleTemplateTypes)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "multiple template types specified")
 	}
 }
@@ -1075,7 +1075,7 @@ spec:
 func TestExitHandler(t *testing.T) {
 	// ensure {{workflow.status}} is not available when not in exit handler
 	err := validate(workflowStatusNotOnExit)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// ensure {{workflow.status}} is available in exit handler
 	err = validate(exitHandlerWorkflowStatusOnExit)
@@ -1141,7 +1141,7 @@ func TestVolumeMountArtifactPathCollision(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "already mounted")
 	}
 	// tweak the mount path and validation should now be successful
@@ -1170,7 +1170,7 @@ spec:
 
 func TestValidActiveDeadlineSeconds(t *testing.T) {
 	err := validate(activeDeadlineSeconds)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "activeDeadlineSeconds must be a positive integer > 0")
 	}
 }
@@ -1193,7 +1193,7 @@ spec:
 
 func TestLeafWithParallelism(t *testing.T) {
 	err := validate(leafWithParallelism)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "is only valid")
 	}
 }
@@ -1255,11 +1255,11 @@ spec:
 
 func TestInvalidArgumentNoFromOrLocation(t *testing.T) {
 	err := validate(invalidStepsArgumentNoFromOrLocation)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "from, artifact location, or key is required")
 	}
 	err = validate(invalidDAGArgumentNoFromOrLocation)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "from, artifact location, or key is required")
 	}
 }
@@ -1292,7 +1292,7 @@ spec:
 
 func TestInvalidArgumentNoValue(t *testing.T) {
 	err := validate(invalidArgumentNoValue)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), ".value or ")
 		assert.Contains(t, err.Error(), ".valueFrom is required")
 	}
@@ -1403,7 +1403,7 @@ func TestSpecArgumentNoValue(t *testing.T) {
 	assert.NoError(t, err)
 	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 var specArgumentSnakeCase = `
@@ -1499,7 +1499,7 @@ func TestCustomTemplatVariable(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
-	assert.Equal(t, err, nil)
+	assert.NoError(t, err)
 }
 
 var templateRefTarget = `
@@ -1596,7 +1596,7 @@ spec:
 
 func TestUndefinedTemplateRef(t *testing.T) {
 	err := validate(undefinedTemplateRef)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "not found")
 	}
 }
@@ -1625,7 +1625,7 @@ func TestValidResourceWorkflow(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	assert.Equal(t, err, nil)
+	assert.NoError(t, err)
 }
 
 var invalidResourceWorkflow = `
@@ -2711,9 +2711,9 @@ func TestWorkflowTemplateWithArgumentValueNotFromEnumList(t *testing.T) {
 
 func TestWorkflowTemplateWithEnumValueWithoutValue(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Lint: true})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Submit: true})
 	assert.EqualError(t, err, "spec.arguments.message.value or spec.arguments.message.valueFrom is required")
 }
@@ -2741,7 +2741,7 @@ func TestSubstituteResourceManifestExpressions(t *testing.T) {
 	// despite spacing in the expr itself we should have only 1 placeholder here
 	patt, _ := regexp.Compile(`placeholder\-\d+`)
 	matches := patt.FindAllString(replaced, -1)
-	assert.Exactly(t, 2, len(matches))
+	assert.Len(t, matches, 2)
 	assert.Equal(t, matches[0], matches[1])
 }
 
@@ -2875,7 +2875,7 @@ spec:
 
 func TestInvalidContainerSetDependencyNotFound(t *testing.T) {
 	err := validate(invalidContainerSetDependencyNotFound)
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "templates.main.containerSet.containers.b dependency 'c' not defined")
 	}
 }
@@ -2944,7 +2944,7 @@ spec:
 	}
 	for _, manifest := range invalidManifests {
 		err := validateWorkflowTemplate(manifest, ValidateOpts{})
-		if assert.NotNil(t, err) {
+		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "containerSet.containers must have a container named \"main\" for input or output")
 		}
 	}
@@ -3339,7 +3339,7 @@ spec:
 func TestShouldCheckValidationToSpacedParameters(t *testing.T) {
 	err := validate(spacedParameterWorkflowTemplate)
 	// Do not allow leading or trailing spaces in parameters
-	if assert.NotNil(t, err) {
+	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{  workflow.thisdoesnotexist  }}")
 	}
 }


### PR DESCRIPTION
This is part of a series of test tidies started by #13365.

The aim is to enable the [testifylint](https://github.com/Antonboom/testifylint) golangci-lint checker.

This patch is just the automated fixes (`testifylint --fix`) excluding the removal of the `t.Parallel` from `cron_test.go`.

---

Some fixes like

```go
assert.True(t, len(pods.Items) > 0, "pod was not created successfully")
```

went to

```go
assert.Positive(t, pods.Items, "pod was not created successfully")
```

and I have manually converted these to

```go
assert.NotEmpty(t, pods.Items, "pod was not created successfully")
```

---

`test/e2e/agent_test.go` also needed `0`->`time.Duration(0)` for one `assert.Equal`.

---

Note to maintainers: Please feel free to apply fixes yourself to this PR