### PR TITLE
fix: all written artifacts should be saved and garbage collected

### DIFF
--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -301,17 +301,17 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 		expectedArtifacts            []artifactState
 		expectedGCPodsOnWFCompletion int
 	}{
-		{
+		/*{
 			workflowFile:                 "@testdata/artifactgc/artgc-multi-strategy-multi-anno.yaml",
 			hasGC:                        true,
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 2,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "first-on-completion-1"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-3", specifiedKey: "first-on-completion-2"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-3", specifiedKey: "first-no-deletion"}, false, false},
-				artifactState{s3Location{bucketName: "my-bucket-3", specifiedKey: "second-on-deletion"}, false, true},
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "second-on-completion"}, true, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "first-on-completion-1"}, true, false},
+				{s3Location{bucketName: "my-bucket-3", specifiedKey: "first-on-completion-2"}, true, false},
+				{s3Location{bucketName: "my-bucket-3", specifiedKey: "first-no-deletion"}, false, false},
+				{s3Location{bucketName: "my-bucket-3", specifiedKey: "second-on-deletion"}, false, true},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "second-on-completion"}, true, false},
 			},
 		},
 		// entire Workflow based on a WorkflowTemplate
@@ -321,8 +321,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 1,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
 			},
 		},
 		// entire Workflow based on a WorkflowTemplate
@@ -332,8 +332,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 1,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
 			},
 		},
 		// Step in Workflow references a WorkflowTemplate's template
@@ -343,8 +343,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 1,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
 			},
 		},
 		// Step in Workflow references a WorkflowTemplate's template
@@ -354,8 +354,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 1,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, false},
 			},
 		},
 		// entire Workflow based on a WorkflowTemplate which has a Step that references another WorkflowTemplate's template
@@ -365,8 +365,8 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 1,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
-				artifactState{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-completion"}, true, false},
+				{s3Location{bucketName: "my-bucket-2", specifiedKey: "on-deletion"}, false, true},
 			},
 		},
 		// Step in Workflow references a WorkflowTemplate's template
@@ -377,15 +377,27 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 0,
 			expectedArtifacts:            []artifactState{},
-		},
+		},*/
 		// Workflow fails to write an artifact that's been defined as an Output
 		{
-			workflowFile:                 "@testdata/artifactgc/artgc-artifact-not-written.yaml",
+			workflowFile:                 "@testdata/artifactgc/artgc-non-optional-artifact-not-written.yaml",
 			hasGC:                        true,
 			workflowShouldSucceed:        false, // artifact not being present causes Workflow to fail
 			expectedGCPodsOnWFCompletion: 0,
 			expectedArtifacts: []artifactState{
-				artifactState{s3Location{bucketName: "my-bucket", derivedKey: &artifactDerivedKey{templateName: "artifact-written", artifactName: "present"}}, false, true},
+				{s3Location{bucketName: "my-bucket", derivedKey: &artifactDerivedKey{templateName: "artifact-written", artifactName: "present"}}, false, true},
+				{s3Location{bucketName: "my-bucket", derivedKey: &artifactDerivedKey{templateName: "some-artifacts-not-written", artifactName: "present"}}, false, true},
+			},
+		},
+		// Workflow doesn't write an artifact that's been defined as an Output, but it's an Optional artifact, so Workflow succeeds
+		{
+			workflowFile:                 "@testdata/artifactgc/artgc-optional-artifact-not-written.yaml",
+			hasGC:                        true,
+			workflowShouldSucceed:        true,
+			expectedGCPodsOnWFCompletion: 0,
+			expectedArtifacts: []artifactState{
+				{s3Location{bucketName: "my-bucket", derivedKey: &artifactDerivedKey{templateName: "artifact-written", artifactName: "present"}}, false, true},
+				{s3Location{bucketName: "my-bucket", derivedKey: &artifactDerivedKey{templateName: "some-artifacts-not-written", artifactName: "present"}}, false, true},
 			},
 		},
 		// Workflow defined output artifact but execution failed, no artifacts to be gced

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -301,7 +301,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 		expectedArtifacts            []artifactState
 		expectedGCPodsOnWFCompletion int
 	}{
-		/*{
+		{
 			workflowFile:                 "@testdata/artifactgc/artgc-multi-strategy-multi-anno.yaml",
 			hasGC:                        true,
 			workflowShouldSucceed:        true,
@@ -377,7 +377,7 @@ func (s *ArtifactsSuite) TestArtifactGC() {
 			workflowShouldSucceed:        true,
 			expectedGCPodsOnWFCompletion: 0,
 			expectedArtifacts:            []artifactState{},
-		},*/
+		},
 		// Workflow fails to write an artifact that's been defined as an Output
 		{
 			workflowFile:                 "@testdata/artifactgc/artgc-non-optional-artifact-not-written.yaml",

--- a/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
+++ b/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
@@ -9,7 +9,6 @@ data:
       podSpecPatch: |
         terminationGracePeriodSeconds: 3
   executor: |
-    image: quay.io/argoproj/argoexec:julie2
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
+++ b/test/e2e/manifests/mixins/workflow-controller-configmap.yaml
@@ -9,6 +9,7 @@ data:
       podSpecPatch: |
         terminationGracePeriodSeconds: 3
   executor: |
+    image: quay.io/argoproj/argoexec:julie2
     imagePullPolicy: IfNotPresent
     resources:
       requests:

--- a/test/e2e/testdata/artifactgc/artgc-non-optional-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-non-optional-artifact-not-written.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: artgc-non-optional-artifact-not-written-
+spec:
+  entrypoint: entrypoint
+  artifactGC:
+    strategy: OnWorkflowDeletion
+  podGC:
+    strategy: ""
+  templates:
+    - name: entrypoint
+      steps:
+      - - name: artifact-written
+          template: artifact-written
+      - - name: some-artifacts-not-written
+          template: some-artifacts-not-written
+    - name: artifact-written
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            echo "something" > /tmp/present
+      outputs:
+        artifacts:
+          - name: present
+            path: /tmp/present
+    - name: some-artifacts-not-written
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            echo "something" > /tmp/present
+      outputs:
+        artifacts:
+          - name: notpresent
+            path: /tmp/notpresent
+          - name: present
+            path: /tmp/present

--- a/test/e2e/testdata/artifactgc/artgc-optional-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-optional-artifact-not-written.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: artgc-artifact-not-written-
+  generateName: artgc-non-optional-artifact-not-written-
 spec:
   entrypoint: entrypoint
   artifactGC:
@@ -11,10 +11,26 @@ spec:
   templates:
     - name: entrypoint
       steps:
+      - - name: some-artifacts-not-written
+          template: some-artifacts-not-written
       - - name: artifact-written
           template: artifact-written
-      - - name: artifact-not-written
-          template: artifact-not-written
+    - name: some-artifacts-not-written
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            echo "something" > /tmp/present
+      outputs:
+        artifacts:
+          - name: notpresent
+            path: /tmp/notpresent
+            optional: true   # artifact is optional - therefore, Workflow can succeed
+          - name: present
+            path: /tmp/present
     - name: artifact-written
       container:
         image: argoproj/argosay:v2
@@ -28,16 +44,3 @@ spec:
         artifacts:
           - name: present
             path: /tmp/present
-    - name: artifact-not-written
-      container:
-        image: argoproj/argosay:v2
-        command:
-          - sh
-          - -c
-        args:
-          - |
-            echo "intentionally not writing anything to disk"
-      outputs:
-        artifacts:
-          - name: notpresent
-            path: /tmp/notpresent

--- a/test/e2e/testdata/artifactgc/artgc-optional-artifact-not-written.yaml
+++ b/test/e2e/testdata/artifactgc/artgc-optional-artifact-not-written.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: artgc-non-optional-artifact-not-written-
+  generateName: artgc-optional-artifact-not-written-
 spec:
   entrypoint: entrypoint
   artifactGC:

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -306,18 +306,23 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 		return artifacts, argoerrs.InternalWrapError(err)
 	}
 
-	var firstArtifactError error
+	aggregateError := ""
 	for _, art := range we.Template.Outputs.Artifacts {
 		saved, err := we.saveArtifact(ctx, common.MainContainerName, &art)
 
-		if err != nil && firstArtifactError == nil {
-			firstArtifactError = err
+		if err != nil {
+			aggregateError += err.Error() + "; "
 		}
 		if saved {
 			artifacts = append(artifacts, art)
 		}
 	}
-	return artifacts, firstArtifactError
+	if aggregateError == "" {
+		return artifacts, nil
+	} else {
+		return artifacts, errors.New(aggregateError)
+	}
+
 }
 
 // save artifact

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -306,39 +306,47 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 		return artifacts, argoerrs.InternalWrapError(err)
 	}
 
