### PR TITLE
build: add `make` targets to dump the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ git-ask-pass.sh
 sdks/python/client/dist/*
 /v3/
 /cmd/argoexec/commands/test.txt
+/db-dumps/
 
 # Do not commit rendered installation manifests since they are misleading to users.
 manifests/install.yaml

--- a/Makefile
+++ b/Makefile
@@ -588,11 +588,22 @@ endif
 
 .PHONY: postgres-cli
 postgres-cli:
-	kubectl exec -ti `kubectl get pod -l app=postgres -o name|cut -c 5-` -- psql -U postgres
+	kubectl exec -ti svc/postgres -- psql -U postgres
+
+.PHONY: postgres-dump
+postgres-dump:
+	@mkdir -p db-dumps
+	kubectl exec svc/postgres -- pg_dump --clean -U postgres > "db-dumps/postgres-$(BUILD_DATE).sql"
 
 .PHONY: mysql-cli
 mysql-cli:
-	kubectl exec -ti `kubectl get pod -l app=mysql -o name|cut -c 5-` -- mysql -u mysql -ppassword argo
+	kubectl exec -ti svc/mysql -- mysql -u mysql -ppassword argo
+
+.PHONY: mysql-dump
+mysql-dump:
+	@mkdir -p db-dumps
+	kubectl exec svc/mysql -- mysqldump --no-tablespaces -u mysql -ppassword argo > "db-dumps/mysql-$(BUILD_DATE).sql"
+
 
 test-cli: ./dist/argo
 

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -148,6 +148,20 @@ You'll have, either:
 * Postgres on <http://localhost:5432>, run `make postgres-cli` to access.
 * MySQL on <http://localhost:3306>, run `make mysql-cli` to access.
 
+To back up the database, use `make postgres-dump` or `make mysql-dump`, which will generate a SQL dump in the `db-dumps/` directory.
+
+```console
+make postgres-dump
+```
+
+To restore the backup, use `make postgres-cli` or `make mysql-cli`, piping in the file from the `db-dumps/` directory.
+
+Note that this is destructive and will delete any data you have stored.
+
+```console
+make postgres-cli < db-dumps/2024-10-16T17:11:58Z.sql
+```
+
 To test SSO integration, use `PROFILE=sso`:
 
 ```bash


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

When working on the DB locally, it's sometimes necessary to make backups, particularly when testing schema migrations (e.g. https://github.com/argoproj/argo-workflows/issues/13601). 

This is similar to https://github.com/argoproj/argo-workflows/pull/13715, and I thought about combining the two PRs, but I figured it's better to keep them separate, since they don't conflict with each other.

### Modifications

This adds two Make targets, `make mysql-dump` and `make postgres-dump`, to run `mysqldump` and `pg_dump`, respectively. I also simplified the existing `make mysql-cli` and `make postgres-cli` commands to use `kubectl exec svc/...` instead of manually grabbing the pod, since passing a service to `kubectl exec` will cause it to automatically select the first (and only) pod in the service.

### Verification

Tested with both `make start PROFILE=postgres` and `make start PROFILE=mysql`. 

<details>
<summary>Results for MySQL</summary>

```console
$ make mysql-dump
GIT_COMMIT=c9f0376594aed5ae0ebc53d3bf2970300406860f GIT_BRANCH=feat-cli-db-generator2 GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec svc/mysql -- mysqldump --no-tablespaces -u mysql -ppassword argo > "db-dumps/mysql-2024-10-16T17:23:43Z.sql"
mysqldump: [Warning] Using a password on the command line interface can be insecure.

$ make mysql-cli < db-dumps/mysql-2024-10-16T17\:23\:43Z.sql
GIT_COMMIT=c9f0376594aed5ae0ebc53d3bf2970300406860f GIT_BRANCH=feat-cli-db-generator2 GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec -ti svc/mysql -- mysql -u mysql -ppassword argo
Unable to use a TTY - input is not a terminal or the right kind of file
mysql: [Warning] Using a password on the command line interface can be insecure.
```
</details>

<details>
<summary>Results for PostgreSQL</summary>

```
$ make postgres-dump
GIT_COMMIT=c9f0376594aed5ae0ebc53d3bf2970300406860f GIT_BRANCH=feat-cli-db-generator2 GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec svc/postgres -- pg_dump -U postgres > "db-dumps/postgres-2024-10-16T17:26:56Z.sql"

$ make postgres-cli < db-dumps/postgres-2024-10-16T17\:28\:02Z.sql
GIT_COMMIT=d05cf6459cdd956cb621a6552f009e21db0a3789 GIT_BRANCH=main GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=true ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec -ti svc/postgres -- psql -U postgres
Unable to use a TTY - input is not a terminal or the right kind of file
SET
SET
SET
SET
SET
 set_config
------------

(1 row)

SET
SET
SET
SET
ALTER TABLE
DROP INDEX
DROP INDEX
DROP INDEX
DROP INDEX
DROP INDEX
DROP INDEX
ALTER TABLE
ALTER TABLE
ALTER TABLE
DROP TABLE
DROP TABLE
DROP TABLE
DROP TABLE
SET
SET
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
COPY 0
COPY 0
COPY 0
COPY 2
ALTER TABLE
ALTER TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE INDEX
ALTER TABLE
```
</details>

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
