### PR TITLE
docs(contrib): add notes on handling merge conflicts during backports

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -115,6 +115,7 @@ Traefik
 Triaging
 TripAdvisor
 UI
+Un-pin
 VSCode
 Valasek
 Webhooks

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,9 +10,7 @@ Then get a list of commits you may want to cherry-pick:
 
 ```bash
 ./hack/cherry-pick.sh release-3.3 "fix"
-./hack/cherry-pick.sh release-3.3 "chore(deps)"
-./hack/cherry-pick.sh release-3.3 "build"
-./hack/cherry-pick.sh release-3.3 "ci"
+./hack/cherry-pick.sh release-3.3 "docs"
 ```
 
 To automatically cherry-pick, run the following:
@@ -21,14 +19,22 @@ To automatically cherry-pick, run the following:
 ./hack/cherry-pick.sh release-3.3 "fix" false
 ```
 
-Then look for "failed to cherry-pick" in the log to find commits that fail to be cherry-picked and decide if a
-manual patch is necessary.
-
 Ignore:
 
 * Fixes for features only on `main`.
 * Dependency upgrades, unless they fix known security issues.
 * Build or CI improvements, unless the release pipeline is blocked without them.
+
+### Merge Conflicts
+
+Then look for `failed to cherry-pick` in the log to find commits with merge conflicts and decide if a manual patch is necessary.
+If you're not sure how to fix a merge conflict, the safest and least risky option is to just not cherry-pick the commit.
+The commit can always be revisited in the future if there is user demand or if necessary to prevent further conflicts.
+
+If you do make a manual patch, add a note in the commit message of what you changed.
+As prior examples, see: [`f19d6d6046`](https://github.com/argoproj/argo-workflows/commit/f19d6d60462fb23c95324ba924c0972d92465a67), [`fbc56d423d`](https://github.com/argoproj/argo-workflows/commit/fbc56d423d106610f899cd487c3bb4ae10a5e3d8), [`37c87dafee`](https://github.com/argoproj/argo-workflows/commit/37c87dafeed5f50ce96664d80009e7d9b4d23e0a)
+
+### Testing
 
 Cherry-pick the first commit. Run `make test` locally before pushing. If the build timeouts the build caches may have
 gone, try re-running.
@@ -70,3 +76,5 @@ git push upstream create-pull-request/changelog
 
 Once the changelog updates have been merged, you should announce on our Slack channels, [`#argo-workflows`](https://cloud-native.slack.com/archives/C01QW9QSSSK) and [`#argo-announcements`](https://cloud-native.slack.com/archives/C02165G1L48).
 See [previous](https://cloud-native.slack.com/archives/C02165G1L48/p1701112932434469) [announcements](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1701112957127489) as examples of what to write in the patch announcement.
+
+In `#argo-workflows`, also "Pin" the release announcement and "Un-pin" the previous announcement for that release branch.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,8 +28,9 @@ Ignore:
 ### Merge Conflicts
 
 Then look for `failed to cherry-pick` in the log to find commits with merge conflicts and decide if a manual patch is necessary.
-If you're not sure how to fix a merge conflict, the safest and least risky option is to just not cherry-pick the commit.
-The commit can always be revisited in the future if there is user demand or if necessary to prevent further conflicts.
+
+If you're not sure how to fix a merge conflict, the safest and least risky option is to _not_ cherry-pick the commit.
+The commit can be revisited in the future if there is user demand or if necessary to prevent further conflicts.
 
 If you do make a manual patch, add a note in the commit message of what you changed.
 As prior examples, see: [`f19d6d6046`](https://github.com/argoproj/argo-workflows/commit/f19d6d60462fb23c95324ba924c0972d92465a67), [`fbc56d423d`](https://github.com/argoproj/argo-workflows/commit/fbc56d423d106610f899cd487c3bb4ae10a5e3d8), [`37c87dafee`](https://github.com/argoproj/argo-workflows/commit/37c87dafeed5f50ce96664d80009e7d9b4d23e0a)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,6 +32,9 @@ Then look for `failed to cherry-pick` in the log to find commits with merge conf
 If you're not sure how to fix a merge conflict, the safest and least risky option is to _not_ cherry-pick the commit.
 The commit can be revisited in the future if there is user demand or if necessary to prevent further conflicts.
 
+Sometimes merge conflicts occur because a `build`, `chore`, `refactor` or other older commit was not previously cherry-picked.
+You can cherry-pick the older commit in order to easily resolve the merge conflict.
+
 If you do make a manual patch, add a note in the commit message of what you changed.
 As prior examples, see: [`f19d6d6046`](https://github.com/argoproj/argo-workflows/commit/f19d6d60462fb23c95324ba924c0972d92465a67), [`fbc56d423d`](https://github.com/argoproj/argo-workflows/commit/fbc56d423d106610f899cd487c3bb4ae10a5e3d8), [`37c87dafee`](https://github.com/argoproj/argo-workflows/commit/37c87dafeed5f50ce96664d80009e7d9b4d23e0a)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Addresses some of my comments in https://github.com/argoproj/argo-workflows/pull/13631#issuecomment-2364062656 and adds some things I've noted [on Slack](https://cloud-native.slack.com/archives/C0510EUH90V/p1720392529225909?thread_ts=1717524624.649829&cid=C0510EUH90V) and in https://github.com/argoproj/argo-workflows/issues/12592#issuecomment-2064373530 before too

### Motivation

<!-- TODO: Say why you made your changes. -->

Add a few small best practices for dealing with merge conflicts that I've been using
- can add more to this section later as we iron them out

Plus clarify a contradictory piece that may have confused Alan

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- split out a "Merge Conflicts" section for this
  - fix up some formatting in the existing sentence to match the docs style guide
  - add what to do if you're not sure how to fix it: don't backport it is the safer option
  - add instruction to add a note in the commit if you did fix a merge conflict
    - add prior examples of this as well

#### Other modifications

- remove `chore(deps)`, `build`, and `ci` from the "list of commits"
  - matching the "Ignore: " below from #11382
  - these also tend to cause the most merge conflicts, directly or indirectly
- add `docs` to this list since we now have versioned documentation #11390 
  - i.e. docs-only improvements unrelated to a feature should also be backported when possible, as [previously discussed](https://github.com/argoproj/argo-workflows/issues/11390#issuecomment-1649834497) and as I've done many times now and Alan's done a few times now too

- add note about pinning release announcements in Slack
  - use the specific terms that the Slack UI uses: "Pin" and "Un-pin"
  - this is something new I've been doing recently

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
