### PR TITLE
fix(ui): allow `links` to metadata with dots. Fixes #11741

### DIFF
--- a/ui/src/app/shared/components/links.test.ts
+++ b/ui/src/app/shared/components/links.test.ts
@@ -56,4 +56,19 @@ describe('process URL', () => {
 
         expect(processURL('https://logging?${workflow.annotations.logQuery}${workflow.annotations.additionalLogParams}', object)).toBe('https://logging?query=env:qa');
     });
+
+    test('workflows annotation.', () => {
+        const object = {
+            status: {},
+            workflow: {
+                metadata: {
+                    annotations: {
+                        'workflows.argoproj.io/pod-name-format': 'v2'
+                    }
+                }
+            }
+        };
+
+        expect(processURL('https://logging?${workflow.metadata.annotations.workflows.argoproj.io/pod-name-format}', object)).toBe('https://logging?v2');
+    });
 });

--- a/ui/src/app/shared/components/links.tsx
+++ b/ui/src/app/shared/components/links.tsx
@@ -23,12 +23,25 @@ function addEpochTimestamp(jsonObject: {metadata: ObjectMeta; workflow?: Workflo
     jsonObject.status.finishedAtEpoch = toEpoch(jsonObject.status.finishedAt);
 }
 
+function splitWithMetadataKnowledge(replaceable: string) {
+    const parts = replaceable.split('.');
+    if (replaceable.startsWith('workflow.metadata.labels') || replaceable.startsWith('workflow.metadata.annotations')) {
+        // Take the first 3 parts, then join the rest
+        const result = parts.slice(0, 3);
+        result.push(parts.slice(3).join('.'));
+
+        return result;
+    }
+    return parts;
+}
+
 export function processURL(urlExpression: string, jsonObject: any) {
     addEpochTimestamp(jsonObject);
     /* replace ${} from input url with corresponding elements from object
     only return null for known variables, otherwise empty string*/
     return urlExpression.replace(/\${[^}]*}/g, x => {
-        const parts = x.replace(/(\$%7B|%7D|\${|})/g, '').split('.');
+        const replaced = x.replace(/(\$%7B|%7D|\${|})/g, '');
+        const parts = splitWithMetadataKnowledge(replaced);
         const emptyVal = parts[0] === 'workflow' ? '' : null;
         const res = parts.reduce((p: any, c: string) => (p && p[c]) || emptyVal, jsonObject);
         return res;


### PR DESCRIPTION
Fixes #11741

### Motivation

You cannot create UI links to our own annotations or labels.

Argo Workflows uses the format `workflows.argoproj.io/something` for annotations and labels. These annotations and labels have dots (`.`) in them.

The [links](https://argo-workflows.readthedocs.io/en/stable/links/) documentation says you can access all workflow fields, using a dot to go down into the child entry.

These two conflict making it impossible to access our own labels and annotations, so fix it for annotations and labels.

This was discovered whilst adding an annotation to the workflows that was useful to link from in a separate feature.

### Modifications

When splitting the variable name up use a specialised splitting function that understands that things under `workflow.metadata.labels` and `workflow.metadata.annotations` are always names and not to split further. It is crude

### Verification

Added a unit test for the hit the special code case. There are already unit tests which test the other case.

Manually tested my new link works.