### PR TITLE
refactor(tests): `if assert.*` -> `require.*`. Fixes #13465

### DIFF
--- a/pkg/apis/workflow/v1alpha1/artifact_repository_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/artifact_repository_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/pointer"
 )
 
@@ -23,49 +24,43 @@ func TestArtifactRepository(t *testing.T) {
 		r := &ArtifactRepository{Artifactory: &ArtifactoryArtifactRepository{RepoURL: "http://my-repo"}}
 		assert.IsType(t, &ArtifactoryArtifactRepository{}, r.Get())
 		l := r.ToArtifactLocation()
-		if assert.NotNil(t, l.Artifactory) {
-			assert.Equal(t, "http://my-repo/{{workflow.name}}/{{pod.name}}", l.Artifactory.URL)
-		}
+		require.NotNil(t, l.Artifactory)
+		assert.Equal(t, "http://my-repo/{{workflow.name}}/{{pod.name}}", l.Artifactory.URL)
 	})
 	t.Run("Azure", func(t *testing.T) {
 		r := &ArtifactRepository{Azure: &AzureArtifactRepository{}}
 		assert.IsType(t, &AzureArtifactRepository{}, r.Get())
 		l := r.ToArtifactLocation()
-		if assert.NotNil(t, l.Azure) {
-			assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.Azure.Blob)
-		}
+		require.NotNil(t, l.Azure)
+		assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.Azure.Blob)
 	})
 	t.Run("GCS", func(t *testing.T) {
 		r := &ArtifactRepository{GCS: &GCSArtifactRepository{}}
 		assert.IsType(t, &GCSArtifactRepository{}, r.Get())
 		l := r.ToArtifactLocation()
-		if assert.NotNil(t, l.GCS) {
-			assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.GCS.Key)
-		}
+		require.NotNil(t, l.GCS)
+		assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.GCS.Key)
 	})
 	t.Run("HDFS", func(t *testing.T) {
 		r := &ArtifactRepository{HDFS: &HDFSArtifactRepository{}}
 		assert.IsType(t, &HDFSArtifactRepository{}, r.Get())
 		l := r.ToArtifactLocation()
-		if assert.NotNil(t, l.HDFS) {
-			assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.HDFS.Path)
-		}
+		require.NotNil(t, l.HDFS)
+		assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.HDFS.Path)
 	})
 	t.Run("OSS", func(t *testing.T) {
 		r := &ArtifactRepository{OSS: &OSSArtifactRepository{}}
 		assert.IsType(t, &OSSArtifactRepository{}, r.Get())
 		l := r.ToArtifactLocation()
-		if assert.NotNil(t, l.OSS) {
-			assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.OSS.Key)
-		}
+		require.NotNil(t, l.OSS)
+		assert.Equal(t, "{{workflow.name}}/{{pod.name}}", l.OSS.Key)
 	})
 	t.Run("S3", func(t *testing.T) {
 		r := &ArtifactRepository{S3: &S3ArtifactRepository{KeyPrefix: "my-key-prefix"}}
 		assert.IsType(t, &S3ArtifactRepository{}, r.Get())
 		l := r.ToArtifactLocation()
-		if assert.NotNil(t, l.S3) {
-			assert.Equal(t, "my-key-prefix/{{workflow.name}}/{{pod.name}}", l.S3.Key)
-		}
+		require.NotNil(t, l.S3)
+		assert.Equal(t, "my-key-prefix/{{workflow.name}}/{{pod.name}}", l.S3.Key)
 	})
 }
 

--- a/pkg/apis/workflow/v1alpha1/data_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/data_types_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetArtifactIfNeeded(t *testing.T) {
 	data := &DataSource{ArtifactPaths: &ArtifactPaths{Artifact{Name: "foo"}}}
 	art, needed := data.GetArtifactIfNeeded()
-	if assert.True(t, needed) {
-		assert.Equal(t, "foo", art.Name)
-	}
+	require.True(t, needed)
+	assert.Equal(t, "foo", art.Name)
 }

--- a/pkg/apis/workflow/v1alpha1/workflow_template_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_template_types_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,9 +16,8 @@ func TestWorkflowTemplates(t *testing.T) {
 		{ObjectMeta: v1.ObjectMeta{Name: "0"}},
 	}
 	sort.Sort(tmpls)
-	if assert.Len(t, tmpls, 3) {
-		assert.Equal(t, "0", tmpls[0].Name)
-		assert.Equal(t, "1", tmpls[1].Name)
-		assert.Equal(t, "2", tmpls[2].Name)
-	}
+	require.Len(t, tmpls, 3)
+	assert.Equal(t, "0", tmpls[0].Name)
+	assert.Equal(t, "1", tmpls[1].Name)
+	assert.Equal(t, "2", tmpls[2].Name)
 }

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -894,9 +894,7 @@ func TestPrometheus_GetDescIsStable(t *testing.T) {
 	}
 	stableDesc := metric.GetKey()
 	for i := 0; i < 10; i++ {
-		if !assert.Equal(t, stableDesc, metric.GetKey()) {
-			break
-		}
+		require.Equal(t, stableDesc, metric.GetKey())
 	}
 }
 

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -516,14 +516,13 @@ func TestArtifactServer_GetOutputArtifact(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
 			s.GetOutputArtifact(recorder, r)
-			if assert.Equal(t, 200, recorder.Result().StatusCode) {
-				assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Header().Get("Content-Disposition"))
-				all, err := io.ReadAll(recorder.Result().Body)
-				if err != nil {
-					panic(fmt.Sprintf("failed to read http body: %v", err))
-				}
-				assert.Equal(t, "my-data", string(all))
+			require.Equal(t, 200, recorder.Result().StatusCode)
+			assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Header().Get("Content-Disposition"))
+			all, err := io.ReadAll(recorder.Result().Body)
+			if err != nil {
+				panic(fmt.Sprintf("failed to read http body: %v", err))
 			}
+			assert.Equal(t, "my-data", string(all))
 		})
 	}
 }
@@ -548,14 +547,13 @@ func TestArtifactServer_GetOutputArtifactWithTemplate(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
 			s.GetOutputArtifact(recorder, r)
-			if assert.Equal(t, 200, recorder.Result().StatusCode) {
-				assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Header().Get("Content-Disposition"))
-				all, err := io.ReadAll(recorder.Result().Body)
-				if err != nil {
-					panic(fmt.Sprintf("failed to read http body: %v", err))
-				}
-				assert.Equal(t, "my-data", string(all))
+			require.Equal(t, 200, recorder.Result().StatusCode)
+			assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Header().Get("Content-Disposition"))
+			all, err := io.ReadAll(recorder.Result().Body)
+			if err != nil {
+				panic(fmt.Sprintf("failed to read http body: %v", err))
 			}
+			assert.Equal(t, "my-data", string(all))
 		})
 	}
 }
@@ -580,14 +578,13 @@ func TestArtifactServer_GetOutputArtifactWithInlineTemplate(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
 			s.GetOutputArtifact(recorder, r)
-			if assert.Equal(t, 200, recorder.Result().StatusCode) {
-				assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Header().Get("Content-Disposition"))
-				all, err := io.ReadAll(recorder.Result().Body)
-				if err != nil {
-					panic(fmt.Sprintf("failed to read http body: %v", err))
-				}
-				assert.Equal(t, "my-data", string(all))
+			require.Equal(t, 200, recorder.Result().StatusCode)
+			assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Header().Get("Content-Disposition"))
+			all, err := io.ReadAll(recorder.Result().Body)
+			if err != nil {
+				panic(fmt.Sprintf("failed to read http body: %v", err))
 			}
+			assert.Equal(t, "my-data", string(all))
 		})
 	}
 }
@@ -611,14 +608,13 @@ func TestArtifactServer_GetInputArtifact(t *testing.T) {
 			r.URL = mustParse(fmt.Sprintf("/input-artifacts/my-ns/my-wf/my-node-1/%s", tt.artifactName))
 			recorder := httptest.NewRecorder()
 			s.GetInputArtifact(recorder, r)
-			if assert.Equal(t, 200, recorder.Result().StatusCode) {
-				assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Result().Header.Get("Content-Disposition"))
-				all, err := io.ReadAll(recorder.Result().Body)
-				if err != nil {
-					panic(fmt.Sprintf("failed to read http body: %v", err))
-				}
-				assert.Equal(t, "my-data", string(all))
+			require.Equal(t, 200, recorder.Result().StatusCode)
+			assert.Equal(t, fmt.Sprintf(`filename="%s"`, tt.fileName), recorder.Result().Header.Get("Content-Disposition"))
+			all, err := io.ReadAll(recorder.Result().Body)
+			if err != nil {
+				panic(fmt.Sprintf("failed to read http body: %v", err))
 			}
+			assert.Equal(t, "my-data", string(all))
 		})
 	}
 }

--- a/server/auth/gatekeeper_test.go
+++ b/server/auth/gatekeeper_test.go
@@ -154,9 +154,8 @@ func TestServer_GetWFClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, wfClient, GetWfClient(ctx))
 		assert.Equal(t, kubeClient, GetKubeClient(ctx))
-		if assert.NotNil(t, GetClaims(ctx)) {
-			assert.Equal(t, "my-sub", GetClaims(ctx).Subject)
-		}
+		require.NotNil(t, GetClaims(ctx))
+		assert.Equal(t, "my-sub", GetClaims(ctx).Subject)
 	})
 	hook := &test.Hook{}
 	log.AddHook(hook)
