### PR TITLE
fix: handle retries when downloading artifacts from minio. Fixes #9908/#10988

### DIFF
--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -102,7 +102,7 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 	if origErr == nil {
 		return true, nil
 	}
-	
+
 	if strings.Contains(origErr.Error(), "fileName is a directory.") {
 		// Handle directory case by checking if it's a valid directory
 		isDir, err := s3cli.IsDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
@@ -117,7 +117,7 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 			return true, nil
 		}
 	}
-	
+
 	if !argos3.IsS3ErrCode(origErr, "NoSuchKey") {
 		return !isTransientS3Err(origErr), fmt.Errorf("failed to get file: %v", origErr)
 	}

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -103,7 +103,7 @@ func loadS3Artifact(s3cli argos3.S3Client, inputArtifact *wfv1.Artifact, path st
 		return true, nil
 	}
 	
-	if strings.Contains(origErr, "fileName is a directory.") {
+	if strings.Contains(origErr.Error(), "fileName is a directory.") {
 		// Handle directory case by checking if it's a valid directory
 		isDir, err := s3cli.IsDirectory(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/argoproj/argo-workflows/issues/9908 and https://github.com/argoproj/argo-workflows/issues/10988

call path:
https://github.com/minio/minio-go/blob/ab1c2fe050a4dd502c863178696a54c44610ca82/api-get-object-file.go#L45
https://github.com/argoproj/pkg/blob/cc60c5cd5c747dad3b8d6d3c6a3af87c6a144b40/s3/s3.go#L301
https://github.com/argoproj/argo-workflows/blob/6b086368f6480a2de5e2d43eec73514de0ad01ac/workflow/artifacts/s3/s3.go#L84