### PR TITLE
ci: fix flaky image gc and mysql connect + add k3s debug log

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -319,7 +319,7 @@ jobs:
             UI=false \
             POD_STATUS_CAPTURE_FINALIZER=true > /tmp/argo.log 2>&1 &
       - name: Wait for controller to be up
-        run: make wait API=${{matrix.use-api}}
+        run: make wait PROFILE=${{matrix.profile}} API=${{matrix.use-api}}
         timeout-minutes: 5
       - name: Run tests ${{matrix.test}}
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -240,6 +240,13 @@ jobs:
             profile: minimal
             use-api: false
     steps:
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
       - name: Install socat (needed by Kubernetes)
         run: sudo apt-get -y install socat
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -280,10 +280,6 @@ jobs:
           kind: KubeletConfiguration
           imageMinimumGCAge: 1h
           imageGCHighThresholdPercent: 100
-          evictionHard:
-            imagefs.available: 0%
-            nodefs.available: 0%
-            nodefs.inodesFree: 0%
           EOT
 
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=stable INSTALL_K3S_EXEC='--docker --kubelet-arg=config=/tmp/kubelet.config' K3S_KUBECONFIG_MODE=644 sh -

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -313,6 +313,9 @@ jobs:
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false
 
       # failure debugging below
+      - name: Failure debug - k3s logs
+        if: ${{ failure() }}
+        run: journalctl -u k3s
       - name: Failure debug - describe MinIO/MySQL deployment
         if: ${{ failure() }}
         run: |

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -267,7 +267,19 @@ jobs:
           else
             export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
           fi
-          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=stable INSTALL_K3S_EXEC=--docker K3S_KUBECONFIG_MODE=644 sh -
+
+          cat >/tmp/kubelet.config <<EOT
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          imageMinimumGCAge: 1h
+          imageGCHighThresholdPercent: 100
+          evictionHard:
+            imagefs.available: 0%
+            nodefs.available: 0%
+            nodefs.inodesFree: 0%
+          EOT
+
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=stable INSTALL_K3S_EXEC='--docker --kubelet-arg=config=/tmp/kubelet.config' K3S_KUBECONFIG_MODE=644 sh -
           until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml cluster-info ; do sleep 10s ; done
           cp /etc/rancher/k3s/k3s.yaml /home/runner/.kubeconfig
           echo "- name: fake_token_user" >> $KUBECONFIG

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -240,13 +240,13 @@ jobs:
             profile: minimal
             use-api: false
     steps:
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
+      - name: Free up disk space
+        run: |
+          printf "==> Available space before cleanup\n"
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          printf "==> Available space after cleanup\n"
+          df -h
       - name: Install socat (needed by Kubernetes)
         run: sudo apt-get -y install socat
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/Makefile
+++ b/Makefile
@@ -574,6 +574,10 @@ ifeq ($(API),true)
 	# Wait for Argo Server
 	until lsof -i :2746 > /dev/null ; do sleep 10s ; done
 endif
+ifeq ($(PROFILE),mysql)
+	# Wait for MySQL
+	until lsof -i :3306 > /dev/null ; do sleep 10s ; done
+endif
 
 .PHONY: postgres-cli
 postgres-cli:

--- a/Makefile
+++ b/Makefile
@@ -576,7 +576,7 @@ ifeq ($(API),true)
 endif
 ifeq ($(PROFILE),mysql)
 	# Wait for MySQL
-	until lsof -i :3306 > /dev/null ; do sleep 10s ; done
+	until (: < /dev/tcp/localhost/3306) ; do sleep 10s ; done
 endif
 
 .PHONY: postgres-cli


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

A bunch of tests have been failing intermittently for awhile now, which is blocking PRs. For example, the `E2E Tests (test-executor, v1.28.13+k3s1, minimal, false)` test fails >50% of the time with the error `ErrImageNeverPull: Container image "quay.io/argoproj/argocli:latest" is not present with pull policy of Never.` ([example run]( https://github.com/argoproj/argo-workflows/actions/runs/11022848664/job/30613101811)). Many of these issues can't be diagnosed without access to the k3s logs.

### Modifications

1. Print the k3s logs using `journalctl` on a build failure. You can see k3s is being run with systemd from the output of the `Install and start K3S` step:
```
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  systemd: Starting k3s
```
2. Add a step to clean up disk space by deleting unused files (e.g. Haskell), since the k3s logs clearly indicate pods are being evicted due to DiskPressure
3. Update `make wait PROFILE=mysql` to wait for mysql to be available, which should fix intermittent failures like `persistence.go:29: test panicked: dial tcp [::1]:3306: connect: connection refused`
4. Add a [Kubelet configuration file](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/) to tell k3s not to garbage collect images, since that's what's causing the `ErrImageNeverPull` errors

### Verification

Will watch action output

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
