### PR TITLE
feat(ui): prefill parameters for workflow submit form. Fixes #12124

### DIFF
--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -150,6 +150,7 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
                         entrypoint={template.spec.entrypoint}
                         templates={template.spec.templates || []}
                         workflowParameters={template.spec.arguments.parameters || []}
+                        history={history}
                     />
                 </SlidingPanel>
             )}

--- a/ui/src/shared/get_workflow_params.test.ts
+++ b/ui/src/shared/get_workflow_params.test.ts
@@ -1,0 +1,38 @@
+import {createBrowserHistory} from 'history';
+
+import {getWorkflowParametersFromQuery} from './get_workflow_params';
+
+describe('get_workflow_params', () => {
+    it('should return an empty object when there are no query parameters', () => {
+        const history = createBrowserHistory();
+        const result = getWorkflowParametersFromQuery(history);
+        expect(result).toEqual({});
+    });
+
+    it('should return the parameters provided in the URL', () => {
+        const history = createBrowserHistory();
+        history.location.search = '?parameters[key1]=value1&parameters[key2]=value2';
+        const result = getWorkflowParametersFromQuery(history);
+        expect(result).toEqual({
+            key1: 'value1',
+            key2: 'value2'
+        });
+    });
+
+    it('should not return any key value pairs which are not in parameters query ', () => {
+        const history = createBrowserHistory();
+        history.location.search = '?retryparameters[key1]=value1&retryparameters[key2]=value2';
+        const result = getWorkflowParametersFromQuery(history);
+        expect(result).toEqual({});
+    });
+
+    it('should only return the parameters provided in the URL', () => {
+        const history = createBrowserHistory();
+        history.location.search = '?parameters[key1]=value1&parameters[key2]=value2&test=123';
+        const result = getWorkflowParametersFromQuery(history);
+        expect(result).toEqual({
+            key1: 'value1',
+            key2: 'value2'
+        });
+    });
+});

--- a/ui/src/shared/get_workflow_params.ts
+++ b/ui/src/shared/get_workflow_params.ts
@@ -1,0 +1,30 @@
+import {History} from 'history';
+
+function extractKey(inputString: string): string | null {
+    // Use regular expression to match the key within square brackets
+    const match = inputString.match(/^parameters\[(.*?)\]$/);
+
+    // If a match is found, return the captured key
+    if (match) {
+        return match[1];
+    }
+
+    // If no match is found, return null or an empty string
+    return null; // Or return '';
+}
+/**
+ * Returns the workflow parameters from the query parameters.
+ */
+export function getWorkflowParametersFromQuery(history: History): {[key: string]: string} {
+    const queryParams = new URLSearchParams(history.location.search);
+
+    const parameters: {[key: string]: string} = {};
+    for (const [key, value] of queryParams.entries()) {
+        const q = extractKey(key);
+        if (q) {
+            parameters[q] = value;
+        }
+    }
+
+    return parameters;
+}

--- a/ui/src/shared/history.ts
+++ b/ui/src/shared/history.ts
@@ -6,8 +6,7 @@ import * as nsUtils from './namespaces';
  * Only "truthy" values are put into the query parameters. I.e. "falsey" values include null, undefined, false, "", 0.
  */
 export function historyUrl(path: string, params: {[key: string]: any}) {
-    const queryParams: string[] = [];
-    let extraSearchParams: URLSearchParams;
+    const queryParams = new URLSearchParams();
     Object.entries(params)
         .filter(([, v]) => v !== null)
         .forEach(([k, v]) => {
@@ -15,14 +14,14 @@ export function historyUrl(path: string, params: {[key: string]: any}) {
             if (path.includes(searchValue)) {
                 path = path.replace(searchValue, v != null ? v : '');
             } else if (k === 'extraSearchParams') {
-                extraSearchParams = v;
+                (v as URLSearchParams).forEach((value, key) => queryParams.set(key, value));
             } else if (v) {
-                queryParams.push(k + '=' + v);
+                queryParams.set(k, v);
             }
             if (k === 'namespace') {
                 nsUtils.setCurrentNamespace(v);
             }
         });
-    const extraString = extraSearchParams ? '&' + extraSearchParams.toString() : '';
-    return uiUrl(path.replace(/{[^}]*}/g, '')) + '?' + queryParams.join('&') + extraString;
+
+    return uiUrl(path.replace(/{[^}]*}/g, '')) + '?' + queryParams.toString();
 }

