### PR TITLE
fix(controller): should fail if `dependencies` fail, despite `continueOn`

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -285,6 +285,48 @@ spec:
 		})
 }
 
+// TestDependenciesContinueOnFailDag similar with TestContinueOnFailDag
+// but continueOn is set on P task, wf should be failed
+func (s *FunctionalSuite) TestDependenciesContinueOnFailDag() {
+	s.Given().
+		Workflow(`
+metadata:
+  generateName: dependencies-continue-on-failed-dag-
+spec:
+  entrypoint: workflow-ignore
+  templates:
+    - name: workflow-ignore
+      dag:
+        failFast: false
+        tasks:
+          - name: F
+            template: fail
+          - name: P
+            template: pass
+            dependencies:
+              - F
+            continueOn:
+              failed: true
+
+    - name: pass
+      container:
+        image: argoproj/argosay:v2
+
+    - name: fail
+      container:
+        image: argoproj/argosay:v2
+        args: [ exit, "1" ]
+`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeFailed).
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("F").Phase)
+			assert.Equal(t, wfv1.NodeOmitted, status.Nodes.FindByDisplayName("P").Phase)
+		})
+}
+
 func (s *FunctionalSuite) TestVolumeClaimTemplate() {
 	s.Given().
 		Workflow(`@testdata/volume-claim-template-workflow.yaml`).

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -3201,7 +3201,7 @@ func TestLeafContinueOn(t *testing.T) {
 
 	ctx := context.Background()
 	woc.operate(ctx)
-	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
+	assert.Equal(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
 }
 
 var dagOutputsReferTaskAggregatedOuputs = `


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!-- Does this PR fix an issue -->

Fixes #13498 

### Motivation
if dependencies continueON task is fulFilled, maybe should not continue, we should consider failed phase
https://github.com/argoproj/argo-workflows/blob/ddbb3c7ad5b498d50514b3c1158ded56e333d75b/workflow/controller/dag.go#L196-L213

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

e2e test `TestDependenciesContinueOnFailDag `
