### PR TITLE
feat: use container name as archive log key

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -912,6 +913,20 @@ func (s *FunctionalSuite) TestOutputArtifactS3BucketCreationEnabled() {
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded)
+}
+
+func (s *FunctionalSuite) TestArchiveContainerTypeTmplLogs() {
+	s.Given().
+		Workflow("@testdata/archive-container-type-tmpl-logs.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectWorkflow(func(t *testing.T, meta *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			assert.Equal(t, "hello-world-logs", status.Nodes[meta.Name].Outputs.Artifacts[0].Name)
+			assert.Equal(t, fmt.Sprintf("%s/%s/hello-world.log", meta.Name, meta.Name), status.Nodes[meta.Name].Outputs.Artifacts[0].S3.Key)
+		})
 }
 
 func (s *FunctionalSuite) TestDataTransformation() {

--- a/test/e2e/testdata/archive-container-type-tmpl-logs.yaml
+++ b/test/e2e/testdata/archive-container-type-tmpl-logs.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: archive-container-type-tmpl-logs-
+spec:
+  entrypoint: hello-world
+  templates:
+    - name: hello-world
+      container:
+        name: hello-world
+        image: busybox
+        command: [echo]
+        args: ["hello world"]
+      archiveLocation:
+        archiveLogs: true

--- a/ui/src/shared/services/workflows-service.ts
+++ b/ui/src/shared/services/workflows-service.ts
@@ -262,7 +262,7 @@ export const WorkflowsService = {
         // return archived log if main container is finished and has artifact
         return from(this.isWorkflowNodePendingOrRunning(workflow, nodeId)).pipe(
             switchMap(isPendingOrRunning => {
-                if (!isPendingOrRunning && hasArtifactLogs(workflow, nodeId, container) && container === 'main') {
+                if (!isPendingOrRunning && hasArtifactLogs(workflow, nodeId, container)) {
                     return getLogsFromArtifact().pipe(catchError(getLogsFromCluster));
                 }
                 return getLogsFromCluster().pipe(catchError(getLogsFromArtifact));


### PR DESCRIPTION
<!-- Does this PR fix an issue -->
Fixes #13590

### Motivation

if tmpl type is `Container` and container.Name not empty,  use container name as artifact log file name

### Verification

e2e test