--- a/ui/src/workflow-templates/workflow-template-details.tsx
+++ b/ui/src/workflow-templates/workflow-template-details.tsx
@@ -145,6 +145,7 @@ export function WorkflowTemplateDetails({history, location, match}: RouteCompone
                             entrypoint={template.spec.entrypoint}
                             templates={template.spec.templates || []}
                             workflowParameters={template.spec.arguments.parameters || []}
+                            history={history}
                         />
                     )}
                     {sidePanel === 'share' && <WidgetGallery namespace={namespace} label={'workflows.argoproj.io/workflow-template=' + name} />}

--- a/ui/src/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/workflows/components/submit-workflow-panel.tsx
@@ -1,11 +1,13 @@
 import {Select} from 'argo-ui/src/components/select/select';
-import React, {useContext, useMemo, useState} from 'react';
+import {History} from 'history';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {uiUrl} from '../../shared/base';
 import {ErrorNotice} from '../../shared/components/error-notice';
 import {getValueFromParameter, ParametersInput} from '../../shared/components/parameters-input';
 import {TagsInput} from '../../shared/components/tags-input/tags-input';
 import {Context} from '../../shared/context';
+import {getWorkflowParametersFromQuery} from '../../shared/get_workflow_params';
 import {Parameter, Template} from '../../shared/models';
 import {services} from '../../shared/services';
 
@@ -16,6 +18,7 @@ interface Props {
     entrypoint: string;
     templates: Template[];
     workflowParameters: Parameter[];
+    history: History;
 }
 
 const workflowEntrypoint = '<default>';
