### PR TITLE
refactor: don't add env variables in ARGO_TEMPLATE. Partial fix for #13089

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -301,6 +301,12 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	simplifiedTmpl.Inputs = wfv1.Inputs{
 		Artifacts: simplifiedTmpl.Inputs.Artifacts,
 	}
+	if simplifiedTmpl.Container != nil && simplifiedTmpl.Container.Env != nil {
+		simplifiedTmpl.Container.Env = []apiv1.EnvVar{}
+	}
+	if simplifiedTmpl.Script != nil && simplifiedTmpl.Script.Env != nil {
+		simplifiedTmpl.Script.Env = []apiv1.EnvVar{}
+	}
 	envVarTemplateValue := wfv1.MustMarshallJSON(simplifiedTmpl)
 
 	// Add standard environment variables, making pod spec larger


### PR DESCRIPTION
Fixes point 8 of https://github.com/argoproj/argo-workflows/issues/13089