### PR TITLE
ci: increase timeout for e2e-tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -189,6 +189,9 @@ jobs:
     needs: [ changed-files, argo-images ]
     if: ${{ needs.changed-files.outputs.e2e-tests == 'true' }}
     runs-on: ubuntu-latest
+    # These tests usually finish in ~25m, but occasionally they take much longer due to resource
+    # contention on the runner, which we have no control over.
+    timeout-minutes: 60
     env:
       KUBECONFIG: /home/runner/.kubeconfig
       E2E_ENV_FACTOR: 2

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -189,7 +189,6 @@ jobs:
     needs: [ changed-files, argo-images ]
     if: ${{ needs.changed-files.outputs.e2e-tests == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     env:
       KUBECONFIG: /home/runner/.kubeconfig
       E2E_ENV_FACTOR: 2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #10807

### Motivation

Occasionally, tests are being canceled due to exceeding the 30 minute timeout. Example: https://github.com/argoproj/argo-workflows/actions/runs/11358993638/job/31594490093

While there are optimizations we can make to the test suite to mitigate this, sometimes resource contention causes things to slow to a crawl for reasons outside our control. In the example above, it spent 9m15s on "Free up unused disk space", which normally takes ~12s. The only thing that step is doing is running `rm -rf`, so that indicates extremely high I/O contention on the runner.

### Modifications

This removes the timeout so it uses the default of 360 minutes ([docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)). This is what ArgoCD does ([source](
https://github.com/argoproj/argo-cd/blob/049ba0aab3965f3fa73447ae2db08f3a2afd95a0/.github/workflows/ci-build.yaml#L398)), and E2E tests for ArgoCD PRs often take ~50 minutes ([example](https://github.com/argoproj/argo-cd/actions/runs/11352918460/job/31576914061)).


### Verification
Wait for actions to run

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
