### PR TITLE
refactor(tests): `assert.Error` -> `require.Error` (`pkg/`)

### DIFF
--- a/pkg/apiclient/http1/facade_test.go
+++ b/pkg/apiclient/http1/facade_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFacade_do(t *testing.T) {
 	f := Facade{baseUrl: "http://my-url"}
 	u, err := f.url("GET", "/{namespace}/{name}", &metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{"foo": "1"}})
-	if assert.NoError(t, err) {
-		assert.Equal(t, "http://my-url/my-ns/?labels.foo=1", u.String())
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "http://my-url/my-ns/?labels.foo=1", u.String())
 }

--- a/pkg/apis/workflow/v1alpha1/anystring_test.go
+++ b/pkg/apis/workflow/v1alpha1/anystring_test.go
@@ -5,90 +5,91 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAnyString(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		x := AnyStringPtr("")
 		data, err := json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `""`, string(data), "string value has quotes")
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `""`, string(data), "string value has quotes")
+
 		i := AnyStringPtr("")
 		err = i.UnmarshalJSON([]byte(`""`))
-		if assert.NoError(t, err) {
-			assert.Equal(t, AnyStringPtr(""), i)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, AnyStringPtr(""), i)
+
 		assert.Equal(t, "", i.String(), "string value does not have quotes")
 	})
 	t.Run("String", func(t *testing.T) {
 		x := AnyStringPtr("my-string")
 		data, err := json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `"my-string"`, string(data), "string value has quotes")
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `"my-string"`, string(data), "string value has quotes")
+
 		i := AnyStringPtr("")
 		err = i.UnmarshalJSON([]byte(`"my-string"`))
-		if assert.NoError(t, err) {
-			assert.Equal(t, AnyStringPtr("my-string"), i)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, AnyStringPtr("my-string"), i)
+
 		assert.Equal(t, "my-string", i.String(), "string value does not have quotes")
 	})
 	t.Run("StringNumber", func(t *testing.T) {
 		x := AnyStringPtr(1)
 		data, err := json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `"1"`, string(data), "number value has quotes")
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `"1"`, string(data), "number value has quotes")
+
 		i := AnyStringPtr("")
 		err = i.UnmarshalJSON([]byte(`"1"`))
-		if assert.NoError(t, err) {
-			assert.Equal(t, AnyStringPtr("1"), i)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, AnyStringPtr("1"), i)
+
 		assert.Equal(t, "1", i.String(), "number value does not have quotes")
 	})
 	t.Run("LargeNumber", func(t *testing.T) {
 		x := ParseAnyString(881217801864)
 		data, err := json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `"881217801864"`, string(data))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `"881217801864"`, string(data))
+
 		i := AnyStringPtr("")
 		err = i.UnmarshalJSON([]byte("881217801864"))
-		if assert.NoError(t, err) {
-			assert.Equal(t, AnyStringPtr("881217801864"), i)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, AnyStringPtr("881217801864"), i)
+
 		assert.Equal(t, "881217801864", i.String())
 	})
 	t.Run("FloatNumber", func(t *testing.T) {
 		x := ParseAnyString(0.2)
 		data, err := json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `"0.2"`, string(data))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `"0.2"`, string(data))
+
 		i := AnyStringPtr("")
 		err = i.UnmarshalJSON([]byte("0.2"))
-		if assert.NoError(t, err) {
-			assert.Equal(t, AnyStringPtr("0.2"), i)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, AnyStringPtr("0.2"), i)
+
 		assert.Equal(t, "0.2", i.String())
 	})
 	t.Run("Boolean", func(t *testing.T) {
 		x := ParseAnyString(true)
 		data, err := json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `"true"`, string(data))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `"true"`, string(data))
+
 		x = ParseAnyString(false)
 		data, err = json.Marshal(x)
-		if assert.NoError(t, err) {
-			assert.Equal(t, `"false"`, string(data))
-		}
+		require.NoError(t, err)
+		assert.Equal(t, `"false"`, string(data))
+
 		i := AnyStringPtr("")
 		err = i.UnmarshalJSON([]byte("true"))
