### PR TITLE
docs: add/remove elements for more clarity on the version of the docs you're on

### DIFF
--- a/docs/assets/js/extra.js
+++ b/docs/assets/js/extra.js
@@ -1,0 +1,8 @@
+// https://squidfunk.github.io/mkdocs-material/customization/?h=java#additional-javascript
+document$.subscribe(postLoad)
+
+function postLoad() {
+  // remove version from GH link so as not to mislead readers that that version is the version of the docs they're on
+  const ghVersion = document.querySelector('.md-source__fact--version'); // https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/javascripts/templates/source/index.tsx#L41
+  if (ghVersion) ghVersion.remove();
+}

--- a/docs/assets/js/extra.js
+++ b/docs/assets/js/extra.js
@@ -2,7 +2,37 @@
 document$.subscribe(postLoad)
 
 function postLoad() {
-  // remove version from GH link so as not to mislead readers that that version is the version of the docs they're on
+  removeGHVersion();
+  addVersionToLogo();
+}
+
+// remove version from GH link so as not to mislead readers that that version is the version of the docs they're on
+function removeGHVersion() {
   const ghVersion = document.querySelector('.md-source__fact--version'); // https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/javascripts/templates/source/index.tsx#L41
   if (ghVersion) ghVersion.remove();
+}
+
+// add version underneath logo
+function addVersionToLogo() {
+  const logo = document.querySelector('.md-logo'); // https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/header.html#L42
+  if (!logo) return;
+
+  // append a span with text content containing the minor version
+  const versionSpan = document.createElement('span');
+  versionSpan.appendChild(document.createTextNode(getMinorVersionFromUrl()));
+  logo.appendChild(versionSpan);
+  // modify the style a bit to account for the new text
+  logo.style.textAlign = 'center';
+  logo.style.marginBottom = '.1rem'; // shrink bottom margin a bit from original .2rem (https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/stylesheets/main/components/_header.scss#L104)
+}
+
+
+// pull the minor version out of the URL, assuming it has `/release-3.5/` or similar in it. default to 'dev'
+function getMinorVersionFromUrl() {
+  const currentUrl = window.location.href;
+  const releaseIndex = currentUrl.indexOf('release-');
+  if (releaseIndex == -1) return 'dev';
+
+  const afterRelease = currentUrl.split(releaseIndex)[1];
+  return afterRelease.split('/')?.[0] ?? 'dev'
 }

