### PR TITLE
fix(docs): Provide versioned links to documentation

### DIFF
--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -63,7 +63,7 @@ func NewServerCommand() *cobra.Command {
 		Use:   "server",
 		Short: "start the Argo Server",
 		Example: fmt.Sprintf(`
-See %s`, help.ArgoServer),
+See %s`, help.ArgoServer()),
 		RunE: func(c *cobra.Command, args []string) error {
 			cmd.SetLogFormatter(logFormat)
 			stats.RegisterStackDumper()

--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	argoKubeOffloadNodeStatusRepo = sqldb.ExplosiveOffloadNodeStatusRepo
-	NoArgoServerErr               = fmt.Errorf("this is impossible if you are not using the Argo Server, see " + help.CLI)
+	NoArgoServerErr               = fmt.Errorf("this is impossible if you are not using the Argo Server, see " + help.CLI())
 )
 
 type argoKubeClient struct {

--- a/pkg/apis/workflow/v1alpha1/version_types.go
+++ b/pkg/apis/workflow/v1alpha1/version_types.go
@@ -1,5 +1,10 @@
 package v1alpha1
 
+import (
+	"errors"
+	"regexp"
+)
+
 type Version struct {
 	Version      string `json:"version" protobuf:"bytes,1,opt,name=version"`
 	BuildDate    string `json:"buildDate" protobuf:"bytes,2,opt,name=buildDate"`
@@ -9,4 +14,17 @@ type Version struct {
 	GoVersion    string `json:"goVersion" protobuf:"bytes,6,opt,name=goVersion"`
 	Compiler     string `json:"compiler" protobuf:"bytes,7,opt,name=compiler"`
 	Platform     string `json:"platform" protobuf:"bytes,8,opt,name=platform"`
+}
+
+var verRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)`)
+
+// BrokenDown returns the major, minor and release components
+// of the version number, or error if this is not a release
+// The error path is considered "normal" in a non-release build.
+func (v Version) Components() (string, string, string, error) {
+	matches := verRe.FindStringSubmatch(v.Version)
+	if matches == nil || matches[1] == "0" {
+		return ``, ``, ``, errors.New("Not a formal release")
+	}
+	return matches[1], matches[2], matches[3], nil
 }

--- a/util/help/topics.go
+++ b/util/help/topics.go
@@ -1,13 +1,35 @@
 package help
 
-const (
-	root       = "https://argo-workflows.readthedocs.io/en/latest"
-	ArgoServer = root + "/argo-server/"
-	CLI        = root + "/cli/argo"
+import (
+	"fmt"
 
-	WorkflowTemplates                          = root + "/workflow-templates/"
-	WorkflowTemplatesReferencingOtherTemplates = WorkflowTemplates + "#referencing-other-workflowtemplates"
-
-	Scaling                        = root + "/scaling/"
-	ConfigureMaximumRecursionDepth = Scaling + "#maximum-recursion-depth"
+	"github.com/argoproj/argo-workflows/v3"
 )
+
+func root() string {
+	version := `latest`
+	if major, minor, _, err := argo.GetVersion().Components(); err == nil {
+		version = fmt.Sprintf("release-%s.%s", major, minor)
+	}
+	return fmt.Sprintf("https://argo-workflows.readthedocs.io/en/%s", version)
+}
+
+// ArgoServer returns a URL to the argo-server documentation
+func ArgoServer() string {
+	return root() + "/argo-server/"
+}
+
+// CLI returns a URL to the cli documentation
+func CLI() string {
+	return root() + "/cli/argo"
+}
+
+// scaling returns a URL to the scaling documentation
+func scaling() string {
+	return root() + "/scaling/"
+}
+
+// ConfigureMaximumRecursionDepth returns a URL to the maximum recursion depth documentation
+func ConfigureMaximumRecursionDepth() string {
+	return scaling() + "#maximum-recursion-depth"
+}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -126,7 +126,7 @@ var (
 	// ErrTimeout indicates a specific template timed out
 	ErrTimeout = errors.New(errors.CodeTimeout, "timeout")
 	// ErrMaxDepthExceeded indicates that the maximum recursion depth was exceeded
-	ErrMaxDepthExceeded = errors.New(errors.CodeTimeout, fmt.Sprintf("Maximum recursion depth exceeded. See %s", help.ConfigureMaximumRecursionDepth))
+	ErrMaxDepthExceeded = errors.New(errors.CodeTimeout, fmt.Sprintf("Maximum recursion depth exceeded. See %s", help.ConfigureMaximumRecursionDepth()))
 )
 
 // maxOperationTime is the maximum time a workflow operation is allowed to run


### PR DESCRIPTION
Raised [in response to this](https://github.com/argoproj/argo-workflows/pull/13265#discussion_r1699400713)

## Motivation

Instead of always linking to latest, link to the versioned documentation where the version of the built software is known

## Modifications

Added a method to split the software version into components.

Changed help.`root` to provide a versioned link to documentation and modified all previous `const` values to be functions as this is now runtime determined. Making the whole thing `const` may be possible but the current encapsulation is nice and none of this is important for performance.

Removed the unused WorkflowTemplates doc links

## Verification

`make codegen` still generates the same link for `argo server`. Forcing the version to 3.5 generates expected 3.5 links.

