### PR TITLE
fix: don't print help for non-validation errors. Fixes #13826

### DIFF
--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -137,6 +137,14 @@ If your server is behind an ingress with a path (running "argo server --base-hre
 		cli.SetLogLevel(logLevel)
 		cmdutil.SetGLogLevel(glogLevel)
 		log.WithField("version", argo.GetVersion()).Debug("CLI version")
+
+		// Disable printing of usage string on errors, except for argument validation errors
+		// (i.e. when the "Args" function returns an error).
+		//
+		// This is set here instead of directly in "command" because Cobra
+		// executes PersistentPreRun after performing argument validation:
+		// https://github.com/spf13/cobra/blob/3a5efaede9d389703a792e2f7bfe3a64bc82ced9/command.go#L939-L957
+		cmd.SilenceUsage = true
 	}
 	command.PersistentFlags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
 	command.PersistentFlags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -757,6 +757,7 @@ func (s *CLISuite) TestWorkflowLint() {
 			RunCli([]string{"lint", "--kinds", "wf", "testdata/workflow-template-nested-template.yaml"}, func(t *testing.T, output string, err error) {
 				require.Error(t, err)
 				assert.Contains(t, output, "found nothing to lint in the specified paths, failing...")
+				assert.NotContains(t, output, "Usage:")
 			})
 	})
 	s.Run("All Kinds", func() {
@@ -1095,6 +1096,7 @@ func (s *CLISuite) TestTemplateCommands() {
 	s.Run("LintWithoutArgs", func() {
 		s.Given().RunCli([]string{"template", "lint"}, func(t *testing.T, output string, err error) {
 			require.Error(t, err)
+			assert.Contains(t, output, "Error: requires at least 1 arg(s), only received 0")
 			assert.Contains(t, output, "Usage:")
 		})
 	})


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13826

### Motivation
https://github.com/argoproj/argo-workflows/pull/13656 changed all CLI commands to use `RunE` instead of `Run` and to use [Cobra validators](https://cobra.dev/#positional-and-custom-arguments) for validating arguments. The default behavior with Cobra is to print the help text for all errors, which can be tedious to scroll through.
### Modifications

This changes the CLI to only print the help text for argument validation errors, which should match the previous behavior.


### Verification
```
$ ./dist/argo submit 'ANYexampleworkflow.yaml'
Error: open ANYexampleworkflow.yaml: no such file or directory

 $ ./dist/argo submit --from workflow/basic 'ANYexampleworkflow.yaml'
Error: cannot combine --from with file arguments
Usage:
  argo submit [FILE... | --from `kind/name] [flags]
<SNIP>
```
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
