### PR TITLE
chore: show `expr` errors

### DIFF
--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -55,13 +55,17 @@ func expressionReplace(w io.Writer, expression string, env map[string]interface{
 	// This allowUnresolved check is not great
 	// it allows for errors that are obviously
 	// not failed reference checks to also pass
+	if err != nil {
+		fmt.Println("failed to compile:", err)
+	}
 	if err != nil && !allowUnresolved {
 		return 0, fmt.Errorf("failed to evaluate expression: %w", err)
 	}
 	result, err := expr.Run(program, env)
 	if (err != nil || result == nil) && allowUnresolved {
 		//  <nil> result is also un-resolved, and any error can be unresolved
-		log.WithError(err).Debug("Result and error are unresolved")
+		log.WithError(err).Infof("Result and error are unresolved: result=%v", result)
+		fmt.Println("", err)
 		return w.Write([]byte(fmt.Sprintf("{{%s%s}}", kindExpression, expression)))
 	}
 	if err != nil {


### PR DESCRIPTION
For #13759 and #11101

Logs error details for expr. ie 
```
failed to compile:  unexpected token Operator(".") (1:28)
| sprig.trim(" abc ") | sprig.upper()
| ...........................^
```

co-authored by @boiledfroginthewell in https://github.com/argoproj/argo-workflows/pull/13774
