### PR TITLE
chore(docs): fix artifact repository ref example name typo

### DIFF
--- a/examples/artifact-repository-ref.yaml
+++ b/examples/artifact-repository-ref.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: artifactory-repository-ref-
+  generateName: artifact-repository-ref-
 spec:
   entrypoint: main
   artifactRepositoryRef:


### PR DESCRIPTION
This example doesn't have anything to do with artifactory.