### PR TITLE
refactor(tests): `assert.Error` -> `require.Error` (`util/`)

### DIFF
--- a/util/archive/archive_test.go
+++ b/util/archive/archive_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func tempFile(dir, prefix, suffix string) (*os.File, error) {
@@ -67,22 +67,22 @@ func TestTarDirectory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f, err := tempFile(os.TempDir()+"/argo-test", "dir-"+tt.name+"-", ".tgz")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			log.Infof("Taring to %s", f.Name())
 
 			err = TarGzToWriter(tt.src, tt.level, bufio.NewWriter(f))
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			err = f.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = os.Remove(f.Name())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -112,31 +112,31 @@ func TestTarFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data, err := tempFile(os.TempDir()+"/argo-test", "file-"+tt.name+"-", "")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = data.WriteString("hello world")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = data.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			dataTarPath := data.Name() + ".tgz"
 			f, err := os.Create(dataTarPath)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			log.Infof("Taring to %s", f.Name())
 
 			err = TarGzToWriter(data.Name(), tt.level, bufio.NewWriter(f))
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			err = os.Remove(data.Name())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = f.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = os.Remove(f.Name())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -161,22 +161,22 @@ func TestZipDirectory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f, err := tempFile(os.TempDir()+"/argo-test", "dir-"+tt.name+"-", ".tgz")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			log.Infof("Zipping to %s", f.Name())
 
 			err = ZipToWriter(tt.src, zip.NewWriter(f))
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			err = f.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = os.Remove(f.Name())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -184,24 +184,24 @@ func TestZipDirectory(t *testing.T) {
 func TestZipFile(t *testing.T) {
 	t.Run("test_zip_file", func(t *testing.T) {
 		data, err := tempFile(os.TempDir()+"/argo-test", "file-random-", "")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, err = data.WriteString("hello world")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = data.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		dataZipPath := data.Name() + ".zip"
 		f, err := os.Create(dataZipPath)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = ZipToWriter(data.Name(), zip.NewWriter(f))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = os.Remove(data.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = f.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = os.Remove(f.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/util/auth/auth_test.go
+++ b/util/auth/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -27,11 +28,9 @@ func TestCanI(t *testing.T) {
 
 	ctx := context.Background()
 	allowed, err := CanI(ctx, kubeClient, "get", "workflow", "", "")
-	if assert.NoError(t, err) {
-		assert.True(t, allowed)
-	}
+	require.NoError(t, err)
+	assert.True(t, allowed)
 	notAllowed, err := CanI(ctx, kubeClient, "list", "workflow", "", "")
-	if assert.NoError(t, err) {
-		assert.False(t, notAllowed)
-	}
+	require.NoError(t, err)
+	assert.False(t, notAllowed)
 }

--- a/util/fields/fields_test.go
+++ b/util/fields/fields_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -48,7 +49,7 @@ func TestCleaner_WithPrefix(t *testing.T) {
 func TestCleanNoop(t *testing.T) {
 	var wf, cleanWf wfv1.Workflow
 	ok, err := NewCleaner("").Clean(wf, cleanWf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ok)
 }
 
@@ -56,7 +57,7 @@ func TestCleanFields(t *testing.T) {
 	var wf, cleanWf wfv1.Workflow
 	wfv1.MustUnmarshal([]byte(sampleWorkflow), &wf)
 	ok, err := NewCleaner("status.phase,metadata.name,spec.entrypoint").Clean(wf, &cleanWf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, wfv1.WorkflowSucceeded, cleanWf.Status.Phase)
 	assert.Equal(t, "whalesay", cleanWf.Spec.Entrypoint)
@@ -68,7 +69,7 @@ func TestCleanFieldsExclude(t *testing.T) {
 	var wf, cleanWf wfv1.Workflow
 	wfv1.MustUnmarshal([]byte(sampleWorkflow), &wf)
 	ok, err := NewCleaner("-status.phase,metadata.name,spec.entrypoint").Clean(wf, &cleanWf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Empty(t, cleanWf.Status.Phase)
 	assert.Empty(t, cleanWf.Spec.Entrypoint)

--- a/util/file/fileutil_test.go
+++ b/util/file/fileutil_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-workflows/v3/util/file"
 )
@@ -37,12 +38,12 @@ func TestGetGzipReader(t *testing.T) {
 		rawContent := "this is the content"
 		content := file.CompressEncodeString(rawContent)
 		buf, err := base64.StdEncoding.DecodeString(content)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		bufReader := bytes.NewReader(buf)
 		reader, err := file.GetGzipReader(bufReader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		res, err := io.ReadAll(reader)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, rawContent, string(res))
 	}
 }
@@ -63,12 +64,13 @@ func TestExistsInTar(t *testing.T) {
 			}
 			hdr := tar.Header{Name: f.name, Mode: int64(mode), Size: int64(len(f.body))}
 			err := writer.WriteHeader(&hdr)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = writer.Write([]byte(f.body))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 		err := writer.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		return tar.NewReader(&buf)
 	}
 

--- a/util/instanceid/service_test.go
+++ b/util/instanceid/service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -50,14 +51,14 @@ func TestWith(t *testing.T) {
 func TestValidate(t *testing.T) {
 	t.Run("NoInstanceID", func(t *testing.T) {
 		s := NewService("")
-		assert.NoError(t, s.Validate(&wfv1.Workflow{}))
-		assert.Error(t, s.Validate(&wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{common.LabelKeyControllerInstanceID: "bar"}}}))
+		require.NoError(t, s.Validate(&wfv1.Workflow{}))
+		require.Error(t, s.Validate(&wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{common.LabelKeyControllerInstanceID: "bar"}}}))
 	})
 	t.Run("InstanceID", func(t *testing.T) {
 		s := NewService("foo")
-		assert.Error(t, s.Validate(&wfv1.Workflow{}))
-		assert.Error(t, s.Validate(&wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{common.LabelKeyControllerInstanceID: "bar"}}}))
-		assert.NoError(t, s.Validate(&wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{common.LabelKeyControllerInstanceID: "foo"}}}))
+		require.Error(t, s.Validate(&wfv1.Workflow{}))
+		require.Error(t, s.Validate(&wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{common.LabelKeyControllerInstanceID: "bar"}}}))
+		require.NoError(t, s.Validate(&wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{common.LabelKeyControllerInstanceID: "foo"}}}))
 	})
 }
 