@@ -28,12 +31,22 @@ const defaultTemplate: Template = {
 
 export function SubmitWorkflowPanel(props: Props) {
     const {navigation} = useContext(Context);
-    const [entrypoint, setEntrypoint] = useState(workflowEntrypoint);
+    const [entrypoint, setEntrypoint] = useState(props.entrypoint || workflowEntrypoint);
     const [parameters, setParameters] = useState<Parameter[]>([]);
     const [workflowParameters, setWorkflowParameters] = useState<Parameter[]>(JSON.parse(JSON.stringify(props.workflowParameters)));
     const [labels, setLabels] = useState(['submit-from-ui=true']);
     const [error, setError] = useState<Error>();
     const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        const templatePropertiesInQuery = getWorkflowParametersFromQuery(props.history);
+        // Get the user arguments from the query params
+        const updatedParams = workflowParameters.map(param => ({
+            name: param.name,
+            value: templatePropertiesInQuery[param.name] || param.value
+        }));
+        setWorkflowParameters(updatedParams);
+    }, [props.history, setWorkflowParameters]);
 
     const templates = useMemo(() => {
         return [defaultTemplate].concat(props.templates);

--- a/ui/src/workflows/components/workflow-creator.tsx
+++ b/ui/src/workflows/components/workflow-creator.tsx
@@ -1,4 +1,5 @@
 import {Select} from 'argo-ui/src/components/select/select';
+import {History} from 'history';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 
@@ -15,7 +16,7 @@ import {WorkflowEditor} from './workflow-editor';
 
 type Stage = 'choose-method' | 'submit-workflow' | 'full-editor';
 
-export function WorkflowCreator({namespace, onCreate}: {namespace: string; onCreate: (workflow: Workflow) => void}) {
+export function WorkflowCreator({namespace, onCreate, history}: {namespace: string; onCreate: (workflow: Workflow) => void; history: History}) {
     const [workflowTemplates, setWorkflowTemplates] = useState<WorkflowTemplate[]>();
     const [workflowTemplate, setWorkflowTemplate] = useState<WorkflowTemplate>();
     const [stage, setStage] = useState<Stage>('choose-method');
@@ -61,6 +62,12 @@ export function WorkflowCreator({namespace, onCreate}: {namespace: string; onCre
         }
     }, [workflowTemplate]);
 
+    useEffect(() => {
+        const queryParams = new URLSearchParams(history.location.search);
+        const template = queryParams.get('template');
+        setWorkflowTemplate((workflowTemplates || []).find(tpl => tpl.metadata.name === template));
+    }, [workflowTemplates, setWorkflowTemplate, history]);
+
     return (
         <>
             {stage === 'choose-method' && (
@@ -92,6 +99,7 @@ export function WorkflowCreator({namespace, onCreate}: {namespace: string; onCre
                         entrypoint={workflowTemplate.spec.entrypoint}
                         templates={workflowTemplate.spec.templates || []}
                         workflowParameters={workflowTemplate.spec.arguments.parameters || []}
+                        history={history}
                     />
                     <a onClick={() => setStage('full-editor')}>
                         Edit using full workflow options <i className='fa fa-caret-right' />

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -135,7 +135,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
         }
         storage.setItem('options', options, {} as WorkflowListRenderOptions);
 
-        const params = new URLSearchParams();
+        const params = new URLSearchParams(history.location.search);
         phases?.forEach(phase => params.append('phase', phase));
         labels?.forEach(label => params.append('label', label));
         if (pagination.offset) {
@@ -346,10 +346,26 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
                     )}
                 </div>
             </div>
-            <SlidingPanel isShown={!!getSidePanel()} onClose={() => navigation.goto('.', {sidePanel: null})}>
+            <SlidingPanel
+                isShown={!!getSidePanel()}
+                onClose={() => {
+                    const qParams: {[key: string]: string | null} = {
+                        sidePanel: null
+                    };
+                    // Remove any lingering query params
+                    for (const key of queryParams.keys()) {
+                        qParams[key] = null;
+                    }
+                    // Add back the pagination and namespace params.
+                    qParams.limit = pagination.limit.toString();
+                    qParams.offset = pagination.offset || null;
+                    qParams.namespace = namespace;
+                    navigation.goto('.', qParams);
+                }}>
                 {getSidePanel() === 'submit-new-workflow' && (
                     <WorkflowCreator
                         namespace={nsUtils.getNamespaceWithDefault(namespace)}
+                        history={history}
                         onCreate={wf => navigation.goto(uiUrl(`workflows/${wf.metadata.namespace}/${wf.metadata.name}`))}
                     />
                 )}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12124

### Motivation
This PR  adds support for developers to prefil submit workflow form by passing in the values through query parameters.

To prefil a submit workflow developers can pass in the following query parameters

```
sidePanel=submit-new-workflow
template=<template that the workflow should follow>
parameters[key]=value // Here the key would be the parameter for the job and value would be the value of the parameter.
You should provide the keys that are supported by the specified template
```

### Modifications
- Updated `workflow-list` component
- Updated `submit-workflow-panel.tsx` component to default entry point if provided.
- Updated `workflow-creator.tsx` to read default values from query parameters.
 - The workflow will be prefilled with the parameters that the template supports
- Added new shared helper function to parse query parameter of the format `?parameters[key]=value`.

### Verification

✅ Visit http://localhost:8080/workflows?namespace=argo&limit=50 and create a new workflow and ensure the default values are populated.
![Screenshot 2024-11-19 at 9 56 16 PM](https://github.com/user-attachments/assets/ddba4ee3-aba4-4d2e-ac38-c33fbca6f5f2)

✅  Visit the [prefilled URL](http://localhost:8080/workflows?namespace=argo&limit=50&sidePanel=submit-new-workflow&template=delightful-dragon&parameters%5Bmessage%5D=test-hello&parameters%5Blimit%5D=2000) and ensure that the values from url query are populated.
![Screenshot 2024-11-19 at 9 56 33 PM](https://github.com/user-attachments/assets/f29816f7-fc89-4704-b3c5-b8e144a57b3d)


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->