### PR TITLE
refactor(tests): `assert.Error` -> `require.Error` (`cmd/`)

### DIFF
--- a/cmd/argo/commands/clustertemplate/util_test.go
+++ b/cmd/argo/commands/clustertemplate/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const cwfts = `
@@ -40,7 +41,6 @@ spec:
 
 func TestUnmarshalCWFT(t *testing.T) {
 	clusterwfts, err := unmarshalClusterWorkflowTemplates([]byte(cwfts), false)
-	if assert.NoError(t, err) {
-		assert.Len(t, clusterwfts, 2)
-	}
+	require.NoError(t, err)
+	assert.Len(t, clusterwfts, 2)
 }

--- a/cmd/argo/commands/common/get_test.go
+++ b/cmd/argo/commands/common/get_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -41,7 +42,7 @@ func testPrintNodeImpl(t *testing.T, expected string, node wfv1.NodeStatus, getA
 		printNode(w, node, workflowName, "", getArgs, util.GetPodNameVersion())
 	}
 	err := w.Flush()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, result.String())
 }
 

--- a/cmd/argo/commands/cron/util_test.go
+++ b/cmd/argo/commands/cron/util_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -62,10 +63,9 @@ func TestPrintCronWorkflow(t *testing.T) {
 func TestNextRuntime(t *testing.T) {
 	var cronWf = v1alpha1.MustUnmarshalCronWorkflow(invalidCwf)
 	next, err := GetNextRuntime(cronWf)
-	if assert.NoError(t, err) {
-		assert.LessOrEqual(t, next.Unix(), time.Now().Add(1*time.Minute).Unix())
-		assert.Greater(t, next.Unix(), time.Now().Unix())
-	}
+	require.NoError(t, err)
+	assert.LessOrEqual(t, next.Unix(), time.Now().Add(1*time.Minute).Unix())
+	assert.Greater(t, next.Unix(), time.Now().Unix())
 }
 
 var cronMultipleSchedules = `
@@ -95,8 +95,7 @@ spec:
 func TestNextRuntimeWithMultipleSchedules(t *testing.T) {
 	var cronWf = v1alpha1.MustUnmarshalCronWorkflow(cronMultipleSchedules)
 	next, err := GetNextRuntime(cronWf)
-	if assert.NoError(t, err) {
-		assert.LessOrEqual(t, next.Unix(), time.Now().Add(1*time.Minute).Unix())
-		assert.Greater(t, next.Unix(), time.Now().Unix())
-	}
+	require.NoError(t, err)
+	assert.LessOrEqual(t, next.Unix(), time.Now().Add(1*time.Minute).Unix())
+	assert.Greater(t, next.Unix(), time.Now().Unix())
 }

--- a/cmd/argo/commands/list_test.go
+++ b/cmd/argo/commands/list_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow"
@@ -18,73 +19,62 @@ import (
 func Test_listWorkflows(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		workflows, err := listEmpty(&metav1.ListOptions{}, listFlags{})
-		if assert.NoError(t, err) {
-			assert.Empty(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.Empty(t, workflows)
 	})
 	t.Run("Nothing", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{}, listFlags{})
-		if assert.NoError(t, err) {
-			assert.NotNil(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, workflows)
 	})
 	t.Run("Status", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{LabelSelector: "workflows.argoproj.io/phase in (Pending,Running)"}, listFlags{status: []string{"Running", "Pending"}})
-		if assert.NoError(t, err) {
-			assert.NotNil(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, workflows)
 	})
 	t.Run("Completed", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{LabelSelector: "workflows.argoproj.io/completed=true"}, listFlags{completed: true})
-		if assert.NoError(t, err) {
-			assert.NotNil(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, workflows)
 	})
 	t.Run("Running", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{LabelSelector: "workflows.argoproj.io/completed!=true"}, listFlags{running: true})
-		if assert.NoError(t, err) {
-			assert.NotNil(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, workflows)
 	})
 	t.Run("Resubmitted", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{LabelSelector: common.LabelKeyPreviousWorkflowName}, listFlags{resubmitted: true})
-		if assert.NoError(t, err) {
-			assert.NotNil(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, workflows)
 	})
 	t.Run("Labels", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{LabelSelector: "foo"}, listFlags{labels: "foo"})
-		if assert.NoError(t, err) {
-			assert.NotNil(t, workflows)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, workflows)
 	})
 	t.Run("Prefix", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{}, listFlags{prefix: "foo-"})
-		if assert.NoError(t, err) {
-			assert.Len(t, workflows, 1)
-		}
+		require.NoError(t, err)
+		assert.Len(t, workflows, 1)
 	})
 	t.Run("Since", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{}, listFlags{createdSince: "1h"})
