### PR TITLE
feat(ui): allow relative `links`. Fixes #13479

### DIFF
--- a/.features/pending/ui-relative-links.md
+++ b/.features/pending/ui-relative-links.md
@@ -1,0 +1,13 @@
+Description: UI `links` can be relative URLs, prefixed with the base UI URL
+Authors: [Doug Goldstein](https://github.com/cardoe)
+Component: UI
+Issues: 13479
+
+Custom UI `links` may now be configured as relative URLs instead of requiring an absolute URL baked into each link.
+When a link has no protocol, the UI prefixes it with the base UI URL.
+This makes it easy to add buttons that point at other pages of the UI, for example a workflow list filtered by namespace and phase:
+
+    links:
+      - name: Failed workflows
+        scope: workflow-list
+        url: "?namespace=argo-events&phase=Failed&phase=Error&limit=50"

--- a/config/config.go
+++ b/config/config.go
@@ -163,6 +163,11 @@ func (c *Config) Sanitize(allowedProtocol []string) error {
 		if err != nil {
 			return err
 		}
+		// If the scheme is empty then we're allowing relative links for
+		// the UI.
+		if u.Scheme == "" {
+			continue
+		}
 		err = c.ValidateProtocol(u.Scheme, allowedProtocol)
 		if err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -268,6 +268,11 @@ func (c *Config) Sanitize(allowedProtocol []string) error {
 		if err != nil {
 			return err
 		}
+		// If the scheme is empty then we're allowing relative links for
+		// the UI.
+		if u.Scheme == "" {
+			continue
+		}
 		err = c.ValidateProtocol(u.Scheme, allowedProtocol)
 		if err != nil {
 			return err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,8 @@ func TestSanitize(t *testing.T) {
 		{Config{Links: []*wfv1.Link{{URL: "javascript:foo"}}}, "protocol javascript is not allowed"},
 		{Config{Links: []*wfv1.Link{{URL: "javASCRipt: //foo"}}}, "protocol javascript is not allowed"},
 		{Config{Links: []*wfv1.Link{{URL: "http://foo.bar/?foo=<script>abc</script>bar"}}}, ""},
+		{Config{Links: []*wfv1.Link{{URL: "/my-namespace"}}}, ""},
+		{Config{Links: []*wfv1.Link{{URL: "?namespace=argo-events&phase=Failed&phase=Error&limit=50"}}}, ""},
 	}
 	for _, tt := range tests {
 		err := tt.c.Sanitize([]string{"http", "https"})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,8 @@ func TestSanitize(t *testing.T) {
 		{Config{Links: []*wfv1.Link{{URL: "javascript:foo"}}}, "protocol javascript is not allowed"},
 		{Config{Links: []*wfv1.Link{{URL: "javASCRipt: //foo"}}}, "protocol javascript is not allowed"},
 		{Config{Links: []*wfv1.Link{{URL: "http://foo.bar/?foo=<script>abc</script>bar"}}}, ""},
+		{Config{Links: []*wfv1.Link{{URL: "/my-namespace"}}}, ""},
+		{Config{Links: []*wfv1.Link{{URL: "?namespace=argo-events&phase=Failed&phase=Error&limit=50"}}}, ""},
 	}
 	for _, tt := range tests {
 		err := tt.c.Sanitize([]string{"http", "https"})

--- a/docs/links.md
+++ b/docs/links.md
@@ -36,3 +36,7 @@ For example, one may find it useful to define a custom label in the workflow and
 
 We can also access workflow fields in a pod link. For example, `${workflow.metadata.name}` returns
 the name of the workflow instead of the name of the pod. If the field doesn't exist on the workflow then the value will be an empty string.
+
+> v3.6 and after
+
+Links can be relative when configured and the UI will prefix them with the base UI URL.

--- a/docs/links.md
+++ b/docs/links.md
@@ -36,3 +36,16 @@ For example, one may find it useful to define a custom label in the workflow and
 
 We can also access workflow fields in a pod link. For example, `${workflow.metadata.name}` returns
 the name of the workflow instead of the name of the pod. If the field doesn't exist on the workflow then the value will be an empty string.
+
+> v4.2 and after
+
+You can configure a link with a relative URL instead of an absolute one.
+The UI prefixes a relative link with the base UI URL, so you do not have to hard-code the server's address in each link.
+This is convenient for links that point back into the UI, such as a button that opens the workflow list with a preset filter:
+
+```yaml
+links:
+  - name: Failed workflows
+    scope: workflow-list
+    url: "?namespace=argo-events&phase=Failed&phase=Error&limit=50"
+```

--- a/ui/src/shared/services/info-service.test.ts
+++ b/ui/src/shared/services/info-service.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import {Link} from '../models';
+import {resolveLinks} from './info-service';
+
+function setBase(href: string) {
+    document.head.innerHTML = `<base href="${href}">`;
+}
+
+const link = (url: string): Link => ({name: 'test', scope: 'workflow-list', url});
+
+describe('resolveLinks', () => {
+    test('absolute links are left unchanged', () => {
+        setBase('/');
+        expect(resolveLinks([link('https://example.com/foo?bar=baz')])[0].url).toBe('https://example.com/foo?bar=baz');
+    });
+
+    test('relative link with a leading slash on the default base', () => {
+        setBase('/');
+        // must not become "//my-namespace", which the browser treats as scheme-relative
+        expect(resolveLinks([link('/my-namespace')])[0].url).toBe('/my-namespace');
+    });
+
+    test('relative link with a leading slash on a mounted base', () => {
+        setBase('/argo/');
+        expect(resolveLinks([link('/my-namespace')])[0].url).toBe('/argo/my-namespace');
+    });
+
+    test('query-only relative link is prefixed with the base', () => {
+        setBase('/argo/');
+        expect(resolveLinks([link('?namespace=argo&phase=Failed')])[0].url).toBe('/argo/?namespace=argo&phase=Failed');
+    });
+
+    test('undefined links yields an empty array', () => {
+        setBase('/');
+        expect(resolveLinks(undefined)).toEqual([]);
+    });
+});

--- a/ui/src/shared/services/info-service.ts
+++ b/ui/src/shared/services/info-service.ts
@@ -1,4 +1,5 @@
 import {GetUserInfoResponse, Info, Version} from '../models';
+import {uiUrl} from '../base';
 import requests from './requests';
 
 let info: Promise<Info>; // we cache this globally rather than in localStorage so it is request once per page refresh
@@ -8,7 +9,23 @@ export const InfoService = {
         if (info) {
             return info;
         }
-        info = requests.get(`api/v1/info`).then(res => res.body as Info);
+        info = requests.get(`api/v1/info`).then(res => {
+            const info = res.body as Info;
+            info.links = info.links.map(link => {
+                // relative UI links don't have a protocol so we're going
+                // to prefix it with the UI base URL
+                try {
+                    new URL(link.url);
+                    return link;
+                } catch {
+                    return {
+                        ...link,
+                        url: uiUrl(link.url)
+                    };
+                }
+            });
+            return info;
+        });
         return info;
     },
 

--- a/ui/src/shared/services/info-service.ts
+++ b/ui/src/shared/services/info-service.ts
@@ -1,14 +1,37 @@
-import {GetUserInfoResponse, Info, Version} from '../models';
+import {uiUrl} from '../base';
+import {GetUserInfoResponse, Info, Link, Version} from '../models';
 import requests from './requests';
 
 let info: Promise<Info>; // we cache this globally rather than in localStorage so it is request once per page refresh
+
+// resolveLinks prefixes relative link URLs with the base UI URL. A link is
+// considered relative when it has no protocol (i.e. `new URL` cannot parse it).
+export function resolveLinks(links?: Link[]): Link[] {
+    return (links || []).map(link => {
+        try {
+            new URL(link.url);
+            return link;
+        } catch {
+            // strip any leading slashes so we don't end up with a double
+            // slash once uiUrl prefixes the base UI URL (which ends in `/`)
+            return {
+                ...link,
+                url: uiUrl(link.url.replace(/^\/+/, ''))
+            };
+        }
+    });
+}
 
 export const InfoService = {
     getInfo() {
         if (info) {
             return info;
         }
-        info = requests.get(`api/v1/info`).then(res => res.body as Info);
+        info = requests.get(`api/v1/info`).then(res => {
+            const info = res.body as Info;
+            info.links = resolveLinks(info.links);
+            return info;
+        });
         return info;
     },
 


### PR DESCRIPTION
Added the ability for users to supply relative links within the UI for the links feature so that buttons and links do not have to have the absolute URL baked into each link. This will allow for easily adding buttons for different filters on the workflow list page for example. fixes #13479 ref #10447


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - UI links can now use relative URLs, including namespace-relative paths and query-only URLs.
  - Relative links are automatically resolved against the base UI URL, while absolute links continue to work unchanged.

- **Documentation**
  - Added configuration guidance and examples for using relative UI links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->