@@ -172,11 +171,10 @@ func TestServer_GetWFClient(t *testing.T) {
 		assert.NotEqual(t, clients, GetWfClient(ctx))
 		assert.NotEqual(t, kubeClient, GetKubeClient(ctx))
 		claims := GetClaims(ctx)
-		if assert.NotNil(t, claims) {
-			assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
-			assert.Equal(t, "my-sa", claims.ServiceAccountName)
-			assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
-		}
+		require.NotNil(t, claims)
+		assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
+		assert.Equal(t, "my-sa", claims.ServiceAccountName)
+		assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
 		assert.Equal(t, "my-sa", hook.LastEntry().Data["serviceAccount"])
 	})
 	t.Run("SSO+RBAC, Namespace delegation ON, precedence=2, Delegated", func(t *testing.T) {
@@ -191,11 +189,10 @@ func TestServer_GetWFClient(t *testing.T) {
 		assert.NotEqual(t, clients, GetWfClient(ctx))
 		assert.NotEqual(t, kubeClient, GetKubeClient(ctx))
 		claims := GetClaims(ctx)
-		if assert.NotNil(t, claims) {
-			assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
-			assert.Equal(t, "user1-sa", claims.ServiceAccountName)
-			assert.Equal(t, "user1-ns", claims.ServiceAccountNamespace)
-		}
+		require.NotNil(t, claims)
+		assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
+		assert.Equal(t, "user1-sa", claims.ServiceAccountName)
+		assert.Equal(t, "user1-ns", claims.ServiceAccountNamespace)
 		assert.Equal(t, "user1-sa", hook.LastEntry().Data["serviceAccount"])
 	})
 	t.Run("SSO+RBAC, Namespace delegation OFF, precedence=2, Not Delegated", func(t *testing.T) {
@@ -209,11 +206,10 @@ func TestServer_GetWFClient(t *testing.T) {
 		assert.NotEqual(t, clients, GetWfClient(ctx))
 		assert.NotEqual(t, kubeClient, GetKubeClient(ctx))
 		claims := GetClaims(ctx)
-		if assert.NotNil(t, claims) {
-			assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
-			assert.Equal(t, "my-sa", claims.ServiceAccountName)
-			assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
-		}
+		require.NotNil(t, claims)
+		assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
+		assert.Equal(t, "my-sa", claims.ServiceAccountName)
+		assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
 		assert.Equal(t, "my-sa", hook.LastEntry().Data["serviceAccount"])
 	})
 	t.Run("SSO+RBAC, Namespace delegation ON, precedence=0, Not delegated", func(t *testing.T) {
@@ -228,11 +224,10 @@ func TestServer_GetWFClient(t *testing.T) {
 		assert.NotEqual(t, clients, GetWfClient(ctx))
 		assert.NotEqual(t, kubeClient, GetKubeClient(ctx))
 		claims := GetClaims(ctx)
-		if assert.NotNil(t, claims) {
-			assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
-			assert.Equal(t, "my-sa", claims.ServiceAccountName)
-			assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
-		}
+		require.NotNil(t, claims)
+		assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
+		assert.Equal(t, "my-sa", claims.ServiceAccountName)
+		assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
 		assert.Equal(t, "my-sa", hook.LastEntry().Data["serviceAccount"])
 	})
 	t.Run("SSO+RBAC, Namespace delegation ON, precedence=1, Not delegated", func(t *testing.T) {
@@ -247,11 +242,10 @@ func TestServer_GetWFClient(t *testing.T) {
 		assert.NotEqual(t, clients, GetWfClient(ctx))
 		assert.NotEqual(t, kubeClient, GetKubeClient(ctx))
 		claims := GetClaims(ctx)
-		if assert.NotNil(t, claims) {
-			assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
-			assert.Equal(t, "my-sa", claims.ServiceAccountName)
-			assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
-		}
+		require.NotNil(t, claims)
+		assert.Equal(t, []string{"my-group", "other-group"}, claims.Groups)
+		assert.Equal(t, "my-sa", claims.ServiceAccountName)
+		assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
 		assert.Equal(t, "my-sa", hook.LastEntry().Data["serviceAccount"])
 	})
 	t.Run("SSO+RBAC,precedence=0", func(t *testing.T) {

--- a/server/auth/mode_test.go
+++ b/server/auth/mode_test.go
@@ -42,21 +42,18 @@ func TestModes_GetMode(t *testing.T) {
 	}
 	t.Run("Client", func(t *testing.T) {
 		mode, valid := m.GetMode("Bearer ")
-		if assert.True(t, valid) {
-			assert.Equal(t, Client, mode)
-		}
+		require.True(t, valid)
+		assert.Equal(t, Client, mode)
 	})
 	t.Run("Server", func(t *testing.T) {
 		mode, valid := m.GetMode("")
-		if assert.True(t, valid) {
-			assert.Equal(t, Server, mode)
-		}
+		require.True(t, valid)
+		assert.Equal(t, Server, mode)
 	})
 	t.Run("SSO", func(t *testing.T) {
 		mode, valid := m.GetMode("Bearer v2:")
-		if assert.True(t, valid) {
-			assert.Equal(t, SSO, mode)
-		}
+		require.True(t, valid)
+		assert.Equal(t, SSO, mode)
 	})
 
 	m = Modes{
@@ -66,8 +63,7 @@ func TestModes_GetMode(t *testing.T) {
 	}
 	t.Run("Server and Auth", func(t *testing.T) {
 		mode, valid := m.GetMode("Bearer ")
-		if assert.True(t, valid) {
-			assert.Equal(t, Server, mode)
-		}
+		require.True(t, valid)
+		assert.Equal(t, Server, mode)
 	})
 }

--- a/server/event/dispatch/operation_test.go
+++ b/server/event/dispatch/operation_test.go
@@ -33,9 +33,8 @@ func Test_metaData(t *testing.T) {
 			"ignored": []string{"false"},
 		})
 		data := metaData(ctx)
-		if assert.Len(t, data, 1) {
-			assert.Equal(t, []string{"true"}, data["x-valid"])
-		}
+		require.Len(t, data, 1)
+		assert.Equal(t, []string{"true"}, data["x-valid"])
 	})
 }
 
@@ -178,17 +177,17 @@ func TestNewOperation(t *testing.T) {
 	// assert
 	list, err := client.ArgoprojV1alpha1().Workflows("my-ns").List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
-	if assert.Len(t, list.Items, 4) {
-		for _, wf := range list.Items {
-			assert.Equal(t, "my-instanceid", wf.Labels[common.LabelKeyControllerInstanceID])
-			assert.Equal(t, "my-sub", wf.Labels[common.LabelKeyCreator])
-			assert.Contains(t, wf.Labels, common.LabelKeyWorkflowEventBinding)
-			assert.Contains(t, "my-param", wf.Spec.Arguments.Parameters[0].Name)
-			paramValues = append(paramValues, string(*wf.Spec.Arguments.Parameters[0].Value))
-		}
-		sort.Strings(paramValues)
-		assert.Equal(t, expectedParamValues, paramValues)
+	require.Len(t, list.Items, 4)
+	for _, wf := range list.Items {
+		assert.Equal(t, "my-instanceid", wf.Labels[common.LabelKeyControllerInstanceID])
+		assert.Equal(t, "my-sub", wf.Labels[common.LabelKeyCreator])
+		assert.Contains(t, wf.Labels, common.LabelKeyWorkflowEventBinding)
+		assert.Contains(t, "my-param", wf.Spec.Arguments.Parameters[0].Name)
+		paramValues = append(paramValues, string(*wf.Spec.Arguments.Parameters[0].Value))
 	}
+	sort.Strings(paramValues)
+	assert.Equal(t, expectedParamValues, paramValues)
+
 	assert.Contains(t, "Warning WorkflowEventBindingError failed to dispatch event: failed to evaluate workflow template expression: unexpected token EOF", <-recorder.Events)
 	assert.Equal(t, "Warning WorkflowEventBindingError failed to dispatch event: failed to get workflow template: workflowtemplates.argoproj.io \"not-found\" not found", <-recorder.Events)
 	assert.Equal(t, "Warning WorkflowEventBindingError failed to dispatch event: failed to validate workflow template instanceid: 'my-wft-3' is not managed by the current Argo Server", <-recorder.Events)

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -75,20 +76,19 @@ spec:
 				finishedTimes = append(finishedTimes, node.FinishedAt.Time)
 			}
 
-			if assert.Len(t, finishedTimes, 4) {
-				sort.Slice(finishedTimes, func(i, j int) bool {
-					return finishedTimes[i].Before(finishedTimes[j])
-				})
-				// Everything finished with a two second tolerance window
-				assert.Less(t, finishedTimes[3].Sub(finishedTimes[0]), time.Duration(2)*time.Second)
-			}
-			if assert.Len(t, startTimes, 4) {
-				sort.Slice(startTimes, func(i, j int) bool {
-					return startTimes[i].Before(startTimes[j])
-				})
-				// Everything started with same time
-				assert.Equal(t, time.Duration(0), startTimes[3].Sub(startTimes[0]))
-			}
+			require.Len(t, finishedTimes, 4)
+			sort.Slice(finishedTimes, func(i, j int) bool {
+				return finishedTimes[i].Before(finishedTimes[j])
+			})
+			// Everything finished with a two second tolerance window
+			assert.Less(t, finishedTimes[3].Sub(finishedTimes[0]), time.Duration(2)*time.Second)
+
+			require.Len(t, startTimes, 4)
+			sort.Slice(startTimes, func(i, j int) bool {
+				return startTimes[i].Before(startTimes[j])
+			})
+			// Everything started with same time
+			assert.Equal(t, time.Duration(0), startTimes[3].Sub(startTimes[0]))
 		})
 }
 
@@ -145,21 +145,20 @@ spec:
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 
 			containsFails := status.Nodes.FindByDisplayName("http-body-contains-google-fails")
-			if assert.NotNil(t, containsFails) {
-				assert.Equal(t, wfv1.NodeFailed, containsFails.Phase)
-			}
+			require.NotNil(t, containsFails)
+			assert.Equal(t, wfv1.NodeFailed, containsFails.Phase)
+
 			containsSucceeds := status.Nodes.FindByDisplayName("http-body-contains-google-succeeds")
