### PR TITLE
feat: Allow markdown title and description in KeyValueEditor

### DIFF
--- a/ui/src/shared/components/editors/key-value-editor.scss
+++ b/ui/src/shared/components/editors/key-value-editor.scss
@@ -1,0 +1,8 @@
+@import 'node_modules/argo-ui/src/styles/config';
+
+.markdown-rows-name {
+  line-height: 1.5em;
+  display: inline-block;
+  vertical-align: middle;
+  white-space: pre-line;
+}

--- a/ui/src/shared/components/editors/key-value-editor.tsx
+++ b/ui/src/shared/components/editors/key-value-editor.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react';
 import {useState} from 'react';
 
+import {ANNOTATION_DESCRIPTION, ANNOTATION_TITLE} from '../../annotations';
+import {SuspenseReactMarkdownGfm} from '../suspense-react-markdown-gfm';
 import {TextInput} from '../text-input';
+
+require('./key-value-editor.scss');
 
 interface KeyValues {
     [key: string]: string;
 }
 
-export function KeyValueEditor({onChange, keyValues = {}, hide}: {keyValues: KeyValues; onChange: (value: KeyValues) => void; hide?: (key: string) => boolean}) {
+interface KeyValueEditorProps {
+    keyValues: KeyValues;
+    onChange: (value: KeyValues) => void;
+    hide?: (key: string) => boolean;
+    source?: string;
+}
+
+export function KeyValueEditor({onChange, keyValues = {}, hide, source}: KeyValueEditorProps) {
     const [name, setName] = useState('');
     const [value, setValue] = useState('');
 
@@ -32,7 +43,9 @@ export function KeyValueEditor({onChange, keyValues = {}, hide}: {keyValues: Key
                 .map(([k, v]) => (
                     <div className='row white-box__details-row' key={k}>
                         <div className='columns small-4'>{k}</div>
-                        <div className='columns small-6'>{v}</div>
+                        <div className='columns small-6 markdown-rows-name'>
+                            {source == 'annotations' && [ANNOTATION_DESCRIPTION, ANNOTATION_TITLE].indexOf(k) !== -1 ? <SuspenseReactMarkdownGfm markdown={v} /> : v}
+                        </div>
                         <div className='columns small-2'>
                             <button onClick={() => deleteItem(k)}>
                                 <i className='fa fa-times-circle' />

--- a/ui/src/shared/components/editors/labels-and-annotations-editor.tsx
+++ b/ui/src/shared/components/editors/labels-and-annotations-editor.tsx
@@ -8,7 +8,7 @@ export function LabelsAndAnnotationsEditor({value, onChange}: {value: kubernetes
         <>
             <div className='white-box'>
                 <h5>Labels</h5>
-                <KeyValueEditor keyValues={value && value.labels} onChange={labels => onChange({...value, labels})} />
+                <KeyValueEditor keyValues={value && value.labels} onChange={labels => onChange({...value, labels})} source={'labels'} />
             </div>
             <div className='white-box'>
                 <h5>Annotations</h5>
@@ -16,6 +16,7 @@ export function LabelsAndAnnotationsEditor({value, onChange}: {value: kubernetes
                     keyValues={value && value.annotations}
                     onChange={annotations => onChange({...value, annotations})}
                     hide={key => key === 'kubectl.kubernetes.io/last-applied-configuration'}
+                    source={'annotations'}
                 />
             </div>
         </>

--- a/ui/src/shared/components/editors/workflow-parameters-editor.tsx
+++ b/ui/src/shared/components/editors/workflow-parameters-editor.tsx
@@ -37,6 +37,7 @@ export function WorkflowParametersEditor<T extends WorkflowSpec>(props: {value: 
                         );
                         props.onChange(props.value);
                     }}
+                    source={'parameters'}
                 />
             </div>
         </>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/13934

### Motivation

Our organization allows non-developers to submit workflows using Argo Workflows.
However, since non-developers only submit WorkflowTemplate, etc., we need to have them read the Workflow description from the UI.
For this reason, we adopted markdown, which is easier to read.

### Modifications

If the KeyValueEditor key is `workflows.argoproj.io/title` or `workflows.argoproj.io/description`, it is now expressed in markdown.

#### ClusterWorkflowTemplate
![image](https://github.com/user-attachments/assets/34d0a37d-e745-44e5-a459-0f78b65d0025)

#### CronWorkflow
![image](https://github.com/user-attachments/assets/724a9ec0-7f0d-4621-9611-6707f303e660)

#### WorkflowTemplate
![image](https://github.com/user-attachments/assets/17c4daa5-ee1b-4cf7-9275-7d6e7251e47a)

### Verification

On the Metadata tab below, we have verified that the Title and Description are marked down.
Also verified that all other fields have not changed.

- [x] CronWorkflow
- [x] ClusterWorkflowTemplate
- [x] WorkflowTemplate

```yaml
  labels:
    workflows.argoproj.io/title: Test-Title
    workflows.argoproj.io/description: This-is-a-simple-hello-world-example
  annotations:
    workflows.argoproj.io/title: '**Test Title**'
    workflows.argoproj.io/description: |
      `This is a simple hello world example.`
      You can also run it in Python: https://couler-proj.github.io/couler/examples/#hello-world
```

I have verified that no other changes have been made to the Input windows of ClusterWorkflowTemplate and WorkflowTemplate.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
