### PR TITLE
chore: properly rename `MustUnmarshalClusterWorkflowTemplate`

### DIFF
--- a/pkg/apis/workflow/v1alpha1/marshall.go
+++ b/pkg/apis/workflow/v1alpha1/marshall.go
@@ -49,7 +49,7 @@ func MustMarshallJSON(v interface{}) string {
 	return string(data)
 }
 
-func MustUnmarshalClusterWorkflow(text interface{}) *ClusterWorkflowTemplate {
+func MustUnmarshalClusterWorkflowTemplate(text interface{}) *ClusterWorkflowTemplate {
 	x := &ClusterWorkflowTemplate{}
 	MustUnmarshal(text, &x)
 	return x

--- a/pkg/apis/workflow/v1alpha1/marshall_test.go
+++ b/pkg/apis/workflow/v1alpha1/marshall_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMustUnmarshalClusterWorkflow(t *testing.T) {
+func TestMustUnmarshalClusterWorkflowTemplate(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatalf("The code did not panic but should have")
@@ -14,6 +14,6 @@ func TestMustUnmarshalClusterWorkflow(t *testing.T) {
 			assert.Equal(t, "no text to unmarshal", r.(string))
 		}
 	}()
-	_ = MustUnmarshalClusterWorkflow([]byte(""))
-	t.Fatalf("MustUnmarshalClusterWorkflow should have panicked and this part should not have been reached.")
+	_ = MustUnmarshalClusterWorkflowTemplate([]byte(""))
+	t.Fatalf("MustUnmarshalClusterWorkflowTemplate should have panicked and this part should not have been reached.")
 }

--- a/workflow/controller/operator_template_scope_test.go
+++ b/workflow/controller/operator_template_scope_test.go
@@ -473,7 +473,7 @@ spec:
 
 func TestTemplateClusterScope(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(testTemplateClusterScopeWorkflowYaml)
-	cwftmpl := wfv1.MustUnmarshalClusterWorkflow(testTemplateClusterScopeWorkflowTemplateYaml1)
+	cwftmpl := wfv1.MustUnmarshalClusterWorkflowTemplate(testTemplateClusterScopeWorkflowTemplateYaml1)
 	wftmpl := wfv1.MustUnmarshalWorkflowTemplate(testTemplateScopeWorkflowTemplateYaml2)
 
 	cancel, controller := newController(wf, cwftmpl, wftmpl)


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation

<!-- TODO: Say why you made your changes. -->
Fix the name of the function, to get better readability.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
rename function  `MustUnmarshalClusterWorkflow` -> `MustUnmarshalClusterWorkflowTemplate`

### Verification

<!-- TODO: Say how you tested your changes. -->
ran locally

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