-			if assert.NotNil(t, containsFails) {
-				assert.Equal(t, wfv1.NodeSucceeded, containsSucceeds.Phase)
-			}
+			require.NotNil(t, containsFails)
+			assert.Equal(t, wfv1.NodeSucceeded, containsSucceeds.Phase)
+
 			statusFails := status.Nodes.FindByDisplayName("http-status-is-201-fails")
-			if assert.NotNil(t, statusFails) {
-				assert.Equal(t, wfv1.NodeFailed, statusFails.Phase)
-			}
+			require.NotNil(t, statusFails)
+			assert.Equal(t, wfv1.NodeFailed, statusFails.Phase)
+
 			statusSucceeds := status.Nodes.FindByDisplayName("http-status-is-201-succeeds")
-			if assert.NotNil(t, statusFails) {
-				assert.Equal(t, wfv1.NodeSucceeded, statusSucceeds.Phase)
-			}
+			require.NotNil(t, statusFails)
+			assert.Equal(t, wfv1.NodeSucceeded, statusSucceeds.Phase)
 		})
 }
 

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -667,10 +667,9 @@ func (s *ArtifactsSuite) TestOutputResult() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			n := status.Nodes.FindByDisplayName("a")
-			if assert.NotNil(t, n) {
-				assert.NotNil(t, n.Outputs.ExitCode)
-				assert.NotNil(t, n.Outputs.Result)
-			}
+			require.NotNil(t, n)
+			assert.NotNil(t, n.Outputs.ExitCode)
+			assert.NotNil(t, n.Outputs.Result)
 		})
 }
 
@@ -744,9 +743,8 @@ spec:
 						},
 					},
 				}
-				if assert.NotNil(t, n) {
-					assert.Equal(t, expectedOutputs, n.Outputs)
-				}
+				require.NotNil(t, n)
+				assert.Equal(t, expectedOutputs, n.Outputs)
 			})
 	})
 }

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1825,13 +1825,12 @@ spec:
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
 			nodeStatus := status.Nodes.FindByDisplayName("release")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, "Hello, World!", nodeStatus.Inputs.Parameters[0].Value.String())
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, "Hello, World!", nodeStatus.Inputs.Parameters[0].Value.String())
+
 			nodeStatus = status.Nodes.FindByDisplayName("approve")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, "Test message; Resumed by: map[User:system:serviceaccount:argo:argo-server]", nodeStatus.Message)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, "Test message; Resumed by: map[User:system:serviceaccount:argo:argo-server]", nodeStatus.Message)
 		})
 }
 

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/argoproj/pkg/humanize"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -277,9 +278,8 @@ spec:
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Len(t, cronWf.Status.Active, 1)
-				if assert.NotNil(t, cronWf.Status.LastScheduledTime) {
-					assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
-				}
+				require.NotNil(t, cronWf.Status.LastScheduledTime)
+				assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
 			})
 	})
 	s.Run("TestSuccessfulJobHistoryLimit", func() {

--- a/test/e2e/daemon_pod_test.go
+++ b/test/e2e/daemon_pod_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -171,9 +172,8 @@ func (s *DaemonPodSuite) TestMarkDaemonedPodSucceeded() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
 			node := status.Nodes.FindByDisplayName("daemoned")
-			if assert.NotNil(t, node) {
-				assert.Equal(t, v1alpha1.NodeSucceeded, node.Phase)
-			}
+			require.NotNil(t, node)
+			assert.Equal(t, v1alpha1.NodeSucceeded, node.Phase)
 		})
 }
 

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -34,51 +35,45 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 			assert.Len(t, n.Outputs.Parameters, 1)
 		}).
 		ExpectPods(func(t *testing.T, pods []apiv1.Pod) {
-			if assert.Len(t, pods, 1) {
-				pod := pods[0]
-				spec := pod.Spec
-				assert.Equal(t, pointer.Bool(false), spec.AutomountServiceAccountToken)
-				assert.Equal(t, &apiv1.PodSecurityContext{
-					RunAsUser:      pointer.Int64(8737),
-					RunAsNonRoot:   pointer.Bool(true),
-					SeccompProfile: &v1.SeccompProfile{Type: "RuntimeDefault"},
-				}, spec.SecurityContext)
-				if assert.Len(t, spec.Volumes, 4) {
-					assert.Contains(t, spec.Volumes[0].Name, "kube-api-access-")
-					assert.Equal(t, "var-run-argo", spec.Volumes[1].Name)
-					assert.Contains(t, spec.Volumes[2].Name, "kube-api-access-")
-					assert.Equal(t, "argo-workflows-agent-ca-certificates", spec.Volumes[3].Name)
-				}
-				if assert.Len(t, spec.Containers, 2) {
-					{
-						plug := spec.Containers[0]
-						if assert.Equal(t, "hello-executor-plugin", plug.Name) {
-							if assert.Len(t, plug.VolumeMounts, 2) {
-								assert.Equal(t, "var-run-argo", plug.VolumeMounts[0].Name)
-								assert.Contains(t, plug.VolumeMounts[1].Name, "kube-api-access-")
-							}
-						}
-					}
-					{
-						agent := spec.Containers[1]
-						if assert.Equal(t, "main", agent.Name) {
-							if assert.Len(t, agent.VolumeMounts, 3) {
-								assert.Equal(t, "var-run-argo", agent.VolumeMounts[0].Name)
-								assert.Contains(t, agent.VolumeMounts[1].Name, "kube-api-access-")
-								assert.Equal(t, "argo-workflows-agent-ca-certificates", agent.VolumeMounts[2].Name)
-							}
-							assert.Equal(t, &apiv1.SecurityContext{
-								RunAsUser:                pointer.Int64(8737),
-								RunAsNonRoot:             pointer.Bool(true),
-								AllowPrivilegeEscalation: pointer.Bool(false),
-								ReadOnlyRootFilesystem:   pointer.Bool(true),
-								Privileged:               pointer.Bool(false),
-								Capabilities:             &apiv1.Capabilities{Drop: []apiv1.Capability{"ALL"}},
-								SeccompProfile:           &v1.SeccompProfile{Type: "RuntimeDefault"},
-							}, agent.SecurityContext)
-						}
-					}
-				}
+			require.Len(t, pods, 1)
+			pod := pods[0]
+			spec := pod.Spec
+			assert.Equal(t, pointer.Bool(false), spec.AutomountServiceAccountToken)
+			assert.Equal(t, &apiv1.PodSecurityContext{
+				RunAsUser:      pointer.Int64(8737),
+				RunAsNonRoot:   pointer.Bool(true),
+				SeccompProfile: &v1.SeccompProfile{Type: "RuntimeDefault"},
+			}, spec.SecurityContext)
+			require.Len(t, spec.Volumes, 4)
+			assert.Contains(t, spec.Volumes[0].Name, "kube-api-access-")
+			assert.Equal(t, "var-run-argo", spec.Volumes[1].Name)
+			assert.Contains(t, spec.Volumes[2].Name, "kube-api-access-")
+			assert.Equal(t, "argo-workflows-agent-ca-certificates", spec.Volumes[3].Name)
+
+			require.Len(t, spec.Containers, 2)
+			{
+				plug := spec.Containers[0]
+				require.Equal(t, "hello-executor-plugin", plug.Name)
+				require.Len(t, plug.VolumeMounts, 2)
+				assert.Equal(t, "var-run-argo", plug.VolumeMounts[0].Name)
+				assert.Contains(t, plug.VolumeMounts[1].Name, "kube-api-access-")
+			}
+			{
+				agent := spec.Containers[1]
+				require.Equal(t, "main", agent.Name)
+				require.Len(t, agent.VolumeMounts, 3)
+				assert.Equal(t, "var-run-argo", agent.VolumeMounts[0].Name)
+				assert.Contains(t, agent.VolumeMounts[1].Name, "kube-api-access-")
+				assert.Equal(t, "argo-workflows-agent-ca-certificates", agent.VolumeMounts[2].Name)
+				assert.Equal(t, &apiv1.SecurityContext{
+					RunAsUser:                pointer.Int64(8737),
+					RunAsNonRoot:             pointer.Bool(true),
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					ReadOnlyRootFilesystem:   pointer.Bool(true),
+					Privileged:               pointer.Bool(false),
+					Capabilities:             &apiv1.Capabilities{Drop: []apiv1.Capability{"ALL"}},
+					SeccompProfile:           &v1.SeccompProfile{Type: "RuntimeDefault"},
+				}, agent.SecurityContext)
 			}
 		}).
 		ExpectWorkflowTaskSet(func(t *testing.T, wfts *wfv1.WorkflowTaskSet) {

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -237,11 +237,10 @@ spec:
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Len(t, status.Nodes, 7)
 			nodeStatus := status.Nodes.FindByDisplayName("B")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, wfv1.NodeFailed, nodeStatus.Phase)
-				assert.Len(t, nodeStatus.Children, 1)
-				assert.Len(t, nodeStatus.OutboundNodes, 1)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeFailed, nodeStatus.Phase)
+			assert.Len(t, nodeStatus.Children, 1)
+			assert.Len(t, nodeStatus.OutboundNodes, 1)
 		})
 }
 
@@ -418,12 +417,12 @@ func (s *FunctionalSuite) TestArtifactRepositoryRef() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
-			if assert.NotEmpty(t, status.ArtifactRepositoryRef) {
-				assert.Equal(t, "argo", status.ArtifactRepositoryRef.Namespace)
-				assert.Equal(t, "artifact-repositories", status.ArtifactRepositoryRef.ConfigMap)
-				assert.Equal(t, "my-key", status.ArtifactRepositoryRef.Key)
-				assert.False(t, status.ArtifactRepositoryRef.Default)
-			}
+			require.NotEmpty(t, status.ArtifactRepositoryRef)
+			assert.Equal(t, "argo", status.ArtifactRepositoryRef.Namespace)
+			assert.Equal(t, "artifact-repositories", status.ArtifactRepositoryRef.ConfigMap)
+			assert.Equal(t, "my-key", status.ArtifactRepositoryRef.Key)
+			assert.False(t, status.ArtifactRepositoryRef.Default)
+
 			// these should never be set because we must get them from the artifactRepositoryRef
 			generated := status.Nodes.FindByDisplayName("generate").Outputs.Artifacts[0].S3
 			assert.Empty(t, generated.Bucket)
