### PR TITLE
docs: remove incorrect statement about DIND not working

### DIFF
--- a/docs/walk-through/docker-in-docker-using-sidecars.md
+++ b/docs/walk-through/docker-in-docker-using-sidecars.md
@@ -1,10 +1,13 @@
 # Docker-in-Docker Using Sidecars
 
-Note: It is increasingly unlikely that the below example will work for you on your version of Kubernetes. [Since Kubernetes 1.24, the dockershim has been unavailable as part of Kubernetes](https://kubernetes.io/blog/2022/02/17/dockershim-faq/), rendering Docker-in-Docker unworkable. It is recommended to seek alternative methods of building containers, such as [Kaniko](https://github.com/GoogleContainerTools/kaniko) or [Buildkit](https://github.com/moby/buildkit). A [Buildkit Workflow example](https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/buildkit-template.yaml) is available in the examples directory of the Argo Workflows repository.
+!!! Note "Alternatives"
+    Alternative methods of building containers, such as [Kaniko](https://github.com/GoogleContainerTools/kaniko) or [Buildkit](https://github.com/moby/buildkit) can be simpler and more secure.
+    See the [Buildkit template](https://github.com/argoproj/argo-workflows/main/examples/buildkit-template.yaml) as an example.
 
----
+You can use [sidecars](sidecars.md) to implement Docker-in-Docker (DIND).
+You can use DIND to run Docker commands inside a container, such as to build and push a container image.
 
-An application of sidecars is to implement Docker-in-Docker (DIND). DIND is useful when you want to run Docker commands from inside a container. For example, you may want to build and push a container image from inside your build container. In the following example, we use the `docker:dind` image to run a Docker daemon in a sidecar and give the main container access to the daemon.
+In the following example, use the `docker:dind` image to run a Docker daemon in a sidecar and give the main container access to the daemon:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/discussions/13010#discussioncomment-9372559, https://github.com/argoproj/argo-workflows/pull/10778#issuecomment-2105499778

### Motivation

<!-- TODO: Say why you made your changes. -->

As users have mentioned, DIND does still work and the specific DIND image used comes with Docker Engine and so does not rely on the k8s container engine


### Modifications

- replace the `dockershim` note with one about "Alternatives", since DIND is still not as secure
  - use a proper admonition for the note as well, instead of "Note:" with a horizontal rule after

- also follow docs style guide for the rest of the page while at it
  - prefer 1 sentence per line, per [style guide](https://argo-workflows.readthedocs.io/en/release-3.5/doc-changes/)
  - use active voice, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-active-voice)
  - simple and direct, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
  - consistently address the user as "you" (instead of using both "you" and "we"), per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#address-the-reader-as-you)
  - not in the style guide, but link to GH instead of `raw.github` as GH is much nicer to read (e.g. syntax highlighting, line numbers, etc etc) and won't auto-download a file on certain browsers (both especially for mobile)


- add a link to the sidecar docs when it is mentioned as well

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
