### PR TITLE
docs: add sidecar kill command for linkerd-proxy

### DIFF
--- a/docs/sidecar-injection.md
+++ b/docs/sidecar-injection.md
@@ -53,6 +53,7 @@ spec:
   podMetadata:
     annotations:
       workflows.argoproj.io/kill-cmd-istio-proxy: '["pilot-agent", "request", "POST", "quitquitquit"]'
+      workflows.argoproj.io/kill-cmd-linkerd-proxy: '["/usr/lib/linkerd/linkerd-await","sleep","1","--shutdown"]'
       workflows.argoproj.io/kill-cmd-vault-agent: '["sh", "-c", "kill -%d 1"]'
       workflows.argoproj.io/kill-cmd-sidecar: '["sh", "-c", "kill -%d $(pidof entrypoint.sh)"]'
 ```


### PR DESCRIPTION
Addresses https://github.com/argoproj/argo-workflows/issues/12103#issuecomment-2376057950

### Motivation
This adds documentation for an annotation to shut down linkerd-proxy containers that are added as a sidecar to workflow pods through the linkerd service mesh.
If these containers are not closed the pod keeps running and is not completed even though the workflow is done