@@ -443,11 +442,10 @@ func (s *FunctionalSuite) TestLoopEmptyParam() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
-			if assert.Len(t, status.Nodes, 5) {
-				nodeStatus := status.Nodes.FindByDisplayName("sleep")
-				assert.Equal(t, wfv1.NodeSkipped, nodeStatus.Phase)
-				assert.Equal(t, "Skipped, empty params", nodeStatus.Message)
-			}
+			require.Len(t, status.Nodes, 5)
+			nodeStatus := status.Nodes.FindByDisplayName("sleep")
+			assert.Equal(t, wfv1.NodeSkipped, nodeStatus.Phase)
+			assert.Equal(t, "Skipped, empty params", nodeStatus.Message)
 		})
 }
 
@@ -460,11 +458,10 @@ func (s *FunctionalSuite) TestDAGEmptyParam() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
-			if assert.Len(t, status.Nodes, 3) {
-				nodeStatus := status.Nodes.FindByDisplayName("sleep")
-				assert.Equal(t, wfv1.NodeSkipped, nodeStatus.Phase)
-				assert.Equal(t, "Skipped, empty params", nodeStatus.Message)
-			}
+			require.Len(t, status.Nodes, 3)
+			nodeStatus := status.Nodes.FindByDisplayName("sleep")
+			assert.Equal(t, wfv1.NodeSkipped, nodeStatus.Phase)
+			assert.Equal(t, "Skipped, empty params", nodeStatus.Message)
 		})
 }
 
@@ -566,9 +563,8 @@ func (s *FunctionalSuite) TestParameterAggregation() {
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
 			nodeStatus := status.Nodes.FindByDisplayName("print(0:res:1)")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
 		})
 }
 
@@ -911,9 +907,9 @@ func (s *FunctionalSuite) TestDataTransformation() {
 		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
 			paths := status.Nodes.FindByDisplayName("get-artifact-path")
-			if assert.NotNil(t, paths) {
-				assert.Equal(t, `["foo/script.py","script.py"]`, *paths.Outputs.Result)
-			}
+			require.NotNil(t, paths)
+			assert.Equal(t, `["foo/script.py","script.py"]`, *paths.Outputs.Result)
+
 			assert.NotNil(t, status.Nodes.FindByDisplayName("process-artifact(0:foo/script.py)"))
 			assert.NotNil(t, status.Nodes.FindByDisplayName("process-artifact(1:script.py)"))
 			for _, value := range status.TaskResultsCompletionStatus {

--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -151,13 +152,11 @@ func (s *ResourceTemplateSuite) TestResourceTemplateWithOutputs() {
 		Then().
 		ExpectWorkflow(func(t *testing.T, md *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			outputs := status.Nodes[md.Name].Outputs
-			if assert.NotNil(t, outputs) {
-				parameters := outputs.Parameters
-				if assert.Len(t, parameters, 2) {
-					assert.Equal(t, "my-pod", parameters[0].Value.String(), "metadata.name is capture for json")
-					assert.Equal(t, "my-pod", parameters[1].Value.String(), "metadata.name is capture for jq")
-				}
-			}
+			require.NotNil(t, outputs)
+			parameters := outputs.Parameters
+			require.Len(t, parameters, 2)
+			assert.Equal(t, "my-pod", parameters[0].Value.String(), "metadata.name is capture for json")
+			assert.Equal(t, "my-pod", parameters[1].Value.String(), "metadata.name is capture for jq")
 			for _, value := range status.TaskResultsCompletionStatus {
 				assert.True(t, value)
 			}

--- a/test/e2e/signals_test.go
+++ b/test/e2e/signals_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,17 +36,16 @@ func (s *SignalsSuite) TestStopBehavior() {
 		ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Contains(t, []wfv1.WorkflowPhase{wfv1.WorkflowFailed, wfv1.WorkflowError}, status.Phase)
 			nodeStatus := status.Nodes.FindByDisplayName("A")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Contains(t, []wfv1.NodePhase{wfv1.NodeFailed, wfv1.NodeError}, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Contains(t, []wfv1.NodePhase{wfv1.NodeFailed, wfv1.NodeError}, nodeStatus.Phase)
+
 			nodeStatus = status.Nodes.FindByDisplayName("A.onExit")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
+
 			nodeStatus = status.Nodes.FindByDisplayName(m.Name + ".onExit")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
 		})
 }
 
@@ -61,9 +61,8 @@ func (s *SignalsSuite) TestStopBehaviorWithDaemon() {
 		ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Contains(t, []wfv1.WorkflowPhase{wfv1.WorkflowFailed, wfv1.WorkflowError}, status.Phase)
 			nodeStatus := status.Nodes.FindByDisplayName("Daemon")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
 		})
 }
 
@@ -79,9 +78,8 @@ func (s *SignalsSuite) TestTerminateBehavior() {
 		ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Contains(t, []wfv1.WorkflowPhase{wfv1.WorkflowFailed, wfv1.WorkflowError}, status.Phase)
 			nodeStatus := status.Nodes.FindByDisplayName("A")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Contains(t, []wfv1.NodePhase{wfv1.NodeFailed, wfv1.NodeError}, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Contains(t, []wfv1.NodePhase{wfv1.NodeFailed, wfv1.NodeError}, nodeStatus.Phase)
 			nodeStatus = status.Nodes.FindByDisplayName("A.onExit")
 			assert.Nil(t, nodeStatus)
 			nodeStatus = status.Nodes.FindByDisplayName(m.Name + ".onExit")
@@ -102,9 +100,8 @@ func (s *SignalsSuite) TestDoNotCreatePodsUnderStopBehavior() {
 		ExpectWorkflow(func(t *testing.T, m *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 			nodeStatus := status.Nodes.FindByDisplayName("A")
-			if assert.NotNil(t, nodeStatus) {
-				assert.Equal(t, wfv1.NodeFailed, nodeStatus.Phase)
-			}
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeFailed, nodeStatus.Phase)
 			nodeStatus = status.Nodes.FindByDisplayName("B")
 			assert.Nil(t, nodeStatus)
 		})
@@ -159,15 +156,14 @@ func (s *SignalsSuite) TestSignaledContainerSet() {
 			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 			assert.Contains(t, status.Message, "(exit code 137)")
 			one := status.Nodes.FindByDisplayName("one")
-			if assert.NotNil(t, one) {
-				assert.Equal(t, wfv1.NodeFailed, one.Phase)
-				assert.Contains(t, one.Message, "(exit code 137)")
-			}
+			require.NotNil(t, one)
+			assert.Equal(t, wfv1.NodeFailed, one.Phase)
+			assert.Contains(t, one.Message, "(exit code 137)")
+
 			two := status.Nodes.FindByDisplayName("two")
-			if assert.NotNil(t, two) {
-				assert.Equal(t, wfv1.NodeFailed, two.Phase)
-				assert.Contains(t, two.Message, "(exit code 143)")
-			}
+			require.NotNil(t, two)
+			assert.Equal(t, wfv1.NodeFailed, two.Phase)
+			assert.Contains(t, two.Message, "(exit code 143)")
 		})
 }
 

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -41,10 +41,10 @@ func Test_BasicAuthString(t *testing.T) {
 		assert.True(t, IsBasicAuthScheme(authString))
 		token := strings.TrimSpace(strings.TrimPrefix(authString, BasicAuthScheme))
 		uname, pwd, ok := decodeBasicAuthToken(token)
-		if assert.True(t, ok) {
-			assert.Equal(t, "admin", uname)
-			assert.Equal(t, "admin", pwd)
-		}
+		require.True(t, ok)
+		assert.Equal(t, "admin", uname)
+		assert.Equal(t, "admin", pwd)
+
 		file, err := os.CreateTemp("", "config.yaml")
 		require.NoError(t, err)
 		_, err = file.WriteString(config)

--- a/workflow/artifacts/http/http_test.go
+++ b/workflow/artifacts/http/http_test.go
@@ -48,9 +48,8 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 		}, "/tmp/not-found")
 		require.Error(t, err)
 		argoError, ok := err.(errors.ArgoError)
-		if assert.True(t, ok) {
-			assert.Equal(t, errors.CodeNotFound, argoError.Code())
-		}
+		require.True(t, ok)
+		assert.Equal(t, errors.CodeNotFound, argoError.Code())
 	})
 }
 
@@ -64,9 +63,8 @@ func TestArtifactoryArtifactDriver_Load(t *testing.T) {
 		}, "/tmp/not-found")
 		require.Error(t, err)
 		argoError, ok := err.(errors.ArgoError)
