### PR TITLE
fix: allow .artifacts.main-logs and workflow.failures variables

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -699,6 +699,8 @@ func resolveAllVariables(scope map[string]interface{}, globalParams map[string]s
 			} else if strings.HasPrefix(trimmedTag, "tasks.name") {
 			} else if strings.HasPrefix(trimmedTag, "steps.name") {
 			} else if strings.HasPrefix(trimmedTag, "node.name") {
+			} else if strings.HasPrefix(trimmedTag, "workflow.failures") {
+			} else if strings.HasSuffix(trimmedTag, ".artifacts.main-logs") {
 			} else if strings.HasPrefix(trimmedTag, "workflow.parameters") && workflowTemplateValidation {
 				// If we are simply validating a WorkflowTemplate in isolation, some of the parameters may come from the Workflow that uses it
 			} else {

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -1038,6 +1038,21 @@ spec:
     container:
       image: alpine:latest
       command: [sh, -c]
+      args: ["echo {{workflow.status}}"]
+`
+
+var workflowFailures = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: exit-handlers-
+spec:
+  entrypoint: pass
+  templates:
+  - name: pass
+    container:
+      image: alpine:latest
+      command: [sh, -c]
       args: ["echo {{workflow.failures}}"]
 `
 
@@ -1045,6 +1060,10 @@ func TestExitHandler(t *testing.T) {
 	// ensure {{workflow.status}} is not available when not in exit handler
 	err := validate(workflowStatusNotOnExit)
 	require.Error(t, err)
+
+	// ensure {{workflow.failures}} is available
+	err = validate(workflowFailures)
+	require.NoError(t, err)
 
 	// ensure {{workflow.status}} is available in exit handler
 	err = validate(exitHandlerWorkflowStatusOnExit)

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -1057,9 +1057,9 @@ spec:
 `
 
 func TestExitHandler(t *testing.T) {
-	// ensure {{workflow.status}} is not available when not in exit handler
+	// ensure {{workflow.status}} is available when not in exit handler
 	err := validate(workflowStatusNotOnExit)
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	// ensure {{workflow.failures}} is available
 	err = validate(workflowFailures)


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/12065 and half of https://github.com/argoproj/argo-workflows/issues/12330 (the non hook usage)