### PR TITLE
fix: avoid exit handler nil pointer when missing outputs. Fixes #13445

### DIFF
--- a/test/e2e/expectedfailures/exit-handler-fail-missing-output.yaml
+++ b/test/e2e/expectedfailures/exit-handler-fail-missing-output.yaml
@@ -34,6 +34,6 @@ spec:
         parameters:
           - name: hello-param
       container:
-        image: argoproj/argosay:v1
-        command: [cowsay]
+        image: busybox
+        command: [echo]
         args: ["Hello param: {{inputs.parameters.hello-param}}"]

--- a/test/e2e/expectedfailures/exit-handler-fail-missing-output.yaml
+++ b/test/e2e/expectedfailures/exit-handler-fail-missing-output.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handler-fail-missing-output-
+  labels:
+    test: test
+spec:
+  entrypoint: failure-workflow
+  templates:
+    - name: failure-workflow
+      steps:
+        - - name: step1
+            template: intentional-fail
+            hooks:
+              exit:
+                template: lifecycle-hook
+                arguments:
+                  parameters:
+                    - name: hello-param
+                      value: '{{steps.step1.outputs.parameters.hello-param}}'
+    - name: intentional-fail
+      outputs:
+        parameters:
+          - name: hello-param
+            valueFrom:
+              path: /tmp/hello_world.txt
+      container:
+        image: alpine:latest
+        command: ["sh", "-c"]
+        args: ["echo intentional failure; exit 1"]
+    - name: lifecycle-hook
+      inputs:
+        parameters:
+          - name: hello-param
+      container:
+        image: argoproj/argosay:v1
+        command: [cowsay]
+        args: ["Hello param: {{inputs.parameters.hello-param}}"]

--- a/workflow/controller/exit_handler.go
+++ b/workflow/controller/exit_handler.go
@@ -57,9 +57,11 @@ func (woc *wfOperationCtx) resolveExitTmplArgument(args wfv1.Arguments, prefix s
 	}
 	if outputs != nil {
 		for _, param := range outputs.Parameters {
+			value := ""
 			if param.Value != nil {
-				scope.addParamToScope(fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name), param.Value.String())
+				value = param.Value.String()
 			}
+			scope.addParamToScope(fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name), value)
 		}
 		for _, arts := range outputs.Artifacts {
 			scope.addArtifactToScope(fmt.Sprintf("%s.outputs.artifacts.%s", prefix, arts.Name), arts)

--- a/workflow/controller/exit_handler.go
+++ b/workflow/controller/exit_handler.go
@@ -57,7 +57,9 @@ func (woc *wfOperationCtx) resolveExitTmplArgument(args wfv1.Arguments, prefix s
 	}
 	if outputs != nil {
 		for _, param := range outputs.Parameters {
-			scope.addParamToScope(fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name), param.Value.String())
+			if param.Value != nil {
+				scope.addParamToScope(fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name), param.Value.String())
+			}
 		}
 		for _, arts := range outputs.Artifacts {
 			scope.addArtifactToScope(fmt.Sprintf("%s.outputs.artifacts.%s", prefix, arts.Name), arts)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13445

### Motivation

This PR addresses a critical issue where exit handlers fail when called on a failed step with a `null` or empty output parameter. Specifically, when a step crashes before creating the output file referenced in `valueFrom`, the exit handler encounters a runtime error: `"invalid memory address or nil pointer dereference".` The problem has been observed in Argo Workflow versions 3.5.5 through 3.5.10.
### Modifications

To resolve this issue:
1. Added a `nil` check before calling `params.Value.String()` in the relevant code section.
2. This check ensures that we only attempt to access the parameter value when it exists, preventing the `nil` pointer dereference.

### Verification

To ensure the effectiveness of this fix and prevent regression, I've added a new end-to-end (e2e) test case. This test case verifies:

1. The presence of an exit handler node in the workflow graph after a step failure.
2. Proper population of the exit handler's input based on the output from the failed step.

Previously, when the issue occurred, the exit node was never created, and the workflow terminated immediately after the first step. The new test confirms that:
1. The workflow correctly transitions to the exit handler node instead of prematurely completing.
2. The exit handler receives and can process the output parameter from the failed step, which during the next `operate` is populated and we can see the `failed` status.
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/934b7423-4acd-4753-ad74-e88149d9f2c4">


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