-		if assert.True(t, ok) {
-			assert.Equal(t, errors.CodeNotFound, argoError.Code())
-		}
+		require.True(t, ok)
+		assert.Equal(t, errors.CodeNotFound, argoError.Code())
 	})
 	t.Run("Found", func(t *testing.T) {
 		err := driver.Load(&wfv1.Artifact{

--- a/workflow/common/convert_test.go
+++ b/workflow/common/convert_test.go
@@ -109,9 +109,8 @@ spec:
 	err = yaml.Unmarshal([]byte(cronWfInstanceIdString), &cronWf)
 	require.NoError(t, err)
 	wf = ConvertCronWorkflowToWorkflow(&cronWf)
-	if assert.Contains(t, wf.GetLabels(), LabelKeyControllerInstanceID) {
-		assert.Equal(t, "test-controller", wf.GetLabels()[LabelKeyControllerInstanceID])
-	}
+	require.Contains(t, wf.GetLabels(), LabelKeyControllerInstanceID)
+	assert.Equal(t, "test-controller", wf.GetLabels()[LabelKeyControllerInstanceID])
 
 	err = yaml.Unmarshal([]byte(cronWfInstanceIdString), &cronWf)
 	require.NoError(t, err)

--- a/workflow/controller/cache_test.go
+++ b/workflow/controller/cache_test.go
@@ -63,10 +63,9 @@ func TestConfigMapCacheLoadHit(t *testing.T) {
 
 	outputs := entry.Outputs
 	require.NoError(t, err)
-	if assert.Len(t, outputs.Parameters, 1) {
-		assert.Equal(t, "hello", outputs.Parameters[0].Name)
-		assert.Equal(t, "foobar", outputs.Parameters[0].Value.String())
-	}
+	require.Len(t, outputs.Parameters, 1)
+	assert.Equal(t, "hello", outputs.Parameters[0].Name)
+	assert.Equal(t, "foobar", outputs.Parameters[0].Value.String())
 }
 
 func TestConfigMapCacheLoadMiss(t *testing.T) {

--- a/workflow/controller/container_set_template_test.go
+++ b/workflow/controller/container_set_template_test.go
@@ -118,14 +118,13 @@ spec:
 		{Name: "input-artifacts", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}, pod.Spec.Volumes)
 
-	if assert.Len(t, pod.Spec.InitContainers, 1) {
-		c := pod.Spec.InitContainers[0]
-		assert.ElementsMatch(t, []corev1.VolumeMount{
-			{Name: "input-artifacts", MountPath: "/argo/inputs/artifacts"},
-			{Name: "workspace", MountPath: "/mainctrfs/workspace"},
-			{Name: "var-run-argo", MountPath: common.VarRunArgoPath},
-		}, c.VolumeMounts)
-	}
+	require.Len(t, pod.Spec.InitContainers, 1)
+	c := pod.Spec.InitContainers[0]
+	assert.ElementsMatch(t, []corev1.VolumeMount{
+		{Name: "input-artifacts", MountPath: "/argo/inputs/artifacts"},
+		{Name: "workspace", MountPath: "/mainctrfs/workspace"},
+		{Name: "var-run-argo", MountPath: common.VarRunArgoPath},
+	}, c.VolumeMounts)
 
 	assert.Len(t, pod.Spec.Containers, 2)
 	for _, c := range pod.Spec.Containers {

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -716,20 +716,17 @@ spec:
 			assert.True(t, controller.processNextItem(ctx))
 
 			expectWorkflow(ctx, controller, "my-wf-0", func(wf *wfv1.Workflow) {
-				if assert.NotNil(t, wf) {
-					assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
-				}
+				require.NotNil(t, wf)
+				assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
 			})
 			expectWorkflow(ctx, controller, "my-wf-1", func(wf *wfv1.Workflow) {
-				if assert.NotNil(t, wf) {
-					assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
-					assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
-				}
+				require.NotNil(t, wf)
+				assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+				assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
 			})
 			expectWorkflow(ctx, controller, "my-wf-2", func(wf *wfv1.Workflow) {
-				if assert.NotNil(t, wf) {
-					assert.Equal(t, wfv1.WorkflowFailed, wf.Status.Phase)
-				}
+				require.NotNil(t, wf)
+				assert.Equal(t, wfv1.WorkflowFailed, wf.Status.Phase)
 			})
 		})
 	}
@@ -995,19 +992,17 @@ status:
 			// process my-wf-0; update status to Pending
 			assert.True(t, controller.processNextItem(ctx))
 			expectWorkflow(ctx, controller, "my-wf-0", func(wf *wfv1.Workflow) {
-				if assert.NotNil(t, wf) {
-					assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
-					assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
-				}
+				require.NotNil(t, wf)
+				assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+				assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
 			})
 
 			// process my-wf-1; update status to Pending
 			assert.True(t, controller.processNextItem(ctx))
 			expectWorkflow(ctx, controller, "my-wf-1", func(wf *wfv1.Workflow) {
-				if assert.NotNil(t, wf) {
-					assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
-					assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
-				}
+				require.NotNil(t, wf)
+				assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+				assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
 			})
 		})
 	}
@@ -1088,23 +1083,21 @@ status:
 				assert.True(t, controller.processNextItem(ctx))
 				if !ns0PendingWfTested {
 					expectNamespacedWorkflow(ctx, controller, "ns-0", "my-ns-0-wf-0", func(wf *wfv1.Workflow) {
-						if assert.NotNil(t, wf) {
-							if wf.Status.Phase != "" {
-								assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
-								assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
-								ns0PendingWfTested = true
-							}
+						require.NotNil(t, wf)
+						if wf.Status.Phase != "" {
+							assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+							assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
+							ns0PendingWfTested = true
 						}
 					})
 				}
 				if !ns1PendingWfTested {
 					expectNamespacedWorkflow(ctx, controller, "ns-1", "my-ns-1-wf-0", func(wf *wfv1.Workflow) {
-						if assert.NotNil(t, wf) {
-							if wf.Status.Phase != "" {
-								assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
-								assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
-								ns1PendingWfTested = true
-							}
+						require.NotNil(t, wf)
+						if wf.Status.Phase != "" {
+							assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+							assert.Equal(t, "Workflow processing has been postponed because too many workflows are already running", wf.Status.Message)
+							ns1PendingWfTested = true
 						}
 					})
 				}

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -3365,14 +3365,11 @@ func TestDAGReferTaskAggregatedOutputs(t *testing.T) {
 	woc.operate(ctx)
 
 	dagNode := woc.wf.Status.Nodes.FindByDisplayName("parameter-aggregation-dag-h8b82")
-	if assert.NotNil(t, dagNode) {
-		if assert.NotNil(t, dagNode.Outputs) {
-			if assert.Len(t, dagNode.Outputs.Parameters, 2) {
-				assert.Equal(t, `["1","2"]`, dagNode.Outputs.Parameters[0].Value.String())
-				assert.Equal(t, `["odd","even"]`, dagNode.Outputs.Parameters[1].Value.String())
-			}
-		}
-	}
+	require.NotNil(t, dagNode)
+	require.NotNil(t, dagNode.Outputs)
+	require.Len(t, dagNode.Outputs.Parameters, 2)
+	assert.Equal(t, `["1","2"]`, dagNode.Outputs.Parameters[0].Value.String())
+	assert.Equal(t, `["odd","even"]`, dagNode.Outputs.Parameters[1].Value.String())
 }
 
 var dagHttpChildrenAssigned = `apiVersion: argoproj.io/v1alpha1
@@ -3450,11 +3447,9 @@ func TestDagHttpChildrenAssigned(t *testing.T) {
 	assert.NotNil(t, dagNode)
 
 	dagNode = woc.wf.Status.Nodes.FindByDisplayName("good1")
-	if assert.NotNil(t, dagNode) {
-		if assert.Len(t, dagNode.Children, 1) {
-			assert.Equal(t, "http-template-nv52d-495103493", dagNode.Children[0])
-		}
-	}
+	require.NotNil(t, dagNode)
+	require.Len(t, dagNode.Children, 1)
+	assert.Equal(t, "http-template-nv52d-495103493", dagNode.Children[0])
 }
 
 var retryTypeDagTaskRunExitNodeAfterCompleted = `

--- a/workflow/controller/estimation/estimator_factory_test.go
+++ b/workflow/controller/estimation/estimator_factory_test.go
@@ -60,57 +60,52 @@ metadata:
 	t.Run("None", func(t *testing.T) {
 		p, err := f.NewEstimator(&wfv1.Workflow{})
 		require.NoError(t, err)
-		if assert.NotNil(t, p) {
-			e := p.(*estimator)
-			assert.Nil(t, e.baselineWF)
-		}
+		require.NotNil(t, p)
+		e := p.(*estimator)
+		assert.Nil(t, e.baselineWF)
 	})
 	t.Run("WorkflowTemplate", func(t *testing.T) {
 		p, err := f.NewEstimator(&wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{common.LabelKeyWorkflowTemplate: "my-wftmpl"}},
 		})
 		require.NoError(t, err)
-		if assert.NotNil(t, p) {
-			e := p.(*estimator)
-			if assert.NotNil(t, e) && assert.NotNil(t, e.baselineWF) {
-				assert.Equal(t, "my-wftmpl-baseline", e.baselineWF.Name)
-			}
-		}
+		require.NotNil(t, p)
+		e := p.(*estimator)
+		require.NotNil(t, e)
+		require.NotNil(t, e.baselineWF)
+		assert.Equal(t, "my-wftmpl-baseline", e.baselineWF.Name)
 	})
 	t.Run("ClusterWorkflowTemplate", func(t *testing.T) {
 		p, err := f.NewEstimator(&wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{common.LabelKeyClusterWorkflowTemplate: "my-cwft"}},
 		})
 		require.NoError(t, err)
-		if assert.NotNil(t, p) {
-			e := p.(*estimator)
-			if assert.NotNil(t, e) && assert.NotNil(t, e.baselineWF) {
-				assert.Equal(t, "my-cwft-baseline", e.baselineWF.Name)
-			}
-		}
+		require.NotNil(t, p)
+		e := p.(*estimator)
+		require.NotNil(t, e)
+		require.NotNil(t, e.baselineWF)
+		assert.Equal(t, "my-cwft-baseline", e.baselineWF.Name)
 	})
 	t.Run("CronWorkflowTemplate", func(t *testing.T) {
 		p, err := f.NewEstimator(&wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{common.LabelKeyCronWorkflow: "my-cwf"}},
 		})
 		require.NoError(t, err)
-		if assert.NotNil(t, p) {
-			e := p.(*estimator)
-			if assert.NotNil(t, e) && assert.NotNil(t, e.baselineWF) {
-				assert.Equal(t, "my-cwf-baseline", e.baselineWF.Name)
-			}
-		}
+		require.NotNil(t, p)
+		e := p.(*estimator)
+		require.NotNil(t, e)
+		require.NotNil(t, e.baselineWF)
+		assert.Equal(t, "my-cwf-baseline", e.baselineWF.Name)
 	})
 	t.Run("WorkflowArchive", func(t *testing.T) {
 		p, err := f.NewEstimator(&wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{common.LabelKeyWorkflowTemplate: "my-archived-wftmpl"}},
 		})
 		require.NoError(t, err)
