### PR TITLE
fix(ui): fix broken workflowtemplate submit button. Fixes #13892

### DIFF
--- a/ui/src/shared/components/object-parser.test.ts
+++ b/ui/src/shared/components/object-parser.test.ts
@@ -1,6 +1,15 @@
 import {exampleWorkflowTemplate} from '../examples';
 import {parse, stringify} from './object-parser';
 
+describe('parse and stringify are inverses', () => {
+    it('handles creationTimestamp', () => {
+        const testWorkflowTemplate = exampleWorkflowTemplate('test');
+        testWorkflowTemplate.metadata.creationTimestamp = '2024-11-17T06:56:52Z';
+        expect(parse(stringify(testWorkflowTemplate, 'yaml'))).toEqual(testWorkflowTemplate);
+        expect(parse(stringify(testWorkflowTemplate, 'json'))).toEqual(testWorkflowTemplate);
+    });
+});
+
 describe('parse', () => {
     it('handles a valid JSON string', () => {
         expect(parse('{}')).toEqual({});

--- a/ui/src/shared/components/object-parser.ts
+++ b/ui/src/shared/components/object-parser.ts
@@ -1,17 +1,16 @@
 import YAML from 'yaml';
 
+// Default is YAML 1.2, but Kubernetes uses YAML 1.1, which leads to subtle bugs.
+// See https://github.com/argoproj/argo-workflows/issues/12205#issuecomment-2111572189
+const yamlVersion = '1.1';
+
 export function parse<T>(value: string): T {
     if (value.startsWith('{')) {
         return JSON.parse(value);
     }
-    return YAML.parse(value, {
-        // Default is YAML 1.2, but Kubernetes uses YAML 1.1, which leads to subtle bugs.
-        // See https://github.com/argoproj/argo-workflows/issues/12205#issuecomment-2111572189
-        version: '1.1',
-        strict: false
-    }) as T;
+    return YAML.parse(value, {version: yamlVersion, strict: false}) as T;
 }
 
 export function stringify<T>(value: T, type: string) {
-    return type === 'yaml' ? YAML.stringify(value, {aliasDuplicateObjects: false}) : JSON.stringify(value, null, '  ');
+    return type === 'yaml' ? YAML.stringify(value, {aliasDuplicateObjects: false, version: yamlVersion, strict: false}) : JSON.stringify(value, null, '  ');
 }


### PR DESCRIPTION
Fixes #13892 

### Motivation

Currently the submit button for workflowtemplates is broken both in main and the new 3.6.0 release. The reason is that the UI thinks the content of the workflowtemplate has been updated in the editor, even when it has not.

The process looks like this:
We fetch the workflow from the backend and keep it as a javascript object, convert it to a yaml string, update the editor content with this string, and then when the editor content is updated we convert it back to a javascript object. We then compare to original object with the parsed object to determine if it has been updated or not. This requires parse and stringify to be inverses, but when we downgraded yaml version from 1.2 to 1.1 in https://github.com/argoproj/argo-workflows/pull/13750 we accidently broke this assumption, because we are now parsing as 1.1 but stringifying as 1.2. This fails when we are dealing with some fields like creationTimestamp, where these versions seem to differ.

### Modifications

This PR sets the yaml version as 1.1 for both parse and stringify.

### Verification

I ran the UI locally in the devcontainer with the fix and submitted workflowtemplates and clusterworkflowtemplates. I also added a test which fails before the fix but passes after the fix.
