### PR TITLE
docs: fix refs to `stopStrategy.expression`

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -4972,7 +4972,7 @@
           "description": "LastScheduleTime is the last time the CronWorkflow was scheduled"
         },
         "phase": {
-          "description": "v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true",
+          "description": "v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true",
           "type": "string"
         },
         "succeeded": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9005,7 +9005,7 @@
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
         },
         "phase": {
-          "description": "v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true",
+          "description": "v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true",
           "type": "string"
         },
         "succeeded": {

--- a/docs/cron-workflows.md
+++ b/docs/cron-workflows.md
@@ -149,8 +149,8 @@ The second will not run because of the `when` expression, which prevents this wo
 
 > v3.6 and after
 
-You can configure a `CronWorkflow` to automatically stop based on an [expression](variables.md#expression) with `stopStrategy.condition`.
-You can use the [variables](variables.md#cronworkflows) `cronworkflow.failed` and `cronworkflow.succeede2d`.
+You can configure a `CronWorkflow` to automatically stop based on an [expression](variables.md#expression) with `stopStrategy.expression`.
+You can use the [variables](variables.md#cronworkflows) `cronworkflow.failed` and `cronworkflow.succeeded`.
 
 For example, if you want to stop scheduling new workflows after one success:
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1314,7 +1314,7 @@ CronWorkflowStatus is the status of a CronWorkflow
 |`conditions`|`Array<`[`Condition`](#condition)`>`|Conditions is a list of conditions the CronWorkflow may have|
 |`failed`|`integer`|v3.6 and after: Failed counts how many times child workflows failed|
 |`lastScheduledTime`|[`Time`](#time)|LastScheduleTime is the last time the CronWorkflow was scheduled|
-|`phase`|`string`|v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true|
+|`phase`|`string`|v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true|
 |`succeeded`|`integer`|v3.6 and after: Succeeded counts how many times child workflows succeeded|
 
 ## WorkflowEventBindingSpec

--- a/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
@@ -90,7 +90,7 @@ type CronWorkflowStatus struct {
 	Succeeded int64 `json:"succeeded" protobuf:"varint,4,rep,name=succeeded"`
 	// v3.6 and after: Failed counts how many times child workflows failed
 	Failed int64 `json:"failed" protobuf:"varint,5,rep,name=failed"`
-	// v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true
+	// v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true
 	Phase CronWorkflowPhase `json:"phase" protobuf:"varint,6,rep,name=phase"`
 }
 

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -529,7 +529,7 @@ message CronWorkflowStatus {
   // v3.6 and after: Failed counts how many times child workflows failed
   optional int64 failed = 5;
 
-  // v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true
+  // v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true
   optional string phase = 6;
 }
 

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -2384,7 +2384,7 @@ func schema_pkg_apis_workflow_v1alpha1_CronWorkflowStatus(ref common.ReferenceCa
 					},
 					"phase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true",
+							Description: "v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1CronWorkflowStatus.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1CronWorkflowStatus.md
@@ -12,7 +12,7 @@ Name | Type | Description | Notes
 **conditions** | [**List&lt;IoArgoprojWorkflowV1alpha1Condition&gt;**](IoArgoprojWorkflowV1alpha1Condition.md) | Conditions is a list of conditions the CronWorkflow may have | 
 **failed** | **Integer** | v3.6 and after: Failed counts how many times child workflows failed | 
 **lastScheduledTime** | **java.time.Instant** |  | 
-**phase** | **String** | v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true | 
+**phase** | **String** | v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true | 
 **succeeded** | **Integer** | v3.6 and after: Succeeded counts how many times child workflows succeeded | 
 
 

--- a/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_cron_workflow_status.py
+++ b/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_cron_workflow_status.py
@@ -126,7 +126,7 @@ class IoArgoprojWorkflowV1alpha1CronWorkflowStatus(ModelNormal):
             conditions ([IoArgoprojWorkflowV1alpha1Condition]): Conditions is a list of conditions the CronWorkflow may have
             failed (int): v3.6 and after: Failed counts how many times child workflows failed
             last_scheduled_time (datetime): Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
-            phase (str): v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true
+            phase (str): v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true
             succeeded (int): v3.6 and after: Succeeded counts how many times child workflows succeeded
 
         Keyword Args:
@@ -221,7 +221,7 @@ class IoArgoprojWorkflowV1alpha1CronWorkflowStatus(ModelNormal):
             conditions ([IoArgoprojWorkflowV1alpha1Condition]): Conditions is a list of conditions the CronWorkflow may have
             failed (int): v3.6 and after: Failed counts how many times child workflows failed
             last_scheduled_time (datetime): Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
-            phase (str): v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true
+            phase (str): v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true
             succeeded (int): v3.6 and after: Succeeded counts how many times child workflows succeeded
 
         Keyword Args:

--- a/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1CronWorkflowStatus.md
+++ b/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1CronWorkflowStatus.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **conditions** | [**[IoArgoprojWorkflowV1alpha1Condition]**](IoArgoprojWorkflowV1alpha1Condition.md) | Conditions is a list of conditions the CronWorkflow may have | 
 **failed** | **int** | v3.6 and after: Failed counts how many times child workflows failed | 
 **last_scheduled_time** | **datetime** | Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers. | 
-**phase** | **str** | v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.condition is true | 
+**phase** | **str** | v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true | 
 **succeeded** | **int** | v3.6 and after: Succeeded counts how many times child workflows succeeded | 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 


### PR DESCRIPTION
The documentation in several places refers to `stopStrategy.condition` but the property is actually `expression`.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

A documentation correction.

### Modifications

I updated all references to `stopStrategy.condition` in docs (`md` and code) to be `stopStrategy.expression`, which is the correct prop.

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
