### PR TITLE
docs: fix metrics page admonitions and other tidying

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,8 +1,8 @@
-# Prometheus Metrics
+# Metrics
 
 > v2.7 and after
 
-!!! Metrics changes in 3.6
+!!! Warning "Metrics changes in 3.6"
     Please read [this short guide](upgrading.md#metrics-changes) on what you must consider when upgrading to 3.6.
 
 ## Introduction
@@ -197,10 +197,12 @@ Metrics for the [Four Golden Signals](https://sre.google/sre-book/monitoring-dis
 - Errors: `count` and `error_count`
 - Saturation: `workers_busy` and `workflow_condition`
 
-!!! High cardinality
+!!! Warning "High cardinality"
     Some metric attributes may have high cardinality and are marked with ⚠️ to warn you. You may need to disable this metric or disable the attribute.
+
 <!-- titles should be the exact metric name for deep-linking, alphabetical ordered -->
 <!-- titles are without argo_workflows prefix -->
+
 #### `cronworkflows_concurrencypolicy_triggered`
 
 A counter of the number of times a CronWorkflow has triggered its `concurrencyPolicy` to limit the number of workflows running.

--- a/docs/workflow-creator.md
+++ b/docs/workflow-creator.md
@@ -11,10 +11,10 @@ metadata:
   name: my-wf
   labels:
     workflows.argoproj.io/creator: admin
-    # labels must be DNS formatted, so the "@" is replaces by '.at.'  
+    # labels must be DNS formatted, so the "@" is replaces by '.at.'
     workflows.argoproj.io/creator-email: admin.at.your.org
     workflows.argoproj.io/creator-preferred-username: admin-preferred-username
 ```
 
-!!! NOTE
+!!! Note
     Labels only contain `[-_.0-9a-zA-Z]`, so any other characters will be turned into `-`.


### PR DESCRIPTION
Tidies metrics page

### Motivation

The metrics page doesn't do material admonitions correctly

Also addressing a couple of other issues on that page.
![image](https://github.com/user-attachments/assets/2fb62106-3716-4835-926a-211fb6bad28e)


### Modifications

Title of metrics page changed from `Prometheus Metrics` to just `Metrics` to show it's new role

Two badly done !!! sections fixed, one shown above. Also modified `workflow-creator.md` to change NOTE->Note to match style of the rest of the !!! admonitions

Added spacing around markdown comment as requested before.

### Verification

Ran `make docs` and viewed both pages to ensure they looked correct at all changed points.