### PR TITLE
build: fix commit-msg Git hook

### DIFF
--- a/hack/git/hooks/commit-msg
+++ b/hack/git/hooks/commit-msg
@@ -6,7 +6,7 @@ grep -q 'Signed-off-by: ' "$1" || {
   exit 1
 }
 
-grep -qE '^(?:build|feat|fix|docs|style|refactor|perf|test|ci|chore|revert)\(?(?:\w+|\s|\-|_)?\)?!?:\s\w+' "$1" || grep -q 'Merge' "$1" || {
+grep -qE '^(build|feat|fix|docs|style|refactor|perf|test|ci|chore|revert)\(?(\w+|\s|\-|_)?\)?!?:\s\w+' "$1" || grep -q 'Merge' "$1" || {
   echo >&2 '❌ Commit message must be semantic: https://github.com/zeke/semantic-pull-requests' >&2
   exit 1
 }


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

The Git hook that verifies the commit messages consistently fails in both the DevContainer and my Ubuntu 24 desktop if the commit title has a scope:
```
$ printf 'feat(sso): test\n\nSigned-off-by: test' > msg && ./hack/git/hooks/commit-msg msg
grep: warning: ? at start of expression
grep: warning: ? at start of expression
❌ Commit message must be semantic: https://github.com/zeke/semantic-pull-requests

$ grep --version
grep (GNU grep) 3.11
Copyright (C) 2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Mike Haertel and others; see
<https://git.savannah.gnu.org/cgit/grep.git/tree/AUTHORS>.

grep -P uses PCRE2 10.42 2022-12-11
```

This is because `(?:` isn't valid extended regular expression syntax.

### Modifications

 Since there aren't any backreferences in this regexp, there's no need for a non-capturing group, so I replaced both instances of `(?:` with `(`.

### Verification
```
$ printf 'feat(sso): test\n\nSigned-off-by: test' > msg && ./hack/git/hooks/commit-msg msg
✅ Commit looks good
```
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
