### PR TITLE
fix: resolve output artifact of the step's hook. Fixes: #13860

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1592,7 +1592,7 @@ func (lch *LifecycleHook) WithArgs(args Arguments) *LifecycleHook {
 var _ TemplateReferenceHolder = &WorkflowStep{}
 
 func (step *WorkflowStep) HasExitHook() bool {
-	return (step.Hooks != nil) || step.OnExit != ""
+	return step.Hooks != nil || step.OnExit != ""
 }
 
 func (step *WorkflowStep) GetExitHook(args Arguments) *LifecycleHook {

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1592,7 +1592,7 @@ func (lch *LifecycleHook) WithArgs(args Arguments) *LifecycleHook {
 var _ TemplateReferenceHolder = &WorkflowStep{}
 
 func (step *WorkflowStep) HasExitHook() bool {
-	return (step.Hooks != nil && step.Hooks.HasExitHook()) || step.OnExit != ""
+	return (step.Hooks != nil) || step.OnExit != ""
 }
 
 func (step *WorkflowStep) GetExitHook(args Arguments) *LifecycleHook {

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1592,7 +1592,7 @@ func (lch *LifecycleHook) WithArgs(args Arguments) *LifecycleHook {
 var _ TemplateReferenceHolder = &WorkflowStep{}
 
 func (step *WorkflowStep) HasExitHook() bool {
-	return step.Hooks != nil || step.OnExit != ""
+	return (step.Hooks != nil && step.Hooks.HasExitHook()) || step.OnExit != ""
 }
 
 func (step *WorkflowStep) GetExitHook(args Arguments) *LifecycleHook {

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -926,7 +926,7 @@ spec:
 			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
-			return strings.Contains(status.Name, ".hooks.succeed")
+			return strings.Contains(status.Name, ".hooks.success")
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
 		})

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -921,10 +921,10 @@ spec:
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted).
+		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
 			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
-		Then().
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".hooks.succeed")
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -872,9 +872,8 @@ spec:
 		}))
 }
 
-func (s *HooksSuite) TestHooksWithArtifacts() {
-	var onExitNodeName string
-	(s.Given().
+func (s *HooksSuite) TestHooksWithArtifactsInSteps() {
+	s.Given().
 		Workflow(`apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -929,7 +928,7 @@ spec:
 			return strings.Contains(status.Name, ".hooks.succeed")
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {
 			assert.Equal(t, v1alpha1.NodeSucceeded, status.Phase)
-		}))
+		})
 }
 
 func TestHooksSuite(t *testing.T) {

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -924,6 +924,7 @@ spec:
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
 			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
+		Then().
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return strings.Contains(status.Name, ".hooks.succeed")
 		}, func(t *testing.T, status *v1alpha1.NodeStatus, pod *apiv1.Pod) {

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -915,7 +915,7 @@ spec:
         path: /tmp/file_path
     script:
       image: python:alpine3.6
-      command: [sh, -c]
+      command: ["sh"]
       source: |
         echo "File Path: {{inputs.artifacts.file_path.path}}"
 `).When().

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -963,7 +963,7 @@ func (ctx *templateValidationCtx) validateSteps(scope map[string]interface{}, tm
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s.steps[%d].%s %s", tmpl.Name, i, step.Name, err.Error())
 			}
 
-			if step.HasExitHook() {
+			if step.HasExitHook() || step.Hooks != nil {
 				ctx.addOutputsToScope(resolvedTmpl, fmt.Sprintf("steps.%s", step.Name), scope, false, false)
 			}
 			resolvedTemplates[step.Name] = resolvedTmpl


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->
When the hooks of the step are not empty, addOutputsToScope should be executed even if there is no exit hook.
<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13860

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
