### PR TITLE
docs(cli): add example of list label value

### DIFF
--- a/cmd/argo/commands/archive/list_label_values.go
+++ b/cmd/argo/commands/archive/list_label_values.go
@@ -18,6 +18,9 @@ func NewListLabelValueCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "list-label-values",
 		Short: "get workflow label values in the archive",
+		Example: `# Get workflow label values in the archive:
+  argo archive list-label-values -l key1
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listOpts := &metav1.ListOptions{
 				LabelSelector: selector,

--- a/docs/cli/argo_archive_list-label-values.md
+++ b/docs/cli/argo_archive_list-label-values.md
@@ -6,6 +6,13 @@ get workflow label values in the archive
 argo archive list-label-values [flags]
 ```
 
+### Examples
+
+```
+# Get workflow label values in the archive:
+  argo archive list-label-values -l key1
+```
+
 ### Options
 
 ```


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/11898

Motivation
Modify the argo archive list-label-values command for more info.

Modifications
Added examples for the argo archive list-label-values command.

Verification
run argo archive list-label-values -h