### PR TITLE
refactor(tests): `assert.Error` -> `require.Error` (other `workflow/` dirs)

### DIFF
--- a/workflow/artifactrepositories/artifactrepositories_test.go
+++ b/workflow/artifactrepositories/artifactrepositories_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
@@ -31,22 +32,22 @@ s3:
   keyFormat: bar
 `},
 		}, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		ref, err := i.Resolve(ctx, &wfv1.ArtifactRepositoryRef{Key: "my-key"}, "my-wf-ns")
-		if assert.NoError(t, err) {
-			assert.Equal(t, "my-wf-ns", ref.Namespace)
-			assert.Equal(t, "artifact-repositories", ref.ConfigMap)
-			assert.Equal(t, "my-key", ref.Key)
-			assert.False(t, ref.Default)
-			assert.NotNil(t, ref.ArtifactRepository)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "my-wf-ns", ref.Namespace)
+		assert.Equal(t, "artifact-repositories", ref.ConfigMap)
+		assert.Equal(t, "my-key", ref.Key)
+		assert.False(t, ref.Default)
+		assert.NotNil(t, ref.ArtifactRepository)
+
 		repo, err := i.Get(ctx, ref)
-		if assert.NoError(t, err) {
-			assert.Equal(t, &wfv1.ArtifactRepository{S3: &wfv1.S3ArtifactRepository{KeyFormat: "bar"}}, repo)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, &wfv1.ArtifactRepository{S3: &wfv1.S3ArtifactRepository{KeyFormat: "bar"}}, repo)
+
 		err = k.CoreV1().ConfigMaps("my-wf-ns").Delete(ctx, "artifact-repositories", metav1.DeleteOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("Explicit.ControllerNamespace", func(t *testing.T) {
 		ctx := context.Background()
@@ -57,40 +58,40 @@ s3:
   keyFormat: bar
 `},
 		}, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		ref, err := i.Resolve(ctx, &wfv1.ArtifactRepositoryRef{Key: "my-key"}, "my-wf-ns")
-		if assert.NoError(t, err) {
-			assert.Equal(t, "my-ctrl-ns", ref.Namespace)
-			assert.Equal(t, "artifact-repositories", ref.ConfigMap)
-			assert.Equal(t, "my-key", ref.Key)
-			assert.False(t, ref.Default)
-			assert.NotNil(t, ref.ArtifactRepository)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "my-ctrl-ns", ref.Namespace)
+		assert.Equal(t, "artifact-repositories", ref.ConfigMap)
+		assert.Equal(t, "my-key", ref.Key)
+		assert.False(t, ref.Default)
+		assert.NotNil(t, ref.ArtifactRepository)
+
 		repo, err := i.Get(ctx, ref)
