### PR TITLE
chore(test): increase executor memory

### DIFF
--- a/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
+++ b/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
@@ -13,7 +13,7 @@ data:
     resources:
       requests:
         cpu: 0.1
-        memory: 128Mi
+        memory: 64Mi
       limits:
         cpu: 0.5
         memory: 256Mi

--- a/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
+++ b/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
@@ -13,10 +13,10 @@ data:
     resources:
       requests:
         cpu: 0.1
-        memory: 64Mi
+        memory: 128Mi
       limits:
         cpu: 0.5
-        memory: 128Mi
+        memory: 256Mi
   retentionPolicy: |
     completed: 10
     failed: 2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation
The executor constantly OOMs locally for me when I run with `make start UI=true`. This increases the memory limits to reduce this from happening.

### Modifications
Increase the memory limits in the controller's configmap.

### Verification

Tested with `kubectl get configmaps` to make sure executor memory limits increased.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
