### PR TITLE
fix(docs): use `sh` instead of `bash` with `busybox`

### DIFF
--- a/examples/work-avoidance.yaml
+++ b/examples/work-avoidance.yaml
@@ -65,7 +65,7 @@ spec:
       script:
         image: busybox
         command:
-          - bash
+          - sh
           - -eux
         source: |
           marker=/work/markers/$(date +%Y-%m-%d)-echo-{{inputs.parameters.num}}


### PR DESCRIPTION
<!-- Does this PR fix an issue -->
create `examples/work-avoidance.yaml` 
echo pod occur error:
```
Error: failed to find name in PATH: exec: "bash": executable file not found in $PATH
```

### Motivation

use `sh` instead of `bash`

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
