### PR TITLE
docs: add `workflow_archive_queue` to metrics docs

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -336,10 +336,11 @@ The rate of this shows how busy that area of the controller is.
 
 Queues:
 
-- `workflow_queue`: the queue of Workflow updates from the cluster
 - `cron_wf_queue`: the queue of CronWorkflow updates from the cluster
-- `workflow_ttl_queue`: workflows which are queued for deletion due to age
 - `pod_cleanup_queue`: pods which are queued for deletion
+- `workflow_queue`: the queue of Workflow updates from the cluster
+- `workflow_ttl_queue`: workflows which are queued for deletion due to age
+- `workflow_archive_queue`: workflows which are queued for archiving
 
 This and associated metrics are all directly sourced from the [client-go workqueue metrics](https://godocs.io/k8s.io/client-go/util/workqueue)
 


### PR DESCRIPTION
Add workflow_archive_queue to metrics documentation and sort the list alphabetically.

This was introduced in #13418.