-		if assert.NoError(t, err) {
-			assert.Len(t, workflows, 1)
-		}
+		require.NoError(t, err)
+		assert.Len(t, workflows, 1)
 	})
 	t.Run("Older", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{}, listFlags{finishedBefore: "1h"})
-		if assert.NoError(t, err) {
-			assert.Len(t, workflows, 1)
-		}
+		require.NoError(t, err)
+		assert.Len(t, workflows, 1)
 	})
 	t.Run("Names", func(t *testing.T) {
 		workflows, err := list(&metav1.ListOptions{FieldSelector: nameFields}, listFlags{fields: nameFields})
-		if assert.NoError(t, err) {
-			assert.Len(t, workflows, 3)
-			// most recent workflow will be shown first
-			assert.Equal(t, "bar-", workflows[0].Name)
-			assert.Equal(t, "baz-", workflows[1].Name)
-			assert.Equal(t, "foo-", workflows[2].Name)
-		}
+		require.NoError(t, err)
+		assert.Len(t, workflows, 3)
+		// most recent workflow will be shown first
+		assert.Equal(t, "bar-", workflows[0].Name)
+		assert.Equal(t, "baz-", workflows[1].Name)
+		assert.Equal(t, "foo-", workflows[2].Name)
 	})
 }
 

--- a/cmd/argo/commands/resubmit_test.go
+++ b/cmd/argo/commands/resubmit_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
@@ -28,7 +28,7 @@ func Test_resubmitWorkflows(t *testing.T) {
 		err := resubmitWorkflows(context.Background(), c, resubmitOpts, cliSubmitOpts, []string{"foo", "bar"})
 		c.AssertNumberOfCalls(t, "ResubmitWorkflow", 2)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Resubmit workflow with memoization", func(t *testing.T) {
@@ -49,7 +49,7 @@ func Test_resubmitWorkflows(t *testing.T) {
 			Memoized:  true,
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Resubmit workflow by selector", func(t *testing.T) {
@@ -89,7 +89,7 @@ func Test_resubmitWorkflows(t *testing.T) {
 			c.AssertCalled(t, "ResubmitWorkflow", mock.Anything, resubmitReq)
 		}
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Resubmit workflow by selector and name", func(t *testing.T) {
@@ -139,7 +139,7 @@ func Test_resubmitWorkflows(t *testing.T) {
 			Memoized:  false,
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Resubmit workflow list error", func(t *testing.T) {
@@ -151,7 +151,7 @@ func Test_resubmitWorkflows(t *testing.T) {
 		cliSubmitOpts := common.CliSubmitOpts{}
 		c.On("ListWorkflows", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		err := resubmitWorkflows(context.Background(), c, resubmitOpts, cliSubmitOpts, []string{})
-		assert.Errorf(t, err, "mock error")
+		require.Errorf(t, err, "mock error")
 	})
 
 	t.Run("Resubmit workflow error", func(t *testing.T) {
@@ -162,6 +162,6 @@ func Test_resubmitWorkflows(t *testing.T) {
 		cliSubmitOpts := common.CliSubmitOpts{}
 		c.On("ResubmitWorkflow", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		err := resubmitWorkflows(context.Background(), c, resubmitOpts, cliSubmitOpts, []string{"foo"})
-		assert.Errorf(t, err, "mock error")
+		require.Errorf(t, err, "mock error")
 	})
 }

--- a/cmd/argo/commands/retry_test.go
+++ b/cmd/argo/commands/retry_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
@@ -28,7 +28,7 @@ func Test_retryWorkflows(t *testing.T) {
 		err := retryWorkflows(context.Background(), c, retryOpts, cliSubmitOpts, []string{"foo", "bar"})
 		c.AssertNumberOfCalls(t, "RetryWorkflow", 2)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Retry workflow by selector", func(t *testing.T) {
@@ -69,7 +69,7 @@ func Test_retryWorkflows(t *testing.T) {
 			c.AssertCalled(t, "RetryWorkflow", mock.Anything, retryReq)
 		}
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Retry workflow by selector and name", func(t *testing.T) {
@@ -121,7 +121,7 @@ func Test_retryWorkflows(t *testing.T) {
 			NodeFieldSelector: "",
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Retry workflow list error", func(t *testing.T) {
@@ -133,7 +133,7 @@ func Test_retryWorkflows(t *testing.T) {
 		cliSubmitOpts := common.CliSubmitOpts{}
 		c.On("ListWorkflows", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		err := retryWorkflows(context.Background(), c, retryOpts, cliSubmitOpts, []string{})
-		assert.Errorf(t, err, "mock error")
+		require.Errorf(t, err, "mock error")
 	})
 
 	t.Run("Retry workflow error", func(t *testing.T) {
@@ -144,6 +144,6 @@ func Test_retryWorkflows(t *testing.T) {
 		cliSubmitOpts := common.CliSubmitOpts{}
 		c.On("RetryWorkflow", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		err := retryWorkflows(context.Background(), c, retryOpts, cliSubmitOpts, []string{"foo"})
-		assert.Errorf(t, err, "mock error")
+		require.Errorf(t, err, "mock error")
 	})
 }

--- a/cmd/argo/commands/stop_test.go
+++ b/cmd/argo/commands/stop_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow"
@@ -24,7 +24,7 @@ func Test_stopWorkflows(t *testing.T) {
 		err := stopWorkflows(context.Background(), c, stopArgs, []string{"foo", "bar"})
 		c.AssertNotCalled(t, "StopWorkflow")
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Stop workflow by names", func(t *testing.T) {
@@ -38,7 +38,7 @@ func Test_stopWorkflows(t *testing.T) {
 		err := stopWorkflows(context.Background(), c, stopArgs, []string{"foo", "bar"})
 		c.AssertNumberOfCalls(t, "StopWorkflow", 2)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Stop workflow by selector", func(t *testing.T) {
@@ -67,7 +67,7 @@ func Test_stopWorkflows(t *testing.T) {
 		err := stopWorkflows(context.Background(), c, stopArgs, []string{})
 		c.AssertNumberOfCalls(t, "StopWorkflow", 3)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Stop workflow by selector and name", func(t *testing.T) {
@@ -97,7 +97,7 @@ func Test_stopWorkflows(t *testing.T) {
 		// after de-duplication, there will be 4 workflows to stop
 		c.AssertNumberOfCalls(t, "StopWorkflow", 4)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Stop workflow list error", func(t *testing.T) {
@@ -108,7 +108,7 @@ func Test_stopWorkflows(t *testing.T) {
 		}
 		c.On("ListWorkflows", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		err := stopWorkflows(context.Background(), c, stopArgs, []string{})
-		assert.Errorf(t, err, "mock error")
+		require.Errorf(t, err, "mock error")
 	})
 
 	t.Run("Stop workflow error", func(t *testing.T) {
@@ -118,6 +118,6 @@ func Test_stopWorkflows(t *testing.T) {
 		}
 		c.On("StopWorkflow", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("mock error"))
 		err := stopWorkflows(context.Background(), c, stopArgs, []string{"foo"})
-		assert.Errorf(t, err, "mock error")
+		require.Errorf(t, err, "mock error")
 	})
 }

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/lint/mocks"
@@ -67,13 +68,13 @@ spec:
 
 func TestLintFile(t *testing.T) {
 	file, err := os.CreateTemp("", "*.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.WriteFile(file.Name(), lintFileData, 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	fmtr, err := GetFormatter("simple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	wfServiceClientMock := &workflowmocks.WorkflowServiceClient{}
 	wftServiceSclientMock := &wftemplatemocks.WorkflowTemplateServiceClient{}
@@ -87,7 +88,7 @@ func TestLintFile(t *testing.T) {
 		Formatter: fmtr,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "steps-" (Workflow): lint error`, file.Name()))
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 1)
@@ -96,13 +97,13 @@ func TestLintFile(t *testing.T) {
 
 func TestLintMultipleKinds(t *testing.T) {
 	file, err := os.CreateTemp("", "*.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.WriteFile(file.Name(), lintFileData, 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	fmtr, err := GetFormatter("simple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	wfServiceClientMock := &workflowmocks.WorkflowServiceClient{}
 	wftServiceSclientMock := &wftemplatemocks.WorkflowTemplateServiceClient{}
@@ -118,7 +119,7 @@ func TestLintMultipleKinds(t *testing.T) {
 		Formatter: fmtr,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "steps-" (Workflow): lint error`, file.Name()))
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "foo" (WorkflowTemplate): lint error`, file.Name()))
@@ -128,22 +129,22 @@ func TestLintMultipleKinds(t *testing.T) {
 
 func TestLintWithOutput(t *testing.T) {
 	file, err := os.CreateTemp("", "*.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.WriteFile(file.Name(), lintFileData, 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	r, w, err := os.Pipe()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = w.Write(lintFileData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	w.Close()
 	stdin := os.Stdin
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
 	fmtr, err := GetFormatter("simple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	wfServiceClientMock := &workflowmocks.WorkflowServiceClient{}
 	wftServiceSclientMock := &wftemplatemocks.WorkflowTemplateServiceClient{}
@@ -171,7 +172,7 @@ func TestLintWithOutput(t *testing.T) {
 	mw.AssertCalled(t, "Write", []byte(expected[0]))
 	mw.AssertCalled(t, "Write", []byte(expected[1]))
 	mw.AssertCalled(t, "Write", []byte(expected[2]))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Success)
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 2)
 	wftServiceSclientMock.AssertNumberOfCalls(t, "LintWorkflowTemplate", 2)
@@ -180,16 +181,16 @@ func TestLintWithOutput(t *testing.T) {
 
 func TestLintStdin(t *testing.T) {
 	r, w, err := os.Pipe()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = w.Write(lintFileData)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	w.Close()
 	stdin := os.Stdin
 	defer func() { os.Stdin = stdin }()
 	os.Stdin = r
 
 	fmtr, err := GetFormatter("simple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	wfServiceClientMock := &workflowmocks.WorkflowServiceClient{}
 	wftServiceSclientMock := &wftemplatemocks.WorkflowTemplateServiceClient{}
@@ -205,7 +206,7 @@ func TestLintStdin(t *testing.T) {
 		Formatter: fmtr,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, `stdin: in "steps-" (Workflow): lint error`)
 	assert.Contains(t, res.msg, `stdin: in "foo" (WorkflowTemplate): lint error`)
@@ -220,13 +221,13 @@ func TestLintDeviceFile(t *testing.T) {
 
 	file, err := os.CreateTemp("", "*.yaml")
 	fd := file.Fd()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.WriteFile(file.Name(), lintFileData, 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	fmtr, err := GetFormatter("simple")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	wfServiceClientMock := &workflowmocks.WorkflowServiceClient{}
 	wftServiceSclientMock := &wftemplatemocks.WorkflowTemplateServiceClient{}
@@ -242,7 +243,7 @@ func TestLintDeviceFile(t *testing.T) {
 		Formatter: fmtr,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Success)
 	assert.Contains(t, res.msg, fmt.Sprintf(`%s: in "steps-" (Workflow): lint error`, deviceFileName))
 	wfServiceClientMock.AssertNumberOfCalls(t, "LintWorkflow", 1)
@@ -287,15 +288,15 @@ func TestGetFormatter(t *testing.T) {
 			if test.formatterName != "" {
 				fmtr, err = GetFormatter(test.formatterName)
 				if test.expectedErr != nil {
-					assert.EqualError(t, err, test.expectedErr.Error())
+					require.EqualError(t, err, test.expectedErr.Error())
 					return
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			}
 
 			r, err := Lint(context.Background(), &LintOptions{Formatter: fmtr})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expectedOutput, r.Msg())
 		})
 	}

--- a/cmd/argoexec/commands/emissary_windows_test.go
+++ b/cmd/argoexec/commands/emissary_windows_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v3/util/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmissary(t *testing.T) {

--- a/cmd/argoexec/commands/emissary_windows_test.go
+++ b/cmd/argoexec/commands/emissary_windows_test.go
@@ -17,13 +17,13 @@ func TestEmissary(t *testing.T) {
 	includeScriptOutput = true
 
 	err := os.WriteFile(varRunArgo+"/template", []byte(`{}`), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("Exit0", func(t *testing.T) {
 		err := run("exit")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		data, err := os.ReadFile(varRunArgo + "/ctr/main/exitcode")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "0", string(data))
 	})
 
@@ -31,13 +31,13 @@ func TestEmissary(t *testing.T) {
 		err := run("exit 1")
 		assert.Equal(t, 1, err.(errors.Exited).ExitCode())
 		data, err := os.ReadFile(varRunArgo + "/ctr/main/exitcode")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "1", string(data))
 	})
 	t.Run("Exit13", func(t *testing.T) {
 		err := run("exit 13")
 		assert.Equal(t, 13, err.(errors.Exited).ExitCode())
-		assert.EqualError(t, err, "exit status 13")
+		require.EqualError(t, err, "exit status 13")
 	})
 }
 


### PR DESCRIPTION
This is part of a series of test tidies started by #13365.

The aim is to enable the `testifylint` `golangci-lint` checker.

This commit converts `assert.Error` checks into `require.Error` for the part of the codebase, as per https://github.com/argoproj/argo-workflows/pull/13270#discussion_r1667248031

In some places checks have been coalesced - in particular the pattern

```go
if assert.Error() {
    assert.Contains(..., "message")
}
```

is now
```go
require.ErrorContains(..., "message")
```

Getting this wrong and missing the `Contains` is still valid Go, so that's a mistake I may have made.

Signed-off-by: Alan Clucas <alan@clucas.org>