### PR TITLE
fix(operator): allow retries to consider exit code from init container and don't consider node as pending if init failed. Fixes #11354/#10717/#10045

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1404,7 +1404,7 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			if new.Outputs.ExitCode == nil {
 				new.Outputs.ExitCode = ptr.To(fmt.Sprint(int(c.State.Terminated.ExitCode)))
 			}
-			initContainerFailed = True
+			initContainerFailed = true
 			break
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/11354 and https://github.com/argoproj/argo-workflows/issues/10717 and https://github.com/argoproj/argo-workflows/issues/10045

Before this fix it would always go into pending because main container was waiting state (https://github.com/argoproj/argo-workflows/blob/4742e9dd6ab2b797d32cb0953849fdcfe82ea325/workflow/controller/operator.go#L1404) even though init container already terminated with non-0 exit

This supersedes https://github.com/argoproj/argo-workflows/pull/13852

cc @terrytangyuan 