### PR TITLE
docs(artifacts): notate OSS as streaming capable in v3.6+

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -623,7 +623,7 @@ configuring the default artifact repository described previously.
 ## Artifact Streaming
 
 With artifact streaming, artifacts don’t need to be saved to disk first. Artifact streaming is only supported in the following
-artifact drivers: S3 (v3.4+), Azure Blob (v3.4+), HTTP (v3.5+), and Artifactory (v3.5+).
+artifact drivers: S3 (v3.4+), Azure Blob (v3.4+), HTTP (v3.5+), Artifactory (v3.5+), and OSS (v3.6+).
 
 Previously, when a user would click the button to download an artifact in the UI, the artifact would need to be written to the
 Argo Server’s disk first before downloading. If many users tried to download simultaneously, they would take up


### PR DESCRIPTION
Missing documentation update from #12908.

Just add `OSS` as streaming capable in v3.6+.
