### PR TITLE
docs: Clarify headless service for promethus scraping

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -116,11 +116,15 @@ metricsConfig: |
   secure: true
 ```
 
-The metric names emitted by this mechanism are prefixed with `argo_workflows_`.
-`Attributes` are exposed as Prometheus `labels` of the same name.
+The metric names emitted by this mechanism are prefixed with `argo_workflows_`. `Attributes` are exposed as Prometheus `labels` of the same name.
 
 Prometheus metrics will return empty metrics on a workflow controller which is not the leader.
-All metrics emitted over Prometheus will have `argo_workflows_` prefixed to their name.
+
+By port-forwarding to the leader controller Pod you can view the metrics in your browser at `https://localhost:9090/metrics`. Assuming you only have one controller replica, you can port-forward with:
+
+```bash
+kubectl -n argo port-forward deploy/workflow-controller 9090:9090
+```
 
 ### Common
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -60,7 +60,8 @@ metricsConfig: |
 
 ### Prometheus scraping
 
-A metrics service is not installed as part of [the default installation](quick-start.md) so you will need to add one if you wish to use a Prometheus Service Monitor. If you have more than one controller pod, using one as a [hot-standby](high-availability.md), you should use [a headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to ensure that each pod is being scraped so that no metrics are missed.
+A metrics service is not installed as part of [the default installation](quick-start.md) so you will need to add one if you wish to use a Prometheus Service Monitor.
+If you have more than one controller pod, using one as a [hot-standby](high-availability.md), you should use [a headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to ensure that each pod is being scraped so that no metrics are missed.
 
 ```yaml
 cat <<EOF | kubectl apply -f -
@@ -116,11 +117,13 @@ metricsConfig: |
   secure: true
 ```
 
-The metric names emitted by this mechanism are prefixed with `argo_workflows_`. `Attributes` are exposed as Prometheus `labels` of the same name.
+The metric names emitted by this mechanism are prefixed with `argo_workflows_`.
+`Attributes` are exposed as Prometheus `labels` of the same name.
 
 Prometheus metrics will return empty metrics on a workflow controller which is not the leader.
 
-By port-forwarding to the leader controller Pod you can view the metrics in your browser at `https://localhost:9090/metrics`. Assuming you only have one controller replica, you can port-forward with:
+By port-forwarding to the leader controller Pod you can view the metrics in your browser at `https://localhost:9090/metrics`.
+Assuming you only have one controller replica, you can port-forward with:
 
 ```bash
 kubectl -n argo port-forward deploy/workflow-controller 9090:9090

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -60,6 +60,41 @@ metricsConfig: |
 
 ### Prometheus scraping
 
+A metrics service is not installed as part of [the default installation](quick-start.md) so you will need to add one if you wish to use a Prometheus Service Monitor. If you have more than one controller pod, using one as a [hot-standby](high-availability.md), you should use [a headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to ensure that each pod is being scraped so that no metrics are missed.
+
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: workflow-controller
+  name: workflow-controller-metrics
+  namespace: argo
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: workflow-controller
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argo-workflows
+  namespace: argo
+spec:
+  endpoints:
+  - port: metrics
+  selector:
+    matchLabels:
+      app: workflow-controller
+EOF
+```
+
 You can adjust various elements of the Prometheus metrics configuration by changing values in the [Workflow Controller Config Map](workflow-controller-configmap.md).
 
 ```yaml
@@ -637,46 +672,3 @@ To define a real-time metric simply add `realtime: true` to a gauge metric with 
     realtime: true
     value: "{{duration}}"
 ```
-
-## Metrics endpoint
-
-By default, metrics are emitted by the workflow-controller on port 9090 on the `/metrics` path.
-By port-forwarding to the pod you can view the metrics in your browser at `http://localhost:9090/metrics`:
-
-`kubectl -n argo port-forward deploy/workflow-controller 9090:9090`
-
-A metrics service is not installed as part of [the default installation](quick-start.md) so you will need to add one if you wish to use a Prometheus Service Monitor:
-
-```yaml
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: workflow-controller
-  name: workflow-controller-metrics
-  namespace: argo
-spec:
-  ports:
-  - name: metrics
-    port: 9090
-    protocol: TCP
-    targetPort: 9090
-  selector:
-    app: workflow-controller
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: argo-workflows
-  namespace: argo
-spec:
-  endpoints:
-  - port: metrics
-  selector:
-    matchLabels:
-      app: workflow-controller
-EOF
-```
-
-If you have more than one controller pod, using one as a [hot-standby](high-availability.md), you should use [a headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to ensure that each pod is being scraped so that no metrics are missed.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation

The docs now separate prometheus and OTEL metrics information, but there was some prometheus stuff hanging towards the bottom of the page. It makes sense to move this up.

Also people struggled to read the last line about using a headless service, so made it more obvious and updated the example to match.


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
