### PR TITLE
docs: add 3.6 json templating upgrading notes

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,11 @@ the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summar
 
 ## Upgrading to v3.6
 
+### JSON templating fix
+
+When accessing a structure or array from json structure in a `jsonpath` expression you could end up getting a golang representation of the structure in error.
+This will now return the json representation as hoped - see #12909.
+
 ### Fixed Server `--basehref` inconsistency
 
 For consistency, the Server now uses `--base-href` and `ARGO_BASE_HREF`.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,11 +5,6 @@ the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summar
 
 ## Upgrading to v3.6
 
-### JSON templating fix
-
-When accessing a structure or array from json structure in a `jsonpath` expression you could end up getting a golang representation of the structure in error.
-This will now return the json representation as hoped - see #12909.
-
 ### Fixed Server `--basehref` inconsistency
 
 For consistency, the Server now uses `--base-href` and `ARGO_BASE_HREF`.
@@ -83,6 +78,11 @@ Custom metrics, as defined by a workflow, could be defined as one type (say coun
 
 The Prometheus `/metrics` endpoint now has TLS enabled by default.
 To disable this set `metricsConfig.secure` to `false`.
+
+### JSON templating fix
+
+When returning a map or array in an expression, you would get a Golang representation.
+This now returns plain JSON.
 
 ## Upgrading to v3.5
 


### PR DESCRIPTION
Fixes #13541
Follow up to add upgrading notes to #12909 

### Motivation

#12909 is a breaking change and wasn't listed in the upgrading notes

### Modifications

Add upgrading notes for this change. The change is subtle and probably affects few users. Some may have worked around it as per #8930 and can optionally remove `toJson` from expressions, but this is not necessary.

### Verification

`make docs` passes