### PR TITLE
chore(lint): enable testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
+    - testifylint
     - typecheck
     - unparam
     - unused

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -475,7 +475,7 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 				if tt.isDirectory {
 					fmt.Printf("got directory listing:\n%s\n", all)
 					// verify that the files are contained in the listing we got back
-					assert.Equal(t, len(tt.directoryFiles), strings.Count(string(all), "<li>"))
+					assert.Len(t, tt.directoryFiles, strings.Count(string(all), "<li>"))
 					for _, file := range tt.directoryFiles {
 						assert.True(t, strings.Contains(string(all), file))
 					}

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -813,12 +813,12 @@ spec:
 		})).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowFailed)
+			assert.Equal(t, v1alpha1.WorkflowFailed, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.DisplayName == onExitNodeName
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
-			assert.Equal(t, true, status.NodeFlag.Hooked)
+			assert.True(t, status.NodeFlag.Hooked)
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
 		}))
 }
@@ -862,12 +862,12 @@ spec:
 		})).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
-			assert.Equal(t, status.Phase, v1alpha1.WorkflowFailed)
+			assert.Equal(t, v1alpha1.WorkflowFailed, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return status.DisplayName == onExitNodeName
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
-			assert.Equal(t, true, status.NodeFlag.Hooked)
+			assert.True(t, status.NodeFlag.Hooked)
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
 		}))
 }


### PR DESCRIPTION
This commit enables testifylint and fixes the 5 changes that have crept in since the beginning of trying to enable it.

This is [part of a series](https://github.com/argoproj/argo-workflows/pulls?q=is%3Apr+testifylint+) which aimed to get this enabled as a useful linter.

The version of golangci-lint we use is a bit old (1.55.1), and isn't catching all the things I was expecting. Once this is merged I'll do a follow up to bump golangci-lint to latest (1.60.1) as well.

Signed-off-by: Alan Clucas <alan@clucas.org>