### PR TITLE
fix(controller): Add configmap already exists judgment on offload Env…

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -460,9 +460,13 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 		}
 		created, err := woc.controller.kubeclientset.CoreV1().ConfigMaps(woc.wf.ObjectMeta.Namespace).Create(ctx, cm, metav1.CreateOptions{})
 		if err != nil {
-			return nil, err
+			if !apierr.IsAlreadyExists(err) {
+				return nil, err
+			}
+			woc.log.Infof("Configmap already exists: %s", cm.Name)
+		} else {
+			woc.log.Infof("Created configmap: %s", created.Name)
 		}
-		woc.log.Infof("Created configmap: %s", created.Name)
 
 		volumeConfig := apiv1.Volume{
 			Name: "argo-env-config",


### PR DESCRIPTION
…VarTemplate

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!-- Does this PR fix an issue -->

Fixes #13755 

### Motivation

if workflow pod used offload envVarTemplate, when pod create failed, and a transient error occurred. The pod will retry on moment, then this node will failed with IsAlreadyExists error.

### Modifications

We should process `Already Exists` error

### Verification

The best way to verifiy is constructing a too lang template, and than simulate a transient error
