### PR TITLE
ci: follow-up changes and fix flaky Windows tests. Fixes #12744

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -240,10 +240,11 @@ jobs:
             profile: minimal
             use-api: false
     steps:
-      - name: Free up disk space
+      - name: Free up unused disk space
         run: |
           printf "==> Available space before cleanup\n"
           df -h
+          # these directories are not used by E2E tests
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
           printf "==> Available space after cleanup\n"
           df -h
@@ -275,14 +276,10 @@ jobs:
             export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
           fi
 
-          cat >/tmp/kubelet.config <<EOT
-          apiVersion: kubelet.config.k8s.io/v1beta1
-          kind: KubeletConfiguration
-          imageMinimumGCAge: 1h
-          imageGCHighThresholdPercent: 100
-          EOT
-
-          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=stable INSTALL_K3S_EXEC='--docker --kubelet-arg=config=/tmp/kubelet.config' K3S_KUBECONFIG_MODE=644 sh -
+          curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=stable \
+            INSTALL_K3S_EXEC="--docker --kubelet-arg=config=${GITHUB_WORKSPACE}/test/e2e/manifests/kubelet-configuration.yaml" \
+            K3S_KUBECONFIG_MODE=644 \
+            sh -
           until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml cluster-info ; do sleep 10s ; done
           cp /etc/rancher/k3s/k3s.yaml /home/runner/.kubeconfig
           echo "- name: fake_token_user" >> $KUBECONFIG

--- a/test/e2e/manifests/kubelet-configuration.yaml
+++ b/test/e2e/manifests/kubelet-configuration.yaml
@@ -1,0 +1,11 @@
+# The E2E CI workflow passes this file to k3s using "--kubelet-arg=config=".
+# Docs: https://docs.k3s.io/cli/agent?_highlight=kubelet&_highlight=arg#customized-flags
+
+# API reference: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# Prevent images from being GC'd during a test run (which will lead to ErrImageNeverPull errors) by
+# raising the minimum age to 1 hour and the disk usage threshold to 100%.
+# We probably don't need to specify both, but it doesn't hurt.
+imageMinimumGCAge: 1h
+imageGCHighThresholdPercent: 100

--- a/workflow/artifacts/http/http_test.go
+++ b/workflow/artifacts/http/http_test.go
@@ -20,13 +20,11 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 	a := &wfv1.HTTPArtifact{
 		URL: "https://github.com/argoproj/argo-workflows",
 	}
-	tempDir, err := os.MkdirTemp("", "http-artifact-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir) // clean up
+	tempDir := t.TempDir()
 
 	t.Run("Found", func(t *testing.T) {
 		tempFile := filepath.Join(tempDir, "found")
-		err = driver.Load(&wfv1.Artifact{
+		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{HTTP: a},
 		}, tempFile)
 		require.NoError(t, err)
@@ -38,7 +36,7 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 		h1 := wfv1.Header{Name: "Accept", Value: "application/json"}
 		h2 := wfv1.Header{Name: "Authorization", Value: "Bearer foo-bar"}
 		a.Headers = []wfv1.Header{h1, h2}
-		err = driver.Load(&wfv1.Artifact{
+		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{HTTP: a},
 		}, tempFile)
 		require.NoError(t, err)
@@ -48,7 +46,7 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 	})
 	t.Run("NotFound", func(t *testing.T) {
 		tempFile := filepath.Join(tempDir, "not-found")
-		err = driver.Load(&wfv1.Artifact{
+		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{
 				HTTP: &wfv1.HTTPArtifact{URL: "https://github.com/argoproj/argo-workflows/not-found"},
 			},
@@ -62,13 +60,11 @@ func TestHTTPArtifactDriver_Load(t *testing.T) {
 
 func TestArtifactoryArtifactDriver_Load(t *testing.T) {
 	driver := &ArtifactDriver{Client: http.DefaultClient}
-	tempDir, err := os.MkdirTemp("", "artifactory-artifact-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir) // clean up
+	tempDir := t.TempDir()
 
 	t.Run("NotFound", func(t *testing.T) {
 		tempFile := filepath.Join(tempDir, "not-found")
-		err = driver.Load(&wfv1.Artifact{
+		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{
 				Artifactory: &wfv1.ArtifactoryArtifact{URL: "https://github.com/argoproj/argo-workflows/not-found"},
 			},
@@ -80,7 +76,7 @@ func TestArtifactoryArtifactDriver_Load(t *testing.T) {
 	})
 	t.Run("Found", func(t *testing.T) {
 		tempFile := filepath.Join(tempDir, "found")
-		err = driver.Load(&wfv1.Artifact{
+		err := driver.Load(&wfv1.Artifact{
 			ArtifactLocation: wfv1.ArtifactLocation{
 				Artifactory: &wfv1.ArtifactoryArtifact{URL: "https://github.com/argoproj/argo-workflows"},
 			},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12744 (hopefully)

### Motivation

This addresses the comments from https://github.com/argoproj/argo-workflows/pull/13660. Also, it hopefully fixes the flaky `CI / Windows Unit Tests (pull_request)` test suite, but this is kind of a shot in the dark.

### Modifications

The errors from `CI / Windows Unit Tests (pull_request)` indicate it's trying to write temp files to `/tmp`:
```
    --- FAIL: TestArtifactoryArtifactDriver_Load/Found (0.00s)
        http_test.go:75:
            	Error Trace:	D:/a/argo-workflows/argo-workflows/workflow/artifacts/http/http_test.go:75
            	Error:      	Received unexpected error:
            	            	open /tmp/found: The system cannot find the path specified.
            	Test:       	TestArtifactoryArtifactDriver_Load/Found
```

which obviously isn't the right directory under Windows, but the test does pass sometimes, and it seems like writing to the wrong directory would cause consistent failures. Regardless, the tests should be using `os.MkdirTemp()` for this anyway.

### Verification

Will check action output
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
