### PR TITLE
fix: ignore error when input artifacts optional. Fixes:#13564

### DIFF
--- a/workflow/controller/scope.go
+++ b/workflow/controller/scope.go
@@ -144,7 +144,11 @@ func (s *wfScope) resolveArtifact(art *wfv1.Artifact) (*wfv1.Artifact, error) {
 			return copyArt, errors.New(errors.CodeBadRequest, "failed to unmarshal artifact subpath for templating")
 		}
 
-		return copyArt, copyArt.AppendToKey(resolvedSubPath)
+		err = copyArt.AppendToKey(resolvedSubPath)
+		if err != nil && copyArt.Optional { //Ignore error when artifact optional
+			return copyArt, nil
+		}
+		return copyArt, err
 	}
 
 	return &valArt, nil

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -315,3 +315,133 @@ func TestOptionalArgumentAndParameter(t *testing.T) {
 	woc.operate(ctx)
 	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 }
+
+var artifactResolutionWhenOptionalAndSubpath = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: artifact-passing-subpath-rx7f4
+spec:
+  entrypoint: artifact-example
+  templates:
+  - name: artifact-example
+    steps:
+    - - name: hello-world-to-file
+        template: hello-world-to-file
+    - - name: hello-world-to-file2
+        template: hello-world-to-file2
+        arguments:
+          artifacts:
+          - name: bar
+            from: "{{steps.hello-world-to-file.outputs.artifacts.foo}}"
+            optional: true
+            subpath: bar.txt
+        withParam: "[0, 1]"
+
+  - name: hello-world-to-file
+    container:
+      image: busybox:latest
+      imagePullPolicy: IfNotPresent
+      command: [sh, -c]
+      args: ["sleep 1; echo hello world"]
+    outputs:
+      artifacts:
+      - name: foo
+        path: /tmp/foo
+        optional: true
+        archive:
+          none: {}
+
+  - name: hello-world-to-file2
+    inputs:
+      artifacts:
+      - name: bar
+        path: /tmp/bar.txt
+        optional: true
+        archive:
+          none: {}
+    container:
+      image: busybox:latest
+      imagePullPolicy: IfNotPresent
+      command: [sh, -c]
+      args: ["sleep 1; echo hello world"]
+status:
+  nodes:
+    artifact-passing-subpath-rx7f4:
+      children:
+      - artifact-passing-subpath-rx7f4-1763046061
+      displayName: artifact-passing-subpath-rx7f4
+      id: artifact-passing-subpath-rx7f4
+      name: artifact-passing-subpath-rx7f4
+      phase: Running
+      progress: 1/1
+      resourcesDuration:
+        cpu: 0
+        memory: 5
+      startedAt: "2024-09-06T04:53:32Z"
+      templateName: artifact-example
+      templateScope: local/artifact-passing-subpath-rx7f4
+      type: Steps
+    artifact-passing-subpath-rx7f4-511855021:
+      boundaryID: artifact-passing-subpath-rx7f4
+      children:
+      - artifact-passing-subpath-rx7f4-1696082680
+      displayName: hello-world-to-file
+      finishedAt: "2024-09-06T04:53:39Z"
+      id: artifact-passing-subpath-rx7f4-511855021
+      name: artifact-passing-subpath-rx7f4[0].hello-world-to-file
+      outputs:
+        artifacts:
+        - archive:
+            none: {}
+          name: foo
+          optional: true
+          path: /tmp/foo
+        - name: main-logs
+          s3:
+            key: artifact-passing-subpath-rx7f4/artifact-passing-subpath-rx7f4-hello-world-to-file-511855021/main.log
+        exitCode: "0"
+      phase: Succeeded
+      progress: 1/1
+      resourcesDuration:
+        cpu: 0
+        memory: 5
+      startedAt: "2024-09-06T04:53:32Z"
+      templateName: hello-world-to-file
+      templateScope: local/artifact-passing-subpath-rx7f4
+      type: Pod
+    artifact-passing-subpath-rx7f4-1763046061:
+      boundaryID: artifact-passing-subpath-rx7f4
+      children:
+      - artifact-passing-subpath-rx7f4-511855021
+      displayName: '[0]'
+      finishedAt: "2024-09-06T04:53:41Z"
+      id: artifact-passing-subpath-rx7f4-1763046061
+      name: artifact-passing-subpath-rx7f4[0]
+      nodeFlag: {}
+      phase: Succeeded
+      progress: 1/1
+      resourcesDuration:
+        cpu: 0
+        memory: 5
+      startedAt: "2024-09-06T04:53:32Z"
+      templateScope: local/artifact-passing-subpath-rx7f4
+      type: StepGroup
+  phase: Running
+  taskResultsCompletionStatus:
+    artifact-passing-subpath-rx7f4-511855021: true`
+
+func TestOptionalArgumentUseSubPathInLoop(t *testing.T) {
+	cancel, controller := newController()
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	ctx := context.Background()
+	wf := wfv1.MustUnmarshalWorkflow(artifactResolutionWhenOptionalAndSubpath)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(wf, controller)
+
+	woc.operate(ctx)
+	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Fixed the problem of workflow failure when using optional Artifacts and containing subpaths and loops.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes: #13564 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
