### PR TITLE
feat(cli): validate `--output` flag and refactor

### DIFF
--- a/cmd/argo/commands/archive/get.go
+++ b/cmd/argo/commands/archive/get.go
@@ -12,12 +12,16 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	workflowarchivepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowarchive"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
 func NewGetCommand() *cobra.Command {
-	var output string
+	var output = common.EnumFlagValue{
+		AllowedValues: []string{"json", "yaml", "wide"},
+		Value:         "wide",
+	}
 	command := &cobra.Command{
 		Use:   "get UID",
 		Short: "get a workflow in the archive",
@@ -39,10 +43,10 @@ func NewGetCommand() *cobra.Command {
 			errors.CheckError(err)
 			wf, err := serviceClient.GetArchivedWorkflow(ctx, &workflowarchivepkg.GetArchivedWorkflowRequest{Uid: uid})
 			errors.CheckError(err)
-			printWorkflow(wf, output)
+			printWorkflow(wf, output.String())
 		},
 	}
-	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
+	command.Flags().VarP(&output, "output", "o", "Output format. "+output.Usage())
 	return command
 }
 

--- a/cmd/argo/commands/archive/list.go
+++ b/cmd/argo/commands/archive/list.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	workflowarchivepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowarchive"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/util/printer"
@@ -19,7 +20,7 @@ import (
 func NewListCommand() *cobra.Command {
 	var (
 		selector  string
-		output    string
+		output    = common.NewPrintWorkflowOutputValue("wide")
 		chunkSize int64
 	)
 	command := &cobra.Command{
@@ -44,11 +45,11 @@ func NewListCommand() *cobra.Command {
 			namespace := client.Namespace()
 			workflows, err := listArchivedWorkflows(ctx, serviceClient, namespace, selector, chunkSize)
 			errors.CheckError(err)
-			err = printer.PrintWorkflows(workflows, os.Stdout, printer.PrintOpts{Output: output, Namespace: true, UID: true})
+			err = printer.PrintWorkflows(workflows, os.Stdout, printer.PrintOpts{Output: output.String(), Namespace: true, UID: true})
 			errors.CheckError(err)
 		},
 	}
-	command.Flags().StringVarP(&output, "output", "o", "wide", "Output format. One of: json|yaml|wide")
+	command.Flags().VarP(&output, "output", "o", "Output format. "+output.Usage())
 	command.Flags().StringVarP(&selector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().Int64VarP(&chunkSize, "chunk-size", "", 0, "Return large lists in chunks rather than all at once. Pass 0 to disable.")
 	return command

--- a/cmd/argo/commands/archive/resubmit.go
+++ b/cmd/argo/commands/archive/resubmit.go
@@ -34,7 +34,7 @@ func (o *resubmitOps) hasSelector() bool {
 func NewResubmitCommand() *cobra.Command {
 	var (
 		resubmitOpts  resubmitOps
-		cliSubmitOpts common.CliSubmitOpts
+		cliSubmitOpts = common.NewCliSubmitOpts()
 	)
 	command := &cobra.Command{
 		Use:   "resubmit [WORKFLOW...]",
@@ -84,7 +84,7 @@ func NewResubmitCommand() *cobra.Command {
 
 	command.Flags().StringArrayVarP(&cliSubmitOpts.Parameters, "parameter", "p", []string{}, "input parameter to override on the original workflow spec")
 	command.Flags().Int32Var(&resubmitOpts.priority, "priority", 0, "workflow priority")
-	command.Flags().StringVarP(&cliSubmitOpts.Output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliSubmitOpts.Output, "output", "o", "Output format. "+cliSubmitOpts.Output.Usage())
 	command.Flags().BoolVarP(&cliSubmitOpts.Wait, "wait", "w", false, "wait for the workflow to complete, only works when a single workflow is resubmitted")
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is resubmitted")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")
@@ -137,7 +137,7 @@ func resubmitArchivedWorkflows(ctx context.Context, archiveServiceClient workflo
 		if err != nil {
 			return err
 		}
-		printWorkflow(lastResubmitted, cliSubmitOpts.Output)
+		printWorkflow(lastResubmitted, cliSubmitOpts.Output.String())
 	}
 
 	if len(resubmittedUids) == 1 {

--- a/cmd/argo/commands/archive/retry.go
+++ b/cmd/argo/commands/archive/retry.go
@@ -36,7 +36,7 @@ func (o *retryOps) hasSelector() bool {
 
 func NewRetryCommand() *cobra.Command {
 	var (
-		cliSubmitOpts common.CliSubmitOpts
+		cliSubmitOpts = common.NewCliSubmitOpts()
 		retryOpts     retryOps
 	)
 	command := &cobra.Command{
@@ -88,7 +88,7 @@ func NewRetryCommand() *cobra.Command {
 	}
 
 	command.Flags().StringArrayVarP(&cliSubmitOpts.Parameters, "parameter", "p", []string{}, "input parameter to override on the original workflow spec")
-	command.Flags().StringVarP(&cliSubmitOpts.Output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliSubmitOpts.Output, "output", "o", "Output format. "+cliSubmitOpts.Output.Usage())
 	command.Flags().BoolVarP(&cliSubmitOpts.Wait, "wait", "w", false, "wait for the workflow to complete, only works when a single workflow is retried")
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is retried")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")
@@ -142,7 +142,7 @@ func retryArchivedWorkflows(ctx context.Context, archiveServiceClient workflowar
 		if err != nil {
 			return err
 		}
-		printWorkflow(lastRetried, cliSubmitOpts.Output)
+		printWorkflow(lastRetried, cliSubmitOpts.Output.String())
 	}
 	if len(retriedUids) == 1 {
 		// watch or wait when there is only one workflow retried

--- a/cmd/argo/commands/clustertemplate/create.go
+++ b/cmd/argo/commands/clustertemplate/create.go
@@ -8,16 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
 )
 
 type cliCreateOpts struct {
-	output string // --output
-	strict bool   // --strict
+	output common.EnumFlagValue // --output
+	strict bool                 // --strict
 }
 
 func NewCreateCommand() *cobra.Command {
-	var cliCreateOpts cliCreateOpts
+	var cliCreateOpts = cliCreateOpts{output: common.NewPrintWorkflowOutputValue("")}
 	command := &cobra.Command{
 		Use:   "create FILE1 FILE2...",
 		Short: "create a cluster workflow template",
@@ -40,7 +41,7 @@ func NewCreateCommand() *cobra.Command {
 			createClusterWorkflowTemplates(cmd.Context(), args, &cliCreateOpts)
 		},
 	}
-	command.Flags().StringVarP(&cliCreateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliCreateOpts.output, "output", "o", "Output format. "+cliCreateOpts.output.Usage())
 	command.Flags().BoolVar(&cliCreateOpts.strict, "strict", true, "perform strict workflow validation")
 	return command
 }
@@ -64,6 +65,6 @@ func createClusterWorkflowTemplates(ctx context.Context, filePaths []string, cli
 		if err != nil {
 			log.Fatalf("Failed to create cluster workflow template: %s,  %v", wftmpl.Name, err)
 		}
-		printClusterWorkflowTemplate(created, cliOpts.output)
+		printClusterWorkflowTemplate(created, cliOpts.output.String())
 	}
 }

--- a/cmd/argo/commands/clustertemplate/get.go
+++ b/cmd/argo/commands/clustertemplate/get.go
@@ -6,11 +6,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	clusterworkflowtmplpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
 )
 
 func NewGetCommand() *cobra.Command {
-	var output string
+	var output = common.NewPrintWorkflowOutputValue("")
 
 	command := &cobra.Command{
 		Use:   "get CLUSTER WORKFLOW_TEMPLATE...",
@@ -28,11 +29,11 @@ func NewGetCommand() *cobra.Command {
 				if err != nil {
 					log.Fatal(err)
 				}
-				printClusterWorkflowTemplate(wftmpl, output)
+				printClusterWorkflowTemplate(wftmpl, output.String())
 			}
 		},
 	}
 
-	command.Flags().StringVarP(&output, "output", "o", "", "Output format. One of: json|yaml|wide")
+	command.Flags().VarP(&output, "output", "o", "Output format. "+output.Usage())
 	return command
 }

--- a/cmd/argo/commands/clustertemplate/lint.go
+++ b/cmd/argo/commands/clustertemplate/lint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/lint"
 	wf "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 )
@@ -13,7 +14,10 @@ import (
 func NewLintCommand() *cobra.Command {
 	var (
 		strict bool
-		output string
+		output = common.EnumFlagValue{
+			AllowedValues: []string{"pretty", "simple"},
+			Value:         "pretty",
+		}
 	)
 
 	command := &cobra.Command{
@@ -33,11 +37,11 @@ func NewLintCommand() *cobra.Command {
 				Printer:          os.Stdout,
 			}
 
-			lint.RunLint(ctx, apiClient, []string{wf.ClusterWorkflowTemplatePlural}, output, false, opts)
+			lint.RunLint(ctx, apiClient, []string{wf.ClusterWorkflowTemplatePlural}, output.String(), false, opts)
 		},
 	}
 
-	command.Flags().StringVarP(&output, "output", "o", "pretty", "Linting results output format. One of: pretty|simple")
+	command.Flags().VarP(&output, "output", "o", "Linting results output format. "+output.Usage())
 	command.Flags().BoolVar(&strict, "strict", true, "perform strict workflow validation")
 	return command
 }

--- a/cmd/argo/commands/clustertemplate/list.go
+++ b/cmd/argo/commands/clustertemplate/list.go
@@ -9,16 +9,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
-type listFlags struct {
-	output string // --output
-}
-
 func NewListCommand() *cobra.Command {
-	var listArgs listFlags
+	var output = common.EnumFlagValue{
+		AllowedValues: []string{"wide", "name"},
+	}
 	command := &cobra.Command{
 		Use:   "list",
 		Short: "list cluster workflow templates",
@@ -42,7 +41,7 @@ func NewListCommand() *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			switch listArgs.output {
+			switch output.String() {
 			case "", "wide":
 				printTable(cwftmplList.Items)
 			case "name":
@@ -50,11 +49,11 @@ func NewListCommand() *cobra.Command {
 					fmt.Println(cwftmp.ObjectMeta.Name)
 				}
 			default:
-				log.Fatalf("Unknown output mode: %s", listArgs.output)
+				log.Fatalf("Unknown output mode: %s", output.String())
 			}
 		},
 	}
-	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
+	command.Flags().VarP(&output, "output", "o", "Output format. "+output.Usage())
 	return command
 }
 

--- a/cmd/argo/commands/clustertemplate/update.go
+++ b/cmd/argo/commands/clustertemplate/update.go
@@ -8,16 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
 )
 
 type cliUpdateOpts struct {
-	output string // --output
-	strict bool   // --strict
+	output common.EnumFlagValue // --output
+	strict bool                 // --strict
 }
 
 func NewUpdateCommand() *cobra.Command {
-	var cliUpdateOpts cliUpdateOpts
+	var cliUpdateOpts = cliUpdateOpts{output: common.NewPrintWorkflowOutputValue("")}
 	command := &cobra.Command{
 		Use:   "update FILE1 FILE2...",
 		Short: "update a cluster workflow template",
@@ -39,7 +40,7 @@ func NewUpdateCommand() *cobra.Command {
 			updateClusterWorkflowTemplates(cmd.Context(), args, &cliUpdateOpts)
 		},
 	}
-	command.Flags().StringVarP(&cliUpdateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliUpdateOpts.output, "output", "o", "Output format. "+cliUpdateOpts.output.Usage())
 	command.Flags().BoolVar(&cliUpdateOpts.strict, "strict", true, "perform strict workflow validation")
 	return command
 }
@@ -70,6 +71,6 @@ func updateClusterWorkflowTemplates(ctx context.Context, filePaths []string, cli
 		if err != nil {
 			log.Fatalf("Failed to update cluster workflow template: %s,  %v", wftmpl.Name, err)
 		}
-		printClusterWorkflowTemplate(updated, cliOpts.output)
+		printClusterWorkflowTemplate(updated, cliOpts.output.String())
 	}
 }

--- a/cmd/argo/commands/common/flags.go
+++ b/cmd/argo/commands/common/flags.go
@@ -9,6 +9,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// EnumFlagValue represents a CLI flag that can take one of a fixed set of values, and validates
+// that the provided value is one of the allowed values.
+// There's several libraries for this (e.g. https://github.com/thediveo/enumflag), but they're overkill.
 type EnumFlagValue struct {
 	AllowedValues []string
 	Value         string

--- a/cmd/argo/commands/common/flags.go
+++ b/cmd/argo/commands/common/flags.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+type EnumFlagValue struct {
+	AllowedValues []string
+	Value         string
+}
+
+func (e *EnumFlagValue) Usage() string {
+	return fmt.Sprintf("One of: %s", strings.Join(e.AllowedValues, "|"))
+}
+
+func (e *EnumFlagValue) String() string {
+	return e.Value
+}
+
+func (e *EnumFlagValue) Set(v string) error {
+	if slices.Contains(e.AllowedValues, v) {
+		e.Value = v
+		return nil
+	} else {
+		return errors.New(e.Usage())
+	}
+}
+
+func (e *EnumFlagValue) Type() string {
+	return "string"
+}
+
+var _ pflag.Value = &EnumFlagValue{}
+
+func NewPrintWorkflowOutputValue(value string) EnumFlagValue {
+	return EnumFlagValue{
+		AllowedValues: []string{"name", "json", "yaml", "wide"},
+		Value:         value,
+	}
+}

--- a/cmd/argo/commands/common/flags_test.go
+++ b/cmd/argo/commands/common/flags_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnumFlagValue(t *testing.T) {
+	e := EnumFlagValue{
+		AllowedValues: []string{"name", "json", "yaml", "wide"},
+		Value:         "json",
+	}
+	t.Run("Usage", func(t *testing.T) {
+		assert.Equal(t, "One of: name|json|yaml|wide", e.Usage())
+	})
+
+	t.Run("String", func(t *testing.T) {
+		assert.Equal(t, "json", e.String())
+	})
+
+	t.Run("Type", func(t *testing.T) {
+		assert.Equal(t, "string", e.Type())
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		err := e.Set("name")
+		require.NoError(t, err)
+		assert.Equal(t, "name", e.Value)
+
+		err = e.Set("invalid")
+		require.Error(t, err, "One of: name|json|yaml|wide")
+	})
+}

--- a/cmd/argo/commands/common/get.go
+++ b/cmd/argo/commands/common/get.go
@@ -20,7 +20,7 @@ import (
 const onExitSuffix = "onExit"
 
 type GetFlags struct {
-	Output                  string
+	Output                  EnumFlagValue
 	NodeFieldSelectorString string
 
 	// Only used for backwards compatibility
@@ -147,9 +147,9 @@ func PrintWorkflowHelper(wf *wfv1.Workflow, getArgs GetFlags) string {
 		w := tabwriter.NewWriter(writerBuffer, 0, 0, 2, ' ', 0)
 		out += "\n"
 		// apply a dummy FgDefault format to align tab writer with the rest of the columns
-		if getArgs.Output == "wide" {
+		if getArgs.Output.String() == "wide" {
 			_, _ = fmt.Fprintf(w, "%s\tTEMPLATE\tPODNAME\tDURATION\tARTIFACTS\tMESSAGE\tRESOURCESDURATION\tNODENAME\n", ansiFormat("STEP", FgDefault))
-		} else if getArgs.Output == "short" {
+		} else if getArgs.Output.String() == "short" {
 			_, _ = fmt.Fprintf(w, "%s\tTEMPLATE\tPODNAME\tDURATION\tMESSAGE\tNODENAME\n", ansiFormat("STEP", FgDefault))
 		} else {
 			_, _ = fmt.Fprintf(w, "%s\tTEMPLATE\tPODNAME\tDURATION\tMESSAGE\n", ansiFormat("STEP", FgDefault))
@@ -171,7 +171,7 @@ func PrintWorkflowHelper(wf *wfv1.Workflow, getArgs GetFlags) string {
 			onExitRoot.renderNodes(w, wf, 0, " ", " ", getArgs)
 		}
 		_ = w.Flush()
-		if getArgs.Output == "short" {
+		if getArgs.Output.String() == "short" {
 			out = writerBuffer.String()
 		} else {
 			out += writerBuffer.String()
@@ -498,7 +498,7 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix str
 	} else {
 		args = []interface{}{nodePrefix, fmtNodeName, fmtTemplateName, "", "", node.Message, ""}
 	}
-	if getArgs.Output == "wide" {
+	if getArgs.Output.String() == "wide" {
 		msg := args[len(args)-2]
 		args[len(args)-2] = getArtifactsString(node)
 		args[len(args)-1] = msg
@@ -507,7 +507,7 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix str
 			args[len(args)-1] = node.HostNodeName
 		}
 		_, _ = fmt.Fprintf(w, "%s%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", args...)
-	} else if getArgs.Output == "short" {
+	} else if getArgs.Output.String() == "short" {
 		if node.Type == wfv1.NodeTypePod {
 			args[len(args)-1] = node.HostNodeName
 		}

--- a/cmd/argo/commands/common/get_test.go
+++ b/cmd/argo/commands/common/get_test.go
@@ -54,9 +54,7 @@ func TestPrintNode(t *testing.T) {
 	nodeTemplateRefName := "testTemplateRef"
 	nodeID := "testID"
 	nodeMessage := "test"
-	getArgs := GetFlags{
-		Output: "",
-	}
+	getArgs := GetFlags{}
 	timestamp := metav1.Time{
 		Time: time.Now(),
 	}
@@ -105,7 +103,7 @@ func TestPrintNode(t *testing.T) {
 	testPrintNodeImpl(t, "", node, getArgs)
 
 	getArgs = GetFlags{
-		Output: "",
+		Output: EnumFlagValue{AllowedValues: []string{"short", "wide"}},
 	}
 
 	node.TemplateName = nodeTemplateName
@@ -124,13 +122,13 @@ func TestPrintNode(t *testing.T) {
 	expectedPodName = util.GeneratePodName(workflowName, nodeName, templateName, nodeID, util.GetPodNameVersion())
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\n", NodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", nodeMessage, ""), node, getArgs)
 
-	getArgs.Output = "wide"
+	require.NoError(t, getArgs.Output.Set("wide"))
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t\n", NodeTypeIconMap[wfv1.NodeTypeSuspend], nodeName, nodeTemplateRefName, nodeTemplateRefName, "", "", getArtifactsString(node), nodeMessage, ""), node, getArgs)
 
 	node.Type = wfv1.NodeTypePod
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\t%s\t%s\n", JobStatusIconMap[wfv1.NodeRunning], nodeName, nodeTemplateRefName, nodeTemplateRefName, expectedPodName, "0s", getArtifactsString(node), nodeMessage, "", kubernetesNodeName), node, getArgs)
 
-	getArgs.Output = "short"
+	require.NoError(t, getArgs.Output.Set("short"))
 	testPrintNodeImpl(t, fmt.Sprintf("%s %s\t%s/%s\t%s\t%s\t%s\t%s\n", JobStatusIconMap[wfv1.NodeRunning], nodeName, nodeTemplateRefName, nodeTemplateRefName, expectedPodName, "0s", nodeMessage, kubernetesNodeName), node, getArgs)
 
 	getArgs.Status = "foobar"

--- a/cmd/argo/commands/common/submit.go
+++ b/cmd/argo/commands/common/submit.go
@@ -11,15 +11,21 @@ import (
 
 // CliSubmitOpts holds submission options specific to CLI submission (e.g. controlling output)
 type CliSubmitOpts struct {
-	Output        string // --output
-	Wait          bool   // --wait
-	Watch         bool   // --watch
-	Log           bool   // --log
-	Strict        bool   // --strict
-	Priority      *int32 // --priority
+	Output        EnumFlagValue // --output
+	Wait          bool          // --wait
+	Watch         bool          // --watch
+	Log           bool          // --log
+	Strict        bool          // --strict
+	Priority      *int32        // --priority
 	GetArgs       GetFlags
 	ScheduledTime string   // --scheduled-time
 	Parameters    []string // --parameter
+}
+
+func NewCliSubmitOpts() CliSubmitOpts {
+	return CliSubmitOpts{
+		Output: NewPrintWorkflowOutputValue(""),
+	}
 }
 
 func WaitWatchOrLog(ctx context.Context, serviceClient workflowpkg.WorkflowServiceClient, namespace string, workflowNames []string, cliSubmitOpts CliSubmitOpts) {
@@ -33,7 +39,7 @@ func WaitWatchOrLog(ctx context.Context, serviceClient workflowpkg.WorkflowServi
 		}
 	}
 	if cliSubmitOpts.Wait {
-		WaitWorkflows(ctx, serviceClient, namespace, workflowNames, false, !(cliSubmitOpts.Output == "" || cliSubmitOpts.Output == "wide"))
+		WaitWorkflows(ctx, serviceClient, namespace, workflowNames, false, !(cliSubmitOpts.Output.String() == "" || cliSubmitOpts.Output.String() == "wide"))
 	} else if cliSubmitOpts.Watch {
 		for _, workflow := range workflowNames {
 			WatchWorkflow(ctx, serviceClient, namespace, workflow, cliSubmitOpts.GetArgs)

--- a/cmd/argo/commands/cron/create.go
+++ b/cmd/argo/commands/cron/create.go
@@ -8,20 +8,21 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	cronworkflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/cronworkflow"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
 
 type cliCreateOpts struct {
-	output   string // --output
-	schedule string // --schedule
-	strict   bool   // --strict
+	output   common.EnumFlagValue // --output
+	schedule string               // --schedule
+	strict   bool                 // --strict
 }
 
 func NewCreateCommand() *cobra.Command {
 	var (
-		cliCreateOpts  cliCreateOpts
+		cliCreateOpts  = cliCreateOpts{output: common.NewPrintWorkflowOutputValue("")}
 		submitOpts     wfv1.SubmitOpts
 		parametersFile string
 	)
@@ -36,7 +37,7 @@ func NewCreateCommand() *cobra.Command {
 	}
 
 	util.PopulateSubmitOpts(command, &submitOpts, &parametersFile, false)
-	command.Flags().StringVarP(&cliCreateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliCreateOpts.output, "output", "o", "Output format. "+cliCreateOpts.output.Usage())
 	command.Flags().BoolVar(&cliCreateOpts.strict, "strict", true, "perform strict workflow validation")
 	command.Flags().StringVar(&cliCreateOpts.schedule, "schedule", "", "override cron workflow schedule")
 	return command

--- a/cmd/argo/commands/cron/get.go
+++ b/cmd/argo/commands/cron/get.go
@@ -3,15 +3,17 @@ package cron
 import (
 	"os"
 
-	"github.com/argoproj/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/argoproj/pkg/errors"
+
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/pkg/apiclient/cronworkflow"
 )
 
 func NewGetCommand() *cobra.Command {
-	var output string
+	var output = common.NewPrintWorkflowOutputValue("")
 
 	command := &cobra.Command{
 		Use:   "get CRON_WORKFLOW...",
@@ -33,11 +35,11 @@ func NewGetCommand() *cobra.Command {
 					Namespace: namespace,
 				})
 				errors.CheckError(err)
-				printCronWorkflow(cronWf, output)
+				printCronWorkflow(cronWf, output.String())
 			}
 		},
 	}
 
-	command.Flags().StringVarP(&output, "output", "o", "", "Output format. One of: json|yaml|wide")
+	command.Flags().VarP(&output, "output", "o", "Output format. "+output.Usage())
 	return command
 }

--- a/cmd/argo/commands/cron/lint.go
+++ b/cmd/argo/commands/cron/lint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/lint"
 	wf "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 )
@@ -13,7 +14,7 @@ import (
 func NewLintCommand() *cobra.Command {
 	var (
 		strict bool
-		output string
+		output = common.EnumFlagValue{AllowedValues: []string{"pretty", "simple"}, Value: "pretty"}
 	)
 
 	command := &cobra.Command{
@@ -31,11 +32,11 @@ func NewLintCommand() *cobra.Command {
 				DefaultNamespace: client.Namespace(),
 				Printer:          os.Stdout,
 			}
-			lint.RunLint(ctx, apiClient, []string{wf.CronWorkflowPlural}, output, false, opts)
+			lint.RunLint(ctx, apiClient, []string{wf.CronWorkflowPlural}, output.String(), false, opts)
 		},
 	}
 
-	command.Flags().StringVarP(&output, "output", "o", "pretty", "Linting results output format. One of: pretty|simple")
+	command.Flags().VarP(&output, "output", "o", "Linting results output format. "+output.Usage())
 	command.Flags().BoolVar(&strict, "strict", true, "perform strict validation")
 	return command
 }

--- a/cmd/argo/commands/cron/update.go
+++ b/cmd/argo/commands/cron/update.go
@@ -8,19 +8,20 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	cronworkflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/cronworkflow"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 )
 
 type cliUpdateOpts struct {
-	output string // --output
-	strict bool   // --strict
+	output common.EnumFlagValue // --output
+	strict bool                 // --strict
 }
 
 func NewUpdateCommand() *cobra.Command {
 	var (
-		cliUpdateOpts  cliUpdateOpts
+		cliUpdateOpts  = cliUpdateOpts{output: common.NewPrintWorkflowOutputValue("")}
 		submitOpts     wfv1.SubmitOpts
 		parametersFile string
 	)
@@ -44,7 +45,7 @@ func NewUpdateCommand() *cobra.Command {
 	}
 
 	util.PopulateSubmitOpts(command, &submitOpts, &parametersFile, false)
-	command.Flags().StringVarP(&cliUpdateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliUpdateOpts.output, "output", "o", "Output format. "+cliUpdateOpts.output.Usage())
 	command.Flags().BoolVar(&cliUpdateOpts.strict, "strict", true, "perform strict workflow validation")
 	return command
 }

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -17,7 +17,11 @@ import (
 )
 
 func NewGetCommand() *cobra.Command {
-	var getArgs common.GetFlags
+	var getArgs = common.GetFlags{
+		Output: common.EnumFlagValue{
+			AllowedValues: []string{"name", "json", "yaml", "short", "wide"},
+		},
+	}
 
 	command := &cobra.Command{
 		Use:   "get WORKFLOW...",
@@ -48,7 +52,7 @@ func NewGetCommand() *cobra.Command {
 		},
 	}
 
-	command.Flags().StringVarP(&getArgs.Output, "output", "o", "", "Output format. One of: json|yaml|short|wide")
+	command.Flags().VarP(&getArgs.Output, "output", "o", "Output format. "+getArgs.Output.Usage())
 	command.Flags().BoolVar(&common.NoColor, "no-color", false, "Disable colorized output")
 	command.Flags().BoolVar(&common.NoUtf8, "no-utf8", false, "Use plain 7-bits ascii characters")
 	command.Flags().StringVar(&getArgs.Status, "status", "", "Filter by status (Pending, Running, Succeeded, Skipped, Failed, Error)")
@@ -57,7 +61,7 @@ func NewGetCommand() *cobra.Command {
 }
 
 func printWorkflow(wf *wfv1.Workflow, getArgs common.GetFlags) {
-	switch getArgs.Output {
+	switch getArgs.Output.String() {
 	case "name":
 		fmt.Println(wf.ObjectMeta.Name)
 	case "json":

--- a/cmd/argo/commands/lint.go
+++ b/cmd/argo/commands/lint.go
@@ -20,8 +20,11 @@ func NewLintCommand() *cobra.Command {
 	var (
 		strict    bool
 		lintKinds []string
-		output    string
-		offline   bool
+		output    = common.EnumFlagValue{
+			AllowedValues: []string{"pretty", "simple"},
+			Value:         "pretty",
+		}
+		offline bool
 	)
 
 	command := &cobra.Command{
@@ -41,12 +44,12 @@ func NewLintCommand() *cobra.Command {
 				os.Exit(1)
 			}
 
-			runLint(cmd.Context(), args, offline, lintKinds, output, strict)
+			runLint(cmd.Context(), args, offline, lintKinds, output.String(), strict)
 		},
 	}
 
 	command.Flags().StringSliceVar(&lintKinds, "kinds", []string{"all"}, fmt.Sprintf("Which kinds will be linted. Can be: %s", strings.Join(allKinds, "|")))
-	command.Flags().StringVarP(&output, "output", "o", "pretty", "Linting results output format. One of: pretty|simple")
+	command.Flags().VarP(&output, "output", "o", "Linting results output format. "+output.Usage())
 	command.Flags().BoolVar(&strict, "strict", true, "Perform strict workflow validation")
 	command.Flags().BoolVar(&offline, "offline", false, "perform offline linting. For resources referencing other resources, the references will be resolved from the provided args")
 	command.Flags().BoolVar(&common.NoColor, "no-color", false, "Disable colorized output")

--- a/cmd/argo/commands/resubmit.go
+++ b/cmd/argo/commands/resubmit.go
@@ -32,7 +32,7 @@ func (o *resubmitOps) hasSelector() bool {
 func NewResubmitCommand() *cobra.Command {
 	var (
 		resubmitOpts  resubmitOps
-		cliSubmitOpts common.CliSubmitOpts
+		cliSubmitOpts = common.NewCliSubmitOpts()
 	)
 	command := &cobra.Command{
 		Use:   "resubmit [WORKFLOW...]",
@@ -85,7 +85,7 @@ func NewResubmitCommand() *cobra.Command {
 
 	command.Flags().StringArrayVarP(&cliSubmitOpts.Parameters, "parameter", "p", []string{}, "input parameter to override on the original workflow spec")
 	command.Flags().Int32Var(&resubmitOpts.priority, "priority", 0, "workflow priority")
-	command.Flags().StringVarP(&cliSubmitOpts.Output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliSubmitOpts.Output, "output", "o", "Output format. "+cliSubmitOpts.Output.Usage())
 	command.Flags().BoolVarP(&cliSubmitOpts.Wait, "wait", "w", false, "wait for the workflow to complete, only works when a single workflow is resubmitted")
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is resubmitted")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")

--- a/cmd/argo/commands/retry.go
+++ b/cmd/argo/commands/retry.go
@@ -34,7 +34,7 @@ func (o *retryOps) hasSelector() bool {
 
 func NewRetryCommand() *cobra.Command {
 	var (
-		cliSubmitOpts common.CliSubmitOpts
+		cliSubmitOpts = common.NewCliSubmitOpts()
 		retryOpts     retryOps
 	)
 	command := &cobra.Command{
@@ -90,7 +90,7 @@ func NewRetryCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringArrayVarP(&cliSubmitOpts.Parameters, "parameter", "p", []string{}, "input parameter to override on the original workflow spec")
-	command.Flags().StringVarP(&cliSubmitOpts.Output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliSubmitOpts.Output, "output", "o", "Output format. "+cliSubmitOpts.Output.Usage())
 	command.Flags().BoolVarP(&cliSubmitOpts.Wait, "wait", "w", false, "wait for the workflow to complete, only works when a single workflow is retried")
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is retried")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -25,7 +25,7 @@ func NewSubmitCommand() *cobra.Command {
 	var (
 		submitOpts     wfv1.SubmitOpts
 		parametersFile string
-		cliSubmitOpts  common.CliSubmitOpts
+		cliSubmitOpts  = common.NewCliSubmitOpts()
 		priority       int32
 		from           string
 	)
@@ -85,7 +85,7 @@ func NewSubmitCommand() *cobra.Command {
 		},
 	}
 	util.PopulateSubmitOpts(command, &submitOpts, &parametersFile, true)
-	command.Flags().StringVarP(&cliSubmitOpts.Output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliSubmitOpts.Output, "output", "o", "Output format. "+cliSubmitOpts.Output.Usage())
 	command.Flags().BoolVarP(&cliSubmitOpts.Wait, "wait", "w", false, "wait for the workflow to complete")
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")
@@ -143,7 +143,7 @@ func validateOptions(workflows []wfv1.Workflow, submitOpts *wfv1.SubmitOpts, cli
 	}
 
 	if submitOpts.DryRun {
-		if cliOpts.Output == "" {
+		if cliOpts.Output.String() == "" {
 			log.Fatalf("--dry-run should have an output option")
 		}
 		if submitOpts.ServerDryRun {
@@ -152,7 +152,7 @@ func validateOptions(workflows []wfv1.Workflow, submitOpts *wfv1.SubmitOpts, cli
 	}
 
 	if submitOpts.ServerDryRun {
-		if cliOpts.Output == "" {
+		if cliOpts.Output.String() == "" {
 			log.Fatalf("--server-dry-run should have an output option")
 		}
 	}

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -8,16 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
 )
 
 type cliCreateOpts struct {
-	output string // --output
-	strict bool   // --strict
+	output common.EnumFlagValue // --output
+	strict bool                 // --strict
 }
 
 func NewCreateCommand() *cobra.Command {
-	var cliCreateOpts cliCreateOpts
+	var cliCreateOpts = cliCreateOpts{output: common.NewPrintWorkflowOutputValue("")}
 	command := &cobra.Command{
 		Use:   "create FILE1 FILE2...",
 		Short: "create a workflow template",
@@ -30,7 +31,7 @@ func NewCreateCommand() *cobra.Command {
 			CreateWorkflowTemplates(cmd.Context(), args, &cliCreateOpts)
 		},
 	}
-	command.Flags().StringVarP(&cliCreateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliCreateOpts.output, "output", "o", "Output format. "+cliCreateOpts.output.Usage())
 	command.Flags().BoolVar(&cliCreateOpts.strict, "strict", true, "perform strict workflow validation")
 	return command
 }
@@ -58,6 +59,6 @@ func CreateWorkflowTemplates(ctx context.Context, filePaths []string, cliOpts *c
 		if err != nil {
 			log.Fatalf("Failed to create workflow template: %v", err)
 		}
-		printWorkflowTemplate(created, cliOpts.output)
+		printWorkflowTemplate(created, cliOpts.output.String())
 	}
 }

--- a/cmd/argo/commands/template/get.go
+++ b/cmd/argo/commands/template/get.go
@@ -6,11 +6,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
 )
 
 func NewGetCommand() *cobra.Command {
-	var output string
+	var output = common.NewPrintWorkflowOutputValue("")
 
 	command := &cobra.Command{
 		Use:   "get WORKFLOW_TEMPLATE...",
@@ -30,11 +31,11 @@ func NewGetCommand() *cobra.Command {
 				if err != nil {
 					log.Fatal(err)
 				}
-				printWorkflowTemplate(wftmpl, output)
+				printWorkflowTemplate(wftmpl, output.String())
 			}
 		},
 	}
 
-	command.Flags().StringVarP(&output, "output", "o", "", "Output format. One of: json|yaml|wide")
+	command.Flags().VarP(&output, "output", "o", "Output format. "+output.Usage())
 	return command
 }

--- a/cmd/argo/commands/template/lint.go
+++ b/cmd/argo/commands/template/lint.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/lint"
 	wf "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 )
@@ -13,7 +14,10 @@ import (
 func NewLintCommand() *cobra.Command {
 	var (
 		strict bool
-		output string
+		output = common.EnumFlagValue{
+			AllowedValues: []string{"pretty", "simple"},
+			Value:         "pretty",
+		}
 	)
 
 	command := &cobra.Command{
@@ -31,11 +35,11 @@ func NewLintCommand() *cobra.Command {
 				DefaultNamespace: client.Namespace(),
 				Printer:          os.Stdout,
 			}
-			lint.RunLint(ctx, apiClient, []string{wf.WorkflowTemplatePlural}, output, false, opts)
+			lint.RunLint(ctx, apiClient, []string{wf.WorkflowTemplatePlural}, output.String(), false, opts)
 		},
 	}
 
-	command.Flags().StringVarP(&output, "output", "o", "pretty", "Linting results output format. One of: pretty|simple")
+	command.Flags().VarP(&output, "output", "o", "Linting results output format. "+output.Usage())
 	command.Flags().BoolVar(&strict, "strict", true, "perform strict workflow validation")
 	return command
 }

--- a/cmd/argo/commands/template/list.go
+++ b/cmd/argo/commands/template/list.go
@@ -13,18 +13,19 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
 type listFlags struct {
-	allNamespaces bool   // --all-namespaces
-	output        string // --output
-	labels        string // --selector
+	allNamespaces bool                 // --all-namespaces
+	output        common.EnumFlagValue // --output
+	labels        string               // --selector
 }
 
 func NewListCommand() *cobra.Command {
-	var listArgs listFlags
+	var listArgs = listFlags{output: common.EnumFlagValue{AllowedValues: []string{"wide", "name"}}}
 	command := &cobra.Command{
 		Use:   "list",
 		Short: "list workflow templates",
@@ -50,7 +51,7 @@ func NewListCommand() *cobra.Command {
 			if err != nil {
 				log.Fatal(err)
 			}
-			switch listArgs.output {
+			switch listArgs.output.String() {
 			case "", "wide":
 				printTable(wftmplList.Items, &listArgs)
 			case "name":
@@ -63,7 +64,7 @@ func NewListCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVarP(&listArgs.allNamespaces, "all-namespaces", "A", false, "Show workflows from all namespaces")
-	command.Flags().StringVarP(&listArgs.output, "output", "o", "", "Output format. One of: wide|name")
+	command.Flags().VarP(&listArgs.output, "output", "o", "Output format. "+listArgs.output.Usage())
 	command.Flags().StringVarP(&listArgs.labels, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	return command
 }

--- a/cmd/argo/commands/template/update.go
+++ b/cmd/argo/commands/template/update.go
@@ -8,16 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/common"
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
 )
 
 type cliUpdateOpts struct {
-	output string // --output
-	strict bool   // --strict
+	output common.EnumFlagValue // --output
+	strict bool                 // --strict
 }
 
 func NewUpdateCommand() *cobra.Command {
-	var cliUpdateOpts cliUpdateOpts
+	var cliUpdateOpts = cliUpdateOpts{output: common.NewPrintWorkflowOutputValue("")}
 	command := &cobra.Command{
 		Use:   "update FILE1 FILE2...",
 		Short: "update a workflow template",
@@ -39,7 +40,7 @@ func NewUpdateCommand() *cobra.Command {
 			updateWorkflowTemplates(cmd.Context(), args, &cliUpdateOpts)
 		},
 	}
-	command.Flags().StringVarP(&cliUpdateOpts.output, "output", "o", "", "Output format. One of: name|json|yaml|wide")
+	command.Flags().VarP(&cliUpdateOpts.output, "output", "o", "Output format. "+cliUpdateOpts.output.Usage())
 	command.Flags().BoolVar(&cliUpdateOpts.strict, "strict", true, "perform strict workflow validation")
 	return command
 }
@@ -75,6 +76,6 @@ func updateWorkflowTemplates(ctx context.Context, filePaths []string, cliOpts *c
 		if err != nil {
 			log.Fatalf("Failed to update workflow template: %v", err)
 		}
-		printWorkflowTemplate(updated, cliOpts.output)
+		printWorkflowTemplate(updated, cliOpts.output.String())
 	}
 }

--- a/docs/cli/argo_archive_list.md
+++ b/docs/cli/argo_archive_list.md
@@ -28,7 +28,7 @@ argo archive list [flags]
 ```
       --chunk-size int    Return large lists in chunks rather than all at once. Pass 0 to disable.
   -h, --help              help for list
-  -o, --output string     Output format. One of: json|yaml|wide (default "wide")
+  -o, --output string     Output format. One of: name|json|yaml|wide (default "wide")
   -l, --selector string   Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
 ```
 

--- a/docs/cli/argo_cluster-template_get.md
+++ b/docs/cli/argo_cluster-template_get.md
@@ -10,7 +10,7 @@ argo cluster-template get CLUSTER WORKFLOW_TEMPLATE... [flags]
 
 ```
   -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide
+  -o, --output string   Output format. One of: name|json|yaml|wide
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/argo_cron_get.md
+++ b/docs/cli/argo_cron_get.md
@@ -10,7 +10,7 @@ argo cron get CRON_WORKFLOW... [flags]
 
 ```
   -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide
+  -o, --output string   Output format. One of: name|json|yaml|wide
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/argo_get.md
+++ b/docs/cli/argo_get.md
@@ -25,7 +25,7 @@ argo get WORKFLOW... [flags]
       --no-color                     Disable colorized output
       --no-utf8                      Use plain 7-bits ascii characters
       --node-field-selector string   selector of node to display, eg: --node-field-selector phase=abc
-  -o, --output string                Output format. One of: json|yaml|short|wide
+  -o, --output string                Output format. One of: name|json|yaml|short|wide
       --status string                Filter by status (Pending, Running, Succeeded, Skipped, Failed, Error)
 ```
 

--- a/docs/cli/argo_list.md
+++ b/docs/cli/argo_list.md
@@ -48,7 +48,7 @@ argo list [flags]
   -h, --help                    help for list
       --no-headers              Don't print headers (default print headers).
       --older string            List completed workflows finished before the specified duration (e.g. 10m, 3h, 1d)
-  -o, --output string           Output format. One of: name|wide|yaml|json
+  -o, --output string           Output format. One of: name|json|yaml|wide
       --prefix string           Filter workflows by prefix
       --resubmitted             Show resubmitted workflows
       --running                 Show running workflows. Mutually exclusive with --completed.

--- a/docs/cli/argo_template_get.md
+++ b/docs/cli/argo_template_get.md
@@ -10,7 +10,7 @@ argo template get WORKFLOW_TEMPLATE... [flags]
 
 ```
   -h, --help            help for get
-  -o, --output string   Output format. One of: json|yaml|wide
+  -o, --output string   Output format. One of: name|json|yaml|wide
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

This is a follow-up to https://github.com/argoproj/argo-workflows/pull/13656#pullrequestreview-2341800427. Many of the CLI commands take an `--output` flag, but this wasn't being validated, and there was a lot of duplication. The duplication has led to docs getting out-of-date, e.g. `argo cluster-template get --help` says `Output format. Must be one of: json|yaml|wide`, but it accepts `name` too.


### Modifications
This introduces a simple `EnumFlagValue` type to represent enum flags like `--output` and changes all commands with an `--output` flag to use it. This will cause Cobra to give a helpful error if you pass an invalid value, e.g.:
```
$ ./dist/argo list -o INVALID
Error: invalid argument "INVALID" for "-o, --output" flag: One of: name|json|yaml|wide
```

### Verification

Ran E2E tests and manually ran a few commands with `./dist/argo`

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
