### PR TITLE
fix(cron): allow unresolved variables outside of `when`

### DIFF
--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -107,7 +107,7 @@ func (woc *cronWfOperationCtx) run(ctx context.Context, scheduledRuntime time.Ti
 
 	proceed, err := woc.enforceRuntimePolicy(ctx)
 	if err != nil {
-		woc.reportCronWorkflowError(ctx, v1alpha1.ConditionTypeSubmissionError, fmt.Sprintf("Concurrency policy error: %s", err))
+		woc.reportCronWorkflowError(ctx, v1alpha1.ConditionTypeSubmissionError, fmt.Sprintf("run policy error: %s", err))
 		return
 	} else if !proceed {
 		return
@@ -255,7 +255,7 @@ func evalWhen(cron *v1alpha1.CronWorkflow) (bool, error) {
 		return false, err
 	}
 
-	newCronStr, err := t.Replace(m, false)
+	newCronStr, err := t.Replace(m, true)
 	if err != nil {
 		return false, err
 	}

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -714,7 +714,7 @@ func TestEvaluateWhen(t *testing.T) {
 	assert.True(t, result)
 }
 
-func TestEvaluateWhenUnresolved(t *testing.T) {
+func TestEvaluateWhenUnresolvedOutside(t *testing.T) {
 	var cronWf v1alpha1.CronWorkflow
 	v1alpha1.MustUnmarshal([]byte(scheduledWf), &cronWf)
 	param := v1alpha1.Parameter{Name: "scheduled-time", Value: v1alpha1.AnyStringPtr("{{workflow.scheduledTime}}")}

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -713,3 +713,18 @@ func TestEvaluateWhen(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result)
 }
+
+func TestEvaluateWhenUnresolved(t *testing.T) {
+	var cronWf v1alpha1.CronWorkflow
+	v1alpha1.MustUnmarshal([]byte(scheduledWf), &cronWf)
+	param := v1alpha1.Parameter{Name: "scheduled-time", Value: v1alpha1.AnyStringPtr("{{workflow.scheduledTime}}")}
+	params := []v1alpha1.Parameter{param}
+	argument := v1alpha1.Arguments{Parameters: params}
+	cronWf.Spec.WorkflowSpec.Arguments = argument
+
+	cronWf.Status.LastScheduledTime = &v1.Time{Time: time.Now().Add(time.Minute * -30)}
+	cronWf.Spec.When = "{{= (now() - cronworkflow.lastScheduledTime).Minutes() >= 30 }}"
+	result, err := evalWhen(&cronWf)
+	require.NoError(t, err)
+	assert.True(t, result)
+}


### PR DESCRIPTION
This PR allows for unresolved variables to be present in cronworkflows during the evaluation of the `when` clause.
This is needed because workflow variables are not accessible/unresolved when the clause is evaluated.