### PR TITLE
fix(cli): check for completion if `finishedAt` unset during `wait`

### DIFF
--- a/cmd/argo/commands/common/wait.go
+++ b/cmd/argo/commands/common/wait.go
@@ -69,7 +69,16 @@ func waitOnOne(serviceClient workflowpkg.WorkflowServiceClient, ctx context.Cont
 			continue
 		}
 		wf := event.Object
-		if wf != nil && !wf.Status.FinishedAt.IsZero() {
+
+		isWorkflowInTerminalState := func(wf *wfv1.Workflow) bool {
+			if !wf.Status.FinishedAt.IsZero() {
+				return true
+			} else {
+				return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError || wf.Status.Phase == wfv1.WorkflowSucceeded
+			}
+		}
+
+		if wf != nil && isWorkflowInTerminalState(wf) {
 			if !quiet {
 				fmt.Printf("%s %s at %v\n", wfName, wf.Status.Phase, wf.Status.FinishedAt)
 			}

--- a/cmd/argo/commands/common/wait.go
+++ b/cmd/argo/commands/common/wait.go
@@ -70,15 +70,7 @@ func waitOnOne(serviceClient workflowpkg.WorkflowServiceClient, ctx context.Cont
 		}
 		wf := event.Object
 
-		isWorkflowInTerminalState := func(wf *wfv1.Workflow) bool {
-			if !wf.Status.FinishedAt.IsZero() {
-				return true
-			} else {
-				return wf.Status.Phase == wfv1.WorkflowFailed || wf.Status.Phase == wfv1.WorkflowError || wf.Status.Phase == wfv1.WorkflowSucceeded
-			}
-		}
-
-		if wf != nil && isWorkflowInTerminalState(wf) {
+		if wf != nil && wf.Status.Phase.Completed() {
 			if !quiet {
 				fmt.Printf("%s %s at %v\n", wfName, wf.Status.Phase, wf.Status.FinishedAt)
 			}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13550 

### Motivation

Described in the issue #13550

### Modifications

Changed wait to rely on workflow phase, in addition to finishedAt field

### Verification

Tested locally on various worklfows

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