--- a/util/intstr/parametrizable_test.go
+++ b/util/intstr/parametrizable_test.go
@@ -4,56 +4,57 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInt(t *testing.T) {
 	i, err := Int(ParsePtr("2"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 2, *i)
 
 	i, err = Int(ParsePtr("-1"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, -1, *i)
 
 	_, err = Int(ParsePtr("{{argo.variable}}"))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	i, err = Int(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, i)
 }
 
 func TestInt32(t *testing.T) {
 	i, err := Int32(ParsePtr("2"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int32(2), *i)
 
 	i, err = Int32(ParsePtr("-1"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int32(-1), *i)
 
 	_, err = Int32(ParsePtr("{{argo.variable}}"))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	i, err = Int32(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, i)
 }
 
 func TestInt64(t *testing.T) {
 	i, err := Int64(ParsePtr("2"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(2), *i)
 
 	i, err = Int64(ParsePtr("-1"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(-1), *i)
 
 	_, err = Int64(ParsePtr("{{argo.variable}}"))
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	i, err = Int64(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, i)
 }
 

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -34,9 +35,9 @@ users:
 func Test_BasicAuthString(t *testing.T) {
 	t.Run("Basic Auth", func(t *testing.T) {
 		restConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(config))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		authString, err := GetAuthString(restConfig, "")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, IsBasicAuthScheme(authString))
 		token := strings.TrimSpace(strings.TrimPrefix(authString, BasicAuthScheme))
 		uname, pwd, ok := decodeBasicAuthToken(token)
@@ -45,16 +46,15 @@ func Test_BasicAuthString(t *testing.T) {
 			assert.Equal(t, "admin", pwd)
 		}
 		file, err := os.CreateTemp("", "config.yaml")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, err = file.WriteString(config)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = file.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		t.Setenv("KUBECONFIG", file.Name())
 		config, err := GetRestConfig(authString)
-		if assert.NoError(t, err) {
-			assert.Equal(t, "admin", config.Username)
-			assert.Equal(t, "admin", config.Password)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "admin", config.Username)
+		assert.Equal(t, "admin", config.Password)
 	})
 }

--- a/util/printer/workflow-printer_test.go
+++ b/util/printer/workflow-printer_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -48,63 +49,63 @@ func TestPrintWorkflows(t *testing.T) {
 	var emptyWorkflows wfv1.Workflows
 	t.Run("Empty", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{}))
+		require.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{}))
 		assert.Equal(t, `No workflows found
 `, b.String())
 	})
 	t.Run("EmptyJSON", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{Output: "json"}))
