### PR TITLE
feat(ui): add history to WorkflowTemplate & ClusterWorkflowTemplate details

### DIFF
--- a/ui/src/app/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/app/cron-workflows/cron-workflow-details.tsx
@@ -18,11 +18,10 @@ import {historyUrl} from '../shared/history';
 import {services} from '../shared/services';
 import {useQueryParams} from '../shared/use-query-params';
 import {WidgetGallery} from '../widgets/widget-gallery';
-import {WorkflowsRow} from '../workflows/components/workflows-row/workflows-row';
+import {WorkflowDetailsList} from '../workflows/components/workflow-details-list/workflow-details-list';
 import {CronWorkflowEditor} from './cron-workflow-editor';
 
 import '../workflows/components/workflow-details/workflow-details.scss';
-import './cron-workflow-details.scss';
 
 export function CronWorkflowDetails({match, location, history}: RouteComponentProps<any>) {
     // boiler-plate
@@ -226,33 +225,7 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
                             <p> You can create new cron workflows here or using the CLI. </p>
                         </ZeroState>
                     ) : (
-                        <div className='argo-table-list workflows-cron-list'>
-                            <div className='row argo-table-list__head'>
-                                <div className='columns small-1 workflows-list__status' />
-                                <div className='row small-11'>
-                                    <div className='columns small-2'>NAME</div>
-                                    <div className='columns small-1'>NAMESPACE</div>
-                                    <div className='columns small-1'>STARTED</div>
-                                    <div className='columns small-1'>FINISHED</div>
-                                    <div className='columns small-1'>DURATION</div>
-                                    <div className='columns small-1'>PROGRESS</div>
-                                    <div className='columns small-2'>MESSAGE</div>
-                                    <div className='columns small-1'>DETAILS</div>
-                                    <div className='columns small-1'>ARCHIVED</div>
-                                    {(columns || []).map(col => {
-                                        return (
-                                            <div className='columns small-1' key={col.key}>
-                                                {col.name}
-                                            </div>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                            {/* checkboxes are not visible and are unused on this page */}
-                            {workflows.map(wf => {
-                                return <WorkflowsRow workflow={wf} key={wf.metadata.uid} checked={false} columns={columns} onChange={null} select={null} />;
-                            })}
-                        </div>
+                        <WorkflowDetailsList workflows={workflows} columns={columns} />
                     )}
                 </>
             </>

--- a/ui/src/app/workflow-templates/workflow-template-details.tsx
+++ b/ui/src/app/workflow-templates/workflow-template-details.tsx
@@ -5,16 +5,19 @@ import * as React from 'react';
 import {useContext, useEffect, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 
-import {WorkflowTemplate} from '../../models';
+import * as models from '../../models';
+import {WorkflowTemplate, Workflow} from '../../models';
 import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {Loading} from '../shared/components/loading';
 import {useCollectEvent} from '../shared/use-collect-event';
+import {ZeroState} from '../shared/components/zero-state';
 import {Context} from '../shared/context';
 import {historyUrl} from '../shared/history';
 import {services} from '../shared/services';
 import {useQueryParams} from '../shared/use-query-params';
 import {WidgetGallery} from '../widgets/widget-gallery';
+import {WorkflowDetailsList} from '../workflows/components/workflow-details-list/workflow-details-list';
 import {SubmitWorkflowPanel} from '../workflows/components/submit-workflow-panel';
 import {WorkflowTemplateEditor} from './workflow-template-editor';
 
@@ -28,6 +31,14 @@ export function WorkflowTemplateDetails({history, location, match}: RouteCompone
     const name = match.params.name;
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel'));
     const [tab, setTab] = useState<string>(queryParams.get('tab'));
+    const [workflows, setWorkflows] = useState<Workflow[]>([]);
+    const [columns, setColumns] = useState<models.Column[]>([]);
+
+    const [template, setTemplate] = useState<WorkflowTemplate>();
+    const [error, setError] = useState<Error>();
+    const [edited, setEdited] = useState(false);
+
+    useEffect(() => setEdited(true), [template]);
 
     useEffect(
         useQueryParams(history, p => {
@@ -50,12 +61,6 @@ export function WorkflowTemplateDetails({history, location, match}: RouteCompone
         [namespace, name, sidePanel, tab]
     );
 
-    const [error, setError] = useState<Error>();
-    const [template, setTemplate] = useState<WorkflowTemplate>();
-    const [edited, setEdited] = useState(false);
-
-    useEffect(() => setEdited(true), [template]);
-
     useEffect(() => {
         services.workflowTemplate
             .get(name, namespace)
@@ -64,6 +69,16 @@ export function WorkflowTemplateDetails({history, location, match}: RouteCompone
             .then(() => setError(null))
             .catch(setError);
     }, [name, namespace]);
+
+    useEffect(() => {
+        (async () => {
+            const workflowList = await services.workflows.list(namespace, null, [`${models.labels.workflowTemplate}=${name}`], {limit: 50});
+            const workflowsInfo = await services.info.getInfo();
+
+            setWorkflows(workflowList.items);
+            setColumns(workflowsInfo.columns);
+        })();
+    }, []);
 
     useCollectEvent('openedWorkflowTemplateDetails');
 
@@ -139,6 +154,16 @@ export function WorkflowTemplateDetails({history, location, match}: RouteCompone
                     {sidePanel === 'share' && <WidgetGallery namespace={namespace} label={'workflows.argoproj.io/workflow-template=' + name} />}
                 </SlidingPanel>
             )}
+            <>
+                <ErrorNotice error={error} />
+                {!workflows ? (
+                    <ZeroState title='No completed workflow templates'>
+                        <p> You can create new workflow templates here or using the CLI. </p>
+                    </ZeroState>
+                ) : (
+                    <WorkflowDetailsList workflows={workflows} columns={columns} />
+                )}
+            </>
         </Page>
     );
 }

--- a/ui/src/app/workflows/components/workflow-details-list/workflow-details-list.scss
+++ b/ui/src/app/workflows/components/workflow-details-list/workflow-details-list.scss
@@ -1,6 +1,6 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
-.workflows-cron-list .workflows-list {
+.workflows-details-list .workflows-list {
   &__status {
     max-width: 80px;
     display: flex;

--- a/ui/src/app/workflows/components/workflow-details-list/workflow-details-list.tsx
+++ b/ui/src/app/workflows/components/workflow-details-list/workflow-details-list.tsx
@@ -34,7 +34,7 @@ export function WorkflowDetailsList(props: WorkflowDetailsList) {
                     })}
                 </div>
             </div>
-            {/* checkboxes are not visible and are unused on this page */}
+            {/* checkboxes are not visible and are unused in details pages */}
             {props.workflows.map(wf => {
                 return <WorkflowsRow workflow={wf} key={wf.metadata.uid} checked={false} columns={props.columns} onChange={null} select={null} />;
             })}

--- a/ui/src/app/workflows/components/workflow-details-list/workflow-details-list.tsx
+++ b/ui/src/app/workflows/components/workflow-details-list/workflow-details-list.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import * as models from '../../../../models';
+import {WorkflowsRow} from '../../../workflows/components/workflows-row/workflows-row';
+
+import './workflow-details-list.scss';
+
+interface WorkflowDetailsList {
+    workflows: models.Workflow[];
+    columns: models.Column[];
+}
+
+export function WorkflowDetailsList(props: WorkflowDetailsList) {
+    return (
+        <div className='argo-table-list workflows-details-list'>
+            <div className='row argo-table-list__head'>
+                <div className='columns small-1 workflows-list__status' />
+                <div className='row small-11'>
+                    <div className='columns small-2'>NAME</div>
+                    <div className='columns small-1'>NAMESPACE</div>
+                    <div className='columns small-1'>STARTED</div>
+                    <div className='columns small-1'>FINISHED</div>
+                    <div className='columns small-1'>DURATION</div>
+                    <div className='columns small-1'>PROGRESS</div>
+                    <div className='columns small-2'>MESSAGE</div>
+                    <div className='columns small-1'>DETAILS</div>
+                    <div className='columns small-1'>ARCHIVED</div>
+                    {(props.columns || []).map(col => {
+                        return (
+                            <div className='columns small-1' key={col.key}>
+                                {col.name}
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+            {/* checkboxes are not visible and are unused on this page */}
+            {props.workflows.map(wf => {
+                return <WorkflowsRow workflow={wf} key={wf.metadata.uid} checked={false} columns={props.columns} onChange={null} select={null} />;
+            })}
+        </div>
+    );
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13282

I didn't have the authority to reopen the #13283, so I am creating a new one.

### Motivation

As indicated in the Issue, it is inconvenient that the history is not visible in the WorkflowTemplate details.
CronWorkflow can see it, so I would like to see consistency.

### Modifications

#### WorkflowTemplate

![image](https://github.com/argoproj/argo-workflows/assets/4182311/6a13b580-c98a-4b1e-bf86-217df9218596)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/6ede2f6e-204c-49be-8606-405825ba94d9)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/2361a570-ea84-496a-bcf9-b71f151ea58d)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/aac46c44-d91a-4587-9713-16a4ece3375d)

<details>
<summary>No history</summary>

![image](https://github.com/argoproj/argo-workflows/assets/4182311/3a792ce4-e29b-4b82-93cb-2e85874ae375)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/375e172b-9932-4f3d-beb1-d9f3979377f8)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/2307d5b6-5a30-4ead-9306-bdd993d48a95)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/6b687076-83f0-4109-9e0a-c17948ef80ff)
</details>

#### ClusterWorkflowTemplate

![image](https://github.com/argoproj/argo-workflows/assets/4182311/90d4f14e-4587-4ea2-aaf7-19b43af26010)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/b5b3e600-f83f-49a1-95ba-7383c5c533b9)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/28c309bd-0d26-4c39-b9b4-80c4b1d16102)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/7297a988-6c52-498a-a123-ac59e3d0fb70)


<details>
<summary>No history</summary>

![image](https://github.com/argoproj/argo-workflows/assets/4182311/f4defbca-43fe-49d2-b0a3-158a91953829)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/79495c4c-920a-44b3-a747-e71ec2fa11b2)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/23c0419f-5fa8-4f47-8ac3-90e3bfd8077e)
![image](https://github.com/argoproj/argo-workflows/assets/4182311/bedc4272-d4e1-4efa-81bd-9b6f7961bfa4)
</details>

### Verification

- [x] no data
- [x] Only the relevant Workflow is displayed in the execution history, even if there are multiple WorkflowTemplates.
- [x] Displayed with no problem even with multiple data.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
