### PR TITLE
fix: only set `ARGO_PROGRESS_FILE` when needed. Partial fix for #13089

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -304,13 +304,16 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 		{Name: common.EnvVarNodeID, Value: nodeID},
 		{Name: common.EnvVarIncludeScriptOutput, Value: strconv.FormatBool(opts.includeScriptOutput)},
 		{Name: common.EnvVarDeadline, Value: woc.getDeadline(opts).Format(time.RFC3339)},
-		{Name: common.EnvVarProgressFile, Value: common.ArgoProgressPath},
 	}
 
-	// only set tick durations if progress is enabled. The EnvVarProgressFile is always set (user convenience) but the
-	// progress is only monitored if the tick durations are >0.
+	// only set tick durations/EnvVarProgressFile if progress is enabled.
+	// The progress is only monitored if the tick durations are >0.
 	if woc.controller.progressPatchTickDuration != 0 && woc.controller.progressFileTickDuration != 0 {
 		envVars = append(envVars,
+			apiv1.EnvVar{
+				Name:  common.EnvVarProgressFile,
+				Value: common.ArgoProgressPath,
+			},
 			apiv1.EnvVar{
 				Name:  common.EnvVarProgressPatchTickDuration,
 				Value: woc.controller.progressPatchTickDuration.String(),

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1989,13 +1989,13 @@ func TestProgressEnvVars(t *testing.T) {
 		})
 	})
 
-	t.Run("setting patch tick duration to 0 disables self reporting progress but still exposes the ARGO_PROGRESS_FILE env var as a convenience.", func(t *testing.T) {
+	t.Run("setting patch tick duration to 0 disables self reporting progress.", func(t *testing.T) {
 		cancel, pod := setup(t, func(workflowController *WorkflowController) {
 			workflowController.progressPatchTickDuration = 0
 		})
 		defer cancel()
 
-		assert.Contains(t, pod.Spec.Containers[0].Env, apiv1.EnvVar{
+		assert.NotContains(t, pod.Spec.Containers[0].Env, apiv1.EnvVar{
 			Name:  common.EnvVarProgressFile,
 			Value: common.ArgoProgressPath,
 		})
@@ -2009,13 +2009,13 @@ func TestProgressEnvVars(t *testing.T) {
 		})
 	})
 
-	t.Run("setting read file tick duration to 0 disables self reporting progress but still exposes the ARGO_PROGRESS_FILE env var as a convenience.", func(t *testing.T) {
+	t.Run("setting read file tick duration to 0 disables self reporting progress.", func(t *testing.T) {
 		cancel, pod := setup(t, func(workflowController *WorkflowController) {
 			workflowController.progressFileTickDuration = 0
 		})
 		defer cancel()
 
-		assert.Contains(t, pod.Spec.Containers[0].Env, apiv1.EnvVar{
+		assert.NotContains(t, pod.Spec.Containers[0].Env, apiv1.EnvVar{
 			Name:  common.EnvVarProgressFile,
 			Value: common.ArgoProgressPath,
 		})


### PR DESCRIPTION
Fixes point 5 of https://github.com/argoproj/argo-workflows/issues/13089

`ARGO_PROGRESS_FILE` is only used when self reporting progress