### PR TITLE
refactor(tests): testifylint don't use `Equal` for floating point tests

### DIFF
--- a/util/env/env_test.go
+++ b/util/env/env_test.go
@@ -28,13 +28,13 @@ func TestLookupEnvIntOr(t *testing.T) {
 }
 
 func TestLookupEnvFloatOr(t *testing.T) {
-	assert.Equal(t, 1., LookupEnvFloatOr("", 1.), "default value")
+	assert.InEpsilon(t, 1., LookupEnvFloatOr("", 1.), 0.001, "default value")
 	t.Setenv("FOO", "not-float")
 	assert.Panics(t, func() { LookupEnvFloatOr("FOO", 1.) }, "bad value")
 	t.Setenv("FOO", "2.0")
-	assert.Equal(t, 2., LookupEnvFloatOr("FOO", 1.), "env var value")
+	assert.InEpsilon(t, 2., LookupEnvFloatOr("FOO", 1.), 0.001, "env var value")
 	t.Setenv("FOO", "")
-	assert.Equal(t, 1., LookupEnvFloatOr("FOO", 1.), "empty var value; default value")
+	assert.InEpsilon(t, 1., LookupEnvFloatOr("FOO", 1.), 0.001, "empty var value; default value")
 }
 
 func TestLookupEnvStringOr(t *testing.T) {

--- a/workflow/controller/operator_metrics_test.go
+++ b/workflow/controller/operator_metrics_test.go
@@ -605,7 +605,7 @@ func TestRealtimeWorkflowMetric(t *testing.T) {
 	value3, err := getMetricGaugeValue(controller.metrics.GetCustomMetric(metricErrorDesc))
 	require.NoError(t, err)
 	// Duration should be same after workflow complete
-	assert.Equal(t, *value2, *value3)
+	assert.InEpsilon(t, *value2, *value3, 0.001)
 }
 
 var testRealtimeWorkflowMetricWithGlobalParameters = `

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5337,7 +5337,7 @@ func TestPanicMetric(t *testing.T) {
 			var writtenMetric dto.Metric
 			err := metric.Write(&writtenMetric)
 			require.NoError(t, err)
-			assert.Equal(t, float64(1), *writtenMetric.Counter.Value)
+			assert.InEpsilon(t, float64(1), *writtenMetric.Counter.Value, 0.001)
 		}
 	}
 	assert.True(t, seen)

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -194,7 +194,7 @@ func TestWorkflowQueueMetrics(t *testing.T) {
 	wfQueue.Add("hello")
 
 	if assert.NotNil(t, m.workqueueMetrics["workflow_queue-adds"]) {
-		assert.Equal(t, 1.0, *write(m.workqueueMetrics["workflow_queue-adds"]).Counter.Value)
+		assert.InEpsilon(t, 1.0, *write(m.workqueueMetrics["workflow_queue-adds"]).Counter.Value, 0.001)
 	}
 }
 

--- a/workflow/metrics/work_queue_test.go
+++ b/workflow/metrics/work_queue_test.go
@@ -19,7 +19,7 @@ func TestMetricsWorkQueue(t *testing.T) {
 
 	m.newWorker("test")
 	assert.Len(t, m.workersBusy, 1)
-	assert.Equal(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value)
+	assert.InDelta(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value, 0.001)
 
 	m.newWorker("test")
 	assert.Len(t, m.workersBusy, 1)
@@ -28,11 +28,11 @@ func TestMetricsWorkQueue(t *testing.T) {
 	defer queue.ShutDown()
 
 	queue.Add("A")
-	assert.Equal(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value)
+	assert.InDelta(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value, 0.001)
 
 	queue.Get()
-	assert.Equal(t, float64(1), *write(m.workersBusy["test"]).Gauge.Value)
+	assert.InDelta(t, float64(1), *write(m.workersBusy["test"]).Gauge.Value, 0.001)
 
 	queue.Done("A")
-	assert.Equal(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value)
+	assert.InDelta(t, float64(0), *write(m.workersBusy["test"]).Gauge.Value, 0.001)
 }


### PR DESCRIPTION
Part of [the refactor](https://github.com/argoproj/argo-workflows/pulls?q=is%3Apr+testifylint+) started by #13365 to enable us to use testifylint, shift to using InEpsilon or InDelta for floating point comparisons. Mostly use `InEpsilon` as it is more resilient, but using `InDelta` for testing against zero.

Reviewers: As with the others in this series, please feel free to apply patches as you see fit.
