### PR TITLE
feat: Set `steps.*.ip` to a json list if the node is an aggregate

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -139,8 +139,8 @@ sprig.trim(inputs.parameters['my-string-param'])
 | Variable | Description|
 |----------|------------|
 | `steps.name` | Name of the step |
-| `steps.<STEPNAME>.id` | unique id of container step |
-| `steps.<STEPNAME>.ip` | IP address of a previous daemon container step |
+| `steps.<STEPNAME>.id` | unique id of container step. |
+| `steps.<STEPNAME>.ip` | IP address of a previous daemon container step. When the previous step uses `withItems` or `withParams`, this contains a JSON array of the IP's of each invocation |
 | `steps.<STEPNAME>.status` | Phase status of any previous step |
 | `steps.<STEPNAME>.exitCode` | Exit code of any previous script or container step |
 | `steps.<STEPNAME>.startedAt` | Time-stamp when the step started |

--- a/docs/walk-through/daemon-containers.md
+++ b/docs/walk-through/daemon-containers.md
@@ -76,3 +76,5 @@ spec:
 ```
 
 Step templates use the `steps` prefix to refer to another step: for example `{{steps.influx.ip}}`. In DAG templates, the `tasks` prefix is used instead: for example `{{tasks.influx.ip}}`.
+
+If the step or task uses `withSequence`, `withItems`, or `withParam`, then this will instead be set to a JSON list of IP addresses.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/13614

### Motivation

<!-- TODO: Say why you made your changes. -->

See https://github.com/argoproj/argo-workflows/issues/13614

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Aggregate nodes of demonized steps/tasks now have the `ip` field set to a JSON list of the pod IPs.

Docs have been updated to note this fact.

### Verification

<!-- TODO: Say how you tested your changes. -->

An e2e test has been added in which a set of nginx damon pods are created and then curl'ed, one each for withSequence/Items/Param. I noticed there was no test for the original single pod ip functionality, so I added a test for it as well to confirm this did not break it.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
