### PR TITLE
docs: add some existing conventions to the docs style guide

### DIFF
--- a/docs/doc-changes.md
+++ b/docs/doc-changes.md
@@ -8,8 +8,14 @@ General guidelines:
 
 * Explain when you would want to use a feature.
 * Provide working examples.
+    * Prefer to [embed files](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#embedding-external-files) from the `examples/` directory.
 * Format code using back-ticks to avoid it being reported as a spelling error.
-* Prefer 1 sentence per line of markdown
+* Prefer 1 sentence per line of markdown.
+* Internally, refer to "Argo Workflows" as "Argo", unless a disambiguation is needed (such as when integrating with Argo CD).
+* Use relative links to other pages or sections
+    * For example, `[architecture](architecture.md)`
+* When documenting a new feature, add an in-line version annotation
+    * For example, `> v3.6 and after`
 * Follow the recommendations in the official [Kubernetes Documentation Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/).
     * Particularly useful sections include [Content best practices](https://kubernetes.io/docs/contribute/style/style-guide/#content-best-practices) and [Patterns to avoid](https://kubernetes.io/docs/contribute/style/style-guide/#patterns-to-avoid).
     * **Note**: Argo does not use the same tooling, so the sections on "shortcodes" and "EditorConfig" are not relevant.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

These are existing conventions that we try to follow most of the time and I figured it would be better to have a centralized link for these. I would previously say "conventionally" / "by convention" or "consistently" / "to be consistent" or link to a past example during review, but having a single source-of-truth is better.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

note a few that have recently been mentioned off the top of my head:
- relative links
  - Examples: https://github.com/argoproj/argo-workflows/pull/11751#discussion_r1316224971, https://github.com/argoproj/argo-workflows/pull/13674#discussion_r1799979342, etc
- "Argo" vs. "Argo Workflows" 
  - Examples: https://github.com/argoproj/argo-workflows/pull/13803#discussion_r1815285614, https://github.com/argoproj/argo-workflows/pull/12467#discussion_r1746330826, etc
- In-line version annotations
  - Internal Examples: https://github.com/argoproj/argo-workflows/pull/12581 and its many back links, https://github.com/argoproj/argo-workflows/pull/13645, https://github.com/argoproj/argo-workflows/pull/11731#discussion_r1314355244, etc
  - External Examples: https://kubernetes.io/docs/contribute/style/style-guide/#avoid-statements-that-will-soon-be-out-of-date (upstream style guide), https://v1-30.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection (upstream), https://github.com/kubernetes/kops/blob/daea619a5980495778fc5ea5e652a277c9433fcb/docs/networking/cilium.md?plain=1#L30 (upstream-ish), https://argo-cd.readthedocs.io/en/release-2.12/user-guide/sync-waves/ (sibling), https://www.postgresql.org/docs/9.2/datatype-json.html (dependency), etc
- embedded example files
   - Examples: e.g. https://github.com/argoproj/argo-workflows/pull/13645

### Verification

<!-- TODO: Say how you tested your changes. -->

`make docs` passes

### Future Work

1. [ ] add more existing conventions

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
