### PR TITLE
chore(deps): bump `golangci-lint` from 1.55.1 to 1.59.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,7 +434,7 @@ dist/manifests/%: manifests/%
 # lint/test/etc
 
 $(GOPATH)/bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.55.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.59.1
 
 .PHONY: lint
 lint: server/static/files.go $(GOPATH)/bin/golangci-lint

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -75,7 +75,7 @@ func TestEmissary(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				err := run("sleep 3")
-				require.EqualError(t, err, fmt.Sprintf("exit status %d", 128+signal))
+				assert.EqualError(t, err, fmt.Sprintf("exit status %d", 128+signal))
 			}()
 			wg.Wait()
 		}

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -185,7 +185,7 @@ func newSso(
 	}
 
 	var filterGroupsRegex []*regexp.Regexp
-	if c.FilterGroupsRegex != nil && len(c.FilterGroupsRegex) > 0 {
+	if len(c.FilterGroupsRegex) > 0 {
 		for _, regex := range c.FilterGroupsRegex {
 			compiledRegex, err := regexp.Compile(regex)
 			if err != nil {
@@ -297,7 +297,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// only return groups that match at least one of the regexes
-	if s.filterGroupsRegex != nil && len(s.filterGroupsRegex) > 0 {
+	if len(s.filterGroupsRegex) > 0 {
 		var filteredGroups []string
 		for _, group := range groups {
 			for _, regex := range s.filterGroupsRegex {

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -690,7 +690,7 @@ func TestWatchWorkflows(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	go func() {
 		err := server.WatchWorkflows(&workflowpkg.WatchWorkflowsRequest{}, &testWatchWorkflowServer{testServerStream{ctx}})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	cancel()
 }
@@ -708,7 +708,7 @@ func TestWatchLatestWorkflow(t *testing.T) {
 				FieldSelector: util.GenerateFieldSelectorFromWorkflowName("@latest"),
 			},
 		}, &testWatchWorkflowServer{testServerStream{ctx}})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	cancel()
 }
@@ -912,7 +912,7 @@ func TestPodLogs(t *testing.T) {
 			Namespace:  "workflows",
 			LogOptions: &corev1.PodLogOptions{},
 		}, &testPodLogsServer{testServerStream{ctx}})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	cancel()
 }

--- a/workflow/artifacts/http/http_test.go
+++ b/workflow/artifacts/http/http_test.go
@@ -104,8 +104,9 @@ func TestSaveHTTPArtifactRedirect(t *testing.T) {
 			// check that content is really there
 			buf := new(bytes.Buffer)
 			_, err = buf.ReadFrom(r.Body)
-			require.NoError(t, err)
-			assert.Equal(t, content, buf.String())
+			if assert.NoError(t, err) {
+				assert.Equal(t, content, buf.String())
+			}
 
 			w.WriteHeader(http.StatusCreated)
 		}


### PR DESCRIPTION
#13467 enabled testifylint, but the results weren't quite lining up with my expectations, so I'd suggested bumping the linter version. This PR does that.

[golangci-lint 1.60.1](https://github.com/golangci/golangci-lint/releases/tag/v1.60.1) was released yesterday, but that bumps govet causing some hard to resolve errors. I'll wait for the dust to settle on that before attempting that update.

gosimple: fixes to `server/auth/sso/sso.go`
`S1009: should omit nil check; len() for []string is defined as zero (gosimple)`

testifylint: undo assert->require changes in functions where they won't work correctly
`go-require: do not use require in http handlers (testifylint)`
`go-require: require must only be used in the goroutine running the
test function (testifylint)`