+		require.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{Output: "json"}))
 		assert.Equal(t, `[]
 `, b.String())
 	})
 	t.Run("EmptyYAML", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{Output: "yaml"}))
+		require.NoError(t, PrintWorkflows(emptyWorkflows, &b, PrintOpts{Output: "yaml"}))
 		assert.Equal(t, `[]
 `, b.String())
 	})
 	t.Run("Default", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{}))
 		assert.Equal(t, `NAME    STATUS    AGE   DURATION   PRIORITY   MESSAGE
 my-wf   Running   0s    3s         2          test-message
 `, b.String())
 	})
 	t.Run("NoHeader", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{NoHeaders: true}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{NoHeaders: true}))
 		assert.Equal(t, `my-wf   Running   0s   3s   2   test-message
 `, b.String())
 	})
 	t.Run("Namespace", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Namespace: true}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Namespace: true}))
 		assert.Equal(t, `NAMESPACE   NAME    STATUS    AGE   DURATION   PRIORITY   MESSAGE
 my-ns       my-wf   Running   0s    3s         2          test-message
 `, b.String())
 	})
 	t.Run("Wide", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "wide"}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "wide"}))
 		assert.Equal(t, `NAME    STATUS    AGE   DURATION   PRIORITY   MESSAGE        P/R/C   PARAMETERS
 my-wf   Running   0s    3s         2          test-message   1/2/3   my-param=my-value
 `, b.String())
 	})
 	t.Run("Name", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "name"}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "name"}))
 		assert.Equal(t, `my-wf
 `, b.String())
 	})
 	t.Run("JSON", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "json"}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "json"}))
 		assert.NotEmpty(t, b.String())
 	})
 	t.Run("YAML", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "yaml"}))
+		require.NoError(t, PrintWorkflows(workflows, &b, PrintOpts{Output: "yaml"}))
 		assert.NotEmpty(t, b.String())
 	})
 }
@@ -132,21 +133,21 @@ func TestPrintWorkflowCostOptimizationNudges(t *testing.T) {
 
 	t.Run("CostOptimizationOnCompletedWorkflows", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(completedWorkflows, &b, PrintOpts{}))
+		require.NoError(t, PrintWorkflows(completedWorkflows, &b, PrintOpts{}))
 		assert.Contains(t, b.String(), "\nYou have at least 101 completed workflows. "+
 			"Reducing the total number of workflows will reduce your costs."+
 			"\nLearn more at https://argo-workflows.readthedocs.io/en/latest/cost-optimisation/\n")
 	})
 	t.Run("CostOptimizationOnIncompleteWorkflows", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(incompleteWorkflows, &b, PrintOpts{}))
