### PR TITLE
feat: Move contextless log messages to debug logging - fixes #13918

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1496,11 +1496,11 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			WithField("new.message", new.Message).
 			WithField("old.progress", old.Progress).
 			WithField("new.progress", new.Progress).
-			Info("node changed")
+			Debug("node changed")
 		return new
 	}
 	woc.log.WithField("nodeID", old.ID).
-		Info("node unchanged")
+		Debug("node unchanged")
 	return nil
 }
 

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -114,7 +114,7 @@ func (woc *wfOperationCtx) taskResultReconciliation() {
 		if !reflect.DeepEqual(old, newNode) {
 			woc.log.
 				WithField("nodeID", nodeID).
-				Info("task-result changed")
+				Debug("task-result changed")
 			woc.wf.Status.Nodes.Set(nodeID, *newNode)
 			woc.updated = true
 		}


### PR DESCRIPTION
<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/13918

### Motivation

'node changed' 'node unchanged' and 'task-result changed' flood the logs when running argo in production with many workflows and parallel runs, move these log statements to debug logging so that we can filter them


### Modifications

Change logging for those three statements from Info to Debug

### Verification

Run the tests. Log messages should be being logged as debug instead of info