### PR TITLE
test: fix HttpHandler test

### DIFF
--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -851,7 +851,7 @@ spec:
           template: http
     - name: http
       http:
-        url: http://dummy.restapiexample.com/api/v1/employees
+        url: https://github.com/
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted).

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -851,7 +851,7 @@ spec:
           template: http
     - name: http
       http:
-        url: https://github.com/
+        url: http://httpbin:9100/get
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted).


### PR DESCRIPTION
`http://dummy.restapiexample.com/api/v1/employees` is called as a test endpoint in this test and must respond 2xx for this test to pass. It is offline, so switch to `https://github.com`.

If github is offline we're probably not running CI anyway.

Signed-off-by: Alan Clucas <alan@clucas.org>