### PR TITLE
docs(contrib): add note for `signal_darwin` error

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -205,6 +205,7 @@ sandboxed
 shortcodes
 stateful
 stderr
+symlinks
 temporality
 triaged
 un-reconciled

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -108,6 +108,8 @@ You can use the `TARGET_PLATFORM` environment variable to compile images for spe
 make argoexec-image TARGET_PLATFORM=linux/arm64,linux/amd64
 ```
 
+!!! Note "expected 'package', found signal..." If you see this error, you need to set git `core.symlinks=true`, just run `git config --global core.symlinks true` or `git -c core.symlinks=true clone`.
+
 To also start the API on <http://localhost:2746>:
 
 ```bash

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -108,7 +108,9 @@ You can use the `TARGET_PLATFORM` environment variable to compile images for spe
 make argoexec-image TARGET_PLATFORM=linux/arm64,linux/amd64
 ```
 
-!!! Note "expected 'package', found signal..." If you see this error, you need to set git `core.symlinks=true`, just run `git config --global core.symlinks true` or `git -c core.symlinks=true clone`.
+!!! Note "Error `expected 'package', found signal_darwin`"
+    You may see this error if symlinks are not configured for your `git` installation.
+    Run `git config core.symlinks true` to correct this.
 
 To also start the API on <http://localhost:2746>:
 


### PR DESCRIPTION
<!-- Does this PR fix an issue -->
add docs note for `make argoexec-image`, if git core.symlinks disable, it may occur error `signal_darwin`

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
