### PR TITLE
fix: move taskresult reconcile earlier to avoid workflow stuck. Fixes: #13085

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -204,6 +204,9 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 
 	woc.log.WithFields(log.Fields{"Phase": woc.wf.Status.Phase, "ResourceVersion": woc.wf.ObjectMeta.ResourceVersion}).Info("Processing workflow")
 
+	// Reconciliation of Outputs (Artifacts). See ReportOutputs() of executor.go.
+	woc.taskResultReconciliation()
+
 	// Set the Execute workflow spec for execution
 	// ExecWF is a runtime execution spec which merged from Wf, WFT and Wfdefault
 	err := woc.setExecWorkflow(ctx)
@@ -230,9 +233,6 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	woc.artifactRepository = repo
 
 	woc.addArtifactGCFinalizer()
-
-	// Reconciliation of Outputs (Artifacts). See ReportOutputs() of executor.go.
-	woc.taskResultReconciliation()
 
 	// Do artifact GC if task result reconciliation is complete.
 	if woc.wf.Status.Fulfilled() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13850 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

The root cause is that taskresult has not been reconceiled. So move taskresult reconcile earlier to avoid workflow stuck.

```
time="2024-11-03T17:44:15.553Z" level=info msg="Processing workflow" Phase=Running ResourceVersion=1753330 namespace=argo workflow=workflow-template-hello-world-gfbjh
time="2024-11-03T17:44:15.554Z" level=debug msg="Task results completion status: map[workflow-template-hello-world-gfbjh-2798872602:false]" namespace=argo workflow=workflow-template-hello-world-gfbjh
time="2024-11-03T17:44:15.554Z" level=debug msg="taskresults of workflow are incomplete or still have daemon nodes, so can't mark workflow completed" fromPhase=Running namespace=argo toPhase=Error workflow=workflow-template-hello-world-gfbjh
time="2024-11-03T17:44:15.554Z" level=error msg="Unable to set ExecWorkflow" error="WorkflowSpec may not change during execution when the controller is set `templateReferencing: Secure`" namespace=argo workflow=workflow-template-hello-world-gfbjh
```

### Verification

The scenario in the issue is verified and the workflow is set to error.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
