### PR TITLE
fix: use templateName where  possible else nothing

### DIFF
--- a/ui/src/workflows/components/workflow-dag/workflow-dag.tsx
+++ b/ui/src/workflows/components/workflow-dag/workflow-dag.tsx
@@ -92,12 +92,12 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
         );
     }
 
-    private nodeLabel(n: NodeStatus, parent?: NodeStatus) {
+    private nodeLabel(n: NodeStatus) {
         const phase = n.type === 'Suspend' && n.phase === 'Running' ? 'Suspended' : n.phase;
         let label = shortNodeName(n);
 
         if (this.state.showInvokingTemplateName) {
-            label = `${parent?.templateRef?.name ?? parent?.templateName ?? n.templateName}:${label}`;
+            label = n.templateName ? `${n.templateName}:${label}` : label;
         }
 
         return {
@@ -228,7 +228,7 @@ export class WorkflowDag extends React.Component<WorkflowDagProps, WorkflowDagRe
                 }
                 const isExpanded: boolean = this.state.expandNodes.has('*') || this.state.expandNodes.has(item.nodeName);
 
-                nodes.set(item.nodeName, this.nodeLabel(child, allNodes[item.parent]));
+                nodes.set(item.nodeName, this.nodeLabel(child));
                 edges.set({v: item.parent, w: item.nodeName}, {});
 
                 // If we have already considered the children of this node, don't consider them again


### PR DESCRIPTION
### Motivation

This change ensures that we directly use the templateName first. In the case that we do not have this field, we then omit the template name all together. 

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
Not verified at the moment. Testing is a TODO. 
