### PR TITLE
docs(cli): add example argo archive list-label-keys

### DIFF
--- a/cmd/argo/commands/archive/list_label_keys.go
+++ b/cmd/argo/commands/archive/list_label_keys.go
@@ -13,6 +13,8 @@ func NewListLabelKeyCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "list-label-keys",
 		Short: "list workflows label keys in the archive",
+		Example: `# List workflows label keys in the archive:
+		argo archive list-label-keys`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, apiClient, err := client.NewAPIClient(cmd.Context())
 			if err != nil {

--- a/docs/cli/argo_archive_list-label-keys.md
+++ b/docs/cli/argo_archive_list-label-keys.md
@@ -6,6 +6,13 @@ list workflows label keys in the archive
 argo archive list-label-keys [flags]
 ```
 
+### Examples
+
+```
+# List workflows label keys in the archive:
+  argo archive list-label-keys
+```
+
 ### Options
 
 ```


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/11898

Motivation
Modify the argo archive list-label-keys command for more information

Modifications
Added examples for the argo archive list-label-keys command.

Verification
run argo archive list-label-keys  -h