### PR TITLE
fix(controller): handle race when starting metrics server. Fixes #10807

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -159,7 +159,11 @@ func NewRootCommand() *cobra.Command {
 							dummyCancel()
 							wg.Wait()
 							go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers)
-							go wfController.RunPrometheusServer(ctx, false)
+							wg.Add(1)
+							go func() {
+								wfController.RunPrometheusServer(ctx, false)
+								wg.Done()
+							}()
 						},
 						OnStoppedLeading: func() {
 							log.WithField("id", nodeID).Info("stopped leading")

--- a/util/telemetry/exporter_prometheus.go
+++ b/util/telemetry/exporter_prometheus.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	promgo "github.com/prometheus/client_golang/prometheus"
@@ -54,8 +53,7 @@ func (config *Config) port() int {
 
 // RunPrometheusServer starts a prometheus metrics server
 // If 'isDummy' is set to true, the dummy metrics server will be started. If it's false, the prometheus metrics server will be started
-func (m *Metrics) RunPrometheusServer(ctx context.Context, isDummy bool, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (m *Metrics) RunPrometheusServer(ctx context.Context, isDummy bool) {
 	if !m.config.Enabled {
 		return
 	}

--- a/util/telemetry/exporter_prometheus.go
+++ b/util/telemetry/exporter_prometheus.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	promgo "github.com/prometheus/client_golang/prometheus"
@@ -53,7 +54,8 @@ func (config *Config) port() int {
 
 // RunPrometheusServer starts a prometheus metrics server
 // If 'isDummy' is set to true, the dummy metrics server will be started. If it's false, the prometheus metrics server will be started
-func (m *Metrics) RunPrometheusServer(ctx context.Context, isDummy bool) {
+func (m *Metrics) RunPrometheusServer(ctx context.Context, isDummy bool, wg *sync.WaitGroup) {
+	defer wg.Done()
 	if !m.config.Enabled {
 		return
 	}

--- a/util/telemetry/exporter_prometheus_test.go
+++ b/util/telemetry/exporter_prometheus_test.go
@@ -19,7 +19,6 @@ import (
 const testScopeName string = "argo-workflows-test"
 
 func TestDisablePrometheusServer(t *testing.T) {
-	var wg sync.WaitGroup
 	config := Config{
 		Enabled: false,
 		Path:    DefaultPrometheusServerPath,
@@ -29,9 +28,7 @@ func TestDisablePrometheusServer(t *testing.T) {
 	defer cancel()
 	m, err := NewMetrics(ctx, testScopeName, testScopeName, &config)
 	require.NoError(t, err)
-	wg.Add(1)
-	go m.RunPrometheusServer(ctx, false, &wg)
-	wg.Wait()
+	m.RunPrometheusServer(ctx, false)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultPrometheusServerPort, DefaultPrometheusServerPath))
 	if resp != nil {
 		defer resp.Body.Close()
@@ -52,7 +49,10 @@ func TestPrometheusServer(t *testing.T) {
 	m, err := NewMetrics(ctx, testScopeName, testScopeName, &config)
 	require.NoError(t, err)
 	wg.Add(1)
-	go m.RunPrometheusServer(ctx, false, &wg)
+	go func() {
+		m.RunPrometheusServer(ctx, false)
+		wg.Done()
+	}()
 	time.Sleep(1 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultPrometheusServerPort, DefaultPrometheusServerPath))
 	require.NoError(t, err)
@@ -83,7 +83,10 @@ func TestDummyPrometheusServer(t *testing.T) {
 	m, err := NewMetrics(ctx, testScopeName, testScopeName, &config)
 	require.NoError(t, err)
 	wg.Add(1)
-	go m.RunPrometheusServer(ctx, true, &wg)
+	go func() {
+		m.RunPrometheusServer(ctx, true)
+		wg.Done()
+	}()
 	time.Sleep(1 * time.Second)
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d%s", DefaultPrometheusServerPort, DefaultPrometheusServerPath))
 	require.NoError(t, err)

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -379,11 +379,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	<-ctx.Done()
 }
 
-func (wfc *WorkflowController) RunPrometheusServer(ctx context.Context, isDummy bool) *gosync.WaitGroup {
-	var wg gosync.WaitGroup
-	wg.Add(1)
-	go wfc.metrics.RunPrometheusServer(ctx, isDummy, &wg)
-	return &wg
+func (wfc *WorkflowController) RunPrometheusServer(ctx context.Context, isDummy bool) {
+	wfc.metrics.RunPrometheusServer(ctx, isDummy)
 }
 
 // Create and the Synchronization Manager

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -379,8 +379,11 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	<-ctx.Done()
 }
 
-func (wfc *WorkflowController) RunPrometheusServer(ctx context.Context, isDummy bool) {
-	go wfc.metrics.RunPrometheusServer(ctx, isDummy)
+func (wfc *WorkflowController) RunPrometheusServer(ctx context.Context, isDummy bool) *gosync.WaitGroup {
+	var wg gosync.WaitGroup
+	wg.Add(1)
+	go wfc.metrics.RunPrometheusServer(ctx, isDummy, &wg)
+	return &wg
 }
 
 // Create and the Synchronization Manager


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #10807 
### Motivation
While investigating the flaky `MetricsSuite/TestMetricsEndpoint` test, I noticed `listen tcp :9090: bind: address already in use` errors in the controller logs ([example](https://github.com/argoproj/argo-workflows/actions/runs/11221357877/job/31191811077)):

```
controller: time="2024-10-07T18:22:14.793Z" level=info msg="Starting dummy metrics server at localhost:9090/metrics"
server: time="2024-10-07T18:22:14.793Z" level=info msg="Creating event controller" asyncDispatch=false operationQueueSize=16 workerCount=4
server: time="2024-10-07T18:22:14.800Z" level=info msg="GRPC Server Max Message Size, MaxGRPCMessageSize, is set" GRPC_MESSAGE_SIZE=104857600
server: time="2024-10-07T18:22:14.800Z" level=info msg="Argo Server started successfully on http://localhost:2746" url="http://localhost:2746"
controller: I1007 18:22:14.800947   25045 leaderelection.go:260] successfully acquired lease argo/workflow-controller
controller: time="2024-10-07T18:22:14.801Z" level=info msg="new leader" leader=local
controller: time="2024-10-07T18:22:14.801Z" level=info msg="Generating Self Signed TLS Certificates for Telemetry Servers"
controller: time="2024-10-07T18:22:14.802Z" level=info msg="Starting prometheus metrics server at localhost:9090/metrics"
controller: panic: listen tcp :9090: bind: address already in use
controller:
controller: goroutine 37 [running]:
controller: github.com/argoproj/argo-workflows/v3/util/telemetry.(*Metrics).RunPrometheusServer.func2()
controller: 	/home/runner/work/argo-workflows/argo-workflows/util/telemetry/exporter_prometheus.go:94 +0x16a
controller: created by github.com/argoproj/argo-workflows/v3/util/telemetry.(*Metrics).RunPrometheusServer in goroutine 36
controller: 	/home/runner/work/argo-workflows/argo-workflows/util/telemetry/exporter_prometheus.go:91 +0x53c
2024/10/07 18:22:14 controller: process exited 25045: exit status 2
controller: exit status 2
2024/10/07 18:22:14 controller: backing off 4s
```

The controller gracefully handles this by automatically restarting, but it definitely shouldn't be happening. I believe this is a race condition introduced in https://github.com/argoproj/argo-workflows/pull/11295. Here's the sequence of events that trigger this:
1. Controller starts
2. Dummy metrics server started on port 9090: https://github.com/argoproj/argo-workflows/blob/07703ab1e5e61f1735008bf79847af49f01af817/cmd/workflow-controller/main.go#L139
3. Leader election takes place and controller starts leading: https://github.com/argoproj/argo-workflows/blob/07703ab1e5e61f1735008bf79847af49f01af817/cmd/workflow-controller/main.go#L141-L151
4. Context for dummy metrics server cancelled: https://github.com/argoproj/argo-workflows/blob/07703ab1e5e61f1735008bf79847af49f01af817/cmd/workflow-controller/main.go#L152
5. Dummy metrics server shuts down: https://github.com/argoproj/argo-workflows/blob/07703ab1e5e61f1735008bf79847af49f01af817/util/telemetry/exporter_prometheus.go#L106-L112
6. Prometheus metrics server started on 9090: https://github.com/argoproj/argo-workflows/blob/07703ab1e5e61f1735008bf79847af49f01af817/cmd/workflow-controller/main.go#L154

The problems is steps 5-6 can happen out-of-order, because the shutdown happens after the context is cancelled. Per [the docs](https://pkg.go.dev/context#CancelFunc), "a CancelFunc does not wait for the work to stop".

### Modifications

The controller needs to explicitly wait for the dummy metrics server to shut down properly before starting the Prometheus metrics server. There's many ways of doing that, and this uses a `WaitGroup`, as that's the simplest approach I could think of.

### Verification
Ran tests locally

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
