### PR TITLE
docs: remove tczhao from sustainability effort

### DIFF
--- a/community/sustainability_effort.md
+++ b/community/sustainability_effort.md
@@ -59,6 +59,5 @@ If you'd like to participate, add yourself here in a PR.
 | Isitha Subasinghe         | [`isubasinghe`](https://github.com/isubasinghe)         |
 | Julie Vogelman            | [`juliev0`](https://github.com/juliev0)                 |
 | Shuangkun Tian            | [`shuangkun`](https://github.com/shuangkun)             |
-| Tianchu Zhao              | [`tczhao`](https://github.com/tczhao)                   |
 | Yuan Tang                 | [`terrytangyuan`](https://github.com/terrytangyuan)     |
 | Mason Malone              | [`MasonM`](https://github.com/MasonM)                   |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation

I am imagining that tczhao has gotten too busy to be a part of this over the last few months?

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