-		if assert.NotNil(t, p) {
-			e := p.(*estimator)
-			if assert.NotNil(t, e) && assert.NotNil(t, e.baselineWF) {
-				assert.Equal(t, "my-archived-wftmpl-baseline", e.baselineWF.Name)
-			}
-		}
+		require.NotNil(t, p)
+		e := p.(*estimator)
+		require.NotNil(t, e)
+		require.NotNil(t, e.baselineWF)
+		assert.Equal(t, "my-archived-wftmpl-baseline", e.baselineWF.Name)
 	})
 }

--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -1062,11 +1062,9 @@ spec:
 
 	hookNode := woc.wf.Status.Nodes.FindByDisplayName(exitNodeName)
 
-	if assert.NotNil(t, hookNode) {
-		assert.NotNil(t, hookNode.Inputs)
-		if assert.Len(t, hookNode.Inputs.Parameters, 1) {
-			assert.NotNil(t, hookNode.Inputs.Parameters[0].Value)
-			assert.Equal(t, hookNode.Inputs.Parameters[0].Value.String(), string(apiv1.PodFailed))
-		}
-	}
+	require.NotNil(t, hookNode)
+	assert.NotNil(t, hookNode.Inputs)
+	require.Len(t, hookNode.Inputs.Parameters, 1)
+	assert.NotNil(t, hookNode.Inputs.Parameters[0].Value)
+	assert.Equal(t, hookNode.Inputs.Parameters[0].Value.String(), string(apiv1.PodFailed))
 }

--- a/workflow/controller/informer/cluster_workflow_template_convert_test.go
+++ b/workflow/controller/informer/cluster_workflow_template_convert_test.go
@@ -24,9 +24,8 @@ func Test_objectToClusterWorkflowTemplate(t *testing.T) {
 			"spec":     "ops",
 		}})
 		require.EqualError(t, err, "malformed cluster workflow template \"my-name\": cannot restore struct from: string")
-		if assert.NotNil(t, v) {
-			assert.Equal(t, "my-name", v.Name)
-		}
+		require.NotNil(t, v)
+		assert.Equal(t, "my-name", v.Name)
 	})
 	t.Run("ClusterWorkflowTemplate", func(t *testing.T) {
 		v, err := objectToClusterWorkflowTemplate(&unstructured.Unstructured{})

--- a/workflow/controller/informer/workflow_template_convert_test.go
+++ b/workflow/controller/informer/workflow_template_convert_test.go
@@ -24,10 +24,9 @@ func Test_objectToWorkflowTemplate(t *testing.T) {
 			"spec":     "ops",
 		}})
 		require.EqualError(t, err, "malformed workflow template \"my-ns/my-name\": cannot restore struct from: string")
-		if assert.NotNil(t, v) {
-			assert.Equal(t, "my-ns", v.Namespace)
-			assert.Equal(t, "my-name", v.Name)
-		}
+		require.NotNil(t, v)
+		assert.Equal(t, "my-ns", v.Namespace)
+		assert.Equal(t, "my-name", v.Name)
 	})
 	t.Run("WorkflowTemplate", func(t *testing.T) {
 		v, err := objectToWorkflowTemplate(&unstructured.Unstructured{})

--- a/workflow/controller/operator_data_test.go
+++ b/workflow/controller/operator_data_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
@@ -236,7 +237,6 @@ func TestDataTemplateCreatesPod(t *testing.T) {
 	woc.operate(ctx)
 
 	node := woc.wf.Status.Nodes.FindByDisplayName("collect-artifact")
-	if assert.NotNil(t, node) {
-		assert.Equal(t, wfv1.NodePending, node.Phase)
-	}
+	require.NotNil(t, node)
+	assert.Equal(t, wfv1.NodePending, node.Phase)
 }

--- a/workflow/controller/operator_template_scope_test.go
+++ b/workflow/controller/operator_template_scope_test.go
@@ -87,40 +87,34 @@ func TestTemplateScope(t *testing.T) {
 	wf = woc.wf
 
 	node := findNodeByName(wf.Status.Nodes, "test-template-scope[0].step")
-	if assert.NotNil(t, node, "Node %s not found", "test-templte-scope") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "local/test-template-scope", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-templte-scope")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "local/test-template-scope", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-templte-scope[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-templte-scope[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].hello")
-	if assert.NotNil(t, node, "Node %s not found", "test-templte-scope[0].hello") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-templte-scope[0].hello")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].other-wftmpl")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].other-wftmpl[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].other-wftmpl[0].hello")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0].hello") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0].hello")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
 }
 
 var testTemplateScopeWithParamWorkflowYaml = `
@@ -183,34 +177,29 @@ func TestTemplateScopeWithParam(t *testing.T) {
 	require.NoError(t, err)
 
 	node := findNodeByName(wf.Status.Nodes, "test-template-scope-with-param[0].step")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "local/test-template-scope-with-param", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "local/test-template-scope-with-param", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-with-param[0].step[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-with-param[0].step[0].print-string(0:x)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0].print-string(0:x)") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0].print-string(0:x)")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-with-param[0].step[0].print-string(1:y)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0].print-string(1:y)") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0].print-string(1:y)")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-with-param[0].step[0].print-string(2:z)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0].print-string(2:z)") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0].print-string(2:z)")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-with-param-1", node.TemplateScope)
 }
 
 var testTemplateScopeNestedStepsWithParamsWorkflowYaml = `
