### PR TITLE
build: ensure Makefile driven dependencies are up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ ui/dist/app/index.html: $(shell find ui/src -type f && find ui -maxdepth 1 -type
 	# `yarn build` is slow, so we guard it with a up-to-date check.
 	JOBS=max yarn --cwd ui build
 
-$(GOPATH)/bin/staticfiles:
+$(GOPATH)/bin/staticfiles: Makefile
 # update this in Nix when updating it here
 ifneq ($(USE_NIX), true)
 	go install bou.ke/staticfiles@dd04075
@@ -290,59 +290,59 @@ swagger: \
 	api/jsonschema/schema.json
 
 
-$(GOPATH)/bin/mockery:
+$(GOPATH)/bin/mockery: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install github.com/vektra/mockery/v2@v2.42.2
 endif
-$(GOPATH)/bin/controller-gen:
+$(GOPATH)/bin/controller-gen: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
 endif
-$(GOPATH)/bin/go-to-protobuf:
+$(GOPATH)/bin/go-to-protobuf: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	# TODO: currently fails on v0.30.3 with
 	# Unable to clean package k8s.io.api.core.v1: remove /home/runner/go/pkg/mod/k8s.io/api@v0.30.3/core/v1/generated.proto: permission denied
 	go install k8s.io/code-generator/cmd/go-to-protobuf@v0.21.5
 endif
-$(GOPATH)/src/github.com/gogo/protobuf:
+$(GOPATH)/src/github.com/gogo/protobuf: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	[ -e $(GOPATH)/src/github.com/gogo/protobuf ] || git clone --depth 1 https://github.com/gogo/protobuf.git -b v1.3.2 $(GOPATH)/src/github.com/gogo/protobuf
+	[ -e $@ ] || git clone --depth 1 https://github.com/gogo/protobuf.git -b v1.3.2 $@
 endif
-$(GOPATH)/bin/protoc-gen-gogo:
+$(GOPATH)/bin/protoc-gen-gogo: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install github.com/gogo/protobuf/protoc-gen-gogo@v1.3.2
 endif
-$(GOPATH)/bin/protoc-gen-gogofast:
+$(GOPATH)/bin/protoc-gen-gogofast: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install github.com/gogo/protobuf/protoc-gen-gogofast@v1.3.2
 endif
-$(GOPATH)/bin/protoc-gen-grpc-gateway:
+$(GOPATH)/bin/protoc-gen-grpc-gateway: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v1.16.0
 endif
-$(GOPATH)/bin/protoc-gen-swagger:
+$(GOPATH)/bin/protoc-gen-swagger: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@v1.16.0
 endif
-$(GOPATH)/bin/openapi-gen:
+$(GOPATH)/bin/openapi-gen: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20220124234850-424119656bbf
 endif
-$(GOPATH)/bin/swagger:
+$(GOPATH)/bin/swagger: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0
 endif
-$(GOPATH)/bin/goimports:
+$(GOPATH)/bin/goimports: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	go install golang.org/x/tools/cmd/goimports@v0.1.7
@@ -354,7 +354,7 @@ ifeq ($(shell uname),Darwin)
 	brew install clang-format
 else
 	sudo apt update
-	sudo apt install clang-format
+	sudo apt install -y clang-format
 endif
 endif
 
@@ -445,7 +445,7 @@ dist/manifests/%: manifests/%
 
 # lint/test/etc
 
-$(GOPATH)/bin/golangci-lint:
+$(GOPATH)/bin/golangci-lint: Makefile
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.61.0
 
 .PHONY: lint
@@ -523,7 +523,7 @@ dist/argosay:
 	cp test/e2e/images/argosay/v2/argosay dist/
 
 .PHONY: kit
-kit:
+kit: Makefile
 ifeq ($(shell command -v kit),)
 ifeq ($(shell uname),Darwin)
 	brew tap kitproj/kit --custom-remote https://github.com/kitproj/kit
@@ -637,9 +637,11 @@ pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go: $(TYPES)
 	# Delete the link
 	[ -e ./v3 ] && rm -rf v3
 
-dist/kubernetes.swagger.json:
+dist/kubernetes.swagger.json: Makefile
 	@mkdir -p dist
-	./hack/recurl.sh dist/kubernetes.swagger.json https://raw.githubusercontent.com/kubernetes/kubernetes/v1.30.3/api/openapi-spec/swagger.json
+	# recurl will only fetch if the file doesn't exist, so delete it
+	rm -f $@
+	./hack/recurl.sh $@ https://raw.githubusercontent.com/kubernetes/kubernetes/v1.30.3/api/openapi-spec/swagger.json
 
 pkg/apiclient/_.secondary.swagger.json: hack/api/swagger/secondaryswaggergen.go pkg/apis/workflow/v1alpha1/openapi_generated.go dist/kubernetes.swagger.json
 	rm -Rf v3 vendor
@@ -684,7 +686,7 @@ docs/cli/argo.md: $(CLI_PKG_FILES) go.sum server/static/files.go hack/docs/cli.g
 
 # docs
 
-/usr/local/bin/mdspell:
+/usr/local/bin/mdspell: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
 	npm list -g markdown-spellcheck@1.3.1 > /dev/null || npm i -g markdown-spellcheck@1.3.1


### PR DESCRIPTION
# Motivation

As a developer when the Makefile changes the version of a program that it uses or another dependency I would like to use the new version of that program or dependency

Created in response to https://cloud-native.slack.com/archives/C0510EUH90V/p1726666701563199

# Modifications

For all make targets that specify their version in the Makefile specify the Makefile as a dependency so they will get refetched if the Makefile changes. This is crude as it will refetch all dependencies regardless of whether they have changed or not, so touching the Makefile will cause a slower rebuild. Correctness trumps speed here in my opinion.

Add `-y` to the `apt get` call installing clang-format so that it becomes non-interactive. It's annoying to have to type `y` when this runs anyway.

Use the special Makefile variable `$@` instead of repeating the target name explicitly in the rules I was touching where it was relevant - following the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle.

Most annoyingly `recurl.sh` doesn't do any work if the target file exists, so remove the file before fetching in the case where that is used so we get an updated version. This foxed me for a while as this was the file causing the original issue linked above in slack.

# Verification

Locally `make codegen` successfully on a dirty checkout which had run codegen prior to https://github.com/argoproj/argo-workflows/pull/13413. 

# Notes to approvers

This is pushed to argoproj so you can make direct edits if you feel that's appropriate for collective ownership of fixing this.

Signed-off-by: Alan Clucas <alan@clucas.org>