### PR TITLE
docs(artifacts): add note about server access

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -182,6 +182,9 @@ create the service account key and store it as a Kubernetes secret,
 `serviceAccountKeySecret` is also not needed in this case. Please follow the
 link to configure Workload Identity
 (<https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity>).
+If using the artifact repository to archive logs, Workload Identity will have to be associated with two Kubernetes service accounts: 
+- The service account used to execute the workflow to write logs
+- The service account used by Argo Server (default: `argo-server`) to retrieve logs
 
 ### Use S3 APIs
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Motivation

When using Workload Identity the calling Kubernetes service account assumes GKE workload identity if it is annotated to do so, but per current docs it isn't clear that there are at least two service accounts that will need to be able to call the bucket. I am raising this change to help others avoid finding 500 errors when trying to retrieve archived logs for Workflows.

### Modifications

Added docs content to explain that argo-server needs Workload identity enabled for use with Archive Logs

### Verification

n/a
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
