### PR TITLE
fix: better error message for multiple workflow controllers running

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -566,7 +566,9 @@ func (woc *wfOperationCtx) podExists(nodeID string) (existing *apiv1.Pod, exists
 	}
 
 	if objectCount > 1 {
-		return nil, false, fmt.Errorf("expected < 2 pods, got %d - this is a bug", len(objs))
+		return nil, false, fmt.Errorf("expected 1 pod, got %d. This can happen when multiple workflow-controller "+
+			"pods are running and both reconciling this Workflow. Check your Argo Workflows installation for a rogue "+
+			"workflow-controller. Otherwise, this is a bug", len(objs))
 	}
 
 	if existing, ok := objs[0].(*apiv1.Pod); ok {


### PR DESCRIPTION
### Motivation

Per various GitHub issues and personal experience, the "expected < 2 pods, got 2 - this is a bug" error message mostly happens these days when users accidentally have multiple workflow controllers running. This is usually caused by a bad install, e.g. installing a cluster-wide Argo Workflows alongside a namespace-scoped one, and having both controllers reconciling Workflows.

### Modifications

Improve the error message to advise users to check for this.

### Verification

I didn't verify this, since it's just a text change.

