### PR TITLE
fix(sync): error if mutex and semaphore are used together in <=v3.5

### DIFF
--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -26,7 +26,6 @@ data:
 
 !!! Warning
     Each synchronization block may only refer to either a semaphore or a mutex.
-    If you specify both only the semaphore will be locked.
 
 ## Workflow-level Synchronization
 

--- a/workflow/validate/testdata/synchronization-invalid-both.yaml
+++ b/workflow/validate/testdata/synchronization-invalid-both.yaml
@@ -6,7 +6,8 @@ spec:
   entrypoint: echo-template
   synchronization:
     # invalid: should only have 1 at a time per block
-    mutex: hello-world
+    mutex:
+      name: hello-world
     semaphore:
       configMapKeyRef:
         name: hello-world

--- a/workflow/validate/testdata/synchronization-invalid-both.yaml
+++ b/workflow/validate/testdata/synchronization-invalid-both.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-invalid-both-
+spec:
+  entrypoint: echo-template
+  synchronization:
+    # invalid: should only have 1 at a time per block
+    mutex: hello-world
+    semaphore:
+      configMapKeyRef:
+        name: hello-world
+        key: hello-world
+  templates:
+    - name: echo-template
+      container:
+        image: busybox
+        command: [echo]
+        args: ['hello world']

--- a/workflow/validate/testdata/synchronization-invalid-neither.yaml
+++ b/workflow/validate/testdata/synchronization-invalid-neither.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-invalid-neither-
+spec:
+  entrypoint: echo-template
+  synchronization:
+    # invalid: should have either mutex or semaphore
+    hello: world
+  templates:
+    - name: echo-template
+      container:
+        image: busybox
+        command: [echo]
+        args: ['hello world']

--- a/workflow/validate/testdata/synchronization-tmpl-invalid-both.yaml
+++ b/workflow/validate/testdata/synchronization-tmpl-invalid-both.yaml
@@ -8,7 +8,8 @@ spec:
     - name: echo-template
       synchronization:
         # invalid: should only have 1 at a time per block
-        mutex: hello-world
+        mutex:
+          name: hello-world
         semaphore:
           configMapKeyRef:
             name: hello-world

--- a/workflow/validate/testdata/synchronization-tmpl-invalid-both.yaml
+++ b/workflow/validate/testdata/synchronization-tmpl-invalid-both.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-tmpl-invalid-both-
+spec:
+  entrypoint: echo-template
+  templates:
+    - name: echo-template
+      synchronization:
+        # invalid: should only have 1 at a time per block
+        mutex: hello-world
+        semaphore:
+          configMapKeyRef:
+            name: hello-world
+            key: hello-world
+      container:
+        image: busybox
+        command: [echo]
+        args: ['hello world']

--- a/workflow/validate/testdata/synchronization-tmpl-invalid-neither.yaml
+++ b/workflow/validate/testdata/synchronization-tmpl-invalid-neither.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-tmpl-invalid-neither-
+spec:
+  entrypoint: echo-template
+  templates:
+    - name: echo-template
+      synchronization:
+        # invalid: should have either mutex or semaphore
+        hello: world
+      container:
+        image: busybox
+        command: [echo]
+        args: ['hello world']

--- a/workflow/validate/testdata/synchronization-tmpl-valid-mutex.yaml
+++ b/workflow/validate/testdata/synchronization-tmpl-valid-mutex.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-tmpl-valid-mutex-
+spec:
+  entrypoint: echo-template
+  templates:
+    - name: echo-template
+      synchronization:
+        mutex: hello-world
+      container:
+        image: busybox
+        command: [echo]
+        args: ['hello world']

--- a/workflow/validate/testdata/synchronization-tmpl-valid-mutex.yaml
+++ b/workflow/validate/testdata/synchronization-tmpl-valid-mutex.yaml
@@ -7,7 +7,8 @@ spec:
   templates:
     - name: echo-template
       synchronization:
-        mutex: hello-world
+        mutex:
+          name: hello-world
       container:
         image: busybox
         command: [echo]

--- a/workflow/validate/testdata/synchronization-valid-mutex.yaml
+++ b/workflow/validate/testdata/synchronization-valid-mutex.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: synchronization-valid-mutex-
+spec:
+  entrypoint: echo-template
+  synchronization:
+    mutex: hello-world
+  templates:
+    - name: echo-template
+      container:
+        image: busybox
+        command: [echo]
+        args: ['hello world']

--- a/workflow/validate/testdata/synchronization-valid-mutex.yaml
+++ b/workflow/validate/testdata/synchronization-valid-mutex.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   entrypoint: echo-template
   synchronization:
