### PR TITLE
feat: don't add configmap volumemounts in wait container. Partial fix for #13089

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -1080,6 +1080,16 @@ func addOutputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.Template) {
 			if util.IsWindowsUNCPath(mnt.MountPath, tmpl) {
 				continue
 			}
+			isConfigMapVolume := false
+			for _, vol := range pod.Spec.Volumes {
+				if vol.Name == mnt.Name && vol.ConfigMap != nil {
+					isConfigMapVolume = true
+					break
+				}
+			}
+			if isConfigMapVolume {
+				continue
+			}
 			mnt.MountPath = filepath.Join(common.ExecutorMainFilesystemDir, mnt.MountPath)
 			// ReadOnly is needed to be false for overlapping volume mounts
 			mnt.ReadOnly = false

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -1082,7 +1082,7 @@ func addOutputArtifactsVolumes(pod *apiv1.Pod, tmpl *wfv1.Template) {
 			}
 			isConfigMapVolume := false
 			for _, vol := range pod.Spec.Volumes {
-				if vol.Name == mnt.Name && vol.ConfigMap != nil {
+				if vol.Name == mnt.Name && vol.ConfigMap != nil && vol.Name != "argo-env-config" {
 					isConfigMapVolume = true
 					break
 				}


### PR DESCRIPTION
Fixes point 2 of https://github.com/argoproj/argo-workflows/issues/13089

### Motivation
Reduce etcd usage

### Modifications
Imagine your workflow mounts 10 different .py related configmaps. Wait container has no use for these configmaps. Init container never had them, only main container needs them

### Verification
Been running successfully in my org for weeks across many different types of workflows