### PR TITLE
docs: 3.5 Swagger UI should reference 3.5 OpenAPI spec -- 3.5 specific

### DIFF
--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -7,7 +7,7 @@
 <script>
   window.onload = function loadSwaggerUI() {
     window.ui = SwaggerUIBundle({
-      url: "https://raw.githubusercontent.com/argoproj/argo-workflows/main/api/openapi-spec/swagger.json",
+      url: "https://raw.githubusercontent.com/argoproj/argo-workflows/release-3.5/api/openapi-spec/swagger.json",
       dom_id: "#swagger-ui",
     });
   };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes "Future Work" part 2 of https://github.com/argoproj/argo-workflows/pull/13818

### Motivation

<!-- TODO: Say why you made your changes. -->

As we have versioned docs now (#11390), the Swagger UI should reference the OpenAPI spec of its release, not `main`

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

In `swagger.md`, change the raw GH URL from `main` to `release-3.5`
- I also backported https://github.com/argoproj/argo-workflows/pull/12518#issuecomment-2439824378 to make this page equivalent to `main` before this change. (the spec was always pointing to `main` both before and after, for clarity)

### Verification

<!-- TODO: Say how you tested your changes. -->

1. `mkdocs build && open site/swagger/index.html`
1. Confirmed that it loads the Swagger UI properly and loads the `release-3.5` spec. <details><summary>Screenshot:</summary> ![Screenshot 2024-10-26 at 11 40 00 PM](https://github.com/user-attachments/assets/d455b66d-0391-418d-bf68-3ac8945a6acc)

</details>

### Notes to Reviewers

This PR is specific to the `release-3.5` branch
  - will modify this upon backport to `release-3.4`

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
