### PR TITLE
fix(controller): podSpecPatch updates override the ref template in `Secure` mode

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4204,6 +4204,9 @@ func (woc *wfOperationCtx) setStoredWfSpec(ctx context.Context) error {
 		wfutil.JoinWorkflowMetaData(&woc.wf.ObjectMeta, &wfDefault.ObjectMeta)
 		workflowTemplateSpec = wftHolder.GetWorkflowSpec()
 	}
+	if len(woc.execWf.Spec.PodSpecPatch) > 0 && woc.controller.Config.WorkflowRestrictions.MustUseReference() {
+		return fmt.Errorf("PodSpecPatch may not be setted during execution when the controller is set `templateReferencing: Secure|Strict`")
+	}
 	// Update the Entrypoint, ShutdownStrategy and Suspend
 	if woc.needsStoredWfSpecUpdate() {
 		// Join workflow, workflow template, and workflow default metadata to workflow spec.


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes #13871

### Motivation
`podSpecPatch` seems not to be set when referencing `wf template` and in `Secure` mode


### Modifications


### Verification
wf:
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  name: workflow-template-hello-world
spec:
  workflowTemplateRef:
    name: workflow-template-print-message
  podSpecPatch: |
    containers:
      - name: main
        image: alpine
        command: [echo]
        args: ["hello world"]
```

kubectl get wf
```
NAME                            STATUS   AGE   MESSAGE
workflow-template-hello-world   Error    6s    PodSpecPatch may not be setted during execution when the controller is set `templateReferencing: Secure`
```

