### PR TITLE
feat(controller): show invalid spec on cronwf res

### DIFF
--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -179,6 +179,7 @@ func (cc *Controller) processNextCronItem(ctx context.Context) bool {
 
 	err = cronWorkflowOperationCtx.validateCronWorkflow(ctx)
 	if err != nil {
+		cc.eventRecorderManager.Get(un.GetNamespace()).Event(un, apiv1.EventTypeWarning, "Invalid", err.Error())
 		logCtx.WithError(err).Error("invalid cron workflow")
 		return true
 	}


### PR DESCRIPTION
Fixes: #6781

### Motivation

Help the user see the validation errors on the cronwf resources early, before they find out later that the workflow didn't trigger.

### Modifications

Add the event to the description of the cronwf, e.g.

```
Events:
  Type     Reason     Age   From                 Message
  ----     ------     ----  ----                 -------
  Warning  Invalid  14s   workflow-controller  cron workflow name "test-cron-wf-very-very-very-very-very-very-very-very-very-very-very-very-long" must not be more than 52 characters long (currently 77)
```

### Verification

I created my own image of `workflow-controller` and deployed it in a local k3s kubernetes with argo-workflow.

I used this artifact as a test:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: test-cron-wf-very-very-very-very-very-very-very-very-very-very-very-very-long
spec:
  schedule: "5 * * * *"
  concurrencyPolicy: "Replace"
  startingDeadlineSeconds: 0
  workflowSpec:
    entrypoint: date
    templates:
    - name: date
      container:
        image: alpine:3.6
        command: [sh, -c]
        args: ["date; sleep 90"]
```