@@ -277,46 +266,39 @@ func TestTemplateScopeNestedStepsWithParams(t *testing.T) {
 	require.NoError(t, err)
 
 	node := findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "local/test-template-scope-nested-steps-with-params", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "local/test-template-scope-nested-steps-with-params", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params[0].step[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-with-param[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params[0].step[0].main")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params[0].step[0].main[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params[0].step[0].main[0].print-string(0:x)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0].print-string(0:x)") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0].print-string(0:x)")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params[0].step[0].main[0].print-string(1:y)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0].print-string(1:y)") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0].print-string(1:y)")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-nested-steps-with-params[0].step[0].main[0].print-string(2:z)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0].print-string(2:z)") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-nested-steps-with-params[0].main[0].print-string(2:z)")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-nested-steps-with-params-1", node.TemplateScope)
 }
 
 var testTemplateScopeDAGWorkflowYaml = `
@@ -386,40 +368,34 @@ func TestTemplateScopeDAG(t *testing.T) {
 	require.NoError(t, err)
 
 	node := findNodeByName(wf.Status.Nodes, "test-template-scope-dag[0].step")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-dag") {
-		assert.Equal(t, wfv1.NodeTypeDAG, node.Type)
-		assert.Equal(t, "local/test-template-scope-dag", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-dag")
+	assert.Equal(t, wfv1.NodeTypeDAG, node.Type)
+	assert.Equal(t, "local/test-template-scope-dag", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-dag[0].step.A")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-dag.A") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-dag.A")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-dag[0].step.B")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B") {
-		assert.Equal(t, wfv1.NodeTypeTaskGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B")
+	assert.Equal(t, wfv1.NodeTypeTaskGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-dag[0].step.B(0:x)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B(0:x") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B(0:x")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-dag[0].step.B(1:y)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B(0:x") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B(0:x")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope-dag[0].step.B(2:z)")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B(0:x") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope-dag.B(0:x")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-dag-1", node.TemplateScope)
 }
 
 func findNodeByName(nodes map[string]wfv1.NodeStatus, name string) *wfv1.NodeStatus {
@@ -488,38 +464,32 @@ func TestTemplateClusterScope(t *testing.T) {
 	require.NoError(t, err)
 
 	node := findNodeByName(wf.Status.Nodes, "test-template-scope[0].step")
-	if assert.NotNil(t, node, "Node %s not found", "test-templte-scope") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "local/test-template-scope", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-templte-scope")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "local/test-template-scope", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-templte-scope[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "cluster/test-template-scope-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-templte-scope[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "cluster/test-template-scope-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].hello")
-	if assert.NotNil(t, node, "Node %s not found", "test-templte-scope[0].hello") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "cluster/test-template-scope-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-templte-scope[0].hello")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "cluster/test-template-scope-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].other-wftmpl")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl") {
-		assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
-		assert.Equal(t, "cluster/test-template-scope-1", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl")
+	assert.Equal(t, wfv1.NodeTypeSteps, node.Type)
+	assert.Equal(t, "cluster/test-template-scope-1", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].other-wftmpl[0]")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0]") {
-		assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0]")
+	assert.Equal(t, wfv1.NodeTypeStepGroup, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
 
 	node = findNodeByName(wf.Status.Nodes, "test-template-scope[0].step[0].other-wftmpl[0].hello")
-	if assert.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0].hello") {
-		assert.Equal(t, wfv1.NodeTypePod, node.Type)
-		assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
-	}
+	require.NotNil(t, node, "Node %s not found", "test-template-scope[0].other-wftmpl[0].hello")
+	assert.Equal(t, wfv1.NodeTypePod, node.Type)
+	assert.Equal(t, "namespaced/test-template-scope-2", node.TemplateScope)
 }

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -341,10 +341,9 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		assert.NotEmpty(t, woc1.wf.Status.StoredWorkflowSpec.Shutdown)
 		assert.Equal(t, wfv1.ShutdownStrategyTerminate, woc1.wf.Status.StoredWorkflowSpec.Shutdown)
 		for _, node := range woc1.wf.Status.Nodes {
-			if assert.NotNil(t, node) {
-				assert.Contains(t, node.Message, "workflow shutdown with strategy")
-				assert.Contains(t, node.Message, "Terminate")
-			}
+			require.NotNil(t, node)
+			assert.Contains(t, node.Message, "workflow shutdown with strategy")
+			assert.Contains(t, node.Message, "Terminate")
 		}
 	})
 	t.Run("WorkflowTemplateRefWithShutdownStop", func(t *testing.T) {
@@ -364,10 +363,9 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		assert.NotEmpty(t, woc1.wf.Status.StoredWorkflowSpec.Shutdown)
 		assert.Equal(t, wfv1.ShutdownStrategyStop, woc1.wf.Status.StoredWorkflowSpec.Shutdown)
 		for _, node := range woc1.wf.Status.Nodes {
-			if assert.NotNil(t, node) {
-				assert.Contains(t, node.Message, "workflow shutdown with strategy")
-				assert.Contains(t, node.Message, "Stop")
-			}
+			require.NotNil(t, node)
+			assert.Contains(t, node.Message, "workflow shutdown with strategy")
+			assert.Contains(t, node.Message, "Stop")
 		}
 	})
 }

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -730,34 +730,30 @@ func TestVolumeAndVolumeMounts(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, pods.Items, 1)
 		pod := pods.Items[0]
-		if assert.Len(t, pod.Spec.Volumes, 3) {
-			assert.Equal(t, "var-run-argo", pod.Spec.Volumes[0].Name)
-			assert.Equal(t, "tmp-dir-argo", pod.Spec.Volumes[1].Name)
-			assert.Equal(t, "volume-name", pod.Spec.Volumes[2].Name)
-		}
-		if assert.Len(t, pod.Spec.InitContainers, 1) {
-			init := pod.Spec.InitContainers[0]
-			if assert.Len(t, init.VolumeMounts, 1) {
-				assert.Equal(t, "var-run-argo", init.VolumeMounts[0].Name)
-			}
-		}
+		require.Len(t, pod.Spec.Volumes, 3)
+		assert.Equal(t, "var-run-argo", pod.Spec.Volumes[0].Name)
+		assert.Equal(t, "tmp-dir-argo", pod.Spec.Volumes[1].Name)
+		assert.Equal(t, "volume-name", pod.Spec.Volumes[2].Name)
+
+		require.Len(t, pod.Spec.InitContainers, 1)
+		init := pod.Spec.InitContainers[0]
+		require.Len(t, init.VolumeMounts, 1)
+		assert.Equal(t, "var-run-argo", init.VolumeMounts[0].Name)
+
 		containers := pod.Spec.Containers
-		if assert.Len(t, containers, 2) {
-			wait := containers[0]
-			if assert.Len(t, wait.VolumeMounts, 3) {
-				assert.Equal(t, "volume-name", wait.VolumeMounts[0].Name)
-				assert.Equal(t, "tmp-dir-argo", wait.VolumeMounts[1].Name)
-				assert.Equal(t, "var-run-argo", wait.VolumeMounts[2].Name)
-			}
-			main := containers[1]
-			assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
-				"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
-				"--", "cowsay"}, main.Command)
-			if assert.Len(t, main.VolumeMounts, 2) {
-				assert.Equal(t, "volume-name", main.VolumeMounts[0].Name)
-				assert.Equal(t, "var-run-argo", main.VolumeMounts[1].Name)
-			}
-		}
+		require.Len(t, containers, 2)
+		wait := containers[0]
+		require.Len(t, wait.VolumeMounts, 3)
+		assert.Equal(t, "volume-name", wait.VolumeMounts[0].Name)
+		assert.Equal(t, "tmp-dir-argo", wait.VolumeMounts[1].Name)
+		assert.Equal(t, "var-run-argo", wait.VolumeMounts[2].Name)
+		main := containers[1]
+		assert.Equal(t, []string{"/var/run/argo/argoexec", "emissary",
+			"--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.cliExecutorLogFormat,
+			"--", "cowsay"}, main.Command)
+		require.Len(t, main.VolumeMounts, 2)
+		assert.Equal(t, "volume-name", main.VolumeMounts[0].Name)
+		assert.Equal(t, "var-run-argo", main.VolumeMounts[1].Name)
 	})
 }
 
@@ -1478,9 +1474,8 @@ func TestMainContainerCustomization(t *testing.T) {
 		require.NoError(t, err)
 		ctr := pod.Spec.Containers[1]
 		assert.NotNil(t, ctr.SecurityContext)
-		if assert.NotNil(t, pod.Spec.Containers[1].Resources) {
-			assert.Equal(t, "0.200", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
-		}
+		require.NotNil(t, pod.Spec.Containers[1].Resources)
+		assert.Equal(t, "0.200", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
 	})
 
 	// Workflow spec's main container takes precedence over config in controller

--- a/workflow/creator/creator_test.go
+++ b/workflow/creator/creator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -24,34 +25,30 @@ func TestLabel(t *testing.T) {
 	t.Run("NotEmpty", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
 		Label(context.WithValue(context.TODO(), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: strings.Repeat("x", 63) + "y"}, Email: "my@email", PreferredUsername: "username"}), wf)
-		if assert.NotEmpty(t, wf.Labels) {
-			assert.Equal(t, strings.Repeat("x", 62)+"y", wf.Labels[common.LabelKeyCreator], "creator is truncated")
-			assert.Equal(t, "my.at.email", wf.Labels[common.LabelKeyCreatorEmail], "'@' is replaced by '.at.'")
-			assert.Equal(t, "username", wf.Labels[common.LabelKeyCreatorPreferredUsername], "username is matching")
-		}
+		require.NotEmpty(t, wf.Labels)
+		assert.Equal(t, strings.Repeat("x", 62)+"y", wf.Labels[common.LabelKeyCreator], "creator is truncated")
+		assert.Equal(t, "my.at.email", wf.Labels[common.LabelKeyCreatorEmail], "'@' is replaced by '.at.'")
+		assert.Equal(t, "username", wf.Labels[common.LabelKeyCreatorPreferredUsername], "username is matching")
 	})
 	t.Run("TooLongHyphen", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
 		Label(context.WithValue(context.TODO(), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: strings.Repeat("-", 63) + "y"}}), wf)
-		if assert.NotEmpty(t, wf.Labels) {
-			assert.Equal(t, "y", wf.Labels[common.LabelKeyCreator])
-		}
+		require.NotEmpty(t, wf.Labels)
+		assert.Equal(t, "y", wf.Labels[common.LabelKeyCreator])
 	})
 	t.Run("InvalidDNSNames", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
 		Label(context.WithValue(context.TODO(), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "!@#$%^&*()--__" + strings.Repeat("y", 35) + "__--!@#$%^&*()"}, PreferredUsername: "us#er@name#"}), wf)
-		if assert.NotEmpty(t, wf.Labels) {
-			assert.Equal(t, strings.Repeat("y", 35), wf.Labels[common.LabelKeyCreator])
-			assert.Equal(t, "us-er-name", wf.Labels[common.LabelKeyCreatorPreferredUsername], "username is truncated")
-		}
+		require.NotEmpty(t, wf.Labels)
+		assert.Equal(t, strings.Repeat("y", 35), wf.Labels[common.LabelKeyCreator])
+		assert.Equal(t, "us-er-name", wf.Labels[common.LabelKeyCreatorPreferredUsername], "username is truncated")
 	})
 	t.Run("InvalidDNSNamesWithMidDashes", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
 		sub := strings.Repeat("x", 20) + strings.Repeat("-", 70) + strings.Repeat("x", 20)
 		Label(context.WithValue(context.TODO(), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: sub}}), wf)
-		if assert.NotEmpty(t, wf.Labels) {
-			assert.Equal(t, strings.Repeat("x", 20), wf.Labels[common.LabelKeyCreator])
-		}
+		require.NotEmpty(t, wf.Labels)
+		assert.Equal(t, strings.Repeat("x", 20), wf.Labels[common.LabelKeyCreator])
 	})
 	t.Run("DifferentUsersFromCreatorLabels", func(t *testing.T) {
 		type input struct {

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -330,9 +330,8 @@ func TestLastUsedSchedule(t *testing.T) {
 
 	woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleString())
 
-	if assert.NotNil(t, woc.cronWf.Annotations) {
-		assert.Equal(t, woc.cronWf.Spec.GetScheduleString(), woc.cronWf.GetLatestSchedule())
-	}
+	require.NotNil(t, woc.cronWf.Annotations)
+	assert.Equal(t, woc.cronWf.Spec.GetScheduleString(), woc.cronWf.GetLatestSchedule())
 }
 
 var forbidMissedSchedule = `apiVersion: argoproj.io/v1alpha1

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -191,7 +191,7 @@ func TestGetCurrentTemplateBase(t *testing.T) {
 	// Get the template base of existing template name.
 	tmplBase := ctx.GetCurrentTemplateBase()
 	wftmpl, ok := tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "base-workflow-template", wftmpl.Name)
 }
 
@@ -214,7 +214,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	newCtx, err := ctx.WithTemplateHolder(&tmplHolder)
 	require.NoError(t, err)
 	tmplGetter, ok := newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "base-workflow-template", tmplGetter.GetName())
 
 	// Get the template base of unexisting template name.
@@ -222,7 +222,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	newCtx, err = ctx.WithTemplateHolder(&tmplHolder)
 	require.NoError(t, err)
 	tmplGetter, ok = newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "base-workflow-template", tmplGetter.GetName())
 
 	// Get the template base of existing template reference.
@@ -230,7 +230,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	newCtx, err = ctx.WithTemplateHolder(&tmplHolder)
 	require.NoError(t, err)
 	tmplGetter, ok = newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 
 	// Get the template base of unexisting template reference.
@@ -255,7 +255,7 @@ func TestResolveTemplate(t *testing.T) {
 	ctx, tmpl, _, err := ctx.ResolveTemplate(&tmplHolder)
 	require.NoError(t, err)
 	wftmpl, ok := ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "base-workflow-template", wftmpl.Name)
 	assert.Equal(t, "whalesay", tmpl.Name)
 
@@ -266,7 +266,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Container)
@@ -277,7 +277,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "local-whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Steps)
@@ -288,7 +288,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "another-whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Steps)
@@ -301,7 +301,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "whalesay-with-arguments", tmpl.Name)
 
@@ -313,7 +313,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "nested-whalesay-with-arguments", tmpl.Name)
 }