-		if assert.NoError(t, err) {
-			assert.Equal(t, AnyStringPtr("true"), i)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, AnyStringPtr("true"), i)
+
 		assert.Equal(t, "true", i.String())
 	})
 }

--- a/pkg/apis/workflow/v1alpha1/container_set_template_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/container_set_template_types_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -29,7 +30,7 @@ func TestContainerSetGetRetryStrategy(t *testing.T) {
 			},
 		}
 		strategy, err := set.GetRetryStrategy()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, wait.Backoff{Steps: 100}, strategy)
 	})
 
@@ -43,7 +44,7 @@ func TestContainerSetGetRetryStrategy(t *testing.T) {
 			},
 		}
 		strategy, err := set.GetRetryStrategy()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, wait.Backoff{
 			Steps:    100,
 			Duration: time.Duration(20 * time.Second),
@@ -86,9 +87,7 @@ volumeMounts:
     mountPath: /workspace
 `
 	err := validateContainerSetTemplate(invalidContainerSetEmpty)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "containers must have at least one container")
-	}
+	require.ErrorContains(t, err, "containers must have at least one container")
 }
 
 func TestInvalidContainerSetDuplicateVolumeMounting(t *testing.T) {
@@ -103,9 +102,7 @@ containers:
     image: argoproj/argosay:v2
 `
 	err := validateContainerSetTemplate(invalidContainerSetDuplicateNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "volumeMounts[1].mountPath '/workspace' already mounted in volumeMounts.workspace")
-	}
+	require.ErrorContains(t, err, "volumeMounts[1].mountPath '/workspace' already mounted in volumeMounts.workspace")
 }
 
 func TestInvalidContainerSetDuplicateNames(t *testing.T) {
@@ -120,9 +117,8 @@ containers:
     image: argoproj/argosay:v2
 `
 	err := validateContainerSetTemplate(invalidContainerSetDuplicateNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "containers[1].name 'a' is not unique")
-	}
+	require.ErrorContains(t, err, "containers[1].name 'a' is not unique")
+
 }
 
 func TestInvalidContainerSetDependencyNotFound(t *testing.T) {
@@ -139,9 +135,7 @@ containers:
       - c
 `
 	err := validateContainerSetTemplate(invalidContainerSetDependencyNotFound)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "containers.b dependency 'c' not defined")
