### PR TITLE
fix: compute and emit realtime metrics while node not fulfilled

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2248,7 +2248,8 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	if processedTmpl.Metrics != nil {
-		// Check if the node did not fulfilled, we should compute real time metrics.
+		// Check if the node was just created or not fulfilled, if it was emit realtime metrics.
+		// If the node did not previously exist, we can infer that it was created during the current operation, emit real time metrics.
 		if _, ok := woc.preExecutionNodePhases[node.ID]; !ok || !node.Fulfilled() {
 			localScope, realTimeScope := woc.prepareMetricScope(node)
 			woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2248,11 +2248,8 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	if processedTmpl.Metrics != nil {
-		// Check if the node did not fulfilled, we should compute real time metrics.
-		if _, ok := woc.preExecutionNodePhases[node.ID]; !ok || !node.Fulfilled() {
-			localScope, realTimeScope := woc.prepareMetricScope(node)
-			woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
-		}
+		localScope, realTimeScope := woc.prepareMetricScope(node)
+		woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
 		// Check if the node completed during this execution, if it did emit metrics
 		//
 		// This check is necessary because sometimes a node will be marked completed during the current execution and will

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2248,8 +2248,11 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	if processedTmpl.Metrics != nil {
-		localScope, realTimeScope := woc.prepareMetricScope(node)
-		woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
+		// Check if the node did not fulfilled, we should compute real time metrics.
+		if _, ok := woc.preExecutionNodePhases[node.ID]; !ok || !node.Fulfilled() {
+			localScope, realTimeScope := woc.prepareMetricScope(node)
+			woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
+		}
 		// Check if the node completed during this execution, if it did emit metrics
 		//
 		// This check is necessary because sometimes a node will be marked completed during the current execution and will

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2248,8 +2248,12 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	if processedTmpl.Metrics != nil {
-		localScope, realTimeScope := woc.prepareMetricScope(node)
-		woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
+		// Check if the node was just created, if it was emit realtime metrics.
+		// If the node did not previously exist, we can infer that it was created during the current operation, emit real time metrics.
+		if _, ok := woc.preExecutionNodePhases[node.ID]; !ok {
+			localScope, realTimeScope := woc.prepareMetricScope(node)
+			woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
+		}
 		// Check if the node completed during this execution, if it did emit metrics
 		//
 		// This check is necessary because sometimes a node will be marked completed during the current execution and will

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2248,8 +2248,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	if processedTmpl.Metrics != nil {
-		// Check if the node was just created or not fulfilled, if it was emit realtime metrics.
-		// If the node did not previously exist, we can infer that it was created during the current operation, emit real time metrics.
+		// Check if the node did not fulfilled, we should compute real time metrics.
 		if _, ok := woc.preExecutionNodePhases[node.ID]; !ok || !node.Fulfilled() {
 			localScope, realTimeScope := woc.prepareMetricScope(node)
 			woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2248,12 +2248,8 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	if processedTmpl.Metrics != nil {
-		// Check if the node was just created, if it was emit realtime metrics.
-		// If the node did not previously exist, we can infer that it was created during the current operation, emit real time metrics.
-		if _, ok := woc.preExecutionNodePhases[node.ID]; !ok {
-			localScope, realTimeScope := woc.prepareMetricScope(node)
-			woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
-		}
+		localScope, realTimeScope := woc.prepareMetricScope(node)
+		woc.computeMetrics(processedTmpl.Metrics.Prometheus, localScope, realTimeScope, true)
 		// Check if the node completed during this execution, if it did emit metrics
 		//
 		// This check is necessary because sometimes a node will be marked completed during the current execution and will


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes #13440

### Motivation
When I use the realtime metrics in templates level. The realtime metrics not emit in every template execution.

Explanation：
Before the modification, the node would only calculate the real-time logic during its first creation. However, if the conditions specified in the "when" clause are not met at that time, it would have to wait until the node finishes running before recalculating the "when" conditions for real-time. This does not align with the intended meaning of real-time.

### Modifications
compute and then emit realtime metrics while node not fulfilled

### How to test ?
Such as this template, I add a prometheus metrics at templates level, It will emit the metrics when `{{duration}} > 100`. 
If workflow keeps running, it never stops. When the `workflowResyncPeriod` time is reached, workflow is scheduled again, but because the node is not fulfilled, the indicator cannot be calculated again, resulting in that the indicator cannot be emitted when the condition is fulfilled.
```
 spec:
  templates:
    - name: gen-random-int
      metrics:
        prometheus:
          - name:  node_timeout_metrics
            help: Duration gauge by name
            when: '{{duration}} > 100'
            gauge:
              value: '{{duration}}'
              realtime: true
```

### My expectation
compute and then emit realtime metrics while node not fulfilled

