### PR TITLE
fix(ui): handle parsing errors properly in object editor

### DIFF
--- a/ui/src/shared/use-editable-object.test.ts
+++ b/ui/src/shared/use-editable-object.test.ts
@@ -1,4 +1,4 @@
-import {createInitialState, reducer} from './use-editable-object';
+import {createInitialState, reducer, setObjectActionCreator} from './use-editable-object';
 
 describe('createInitialState', () => {
     test('without object', () => {
@@ -59,8 +59,8 @@ describe('reducer', () => {
         });
     });
 
-    test('setObject with string', () => {
-        const newState = reducer(testState, {type: 'setObject', payload: 'a: 2'});
+    test('setObject with object and string', () => {
+        const newState = reducer(testState, {type: 'setObject', payload: {object: {a: 2}, serialization: 'a: 2'}});
         expect(newState).toEqual({
             object: {a: 2},
             serialization: 'a: 2',
@@ -70,25 +70,14 @@ describe('reducer', () => {
         });
     });
 
-    test('setObject with object', () => {
-        const newState = reducer(testState, {type: 'setObject', payload: {a: 2}});
+    test('setObject with only object', () => {
+        const newState = reducer(testState, {type: 'setObject', payload: {object: {a: 2}}});
         expect(newState).toEqual({
             object: {a: 2},
             serialization: 'a: 2\n',
             lang: 'yaml',
             initialSerialization: 'a: 1\n',
             edited: true
-        });
-    });
-
-    test('resetObject with string', () => {
-        const newState = reducer(testState, {type: 'resetObject', payload: 'a: 2'});
-        expect(newState).toEqual({
-            object: {a: 2},
-            serialization: 'a: 2',
-            lang: 'yaml',
-            initialSerialization: 'a: 2',
-            edited: false
         });
     });
 
@@ -101,5 +90,25 @@ describe('reducer', () => {
             initialSerialization: 'a: 2\n',
             edited: false
         });
+    });
+});
+
+describe('setObjectActionCreator', () => {
+    test('with object', () => {
+        expect(setObjectActionCreator({a: 2})).toEqual({
+            type: 'setObject',
+            payload: {object: {a: 2}}
+        });
+    });
+
+    test('with string', () => {
+        expect(setObjectActionCreator('a: 2')).toEqual({
+            type: 'setObject',
+            payload: {object: {a: 2}, serialization: 'a: 2'}
+        });
+    });
+
+    test("with string that can't be parsed", () => {
+        expect(() => setObjectActionCreator('@')).toThrow('Plain value cannot start with reserved character @');
     });
 });

--- a/ui/src/shared/use-editable-object.ts
+++ b/ui/src/shared/use-editable-object.ts
@@ -3,7 +3,8 @@ import {useReducer} from 'react';
 import {Lang, parse, stringify} from '../shared/components/object-parser';
 import {ScopedLocalStorage} from '../shared/scoped-local-storage';
 
-type Action<T> = {type: 'setLang'; payload: Lang} | {type: 'setObject'; payload: string | T} | {type: 'resetObject'; payload: string | T};
+type SetObjectAction<T> = {type: 'setObject'; payload: {object: T; serialization?: string}};
+type Action<T> = {type: 'setLang'; payload: Lang} | SetObjectAction<T> | {type: 'resetObject'; payload: T};
 
 interface State<T> {
     /** The parsed form of the object, kept in sync with "serialization" */
@@ -24,19 +25,16 @@ const storage = new ScopedLocalStorage('object-editor');
 export function reducer<T>(state: State<T>, action: Action<T>) {
     const newState = {...state};
     switch (action.type) {
-        case 'resetObject':
         case 'setObject':
-            if (typeof action.payload === 'string') {
-                newState.object = parse(action.payload);
-                newState.serialization = action.payload;
-            } else {
-                newState.object = action.payload;
-                newState.serialization = stringify(action.payload, newState.lang);
-            }
-            if (action.type === 'resetObject') {
-                newState.initialSerialization = newState.serialization;
-            }
+            newState.object = action.payload.object;
+            newState.serialization = action.payload.serialization ?? stringify(newState.object, newState.lang);
             newState.edited = newState.initialSerialization !== newState.serialization;
+            return newState;
+        case 'resetObject':
+            newState.object = action.payload;
+            newState.serialization = stringify(newState.object, newState.lang);
+            newState.initialSerialization = newState.serialization;
+            newState.edited = false;
             return newState;
         case 'setLang':
             newState.lang = action.payload;
@@ -62,18 +60,30 @@ export function createInitialState<T>(object?: T): State<T> {
 }
 
 /**
+ * Action creator for setObject that can accept a string and parse it.
+ * The reason the parsing logic isn't in the reducer is because we want parse
+ * errors to be propagated to the caller.
+ */
+export function setObjectActionCreator<T>(value: string | T): SetObjectAction<T> {
+    return {
+        type: 'setObject',
+        payload: typeof value === 'string' ? {object: parse<T>(value), serialization: value} : {object: value}
+    };
+}
+
+/**
  * useEditableObject is a React hook to manage the state of an object that can be serialized and edited, encapsulating the logic to
  * parse/stringify the object as necessary.
  */
 export function useEditableObject<T>(object?: T): State<T> & {
     setObject: (value: string | T) => void;
-    resetObject: (value: string | T) => void;
+    resetObject: (value: T) => void;
     setLang: (lang: Lang) => void;
 } {
     const [state, dispatch] = useReducer(reducer<T>, object, createInitialState);
     return {
         ...state,
-        setObject: value => dispatch({type: 'setObject', payload: value}),
+        setObject: value => dispatch(setObjectActionCreator<T>(value)),
         resetObject: value => dispatch({type: 'resetObject', payload: value}),
         setLang: value => dispatch({type: 'setLang', payload: value})
     };


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation
https://github.com/argoproj/argo-workflows/pull/13915 introduced a regression where edits made in an object editor that introduce syntax errors cause a full screen error. 
![image](https://github.com/user-attachments/assets/b9c77b7e-c6e6-4181-a7c7-313e62780b6e)


This is happening because parsing was lifted out of `<ObjectEditor>` and into a reducer. Before https://github.com/argoproj/argo-workflows/pull/13915, the object editor used the following to catch parse errors: https://github.com/argoproj/argo-workflows/blob/eb4f2456e077d89324ea71ef5f5e92cdccd8157a/ui/src/shared/components/object-editor.tsx#L131-L136

After  https://github.com/argoproj/argo-workflows/pull/13915, the parsing logic was moved to `reducer()`, which is executed async, and therefore errors aren't propagated to the `catch (e) {}` block:
https://github.com/argoproj/argo-workflows/blob/1392ef516fd69a2cae875d746c1155f940e4948c/ui/src/shared/components/object-editor.tsx#L117-L122


### Modifications

This moves the parsing logic to the `setObject()` function (which gets passed as `onChange` to `<ObjectEditor>`), which means errors will now be caught by the `catch (e) {}` block.

### Verification

Tested by going http://localhost:8080/workflow-templates, creating a new `WorkflowTemplate`, and making edits.

https://github.com/user-attachments/assets/df1b774b-6614-4096-884d-534333fc4f46



<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
