### PR TITLE
fix: allow `workflow.failures` variable in exit hooks. Fixes #12789

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -282,6 +282,21 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 	if err != nil {
 		return err
 	}
+	// validate hook if it is an exit hook
+	for hookName, hook := range wf.Spec.Hooks {
+		if hookName != wfv1.ExitLifecycleEvent {
+			continue
+		}
+		tmplHolder = &wfv1.WorkflowStep{Template: hook.Template}
+		if hook.TemplateRef != nil {
+			tmplHolder = &wfv1.WorkflowStep{TemplateRef: hook.TemplateRef}
+		}
+		ctx.globalParams[common.GlobalVarWorkflowFailures] = placeholderGenerator.NextPlaceholder()
+		_, err = ctx.validateTemplateHolder(tmplHolder, tmplCtx, &wf.Spec.Arguments, opts.WorkflowTemplateValidation)
+		if err != nil {
+			return err
+		}
+	}
 
 	if !wf.Spec.PodGC.GetStrategy().IsValid() {
 		return errors.Errorf(errors.CodeBadRequest, "podGC.strategy unknown strategy '%s'", wf.Spec.PodGC.Strategy)

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -292,7 +292,7 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 			tmplHolder = &wfv1.WorkflowStep{TemplateRef: hook.TemplateRef}
 		}
 		ctx.globalParams[common.GlobalVarWorkflowFailures] = placeholderGenerator.NextPlaceholder()
-		_, err = ctx.validateTemplateHolder(tmplHolder, tmplCtx, &wf.Spec.Arguments, opts.WorkflowTemplateValidation)
+		_, err = ctx.validateTemplateHolder(tmplHolder, tmplCtx, &FakeArguments{}, opts.WorkflowTemplateValidation)
 		if err != nil {
 			return err
 		}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -292,7 +292,7 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 			tmplHolder = &wfv1.WorkflowStep{TemplateRef: hook.TemplateRef}
 		}
 		ctx.globalParams[common.GlobalVarWorkflowFailures] = placeholderGenerator.NextPlaceholder()
-		_, err = ctx.validateTemplateHolder(tmplHolder, tmplCtx, &FakeArguments{}, opts.WorkflowTemplateValidation)
+		_, err = ctx.validateTemplateHolder(tmplHolder, tmplCtx, &hook.Arguments, opts.WorkflowTemplateValidation)
 		if err != nil {
 			return err
 		}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -1051,6 +1051,79 @@ func TestExitHandler(t *testing.T) {
 	require.NoError(t, err)
 }
 
+var workflowFailuresNotOnExit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.failures}}"]
+`
+
+var workflowFailuresOnExit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  onExit: fail
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 0"]
+  - name: fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.failures}}"]
+`
+
+var workflowFailuresExitHook = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  hooks:
+    exit:
+      template: fail
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 0"]
+  - name: fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.failures}}"]
+`
+
+func TestExitHandlerWorkflowFailures(t *testing.T) {
+	// ensure {{workflow.failures}} is not available when not in onExit or in exit hooks
+	err := validate(workflowFailuresNotOnExit)
+	assert.NotNil(t, err)
+
+	// ensure {{workflow.failures}} is available in onExit
+	err = validate(workflowFailuresOnExit)
+	assert.NoError(t, err)
+
+	// ensure {{workflow.failures}} is available in exit hook
+	err = validate(workflowFailuresExitHook)
+	assert.NoError(t, err)
+}
+
 var workflowWithPriority = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -1110,63 +1110,12 @@ spec:
       args: ["echo {{workflow.failures}}"]
 `
 
-func TestExitHandlerWorkflowFailures(t *testing.T) {
-	// ensure {{workflow.failures}} is not available when not in onExit or in exit hooks
-	err := validate(workflowFailuresNotOnExit)
-	assert.NotNil(t, err)
-
-	// ensure {{workflow.failures}} is available in onExit
-	err = validate(workflowFailuresOnExit)
-	assert.NoError(t, err)
-
-	// ensure {{workflow.failures}} is available in exit hook
-	err = validate(workflowFailuresExitHook)
-	assert.NoError(t, err)
-}
-
-var workflowFailuresNotOnExit = `
+var workflowTemplateFailuresExitHook = `
 apiVersion: argoproj.io/v1alpha1
-kind: Workflow
+kind: WorkflowTemplate
 metadata:
-  generateName: exit-handlers-
+  name: exit-handlers-template
 spec:
-  entrypoint: pass
-  templates:
-  - name: pass
-    container:
-      image: alpine:latest
-      command: [sh, -c]
-      args: ["echo {{workflow.failures}}"]
-`
-
-var workflowFailuresOnExit = `
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: exit-handlers-
-spec:
-  entrypoint: pass
-  onExit: fail
-  templates:
-  - name: pass
-    container:
-      image: alpine:latest
-      command: [sh, -c]
-      args: ["exit 0"]
-  - name: fail
-    container:
-      image: alpine:latest
-      command: [sh, -c]
-      args: ["echo {{workflow.failures}}"]
-`
-
-var workflowFailuresExitHook = `
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: exit-handlers-
-spec:
-  entrypoint: pass
   hooks:
     exit:
       template: fail
@@ -1194,6 +1143,10 @@ func TestExitHandlerWorkflowFailures(t *testing.T) {
 
 	// ensure {{workflow.failures}} is available in exit hook
 	err = validate(workflowFailuresExitHook)
+	assert.NoError(t, err)
+
+	// ensure {{workflow.failures}} is available in exit hook in WorkflowTemplate
+	err = validateWorkflowTemplate(workflowTemplateFailuresExitHook, ValidateOpts{})
 	assert.NoError(t, err)
 }
 

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -1124,6 +1124,79 @@ func TestExitHandlerWorkflowFailures(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+var workflowFailuresNotOnExit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.failures}}"]
+`
+
+var workflowFailuresOnExit = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  onExit: fail
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 0"]
+  - name: fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.failures}}"]
+`
+
+var workflowFailuresExitHook = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  hooks:
+    exit:
+      template: fail
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["exit 0"]
+  - name: fail
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args: ["echo {{workflow.failures}}"]
+`
+
+func TestExitHandlerWorkflowFailures(t *testing.T) {
+	// ensure {{workflow.failures}} is not available when not in onExit or in exit hooks
+	err := validate(workflowFailuresNotOnExit)
+	assert.NotNil(t, err)
+
+	// ensure {{workflow.failures}} is available in onExit
+	err = validate(workflowFailuresOnExit)
+	assert.NoError(t, err)
+
+	// ensure {{workflow.failures}} is available in exit hook
+	err = validate(workflowFailuresExitHook)
+	assert.NoError(t, err)
+}
+
 var workflowWithPriority = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Updated version of Original PR #12798


<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
