### PR TITLE
fix(test): Remove `\c` from echo string.

### DIFF
--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -50,11 +50,11 @@ func TestEmissary(t *testing.T) {
 	})
 	t.Run("Sub-process", func(t *testing.T) {
 		_ = os.Remove(varRunArgo + "/ctr/main/stdout")
-		err := run(`(sleep 60; echo 'should not wait for sub-process')& echo "hello\c"`)
+		err := run(`(sleep 60; echo 'should not wait for sub-process')& echo "hello"`)
 		require.NoError(t, err)
 		data, err := os.ReadFile(varRunArgo + "/ctr/main/stdout")
 		require.NoError(t, err)
-		assert.Equal(t, "hello", string(data))
+		assert.Equal(t, "hello\n", string(data))
 	})
 	t.Run("Combined", func(t *testing.T) {
 		err := run("echo hello > /dev/stderr")

--- a/workflow/executor/os-specific/command_test.go
+++ b/workflow/executor/os-specific/command_test.go
@@ -17,7 +17,7 @@ func TestSimpleStartCloser(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		shell = "pwsh.exe"
 	}
-	cmd := exec.Command(shell, "-c", `echo "A123456789B123456789C123456789D123456789E123456789\c"`)
+	cmd := exec.Command(shell, "-c", `echo "A123456789B123456789C123456789D123456789E123456789"`)
 	var stdoutWriter bytes.Buffer
 	slowWriter := SlowWriter{
 		&stdoutWriter,
@@ -34,9 +34,9 @@ func TestSimpleStartCloser(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	closer()
 
-	expected := "A123456789B123456789C123456789D123456789E123456789"
+	expected := "A123456789B123456789C123456789D123456789E123456789\n"
 	if runtime.GOOS == "windows" {
-		expected = "A123456789B123456789C123456789D123456789E123456789\\c\r\n"
+		expected = "A123456789B123456789C123456789D123456789E123456789\r\n"
 	}
 	assert.Equal(t, expected, stdoutWriter.String())
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13565

### Motivation

`echo` in CentOS's built-in sh does not support the escape character  `\c`, causing `make test` to fail.

CentOS 8.5
```shell
# uname -a
Linux VM-0-17-centos 4.18.0-348.7.1.el8_5.x86_64 #1 SMP Wed Dec 22 13:25:12 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux

# sh -c 'echo "hello\c"'
hello\c
```

### Modifications

Remove `\c` from echo string.

### Verification

`make test` in different os.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