-    mutex: hello-world
+    mutex:
+      name: hello-world
   templates:
     - name: echo-template
       container:

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -139,7 +139,7 @@ func validateHooks(hooks wfv1.LifecycleHooks, hookBaseName string) error {
 // validateSync takes a synchronization struct and validates that only one of mutex or semaphore is used.
 // using both in one block results in an error, otherwise nil
 func validateSync(sync *wfv1.Synchronization, errPrefix string) error {
-	// no synchronization is invalid
+	// no synchronization is valid
 	if sync == nil {
 		return nil
 	}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -136,6 +136,24 @@ func validateHooks(hooks wfv1.LifecycleHooks, hookBaseName string) error {
 	return nil
 }
 
+// validateSync takes a synchronization struct and validates that only one of mutex or semaphore is used.
+// using both in one block results in an error, otherwise nil
+func validateSync(sync *wfv1.Synchronization, errPrefix string) error {
+	// no synchronization is invalid
+	if sync == nil {
+		return nil
+	}
+	// must be one or the other
+	if sync.Mutex != nil && sync.Semaphore != nil {
+		return errors.Errorf(errors.CodeBadRequest, "%s", errPrefix, "Each synchronization block may only refer to either a semaphore or a mutex.")
+	}
+	// can't be something other than mutex or semaphore
+	if sync.Mutex == nil && sync.Semaphore == nil {
+		return errors.Errorf(errors.CodeBadRequest, "%s", errPrefix, "A synchronization block must refer to either a semaphore or a mutex.")
+	}
+	return nil
+}
+
 // ValidateWorkflow accepts a workflow and performs validation against it.
 func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wf *wfv1.Workflow, opts ValidateOpts) error {
 	ctx := newTemplateValidationCtx(wf, opts)
@@ -253,6 +271,11 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 		if err != nil {
 			return err
 		}
+	}
+
+	err = validateSync(wf.Spec.Synchronization, "spec.synchronization")
+	if err != nil {
+		return err
 	}
 
 	// Validate OnExit hooks
@@ -408,8 +431,12 @@ func (ctx *templateValidationCtx) validateInitContainers(containers []wfv1.UserC
 }
 
 func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx *templateresolution.Context, args wfv1.ArgumentsProvider, workflowTemplateValidation bool) error {
-
 	if err := validateTemplateType(tmpl); err != nil {
+		return err
+	}
+
+	err := validateSync(tmpl.Synchronization, fmt.Sprintf("templates.%s.synchronization", tmpl.Name))
+	if err != nil {
 		return err
 	}
 

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -3364,6 +3364,18 @@ func TestSynchronization(t *testing.T) {
 			workflow:        "@testdata/synchronization-invalid-neither.yaml",
 			expectedSuccess: false,
 		},
+		{
+			workflow:        "@testdata/synchronization-tmpl-valid-mutex.yaml",
+			expectedSuccess: true,
+		},
+		{
+			workflow:        "@testdata/synchronization-tmpl-invalid-both.yaml",
+			expectedSuccess: false,
+		},
+		{
+			workflow:        "@testdata/synchronization-tmpl-invalid-neither.yaml",
+			expectedSuccess: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -567,7 +569,7 @@ spec:
     - name: missing
   entrypoint: whalesay
   templates:
-  - 
+  -
     container:
       args:
       - hello world
@@ -3000,7 +3002,7 @@ metadata:
 spec:
   entrypoint: steps-timing
   templates:
-    
+
     - name: steps-timing
       steps:
         - - name: one
@@ -3015,12 +3017,12 @@ spec:
                   value: "{{steps.one.finishedAt}}"
                 - name: id
                   value: "{{steps.one.id}}"
-    
+
     - name: wait
       container:
         image: alpine:3.7
         command: [sleep, "5"]
-    
+
     - name: printer
       inputs:
         parameters:
@@ -3341,5 +3343,38 @@ func TestShouldCheckValidationToSpacedParameters(t *testing.T) {
 	// Do not allow leading or trailing spaces in parameters
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "failed to resolve {{  workflow.thisdoesnotexist  }}")
+	}
+}
+
+func TestSynchronization(t *testing.T) {
+	tests := []struct {
+		name            string
+		workflow        string
+		expectedSuccess bool
+	}{
+		{
+			workflow:        "@testdata/synchronization-valid-mutex.yaml",
+			expectedSuccess: true,
+		},
+		{
+			workflow:        "@testdata/synchronization-invalid-both.yaml",
+			expectedSuccess: false,
+		},
+		{
+			workflow:        "@testdata/synchronization-invalid-neither.yaml",
+			expectedSuccess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := wfv1.MustUnmarshalWorkflow(tt.workflow)
+			err := ValidateWorkflow(wftmplGetter, cwftmplGetter, wf, ValidateOpts{})
+			if tt.expectedSuccess {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/11859
Addresses https://github.com/argoproj/argo-workflows/pull/13358#issuecomment-2250795586, https://github.com/argoproj/argo-workflows/pull/13645#discussion_r1770613962

### Motivation

<!-- TODO: Say why you made your changes. -->

- this is an invalid spec/syntax, so instead of silently ignoring the mutex, throw a validation error

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- add `validateSync` function to `validate.go` and use during `validateWorkflow` and `validateTemplate`
  - check for using mutex and semaphore together and also using neither
    - the latter check means that we could simplify later code around "unknown" sync types, i.e. https://github.com/argoproj/argo-workflows/pull/13358#discussion_r1705600604, https://github.com/argoproj/argo-workflows/pull/13358#discussion_r1714498505 

- remove doc sentence on mutex being ignored, as it will error now instead

### Verification

<!-- TODO: Say how you tested your changes. -->

add unit tests for both invalid cases and one valid case for Workflow-level and template-level synchronization in `validate_test.go`

### Future Work

1. [ ] make similar validation for 3.6 -- neither case in particular
1. [ ] simplify later logic around "unknown" sync types per above

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