-		if assert.NoError(t, err) {
-			assert.Equal(t, &wfv1.ArtifactRepository{S3: &wfv1.S3ArtifactRepository{KeyFormat: "bar"}}, repo)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, &wfv1.ArtifactRepository{S3: &wfv1.S3ArtifactRepository{KeyFormat: "bar"}}, repo)
+
 		err = k.CoreV1().ConfigMaps("my-ctrl-ns").Delete(ctx, "artifact-repositories", metav1.DeleteOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("Explicit.ConfigMapNotFound", func(t *testing.T) {
 		ctx := context.Background()
 		_, err := i.Resolve(ctx, &wfv1.ArtifactRepositoryRef{}, "my-wf-ns")
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 	t.Run("Explicit.ConfigMapMissingKey", func(t *testing.T) {
 		ctx := context.Background()
 		_, err := k.CoreV1().ConfigMaps("my-ns").Create(ctx, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "artifact-repositories"},
 		}, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = i.Resolve(ctx, &wfv1.ArtifactRepositoryRef{}, "my-wf-ns")
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		err = k.CoreV1().ConfigMaps("my-ns").Delete(ctx, "artifact-repositories", metav1.DeleteOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("WorkflowNamespaceDefault", func(t *testing.T) {
 		ctx := context.Background()
@@ -104,22 +105,22 @@ s3:
   keyFormat: bar
 `},
 		}, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		ref, err := i.Resolve(ctx, nil, "my-wf-ns")
-		if assert.NoError(t, err) {
-			assert.Equal(t, "my-wf-ns", ref.Namespace)
-			assert.Equal(t, "artifact-repositories", ref.ConfigMap)
-			assert.Equal(t, "default-v1", ref.Key)
-			assert.False(t, ref.Default)
-			assert.NotNil(t, ref.ArtifactRepository)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "my-wf-ns", ref.Namespace)
+		assert.Equal(t, "artifact-repositories", ref.ConfigMap)
+		assert.Equal(t, "default-v1", ref.Key)
+		assert.False(t, ref.Default)
+		assert.NotNil(t, ref.ArtifactRepository)
+
 		repo, err := i.Get(ctx, ref)
-		if assert.NoError(t, err) {
-			assert.Equal(t, &wfv1.ArtifactRepository{S3: &wfv1.S3ArtifactRepository{KeyFormat: "bar"}}, repo)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, &wfv1.ArtifactRepository{S3: &wfv1.S3ArtifactRepository{KeyFormat: "bar"}}, repo)
+
 		err = k.CoreV1().ConfigMaps("my-wf-ns").Delete(ctx, "artifact-repositories", metav1.DeleteOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("DefaultWithNamespace", func(t *testing.T) {
 		ctx := context.Background()
@@ -128,19 +129,19 @@ s3:
 				Name: "artifact-repositories",
 			},
 		}, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		ref, err := i.Resolve(ctx, nil, "my-wf-ns")
-		if assert.NoError(t, err) {
-			assert.Equal(t, defaultArtifactRepositoryRefStatus, ref)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, defaultArtifactRepositoryRefStatus, ref)
+
 		err = k.CoreV1().ConfigMaps("my-wf-ns").Delete(ctx, "artifact-repositories", metav1.DeleteOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("Default", func(t *testing.T) {
 		ctx := context.Background()
 		ref, err := i.Resolve(ctx, nil, "my-wf-ns")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, defaultArtifactRepositoryRefStatus, ref)
 	})
 }

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -18,6 +18,7 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetermineAccountName(t *testing.T) {
@@ -33,9 +34,9 @@ func TestDetermineAccountName(t *testing.T) {
 	}
 	for _, u := range validUrls {
 		u, err := url.Parse(u)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		accountName, err := determineAccountName(u)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "accountname", accountName)
 	}
 
@@ -44,9 +45,9 @@ func TestDetermineAccountName(t *testing.T) {
 	}
 	for _, u := range invalidUrls {
 		u, err := url.Parse(u)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		accountName, err := determineAccountName(u)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, "", accountName)
 	}
 }
@@ -62,11 +63,11 @@ func TestArtifactDriver_WithServiceKey_DownloadDirectory_Subdir(t *testing.T) {
 
 	// ensure container exists
 	containerClient, err := driver.newAzureContainerClient()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = containerClient.Create(context.Background(), nil)
 	var responseError *azcore.ResponseError
 	if err != nil && !(errors.As(err, &responseError) && responseError.ErrorCode == "ContainerAlreadyExists") {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	// test read/write operations to the azurite container  using the container client
@@ -106,7 +107,7 @@ func TestArtifactDriver_WithSASToken_DownloadDirectory_Subdir(t *testing.T) {
 
 	// ensure container exists
 	containerClient, err := driver.newAzureContainerClient()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// test read/write operations to the azurite container  using the container client
 	testContainerClientReadWriteOperations(t, containerClient, driver)
@@ -118,7 +119,7 @@ func testContainerClientReadWriteOperations(t *testing.T, containerClient *conta
 	// download the dir, containing a subdir
 	blobClient := containerClient.NewBlockBlobClient("dir/subdir/file-in-subdir.txt")
 	_, err := blobClient.UploadBuffer(context.Background(), []byte("foo"), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	azureArtifact := wfv1.AzureArtifact{
 		Blob: "dir",
@@ -130,7 +131,7 @@ func testContainerClientReadWriteOperations(t *testing.T, containerClient *conta
 	}
 	dstDir := t.TempDir()
 	err = driver.DownloadDirectory(containerClient, &argoArtifact, filepath.Join(dstDir, "dir"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.FileExists(t, filepath.Join(dstDir, "dir", "subdir", "file-in-subdir.txt"))
 }
 

--- a/workflow/artifacts/common/load_to_stream_test.go
+++ b/workflow/artifacts/common/load_to_stream_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -104,7 +105,7 @@ func TestLoadToStream(t *testing.T) {
 
 			stream, err := LoadToStream(&wfv1.Artifact{}, tc.artifactDriver)
 			if tc.errMsg == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, stream)
 				stream.Close()
 
@@ -115,7 +116,7 @@ func TestLoadToStream(t *testing.T) {
 				}
 				assert.Equal(t, len(filesBefore), len(filesAfter))
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, tc.errMsg, err.Error())
 			}
 		})

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -14,13 +15,13 @@ import (
 func TestGitArtifactDriver_Save(t *testing.T) {
 	driver := &ArtifactDriver{}
 	err := driver.Save("", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestGitArtifactDriver_Load(t *testing.T) {
 	t.Run("EmptyRepo", func(t *testing.T) {
 		driver := &ArtifactDriver{}
-		assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/empty-test-repo.git"}))
+		require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/empty-test-repo.git"}))
 		assert.DirExists(t, path)
 	})
 	t.Run("PrivateRepo", func(t *testing.T) {
@@ -33,9 +34,9 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 				t.SkipNow()
 			}
 			privateKey, err := os.ReadFile(homedir.HomeDir() + "/.ssh/id_rsa")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			driver := &ArtifactDriver{SSHPrivateKey: string(privateKey)}
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "git@github.com:argoproj-labs/private-test-repo.git"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "git@github.com:argoproj-labs/private-test-repo.git"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 		t.Run("HTTPS", func(t *testing.T) {
@@ -44,31 +45,31 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 				t.SkipNow()
 			}
 			driver := &ArtifactDriver{Username: "alexec", Password: token}
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/private-test-repo.git"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/private-test-repo.git"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 	})
 	t.Run("PublicRepo", func(t *testing.T) {
 		driver := &ArtifactDriver{}
-		assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git"}))
+		require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git"}))
 		assert.FileExists(t, path+"/README.md")
 	})
 	t.Run("Depth", func(t *testing.T) {
 		driver := &ArtifactDriver{}
 		var depth uint64 = 1
-		assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Depth: &depth}))
+		require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Depth: &depth}))
 		assert.FileExists(t, path+"/README.md")
 	})
 	t.Run("FetchRefs", func(t *testing.T) {
 		driver := &ArtifactDriver{}
 		t.Run("Garbage", func(t *testing.T) {
-			assert.Error(t, load(driver, &wfv1.GitArtifact{
+			require.Error(t, load(driver, &wfv1.GitArtifact{
 				Repo:  "https://github.com/argoproj-labs/test-repo.git",
 				Fetch: []string{"garbage"},
 			}))
 		})
 		t.Run("Valid", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{
+			require.NoError(t, load(driver, &wfv1.GitArtifact{
 				Repo:  "https://github.com/argoproj-labs/test-repo.git",
 				Fetch: []string{"+refs/heads/*:refs/remotes/origin/*"},
 			}))
@@ -78,45 +79,45 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 	t.Run("Revision", func(t *testing.T) {
 		driver := &ArtifactDriver{}
 		t.Run("Garbage", func(t *testing.T) {
-			assert.Error(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "garbage"}))
+			require.Error(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "garbage"}))
 		})
 		t.Run("Hash", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "6093d6a"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "6093d6a"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 		t.Run("HEAD", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "HEAD"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "HEAD"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 		t.Run("HEAD~1", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "HEAD~1"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "HEAD~1"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 		t.Run("Main", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "main"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "main"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 		t.Run("RemoteBranch", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "origin/my-branch"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "origin/my-branch"}))
 			assert.FileExists(t, path+"/my-branch")
 		})
 		t.Run("LocalBranch", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "my-branch"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "my-branch"}))
 			assert.FileExists(t, path+"/my-branch")
 		})
 		t.Run("Tag", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "v0.0.0"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo.git", Revision: "v0.0.0"}))
 			assert.FileExists(t, path+"/README.md")
 		})
 	})
 	t.Run("Submodules", func(t *testing.T) {
 		driver := &ArtifactDriver{}
 		t.Run("Disabled", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo-w-submodule.git", DisableSubmodules: true}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo-w-submodule.git", DisableSubmodules: true}))
 			assert.FileExists(t, path+"/README.md")
 		})
 		t.Run("Enabled", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo-w-submodule.git"}))
+			require.NoError(t, load(driver, &wfv1.GitArtifact{Repo: "https://github.com/argoproj-labs/test-repo-w-submodule.git"}))
 			assert.FileExists(t, path+"/test-repo/README.md")
 		})
 	})
@@ -124,7 +125,7 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 	t.Run("SingleBranch", func(t *testing.T) {
 		driver := &ArtifactDriver{}
 		t.Run("LocalBranch", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{
+			require.NoError(t, load(driver, &wfv1.GitArtifact{
 				Repo:         "https://github.com/argoproj-labs/test-repo.git",
 				Branch:       "my-branch",
 				SingleBranch: true,
@@ -133,7 +134,7 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 			assertOnlyFile(t, path+"/.git/refs/heads", "my-branch")
 		})
 		t.Run("Revision", func(t *testing.T) {
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{
+			require.NoError(t, load(driver, &wfv1.GitArtifact{
 				Repo:         "https://github.com/argoproj-labs/test-repo.git",
 				Branch:       "my-branch",
 				SingleBranch: true,
@@ -144,7 +145,7 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 		})
 		t.Run("Depth", func(t *testing.T) {
 			var depth uint64 = 1
-			assert.NoError(t, load(driver, &wfv1.GitArtifact{
+			require.NoError(t, load(driver, &wfv1.GitArtifact{
 				Repo:         "https://github.com/argoproj-labs/test-repo.git",
 				Branch:       "my-branch",
 				SingleBranch: true,
@@ -154,14 +155,14 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 			assertOnlyFile(t, path+"/.git/refs/heads", "my-branch")
 		})
 		t.Run("NoBranchSpecified", func(t *testing.T) {
-			assert.Error(t, load(driver, &wfv1.GitArtifact{
+			require.Error(t, load(driver, &wfv1.GitArtifact{
 				Repo:         "https://github.com/argoproj-labs/test-repo.git",
 				Branch:       "",
 				SingleBranch: true,
 			}))
 		})
 		t.Run("Garbage", func(t *testing.T) {
-			assert.Error(t, load(driver, &wfv1.GitArtifact{
+			require.Error(t, load(driver, &wfv1.GitArtifact{
 				Repo:         "https://github.com/argoproj-labs/test-repo.git",
 				Branch:       "garbage",
 				SingleBranch: true,
@@ -174,7 +175,7 @@ const path = "/tmp/repo"
 
 func assertOnlyFile(t *testing.T, dir string, file string) {
 	files, err := os.ReadDir(dir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, f := range files {
 		assert.Equal(t, file, f.Name())

--- a/workflow/artifacts/http/clients_test.go
+++ b/workflow/artifacts/http/clients_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -19,15 +20,15 @@ func TestCreateOauth2Client(t *testing.T) {
 func TestCreateClientWithCertificateInvalidCert(t *testing.T) {
 	client, err := CreateClientWithCertificate([]byte("invalidCert"), []byte("invalidKey"))
 
+	require.Error(t, err)
 	assert.Nil(t, client)
-	assert.Error(t, err)
 }
 
 func TestCreateClientWithCertificateValidCert(t *testing.T) {
 	client, err := CreateClientWithCertificate([]byte(CERT_PEM), []byte(KEY_PEM))
 
+	require.NoError(t, err)
 	assert.NotNil(t, client)
-	assert.NoError(t, err)
 }
 
 // test certificate pair

--- a/workflow/artifacts/http/http_test.go
+++ b/workflow/artifacts/http/http_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-workflows/v3/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -23,10 +24,9 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{HTTP: a},
 		}, "/tmp/found")
-		if assert.NoError(t, err) {
-			_, err := os.Stat("/tmp/found")
-			assert.NoError(t, err)
-		}
+		require.NoError(t, err)
+		_, err = os.Stat("/tmp/found")
+		require.NoError(t, err)
 	})
 	t.Run("FoundWithRequestHeaders", func(t *testing.T) {
 		h1 := wfv1.Header{Name: "Accept", Value: "application/json"}
@@ -35,10 +35,9 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{HTTP: a},
 		}, "/tmp/found-with-request-headers")
-		if assert.NoError(t, err) {
-			_, err := os.Stat("/tmp/found-with-request-headers")
-			assert.NoError(t, err)
-		}
+		require.NoError(t, err)
+		_, err = os.Stat("/tmp/found-with-request-headers")
+		require.NoError(t, err)
 		assert.FileExists(t, "/tmp/found-with-request-headers")
 	})
 	t.Run("NotFound", func(t *testing.T) {
@@ -47,11 +46,10 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 				HTTP: &wfv1.HTTPArtifact{URL: "https://github.com/argoproj/argo-workflows/not-found"},
 			},
 		}, "/tmp/not-found")
-		if assert.Error(t, err) {
-			argoError, ok := err.(errors.ArgoError)
-			if assert.True(t, ok) {
-				assert.Equal(t, errors.CodeNotFound, argoError.Code())
-			}
+		require.Error(t, err)
+		argoError, ok := err.(errors.ArgoError)
+		if assert.True(t, ok) {
+			assert.Equal(t, errors.CodeNotFound, argoError.Code())
 		}
 	})
 }
@@ -64,11 +62,10 @@ func TestArtifactoryArtifactDriver_Load(t *testing.T) {
 				Artifactory: &wfv1.ArtifactoryArtifact{URL: "https://github.com/argoproj/argo-workflows/not-found"},
 			},
 		}, "/tmp/not-found")
-		if assert.Error(t, err) {
-			argoError, ok := err.(errors.ArgoError)
-			if assert.True(t, ok) {
-				assert.Equal(t, errors.CodeNotFound, argoError.Code())
-			}
+		require.Error(t, err)
+		argoError, ok := err.(errors.ArgoError)
+		if assert.True(t, ok) {
+			assert.Equal(t, errors.CodeNotFound, argoError.Code())
 		}
 	})
 	t.Run("Found", func(t *testing.T) {
@@ -77,10 +74,9 @@ func TestArtifactoryArtifactDriver_Load(t *testing.T) {
 				Artifactory: &wfv1.ArtifactoryArtifact{URL: "https://github.com/argoproj/argo-workflows"},
 			},
 		}, "/tmp/found")
-		if assert.NoError(t, err) {
-			_, err := os.Stat("/tmp/found")
-			assert.NoError(t, err)
-		}
+		require.NoError(t, err)
+		_, err = os.Stat("/tmp/found")
+		require.NoError(t, err)
 	})
 }
 
@@ -129,7 +125,7 @@ func TestSaveHTTPArtifactRedirect(t *testing.T) {
 			},
 		}
 		err := driver.Save(tempFile, &art)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 }

--- a/workflow/artifacts/raw/raw_test.go
+++ b/workflow/artifacts/raw/raw_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/workflow/artifacts/raw"
@@ -20,7 +21,7 @@ const (
 func TestLoad(t *testing.T) {
 	content := fmt.Sprintf("time: %v", time.Now().UnixNano())
 	lf, err := os.CreateTemp("", LoadFileName)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.Remove(lf.Name())
 
 	art := &wfv1.Artifact{}
@@ -29,10 +30,10 @@ func TestLoad(t *testing.T) {
 	}
 	driver := &raw.ArtifactDriver{}
 	err = driver.Load(art, lf.Name())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dat, err := os.ReadFile(lf.Name())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, content, string(dat))
 }
 
@@ -44,10 +45,10 @@ func TestOpenStream(t *testing.T) {
 	}
 	driver := &raw.ArtifactDriver{}
 	rc, err := driver.OpenStream(art)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer rc.Close()
 
 	dat, err := io.ReadAll(rc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, content, string(dat))
 }

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -11,6 +11,7 @@ import (
 	argos3 "github.com/argoproj/pkg/s3"
 	"github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -229,10 +230,10 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 				},
 			})
 			if tc.errMsg == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, stream)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, tc.errMsg, err.Error())
 			}
 		})
@@ -606,10 +607,10 @@ func TestListObjects(t *testing.T) {
 					},
 				})
 			if tc.expectedSuccess {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Len(t, files, tc.expectedNumFiles)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, tc.expectedErrMsg, err.Error())
 			}
 		})

--- a/workflow/common/ancestry_test.go
+++ b/workflow/common/ancestry_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -82,19 +83,19 @@ func TestGetTaskDependenciesFromDepends(t *testing.T) {
 func TestValidateTaskResults(t *testing.T) {
 	task := &wfv1.DAGTask{Depends: "(task-1 || task-2.Succeeded) && !task-3"}
 	err := ValidateTaskResults(task)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	task = &wfv1.DAGTask{Depends: "((task-1.Succeeded || task-1.Failed) || task-2.Succeeded) && !task-3.Skipped && task-2.Failed || task-6.Succeeded"}
 	err = ValidateTaskResults(task)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	task = &wfv1.DAGTask{Depends: "((task-1.Succeeded || task-1.Omitted) || task-2.Succeeded) && !task-3.Skipped && task-2.Failed || task-6.Succeeded"}
 	err = ValidateTaskResults(task)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	task = &wfv1.DAGTask{Depends: "(task-1.DoeNotExist || task-2.Succeeded)"}
 	err = ValidateTaskResults(task)
-	assert.Error(t, err, "task result 'DoeNotExist' for task 'task-1' is invalid")
+	require.Error(t, err, "task result 'DoeNotExist' for task 'task-1' is invalid")
 }
 
 func TestGetTaskDependsLogic(t *testing.T) {

--- a/workflow/common/convert_test.go
+++ b/workflow/common/convert_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -79,7 +80,7 @@ status:
 	wf := ConvertCronWorkflowToWorkflow(&cronWf)
 	wf.GetAnnotations()[AnnotationKeyCronWfScheduledTime] = "2021-02-19T10:29:05-08:00"
 	wfString, err := yaml.Marshal(wf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedWf, string(wfString))
 
 	cronWfInstanceIdString := `apiVersion: argoproj.io/v1alpha1
@@ -106,16 +107,16 @@ spec:
 `
 
 	err = yaml.Unmarshal([]byte(cronWfInstanceIdString), &cronWf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	wf = ConvertCronWorkflowToWorkflow(&cronWf)
 	if assert.Contains(t, wf.GetLabels(), LabelKeyControllerInstanceID) {
 		assert.Equal(t, "test-controller", wf.GetLabels()[LabelKeyControllerInstanceID])
 	}
 
 	err = yaml.Unmarshal([]byte(cronWfInstanceIdString), &cronWf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	scheduledTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05-07:00")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	wf = ConvertCronWorkflowToWorkflowWithProperties(&cronWf, "test-name", scheduledTime)
 	assert.Equal(t, "test-name", wf.Name)
 	assert.Len(t, wf.GetAnnotations(), 2)

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -140,10 +141,10 @@ func TestFindOverlappingVolume(t *testing.T) {
 
 func TestUnknownFieldEnforcerForWorkflowStep(t *testing.T) {
 	_, err := SplitWorkflowYAMLFile([]byte(validWf), false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = SplitWorkflowYAMLFile([]byte(invalidWf), false)
-	assert.EqualError(t, err, `json: unknown field "doesNotExist"`)
+	require.EqualError(t, err, `json: unknown field "doesNotExist"`)
 }
 
 func TestParseObjects(t *testing.T) {
@@ -152,7 +153,7 @@ func TestParseObjects(t *testing.T) {
 	res := ParseObjects([]byte(invalidWf), false)
 	assert.Len(t, res, 1)
 	assert.NotNil(t, res[0].Object)
-	assert.EqualError(t, res[0].Err, "json: unknown field \"doesNotExist\"")
+	require.EqualError(t, res[0].Err, "json: unknown field \"doesNotExist\"")
 
 	invalidObj := []byte(`<div class="blah" style="display: none; outline: none;" tabindex="0"></div>`)
 	assert.Empty(t, ParseObjects(invalidObj, false))
@@ -226,13 +227,11 @@ func TestSubstituteConfigMapKeyRefParamWithNoParamsDefined(t *testing.T) {
 
 	for _, inParam := range obj.GetTemplateByName("whalesay").Inputs.Parameters {
 		cmName, err := substituteConfigMapKeyRefParam(inParam.ValueFrom.ConfigMapKeyRef.Name, globalParams)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "parameter workflow.parameters.name not found")
+		require.EqualError(t, err, "parameter workflow.parameters.name not found")
 		assert.Equal(t, "", cmName)
 
 		cmKey, err := substituteConfigMapKeyRefParam(inParam.ValueFrom.ConfigMapKeyRef.Key, globalParams)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "parameter workflow.parameters.key not found")
+		require.EqualError(t, err, "parameter workflow.parameters.key not found")
 		assert.Equal(t, "", cmKey)
 	}
 }
@@ -262,13 +261,13 @@ func TestOverridableDefaultInputArts(t *testing.T) {
 	localParams := make(map[string]string)
 
 	newTmpl, err := ProcessArgs(&tmpl, &inputs, globalParams, localParams, false, "", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Artifacts[0].Raw.Data, rawArt.Data)
 
 	inputs.Artifacts = []wfv1.Artifact{inputArt}
 	newTmpl, err = ProcessArgs(&tmpl, &inputs, globalParams, localParams, false, "", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Artifacts[0].Raw.Data, inputRawArt.Data)
 }
@@ -313,12 +312,12 @@ func TestOverridableTemplateInputParamsValue(t *testing.T) {
 	localParams := make(map[string]string)
 
 	newTmpl, err := ProcessArgs(&tmpl, &valueArgs, globalParams, localParams, false, "", configMapStore)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), valueArgs.Parameters[0].Value.String())
 
 	newTmpl, err = ProcessArgs(&tmpl, &valueFromArgs, globalParams, localParams, false, "", configMapStore)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), overrideConfigMapValue)
 }
@@ -371,12 +370,12 @@ func TestOverridableTemplateInputParamsValueFrom(t *testing.T) {
 	localParams := make(map[string]string)
 
 	newTmpl, err := ProcessArgs(&tmpl, &valueArgs, globalParams, localParams, false, "", configMapStore)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), valueArgs.Parameters[0].Value.String())
 
 	newTmpl, err = ProcessArgs(&tmpl, &valueFromArgs, globalParams, localParams, false, "", configMapStore)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), overrideConfigMapValue)
 }

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argoproj/pkg/humanize"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -77,7 +78,7 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 	}
 	woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 	missedExecutionTime, err := woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// The missedExecutionTime should be the last complete minute mark, which we can get with inferScheduledTime
 	assert.Equal(t, inferScheduledTime().Unix(), missedExecutionTime.Unix())
 
@@ -89,14 +90,14 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 		log:    logrus.WithFields(logrus.Fields{}),
 	}
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 
 	// Same test, but simulate a change to the schedule immediately prior by setting a different last-used-schedule annotation
 	// In this case, since a schedule change is detected, not workflow should be run
 	woc.cronWf.SetSchedule("0 * * * *")
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 
 	// Run the same test in a different timezone
@@ -118,7 +119,7 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 	// Reset last-used-schedule as if the current schedule has been used before
 	woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// The missedExecutionTime should be the last complete minute mark, which we can get with inferScheduledTime
 	assert.Equal(t, inferScheduledTime().Unix(), missedExecutionTime.Unix())
 
@@ -130,14 +131,14 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 		log:    logrus.WithFields(logrus.Fields{}),
 	}
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 
 	// Same test, but simulate a change to the schedule immediately prior by setting a different last-used-schedule annotation
 	// In this case, since a schedule change is detected, not workflow should be run
 	woc.cronWf.SetSchedule("0 * * * *")
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 }
 
@@ -245,7 +246,7 @@ func TestSpecError(t *testing.T) {
 	}
 
 	err := woc.validateCronWorkflow()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Len(t, woc.cronWf.Status.Conditions, 1)
 	submissionErrorCond := woc.cronWf.Status.Conditions[0]
 	assert.Equal(t, v1.ConditionTrue, submissionErrorCond.Status)
@@ -270,7 +271,7 @@ func TestScheduleTimeParam(t *testing.T) {
 	}
 	woc.Run()
 	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(context.Background(), v1.ListOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, wsl.Items.Len())
 	wf := wsl.Items[0]
 	assert.NotNil(t, wf)
@@ -320,9 +321,8 @@ func TestLastUsedSchedule(t *testing.T) {
 	}
 
 	missedExecutionTime, err := woc.shouldOutstandingWorkflowsBeRun()
-	if assert.NoError(t, err) {
-		assert.Equal(t, time.Time{}, missedExecutionTime)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, time.Time{}, missedExecutionTime)
 
 	woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 
@@ -392,7 +392,7 @@ func TestMissedScheduleAfterCronScheduleWithForbid(t *testing.T) {
 		}
 		woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 		missedExecutionTime, err := woc.shouldOutstandingWorkflowsBeRun()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, missedExecutionTime.IsZero())
 	})
 }
@@ -449,7 +449,7 @@ func TestMultipleSchedules(t *testing.T) {
 	}
 	woc.Run()
 	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(context.Background(), v1.ListOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, wsl.Items.Len())
 	wf := wsl.Items[0]
 	assert.NotNil(t, wf)
@@ -509,7 +509,7 @@ func TestSpecErrorWithScheduleAndSchedules(t *testing.T) {
 	}
 
 	err := woc.validateCronWorkflow()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Len(t, woc.cronWf.Status.Conditions, 1)
 	submissionErrorCond := woc.cronWf.Status.Conditions[0]
 	assert.Equal(t, v1.ConditionTrue, submissionErrorCond.Status)
@@ -568,7 +568,7 @@ func TestSpecErrorWithValidAndInvalidSchedules(t *testing.T) {
 	}
 
 	err := woc.validateCronWorkflow()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Len(t, woc.cronWf.Status.Conditions, 1)
 	submissionErrorCond := woc.cronWf.Status.Conditions[0]
 	assert.Equal(t, v1.ConditionTrue, submissionErrorCond.Status)
@@ -604,7 +604,7 @@ func TestRunOutstandingWorkflowsWithMultipleSchedules(t *testing.T) {
 	}
 	woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 	missedExecutionTime, err := woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// The missedExecutionTime should be the last complete minute mark, which we can get with inferScheduledTime
 	assert.Equal(t, inferScheduledTime().Unix(), missedExecutionTime.Unix())
 
@@ -616,14 +616,14 @@ func TestRunOutstandingWorkflowsWithMultipleSchedules(t *testing.T) {
 		log:    logrus.WithFields(logrus.Fields{}),
 	}
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 
 	// Same test, but simulate a change to the schedule immediately prior by setting a different last-used-schedule annotation
 	// In this case, since a schedule change is detected, not workflow should be run
 	woc.cronWf.SetSchedules([]string{"0 * * * *,1 * * * *"})
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 
 	// Run the same test in a different timezone
@@ -645,7 +645,7 @@ func TestRunOutstandingWorkflowsWithMultipleSchedules(t *testing.T) {
 	// Reset last-used-schedule as if the current schedule has been used before
 	woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// The missedExecutionTime should be the last complete minute mark, which we can get with inferScheduledTime
 	assert.Equal(t, inferScheduledTime().Unix(), missedExecutionTime.Unix())
 
@@ -657,13 +657,13 @@ func TestRunOutstandingWorkflowsWithMultipleSchedules(t *testing.T) {
 		log:    logrus.WithFields(logrus.Fields{}),
 	}
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 
 	// Same test, but simulate a change to the schedule immediately prior by setting a different last-used-schedule annotation
 	// In this case, since a schedule change is detected, not workflow should be run
 	woc.cronWf.SetSchedules([]string{"0 * * * *,1 * * * *"})
 	missedExecutionTime, err = woc.shouldOutstandingWorkflowsBeRun()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, missedExecutionTime.IsZero())
 }

--- a/workflow/data/data_test.go
+++ b/workflow/data/data_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -28,15 +29,14 @@ func (t nullTestDataSourceProcessor) ProcessArtifactPaths(*v1alpha1.ArtifactPath
 func TestProcessSource(t *testing.T) {
 	artifactPathsSource := v1alpha1.DataSource{ArtifactPaths: &v1alpha1.ArtifactPaths{}}
 	data, err := processSource(artifactPathsSource, &testDataSourceProcessor{})
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}, data)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}, data)
 
 	_, err = processSource(artifactPathsSource, &nullTestDataSourceProcessor{})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = processSource(v1alpha1.DataSource{}, &nullTestDataSourceProcessor{})
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestProcessTransformation(t *testing.T) {
@@ -44,60 +44,52 @@ func TestProcessTransformation(t *testing.T) {
 
 	filterFiles := &v1alpha1.Transformation{{Expression: `filter(data, {# endsWith '.py'})`}}
 	filtered, err := processTransformation(files, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"foo.py", "goo/foo.py"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"foo.py", "goo/foo.py"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {# contains '/'})`}}
 	filtered, err = processTransformation(files, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"goo/foo.py", "moo/bar.pdf"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"goo/foo.py", "moo/bar.pdf"}, filtered)
+
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {# contains 'foo'})`}}
 	filtered, err = processTransformation(filtered, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"goo/foo.py"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"goo/foo.py"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {# contains '/'})`}, {Expression: `filter(data, {# contains 'foo'})`}}
 	filtered, err = processTransformation(files, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"goo/foo.py"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"goo/foo.py"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {not(# contains '/')})`}}
 	filtered, err = processTransformation(files, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"foo.py", "bar.pdf"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"foo.py", "bar.pdf"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `map(data, {# + '.processed'})`}}
 	filtered, err = processTransformation(files, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"foo.py.processed", "bar.pdf.processed", "goo/foo.py.processed", "moo/bar.pdf.processed"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"foo.py.processed", "bar.pdf.processed", "goo/foo.py.processed", "moo/bar.pdf.processed"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {not(# contains '/')})`}, {Expression: `map(data, {# + '.processed'})`}}
 	filtered, err = processTransformation(files, filterFiles)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []interface{}{"foo.py.processed", "bar.pdf.processed"}, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"foo.py.processed", "bar.pdf.processed"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {not(# contains '/')})`}, {Expression: `map(data, {# + '.processed'})`}, {}}
 	_, err = processTransformation(files, filterFiles)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	filtered, err = processTransformation(files, nil)
-	if assert.NoError(t, err) {
-		assert.Equal(t, files, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, files, filtered)
 
 	filtered, err = processTransformation(files, &v1alpha1.Transformation{})
-	if assert.NoError(t, err) {
-		assert.Equal(t, files, filtered)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, files, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `map(data, {# + '.processed'}`}}
 	_, err = processTransformation(files, filterFiles)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/workflow/executor/common/common_test.go
+++ b/workflow/executor/common/common_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -48,7 +48,7 @@ func TestTerminatePodWithContainerName(t *testing.T) {
 	}
 	ctx := context.Background()
 	err := TerminatePodWithContainerNames(ctx, mock, []string{"container-name"}, syscall.SIGTERM)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// w/ ShareProcessNamespace.
 	mock = &MockKC{
@@ -68,7 +68,7 @@ func TestTerminatePodWithContainerName(t *testing.T) {
 		},
 	}
 	err = TerminatePodWithContainerNames(ctx, mock, []string{"container-name"}, syscall.SIGTERM)
-	assert.EqualError(t, err, "cannot terminate a process-namespace-shared Pod foo")
+	require.EqualError(t, err, "cannot terminate a process-namespace-shared Pod foo")
 
 	// w/ HostPID.
 	mock = &MockKC{
@@ -88,7 +88,7 @@ func TestTerminatePodWithContainerName(t *testing.T) {
 		},
 	}
 	err = TerminatePodWithContainerNames(ctx, mock, []string{"container-name"}, syscall.SIGTERM)
-	assert.EqualError(t, err, "cannot terminate a hostPID Pod foo")
+	require.EqualError(t, err, "cannot terminate a hostPID Pod foo")
 
 	// w/ RestartPolicy.
 	mock = &MockKC{
@@ -108,7 +108,7 @@ func TestTerminatePodWithContainerName(t *testing.T) {
 		},
 	}
 	err = TerminatePodWithContainerNames(ctx, mock, []string{"container-name"}, syscall.SIGTERM)
-	assert.EqualError(t, err, "cannot terminate pod with a \"Always\" restart policy")
+	require.EqualError(t, err, "cannot terminate pod with a \"Always\" restart policy")
 
 	// Successfully call KillContainer of the client interface.
 	mock = &MockKC{
@@ -128,7 +128,7 @@ func TestTerminatePodWithContainerName(t *testing.T) {
 		},
 	}
 	err = TerminatePodWithContainerNames(ctx, mock, []string{"container-name"}, syscall.SIGTERM)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // TestWaitForTermination ensure we SIGTERM container with input wait time
@@ -144,7 +144,7 @@ func TestWaitForTermination(t *testing.T) {
 	}
 	ctx := context.Background()
 	err := WaitForTermination(ctx, mock, []string{"container-name"}, time.Duration(10)*time.Second)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Fail SIGTERM Container
 	mock = &MockKC{
@@ -156,7 +156,7 @@ func TestWaitForTermination(t *testing.T) {
 		},
 	}
 	err = WaitForTermination(ctx, mock, []string{"container-name"}, time.Duration(1)*time.Second)
-	assert.EqualError(t, err, "timeout after 1s")
+	require.EqualError(t, err, "timeout after 1s")
 }
 
 // TestKillGracefully ensure we kill container gracefully with input wait time
@@ -180,5 +180,5 @@ func TestKillGracefully(t *testing.T) {
 	}
 	ctx := context.Background()
 	err := KillGracefully(ctx, mock, []string{"container-name"}, time.Second)
-	assert.EqualError(t, err, "timeout after 1s")
+	require.EqualError(t, err, "timeout after 1s")
 }

--- a/workflow/executor/os-specific/command_test.go
+++ b/workflow/executor/os-specific/command_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleStartCloser(t *testing.T) {
@@ -26,9 +27,9 @@ func TestSimpleStartCloser(t *testing.T) {
 	cmd.Stdout = slowWriter
 
 	closer, err := StartCommand(cmd)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = cmd.Wait()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Wait for echo command to exit before calling closer
 	time.Sleep(100 * time.Millisecond)
 	closer()

--- a/workflow/gccontroller/gc_controller_test.go
+++ b/workflow/gccontroller/gc_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
@@ -366,7 +367,7 @@ func TestEnqueueWF(t *testing.T) {
 	// Veirfy we do not enqueue if not completed
 	wf := wfv1.MustUnmarshalWorkflow([]byte(completedWf))
 	un, err = util.ToUnstructured(wf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 0, controller.workqueue.Len())
 }
@@ -383,7 +384,7 @@ func TestTTLStrategySucceeded(t *testing.T) {
 	wf.Spec.TTLStrategy = &wfv1.TTLStrategy{SecondsAfterSuccess: &ten}
 	wf.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-5 * time.Second)}
 	un, err = util.ToUnstructured(wf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 0, controller.workqueue.Len())
 
@@ -391,18 +392,18 @@ func TestTTLStrategySucceeded(t *testing.T) {
 	wf1.Spec.TTLStrategy = &wfv1.TTLStrategy{SecondsAfterSuccess: &ten}
 	wf1.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-11 * time.Second)}
 	un, err = util.ToUnstructured(wf1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 1, controller.workqueue.Len())
 
 	wf2 := wfv1.MustUnmarshalWorkflow([]byte(wftRefWithTTLinWFT))
 	wf2.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-11 * time.Second)}
 	un, err = util.ToUnstructured(wf2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	_, err = controller.wfclientset.ArgoprojV1alpha1().Workflows("default").Create(ctx, wf2, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	controller.processNextWorkItem(ctx)
 	assert.Equal(t, 1, controller.workqueue.Len())
@@ -410,10 +411,10 @@ func TestTTLStrategySucceeded(t *testing.T) {
 	wf3 := wfv1.MustUnmarshalWorkflow([]byte(wftRefWithTTLinWF))
 	wf3.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-11 * time.Second)}
 	un, err = util.ToUnstructured(wf3)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = controller.wfclientset.ArgoprojV1alpha1().Workflows("default").Create(ctx, wf3, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	controller.processNextWorkItem(ctx)
 	assert.Equal(t, 1, controller.workqueue.Len())
@@ -431,7 +432,7 @@ func TestTTLStrategyFailed(t *testing.T) {
 	wf.Spec.TTLStrategy = &wfv1.TTLStrategy{SecondsAfterFailure: &ten}
 	wf.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-5 * time.Second)}
 	un, err = util.ToUnstructured(wf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 0, controller.workqueue.Len())
 
@@ -439,7 +440,7 @@ func TestTTLStrategyFailed(t *testing.T) {
 	wf1.Spec.TTLStrategy = &wfv1.TTLStrategy{SecondsAfterFailure: &ten}
 	wf1.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-11 * time.Second)}
 	un, err = util.ToUnstructured(wf1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 1, controller.workqueue.Len())
 }
@@ -452,14 +453,14 @@ func TestNoTTLStrategyFailed(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow([]byte(failedWf))
 	wf.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-5 * time.Second)}
 	un, err = util.ToUnstructured(wf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 0, controller.workqueue.Len())
 
 	wf1 := wfv1.MustUnmarshalWorkflow([]byte(failedWf))
 	wf1.Status.FinishedAt = metav1.Time{Time: controller.clock.Now().Add(-11 * time.Second)}
 	un, err = util.ToUnstructured(wf1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller, un)
 	assert.Equal(t, 0, controller.workqueue.Len())
 }
@@ -476,7 +477,7 @@ func TestTTLStrategyFromUnstructured(t *testing.T) {
 	wf3.Status.FinishedAt = metav1.Time{Time: controller3.clock.Now().Add(-6 * time.Second)}
 	un, err = util.ToUnstructured(wf3)
 	t.Log(wf3.Spec.TTLStrategy)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	enqueueWF(controller3, un)
 	assert.Equal(t, 0, controller3.workqueue.Len())
 }

--- a/workflow/hydrator/fake/always_test.go
+++ b/workflow/hydrator/fake/always_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -13,21 +14,21 @@ func TestAlways(t *testing.T) {
 	wf := &wfv1.Workflow{Status: wfv1.WorkflowStatus{Nodes: wfv1.Nodes{"foo": wfv1.NodeStatus{}}}}
 	t.Run("Dehydrate", func(t *testing.T) {
 		err := h.Dehydrate(wf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, h.IsHydrated(wf))
 		assert.Empty(t, wf.Status.Nodes)
 		assert.NotEmpty(t, wf.Status.OffloadNodeStatusVersion)
 	})
 	t.Run("Hydrate", func(t *testing.T) {
 		err := h.Hydrate(wf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, h.IsHydrated(wf))
 		assert.NotEmpty(t, wf.Status.Nodes)
 		assert.Empty(t, wf.Status.OffloadNodeStatusVersion)
 	})
 	t.Run("HydrateWithNodes", func(t *testing.T) {
 		err := h.Dehydrate(wf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.HydrateWithNodes(wf, wfv1.Nodes{"foo": wfv1.NodeStatus{}})
 		assert.NotEmpty(t, wf.Status.Nodes)
 		assert.Empty(t, wf.Status.OffloadNodeStatusVersion)

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -69,12 +70,11 @@ func TestMetrics(t *testing.T) {
 	assert.Nil(t, m.GetCustomMetric("does-not-exist"))
 
 	err := m.UpsertCustomMetric("metric", "", newCounter("test", "test", nil), false)
-	if assert.NoError(t, err) {
-		assert.NotNil(t, m.GetCustomMetric("metric"))
-	}
+	require.NoError(t, err)
+	assert.NotNil(t, m.GetCustomMetric("metric"))
 
 	err = m.UpsertCustomMetric("metric2", "", newCounter("test", "new test", nil), false)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	badMetric, err := constructOrUpdateGaugeMetric(nil, &v1alpha1.Prometheus{
 		Name:   "count",
@@ -84,18 +84,17 @@ func TestMetrics(t *testing.T) {
 			Value: "1",
 		},
 	})
-	if assert.NoError(t, err) {
-		err = m.UpsertCustomMetric("asdf", "", badMetric, false)
-		assert.Error(t, err)
-	}
+	require.NoError(t, err)
+	err = m.UpsertCustomMetric("asdf", "", badMetric, false)
+	require.Error(t, err)
 }
 
 func TestErrors(t *testing.T) {
 	_, err := ConstructRealTimeGaugeMetric(&v1alpha1.Prometheus{Name: "invalid.name"}, func() float64 { return 0.0 })
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	_, err = ConstructRealTimeGaugeMetric(&v1alpha1.Prometheus{Name: "name", Labels: []*v1alpha1.MetricLabel{{Key: "invalid-key", Value: "value"}}}, func() float64 { return 0.0 })
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMetricGC(t *testing.T) {
@@ -109,9 +108,8 @@ func TestMetricGC(t *testing.T) {
 	assert.Empty(t, m.customMetrics)
 
 	err := m.UpsertCustomMetric("metric", "", newCounter("test", "test", nil), false)
-	if assert.NoError(t, err) {
-		assert.Len(t, m.customMetrics, 1)
-	}
+	require.NoError(t, err)
+	assert.Len(t, m.customMetrics, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -142,9 +140,8 @@ func TestRealtimeMetricGC(t *testing.T) {
 	assert.Empty(t, m.customMetrics)
 
 	err := m.UpsertCustomMetric("realtime_metric", "workflow-uid", newCounter("test", "test", nil), true)
-	if assert.NoError(t, err) {
-		assert.Len(t, m.customMetrics, 1)
-	}
+	require.NoError(t, err)
+	assert.Len(t, m.customMetrics, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -211,10 +208,10 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	m := New(config, config)
 
 	rtMetric, err := ConstructRealTimeGaugeMetric(&v1alpha1.Prometheus{Name: "name", Help: "hello"}, func() float64 { return 0.0 })
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = m.UpsertCustomMetric("metrickey", "123", rtMetric, true)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, m.workflows["123"])
 	assert.Len(t, m.customMetrics, 1)
 
@@ -223,10 +220,10 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	assert.Empty(t, m.customMetrics)
 
 	metric, err := ConstructOrUpdateMetric(nil, &v1alpha1.Prometheus{Name: "name", Help: "hello", Gauge: &v1alpha1.Gauge{Value: "1"}})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = m.UpsertCustomMetric("metrickey", "456", metric, false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, m.workflows["456"])
 	assert.Len(t, m.customMetrics, 1)
 

--- a/workflow/metrics/server_test.go
+++ b/workflow/metrics/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDisableMetricsServer(t *testing.T) {
@@ -31,7 +32,7 @@ func TestDisableMetricsServer(t *testing.T) {
 		defer resp.Body.Close()
 	}
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection refused") // expect that the metrics server not to start
 }
 
@@ -49,13 +50,13 @@ func TestMetricsServer(t *testing.T) {
 	m.RunServer(ctx, false)
 	time.Sleep(1 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bodyString := string(bodyBytes)
 	assert.NotEmpty(t, bodyString)
@@ -75,13 +76,13 @@ func TestDummyMetricsServer(t *testing.T) {
 	m.RunServer(ctx, true)
 	time.Sleep(1 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultMetricsServerPort, DefaultMetricsServerPath))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	defer resp.Body.Close()
 
 	bodyBytes, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bodyString := string(bodyBytes)
 

--- a/workflow/packer/packer_test.go
+++ b/workflow/packer/packer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -22,17 +23,16 @@ func TestDecompressWorkflow(t *testing.T) {
 			},
 		}
 		err := CompressWorkflowIfNeeded(wf)
-		if assert.NoError(t, err) {
-			assert.NotNil(t, wf)
-			assert.NotEmpty(t, wf.Status.Nodes)
-			assert.Empty(t, wf.Status.CompressedNodes)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, wf)
+		assert.NotEmpty(t, wf.Status.Nodes)
+		assert.Empty(t, wf.Status.CompressedNodes)
+
 		err = DecompressWorkflow(wf)
-		if assert.NoError(t, err) {
-			assert.NotNil(t, wf)
-			assert.NotEmpty(t, wf.Status.Nodes)
-			assert.Empty(t, wf.Status.CompressedNodes)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, wf)
+		assert.NotEmpty(t, wf.Status.Nodes)
+		assert.Empty(t, wf.Status.CompressedNodes)
 	})
 	t.Run("LargeWorkflow", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -41,17 +41,16 @@ func TestDecompressWorkflow(t *testing.T) {
 			},
 		}
 		err := CompressWorkflowIfNeeded(wf)
-		if assert.NoError(t, err) {
-			assert.NotNil(t, wf)
-			assert.Empty(t, wf.Status.Nodes)
-			assert.NotEmpty(t, wf.Status.CompressedNodes)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, wf)
+		assert.Empty(t, wf.Status.Nodes)
+		assert.NotEmpty(t, wf.Status.CompressedNodes)
+
 		err = DecompressWorkflow(wf)
-		if assert.NoError(t, err) {
-			assert.NotNil(t, wf)
-			assert.NotEmpty(t, wf.Status.Nodes)
-			assert.Empty(t, wf.Status.CompressedNodes)
-		}
+		require.NoError(t, err)
+		assert.NotNil(t, wf)
+		assert.NotEmpty(t, wf.Status.Nodes)
+		assert.Empty(t, wf.Status.CompressedNodes)
 	})
 	t.Run("TooLargeToCompressWorkflow", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -61,12 +60,11 @@ func TestDecompressWorkflow(t *testing.T) {
 			},
 		}
 		err := CompressWorkflowIfNeeded(wf)
-		if assert.Error(t, err) {
-			assert.True(t, IsTooLargeError(err))
-			// if too large, we want the original back please
-			assert.NotNil(t, wf)
-			assert.NotEmpty(t, wf.Status.Nodes)
-			assert.Empty(t, wf.Status.CompressedNodes)
-		}
+		require.Error(t, err)
+		assert.True(t, IsTooLargeError(err))
+		// if too large, we want the original back please
+		assert.NotNil(t, wf)
+		assert.NotEmpty(t, wf.Status.Nodes)
+		assert.Empty(t, wf.Status.CompressedNodes)
 	})
 }

--- a/workflow/sync/mutex_test.go
+++ b/workflow/sync/mutex_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/pointer"
@@ -72,7 +73,7 @@ spec:
     mutex:
       name: test
   templates:
-  - 
+  -
     container:
       args:
       - hello world
@@ -120,7 +121,7 @@ func TestMutexLock(t *testing.T) {
 
 		ctx := context.Background()
 		wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		concurrenyMgr.Initialize(wfList.Items)
 		assert.Len(t, concurrenyMgr.syncLockMap, 1)
 	})
@@ -134,7 +135,7 @@ func TestMutexLock(t *testing.T) {
 		wf2 := wf.DeepCopy()
 		wf3 := wf.DeepCopy()
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -145,14 +146,14 @@ func TestMutexLock(t *testing.T) {
 
 		// Try to acquire again
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, status)
 		assert.Empty(t, msg)
 		assert.False(t, wfUpdate)
 
 		wf1.Name = "two"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -161,14 +162,14 @@ func TestMutexLock(t *testing.T) {
 		wf2.Spec.Priority = pointer.Int32(5)
 		holderKey2 := getHolderKey(wf2, "")
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
 
 		wf3.Name = "four"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf3, "", wf3.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -180,14 +181,14 @@ func TestMutexLock(t *testing.T) {
 
 		// Low priority workflow try to acquire the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.False(t, wfUpdate)
 
 		// High Priority workflow acquires the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -208,7 +209,7 @@ func TestMutexLock(t *testing.T) {
 		wf2 := wf.DeepCopy()
 		wf3 := wf.DeepCopy()
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -219,7 +220,7 @@ func TestMutexLock(t *testing.T) {
 
 		// Try to acquire again
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, status)
 		assert.Empty(t, msg)
 		assert.False(t, wfUpdate)
@@ -227,7 +228,7 @@ func TestMutexLock(t *testing.T) {
 		wf1.Name = "two"
 		wf1.Namespace = "two"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -237,7 +238,7 @@ func TestMutexLock(t *testing.T) {
 		wf2.Spec.Priority = pointer.Int32(5)
 		holderKey2 := getHolderKey(wf2, "")
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -245,7 +246,7 @@ func TestMutexLock(t *testing.T) {
 		wf3.Name = "four"
 		wf3.Namespace = "four"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf3, "", wf3.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -257,14 +258,14 @@ func TestMutexLock(t *testing.T) {
 
 		// Low priority workflow try to acquire the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.False(t, wfUpdate)
 
 		// High Priority workflow acquires the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -388,7 +389,7 @@ func TestMutexTmplLevel(t *testing.T) {
 		tmpl := wf.Spec.Templates[1]
 
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "synchronization-tmpl-level-mutex-vjcdk-3941195474", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -398,13 +399,13 @@ func TestMutexTmplLevel(t *testing.T) {
 
 		// Try to acquire again
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "synchronization-tmpl-level-mutex-vjcdk-2216915482", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, wfUpdate)
 		assert.False(t, status)
 		assert.NotEmpty(t, msg)
 
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "synchronization-tmpl-level-mutex-vjcdk-1432992664", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, wfUpdate)
 		assert.False(t, status)
@@ -416,7 +417,7 @@ func TestMutexTmplLevel(t *testing.T) {
 		assert.Empty(t, wf.Status.Synchronization.Mutex.Holding)
 
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "synchronization-tmpl-level-mutex-vjcdk-2216915482", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -333,7 +334,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("InitializeSynchronization", func(t *testing.T) {
@@ -343,7 +344,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		wfclientset := fakewfclientset.NewSimpleClientset(wf)
 
 		wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		concurrenyMgr.Initialize(wfList.Items)
 		assert.Len(t, concurrenyMgr.syncLockMap, 1)
 	})
@@ -355,7 +356,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		wf.Status.Synchronization.Semaphore.Holding = invalidSync
 		wfclientset := fakewfclientset.NewSimpleClientset(wf)
 		wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		concurrenyMgr.Initialize(wfList.Items)
 		assert.Empty(t, concurrenyMgr.syncLockMap)
 	})
@@ -370,7 +371,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		wf2 := wf.DeepCopy()
 		wf3 := wf.DeepCopy()
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -381,14 +382,14 @@ func TestSemaphoreWfLevel(t *testing.T) {
 
 		// Try to acquire again
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, status)
 		assert.Empty(t, msg)
 		assert.False(t, wfUpdate)
 
 		wf1.Name = "two"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -397,14 +398,14 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		wf2.Spec.Priority = pointer.Int32(5)
 		holderKey2 := getHolderKey(wf2, "")
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
 
 		wf3.Name = "four"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf3, "", wf3.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -416,14 +417,14 @@ func TestSemaphoreWfLevel(t *testing.T) {
 
 		// Low priority workflow try to acquire the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
 
 		// High Priority workflow acquires the lock
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -451,7 +452,7 @@ func TestResizeSemaphoreSize(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("WfLevelAcquireAndRelease", func(t *testing.T) {
@@ -462,7 +463,7 @@ func TestResizeSemaphoreSize(t *testing.T) {
 		wf1 := wf.DeepCopy()
 		wf2 := wf.DeepCopy()
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -472,27 +473,27 @@ func TestResizeSemaphoreSize(t *testing.T) {
 
 		wf1.Name = "two"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
 
 		wf2.Name = "three"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
 
 		// Increase the semaphore Size
 		cm, err := kube.CoreV1().ConfigMaps("default").Get(ctx, "my-config", metav1.GetOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		cm.Data["workflow"] = "3"
 		_, err = kube.CoreV1().ConfigMaps("default").Update(ctx, cm, metav1.UpdateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, status)
 		assert.Empty(t, msg)
 		assert.True(t, wfUpdate)
@@ -501,7 +502,7 @@ func TestResizeSemaphoreSize(t *testing.T) {
 		assert.Equal(t, wf1.Name, wf1.Status.Synchronization.Semaphore.Holding[0].Holders[0])
 
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -518,7 +519,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("TemplateLevelAcquireAndRelease", func(t *testing.T) {
@@ -530,7 +531,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 		tmpl := wf.Spec.Templates[2]
 
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -540,13 +541,13 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 
 		// Try to acquire again
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, status)
 		assert.False(t, wfUpdate)
 		assert.Empty(t, msg)
 
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "semaphore-tmpl-level-xjvln-1607747183", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.True(t, wfUpdate)
 		assert.False(t, status)
@@ -557,7 +558,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 		assert.Empty(t, wf.Status.Synchronization.Semaphore.Holding[0].Holders)
 
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf, "semaphore-tmpl-level-xjvln-1607747183", tmpl.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -576,7 +577,7 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("TriggerWfsWithAvailableLocks", func(t *testing.T) {
@@ -589,7 +590,7 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 			wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
 			wf.Name = fmt.Sprintf("%s-%d", "acquired", i)
 			status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.Empty(msg)
 			assert.True(status)
 			assert.True(wfUpdate)
@@ -600,7 +601,7 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 			wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
 			wf.Name = fmt.Sprintf("%s-%d", "wait", i)
 			status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.NotEmpty(msg)
 			assert.False(status)
 			assert.True(wfUpdate)
@@ -625,7 +626,7 @@ func TestMutexWfLevel(t *testing.T) {
 		wf2 := wf.DeepCopy()
 
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "", wf.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, msg)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
@@ -635,14 +636,14 @@ func TestMutexWfLevel(t *testing.T) {
 
 		wf1.Name = "two"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf1, "", wf1.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
 
 		wf2.Name = "three"
 		status, wfUpdate, msg, err = concurrenyMgr.TryAcquire(wf2, "", wf2.Spec.Synchronization)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, msg)
 		assert.False(t, status)
 		assert.True(t, wfUpdate)
@@ -666,7 +667,7 @@ func TestCheckWorkflowExistence(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("WorkflowDeleted", func(t *testing.T) {
@@ -709,7 +710,7 @@ func TestTriggerWFWithSemaphoreAndMutex(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
-	assert.NoError(err)
+	require.NoError(t, err)
 	wf := wfv1.MustUnmarshalWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -845,7 +846,7 @@ status:
 	t.Run("InitializeMutex", func(t *testing.T) {
 		tmpl := wf.Spec.Templates[1]
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "synchronization-tmpl-level-sgg6t-1949670081", tmpl.Synchronization)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Empty(msg)
 		assert.True(status)
 		assert.True(wfUpdate)
@@ -855,7 +856,7 @@ status:
 	t.Run("InitializeSemaphore", func(t *testing.T) {
 		tmpl := wf.Spec.Templates[2]
 		status, wfUpdate, msg, err := concurrenyMgr.TryAcquire(wf, "synchronization-tmpl-level-sgg6t-1899337224", tmpl.Synchronization)
-		assert.NoError(err)
+		require.NoError(t, err)
 		assert.Empty(msg)
 		assert.True(status)
 		assert.True(wfUpdate)

--- a/workflow/sync/throttler_test.go
+++ b/workflow/sync/throttler_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -123,9 +124,9 @@ status:
   startedAt: "2020-06-19T17:37:05Z"
 `))
 	wfList, err := wfclientset.ArgoprojV1alpha1().Workflows("default").List(ctx, metav1.ListOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = throttler.Init(wfList.Items)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, throttler.Admit("default/a"))
 	assert.True(t, throttler.Admit("default/b"))
 

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -105,14 +106,12 @@ func TestGetTemplateByName(t *testing.T) {
 	ctx := NewContextFromClientSet(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(metav1.NamespaceDefault), wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates(), wftmpl, nil)
 
 	tmpl, err := ctx.GetTemplateByName("whalesay")
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Container)
 
 	_, err = ctx.GetTemplateByName("unknown")
-	assert.EqualError(t, err, "template unknown not found")
+	require.EqualError(t, err, "template unknown not found")
 }
 
 func TestGetTemplateFromRef(t *testing.T) {
@@ -131,21 +130,19 @@ func TestGetTemplateFromRef(t *testing.T) {
 	// Get the template of existing template reference.
 	tmplRef := wfv1.TemplateRef{Name: "some-workflow-template", Template: "whalesay"}
 	tmpl, err := ctx.GetTemplateFromRef(&tmplRef)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Container)
 
 	// Get the template of unexisting template reference.
 	tmplRef = wfv1.TemplateRef{Name: "unknown-workflow-template", Template: "whalesay"}
 	_, err = ctx.GetTemplateFromRef(&tmplRef)
-	assert.EqualError(t, err, "workflow template unknown-workflow-template not found")
+	require.EqualError(t, err, "workflow template unknown-workflow-template not found")
 
 	// Get the template of unexisting template name of existing template reference.
 	tmplRef = wfv1.TemplateRef{Name: "some-workflow-template", Template: "unknown"}
 	_, err = ctx.GetTemplateFromRef(&tmplRef)
-	assert.EqualError(t, err, "template unknown not found in workflow template some-workflow-template")
+	require.EqualError(t, err, "template unknown not found in workflow template some-workflow-template")
 }
 
 func TestGetTemplate(t *testing.T) {
@@ -164,30 +161,26 @@ func TestGetTemplate(t *testing.T) {
 	// Get the template of existing template name.
 	tmplHolder := wfv1.WorkflowStep{Template: "whalesay"}
 	tmpl, err := ctx.GetTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Container)
 
 	// Get the template of unexisting template name.
 	tmplHolder = wfv1.WorkflowStep{Template: "unexisting"}
 	_, err = ctx.GetTemplate(&tmplHolder)
-	assert.EqualError(t, err, "template unexisting not found")
+	require.EqualError(t, err, "template unexisting not found")
 
 	// Get the template of existing template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "whalesay"}}
 	tmpl, err = ctx.GetTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Container)
 
 	// Get the template of unexisting template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "unknown-workflow-template", Template: "whalesay"}}
 	_, err = ctx.GetTemplate(&tmplHolder)
-	assert.EqualError(t, err, "workflow template unknown-workflow-template not found")
+	require.EqualError(t, err, "workflow template unknown-workflow-template not found")
 }
 
 func TestGetCurrentTemplateBase(t *testing.T) {
@@ -221,7 +214,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	// Get the template base of existing template name.
 	tmplHolder := wfv1.WorkflowStep{Template: "whalesay"}
 	newCtx, err := ctx.WithTemplateHolder(&tmplHolder)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmplGetter, ok := newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -231,7 +224,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	// Get the template base of unexisting template name.
 	tmplHolder = wfv1.WorkflowStep{Template: "unknown"}
 	newCtx, err = ctx.WithTemplateHolder(&tmplHolder)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmplGetter, ok = newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -241,7 +234,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	// Get the template base of existing template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "whalesay"}}
 	newCtx, err = ctx.WithTemplateHolder(&tmplHolder)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmplGetter, ok = newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -251,28 +244,24 @@ func TestWithTemplateHolder(t *testing.T) {
 	// Get the template base of unexisting template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "unknown-workflow-template", Template: "whalesay"}}
 	_, err = ctx.WithTemplateHolder(&tmplHolder)
-	assert.EqualError(t, err, "workflowtemplates.argoproj.io \"unknown-workflow-template\" not found")
+	require.EqualError(t, err, "workflowtemplates.argoproj.io \"unknown-workflow-template\" not found")
 }
 
 func TestResolveTemplate(t *testing.T) {
 	wfClientset := fakewfclientset.NewSimpleClientset()
 	err := createWorkflowTemplate(wfClientset, anotherWorkflowTemplateYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	err = createWorkflowTemplate(wfClientset, someWorkflowTemplateYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	wftmpl := unmarshalWftmpl(baseWorkflowTemplateYaml)
 	ctx := NewContextFromClientSet(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(metav1.NamespaceDefault), wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates(), wftmpl, nil)
 
 	// Get the template of template name.
 	tmplHolder := wfv1.WorkflowStep{Template: "whalesay"}
 	ctx, tmpl, _, err := ctx.ResolveTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	wftmpl, ok := ctx.tmplBase.(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -284,9 +273,8 @@ func TestResolveTemplate(t *testing.T) {
 	// Get the template of template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "whalesay"}}
 	ctx, tmpl, _, err = ctx.ResolveTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -298,9 +286,8 @@ func TestResolveTemplate(t *testing.T) {
 	// Get the template of local nested template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "local-whalesay"}}
 	ctx, tmpl, _, err = ctx.ResolveTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -312,9 +299,8 @@ func TestResolveTemplate(t *testing.T) {
 	// Get the template of nested template reference.
 	tmplHolder = wfv1.WorkflowStep{TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "another-whalesay"}}
 	ctx, tmpl, _, err = ctx.ResolveTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -328,9 +314,8 @@ func TestResolveTemplate(t *testing.T) {
 		TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "whalesay-with-arguments"},
 	}
 	ctx, tmpl, _, err = ctx.ResolveTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -343,9 +328,8 @@ func TestResolveTemplate(t *testing.T) {
 		TemplateRef: &wfv1.TemplateRef{Name: "some-workflow-template", Template: "nested-whalesay-with-arguments"},
 	}
 	ctx, tmpl, _, err = ctx.ResolveTemplate(&tmplHolder)
-	if !assert.NoError(t, err) {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
 	if !assert.True(t, ok) {
 		t.Fatal("tmplBase is not a WorkflowTemplate")
@@ -376,13 +360,11 @@ func TestOnWorkflowTemplate(t *testing.T) {
 	ctx := NewContextFromClientSet(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(metav1.NamespaceDefault), wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates(), wftmpl, nil)
 
 	err := createWorkflowTemplate(wfClientset, anotherWorkflowTemplateYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Get the template base of existing template name.
 	newCtx, err := ctx.WithWorkflowTemplate("another-workflow-template")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	tmpl := newCtx.tmplBase.GetTemplateByName("whalesay")
 	assert.NotNil(t, tmpl)
 }

--- a/workflow/util/merge_test.go
+++ b/workflow/util/merge_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -46,7 +47,7 @@ func TestMergeWorkflows(t *testing.T) {
 	targetWf := wfv1.MustUnmarshalWorkflow(patchWF)
 
 	err := MergeTo(patchWf, targetWf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "start", targetWf.Spec.Entrypoint)
 	assert.Equal(t, "argo1", targetWf.Spec.ServiceAccountName)
 	assert.Equal(t, "message", targetWf.Spec.Arguments.Parameters[0].Name)
@@ -368,7 +369,7 @@ func TestJoinWfSpecs(t *testing.T) {
 	result := wfv1.MustUnmarshalWorkflow(resultSpec)
 
 	targetWf, err := JoinWorkflowSpec(&wf1.Spec, wft.GetWorkflowSpec(), &wfDefault.Spec)
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Equal(result.Spec, targetWf.Spec)
 	assert.Len(targetWf.Spec.Templates, 3)
 	assert.Equal("whalesay", targetWf.Spec.Entrypoint)
@@ -381,7 +382,7 @@ func TestJoinWfSpecArguments(t *testing.T) {
 	result := wfv1.MustUnmarshalWorkflow(wfArgumentsResult)
 
 	targetWf, err := JoinWorkflowSpec(&wf.Spec, wft.GetWorkflowSpec(), nil)
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Equal(result.Spec.Arguments, targetWf.Spec.Arguments)
 }
 
@@ -463,7 +464,7 @@ func TestMergeHooks(t *testing.T) {
 		targetHookWf := wfv1.MustUnmarshalWorkflow(baseNilHookWF)
 
 		err := MergeTo(patchHookWf, targetHookWf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, targetHookWf.Spec.Hooks)
 	})
 
@@ -472,7 +473,7 @@ func TestMergeHooks(t *testing.T) {
 		targetHookWf := wfv1.MustUnmarshalWorkflow(baseNilHookWF)
 
 		err := MergeTo(patchHookWf, targetHookWf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, targetHookWf.Spec.Hooks, 2)
 		assert.Equal(t, "c", targetHookWf.Spec.Hooks[`foo`].Template)
 		assert.Equal(t, "b", targetHookWf.Spec.Hooks[`bar`].Template)
@@ -484,7 +485,7 @@ func TestMergeHooks(t *testing.T) {
 		targetHookWf := wfv1.MustUnmarshalWorkflow(baseHookWF)
 
 		err := MergeTo(patchHookWf, targetHookWf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, targetHookWf.Spec.Hooks, 2)
 		assert.Equal(t, "a", targetHookWf.Spec.Hooks[`foo`].Template)
 		assert.Equal(t, "b", targetHookWf.Spec.Hooks[`bar`].Template)

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,7 +51,7 @@ spec:
 	wfClientSet := argofake.NewSimpleClientset()
 	ctx := context.Background()
 	newWf, err := SubmitWorkflow(ctx, nil, wfClientSet, "test-namespace", newWf, &wfv1.SubmitOpts{DryRun: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wf.Spec, newWf.Spec)
 	assert.Equal(t, wf.Status, newWf.Status)
 }
@@ -75,7 +76,7 @@ func TestResubmitWorkflowWithOnExit(t *testing.T) {
 	}
 	wf.Status.Nodes.Set(onExitID, onExitNode)
 	newWF, err := FormulateResubmitWorkflow(context.Background(), &wf, true, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	newWFOnExitName := newWF.ObjectMeta.Name + ".onExit"
 	newWFOneExitID := newWF.NodeID(newWFOnExitName)
 	_, ok := newWF.Status.Nodes[newWFOneExitID]
@@ -113,7 +114,7 @@ func TestReadFromSingleorMultiplePath(t *testing.T) {
 			}
 			body, err := ReadFromFilePathsOrUrls(filePaths...)
 			assert.Equal(t, len(body), len(filePaths))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			for i := range body {
 				assert.Equal(t, body[i], []byte(tc.contents[i]))
 			}
@@ -161,7 +162,7 @@ func TestReadFromSingleorMultiplePathErrorHandling(t *testing.T) {
 				}
 			}
 			body, err := ReadFromFilePathsOrUrls(filePaths...)
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Empty(t, body)
 		})
 	}
@@ -248,26 +249,25 @@ func TestResumeWorkflowByNodeName(t *testing.T) {
 
 		ctx := context.Background()
 		_, err := wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// will return error as displayName does not match any nodes
 		err = ResumeWorkflow(ctx, wfIf, hydratorfake.Noop, "suspend", "displayName=nonexistant")
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		// displayName didn't match suspend node so should still be running
 		wf, err := wfIf.Get(ctx, "suspend", metav1.GetOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByDisplayName("approve").Phase)
 
 		err = ResumeWorkflow(ctx, wfIf, hydratorfake.Noop, "suspend", "displayName=approve")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// displayName matched node so has succeeded
 		wf, err = wfIf.Get(ctx, "suspend", metav1.GetOptions{})
-		if assert.NoError(t, err) {
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByDisplayName("approve").Phase)
-			assert.Equal(t, "", wf.Status.Nodes.FindByDisplayName("approve").Message)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByDisplayName("approve").Phase)
+		assert.Equal(t, "", wf.Status.Nodes.FindByDisplayName("approve").Message)
 	})
 
 	t.Run("With user info", func(t *testing.T) {
@@ -279,26 +279,25 @@ func TestResumeWorkflowByNodeName(t *testing.T) {
 		uim := creator.UserInfoMap(ctx)
 
 		_, err := wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// will return error as displayName does not match any nodes
 		err = ResumeWorkflow(ctx, wfIf, hydratorfake.Noop, "suspend", "displayName=nonexistant")
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		// displayName didn't match suspend node so should still be running
 		wf, err := wfIf.Get(ctx, "suspend", metav1.GetOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByDisplayName("approve").Phase)
 
 		err = ResumeWorkflow(ctx, wfIf, hydratorfake.Noop, "suspend", "displayName=approve")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// displayName matched node so has succeeded
 		wf, err = wfIf.Get(ctx, "suspend", metav1.GetOptions{})
-		if assert.NoError(t, err) {
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByDisplayName("approve").Phase)
-			assert.Equal(t, fmt.Sprintf("Resumed by: %v", uim), wf.Status.Nodes.FindByDisplayName("approve").Message)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByDisplayName("approve").Phase)
+		assert.Equal(t, fmt.Sprintf("Resumed by: %v", uim), wf.Status.Nodes.FindByDisplayName("approve").Message)
 	})
 }
 
@@ -308,31 +307,31 @@ func TestStopWorkflowByNodeName(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// will return error as displayName does not match any nodes
 	err = StopWorkflow(ctx, wfIf, hydratorfake.Noop, "suspend", "displayName=nonexistant", "error occurred")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// displayName didn't match suspend node so should still be running
 	wf, err := wfIf.Get(ctx, "suspend", metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes.FindByDisplayName("approve").Phase)
 
 	err = StopWorkflow(ctx, wfIf, hydratorfake.Noop, "suspend", "displayName=approve", "error occurred")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// displayName matched node so has succeeded
 	wf, err = wfIf.Get(ctx, "suspend", metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, wfv1.NodeFailed, wf.Status.Nodes.FindByDisplayName("approve").Phase)
 
 	origWf.Status = wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded}
 	origWf.Name = "succeeded-wf"
 	_, err = wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = StopWorkflow(ctx, wfIf, hydratorfake.Noop, "succeeded-wf", "", "")
-	assert.EqualError(t, err, "cannot shutdown a completed workflow: workflow: \"succeeded-wf\", namespace: \"\"")
+	require.EqualError(t, err, "cannot shutdown a completed workflow: workflow: \"succeeded-wf\", namespace: \"\"")
 }
 
 // Regression test for #6478
@@ -467,23 +466,22 @@ func TestUpdateSuspendedNode(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-	if assert.NoError(t, err) {
-		err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "does-not-exist", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
-		assert.EqualError(t, err, "workflows.argoproj.io \"does-not-exist\" not found")
-		err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "displayName=does-not-exists", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
-		assert.EqualError(t, err, "currently, set only targets suspend nodes: no suspend nodes matching nodeFieldSelector: displayName=does-not-exists")
-		err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"does-not-exist": "Hello World"}})
-		assert.EqualError(t, err, "node is not expecting output parameter 'does-not-exist'")
-		err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
-		assert.NoError(t, err)
-		err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "name=suspend-template-kgfn7[0].approve", SetOperationValues{OutputParameters: map[string]string{"message2": "Hello World 2"}})
-		assert.NoError(t, err)
+	require.NoError(t, err)
+	err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "does-not-exist", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
+	require.EqualError(t, err, "workflows.argoproj.io \"does-not-exist\" not found")
+	err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "displayName=does-not-exists", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
+	require.EqualError(t, err, "currently, set only targets suspend nodes: no suspend nodes matching nodeFieldSelector: displayName=does-not-exists")
+	err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"does-not-exist": "Hello World"}})
+	require.EqualError(t, err, "node is not expecting output parameter 'does-not-exist'")
+	err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
+	require.NoError(t, err)
+	err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template", "name=suspend-template-kgfn7[0].approve", SetOperationValues{OutputParameters: map[string]string{"message2": "Hello World 2"}})
+	require.NoError(t, err)
 
-		// make sure global variable was updated
-		wf, err := wfIf.Get(ctx, "suspend-template", metav1.GetOptions{})
-		assert.NoError(t, err)
-		assert.Equal(t, "Hello World 2", wf.Status.Outputs.Parameters[0].Value.String())
-	}
+	// make sure global variable was updated
+	wf, err := wfIf.Get(ctx, "suspend-template", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello World 2", wf.Status.Outputs.Parameters[0].Value.String())
 
 	noSpaceWf := wfv1.MustUnmarshalWorkflow(susWorkflow)
 	noSpaceWf.Name = "suspend-template-no-outputs"
@@ -491,10 +489,9 @@ func TestUpdateSuspendedNode(t *testing.T) {
 	node.Outputs = nil
 	noSpaceWf.Status.Nodes["suspend-template-kgfn7-2667278707"] = node
 	_, err = wfIf.Create(ctx, noSpaceWf, metav1.CreateOptions{})
-	if assert.NoError(t, err) {
-		err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template-no-outputs", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
-		assert.EqualError(t, err, "cannot set output parameters because node is not expecting any raw parameters")
-	}
+	require.NoError(t, err)
+	err = updateSuspendedNode(ctx, wfIf, hydratorfake.Noop, "suspend-template-no-outputs", "displayName=approve", SetOperationValues{OutputParameters: map[string]string{"message": "Hello World"}})
+	require.EqualError(t, err, "cannot set output parameters because node is not expecting any raw parameters")
 }
 
 func TestSelectorMatchesNode(t *testing.T) {
@@ -547,7 +544,7 @@ func TestSelectorMatchesNode(t *testing.T) {
 				},
 			}
 			selector, err := fields.ParseSelector(tc.selector)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if tc.outcome {
 				assert.True(t, SelectorMatchesNode(selector, node))
 			} else {
@@ -570,28 +567,28 @@ func TestGetNodeType(t *testing.T) {
 
 func TestApplySubmitOpts(t *testing.T) {
 	t.Run("Nil", func(t *testing.T) {
-		assert.NoError(t, ApplySubmitOpts(&wfv1.Workflow{}, nil))
+		require.NoError(t, ApplySubmitOpts(&wfv1.Workflow{}, nil))
 	})
 	t.Run("InvalidLabels", func(t *testing.T) {
-		assert.Error(t, ApplySubmitOpts(&wfv1.Workflow{}, &wfv1.SubmitOpts{Labels: "a"}))
+		require.Error(t, ApplySubmitOpts(&wfv1.Workflow{}, &wfv1.SubmitOpts{Labels: "a"}))
 	})
 	t.Run("Labels", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
 		err := ApplySubmitOpts(wf, &wfv1.SubmitOpts{Labels: "a=1,b=1"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, wf.GetLabels(), 2)
 	})
 	t.Run("MergeLabels", func(t *testing.T) {
 		wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "0", "b": "0"}}}
 		err := ApplySubmitOpts(wf, &wfv1.SubmitOpts{Labels: "a=1"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		if assert.Len(t, wf.GetLabels(), 2) {
 			assert.Equal(t, "1", wf.GetLabels()["a"])
 			assert.Equal(t, "0", wf.GetLabels()["b"])
 		}
 	})
 	t.Run("InvalidParameters", func(t *testing.T) {
-		assert.Error(t, ApplySubmitOpts(&wfv1.Workflow{}, &wfv1.SubmitOpts{Parameters: []string{"a"}}))
+		require.Error(t, ApplySubmitOpts(&wfv1.Workflow{}, &wfv1.SubmitOpts{Parameters: []string{"a"}}))
 	})
 	t.Run("Parameters", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -602,7 +599,7 @@ func TestApplySubmitOpts(t *testing.T) {
 			},
 		}
 		err := ApplySubmitOpts(wf, &wfv1.SubmitOpts{Parameters: []string{"a=81861780812"}})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		parameters := wf.Spec.Arguments.Parameters
 		if assert.Len(t, parameters, 1) {
 			assert.Equal(t, "a", parameters[0].Name)
@@ -612,20 +609,20 @@ func TestApplySubmitOpts(t *testing.T) {
 	t.Run("PodPriorityClassName", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
 		err := ApplySubmitOpts(wf, &wfv1.SubmitOpts{PodPriorityClassName: "abc"})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "abc", wf.Spec.PodPriorityClassName)
 	})
 }
 
 func TestReadParametersFile(t *testing.T) {
 	file, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = os.Remove(file.Name()) }()
 	err = os.WriteFile(file.Name(), []byte(`a: 81861780812`), 0o600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	opts := &wfv1.SubmitOpts{}
 	err = ReadParametersFile(file.Name(), opts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	parameters := opts.Parameters
 	if assert.Len(t, parameters, 1) {
 		assert.Equal(t, "a=81861780812", parameters[0])
@@ -655,20 +652,19 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 			},
 		}
 		wf, err := FormulateResubmitWorkflow(context.Background(), wf, false, nil)
-		if assert.NoError(t, err) {
-			assert.Contains(t, wf.GetLabels(), common.LabelKeyControllerInstanceID)
-			assert.Contains(t, wf.GetLabels(), common.LabelKeyClusterWorkflowTemplate)
-			assert.Contains(t, wf.GetLabels(), common.LabelKeyCronWorkflow)
-			assert.Contains(t, wf.GetLabels(), common.LabelKeyWorkflowTemplate)
-			assert.NotContains(t, wf.GetLabels(), common.LabelKeyCreator)
-			assert.NotContains(t, wf.GetLabels(), common.LabelKeyPhase)
-			assert.NotContains(t, wf.GetLabels(), common.LabelKeyCompleted)
-			assert.NotContains(t, wf.GetLabels(), common.LabelKeyWorkflowArchivingStatus)
-			assert.Contains(t, wf.GetLabels(), common.LabelKeyPreviousWorkflowName)
-			assert.Len(t, wf.OwnerReferences, 1)
-			assert.Equal(t, "test", wf.OwnerReferences[0].APIVersion)
-			assert.Equal(t, "testObj", wf.OwnerReferences[0].Name)
-		}
+		require.NoError(t, err)
+		assert.Contains(t, wf.GetLabels(), common.LabelKeyControllerInstanceID)
+		assert.Contains(t, wf.GetLabels(), common.LabelKeyClusterWorkflowTemplate)
+		assert.Contains(t, wf.GetLabels(), common.LabelKeyCronWorkflow)
+		assert.Contains(t, wf.GetLabels(), common.LabelKeyWorkflowTemplate)
+		assert.NotContains(t, wf.GetLabels(), common.LabelKeyCreator)
+		assert.NotContains(t, wf.GetLabels(), common.LabelKeyPhase)
+		assert.NotContains(t, wf.GetLabels(), common.LabelKeyCompleted)
+		assert.NotContains(t, wf.GetLabels(), common.LabelKeyWorkflowArchivingStatus)
+		assert.Contains(t, wf.GetLabels(), common.LabelKeyPreviousWorkflowName)
+		assert.Len(t, wf.OwnerReferences, 1)
+		assert.Equal(t, "test", wf.OwnerReferences[0].APIVersion)
+		assert.Equal(t, "testObj", wf.OwnerReferences[0].Name)
 	})
 	t.Run("OverrideCreatorLabels", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -692,11 +688,10 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 			PreferredUsername: "bar",
 		})
 		wf, err := FormulateResubmitWorkflow(ctx, wf, false, nil)
-		if assert.NoError(t, err) {
-			assert.Equal(t, "yyyy-yyyy-yyyy-yyyy", wf.Labels[common.LabelKeyCreator])
-			assert.Equal(t, "bar.at.example.com", wf.Labels[common.LabelKeyCreatorEmail])
-			assert.Equal(t, "bar", wf.Labels[common.LabelKeyCreatorPreferredUsername])
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "yyyy-yyyy-yyyy-yyyy", wf.Labels[common.LabelKeyCreator])
+		assert.Equal(t, "bar.at.example.com", wf.Labels[common.LabelKeyCreatorEmail])
+		assert.Equal(t, "bar", wf.Labels[common.LabelKeyCreatorPreferredUsername])
 	})
 	t.Run("UnlabelCreatorLabels", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -715,11 +710,11 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 			},
 		}
 		wf, err := FormulateResubmitWorkflow(context.Background(), wf, false, nil)
-		if assert.NoError(t, err) {
-			assert.Emptyf(t, wf.Labels[common.LabelKeyCreator], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreator)
-			assert.Emptyf(t, wf.Labels[common.LabelKeyCreatorEmail], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreatorEmail)
-			assert.Emptyf(t, wf.Labels[common.LabelKeyCreatorPreferredUsername], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreatorPreferredUsername)
-		}
+		require.NoError(t, err)
+		assert.Emptyf(t, wf.Labels[common.LabelKeyCreator], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreator)
+		assert.Emptyf(t, wf.Labels[common.LabelKeyCreatorEmail], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreatorEmail)
+		assert.Emptyf(t, wf.Labels[common.LabelKeyCreatorPreferredUsername], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreatorPreferredUsername)
+
 	})
 	t.Run("OverrideParams", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -730,9 +725,8 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 			}},
 		}
 		wf, err := FormulateResubmitWorkflow(context.Background(), wf, false, []string{"message=modified"})
-		if assert.NoError(t, err) {
-			assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
 	})
 }
 
@@ -893,13 +887,12 @@ func TestDeepDeleteNodes(t *testing.T) {
 
 	ctx := context.Background()
 	wf, err := wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-	if assert.NoError(t, err) {
-		newWf, _, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		assert.NoError(t, err)
-		newWfBytes, err := yaml.Marshal(newWf)
-		assert.NoError(t, err)
-		assert.NotContains(t, string(newWfBytes), "steps-9fkqc-3224593506")
-	}
+	require.NoError(t, err)
+	newWf, _, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
+	require.NoError(t, err)
+	newWfBytes, err := yaml.Marshal(newWf)
+	require.NoError(t, err)
+	assert.NotContains(t, string(newWfBytes), "steps-9fkqc-3224593506")
 }
 
 var exitHandler = `
@@ -926,8 +919,8 @@ spec:
           - python
         resources: {}
         source: |
-          import sys; 
-          exit_code = 1; 
+          import sys;
+          exit_code = 1;
           sys.exit(exit_code)
     - name: handler
       inputs:
@@ -1024,14 +1017,13 @@ func TestRetryExitHandler(t *testing.T) {
 
 	ctx := context.Background()
 	wf, err := wfIf.Create(ctx, origWf, metav1.CreateOptions{})
-	if assert.NoError(t, err) {
-		newWf, _, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		assert.NoError(t, err)
-		newWfBytes, err := yaml.Marshal(newWf)
-		assert.NoError(t, err)
-		t.Log(string(newWfBytes))
-		assert.NotContains(t, string(newWfBytes), "retry-script-6xt68-3924170365")
-	}
+	require.NoError(t, err)
+	newWf, _, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
+	require.NoError(t, err)
+	newWfBytes, err := yaml.Marshal(newWf)
+	require.NoError(t, err)
+	t.Log(string(newWfBytes))
+	assert.NotContains(t, string(newWfBytes), "retry-script-6xt68-3924170365")
 }
 
 func TestFormulateRetryWorkflow(t *testing.T) {
@@ -1058,29 +1050,29 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		if assert.NoError(t, err) {
-			assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
-			assert.Equal(t, metav1.Time{}, wf.Status.FinishedAt)
-			assert.True(t, wf.Status.StartedAt.After(createdTime.Time))
-			assert.NotContains(t, wf.Labels, common.LabelKeyCompleted)
-			assert.NotContains(t, wf.Labels, common.LabelKeyWorkflowArchivingStatus)
-			for _, node := range wf.Status.Nodes {
-				switch node.Phase {
-				case wfv1.NodeSucceeded:
-					assert.Equal(t, "succeeded", node.Message)
-					assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-					assert.Equal(t, createdTime, node.StartedAt)
-					assert.Equal(t, finishedTime, node.FinishedAt)
-				case wfv1.NodeFailed:
-					assert.Equal(t, "", node.Message)
-					assert.Equal(t, wfv1.NodeRunning, node.Phase)
-					assert.Equal(t, metav1.Time{}, node.FinishedAt)
-					assert.True(t, node.StartedAt.After(createdTime.Time))
-				}
+		require.NoError(t, err)
+		assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
+		assert.Equal(t, metav1.Time{}, wf.Status.FinishedAt)
+		assert.True(t, wf.Status.StartedAt.After(createdTime.Time))
+		assert.NotContains(t, wf.Labels, common.LabelKeyCompleted)
+		assert.NotContains(t, wf.Labels, common.LabelKeyWorkflowArchivingStatus)
+		for _, node := range wf.Status.Nodes {
+			switch node.Phase {
+			case wfv1.NodeSucceeded:
+				assert.Equal(t, "succeeded", node.Message)
+				assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
+				assert.Equal(t, createdTime, node.StartedAt)
+				assert.Equal(t, finishedTime, node.FinishedAt)
+			case wfv1.NodeFailed:
+				assert.Equal(t, "", node.Message)
+				assert.Equal(t, wfv1.NodeRunning, node.Phase)
+				assert.Equal(t, metav1.Time{}, node.FinishedAt)
+				assert.True(t, node.StartedAt.After(createdTime.Time))
 			}
 		}
+
 	})
 	t.Run("DAG", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -1095,13 +1087,11 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 1) {
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes[""].Phase)
-			}
-
+		require.NoError(t, err)
+		if assert.Len(t, wf.Status.Nodes, 1) {
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes[""].Phase)
 		}
 	})
 	t.Run("Skipped and Suspended Nodes", func(t *testing.T) {
@@ -1130,19 +1120,18 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 				}},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=suspended", nil)
-		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 3) {
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["entrypoint"].Phase)
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["suspended"].Phase)
-				assert.Equal(t, wfv1.Parameter{
-					Name:      "param-1",
-					Value:     nil,
-					ValueFrom: &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}},
-				}, wf.Status.Nodes["suspended"].Outputs.Parameters[0])
-				assert.Equal(t, wfv1.NodeSkipped, wf.Status.Nodes["skipped"].Phase)
-			}
+		require.NoError(t, err)
+		if assert.Len(t, wf.Status.Nodes, 3) {
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["entrypoint"].Phase)
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["suspended"].Phase)
+			assert.Equal(t, wfv1.Parameter{
+				Name:      "param-1",
+				Value:     nil,
+				ValueFrom: &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}},
+			}, wf.Status.Nodes["suspended"].Outputs.Parameters[0])
+			assert.Equal(t, wfv1.NodeSkipped, wf.Status.Nodes["skipped"].Phase)
 		}
 	})
 	t.Run("Nested DAG with Non-group Node Selected", func(t *testing.T) {
@@ -1162,16 +1151,15 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=3", nil)
-		if assert.NoError(t, err) {
-			// Node #3, #4 are deleted and will be recreated so only 3 nodes left in wf.Status.Nodes
-			if assert.Len(t, wf.Status.Nodes, 3) {
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-1"].Phase)
-				// The parent group nodes should be running.
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
-			}
+		require.NoError(t, err)
+		// Node #3, #4 are deleted and will be recreated so only 3 nodes left in wf.Status.Nodes
+		if assert.Len(t, wf.Status.Nodes, 3) {
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-1"].Phase)
+			// The parent group nodes should be running.
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
 		}
 	})
 	t.Run("Nested DAG without Node Selected", func(t *testing.T) {
@@ -1191,18 +1179,18 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "", nil)
-		if assert.NoError(t, err) {
-			// Node #2, #3, and #4 are deleted and will be recreated so only 2 nodes left in wf.Status.Nodes
-			if assert.Len(t, wf.Status.Nodes, 4) {
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-2"].Phase)
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-				assert.Equal(t, "", string(wf.Status.Nodes["4"].Phase))
-			}
+		require.NoError(t, err)
+		// Node #2, #3, and #4 are deleted and will be recreated so only 2 nodes left in wf.Status.Nodes
+		if assert.Len(t, wf.Status.Nodes, 4) {
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-2"].Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
+			assert.Equal(t, "", string(wf.Status.Nodes["4"].Phase))
 		}
+
 	})
 	t.Run("OverrideParams", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -1222,9 +1210,9 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 				}},
 		}
 		wf, _, err := FormulateRetryWorkflow(context.Background(), wf, false, "", []string{"message=modified"})
-		if assert.NoError(t, err) {
-			assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
+
 	})
 
 	t.Run("OverrideParamsSubmitFromWfTmpl", func(t *testing.T) {
@@ -1250,10 +1238,10 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 				}},
 		}
 		wf, _, err := FormulateRetryWorkflow(context.Background(), wf, false, "", []string{"message=modified"})
-		if assert.NoError(t, err) {
-			assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
-			assert.Equal(t, "modified", wf.Status.StoredWorkflowSpec.Arguments.Parameters[0].Value.String())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
+		assert.Equal(t, "modified", wf.Status.StoredWorkflowSpec.Arguments.Parameters[0].Value.String())
+
 	})
 
 	t.Run("Fail on running workflow", func(t *testing.T) {
@@ -1268,9 +1256,9 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("Fail on pending workflow", func(t *testing.T) {
@@ -1285,9 +1273,9 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("Fail on successful workflow without restartSuccessful and nodeFieldSelector", func(t *testing.T) {
@@ -1305,9 +1293,9 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("Retry successful workflow with restartSuccessful and nodeFieldSelector", func(t *testing.T) {
@@ -1327,17 +1315,16 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=4", nil)
-		if assert.NoError(t, err) {
-			// Node #4 is deleted and will be recreated so only 4 nodes left in wf.Status.Nodes
-			if assert.Len(t, wf.Status.Nodes, 4) {
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["successful-workflow-2"].Phase)
-				// The parent group nodes should be running.
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-			}
+		require.NoError(t, err)
+		// Node #4 is deleted and will be recreated so only 4 nodes left in wf.Status.Nodes
+		if assert.Len(t, wf.Status.Nodes, 4) {
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["successful-workflow-2"].Phase)
+			// The parent group nodes should be running.
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
 		}
 	})
 
@@ -1359,14 +1346,13 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
-		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 4) {
-				assert.Equal(t, wfv1.NodeFailed, wf.Status.Nodes["2"].Phase)
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-				assert.Len(t, podsToDelete, 2)
-			}
+		require.NoError(t, err)
+		if assert.Len(t, wf.Status.Nodes, 4) {
+			assert.Equal(t, wfv1.NodeFailed, wf.Status.Nodes["2"].Phase)
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
+			assert.Len(t, podsToDelete, 2)
 		}
 	})
 
@@ -1388,14 +1374,13 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 			},
 		}
 		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, true, "id=3", nil)
-		if assert.NoError(t, err) {
-			if assert.Len(t, wf.Status.Nodes, 2) {
-				assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
-				assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["continue-on-failed-workflow-2"].Phase)
-				assert.Len(t, podsToDelete, 4)
-			}
+		require.NoError(t, err)
+		if assert.Len(t, wf.Status.Nodes, 2) {
+			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
+			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["continue-on-failed-workflow-2"].Phase)
+			assert.Len(t, podsToDelete, 4)
 		}
 	})
 }
@@ -1420,17 +1405,16 @@ spec:
           image: my-image`), un)
 	x := &wfv1.CronWorkflow{}
 	err := FromUnstructuredObj(un, x)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestToUnstructured(t *testing.T) {
 	un, err := ToUnstructured(&wfv1.Workflow{})
-	if assert.NoError(t, err) {
-		gv := un.GetObjectKind().GroupVersionKind()
-		assert.Equal(t, workflow.WorkflowKind, gv.Kind)
-		assert.Equal(t, workflow.Group, gv.Group)
-		assert.Equal(t, workflow.Version, gv.Version)
-	}
+	require.NoError(t, err)
+	gv := un.GetObjectKind().GroupVersionKind()
+	assert.Equal(t, workflow.WorkflowKind, gv.Kind)
+	assert.Equal(t, workflow.Group, gv.Group)
+	assert.Equal(t, workflow.Version, gv.Version)
 }
 
 func TestGetTemplateFromNode(t *testing.T) {
@@ -1940,7 +1924,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 
 	// Retry top individual pod node
 	wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step1", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 1)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Len(t, podsToDelete, 6)
@@ -1948,7 +1932,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry top individual suspend node
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step2", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 3)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -1958,7 +1942,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the starting on first DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -1979,7 +1963,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the starting on second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -2000,7 +1984,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the first individual node (suspended node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step1", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -2021,7 +2005,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the second individual node (pod node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -2043,7 +2027,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the third individual node (pod node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step3", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 13)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -2066,7 +2050,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the last individual node (suspend node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step2", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 15)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -2090,7 +2074,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the node that connects the two branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step4", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 16)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)
@@ -2113,7 +2097,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the last node (failing node)
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step5-tofail", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 16)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -3,7 +3,7 @@ package validate
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var dagCycle = `
@@ -34,9 +34,7 @@ spec:
 
 func TestDAGCycle(t *testing.T) {
 	err := validate(dagCycle)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "cycle")
-	}
+	require.ErrorContains(t, err, "cycle")
 }
 
 var dagAnyWithoutExpandingTask = `
@@ -63,9 +61,7 @@ spec:
 
 func TestAnyWithoutExpandingTask(t *testing.T) {
 	err := validate(dagAnyWithoutExpandingTask)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "does not contain any items")
-	}
+	require.ErrorContains(t, err, "does not contain any items")
 }
 
 var dagUndefinedTemplate = `
@@ -85,9 +81,7 @@ spec:
 
 func TestDAGUndefinedTemplate(t *testing.T) {
 	err := validate(dagUndefinedTemplate)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "undefined")
-	}
+	require.ErrorContains(t, err, "undefined")
 }
 
 var dagUnresolvedVar = `
@@ -310,21 +304,18 @@ spec:
 
 func TestDAGVariableResolution(t *testing.T) {
 	err := validate(dagUnresolvedVar)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve {{tasks.A.outputs.parameters.unresolvable}}")
-	}
+	require.ErrorContains(t, err, "failed to resolve {{tasks.A.outputs.parameters.unresolvable}}")
+
 	err = validate(dagResolvedVar)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = validate(dagResolvedVarNotAncestor)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "templates.unresolved.tasks.C missing dependency 'B' for parameter 'message'")
-	}
+	require.ErrorContains(t, err, "templates.unresolved.tasks.C missing dependency 'B' for parameter 'message'")
 
 	err = validate(dagResolvedGlobalVar)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(dagResolvedGlobalVarReversed)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var dagResolvedArt = `
@@ -382,7 +373,7 @@ spec:
 
 func TestDAGArtifactResolution(t *testing.T) {
 	err := validate(dagResolvedArt)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var dagStatusReference = `
@@ -616,28 +607,23 @@ spec:
 
 func TestDAGStatusReference(t *testing.T) {
 	err := validate(dagStatusReference)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = validate(dagStatusNoFutureReferenceSimple)
 	// Can't reference the status of steps that have not run yet
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
-	}
+	require.ErrorContains(t, err, "failed to resolve {{tasks.B.status}}")
+
 	err = validate(dagStatusNoFutureReferenceWhenFutureReferenceHasChild)
 	// Can't reference the status of steps that have not run yet, even if the referenced steps have children
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
-	}
+	require.ErrorContains(t, err, "failed to resolve {{tasks.B.status}}")
 
 	err = validate(dagStatusPastReferenceChain)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = validate(dagStatusOnlyDirectAncestors)
 	// Can't reference steps that are not direct ancestors of node
 	// Here Node E references the status of Node B, even though it is not its descendent
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve {{tasks.B.status}}")
-	}
+	require.ErrorContains(t, err, "failed to resolve {{tasks.B.status}}")
 }
 
 var dagNonexistantTarget = `
@@ -672,9 +658,8 @@ spec:
 
 func TestDAGNonExistantTarget(t *testing.T) {
 	err := validate(dagNonexistantTarget)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "target 'DOESNTEXIST' is not defined")
-	}
+	require.ErrorContains(t, err, "target 'DOESNTEXIST' is not defined")
+
 }
 
 var dagTargetSubstitution = `
@@ -713,7 +698,7 @@ spec:
 
 func TestDAGTargetSubstitution(t *testing.T) {
 	err := validate(dagTargetSubstitution)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var dagTargetMissingInputParam = `
@@ -747,7 +732,7 @@ spec:
 
 func TestDAGTargetMissingInputParam(t *testing.T) {
 	err := validate(dagTargetMissingInputParam)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 var dagDependsAndDependencies = `
@@ -778,7 +763,7 @@ spec:
 
 func TestDependsAndDependencies(t *testing.T) {
 	err := validate(dagDependsAndDependencies)
-	assert.Error(t, err, "templates.dag-target cannot use both 'depends' and 'dependencies' in the same DAG template")
+	require.ErrorContains(t, err, "templates.dag-target cannot use both 'depends' and 'dependencies' in the same DAG template")
 }
 
 var dagDependsAndContinueOn = `
@@ -810,7 +795,7 @@ spec:
 
 func TestDependsAndContinueOn(t *testing.T) {
 	err := validate(dagDependsAndContinueOn)
-	assert.Error(t, err, "templates.dag-target cannot use 'continueOn' when using 'depends'. Instead use 'dep-task.Failed'/'dep-task.Errored'")
+	require.ErrorContains(t, err, "templates.dag-target cannot use 'continueOn' when using 'depends'. Instead use 'dep-task.Failed'/'dep-task.Errored'")
 }
 
 var dagDependsDigit = `
@@ -862,9 +847,7 @@ spec:
 
 func TestDAGDependsDigit(t *testing.T) {
 	err := validate(dagDependsDigit)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
-	}
+	require.ErrorContains(t, err, "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 }
 
 var dagDependenciesDigit = `
@@ -916,9 +899,7 @@ spec:
 
 func TestDAGDependenciesDigit(t *testing.T) {
 	err := validate(dagDependenciesDigit)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
-	}
+	require.ErrorContains(t, err, "templates.diamond.tasks.5A name cannot begin with a digit when using either 'depends' or 'dependencies'")
 }
 
 var dagWithDigitNoDepends = `
@@ -947,7 +928,7 @@ spec:
 
 func TestDAGWithDigitNameNoDepends(t *testing.T) {
 	err := validate(dagWithDigitNoDepends)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var dagOutputsResolveTaskAggregatedOutputs = `
@@ -1037,7 +1018,7 @@ spec:
 
 func TestDAGOutputsResolveTaskAggregatedOutputs(t *testing.T) {
 	err := validate(dagOutputsResolveTaskAggregatedOutputs)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var dagMissingParamValueInTask = `
@@ -1074,9 +1055,7 @@ spec:
 
 func TestDAGMissingParamValueInTask(t *testing.T) {
 	err := validate(dagMissingParamValueInTask)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), ".valueFrom only allows: default, configMapKeyRef and supplied")
-	}
+	require.ErrorContains(t, err, ".valueFrom only allows: default, configMapKeyRef and supplied")
 }
 
 var dagArgParamValueFromConfigMapInTask = `
@@ -1109,7 +1088,7 @@ spec:
 
 func TestDAGArgParamValueFromConfigMapInTask(t *testing.T) {
 	err := validate(dagArgParamValueFromConfigMapInTask)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var failDagArgParamValueFromPathInTask = `
@@ -1139,7 +1118,5 @@ spec:
 
 func TestFailDAGArgParamValueFromPathInTask(t *testing.T) {
 	err := validate(failDagArgParamValueFromPathInTask)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "valueFrom only allows: default, configMapKeyRef and supplied")
-	}
+	require.ErrorContains(t, err, "valueFrom only allows: default, configMapKeyRef and supplied")
 }

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -124,17 +125,13 @@ spec:
 
 func TestDuplicateOrEmptyNames(t *testing.T) {
 	err := validate(dupTemplateNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "not unique")
-	}
+	require.ErrorContains(t, err, "not unique")
+
 	err = validate(dupInputNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "not unique")
-	}
+	require.ErrorContains(t, err, "not unique")
+
 	err = validate(emptyName)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "name is required")
-	}
+	require.ErrorContains(t, err, "name is required")
 }
 
 var unresolvedInput = `
@@ -203,17 +200,13 @@ spec:
 
 func TestUnresolved(t *testing.T) {
 	err := validate(unresolvedInput)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve")
-	}
+	require.ErrorContains(t, err, "failed to resolve")
+
 	err = validate(unresolvedStepInput)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve")
-	}
+	require.ErrorContains(t, err, "failed to resolve")
+
 	err = validate(unresolvedOutput)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve")
-	}
+	require.ErrorContains(t, err, "failed to resolve")
 }
 
 var ioArtifactPaths = `
@@ -259,7 +252,7 @@ spec:
 
 func TestResolveIOArtifactPathPlaceholders(t *testing.T) {
 	err := validate(ioArtifactPaths)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var outputParameterPath = `
@@ -283,7 +276,7 @@ spec:
 
 func TestResolveOutputParameterPathPlaceholder(t *testing.T) {
 	err := validate(outputParameterPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var stepOutputReferences = `
@@ -320,7 +313,7 @@ spec:
 
 func TestStepOutputReference(t *testing.T) {
 	err := validate(stepOutputReferences)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var stepStatusReferences = `
@@ -358,7 +351,7 @@ spec:
 
 func TestStepStatusReference(t *testing.T) {
 	err := validate(stepStatusReferences)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var stepStatusReferencesNoFutureReference = `
@@ -397,9 +390,7 @@ spec:
 func TestStepStatusReferenceNoFutureReference(t *testing.T) {
 	err := validate(stepStatusReferencesNoFutureReference)
 	// Can't reference the status of steps that have not run yet
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve {{steps.two.status}}")
-	}
+	require.ErrorContains(t, err, "failed to resolve {{steps.two.status}}")
 }
 
 var stepArtReferences = `
@@ -455,7 +446,7 @@ spec:
 
 func TestStepArtReference(t *testing.T) {
 	err := validate(stepArtReferences)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var paramWithValueFromConfigMapRef = `
@@ -480,7 +471,7 @@ spec:
 
 func TestParamWithValueFromConfigMapRef(t *testing.T) {
 	err := validate(paramWithValueFromConfigMapRef)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var paramWithoutValue = `
@@ -501,9 +492,7 @@ spec:
 
 func TestParamWithoutValue(t *testing.T) {
 	err := validate(paramWithoutValue)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "not supplied")
-	}
+	require.ErrorContains(t, err, "not supplied")
 }
 
 var globalParam = `
@@ -567,7 +556,7 @@ spec:
     - name: missing
   entrypoint: whalesay
   templates:
-  - 
+  -
     container:
       args:
       - hello world
@@ -635,13 +624,13 @@ spec:
 
 func TestGlobalParam(t *testing.T) {
 	err := validate(globalParam)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = validate(nestedGlobalParam)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = validate(unsuppliedArgValue)
-	assert.EqualError(t, err, "spec.arguments.missing.value or spec.arguments.missing.valueFrom is required")
+	require.EqualError(t, err, "spec.arguments.missing.value or spec.arguments.missing.valueFrom is required")
 }
 
 var invalidTemplateNames = `
@@ -662,9 +651,7 @@ spec:
 
 func TestInvalidTemplateName(t *testing.T) {
 	err := validate(invalidTemplateNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.ErrorContains(t, err, invalidErr)
 }
 
 var invalidArgParamNames = `
@@ -689,7 +676,7 @@ spec:
 
 func TestInvalidArgParamName(t *testing.T) {
 	err := validate(invalidArgParamNames)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 var invalidArgArtNames = `
@@ -720,9 +707,7 @@ spec:
 
 func TestInvalidArgArtName(t *testing.T) {
 	err := validate(invalidArgArtNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.ErrorContains(t, err, invalidErr)
 }
 
 var invalidStepNames = `
@@ -767,9 +752,7 @@ spec:
 
 func TestInvalidStepName(t *testing.T) {
 	err := validate(invalidStepNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.ErrorContains(t, err, invalidErr)
 }
 
 var invalidInputParamNames = `
@@ -793,9 +776,7 @@ spec:
 
 func TestInvalidInputParamName(t *testing.T) {
 	err := validate(invalidInputParamNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.ErrorContains(t, err, invalidErr)
 }
 
 var invalidInputArtNames = `
@@ -845,9 +826,7 @@ spec:
 
 func TestInvalidInputArtName(t *testing.T) {
 	err := validate(invalidInputArtNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.ErrorContains(t, err, invalidErr)
 }
 
 var invalidOutputArtNames = `
@@ -871,9 +850,7 @@ spec:
 
 func TestInvalidOutputArtName(t *testing.T) {
 	err := validate(invalidOutputArtNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.Error(t, err, invalidErr)
 }
 
 var invalidOutputParamNames = `
@@ -986,25 +963,19 @@ spec:
 
 func TestInvalidOutputParam(t *testing.T) {
 	err := validate(invalidOutputParamNames)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), invalidErr)
-	}
+	require.ErrorContains(t, err, invalidErr)
+
 	err = validate(invalidOutputMissingValueFrom)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "does not have valueFrom or value specified")
-	}
+	require.ErrorContains(t, err, "does not have valueFrom or value specified")
+
 	err = validate(invalidOutputMultipleValueFrom)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "multiple valueFrom")
-	}
+	require.ErrorContains(t, err, "multiple valueFrom")
+
 	err = validate(invalidOutputIncompatibleValueFromPath)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), ".path must be specified for Container templates")
-	}
+	require.ErrorContains(t, err, ".path must be specified for Container templates")
+
 	err = validate(invalidOutputIncompatibleValueFromParam)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), ".parameter or expression must be specified for Steps templates")
-	}
+	require.ErrorContains(t, err, ".parameter or expression must be specified for Steps templates")
 }
 
 var multipleTemplateTypes = `
@@ -1031,9 +1002,7 @@ spec:
 
 func TestMultipleTemplateTypes(t *testing.T) {
 	err := validate(multipleTemplateTypes)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "multiple template types specified")
-	}
+	require.ErrorContains(t, err, "multiple template types specified")
 }
 
 var exitHandlerWorkflowStatusOnExit = `
@@ -1075,11 +1044,11 @@ spec:
 func TestExitHandler(t *testing.T) {
 	// ensure {{workflow.status}} is not available when not in exit handler
 	err := validate(workflowStatusNotOnExit)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// ensure {{workflow.status}} is available in exit handler
 	err = validate(exitHandlerWorkflowStatusOnExit)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var workflowWithPriority = `
@@ -1100,7 +1069,7 @@ spec:
 
 func TestPriorityVariable(t *testing.T) {
 	err := validate(workflowWithPriority)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var volumeMountArtifactPathCollision = `
@@ -1141,15 +1110,14 @@ func TestVolumeMountArtifactPathCollision(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "already mounted")
-	}
+	require.ErrorContains(t, err, "already mounted")
+
 	// tweak the mount path and validation should now be successful
 	wf.Spec.Templates[0].Container.VolumeMounts[0].MountPath = "/differentpath"
 
 	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var activeDeadlineSeconds = `
@@ -1170,9 +1138,7 @@ spec:
 
 func TestValidActiveDeadlineSeconds(t *testing.T) {
 	err := validate(activeDeadlineSeconds)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "activeDeadlineSeconds must be a positive integer > 0")
-	}
+	require.ErrorContains(t, err, "activeDeadlineSeconds must be a positive integer > 0")
 }
 
 var leafWithParallelism = `
@@ -1193,9 +1159,7 @@ spec:
 
 func TestLeafWithParallelism(t *testing.T) {
 	err := validate(leafWithParallelism)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "is only valid")
-	}
+	require.ErrorContains(t, err, "is only valid")
 }
 
 var invalidStepsArgumentNoFromOrLocation = `
@@ -1255,13 +1219,10 @@ spec:
 
 func TestInvalidArgumentNoFromOrLocation(t *testing.T) {
 	err := validate(invalidStepsArgumentNoFromOrLocation)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "from, artifact location, or key is required")
-	}
+	require.ErrorContains(t, err, "from, artifact location, or key is required")
+
 	err = validate(invalidDAGArgumentNoFromOrLocation)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "from, artifact location, or key is required")
-	}
+	require.ErrorContains(t, err, "from, artifact location, or key is required")
 }
 
 var invalidArgumentNoValue = `
@@ -1292,10 +1253,9 @@ spec:
 
 func TestInvalidArgumentNoValue(t *testing.T) {
 	err := validate(invalidArgumentNoValue)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), ".value or ")
-		assert.Contains(t, err.Error(), ".valueFrom is required")
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".value or ")
+	assert.Contains(t, err.Error(), ".valueFrom is required")
 }
 
 var validWithItems = `
@@ -1334,7 +1294,7 @@ spec:
 
 func TestValidWithItems(t *testing.T) {
 	err := validate(validWithItems)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var podNameVariable = `
@@ -1368,13 +1328,13 @@ spec:
 
 func TestPodNameVariable(t *testing.T) {
 	err := validate(podNameVariable)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestGlobalParamWithVariable(t *testing.T) {
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wfv1.MustUnmarshalWorkflow("@../../test/e2e/functional/global-outputs-variable.yaml"), ValidateOpts{})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var specArgumentNoValue = `
@@ -1400,10 +1360,10 @@ func TestSpecArgumentNoValue(t *testing.T) {
 	wf := unmarshalWf(specArgumentNoValue)
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 var specArgumentSnakeCase = `
@@ -1440,7 +1400,7 @@ func TestSpecArgumentSnakeCase(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var specBadSequenceCountAndEnd = `
@@ -1477,7 +1437,7 @@ func TestSpecBadSequenceCountAndEnd(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 var customVariableInput = `
@@ -1499,7 +1459,7 @@ func TestCustomTemplatVariable(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{Lint: true})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateRefTarget = `
@@ -1517,7 +1477,7 @@ spec:
 
 func TestWorkflowTemplate(t *testing.T) {
 	err := validateWorkflowTemplate(templateRefTarget, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateWithGlobalParams = `
@@ -1535,7 +1495,7 @@ spec:
 
 func TestWorkflowTemplateWithGlobalParams(t *testing.T) {
 	err := validateWorkflowTemplate(templateWithGlobalParams, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateRefNestedTarget = `
@@ -1571,11 +1531,11 @@ spec:
 
 func TestNestedTemplateRef(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefTarget)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = createWorkflowTemplateFromSpec(templateRefNestedTarget)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(nestedTemplateRef)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var undefinedTemplateRef = `
@@ -1596,9 +1556,7 @@ spec:
 
 func TestUndefinedTemplateRef(t *testing.T) {
 	err := validate(undefinedTemplateRef)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "not found")
-	}
+	require.ErrorContains(t, err, "not found")
 }
 
 var validResourceWorkflow = `
@@ -1625,7 +1583,7 @@ func TestValidResourceWorkflow(t *testing.T) {
 
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var invalidResourceWorkflow = `
@@ -1668,11 +1626,11 @@ spec:
 func TestInvalidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(invalidResourceWorkflow)
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
-	assert.EqualError(t, err, "templates.whalesay.resource.manifest must be a valid yaml")
+	require.EqualError(t, err, "templates.whalesay.resource.manifest must be a valid yaml")
 
 	wf = unmarshalWf(invalidActionResourceWorkflow)
 	err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
-	assert.EqualError(t, err, "templates.whalesay.resource.action must be one of: get, create, apply, delete, replace, patch")
+	require.EqualError(t, err, "templates.whalesay.resource.action must be one of: get, create, apply, delete, replace, patch")
 }
 
 var invalidPodGC = `
@@ -1692,7 +1650,7 @@ spec:
 func TestIncorrectPodGCStrategy(t *testing.T) {
 	wf := unmarshalWf(invalidPodGC)
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
-	assert.EqualError(t, err, "podGC.strategy unknown strategy 'Foo'")
+	require.EqualError(t, err, "podGC.strategy unknown strategy 'Foo'")
 }
 
 func TestInvalidPodGCLabelSelector(t *testing.T) {
@@ -1711,7 +1669,7 @@ spec:
       image: docker/whalesay
 `)
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
-	assert.EqualError(t, err, "podGC.labelSelector invalid: \"InvalidOperator\" is not a valid label selector operator")
+	require.EqualError(t, err, "podGC.labelSelector invalid: \"InvalidOperator\" is not a valid label selector operator")
 }
 
 var allowPlaceholderInVariableTakenFromInputs = `
@@ -1814,7 +1772,7 @@ func TestAllowPlaceholderInVariableTakenFromInputs(t *testing.T) {
 		wf := unmarshalWf(allowPlaceholderInVariableTakenFromInputs)
 		err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -1873,7 +1831,7 @@ func TestRuntimeResolutionOfVariableNames(t *testing.T) {
 	wf := unmarshalWf(runtimeResolutionOfVariableNames)
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var stepWithItemParam = `
@@ -1921,7 +1879,7 @@ spec:
 
 func TestStepWithItemParam(t *testing.T) {
 	err := validate(stepWithItemParam)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var invalidMetricName = `
@@ -1945,7 +1903,7 @@ spec:
 
 func TestInvalidMetricName(t *testing.T) {
 	err := validate(invalidMetricName)
-	assert.EqualError(t, err, "templates.whalesay metric name 'invalid.metric.name' is invalid. Metric names must contain alphanumeric characters, '_', or ':'")
+	require.EqualError(t, err, "templates.whalesay metric name 'invalid.metric.name' is invalid. Metric names must contain alphanumeric characters, '_', or ':'")
 }
 
 var invalidMetricLabelName = `
@@ -1972,7 +1930,7 @@ spec:
 
 func TestInvalidMetricLabelName(t *testing.T) {
 	err := validate(invalidMetricLabelName)
-	assert.EqualError(t, err, "metric label 'invalid.key' is invalid: keys may only contain alphanumeric characters, '_', or ':'")
+	require.EqualError(t, err, "metric label 'invalid.key' is invalid: keys may only contain alphanumeric characters, '_', or ':'")
 }
 
 var invalidMetricHelp = `
@@ -1995,7 +1953,7 @@ spec:
 
 func TestInvalidMetricHelp(t *testing.T) {
 	err := validate(invalidMetricHelp)
-	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' must contain a help string under 'help: ' field")
+	require.EqualError(t, err, "templates.whalesay metric 'metric_name' must contain a help string under 'help: ' field")
 }
 
 var invalidRealtimeMetricGauge = `
@@ -2020,7 +1978,7 @@ spec:
 
 func TestInvalidMetricGauge(t *testing.T) {
 	err := validate(invalidRealtimeMetricGauge)
-	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' error: 'resourcesDuration.*' metrics cannot be used in real-time")
+	require.EqualError(t, err, "templates.whalesay metric 'metric_name' error: 'resourcesDuration.*' metrics cannot be used in real-time")
 }
 
 var invalidNoValueMetricGauge = `
@@ -2044,7 +2002,7 @@ spec:
 
 func TestInvalidNoValueMetricGauge(t *testing.T) {
 	err := validate(invalidNoValueMetricGauge)
-	assert.EqualError(t, err, "templates.whalesay metric 'metric_name' error: missing gauge.value")
+	require.EqualError(t, err, "templates.whalesay metric 'metric_name' error: missing gauge.value")
 }
 
 var validMetricGauges = `
@@ -2078,7 +2036,7 @@ spec:
 
 func TestValidMetricGauge(t *testing.T) {
 	err := validate(validMetricGauges)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var globalVariables = `
@@ -2127,7 +2085,7 @@ spec:
 
 func TestWorkflowGlobalVariables(t *testing.T) {
 	err := validate(globalVariables)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var wfTemplateWithEntrypoint = `
@@ -2150,7 +2108,7 @@ spec:
 
 func TestWorkflowTemplateWithEntrypoint(t *testing.T) {
 	err := validateWorkflowTemplate(wfTemplateWithEntrypoint, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var wfWithWFTRefNoEntrypoint = `
@@ -2181,9 +2139,9 @@ spec:
 
 func TestWorkflowWithWFTRefWithEntrypoint(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateWithEntrypoint)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRefNoEntrypoint)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 const wfWithWFTRef = `
@@ -2212,9 +2170,9 @@ spec:
 
 func TestWorkflowWithWFTRef(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefTarget)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRef)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 const invalidWFWithWFTRef = `
@@ -2239,9 +2197,9 @@ spec:
 
 func TestValidateFieldsWithWFTRef(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefTarget)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(invalidWFWithWFTRef)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 var invalidWfNoImage = `apiVersion: argoproj.io/v1alpha1
@@ -2261,7 +2219,7 @@ spec:
 
 func TestInvalidWfNoImageField(t *testing.T) {
 	err := validate(invalidWfNoImage)
-	assert.EqualError(t, err, "templates.whalesay.container.image may not be empty")
+	require.EqualError(t, err, "templates.whalesay.container.image may not be empty")
 }
 
 var invalidWfNoImageScript = `apiVersion: argoproj.io/v1alpha1
@@ -2281,7 +2239,7 @@ spec:
 
 func TestInvalidWfNoImageFieldScript(t *testing.T) {
 	err := validate(invalidWfNoImageScript)
-	assert.EqualError(t, err, "templates.whalesay.script.image may not be empty")
+	require.EqualError(t, err, "templates.whalesay.script.image may not be empty")
 }
 
 var invalidWfNoImageScriptInTemplateDefault = `apiVersion: argoproj.io/v1alpha1
@@ -2302,7 +2260,7 @@ spec:
 
 func TestIinvalidWfNoImageScriptInTemplateDefault(t *testing.T) {
 	err := validate(invalidWfNoImageScriptInTemplateDefault)
-	assert.EqualError(t, err, "templates.whalesay.script.image may not be empty")
+	require.EqualError(t, err, "templates.whalesay.script.image may not be empty")
 }
 
 var validWfImageScriptInTemplateDefault = `apiVersion: argoproj.io/v1alpha1
@@ -2325,7 +2283,7 @@ spec:
 
 func TestValidWfImageScriptInTemplateDefault(t *testing.T) {
 	err := validate(validWfImageScriptInTemplateDefault)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var validWfImageContainerInTemplateDefault = `apiVersion: argoproj.io/v1alpha1
@@ -2348,7 +2306,7 @@ spec:
 
 func TestValidWfImageContainerInTemplateDefault(t *testing.T) {
 	err := validate(validWfImageContainerInTemplateDefault)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateRefScriptImageDefaultTarget = `
@@ -2381,9 +2339,9 @@ spec:
 
 func TestValidateFieldsWithWFTRefScriptImageInDefault(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefScriptImageDefaultTarget)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRefScriptImageInDefault)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateRefContainerImageDefaultTarget = `
@@ -2416,9 +2374,9 @@ spec:
 
 func TestValidateFieldsWithWFTRefContainerImageInDefault(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefContainerImageDefaultTarget)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRefContainerImageInDefault)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateRefWithParam = `
@@ -2455,9 +2413,9 @@ spec:
 
 func TestWorkflowWithWFTRefWithOverrideParam(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefWithParam)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRefOverrideParam)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var testWorkflowTemplateLabels = `
@@ -2487,7 +2445,7 @@ spec:
 
 func TestWorkflowTemplateLabels(t *testing.T) {
 	err := validateWorkflowTemplate(testWorkflowTemplateLabels, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 const templateRefWithArtifactArgument = `
@@ -2527,9 +2485,9 @@ spec:
 
 func TestWorkflowWithWFTRefWithOutOwnArtifactArgument(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefWithArtifactArgument)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRefAndNoOwnArtifact)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 const wfWithWFTRefAndOwnArtifactArgument = `
@@ -2550,9 +2508,9 @@ spec:
 
 func TestWorkflowWithWFTRefWithArtifactArgument(t *testing.T) {
 	err := createWorkflowTemplateFromSpec(templateRefWithArtifactArgument)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validate(wfWithWFTRefAndOwnArtifactArgument)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var workflowTeamplateWithEnumValues = `
@@ -2684,38 +2642,38 @@ spec:
 
 func TestWorkflowTemplateWithEnumValue(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTeamplateWithEnumValues, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValues, ValidateOpts{Lint: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValues, ValidateOpts{Submit: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestWorkflowTemplateWithEmptyEnumList(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{})
-	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
+	require.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 	err = validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{Lint: true})
-	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
+	require.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 	err = validateWorkflowTemplate(workflowTemplateWithEmptyEnumList, ValidateOpts{Submit: true})
-	assert.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
+	require.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 }
 
 func TestWorkflowTemplateWithArgumentValueNotFromEnumList(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{})
-	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
+	require.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 	err = validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Lint: true})
-	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
+	require.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 	err = validateWorkflowTemplate(workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Submit: true})
-	assert.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
+	require.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 }
 
 func TestWorkflowTemplateWithEnumValueWithoutValue(t *testing.T) {
 	err := validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Lint: true})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = validateWorkflowTemplate(workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Submit: true})
-	assert.EqualError(t, err, "spec.arguments.message.value or spec.arguments.message.valueFrom is required")
+	require.EqualError(t, err, "spec.arguments.message.value or spec.arguments.message.valueFrom is required")
 }
 
 var resourceManifestWithExpressions = `
@@ -2783,7 +2741,7 @@ spec:
 
 func TestWorkflowTemplateWithResourceManifest(t *testing.T) {
 	err := validate(validWorkflowTemplateWithResourceManifest)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var validActiveDeadlineSecondsArgoVariable = `
@@ -2827,25 +2785,25 @@ spec:
 
 func TestValidActiveDeadlineSecondsArgoVariable(t *testing.T) {
 	err := validateWorkflowTemplate(validActiveDeadlineSecondsArgoVariable, ValidateOpts{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMaxLengthName(t *testing.T) {
 	wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
-	assert.EqualError(t, err, "workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
+	require.EqualError(t, err, "workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	wftmpl := &wfv1.WorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	err = ValidateWorkflowTemplate(wftmplGetter, cwftmplGetter, wftmpl, ValidateOpts{})
-	assert.EqualError(t, err, "workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
+	require.EqualError(t, err, "workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwftmpl := &wfv1.ClusterWorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
 	err = ValidateClusterWorkflowTemplate(wftmplGetter, cwftmplGetter, cwftmpl, ValidateOpts{})
-	assert.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
+	require.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 60)}}
 	err = ValidateCronWorkflow(wftmplGetter, cwftmplGetter, cwf)
-	assert.EqualError(t, err, "cron workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 52 characters long (currently 60)")
+	require.EqualError(t, err, "cron workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 52 characters long (currently 60)")
 }
 
 var invalidContainerSetDependencyNotFound = `
@@ -2875,9 +2833,7 @@ spec:
 
 func TestInvalidContainerSetDependencyNotFound(t *testing.T) {
 	err := validate(invalidContainerSetDependencyNotFound)
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "templates.main.containerSet.containers.b dependency 'c' not defined")
-	}
+	require.ErrorContains(t, err, "templates.main.containerSet.containers.b dependency 'c' not defined")
 }
 
 func TestInvalidContainerSetNoMainContainer(t *testing.T) {
@@ -2944,9 +2900,7 @@ spec:
 	}
 	for _, manifest := range invalidManifests {
 		err := validateWorkflowTemplate(manifest, ValidateOpts{})
-		if assert.Error(t, err) {
-			assert.Contains(t, err.Error(), "containerSet.containers must have a container named \"main\" for input or output")
-		}
+		require.ErrorContains(t, err, "containerSet.containers must have a container named \"main\" for input or output")
 	}
 }
 
@@ -2983,7 +2937,7 @@ spec:
 		dependencies: make(map[string]map[string]common.DependencyType),
 	}
 	err := sortDAGTasks(&tmpl, dagValidationCtx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var taskOrderAfterSort, expectedOrder []string
 	expectedOrder = []string{"8ea51cf2", "ba1f414f", "f7d273f8"}
 	for _, task := range tmpl.DAG.Tasks {
@@ -3000,7 +2954,7 @@ metadata:
 spec:
   entrypoint: steps-timing
   templates:
-    
+
     - name: steps-timing
       steps:
         - - name: one
@@ -3015,12 +2969,12 @@ spec:
                   value: "{{steps.one.finishedAt}}"
                 - name: id
                   value: "{{steps.one.id}}"
-    
+
     - name: wait
       container:
         image: alpine:3.7
         command: [sleep, "5"]
-    
+
     - name: printer
       inputs:
         parameters:
@@ -3031,7 +2985,7 @@ spec:
         image: alpine:3.7
         command: [echo, "{{inputs.parameters.startedat}}"]`
 	err := validate(wf)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var templateReferenceWorkflowConfigMapRefArgument = `
@@ -3062,7 +3016,7 @@ spec:
 
 func TestTemplateReferenceWorkflowConfigMapRefArgument(t *testing.T) {
 	err := validate(templateReferenceWorkflowConfigMapRefArgument)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var stepsOutputParametersForScript = `
@@ -3109,7 +3063,7 @@ spec:
 
 func TestStepsOutputParametersForScript(t *testing.T) {
 	err := validate(stepsOutputParametersForScript)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var stepsOutputParametersForContainerSet = `
@@ -3159,7 +3113,7 @@ spec:
 
 func TestStepsOutputParametersForContainerSet(t *testing.T) {
 	err := validate(stepsOutputParametersForContainerSet)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var globalAnnotationsAndLabels = `apiVersion: argoproj.io/v1alpha1
@@ -3186,7 +3140,7 @@ spec:
 
 func TestResolveAnnotationsAndLabelsJSson(t *testing.T) {
 	err := validate(globalAnnotationsAndLabels)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 var testInitContainerHasName = `
@@ -3222,7 +3176,7 @@ spec:
 
 func TestInitContainerHasName(t *testing.T) {
 	err := validate(testInitContainerHasName)
-	assert.EqualError(t, err, "templates.main.tasks.spurious initContainers must all have container name")
+	require.EqualError(t, err, "templates.main.tasks.spurious initContainers must all have container name")
 }
 
 var nodeNamePlumbsCorrectly = `
@@ -3255,7 +3209,7 @@ spec:
 
 func TestNodeNameParameterInterpoliates(t *testing.T) {
 	err := validate(nodeNamePlumbsCorrectly)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSubstituteGlobalVariablesLabelsAnnotations(t *testing.T) {
@@ -3306,14 +3260,14 @@ func TestSubstituteGlobalVariablesLabelsAnnotations(t *testing.T) {
 			wftmpl := wfv1.MustUnmarshalWorkflowTemplate(tt.workflowTemplate)
 			err := createWorkflowTemplate(wftmpl)
 			if err != nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			err = ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
 			if tt.expectedSuccess {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 			}
 
 			_ = deleteWorkflowTemplate(wftmpl.Name)
@@ -3339,7 +3293,5 @@ spec:
 func TestShouldCheckValidationToSpacedParameters(t *testing.T) {
 	err := validate(spacedParameterWorkflowTemplate)
 	// Do not allow leading or trailing spaces in parameters
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "failed to resolve {{  workflow.thisdoesnotexist  }}")
-	}
+	require.ErrorContains(t, err, "failed to resolve {{  workflow.thisdoesnotexist  }}")
 }


### PR DESCRIPTION
This is part of a series of test tidies started by #13365.

The aim is to enable the `testifylint` `golangci-lint` checker.

This commit converts `assert.Error` checks into `require.Error` for the part of the codebase, as per https://github.com/argoproj/argo-workflows/pull/13270#discussion_r1667248031

In some places checks have been coalesced - in particular the pattern

```go
if assert.Error() {
    assert.Contains(..., "message")
}
```

is now
```go
require.ErrorContains(..., "message")
```

Getting this wrong and missing the `Contains` is still valid Go, so that's a mistake I may have made.

Signed-off-by: Alan Clucas <alan@clucas.org>