### PR TITLE
chore: update kit reference in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,12 +533,7 @@ dist/argosay:
 .PHONY: kit
 kit: Makefile
 ifeq ($(shell command -v kit),)
-ifeq ($(shell uname),Darwin)
-	brew tap kitproj/kit --custom-remote https://github.com/kitproj/kit
-	brew install kit
-else
 	curl -q https://raw.githubusercontent.com/kitproj/kit/main/install.sh | tag=v0.1.8 sh
-endif
 endif
 
 


### PR DESCRIPTION
Without this on mac the wrong kit project was being installed (https://github.com/johnlindquist/kit instead of https://github.com/kitproj/kit)