+		require.NoError(t, PrintWorkflows(incompleteWorkflows, &b, PrintOpts{}))
 		assert.Contains(t, b.String(), "\nYou have at least 101 incomplete workflows. "+
 			"Reducing the total number of workflows will reduce your costs."+
 			"\nLearn more at https://argo-workflows.readthedocs.io/en/latest/cost-optimisation/\n")
 	})
 	t.Run("CostOptimizationOnCompletedAndIncompleteWorkflows", func(t *testing.T) {
 		var b bytes.Buffer
-		assert.NoError(t, PrintWorkflows(completedAndIncompleteWorkflows, &b, PrintOpts{}))
+		require.NoError(t, PrintWorkflows(completedAndIncompleteWorkflows, &b, PrintOpts{}))
 		assert.Contains(t, b.String(), "\nYou have at least 101 incomplete and 101 completed workflows. "+
 			"Reducing the total number of workflows will reduce your costs."+
 			"\nLearn more at https://argo-workflows.readthedocs.io/en/latest/cost-optimisation/\n")

--- a/util/template/replace_test.go
+++ b/util/template/replace_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func toJsonString(v interface{}) string {
@@ -15,85 +16,83 @@ func toJsonString(v interface{}) string {
 func Test_Replace(t *testing.T) {
 	t.Run("InvalidTemplate", func(t *testing.T) {
 		_, err := Replace(toJsonString("{{"), nil, false)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 	t.Run("Simple", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			r, err := Replace(toJsonString("{{foo}}"), map[string]string{"foo": "bar"}, false)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, toJsonString("bar"), r)
 		})
 		t.Run("Unresolved", func(t *testing.T) {
 			t.Run("Allowed", func(t *testing.T) {
 				_, err := Replace(toJsonString("{{foo}}"), nil, true)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			})
 			t.Run("Disallowed", func(t *testing.T) {
 				_, err := Replace(toJsonString("{{foo}}"), nil, false)
-				assert.EqualError(t, err, "failed to resolve {{foo}}")
+				require.EqualError(t, err, "failed to resolve {{foo}}")
 			})
 		})
 	})
 	t.Run("Expression", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			r, err := Replace(toJsonString("{{=foo}}"), map[string]string{"foo": "bar"}, false)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, toJsonString("bar"), r)
 		})
 		t.Run("Valid WorkflowStatus", func(t *testing.T) {
 			replaced, err := Replace(toJsonString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.status": "Succeeded"}, false)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, toJsonString(`SUCCESSFUL`), replaced)
 			replaced, err = Replace(toJsonString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.status": "Failed"}, false)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, toJsonString(`FAILED`), replaced)
 		})
 		t.Run("Valid WorkflowFailures", func(t *testing.T) {
 			replaced, err := Replace(toJsonString(`{{=workflow.failures == "{\"foo\":\"bar\"}" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.failures": `{"foo":"bar"}`}, false)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, toJsonString(`SUCCESSFUL`), replaced)
 			replaced, err = Replace(toJsonString(`{{=workflow.failures == "{\"foo\":\"bar\"}" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.failures": `{"foo":"barr"}`}, false)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, toJsonString(`FAILED`), replaced)
 		})
 		t.Run("Unresolved", func(t *testing.T) {
 			t.Run("Allowed", func(t *testing.T) {
 				_, err := Replace(toJsonString("{{=foo}}"), nil, true)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			})
 			t.Run("AllowedRetries", func(t *testing.T) {
 				replaced, err := Replace(toJsonString("{{=sprig.int(retries)}}"), nil, true)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, toJsonString("{{=sprig.int(retries)}}"), replaced)
 			})
 			t.Run("AllowedWorkflowStatus", func(t *testing.T) {
 				replaced, err := Replace(toJsonString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), nil, true)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, toJsonString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), replaced)
 			})
 			t.Run("AllowedWorkflowFailures", func(t *testing.T) {
 				replaced, err := Replace(toJsonString(`{{=workflow.failures == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), nil, true)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, toJsonString(`{{=workflow.failures == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), replaced)
 			})
 			t.Run("Disallowed", func(t *testing.T) {
 				_, err := Replace(toJsonString("{{=foo}}"), nil, false)
-				assert.EqualError(t, err, "failed to evaluate expression: unknown name foo (1:1)\n | foo\n | ^")
+				require.EqualError(t, err, "failed to evaluate expression: unknown name foo (1:1)\n | foo\n | ^")
 			})
 			t.Run("DisallowedWorkflowStatus", func(t *testing.T) {
 				_, err := Replace(toJsonString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), nil, false)
-				assert.ErrorContains(t, err, "failed to evaluate expression")
+				require.ErrorContains(t, err, "failed to evaluate expression")
 			})
 			t.Run("DisallowedWorkflowFailures", func(t *testing.T) {
 				_, err := Replace(toJsonString(`{{=workflow.failures == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), nil, false)
-				assert.ErrorContains(t, err, "failed to evaluate expression")
+				require.ErrorContains(t, err, "failed to evaluate expression")
 			})
 		})
 		t.Run("Error", func(t *testing.T) {
 			_, err := Replace(toJsonString("{{=!}}"), nil, false)
-			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "failed to evaluate expression")
-			}
+			require.ErrorContains(t, err, "failed to evaluate expression")
 		})
 	})
 }
@@ -105,54 +104,48 @@ func TestNestedReplaceString(t *testing.T) {
     {{ .Data.data.gitcreds }}
   {{- end }}`)
 	replacement, err := Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("{{- with secret \"hello world\" -}}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("{{- with secret \"hello world\" -}}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
 
 	test = toJsonString(`{{- with {{ secret "{{inputs.parameters.message}}" -}}
     {{ .Data.data.gitcreds }}
   {{- end }}`)
 
 	replacement, err = Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("{{- with {{ secret \"hello world\" -}}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("{{- with {{ secret \"hello world\" -}}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
 
 	test = toJsonString(`{{- with {{ secret "{{inputs.parameters.message}}" -}} }}
     {{ .Data.data.gitcreds }}
   {{- end }}`)
 
 	replacement, err = Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("{{- with {{ secret \"hello world\" -}} }}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("{{- with {{ secret \"hello world\" -}} }}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
 
 	test = toJsonString(`{{- with secret "{{inputs.parameters.message}}" -}} }}
     {{ .Data.data.gitcreds }}
   {{- end }}`)
 
 	replacement, err = Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("{{- with secret \"hello world\" -}} }}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("{{- with secret \"hello world\" -}} }}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
 
 	test = toJsonString(`{{- with {{ {{ }} secret "{{inputs.parameters.message}}" -}} }}
     {{ .Data.data.gitcreds }}
   {{- end }}`)
 
 	replacement, err = Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("{{- with {{ {{ }} secret \"hello world\" -}} }}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("{{- with {{ {{ }} secret \"hello world\" -}} }}\n    {{ .Data.data.gitcreds }}\n  {{- end }}"), replacement)
 
 	test = toJsonString(`{{- with {{ {{ }} secret "{{does-not-exist}}" -}} }}
     {{ .Data.data.gitcreds }}
   {{- end }}`)
 
 	replacement, err = Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, test, replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, test, replacement)
 }
 
 func TestReplaceStringWithWhiteSpace(t *testing.T) {
@@ -160,9 +153,8 @@ func TestReplaceStringWithWhiteSpace(t *testing.T) {
 
 	test := toJsonString(`{{ inputs.parameters.message }}`)
 	replacement, err := Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("hello world"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("hello world"), replacement)
 }
 
 func TestReplaceStringWithExpression(t *testing.T) {
@@ -170,13 +162,11 @@ func TestReplaceStringWithExpression(t *testing.T) {
 
 	test := toJsonString(`test {{= sprig.trunc(5, inputs.parameters.message) }}`)
 	replacement, err := Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("test hello"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("test hello"), replacement)
 
 	test = toJsonString(`test {{= sprig.trunc(-5, inputs.parameters.message) }}`)
 	replacement, err = Replace(test, replaceMap, true)
-	if assert.NoError(t, err) {
-		assert.Equal(t, toJsonString("test world"), replacement)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, toJsonString("test world"), replacement)
 }

--- a/util/template/resolve_var_test.go
+++ b/util/template/resolve_var_test.go
@@ -4,38 +4,39 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ResolveVar(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			v, err := ResolveVar("{{foo}}", map[string]interface{}{"foo": "bar"})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "bar", v)
 		})
 		t.Run("Whitespace", func(t *testing.T) {
 			v, err := ResolveVar("{{ foo }}", map[string]interface{}{"foo": "bar"})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "bar", v)
 		})
 		t.Run("Unresolved", func(t *testing.T) {
 			_, err := ResolveVar("{{foo}}", nil)
-			assert.EqualError(t, err, "Unable to resolve: \"foo\"")
+			require.EqualError(t, err, "Unable to resolve: \"foo\"")
 		})
 	})
 	t.Run("Expression", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			v, err := ResolveVar("{{=foo}}", map[string]interface{}{"foo": "bar"})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, "bar", v)
 		})
 		t.Run("Unresolved", func(t *testing.T) {
 			_, err := ResolveVar("{{=foo}}", nil)
-			assert.EqualError(t, err, "Unable to compile: \"foo\"")
+			require.EqualError(t, err, "Unable to compile: \"foo\"")
 		})
 		t.Run("Error", func(t *testing.T) {
 			_, err := ResolveVar("{{=!}}", nil)
-			assert.EqualError(t, err, "Unable to compile: \"!\"")
+			require.EqualError(t, err, "Unable to compile: \"!\"")
 		})
 	})
 }

--- a/util/template/template_test.go
+++ b/util/template/template_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type SimpleValue struct {
@@ -13,12 +14,12 @@ type SimpleValue struct {
 
 func processTemplate(t *testing.T, tmpl SimpleValue, replaceMap map[string]string) SimpleValue {
 	tmplBytes, err := json.Marshal(tmpl)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r, err := Replace(string(tmplBytes), replaceMap, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var newTmpl SimpleValue
 	err = json.Unmarshal([]byte(r), &newTmpl)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return newTmpl
 }
 

--- a/util/template/validate_test.go
+++ b/util/template/validate_test.go
@@ -4,24 +4,24 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Validate(t *testing.T) {
 	t.Run("InvalidTemplate", func(t *testing.T) {
 		err := Validate("{{", func(tag string) error { return fmt.Errorf("") })
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 	t.Run("InvalidTag", func(t *testing.T) {
 		err := Validate("{{foo}}", func(tag string) error { return fmt.Errorf(tag) })
-		assert.EqualError(t, err, "foo")
+		require.EqualError(t, err, "foo")
 	})
 	t.Run("Simple", func(t *testing.T) {
 		err := Validate("{{foo}}", func(tag string) error { return nil })
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("Expression", func(t *testing.T) {
 		err := Validate("{{=foo}}", func(tag string) error { return fmt.Errorf(tag) })
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/util/tls/tls_test.go
+++ b/util/tls/tls_test.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerate(t *testing.T) {
 	t.Run("Create certificate with default options", func(t *testing.T) {
 		certBytes, privKey, err := generate()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, privKey)
 		cert, err := x509.ParseCertificate(certBytes)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, cert)
 		assert.Len(t, cert.DNSNames, 1)
 		assert.Equal(t, "localhost", cert.DNSNames[0])
@@ -26,14 +27,14 @@ func TestGenerate(t *testing.T) {
 func TestGeneratePEM(t *testing.T) {
 	t.Run("Create PEM from certficate options", func(t *testing.T) {
 		cert, key, err := generatePEM()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, cert)
 		assert.NotNil(t, key)
 	})
 
 	t.Run("Create X509KeyPair", func(t *testing.T) {
 		cert, err := GenerateX509KeyPair()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, cert)
 	})
 }

--- a/util/wait/backoff_test.go
+++ b/util/wait/backoff_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -13,13 +14,13 @@ func TestExponentialBackoff2(t *testing.T) {
 		err := Backoff(wait.Backoff{Steps: 1}, func() (bool, error) {
 			return true, nil
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("Error", func(t *testing.T) {
 		err := Backoff(wait.Backoff{Steps: 1}, func() (bool, error) {
 			return true, errors.New("foo")
 		})
-		assert.EqualError(t, err, "foo")
+		require.EqualError(t, err, "foo")
 	})
 	t.Run("Timeout", func(t *testing.T) {
 		err := Backoff(wait.Backoff{Steps: 1}, func() (bool, error) {
@@ -31,6 +32,6 @@ func TestExponentialBackoff2(t *testing.T) {
 		err := Backoff(wait.Backoff{Steps: 1}, func() (bool, error) {
 			return false, errors.New("foo")
 		})
-		assert.EqualError(t, err, "timed out waiting for the condition: foo")
+		require.EqualError(t, err, "timed out waiting for the condition: foo")
 	})
 }


### PR DESCRIPTION
This is part of a series of test tidies started by #13365.

The aim is to enable the `testifylint` `golangci-lint` checker.

This commit converts `assert.Error` checks into `require.Error` for the part of the codebase, as per https://github.com/argoproj/argo-workflows/pull/13270#discussion_r1667248031

In some places checks have been coalesced - in particular the pattern

```go
if assert.Error() {
    assert.Contains(..., "message")
}
```

is now
```go
require.ErrorContains(..., "message")
```

Getting this wrong and missing the `Contains` is still valid Go, so that's a mistake I may have made.

Signed-off-by: Alan Clucas <alan@clucas.org>