### PR TITLE
chore(tests): fix lint failures

### DIFF
--- a/test/e2e/suspend_test.go
+++ b/test/e2e/suspend_test.go
@@ -113,7 +113,7 @@ spec:
 			return status.Name == "suspend-node-timeout-with-default-value[0].approve"
 		}, func(t *testing.T, status *wfv1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, wfv1.NodeSucceeded, status.Phase)
-			assert.Equal(t, 1, len(status.Outputs.Parameters))
+			assert.Len(t, status.Outputs.Parameters, 1)
 			assert.Equal(t, "message", status.Outputs.Parameters[0].Name)
 			assert.Equal(t, wfv1.AnyStringPtr("default message"), status.Outputs.Parameters[0].Value)
 		}).
@@ -121,7 +121,7 @@ spec:
 			return status.Name == "suspend-node-timeout-with-default-value[1].release"
 		}, func(t *testing.T, status *wfv1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, wfv1.NodeSucceeded, status.Phase)
-			assert.Equal(t, 1, len(status.Inputs.Parameters))
+			assert.Len(t, status.Inputs.Parameters, 1)
 			assert.Equal(t, "message", status.Inputs.Parameters[0].Name)
 			assert.Equal(t, wfv1.AnyStringPtr("default message"), status.Inputs.Parameters[0].Value)
 		})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->
### Motivation

Every PR has been failing the `make lint` checked with the following error since https://github.com/argoproj/argo-workflows/pull/12960 was merged ([example](https://github.com/argoproj/argo-workflows/actions/runs/11636897786/job/32409181464)):
```
 			assert.Equal(t, 1, len(status.Outputs.Parameters))
			^
Error: test/e2e/suspend_test.go:124:4: len: use assert.Len (testifylint)
			assert.Equal(t, 1, len(status.Inputs.Parameters))
			^
make: *** [Makefile:466: lint] Error 1
```

This is happening due to a conflict between that PR and https://github.com/argoproj/argo-workflows/pull/13467. The latter PR was merged on August 14th, but [the latest CI run for the former](https://github.com/argoproj/argo-workflows/actions/runs/9191558853/job/25278229097) was on May 22nd.


### Modifications

Change to use `assert.Len()`

### Verification

Ran `make lint` locally
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
