### PR TITLE
ci: bump minimum k8s version to 1.29

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -230,15 +230,15 @@ jobs:
             profile: minimal
             use-api: true
           - test: test-executor
-            install_k3s_version: v1.28.13+k3s1
+            install_k3s_version: v1.29.10+k3s1
             profile: minimal
             use-api: false
           - test: test-corefunctional
-            install_k3s_version: v1.28.13+k3s1
+            install_k3s_version: v1.29.10+k3s1
             profile: minimal
             use-api: false
           - test: test-functional
-            install_k3s_version: v1.28.13+k3s1
+            install_k3s_version: v1.29.10+k3s1
             profile: minimal
             use-api: false
     steps:
@@ -273,7 +273,7 @@ jobs:
       - name: Install and start K3S
         run: |
           if ! echo "${{ matrix.install_k3s_version }}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+\+k3s1$'; then
-            export INSTALL_K3S_VERSION=v1.31.0+k3s1
+            export INSTALL_K3S_VERSION=v1.31.2+k3s1
           else
             export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
           fi

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -40,12 +40,12 @@ Otherwise, we typically release every two weeks:
 
 ## Kubernetes Compatibility Matrix
 
-| Argo Workflows \ Kubernetes | 1.28 | 1.29 | 1.30 | 1.31 |
-|-----------------------------|------|------|------|------|
-| **main**                    | `✓`  | `✓`  | `✓`  | `✓`  |
-| **3.6**                    | `✓`  | `✓`  | `✓`  | `✓`  |
-| **3.5**                     | `✓`  | `✓`  | `✓`  | `?`  |
-| **3.4**                     | `?`  | `?`  | `?`  | `?`  |
+| Argo Workflows \ Kubernetes | 1.29 | 1.30 | 1.31 |
+|-----------------------------|------|------|------|
+| **main**                    | `✓`  | `✓`  | `✓`  |
+| **3.6**                     | `✓`  | `✓`  | `✓`  |
+| **3.5**                     | `✓`  | `✓`  | `?`  |
+| **3.4**                     | `?`  | `?`  | `?`  |
 
 * `✓` Fully supported versions.
 * `?` Due to breaking changes might not work. Also, we haven't thoroughly tested against this version.
@@ -59,4 +59,4 @@ Note that Kubernetes [is backward compatible with clients](https://github.com/ku
 The caveats with newer k8s versions are possible changes to experimental APIs and unused new features.
 Argo uses stable Kubernetes APIs such as Pods and ConfigMaps; see the Controller and Server RBAC of your [installation](installation.md) for a full list.
 
-The `main` branch is currently [tested on Kubernetes 1.28](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L228) and [1.31](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L263).
+The `main` branch is currently [tested on Kubernetes 1.29](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L228) and [1.31](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L263).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

*  K8s 1.28 is EOL

### Modifications

* increases minimum k8s version in CI to 1.29

### Verification

E2e tests will verify

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
