### PR TITLE
ci: login to Docker Hub to avoid rate limiting

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -252,6 +252,11 @@ jobs:
           df -h
       - name: Install socat (needed by Kubernetes)
         run: sudo apt-get -y install socat
+      - name: Docker Login
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Partial fix for #10807

### Motivation

E2E test builds are occasionally failing while pulling images from Docker Hub due to rate limiting. [Example](https://github.com/argoproj/argo-workflows/actions/runs/11564257560/job/32189242898):
>  Oct 28 23:30:52 fv-az802-461 k3s[2185]: E1028 23:30:52.151698    2185 kuberuntime_image.go:53] "Failed to pull image" err="Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit" image="minio/minio:RELEASE.2022-11-17T23-20-09Z"

As explained in the error, logging in increases the limit.


### Modifications
We're already doing this in the "Release" workflow, so this copies that over: https://github.com/argoproj/argo-workflows/blob/eb23eb6b84a1ecf0826a4e16d6a2032fd0cb08b7/.github/workflows/release.yaml#L51-L55

### Verification

Wait for actions to run
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
