### PR TITLE
fix(controller): retry transient error on agent pod creation

### DIFF
--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/util/env"
+	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
@@ -39,7 +40,7 @@ func (woc *wfOperationCtx) reconcileAgentPod(ctx context.Context) error {
 		return err
 	}
 	// Check Pod is just created
-	if pod.Status.Phase != "" {
+	if pod != nil && pod.Status.Phase != "" {
 		woc.updateAgentPodStatus(pod)
 	}
 	return nil
@@ -256,6 +257,10 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 			if existing, err := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.ObjectMeta.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err == nil {
 				return existing, nil
 			}
+		}
+		if errorsutil.IsTransientErr(err) {
+			woc.requeue()
+			return created, nil
 		}
 		return nil, errors.InternalWrapError(fmt.Errorf("failed to create Agent pod. Reason: %v", err))
 	}


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13654 

### Motivation

When I use the HTTP template, I find it pending all the time. 
![image](https://github.com/user-attachments/assets/5d96a3f1-ada5-4d54-83dc-8e598d020294)
Then I saw that the workflow status was error, and encountered a transient error.
![image](https://github.com/user-attachments/assets/a728fa6c-9297-4b5b-81fd-96215c0bf235)
error is : `failed to create Agent pod. Reason: Operation cannot be fulfilled on resourcequotas "xxxx": the object has been modified; please apply your changes to the latest version and try again`

### Modifications
When the agent pod creation encounters transient errors, just retry. 
