### PR TITLE
docs: in-line versioning + deprecation for multi-semaphore

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2399,7 +2399,11 @@ Mutex holds Mutex configuration
 
 - [`synchronization-mutex-tmpl-level-legacy.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level-legacy.yaml)
 
+- [`synchronization-mutex-tmpl-level.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level.yaml)
+
 - [`synchronization-mutex-wf-level-legacy.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level-legacy.yaml)
+
+- [`synchronization-mutex-wf-level.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level.yaml)
 </details>
 
 ### Fields
@@ -3291,7 +3295,11 @@ MutexStatus contains which objects hold mutex locks, and which objects this work
 
 - [`synchronization-mutex-tmpl-level-legacy.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level-legacy.yaml)
 
+- [`synchronization-mutex-tmpl-level.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level.yaml)
+
 - [`synchronization-mutex-wf-level-legacy.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level-legacy.yaml)
+
+- [`synchronization-mutex-wf-level.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level.yaml)
 </details>
 
 ### Fields

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -208,30 +208,6 @@ Examples:
 !!! Warning
     If a Workflow is at the front of the queue and it needs to acquire multiple locks, all other Workflows that also need those same locks will wait. This applies even if the other Workflows only wish to acquire a subset of those locks.
 
-## Legacy
-
-In workflows prior to 3.6 you can only specify one lock in any one workflow or template using either a mutex:
-
-```yaml
-    synchronization:
-      mutex:
-     ...
-```
-
-or a semaphore:
-
-```yaml
-    synchronizaion:
-   semamphore:
-     ...
-```
-
-Specifying both would not work in <3.6, only the semaphore would be used.
-
-The single `mutex` and `semaphore` syntax still works in version 3.6 but is considered deprecated.
-Both the `mutex` and the `semaphore` will be taken in version 3.6 with this syntax.
-This syntax can be mixed with `mutexes` and `semaphores`, all locks will be required.
-
 ## Other Parallelism support
 
 You can also [restrict parallelism at the Controller-level](parallelism.md).

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -24,10 +24,6 @@ data:
   template: "2"  # Two instances of template can run at a given time in particular namespace
 ```
 
-!!! Warning
-    Each synchronization block may only refer to either a semaphore or a mutex.
-    If you specify both only the semaphore will be locked.
-
 ## Workflow-level Synchronization
 
 You can limit parallel execution of workflows by using the same synchronization reference.

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -44,6 +44,10 @@ spec:
       - configMapKeyRef:
           name: my-config
           key: workflow
+    # semaphore: # deprecated: v3.5 and before
+    #   configMapKeyRef:
+    #     name: my-config
+    #     key: workflow
   templates:
   - name: hello-world
     container:
@@ -64,6 +68,8 @@ spec:
   synchronization:
     mutexes: # v3.6 and after
       - name: workflow
+    # mutex: # deprecated: v3.5 and before
+    #   name: template
   templates:
   - name: hello-world
     container:
@@ -105,6 +111,10 @@ spec:
         - configMapKeyRef:
             name: my-config
             key: template
+      # semaphore: # deprecated: v3.5 and before
+      #   configMapKeyRef:
+      #     name: my-config
+      #     key: workflow
     container:
       image: alpine:latest
       command: [sh, -c]
@@ -135,6 +145,8 @@ spec:
     synchronization:
       mutexes: # v3.6 and after
         - name: template
+      # mutex: # deprecated: v3.5 and before
+      #   name: template
     container:
       image: alpine:latest
       command: [sh, -c]

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -40,7 +40,7 @@ metadata:
 spec:
   entrypoint: hello-world
   synchronization:
-    semaphores:
+    semaphores: # v3.6 and after
       - configMapKeyRef:
           name: my-config
           key: workflow
@@ -62,7 +62,7 @@ metadata:
 spec:
   entrypoint: hello-world
   synchronization:
-    mutexes:
+    mutexes: # v3.6 and after
       - name: workflow
   templates:
   - name: hello-world
@@ -101,7 +101,7 @@ spec:
 
   - name: acquire-lock
     synchronization:
-      semaphores:
+      semaphores: # v3.6 and after
         - configMapKeyRef:
             name: my-config
             key: template
@@ -133,7 +133,7 @@ spec:
 
   - name: acquire-lock
     synchronization:
-      mutexes:
+      mutexes: # v3.6 and after
         - name: template
     container:
       image: alpine:latest
@@ -147,10 +147,6 @@ Examples:
 1. [Workflow level mutex](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level.yaml)
 1. [Step level semaphore](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-tmpl-level.yaml)
 1. [Step level mutex](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level.yaml)
-1. [Legacy workflow level semaphore](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-wf-level-legacy.yaml)
-1. [Legacy workflow level mutex](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level-legacy.yaml)
-1. [Legacy step level semaphore](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-tmpl-level-legacy.yaml)
-1. [Legacy step level mutex](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level-legacy.yaml)
 
 ## Queuing
 

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -32,50 +32,14 @@ In this example the synchronization key `workflow` is configured as limit `"1"`,
 
 Using a semaphore configured by a `ConfigMap`:
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: synchronization-wf-level-
-spec:
-  entrypoint: hello-world
-  synchronization:
-    semaphores: # v3.6 and after
-      - configMapKeyRef:
-          name: my-config
-          key: workflow
-    # semaphore: # deprecated: v3.5 and before
-    #   configMapKeyRef:
-    #     name: my-config
-    #     key: workflow
-  templates:
-  - name: hello-world
-    container:
-      image: busybox
-      command: [echo]
-      args: ["hello world"]
+```yaml title="examples/synchronization-wf-level.yaml"
+--8<-- "examples/synchronization-wf-level.yaml:12"
 ```
 
 Using a mutex is equivalent to a limit `"1"` semaphore:
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: synchronization-wf-level-
-spec:
-  entrypoint: hello-world
-  synchronization:
-    mutexes: # v3.6 and after
-      - name: workflow
-    # mutex: # deprecated: v3.5 and before
-    #   name: template
-  templates:
-  - name: hello-world
-    container:
-      image: busybox
-      command: [echo]
-      args: ["hello world"]
+```yaml title="examples/synchronization-mutex-wf-level.yaml"
+--8<-- "examples/synchronization-mutex-wf-level.yaml:3"
 ```
 
 ## Template-level Synchronization
@@ -87,78 +51,15 @@ This applies even when multiple steps or tasks within a workflow or different wo
 
 Using a semaphore configured by a `ConfigMap`:
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: synchronization-tmpl-level-
-spec:
-  entrypoint: synchronization-tmpl-level-example
-  templates:
-  - name: synchronization-tmpl-level-example
-    steps:
-    - - name: synchronization-acquire-lock
-        template: acquire-lock
-        arguments:
-          parameters:
-          - name: seconds
-            value: "{{item}}"
-        withParam: '["1","2","3","4","5"]'
-
-  - name: acquire-lock
-    synchronization:
-      semaphores: # v3.6 and after
-        - configMapKeyRef:
-            name: my-config
-            key: template
-      # semaphore: # deprecated: v3.5 and before
-      #   configMapKeyRef:
-      #     name: my-config
-      #     key: workflow
-    container:
-      image: alpine:latest
-      command: [sh, -c]
-      args: ["sleep 10; echo acquired lock"]
+```yaml title="examples/synchronization-tmpl-level.yaml"
+--8<-- "examples/synchronization-tmpl-level.yaml:11"
 ```
 
 Using a mutex will limit to a single concurrent execution of the template:
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: synchronization-tmpl-level-
-spec:
-  entrypoint: synchronization-tmpl-level-example
-  templates:
-  - name: synchronization-tmpl-level-example
-    steps:
-    - - name: synchronization-acquire-lock
-        template: acquire-lock
-        arguments:
-          parameters:
-          - name: seconds
-            value: "{{item}}"
-        withParam: '["1","2","3","4","5"]'
-
-  - name: acquire-lock
-    synchronization:
-      mutexes: # v3.6 and after
-        - name: template
-      # mutex: # deprecated: v3.5 and before
-      #   name: template
-    container:
-      image: alpine:latest
-      command: [sh, -c]
-      args: ["sleep 10; echo acquired lock"]
+```yaml title="examples/synchronization-mutex-tmpl-level.yaml"
+--8<-- "examples/synchronization-mutex-tmpl-level.yaml:3"
 ```
-
-Examples:
-
-1. [Workflow level semaphore](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-wf-level.yaml)
-1. [Workflow level mutex](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-wf-level.yaml)
-1. [Step level semaphore](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-tmpl-level.yaml)
-1. [Step level mutex](https://github.com/argoproj/argo-workflows/blob/main/examples/synchronization-mutex-tmpl-level.yaml)
 
 ## Queuing
 

--- a/examples/synchronization-mutex-tmpl-level-legacy.yaml
+++ b/examples/synchronization-mutex-tmpl-level-legacy.yaml
@@ -28,7 +28,7 @@ spec:
 
   - name: acquire-lock
     synchronization:
-      mutex:
+      mutex: # deprecated: v3.5 and before
         name: welcome
     container:
       image: alpine:latest
@@ -37,7 +37,7 @@ spec:
 
   - name: acquire-lock-1
     synchronization:
-      mutex:
+      mutex: # deprecated: v3.5 and before
         name: test
     container:
       image: alpine:latest

--- a/examples/synchronization-mutex-tmpl-level-legacy.yaml
+++ b/examples/synchronization-mutex-tmpl-level-legacy.yaml
@@ -29,6 +29,8 @@ spec:
     synchronization:
       mutex: # deprecated: v3.5 and before
         name: welcome
+      # mutexes: # v3.6 and after
+      #   - name: welcome
     container:
       image: alpine:latest
       command: [sh, -c]
@@ -38,6 +40,8 @@ spec:
     synchronization:
       mutex: # deprecated: v3.5 and before
         name: test
+      # mutexes: # v3.6 and after
+      #   - name: test
     container:
       image: alpine:latest
       command: [sh, -c]

--- a/examples/synchronization-mutex-tmpl-level-legacy.yaml
+++ b/examples/synchronization-mutex-tmpl-level-legacy.yaml
@@ -1,6 +1,5 @@
 # This example demonstrates the use of a Synchronization Mutex lock on template execution. Mutex lock limits
 # only one of the template execution across the workflows in the namespace which has same Mutex lock.
-
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:

--- a/examples/synchronization-mutex-tmpl-level.yaml
+++ b/examples/synchronization-mutex-tmpl-level.yaml
@@ -1,6 +1,5 @@
 # This example demonstrates the use of a Synchronization Mutex lock on template execution. Mutex lock limits
 # only one of the template execution across the workflows in the namespace which has same Mutex lock.
-
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -30,6 +29,8 @@ spec:
     synchronization:
       mutexes: # v3.6 and after
         - name: welcome
+      # mutex: # deprecated: v3.5 and before
+      #   name: welcome
     container:
       image: alpine:latest
       command: [sh, -c]
@@ -39,6 +40,8 @@ spec:
     synchronization:
       mutexes: # v3.6 and after
         - name: test
+      # mutex: # deprecated: v3.5 and before
+      #   name: test
     container:
       image: alpine:latest
       command: [sh, -c]

--- a/examples/synchronization-mutex-tmpl-level.yaml
+++ b/examples/synchronization-mutex-tmpl-level.yaml
@@ -28,7 +28,7 @@ spec:
 
   - name: acquire-lock
     synchronization:
-      mutexes:
+      mutexes: # v3.6 and after
         - name: welcome
     container:
       image: alpine:latest
@@ -37,7 +37,7 @@ spec:
 
   - name: acquire-lock-1
     synchronization:
-      mutexes:
+      mutexes: # v3.6 and after
         - name: test
     container:
       image: alpine:latest

--- a/examples/synchronization-mutex-wf-level-legacy.yaml
+++ b/examples/synchronization-mutex-wf-level-legacy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   entrypoint: hello-world
   synchronization:
-    mutex:
+    mutex: # deprecated: v3.5 and before
       name:  test
   templates:
     - name: hello-world

--- a/examples/synchronization-mutex-wf-level-legacy.yaml
+++ b/examples/synchronization-mutex-wf-level-legacy.yaml
@@ -8,7 +8,9 @@ spec:
   entrypoint: hello-world
   synchronization:
     mutex: # deprecated: v3.5 and before
-      name:  test
+      name: test
+    # mutexes: # v3.6 and after
+    #   - name: test
   templates:
     - name: hello-world
       container:

--- a/examples/synchronization-mutex-wf-level.yaml
+++ b/examples/synchronization-mutex-wf-level.yaml
@@ -9,6 +9,8 @@ spec:
   synchronization:
     mutexes: # v3.6 and after
       - name:  test
+    # mutex: # deprecated: v3.5 and before
+    #  name:  test
   templates:
     - name: hello-world
       container:

--- a/examples/synchronization-mutex-wf-level.yaml
+++ b/examples/synchronization-mutex-wf-level.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   entrypoint: hello-world
   synchronization:
-    mutexes:
+    mutexes: # v3.6 and after
       - name:  test
   templates:
     - name: hello-world

--- a/examples/synchronization-tmpl-level-legacy.yaml
+++ b/examples/synchronization-tmpl-level-legacy.yaml
@@ -27,7 +27,7 @@ spec:
 
   - name: acquire-lock
     synchronization:
-      semaphore:
+      semaphore: # deprecated: v3.5 and before
         configMapKeyRef:
           name: my-config
           key: template

--- a/examples/synchronization-tmpl-level-legacy.yaml
+++ b/examples/synchronization-tmpl-level-legacy.yaml
@@ -31,6 +31,10 @@ spec:
         configMapKeyRef:
           name: my-config
           key: template
+      # semaphores: # v3.6 and after
+      #   - configMapKeyRef:
+      #       name: my-config
+      #       key: template
     container:
       image: alpine:latest
       command: [sh, -c]

--- a/examples/synchronization-tmpl-level.yaml
+++ b/examples/synchronization-tmpl-level.yaml
@@ -27,7 +27,7 @@ spec:
 
   - name: acquire-lock
     synchronization:
-      semaphores:
+      semaphores: # v3.6 and after
         - configMapKeyRef:
             name: my-config
             key: template

--- a/examples/synchronization-tmpl-level.yaml
+++ b/examples/synchronization-tmpl-level.yaml
@@ -31,6 +31,10 @@ spec:
         - configMapKeyRef:
             name: my-config
             key: template
+      # semaphore: # deprecated: v3.5 and before
+      #   configMapKeyRef:
+      #     name: my-config
+      #     key: template
     container:
       image: alpine:latest
       command: [sh, -c]

--- a/examples/synchronization-wf-level-legacy.yaml
+++ b/examples/synchronization-wf-level-legacy.yaml
@@ -20,6 +20,10 @@ spec:
       configMapKeyRef:
         name: my-config
         key: workflow
+    # semaphores: # v3.6 and after
+    #   - configMapKeyRef:
+    #       name: my-config
+    #       key: workflow
   templates:
     - name: hello-world
       container:

--- a/examples/synchronization-wf-level-legacy.yaml
+++ b/examples/synchronization-wf-level-legacy.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   entrypoint: hello-world
   synchronization:
-    semaphore:
+    semaphore: # deprecated: v3.5 and before
       configMapKeyRef:
         name: my-config
         key: workflow

--- a/examples/synchronization-wf-level.yaml
+++ b/examples/synchronization-wf-level.yaml
@@ -20,6 +20,10 @@ spec:
       - configMapKeyRef:
           name: my-config
           key: workflow
+    # semaphore: # deprecated: v3.5 and before
+    #   configMapKeyRef:
+    #     name: my-config
+    #     key: workflow
   templates:
     - name: hello-world
       container:

--- a/examples/synchronization-wf-level.yaml
+++ b/examples/synchronization-wf-level.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   entrypoint: hello-world
   synchronization:
-    semaphores:
+    semaphores: # v3.6 and after
       - configMapKeyRef:
           name: my-config
           key: workflow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ markdown_extensions:
   - admonition
   - md_in_html
   - pymdownx.details
+  - pymdownx.snippets
   - pymdownx.superfences:
       custom_fences:
         # support mermaid diagrams per https://squidfunk.github.io/mkdocs-material/reference/diagrams/#configuration


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Addresses #13644, https://github.com/argoproj/argo-workflows/pull/13358#discussion_r1770585773 etc: <details>
> > Since people will look at the examples and not know that they have future syntax etc
> 
> Indeed it looks like this is happening almost as soon as this was merged 😕 #13644 plus [two](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1726994955560259) [Slack threads](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1726835793647219?thread_ts=1726835793.647219&cid=C01QW9QSSSK). The issue and former Slack thread are also from a [long](https://github.com/argoproj/argo-workflows/discussions?discussions_q=author%3Ani-todo-spot) [time](https://github.com/argoproj/argo-workflows/issues?q=author%3Ani-todo-spot) user, i.e. not a newbie.

And ofc [this contributor thread](https://cloud-native.slack.com/archives/C0510EUH90V/p1721656672337809) and [previous Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit#heading=h.5a2asxhc64ss) with Alan and I butting heads mostly over in-line version specifiers 😅 

</details>

### Motivation

<!-- TODO: Say why you made your changes. -->

Mitigate users not realizing they're on the `latest` version of the docs and attempting to use features that don't exist yet, getting errors, and then filing issues or support requests about it. 
To some extent, it is inevitable, but in-line versioning is a mitigation in an effort to help users self-service.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove warning about using mutexes and semaphores together as that is possible in 3.6 after #13358 -- the warning should only be in earlier versions

- use [snippet embeds](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files) to directly use examples in the docs without duplication
  - single source-of-truth that is testable, consistent, and more discoverable. also avoids potential mistakes/differences, etc
    - Mentioned this in https://github.com/argoproj/argo-workflows/pull/13429#issuecomment-2267597431 and elsewhere, thought this was a good time to start using them
  - no longer need a list of examples on this page as such

- add in-line comments with version specifiers on `mutexes` and `semaphores` syntax
- add deprecation comments with version specifiers on `mutex` and `semaphore` syntax
- add alternative syntax in comments, as suggested in https://github.com/argoproj/argo-workflows/pull/13358#discussion_r1685896125
  - this should make it very hard for users to get wrong, which is the intent
  
- remove "Legacy" section as this does not match conventions
  - we conventionally don't explicitly describe prior state in the docs and leave that to the older versions of the docs (#11390)
    - (if we did, we could have "legacy" sections ad infinitum. In [the Slack thread](https://cloud-native.slack.com/archives/C0510EUH90V/p1721898722960129?thread_ts=1721656672.337809&cid=C0510EUH90V), this is also 3., that we do _not_ do and is one of the purposes of versioned docs)
  - users also don't read separate sections like this, they get an error and file an issue before they even reach this section, _literally_ per #13644 et al
  - the in-line comments cover this with more direct examples and as you're reading the example instead of after. this follows "show, don't tell" and style guide on directness.
    - the in-line is also more implicit of a reference to older syntax as opposed to an entire explicit section on it
  - we also conventionally don't describe bugs in the docs; combining `mutex` with `semaphore` and it not erroring out but silently ignoring the `mutex` is a confusing bug.
    - (if we did describe bugs, we could have those ad infinitum in the docs as well) 

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes.

<details><summary>Here's a screenshot of the example snippet embeds:</summary>

![Screenshot 2024-09-22 at 1 06 26 PM](https://github.com/user-attachments/assets/1d116a1c-b2f6-4251-a4e0-40859bfde54e)

</details>

### Future Work

1. [ ] Use embeds for examples in more places in the docs

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