@@ -328,7 +328,7 @@ func TestWithTemplateBase(t *testing.T) {
 	// Get the template base of existing template name.
 	newCtx := ctx.WithTemplateBase(anotherWftmpl)
 	wftmpl, ok := newCtx.tmplBase.(*wfv1.WorkflowTemplate)
-	require.True(t, ok)
+	require.True(t, ok, "tmplBase is not a WorkflowTemplate")
 	assert.Equal(t, "another-workflow-template", wftmpl.Name)
 }
 

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -191,9 +191,7 @@ func TestGetCurrentTemplateBase(t *testing.T) {
 	// Get the template base of existing template name.
 	tmplBase := ctx.GetCurrentTemplateBase()
 	wftmpl, ok := tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "base-workflow-template", wftmpl.Name)
 }
 
@@ -216,9 +214,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	newCtx, err := ctx.WithTemplateHolder(&tmplHolder)
 	require.NoError(t, err)
 	tmplGetter, ok := newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "base-workflow-template", tmplGetter.GetName())
 
 	// Get the template base of unexisting template name.
@@ -226,9 +222,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	newCtx, err = ctx.WithTemplateHolder(&tmplHolder)
 	require.NoError(t, err)
 	tmplGetter, ok = newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "base-workflow-template", tmplGetter.GetName())
 
 	// Get the template base of existing template reference.
@@ -236,9 +230,7 @@ func TestWithTemplateHolder(t *testing.T) {
 	newCtx, err = ctx.WithTemplateHolder(&tmplHolder)
 	require.NoError(t, err)
 	tmplGetter, ok = newCtx.GetCurrentTemplateBase().(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 
 	// Get the template base of unexisting template reference.
@@ -263,9 +255,7 @@ func TestResolveTemplate(t *testing.T) {
 	ctx, tmpl, _, err := ctx.ResolveTemplate(&tmplHolder)
 	require.NoError(t, err)
 	wftmpl, ok := ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "base-workflow-template", wftmpl.Name)
 	assert.Equal(t, "whalesay", tmpl.Name)
 
@@ -276,9 +266,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Container)
@@ -289,9 +277,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "local-whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Steps)
@@ -302,9 +288,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "another-whalesay", tmpl.Name)
 	assert.NotNil(t, tmpl.Steps)
@@ -317,9 +301,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "whalesay-with-arguments", tmpl.Name)
 
@@ -331,9 +313,7 @@ func TestResolveTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplGetter, ok = ctx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "some-workflow-template", tmplGetter.GetName())
 	assert.Equal(t, "nested-whalesay-with-arguments", tmpl.Name)
 }
@@ -348,9 +328,7 @@ func TestWithTemplateBase(t *testing.T) {
 	// Get the template base of existing template name.
 	newCtx := ctx.WithTemplateBase(anotherWftmpl)
 	wftmpl, ok := newCtx.tmplBase.(*wfv1.WorkflowTemplate)
-	if !assert.True(t, ok) {
-		t.Fatal("tmplBase is not a WorkflowTemplate")
-	}
+	require.True(t, ok)
 	assert.Equal(t, "another-workflow-template", wftmpl.Name)
 }
 

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -582,10 +582,9 @@ func TestApplySubmitOpts(t *testing.T) {
 		wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"a": "0", "b": "0"}}}
 		err := ApplySubmitOpts(wf, &wfv1.SubmitOpts{Labels: "a=1"})
 		require.NoError(t, err)
-		if assert.Len(t, wf.GetLabels(), 2) {
-			assert.Equal(t, "1", wf.GetLabels()["a"])
-			assert.Equal(t, "0", wf.GetLabels()["b"])
-		}
+		require.Len(t, wf.GetLabels(), 2)
+		assert.Equal(t, "1", wf.GetLabels()["a"])
+		assert.Equal(t, "0", wf.GetLabels()["b"])
 	})
 	t.Run("InvalidParameters", func(t *testing.T) {
 		require.Error(t, ApplySubmitOpts(&wfv1.Workflow{}, &wfv1.SubmitOpts{Parameters: []string{"a"}}))
@@ -601,10 +600,9 @@ func TestApplySubmitOpts(t *testing.T) {
 		err := ApplySubmitOpts(wf, &wfv1.SubmitOpts{Parameters: []string{"a=81861780812"}})
 		require.NoError(t, err)
 		parameters := wf.Spec.Arguments.Parameters
-		if assert.Len(t, parameters, 1) {
-			assert.Equal(t, "a", parameters[0].Name)
-			assert.Equal(t, "81861780812", parameters[0].Value.String())
-		}
+		require.Len(t, parameters, 1)
+		assert.Equal(t, "a", parameters[0].Name)
+		assert.Equal(t, "81861780812", parameters[0].Value.String())
 	})
 	t.Run("PodPriorityClassName", func(t *testing.T) {
 		wf := &wfv1.Workflow{}
@@ -624,9 +622,8 @@ func TestReadParametersFile(t *testing.T) {
 	err = ReadParametersFile(file.Name(), opts)
 	require.NoError(t, err)
 	parameters := opts.Parameters
-	if assert.Len(t, parameters, 1) {
-		assert.Equal(t, "a=81861780812", parameters[0])
-	}
+	require.Len(t, parameters, 1)
+	assert.Equal(t, "a=81861780812", parameters[0])
 }
 
 func TestFormulateResubmitWorkflow(t *testing.T) {
@@ -1090,9 +1087,8 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
 		require.NoError(t, err)
-		if assert.Len(t, wf.Status.Nodes, 1) {
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes[""].Phase)
-		}
+		require.Len(t, wf.Status.Nodes, 1)
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes[""].Phase)
 	})
 	t.Run("Skipped and Suspended Nodes", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -1123,16 +1119,15 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=suspended", nil)
 		require.NoError(t, err)
-		if assert.Len(t, wf.Status.Nodes, 3) {
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["entrypoint"].Phase)
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["suspended"].Phase)
-			assert.Equal(t, wfv1.Parameter{
-				Name:      "param-1",
-				Value:     nil,
-				ValueFrom: &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}},
-			}, wf.Status.Nodes["suspended"].Outputs.Parameters[0])
-			assert.Equal(t, wfv1.NodeSkipped, wf.Status.Nodes["skipped"].Phase)
-		}
+		require.Len(t, wf.Status.Nodes, 3)
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["entrypoint"].Phase)
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["suspended"].Phase)
+		assert.Equal(t, wfv1.Parameter{
+			Name:      "param-1",
+			Value:     nil,
+			ValueFrom: &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}},
+		}, wf.Status.Nodes["suspended"].Outputs.Parameters[0])
+		assert.Equal(t, wfv1.NodeSkipped, wf.Status.Nodes["skipped"].Phase)
 	})
 	t.Run("Nested DAG with Non-group Node Selected", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -1155,12 +1150,11 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=3", nil)
 		require.NoError(t, err)
 		// Node #3, #4 are deleted and will be recreated so only 3 nodes left in wf.Status.Nodes
-		if assert.Len(t, wf.Status.Nodes, 3) {
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-1"].Phase)
-			// The parent group nodes should be running.
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
-		}
+		require.Len(t, wf.Status.Nodes, 3)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-1"].Phase)
+		// The parent group nodes should be running.
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["2"].Phase)
 	})
 	t.Run("Nested DAG without Node Selected", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -1183,13 +1177,12 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "", nil)
 		require.NoError(t, err)
 		// Node #2, #3, and #4 are deleted and will be recreated so only 2 nodes left in wf.Status.Nodes
-		if assert.Len(t, wf.Status.Nodes, 4) {
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-2"].Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-			assert.Equal(t, "", string(wf.Status.Nodes["4"].Phase))
-		}
+		require.Len(t, wf.Status.Nodes, 4)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["my-nested-dag-2"].Phase)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
+		assert.Equal(t, "", string(wf.Status.Nodes["4"].Phase))
 
 	})
 	t.Run("OverrideParams", func(t *testing.T) {
@@ -1319,13 +1312,12 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		wf, _, err = FormulateRetryWorkflow(ctx, wf, true, "id=4", nil)
 		require.NoError(t, err)
 		// Node #4 is deleted and will be recreated so only 4 nodes left in wf.Status.Nodes
-		if assert.Len(t, wf.Status.Nodes, 4) {
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["successful-workflow-2"].Phase)
-			// The parent group nodes should be running.
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-		}
+		require.Len(t, wf.Status.Nodes, 4)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["successful-workflow-2"].Phase)
+		// The parent group nodes should be running.
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["1"].Phase)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
 	})
 
 	t.Run("Retry continue on failed workflow", func(t *testing.T) {
@@ -1349,11 +1341,10 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
 		require.NoError(t, err)
-		if assert.Len(t, wf.Status.Nodes, 4) {
-			assert.Equal(t, wfv1.NodeFailed, wf.Status.Nodes["2"].Phase)
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
-			assert.Len(t, podsToDelete, 2)
-		}
+		require.Len(t, wf.Status.Nodes, 4)
+		assert.Equal(t, wfv1.NodeFailed, wf.Status.Nodes["2"].Phase)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
+		assert.Len(t, podsToDelete, 2)
 	})
 
 	t.Run("Retry continue on failed workflow with restartSuccessful and nodeFieldSelector", func(t *testing.T) {
@@ -1377,11 +1368,10 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, true, "id=3", nil)
 		require.NoError(t, err)
-		if assert.Len(t, wf.Status.Nodes, 2) {
-			assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
-			assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["continue-on-failed-workflow-2"].Phase)
-			assert.Len(t, podsToDelete, 4)
-		}
+		require.Len(t, wf.Status.Nodes, 2)
+		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
+		assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["continue-on-failed-workflow-2"].Phase)
+		assert.Len(t, podsToDelete, 4)
 	})
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13465 

### Motivation
Reduce unneeded nesting by changing `if assert.*` to `require.*`.

### Modifications
Updated tests where `if assert.*` is used to `require.*`

### Verification
Tests

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