+	var firstArtifactError error
 	for _, art := range we.Template.Outputs.Artifacts {
-		err := we.saveArtifact(ctx, common.MainContainerName, &art)
-		if err != nil {
-			return artifacts, err
+		saved, err := we.saveArtifact(ctx, common.MainContainerName, &art)
+
+		if err != nil && firstArtifactError == nil {
+			firstArtifactError = err
 		}
-		artifacts = append(artifacts, art)
+		if saved {
+			artifacts = append(artifacts, art)
+		}
 	}
-	return artifacts, nil
+	fmt.Printf("deletethis: SaveArtifacts returns error %+v\n", firstArtifactError)
+	return artifacts, firstArtifactError
 }
 
-func (we *WorkflowExecutor) saveArtifact(ctx context.Context, containerName string, art *wfv1.Artifact) error {
+// return whether artifact was in fact saved, and if there was an error
+func (we *WorkflowExecutor) saveArtifact(ctx context.Context, containerName string, art *wfv1.Artifact) (bool, error) {
 	// Determine the file path of where to find the artifact
 	err := art.CleanPath()
 	if err != nil {
-		return err
+		return false, err
 	}
 	fileName, localArtPath, err := we.stageArchiveFile(containerName, art)
 	if err != nil {
 		if art.Optional && argoerrs.IsCode(argoerrs.CodeNotFound, err) {
 			log.Warnf("Ignoring optional artifact '%s' which does not exist in path '%s': %v", art.Name, art.Path, err)
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 	fi, err := os.Stat(localArtPath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	size := fi.Size()
 	if size == 0 {
 		log.Warnf("The file %q is empty. It may not be uploaded successfully depending on the artifact driver", localArtPath)
 	}
-	return we.saveArtifactFromFile(ctx, art, fileName, localArtPath)
+	err = we.saveArtifactFromFile(ctx, art, fileName, localArtPath)
+	fmt.Printf("deletethis: saveArtifactFromFile() returned err=%+v\n", err)
+	return err == nil, err
 }
 
 // fileBase is probably path.Base(filePath), but can be something else

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -320,6 +320,7 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 	return artifacts, firstArtifactError
 }
 
+// save artifact
 // return whether artifact was in fact saved, and if there was an error
 func (we *WorkflowExecutor) saveArtifact(ctx context.Context, containerName string, art *wfv1.Artifact) (bool, error) {
 	// Determine the file path of where to find the artifact

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -317,7 +317,6 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 			artifacts = append(artifacts, art)
 		}
 	}
-	fmt.Printf("deletethis: SaveArtifacts returns error %+v\n", firstArtifactError)
 	return artifacts, firstArtifactError
 }
 
@@ -345,7 +344,6 @@ func (we *WorkflowExecutor) saveArtifact(ctx context.Context, containerName stri
 		log.Warnf("The file %q is empty. It may not be uploaded successfully depending on the artifact driver", localArtPath)
 	}
 	err = we.saveArtifactFromFile(ctx, art, fileName, localArtPath)
-	fmt.Printf("deletethis: saveArtifactFromFile() returned err=%+v\n", err)
 	return err == nil, err
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13583 

### Motivation

Two issues:
1. Optional artifacts that were not written were still being passed back through the `WorkflowTaskResult`, which was causing Artifact GC to try to delete them (and fail to do so)
2. If any non-optional artifact did fail to get saved because it wasn't present, other artifacts would not get saved

### Modifications

To address # 1 above, only write to `WorkflowTaskResult` the artifacts which have been written, whether or not they're marked "Optional". This is what Artifact GC will attempt to delete.

To address # 2 above, don't prematurely return if an artifact fails to be saved.

### Verification

e2e test for Artifact GC now includes tests for these cases. 
To test # 1 above, see [artgc-optional-artifact-not-written.yaml](https://github.com/argoproj/argo-workflows/pull/13678/files#diff-425d1aaa0cb7f000f0b87bfcdbe2389784b658074e26aca417fc238560095ed2), which includes an Optional artifact that isn't present, which we confirm does not fail ArtifactGC. We also confirm that the Workflow succeeds in this case.

To test # 2 above, see [artgc-non-optional-artifact-not-written.yaml ](https://github.com/argoproj/argo-workflows/pull/13678/files#diff-683e9c31fb266e08c908dd874acef8d9af11a0594694d52a228260eeee53b888), which includes a non-Optional artifact that isn't present, plus another artifact which is present and we confirm does get saved. We also confirm that the Workflow succeeds in this case, since the Artifact that wasn't present was non-optional.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
