### PR TITLE
build: resolve error for toolchain not available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.22.0
+go 1.22.5
 
 require (
 	cloud.google.com/go/storage v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.36.0


### PR DESCRIPTION
This fixes the following issue in my local setup:
```
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

See https://github.com/golang/go/issues/65568