### PR TITLE
fix: consistent variable substitution for `configMapKeyRef`. Fixes #13890

### DIFF
--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -805,7 +806,7 @@ spec:
         args: ["sleep", "5"]
 `).When().
 		SubmitWorkflow().
-		WaitForWorkflow(fixtures.ToBeCompleted).
+		WaitForWorkflow(fixtures.ToBeCompleted, 2*time.Minute).
 		WaitForWorkflow(fixtures.Condition(func(wf *v1alpha1.Workflow) (bool, string) {
 			onExitNodeName = common.GenerateOnExitNodeName(wf.ObjectMeta.Name)
 			onExitNode := wf.Status.Nodes.FindByDisplayName(onExitNodeName)

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -133,14 +133,19 @@ func overwriteWithArguments(argParam, inParam *wfv1.Parameter) {
 func substituteAndGetConfigMapValue(inParam *wfv1.Parameter, globalParams Parameters, namespace string, configMapStore ConfigMapStore) error {
 	if inParam.ValueFrom != nil && inParam.ValueFrom.ConfigMapKeyRef != nil {
 		if configMapStore != nil {
+			replaceMap := make(map[string]interface{})
+			for k, v := range globalParams {
+				replaceMap[k] = v
+			}
+
 			// SubstituteParams is called only at the end of this method. To support parametrization of the configmap
 			// we need to perform a substitution here over the name and the key of the ConfigMapKeyRef.
-			cmName, err := substituteConfigMapKeyRefParam(inParam.ValueFrom.ConfigMapKeyRef.Name, globalParams)
+			cmName, err := substituteConfigMapKeyRefParam(inParam.ValueFrom.ConfigMapKeyRef.Name, replaceMap)
 			if err != nil {
 				log.WithError(err).Error("unable to substitute name for ConfigMapKeyRef")
 				return err
 			}
-			cmKey, err := substituteConfigMapKeyRefParam(inParam.ValueFrom.ConfigMapKeyRef.Key, globalParams)
+			cmKey, err := substituteConfigMapKeyRefParam(inParam.ValueFrom.ConfigMapKeyRef.Key, replaceMap)
 			if err != nil {
 				log.WithError(err).Error("unable to substitute key for ConfigMapKeyRef")
 				return err
@@ -219,21 +224,17 @@ func ProcessArgs(tmpl *wfv1.Template, args wfv1.ArgumentsProvider, globalParams,
 	return SubstituteParams(newTmpl, globalParams, localParams)
 }
 
-// substituteConfigMapKeyRefParam check if ConfigMapKeyRef's key is a param and perform the substitution.
-func substituteConfigMapKeyRefParam(in string, globalParams Parameters) (string, error) {
-	if strings.HasPrefix(in, "{{") && strings.HasSuffix(in, "}}") {
-		k := strings.TrimSuffix(strings.TrimPrefix(in, "{{"), "}}")
-		k = strings.Trim(k, " ")
-
-		v, ok := globalParams[k]
-		if !ok {
-			err := errors.InternalError(fmt.Sprintf("parameter %s not found", k))
-			log.WithError(err).Error()
-			return "", err
-		}
-		return v, nil
+// substituteConfigMapKeyRefParam performs template substitution for ConfigMapKeyRef
+func substituteConfigMapKeyRefParam(in string, replaceMap map[string]interface{}) (string, error) {
+	tmpl, err := template.NewTemplate(in)
+	if err != nil {
+		return "", err
 	}
-	return in, nil
+	replacedString, err := tmpl.Replace(replaceMap, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to substitute configMapKeyRef: %w", err)
+	}
+	return replacedString, nil
 }
 
 // SubstituteParams returns a new copy of the template with global, pod, and input parameters substituted


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13890

### Motivation

Support for substituting variables in `configMapKeyRef` was added in https://github.com/argoproj/argo-workflows/pull/7542 by manually parsing templates out of the string, instead of using the standard `template.Replace()` function. Since the manual parsing logic uses the same syntax as [simple template tags](https://argo-workflows.readthedocs.io/en/latest/variables/#simple) (e.g. `{{workflow.parameters.cm-name}}`), users reasonably expect it to work the same, but it doesn't, which leads to confusion. Additionally, supporting templates like `{{workflow.parameters.cm-name}}-cm` is important, because that's a common pattern.

### Modifications

This replaces the manual parsing code with the standard `template.Replace()` function that everything else uses. 

### Verification
Verified by running the example workflow from https://github.com/argoproj/argo-workflows/issues/13890 locally: 
![image](https://github.com/user-attachments/assets/f0ada703-3c78-426a-8e15-e61fbe646bf2)


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
