### PR TITLE
fix(test): fix http-template test

### DIFF
--- a/examples/http-hello-world.yaml
+++ b/examples/http-hello-world.yaml
@@ -22,8 +22,8 @@ spec:
             continueOn:
               failed: true
             arguments:
-              parameters: [{name: url, value: "http://openlibrary.org/people/george08/nofound.json"}]
-  
+              parameters: [{name: url, value: "https://raw.githubusercontent.com/argoproj/argo-workflows/thisisnotahash/pkg/apis/workflow/v1alpha1/generated.swagger.json"}]
+
     - name: http
       inputs:
         parameters:
@@ -31,4 +31,3 @@ spec:
       http:
        # url: http://dummy.restapiexample.com/api/v1/employees
        url: "{{inputs.parameters.url}}"
-      


### PR DESCRIPTION
The http-template example is tested as part of the examples suite. `example` folder tests have a timeout of 30 seconds.

This test attempts to get from a currently offline source of `http://openlibrary.org`. It is supposed to fail to retrieve, but because the site is offline the test times out before the http GET times out, so the test fails.

See this at https://github.com/argoproj/argo-workflows/actions/runs/11275007994/job/31355710660

### Modifications

Modify the URL to use the `successful` server, which is also github so likely to be up if CI is running. Just modify the path to be invalid, so the expected outcome of a "fail to GET" is honoured. 

### Verification

Tested locally