### PR TITLE
docs: additional details on jsonb migration for 3.6

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -32,12 +32,53 @@ For the Emissary executor to work properly, you must set up RBAC. See [workflow 
 
 ### Archived Workflows on PostgreSQL
 
-This upgrade will transform an archived workflow column from type `json` to type `jsonb`.
-This will take some time if you have a lot of archived workflows.
+To improve performance, this upgrade will transform the column used to store archived workflows from type `json` to type `jsonb` on controller start-up.
 This requires PostgreSQL version 9.4 or higher.
 
-You can perform this modification prior to upgrading with `alter table argo_archived_workflows alter column workflow set data type jsonb using workflow::jsonb`.
-This is considered safe to do whilst running version 3.5 as the column types are compatible.
+The migration involves obtaining an [ACCESS EXCLUSIVE](https://www.postgresql.org/docs/current/explicit-locking.html) lock on the `argo_archived_wokflows` table, which blocks all reads and writes until it has finished.
+For the vast majority of users, we anticipate this will take less than a minute, but it could take much longer if you have a large number of workflows (100,000+), or the average workflow size is high (100KB+).
+
+If this is the case for you, and minimizing downtime is important, you have a few options:
+
+1. If you don't actually need the archived workflows anymore, simply delete them with `delete from argo_archived_workflows` and the migration will complete almost instantly.
+2. Using a variation of [Altering a Postgres Column with Minimal Downtime](https://making.lyst.com/2020/05/26/altering-a-postgres-column-with-minimal-downtime/), it's possible to manually perform this migration with nearly no downtime. This is a two-step process;
+    1. Before the migration, run the following queries to create a temporary `workflowjsonb` column and populate it with the existing data. This is safe to do whilst running version 3.5 because the column types are compatible.
+
+         ```sql
+         -- Add temporary workflowjsonb column
+         ALTER TABLE argo_archived_workflows ADD COLUMN workflowjsonb JSONB NULL;
+         
+         -- Add trigger to update workflowjsonb for each insert
+         CREATE OR REPLACE FUNCTION update_workflow_jsonb() RETURNS TRIGGER AS $BODY$
+         BEGIN
+             NEW.workflowjsonb=NEW.workflow;
+             RETURN NEW;
+         END
+         $BODY$ LANGUAGE PLPGSQL;
+         
+         CREATE TRIGGER argo_archived_workflows_update_workflow_jsonb
+         BEFORE INSERT ON argo_archived_workflows
+         FOR EACH ROW EXECUTE PROCEDURE update_workflow_jsonb();
+         
+         -- Backfill existing rows
+         UPDATE argo_archived_workflows SET workflowjsonb = workflow WHERE workflowjsonb IS NULL;
+         ```
+
+    2. Once the above has completed and you're ready to proceed with the migration, run the following queries before starting the controller:
+
+         ```sql
+         BEGIN;
+         LOCK TABLE argo_archived_workflows IN SHARE ROW EXCLUSIVE MODE;
+         DROP TRIGGER argo_archived_workflows_update_workflow_jsonb ON argo_archived_workflows;
+         ALTER TABLE argo_archived_workflows DROP COLUMN workflow;
+         ALTER TABLE argo_archived_workflows RENAME COLUMN workflowjsonb TO workflow;
+         ALTER TABLE argo_archived_workflows ADD CONSTRAINT workflow CHECK (workflow IS NOT NULL) NOT VALID;
+         COMMIT;
+         ```
+
+3. Version 3.6 retains compatibility with workflows stored as type `json`.
+  Therefore, it's currently safe to bypass the migration by running `update schema_history set schema_version=60`.
+  This should only be used as an emergency stop-gap, as future versions may drop support for `json` without notice.
 
 ### Metrics changes
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -32,13 +32,13 @@ For the Emissary executor to work properly, you must set up RBAC. See [workflow 
 
 ### Archived Workflows on PostgreSQL
 
-To improve performance, this upgrade will transform the column used to store archived workflows from type `json` to type `jsonb` on controller start-up.
+To improve performance, this upgrade will automatically transform the column used to store archived workflows from type `json` to type `jsonb` on controller start-up.
 This requires PostgreSQL version 9.4 or higher.
 
 The migration involves obtaining an [ACCESS EXCLUSIVE](https://www.postgresql.org/docs/current/explicit-locking.html) lock on the `argo_archived_wokflows` table, which blocks all reads and writes until it has finished.
 For the vast majority of users, we anticipate this will take less than a minute, but it could take much longer if you have a large number of workflows (100,000+), or the average workflow size is high (100KB+).
-
-If this is the case for you, and minimizing downtime is important, you have a few options:
+If you don't fall into one of those two categories, or if minimizing downtime isn't important to you, then you don't need to read any further. 
+Otherwise, you have a few options to keep downtime to a minimum:
 
 1. If you don't actually need the archived workflows anymore, simply delete them with `delete from argo_archived_workflows` and the migration will complete almost instantly.
 2. Using a variation of [Altering a Postgres Column with Minimal Downtime](https://making.lyst.com/2020/05/26/altering-a-postgres-column-with-minimal-downtime/), it's possible to manually perform this migration with nearly no downtime. This is a two-step process;

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -37,7 +37,7 @@ This requires PostgreSQL version 9.4 or higher.
 
 The migration involves obtaining an [ACCESS EXCLUSIVE](https://www.postgresql.org/docs/current/explicit-locking.html) lock on the `argo_archived_wokflows` table, which blocks all reads and writes until it has finished.
 For the vast majority of users, we anticipate this will take less than a minute, but it could take much longer if you have a large number of workflows (100,000+), or the average workflow size is high (100KB+).
-If you don't fall into one of those two categories, or if minimizing downtime isn't important to you, then you don't need to read any further. 
+If you don't fall into one of those two categories, or if minimizing downtime isn't important to you, then you don't need to read any further.
 Otherwise, you have a few options to keep downtime to a minimum:
 
 1. If you don't actually need the archived workflows anymore, simply delete them with `delete from argo_archived_workflows` and the migration will complete almost instantly.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -37,7 +37,7 @@ This requires PostgreSQL version 9.4 or higher.
 
 The migration involves obtaining an [ACCESS EXCLUSIVE](https://www.postgresql.org/docs/current/explicit-locking.html) lock on the `argo_archived_wokflows` table, which blocks all reads and writes until it has finished.
 For the vast majority of users, we anticipate this will take less than a minute, but it could take much longer if you have a large number of workflows (100,000+), or the average workflow size is high (100KB+).
-If you don't fall into one of those two categories, or if minimizing downtime isn't important to you, then you don't need to read any further.
+**If you don't fall into one of those two categories, or if minimizing downtime isn't important to you, then you don't need to read any further.**
 Otherwise, you have a few options to keep downtime to a minimum:
 
 1. If you don't actually need the archived workflows anymore, simply delete them with `delete from argo_archived_workflows` and the migration will complete almost instantly.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -42,7 +42,7 @@ If this is the case for you, and minimizing downtime is important, you have a fe
 
 1. If you don't actually need the archived workflows anymore, simply delete them with `delete from argo_archived_workflows` and the migration will complete almost instantly.
 2. Using a variation of [Altering a Postgres Column with Minimal Downtime](https://making.lyst.com/2020/05/26/altering-a-postgres-column-with-minimal-downtime/), it's possible to manually perform this migration with nearly no downtime. This is a two-step process;
-    1. Before the migration, run the following queries to create a temporary `workflowjsonb` column and populate it with the existing data. This is safe to do whilst running version 3.5 because the column types are compatible.
+    1. Before the upgrade, run the following queries to create a temporary `workflowjsonb` column and populate it with the existing data. This is safe to do whilst running version 3.5 because the column types are compatible.
 
          ```sql
          -- Add temporary workflowjsonb column
@@ -64,7 +64,7 @@ If this is the case for you, and minimizing downtime is important, you have a fe
          UPDATE argo_archived_workflows SET workflowjsonb = workflow WHERE workflowjsonb IS NULL;
          ```
 
-    2. Once the above has completed and you're ready to proceed with the migration, run the following queries before starting the controller:
+    2. Once the above has completed and you're ready to proceed with the upgrade, run the following queries before starting the controller:
 
          ```sql
          BEGIN;
@@ -77,7 +77,7 @@ If this is the case for you, and minimizing downtime is important, you have a fe
          ```
 
 3. Version 3.6 retains compatibility with workflows stored as type `json`.
-  Therefore, it's currently safe to bypass the migration by running `update schema_history set schema_version=60`.
+  Therefore, it's currently safe to [skip the migration](workflow-archive.md#automatic-database-migration) by setting `skipMigration: true`.
   This should only be used as an emergency stop-gap, as future versions may drop support for `json` without notice.
 
 ### Metrics changes


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation
This adds some additional details about the migration introduced in https://github.com/argoproj/argo-workflows/pull/13779, primarily to assist users with a very large number of archived workflows who may not be comfortable with extended downtime.


### Modifications

The manual minimal-downtime migration strategy is inspired by [Altering a Postgres Column with Minimal Downtime](https://making.lyst.com/2020/05/26/altering-a-postgres-column-with-minimal-downtime/).  I tested it locally after populating my local database with 100,000 rows using https://github.com/argoproj/argo-workflows/pull/13715:

```
$ time make postgres-cli < migrate_before.sql
GIT_COMMIT=f25960ac6f63bc3cf1a3b8a9813cf43c61921262 GIT_BRANCH=fix-migrate-jsonb GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec -ti svc/postgres -- psql -U postgres
Unable to use a TTY - input is not a terminal or the right kind of file
ALTER TABLE
CREATE FUNCTION
CREATE TRIGGER
UPDATE 100000

real    1m16.118s
user    0m2.639s
sys     0m0.548s

$ time make postgres-cli < migrate_after.sql
GIT_COMMIT=49ff7a44ba307416282a1f5cd3b844d19bce7f88 GIT_BRANCH=main GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=true ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec -ti svc/postgres -- psql -U postgres
Unable to use a TTY - input is not a terminal or the right kind of file
BEGIN
LOCK TABLE
DROP TRIGGER
ALTER TABLE
ALTER TABLE
ALTER TABLE
COMMIT

real    0m1.503s
user    0m2.786s
sys     0m0.540s
```

### Verification
Ran `make docs-serve`:

![image](https://github.com/user-attachments/assets/ca23bcde-66ea-4872-bdc0-d4e63a3129e9)

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
