### PR TITLE
fix(operator): allow retries to consider exit code from init container. Fixes #11354

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1448,7 +1448,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			if new.Outputs == nil {
 				new.Outputs = &wfv1.Outputs{}
 			}
-			new.Outputs.ExitCode = fmt.Sprint(int(c.State.Terminated.ExitCode))
+			if new.Outputs.ExitCode == nil {
+				new.Outputs.ExitCode = ptr.To(fmt.Sprint(int(c.State.Terminated.ExitCode)))
+			}
 			break
 		}
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1445,6 +1445,10 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		if c.State.Terminated != nil && int(c.State.Terminated.ExitCode) != 0 {
 			new.Phase = wfv1.NodeFailed
 			woc.log.WithField("new.phase", new.Phase).Info("marking node as failed since init container has non-zero exit code")
+			if new.Outputs == nil {
+				new.Outputs = &wfv1.Outputs{}
+			}
+			new.Outputs.ExitCode = fmt.Sprint(int(c.State.Terminated.ExitCode))
 			break
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/11354