### PR TITLE
fix: provide fallback for 3.4 to 3.5 transition with absent `NodeFlag`. Fixes #12162

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -323,6 +323,32 @@ func IsDone(un *unstructured.Unstructured) bool {
 		un.GetLabels()[LabelKeyWorkflowArchivingStatus] != "Pending"
 }
 
+func CheckHookNode(nodeName string) bool {
+	names := strings.Split(nodeName, ".")
+	if len(names) == 2 {
+		return names[1] == "onExit"
+	}
+
+	if len(names) <= 2 {
+		return false
+	}
+
+	if names[len(names)-1] == "onExit" || names[len(names)-2] == "hooks" {
+		return true
+	}
+	return false
+}
+
+// Used to check if a child node is a retry type
+func CheckRetryNode(parentsMap map[string]*wfv1.NodeStatus, nodeID string) bool {
+	parent, found := parentsMap[nodeID]
+	if !found {
+		return false
+	}
+
+	return parent.Type == wfv1.NodeTypeRetry
+}
+
 // Check whether child hooked nodes Fulfilled
 func CheckAllHooksFullfilled(node *wfv1.NodeStatus, nodes wfv1.Nodes) bool {
 	childs := node.Children

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -323,6 +323,8 @@ func IsDone(un *unstructured.Unstructured) bool {
 		un.GetLabels()[LabelKeyWorkflowArchivingStatus] != "Pending"
 }
 
+// CheckHookNode is used to determine if
+// a node was a hook node via its name.
 func CheckHookNode(nodeName string) bool {
 	names := strings.Split(nodeName, ".")
 	if len(names) == 2 {
@@ -339,8 +341,9 @@ func CheckHookNode(nodeName string) bool {
 	return false
 }
 
-// Used to check if a child node is a retry type
-func CheckRetryNode(parentsMap map[string]*wfv1.NodeStatus, nodeID string) bool {
+// CheckRetryNodeParent determines if a node is a retriable node,
+// that is if the node is the child of a retry node.
+func CheckRetryNodeParent(parentsMap map[string]*wfv1.NodeStatus, nodeID string) bool {
 	parent, found := parentsMap[nodeID]
 	if !found {
 		return false

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -205,10 +205,6 @@ func (woc *wfOperationCtx) maybeUpgradeWithNodeFlags() {
 		}
 	}
 
-	// Can be merged in with the previous loop.
-	// Merging wouldn't impact performance in a significant enough way.
-	// In fact this might be more performant thanks to better branch prediction
-	// in the previous loop.
 	for key, node := range woc.wf.Status.Nodes {
 		newNode := node
 		if common.CheckHookNode(node.Name) {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -181,7 +181,7 @@ func newWorkflowOperationCtx(wf *wfv1.Workflow, wfc *WorkflowController) *wfOper
 	return &woc
 }
 
-// Determines if this workflow is definitely after the introduction of
+// definitePostNodeFlagsWf determines if this workflow is definitely after the introduction of
 // the NodeFlag field.
 // used to avoid the O(n*m) loop in maybeUpgradeWithNodeFlags
 func (woc *wfOperationCtx) definitePostNodeFlagsWf() bool {
@@ -193,8 +193,9 @@ func (woc *wfOperationCtx) definitePostNodeFlagsWf() bool {
 	return false
 }
 
+// maybeUpgradeWithNodeFlags upgrades old workflows without
+// NodeFlag fields into ones with.
 func (woc *wfOperationCtx) maybeUpgradeWithNodeFlags() {
-
 	parentsMap := make(map[string]*wfv1.NodeStatus)
 
 	for _, node := range woc.wf.Status.Nodes {
@@ -214,7 +215,7 @@ func (woc *wfOperationCtx) maybeUpgradeWithNodeFlags() {
 			newNode.NodeFlag = &wfv1.NodeFlag{Hooked: true}
 		}
 
-		if common.CheckRetryNode(parentsMap, node.ID) {
+		if common.CheckRetryNodeParent(parentsMap, node.ID) {
 			if newNode.NodeFlag == nil {
 				newNode.NodeFlag = &wfv1.NodeFlag{}
 			}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -181,6 +181,49 @@ func newWorkflowOperationCtx(wf *wfv1.Workflow, wfc *WorkflowController) *wfOper
 	return &woc
 }
 
+// Determines if this workflow is definitely after the introduction of
+// the NodeFlag field.
+// used to avoid the O(n*m) loop in maybeUpgradeWithNodeFlags
+func (woc *wfOperationCtx) definitePostNodeFlagsWf() bool {
+	for _, node := range woc.wf.Status.Nodes {
+		if node.NodeFlag != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (woc *wfOperationCtx) maybeUpgradeWithNodeFlags() {
+
+	parentsMap := make(map[string]*wfv1.NodeStatus)
+
+	for _, node := range woc.wf.Status.Nodes {
+		node := node
+		for _, childNodeID := range node.Children {
+			parentsMap[childNodeID] = &node
+		}
+	}
+
+	// Can be merged in with the previous loop.
+	// Merging wouldn't impact performance in a significant enough way.
+	// In fact this might be more performant thanks to better branch prediction
+	// in the previous loop.
+	for key, node := range woc.wf.Status.Nodes {
+		newNode := node
+		if common.CheckHookNode(node.Name) {
+			newNode.NodeFlag = &wfv1.NodeFlag{Hooked: true}
+		}
+
+		if common.CheckRetryNode(parentsMap, node.ID) {
+			if newNode.NodeFlag == nil {
+				newNode.NodeFlag = &wfv1.NodeFlag{}
+			}
+			newNode.NodeFlag.Retried = true
+		}
+		woc.wf.Status.Nodes[key] = newNode
+	}
+}
+
 // operate is the main operator logic of a workflow. It evaluates the current state of the workflow,
 // and its pods and decides how to proceed down the execution path.
 // TODO: an error returned by this method should result in requeuing the workflow to be retried at a
@@ -203,6 +246,10 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 			woc.controller.metrics.OperationPanic()
 		}
 	}()
+
+	if !woc.definitePostNodeFlagsWf() {
+		woc.maybeUpgradeWithNodeFlags()
+	}
 
 	woc.log.WithFields(log.Fields{"Phase": woc.wf.Status.Phase, "ResourceVersion": woc.wf.ObjectMeta.ResourceVersion}).Info("Processing workflow")
 
@@ -1872,7 +1919,7 @@ type executeTemplateOpts struct {
 // nodeName is the name to be used as the name of the node, and boundaryID indicates which template
 // boundary this node belongs to.
 func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string, orgTmpl wfv1.TemplateReferenceHolder, tmplCtx *templateresolution.Context, args wfv1.Arguments, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
-	woc.log.Debugf("Evaluating node %s: template: %s, boundaryID: %s", nodeName, common.GetTemplateHolderString(orgTmpl), opts.boundaryID)
+	woc.log.Debugf("Evaluating node %s: template: %s, boundaryID: %s, stack depth: %d", nodeName, common.GetTemplateHolderString(orgTmpl), opts.boundaryID, woc.currentStackDepth)
 
 	// Set templateScope from which the template resolution starts.
 	templateScope := tmplCtx.GetTemplateScope()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12162 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