-	}
+	require.ErrorContains(t, err, "containers.b dependency 'c' not defined")
 }
 
 func TestInvalidContainerSetDependencyCycle(t *testing.T) {
@@ -160,9 +154,7 @@ containers:
       - a
 `
 	err := validateContainerSetTemplate(invalidContainerSetDependencyCycle)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "containers dependency cycle detected: b->a->b")
-	}
+	require.ErrorContains(t, err, "containers dependency cycle detected: b->a->b")
 }
 
 func TestValidContainerSet(t *testing.T) {
@@ -188,5 +180,5 @@ containers:
       - c
 `
 	err := validateContainerSetTemplate(validContainerSet)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/apis/workflow/v1alpha1/item_test.go
+++ b/pkg/apis/workflow/v1alpha1/item_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestItem(t *testing.T) {
@@ -29,10 +30,10 @@ func TestItem(t *testing.T) {
 
 func runItemTest(t *testing.T, data string, expectedType Type) {
 	itm, err := ParseItem(data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedType, itm.GetType())
 	jsonBytes, err := json.Marshal(itm)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, data, string(jsonBytes), "marshalling is symmetric")
 	if strings.HasPrefix(data, `"`) {
 		assert.Equal(t, data, fmt.Sprintf("\"%v\"", itm))

--- a/pkg/apis/workflow/v1alpha1/plugin_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/plugin_types_test.go
@@ -3,20 +3,20 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlugin_UnmarshalJSON(t *testing.T) {
 	t.Run("Invalid", func(t *testing.T) {
 		p := Plugin{}
-		assert.EqualError(t, p.UnmarshalJSON([]byte(`1`)), "json: cannot unmarshal number into Go value of type map[string]interface {}")
+		require.EqualError(t, p.UnmarshalJSON([]byte(`1`)), "json: cannot unmarshal number into Go value of type map[string]interface {}")
 	})
 	t.Run("NoKeys", func(t *testing.T) {
 		p := Plugin{}
-		assert.EqualError(t, p.UnmarshalJSON([]byte(`{}`)), "expected exactly one key, got 0")
+		require.EqualError(t, p.UnmarshalJSON([]byte(`{}`)), "expected exactly one key, got 0")
 	})
 	t.Run("OneKey", func(t *testing.T) {
 		p := Plugin{}
-		assert.NoError(t, p.UnmarshalJSON([]byte(`{"foo":1}`)))
+		require.NoError(t, p.UnmarshalJSON([]byte(`{"foo":1}`)))
 	})
 }

--- a/pkg/apis/workflow/v1alpha1/validation_utils_test.go
+++ b/pkg/apis/workflow/v1alpha1/validation_utils_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateWorkflowFieldNames(t *testing.T) {
@@ -55,9 +55,9 @@ func TestValidateWorkflowFieldNames(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := validateWorkflowFieldNames(tc.names, tc.isParamOrArtifact)
 			if tc.expectedErr != nil {
-				assert.EqualError(t, err, tc.expectedErr.Error())
+				require.EqualError(t, err, tc.expectedErr.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -101,9 +101,9 @@ func TestVerifyNoCycles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := validateNoCycles(tc.depGraph)
 			if tc.expectedErr != nil {
-				assert.Errorf(t, err, tc.expectedErr.Error())
+				require.Errorf(t, err, tc.expectedErr.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/plugins/spec/plugin_types_test.go
+++ b/pkg/plugins/spec/plugin_types_test.go
@@ -3,27 +3,27 @@ package spec
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestPlugin_Validate(t *testing.T) {
 	err := Plugin{}.Validate()
-	assert.EqualError(t, err, "sidecar is invalid: at least one port is mandatory")
+	require.EqualError(t, err, "sidecar is invalid: at least one port is mandatory")
 }
 
 func TestSidecar_Validate(t *testing.T) {
 	t.Run("NoPorts", func(t *testing.T) {
-		assert.EqualError(t, Sidecar{}.Validate(), "at least one port is mandatory")
+		require.EqualError(t, Sidecar{}.Validate(), "at least one port is mandatory")
 	})
 	t.Run("ResourceRequestsMissing", func(t *testing.T) {
-		assert.EqualError(t, Sidecar{
+		require.EqualError(t, Sidecar{
 			Container: apiv1.Container{Ports: []apiv1.ContainerPort{{}}},
 		}.Validate(), "resources requests are mandatory")
 	})
 	t.Run("ResourceLimitsMissing", func(t *testing.T) {
-		assert.EqualError(t,
+		require.EqualError(t,
 			Sidecar{
 				Container: apiv1.Container{
 					Ports: []apiv1.ContainerPort{{}},
@@ -34,7 +34,7 @@ func TestSidecar_Validate(t *testing.T) {
 			}.Validate(), "resources limits are mandatory")
 	})
 	t.Run("SecurityContext", func(t *testing.T) {
-		assert.EqualError(t, Sidecar{
+		require.EqualError(t, Sidecar{
 			Container: apiv1.Container{
 				Ports: []apiv1.ContainerPort{{}},
 				Resources: apiv1.ResourceRequirements{


### PR DESCRIPTION
This is part of a series of test tidies started by #13365.

The aim is to enable the `testifylint` `golangci-lint` checker.

This commit converts `assert.Error` checks into `require.Error` for the part of the codebase, as per https://github.com/argoproj/argo-workflows/pull/13270#discussion_r1667248031

In some places checks have been coalesced - in particular the pattern

```go
if assert.Error() {
    assert.Contains(..., "message")
}
```

is now
```go
require.ErrorContains(..., "message")
```

Getting this wrong and missing the `Contains` is still valid Go, so that's a mistake I may have made.

Signed-off-by: Alan Clucas <alan@clucas.org>