### PR TITLE
refactor(tests): `assert.Error` -> `require.Error` (other unit tests)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -25,9 +26,9 @@ func TestSanitize(t *testing.T) {
 	for _, tt := range tests {
 		err := tt.c.Sanitize([]string{"http", "https"})
 		if tt.err != "" {
-			assert.Equal(t, err.Error(), tt.err)
+			require.EqualError(t, err, tt.err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 }

--- a/config/controller_test.go
+++ b/config/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
 )
 
@@ -11,7 +12,7 @@ func Test_parseConfigMap(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		c := &Config{}
 		err := parseConfigMap(&apiv1.ConfigMap{}, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("Complex", func(t *testing.T) {
 		c := &Config{}
@@ -26,13 +27,12 @@ func Test_parseConfigMap(t *testing.T) {
       secretKeySecret:
         name: my-minio-cred
         key: secretkey`}}, c)
-		if assert.NoError(t, err) {
-			assert.NotEmpty(t, c.ArtifactRepository)
-		}
+		require.NoError(t, err)
+		assert.NotEmpty(t, c.ArtifactRepository)
 	})
 	t.Run("Garbage", func(t *testing.T) {
 		c := &Config{}
 		err := parseConfigMap(&apiv1.ConfigMap{Data: map[string]string{"garbage": "garbage"}}, c)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/config/ttl_test.go
+++ b/config/ttl_test.go
@@ -5,28 +5,26 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTTL(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		ttl := TTL(-1)
 		err := ttl.UnmarshalJSON([]byte(`""`))
-		if assert.NoError(t, err) {
-			assert.Equal(t, TTL(0), ttl)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, TTL(0), ttl)
 	})
 	t.Run("1h", func(t *testing.T) {
 		ttl := TTL(-1)
 		err := ttl.UnmarshalJSON([]byte(`"1h"`))
-		if assert.NoError(t, err) {
-			assert.Equal(t, TTL(1*time.Hour), ttl)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, TTL(1*time.Hour), ttl)
 	})
 	t.Run("1d", func(t *testing.T) {
 		ttl := TTL(-1)
 		err := ttl.UnmarshalJSON([]byte(`"1d"`))
-		if assert.NoError(t, err) {
-			assert.Equal(t, TTL(24*time.Hour), ttl)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, TTL(24*time.Hour), ttl)
 	})
 }

--- a/persist/sqldb/archived_workflow_labels_test.go
+++ b/persist/sqldb/archived_workflow_labels_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/upper/db/v4"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -32,9 +33,8 @@ func Test_labelsClause(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, req := range tt.requirements {
 				got, err := requirementToCondition(tt.dbType, req, archiveTableName, archiveLabelsTableName, true)
-				if assert.NoError(t, err) {
-					assert.Equal(t, tt.want, *got)
-				}
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, *got)
 			}
 		})
 	}

--- a/persist/sqldb/offload_node_status_repo_test.go
+++ b/persist/sqldb/offload_node_status_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -11,16 +12,14 @@ import (
 func Test_nodeStatusVersion(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		marshalled, version, err := nodeStatusVersion(nil)
-		if assert.NoError(t, err) {
-			assert.NotEmpty(t, marshalled)
-			assert.Equal(t, "fnv:784127654", version)
-		}
+		require.NoError(t, err)
+		assert.NotEmpty(t, marshalled)
+		assert.Equal(t, "fnv:784127654", version)
 	})
 	t.Run("NonEmpty", func(t *testing.T) {
 		marshalled, version, err := nodeStatusVersion(wfv1.Nodes{"my-node": wfv1.NodeStatus{}})
-		if assert.NoError(t, err) {
-			assert.NotEmpty(t, marshalled)
-			assert.Equal(t, "fnv:2308444803", version)
-		}
+		require.NoError(t, err)
+		assert.NotEmpty(t, marshalled)
+		assert.Equal(t, "fnv:2308444803", version)
 	})
 }


### PR DESCRIPTION
This is part of a series of test tidies started by #13365.

The aim is to enable the `testifylint` `golangci-lint` checker.

This commit converts `assert.Error` checks into `require.Error` for the part of the codebase, as per https://github.com/argoproj/argo-workflows/pull/13270#discussion_r1667248031

In some places checks have been coalesced - in particular the pattern

```go
if assert.Error() {
    assert.Contains(..., "message")
}
```

is now
```go
require.ErrorContains(..., "message")
```

Getting this wrong and missing the `Contains` is still valid Go, so that's a mistake I may have made.

Signed-off-by: Alan Clucas <alan@clucas.org>