### PR TITLE
build: fix `Makefile` dependencies for `zz_generated.deepcopy.go` to include `code-generator` which it uses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,7 +624,7 @@ pkg/apis/workflow/v1alpha1/openapi_generated.go: $(GOPATH)/bin/openapi-gen $(TYP
 
 
 # generates many other files (listers, informers, client etc).
-pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go: $(TYPES)
+pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go: $(GOPATH)/bin/go-to-protobuf $(TYPES)
 	# These files are generated on a v3/ folder by the tool. Link them to the root folder
 	[ -e ./v3 ] || ln -s . v3
 	bash $(GOPATH)/pkg/mod/k8s.io/code-generator@v0.21.5/generate-groups.sh \


### PR DESCRIPTION
# Motivation

I'd like to be able to `make <whatever>` and it just work.

`$(GOPATH)/pkg/mod/k8s.io/code-generator@v0.21.5/generate-groups.sh` is created as part of installing go-to-protobuf, but this is not a dependency of `pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go` which uses `generate-groups.sh`

If I change the version of code-generator in use I get 
```bash
bash: /home/vscode/go/pkg/mod/k8s.io/code-generator@v0.21.5/generate-groups.sh: No such file or directory
```

# Modification

I have added this as a direct dependency. We could have a make target of `$(GOPATH)/pkg/mod/k8s.io/code-generator@v0.21.5/generate-groups.sh` which might make things clearer, but I'm unconvinced it does, so I did the smaller change.

# Verification

If I change the version of code-generator we use and install it will now do a rebuild `zz_generated.deepcopy.go` correctly.