--- a/docs/assets/js/extra.js
+++ b/docs/assets/js/extra.js
@@ -8,20 +8,36 @@ function postLoad() {
 
 // remove version from GH link so as not to mislead readers that that version is the version of the docs they're on
 function removeGHVersion() {
-  const ghVersion = document.querySelector('.md-source__fact--version'); // https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/javascripts/templates/source/index.tsx#L41
-  if (ghVersion) ghVersion.remove();
+  // Selector: https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/javascripts/templates/source/index.tsx#L41
+  // Used in Header (https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/header.html#L106) and SideNav (https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/nav.html#L58)
+  document.querySelectorAll('.md-source__fact--version').forEach(removeGHVersionElem);
+}
+
+function removeGHVersionElem(ghVersion) {
+  ghVersion.remove();
+}
+
+function addVersionToLogo() {
+  // Selectors: Header (https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/header.html#L42) and SideNav (https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/nav.html#L46)
+  document.querySelectorAll('.md-logo').forEach(addVersionToLogoElem);
 }
 
 // add version underneath logo
-function addVersionToLogo() {
-  const logo = document.querySelector('.md-logo'); // https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/header.html#L42
-  if (!logo) return;
+function addVersionToLogoElem(logo, index) {
+  const isSideNav = index == 1; // 0 is header, 1 is sidenav
 
   // append a span with text content containing the minor version
   const versionSpan = document.createElement('span');
   versionSpan.appendChild(document.createTextNode(getMinorVersionFromUrl()));
+  versionSpan.style.fontSize = '12px'; // small but not tiny
+  if (isSideNav) {
+    versionSpan.style.position = 'absolute';
+    versionSpan.style.top = '20%'; // align with the argonaut logo's "ears" (top of text starts at 20%)
+    versionSpan.style.left = '65px'; // logo is 48 x 48 plus a margin; rough eyeballed calculation
+  }
   logo.appendChild(versionSpan);
-  // modify the style a bit to account for the new text
+
+  // modify the parent's style a bit to account for the new text
   logo.style.textAlign = 'center';
   logo.style.marginBottom = '.1rem'; // shrink bottom margin a bit from original .2rem (https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/stylesheets/main/components/_header.scss#L104)
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,8 @@ extra:
   analytics:
     provider: google
     property: G-5Z1VTPDL73
+extra_javascript:
+  - assets/js/extra.js
 markdown_extensions:
   - codehilite
   - admonition


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

In [CNCF Tech Docs Office Hours on Sept 25th](https://docs.google.com/document/d/1roexHTLCrErYjNT2NEoRsVnn_YNbQzZ1gyXNK8hXR4Q/edit?tab=t.0#heading=h.psfvntb79ssg), a couple of items in the docs stood out as confusing or lacking clarity around versions, including the GH link and a lack of version in the header/logo/home button
  - which I briefly summarized in the [Oct 1st Contributor Meeting](https://docs.google.com/document/d/1tznN5LB-KrNkC6dmeIzpKfuyvZWgCJpRuS-E84zseC8/edit?tab=t.0#heading=h.gfymrsa8jhi7)
  - technically a follow-up to #11390 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- remove version number from GH link
  - use JS here as this is _not_ [overrideable via partial](https://squidfunk.github.io/mkdocs-material/customization/?h=java#overriding-partials):
    - the `source` partial [uses](https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/partials/source.html#L28) a [JS component](https://github.com/squidfunk/mkdocs-material/blob/198a6801fcf687ecb4d22e5c493fdf80427bdd33/src/templates/assets/javascripts/templates/source/index.tsx#L37)
    - follows [JS customization docs](https://squidfunk.github.io/mkdocs-material/customization/?h=java#additional-javascript)
    
- add minor version number underneath the logo in the header (the "home" button)
  - when no version or `latest`, use "dev" instead, as that is more clear than "latest", per Tech Docs OH
    - unfortunately can't change the actual name in RTD though
  - this uses some hacky JS to insert the version based on the URL since there is no other way to configure this in `mkdocs`
    - versioning is outside of its scope, either via plugins, or in our case, RTD, so can't be done via partial either
    - organize the JS a bit more into functions at least though
    
    
- handle sidenav vs. header on mobile


### Verification

<!-- TODO: Say how you tested your changes. -->

Visually inspected. See screenshots:

<details><summary>Before:</summary>

Header:
![before header - Screenshot 2024-10-24 at 3 52 41 PM](https://github.com/user-attachments/assets/c7e43f74-bd05-4a6f-b1ab-c304f1ee76a5)

SideNav:
![before sidenav - Screenshot 2024-10-24 at 3 53 27 PM](https://github.com/user-attachments/assets/a4096a7e-40fd-45cf-b412-1b3b921888a7)

</details>

<details><summary>After:</summary>

Header:
![after header - Screenshot 2024-10-24 at 2 43 19 PM](https://github.com/user-attachments/assets/7acf7608-0d52-4b46-a342-4e4f0086ed6e)

SideNav:
![after sidenav - Screenshot 2024-10-24 at 3 47 37 PM](https://github.com/user-attachments/assets/f4cc595d-e5fe-4617-a752-c2cdd05b698a)

</details>

### Future Work

1. [ ] Also add a floating version warning banner for old versions and latest, as mentioned in the TechDocs Office Hours (referencing https://github.com/etcd-io/website/issues/813) as well as my own comments in https://github.com/argoproj/argo-workflows/issues/11390#issuecomment-2007818981 (referencing [CD's banner](https://github.com/argoproj/argo-cd/blob/1675b0b2aeac95316a65252e2b6c6dfff5704e72/docs/assets/versions.js#L136))
    - the RTD version warning gets ignored and closed too easily. It's also permanently closed right now per https://github.com/readthedocs/addons/issues/133#issuecomment-2192770978 / https://github.com/readthedocs/addons/pull/283

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
