### PR TITLE
fix: remove non-transient logs on missing `artifact-repositories` configmap

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -23,12 +23,31 @@ func IgnoreContainerNotFoundErr(err error) error {
 	return err
 }
 
+// IsTransientErr reports whether the error is transient and logs it.
 func IsTransientErr(err error) bool {
+	isTransient := IsTransientErrQuiet(err)
+	if !isTransient {
+		log.Warnf("Non-transient error: %v", err)
+	}
+	return isTransient
+}
+
+// IsTransientErrQuiet reports whether the error is transient and logs only if it is.
+func IsTransientErrQuiet(err error) bool {
+	isTransient := isTransientErr(err)
+	if isTransient {
+		log.Infof("Transient error: %v", err)
+	}
+	return isTransient
+}
+
+// isTransientErr reports whether the error is transient.
+func isTransientErr(err error) bool {
 	if err == nil {
 		return false
 	}
 	err = argoerrs.Cause(err)
-	isTransient := isExceededQuotaErr(err) ||
+	return isExceededQuotaErr(err) ||
 		apierr.IsTooManyRequests(err) ||
 		isResourceQuotaConflictErr(err) ||
 		isResourceQuotaTimeoutErr(err) ||
@@ -39,12 +58,6 @@ func IsTransientErr(err error) bool {
 		matchTransientErrPattern(err) ||
 		errors.Is(err, NewErrTransient("")) ||
 		isTransientSqbErr(err)
-	if isTransient {
-		log.Infof("Transient error: %v", err)
-	} else {
-		log.Warnf("Non-transient error: %v", err)
-	}
-	return isTransient
 }
 
 func matchTransientErrPattern(err error) bool {

--- a/workflow/artifactrepositories/artifactrepositories.go
+++ b/workflow/artifactrepositories/artifactrepositories.go
@@ -90,7 +90,7 @@ func (s *artifactRepositories) get(ctx context.Context, ref *wfv1.ArtifactReposi
 	err := waitutil.Backoff(retry.DefaultRetry, func() (bool, error) {
 		var err error
 		cm, err = s.kubernetesInterface.CoreV1().ConfigMaps(namespace).Get(ctx, configMap, metav1.GetOptions{})
-		return !errorsutil.IsTransientErr(err), err
+		return !errorsutil.IsTransientErrQuiet(err), err
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #9085.

### Motivation

Remove high levels of error messages that aren't errors. Reduce additional observability costs associated with running Argo Workflows, although negligble.

Clarify the difference between side-effect and non-side-effect functions in utility module.

### Modifications

Renames `IsTransientErr` to `LogIsTransientErr`, which is easily undoable if it's more noise than signal.

Introduces a `LogOnlyTransientErr`, which only logs errors if they're transient. Suitable for a use-case such as trying to fetch an object that doesn't exist when it's optional.

### Verification

No verification performed due to the (deceptive) simplicity of the change.
