### PR TITLE
fix: correct retry logic

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -9,18 +9,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
-	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/argoproj/argo-workflows/v3/errors"
 	"github.com/argoproj/argo-workflows/v3/persist/sqldb"
 	workflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow"
@@ -40,6 +28,17 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/templateresolution"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 	"github.com/argoproj/argo-workflows/v3/workflow/validate"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -9,6 +9,18 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/argoproj/argo-workflows/v3/errors"
 	"github.com/argoproj/argo-workflows/v3/persist/sqldb"
 	workflowpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow"
@@ -28,17 +40,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/templateresolution"
 	"github.com/argoproj/argo-workflows/v3/workflow/util"
 	"github.com/argoproj/argo-workflows/v3/workflow/validate"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
-	corev1 "k8s.io/api/core/v1"
-	apierr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
 )
 
 const (

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -6516,6 +6516,7 @@ status:
   phase: Failed
   nodes:
     my-wf:
+      id: my-wf
       name: my-wf
       phase: Failed
 `)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -972,7 +972,7 @@ func consumeDAG(n *node, resetFunc resetFn) (*node, error) {
 }
 
 func consumePod(n *node, resetFunc resetFn, addToDelete deleteFn) (*node, error) {
-	// this sets to reset but resets are overriden by deletes in the final FormulateRetryWorkflow logic.
+	// this sets to reset but resets are overridden by deletes in the final FormulateRetryWorkflow logic.
 	curr, err := consumeTill(n, wfv1.NodeTypePod, resetFunc)
 	if err != nil {
 		return nil, err

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -840,7 +840,6 @@ func newWorkflowsDag(wf *wfv1.Workflow) ([]*node, error) {
 	// create mapping from node to parent
 	// as well as creating temp mappings from nodeID to node
 	for _, wfNode := range wf.Status.Nodes {
-		wfNode := wfNode
 		n := node{}
 		n.n = &wfNode
 		nodes[wfNode.ID] = &n
@@ -850,7 +849,6 @@ func newWorkflowsDag(wf *wfv1.Workflow) ([]*node, error) {
 	}
 
 	for _, wfNode := range wf.Status.Nodes {
-		wfNode := wfNode
 		parentWfNode, ok := parentsMap[wfNode.ID]
 		if !ok && wfNode.Name != wf.Name && !strings.HasPrefix(wfNode.Name, wf.ObjectMeta.Name+".onExit") {
 			return nil, fmt.Errorf("couldn't find parent node for %s", wfNode.ID)
@@ -1081,7 +1079,6 @@ func resetPath(isOnExitNode bool, onExitNodeName string, allNodes []*node, toNod
 			return nil, nil, fmt.Errorf("must find %s but reached the root node", mustFind)
 		}
 
-		err = nil
 		switch mustFind {
 		case wfv1.NodeTypePod:
 			curr, err = consumePod(curr, addToReset, addToDelete)
@@ -1150,10 +1147,7 @@ func dagSortedNodes(nodes []*node, rootNodeName string) []*node {
 		curr := queue[0]
 		sortedNodes = append(sortedNodes, curr)
 		queue = queue[1:]
-
-		for i := range curr.children {
-			queue = append(queue, curr.children[i])
-		}
+		queue = append(queue, curr.children...)
 	}
 
 	return sortedNodes

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1859,8 +1859,8 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry top individual pod node
 	wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step1", nil)
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(wf.Status.Nodes))
-	assert.Equal(t, 6, len(podsToDelete))
+	assert.Len(t, wf.Status.Nodes, 1)
+	assert.Len(t, podsToDelete, 6)
 
 	// Retry top individual suspend node
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
@@ -1931,6 +1931,7 @@ func TestRetryWorkflowWithNestedDAGsWithSuspendNodes(t *testing.T) {
 	// Retry the second individual node (pod node) connecting to the second DAG in one of the branches
 	wf = wfv1.MustUnmarshalWorkflow(retryWorkflowWithNestedDAGsWithSuspendNodes)
 	wf, podsToDelete, err = FormulateRetryWorkflow(ctx, wf, true, "name=fail-two-nested-dag-suspend.dag1-step3-middle2.dag2-branch2-step1.dag3-step2", nil)
+	require.NoError(t, err)
 	assert.Len(t, wf.Status.Nodes, 12)
 	assert.Equal(t, wfv1.NodeRunning, wf.Status.Nodes["fail-two-nested-dag-suspend"].Phase)
 	assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByName("fail-two-nested-dag-suspend.dag1-step1").Phase)

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1286,9 +1286,9 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		wf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
 		require.NoError(t, err)
-		require.Len(t, wf.Status.Nodes, 2)
+		require.Len(t, wf.Status.Nodes, 4)
 		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["1"].Phase)
-		assert.Len(t, podsToDelete, 3)
+		assert.Len(t, podsToDelete, 1)
 	})
 
 	t.Run("Retry continue on failed workflow with restartSuccessful and nodeFieldSelector", func(t *testing.T) {

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -2278,9 +2278,7 @@ func TestDagConversion(t *testing.T) {
 			numNilParent++
 		}
 	}
-
 	assert.Equal(1, numNilParent)
-
 }
 
 const dagDiamondRetry = `apiVersion: argoproj.io/v1alpha1
@@ -3800,8 +3798,8 @@ func TestNestedDAG(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(nestedDAG)
 
 	newWf, podsToDelete, err := FormulateRetryWorkflow(context.Background(), wf, true, "id=dag-nested-zxlc2-744943701", []string{})
+
 	require.NoError(err)
 	_ = newWf
 	_ = podsToDelete
-
 }


### PR DESCRIPTION


Fixes #12543 and other retry related issues.

### Motivation
The current retry logic is too simplistic, it relies only on resetting nodes by traversing boundary nodes.
This approach does not work, it needs to be a combination of manual traversal and boundary node traversal.

In addition to this the current logic does not take care of various edge cases, for example container sets.

It was clear some rethinking needed to be done such that:
a) edge cases were taken care of.
b) retry logic was simpler to understand and hopefully fix if any further bug were to arise.

### Modifications

This is a complete rewrite of the `FormulateRetryWorkflow` function.

### Verification

Extensive testing performed manually to verify that behaviour is as expected.