### PR TITLE
docs: correctly document `result` output parameter

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -6211,7 +6211,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "result": {
-          "description": "Result holds the result (stdout) of a script template",
+          "description": "Result holds the result (stdout) of a script or container template, or the response body of an HTTP template",
           "type": "string"
         }
       },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10236,7 +10236,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "result": {
-          "description": "Result holds the result (stdout) of a script template",
+          "description": "Result holds the result (stdout) of a script or container template, or the response body of an HTTP template",
           "type": "string"
         }
       }

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -2462,7 +2462,7 @@ save/load the directory appropriately.
 | artifacts | [Artifacts](#artifacts)| `Artifacts` |  | |  |  |
 | exitCode | string| `string` |  | | ExitCode holds the exit code of a script template |  |
 | parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters holds the list of output parameters produced by a step</br>+patchStrategy=merge</br>+patchMergeKey=name |  |
-| result | string| `string` |  | | Result holds the result (stdout) of a script template |  |
+| result | string| `string` |  | | Result holds the result (stdout) of a script or container template, or the response body of an HTTP template |  |
 
 
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2004,7 +2004,7 @@ Outputs hold parameters, artifacts, and results from a step
 |`artifacts`|`Array<`[`Artifact`](#artifact)`>`|Artifacts holds the list of output artifacts produced by a step|
 |`exitCode`|`string`|ExitCode holds the exit code of a script template|
 |`parameters`|`Array<`[`Parameter`](#parameter)`>`|Parameters holds the list of output parameters produced by a step|
-|`result`|`string`|Result holds the result (stdout) of a script template|
+|`result`|`string`|Result holds the result (stdout) of a script or container template, or the response body of an HTTP template|
 
 ## SynchronizationStatus
 

--- a/docs/http-template.md
+++ b/docs/http-template.md
@@ -3,6 +3,7 @@
 > v3.2 and after
 
 `HTTP Template` is a type of template which can execute HTTP Requests.
+The body of the response is automatically exported into the `result` output parameter.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -146,7 +146,7 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `steps.<STEPNAME>.startedAt` | Time-stamp when the step started |
 | `steps.<STEPNAME>.finishedAt` | Time-stamp when the step finished |
 | `steps.<TASKNAME>.hostNodeName` | Host node where task ran (available from version 3.5) |
-| `steps.<STEPNAME>.outputs.result` | Output result of any previous container or script step |
+| `steps.<STEPNAME>.outputs.result` | Output result of any previous container, script, or HTTP step |
 | `steps.<STEPNAME>.outputs.parameters` | When the previous step uses `withItems` or `withParams`, this contains a JSON array of the output parameter maps of each invocation |
 | `steps.<STEPNAME>.outputs.parameters.<NAME>` | Output parameter of any previous step. When the previous step uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
 | `steps.<STEPNAME>.outputs.artifacts.<NAME>` | Output artifact of any previous step |
@@ -163,7 +163,7 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `tasks.<TASKNAME>.startedAt` | Time-stamp when the task started |
 | `tasks.<TASKNAME>.finishedAt` | Time-stamp when the task finished |
 | `tasks.<TASKNAME>.hostNodeName` | Host node where task ran (available from version 3.5) |
-| `tasks.<TASKNAME>.outputs.result` | Output result of any previous container or script task |
+| `tasks.<TASKNAME>.outputs.result` | Output result of any previous container, script, or HTTP task |
 | `tasks.<TASKNAME>.outputs.parameters` | When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter maps of each invocation |
 | `tasks.<TASKNAME>.outputs.parameters.<NAME>` | Output parameter of any previous task. When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
 | `tasks.<TASKNAME>.outputs.artifacts.<NAME>` | Output artifact of any previous task |

--- a/docs/walk-through/output-parameters.md
+++ b/docs/walk-through/output-parameters.md
@@ -47,9 +47,9 @@ DAG templates use the tasks prefix to refer to another task, for example `{{task
 
 ## `result` output parameter
 
-The `result` output parameter captures standard output.
+For script and container templates, the `result` output parameter captures up to 256 kb of the standard output.
+For HTTP templates, `result` captures the response body.
 It is accessible from the `outputs` map: `outputs.result`.
-Only 256 kb of the standard output stream will be captured.
 
 ### Scripts
 
@@ -59,3 +59,7 @@ Outputs of a `script` are assigned to standard output and captured in the `resul
 
 Container steps and tasks also have their standard output captured in the `result` parameter.
 Given a `task`, called `log-int`, `result` would then be accessible as `{{ tasks.log-int.outputs.result }}`. If using [steps](steps.md), substitute `tasks` for `steps`: `{{ steps.log-int.outputs.result }}`.
+
+### HTTP
+
+[HTTP templates](../http-template.md) capture the response body in the `result` parameter if the body is non-empty.

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -1221,7 +1221,7 @@ message Outputs {
   // +patchMergeKey=name
   repeated Artifact artifacts = 2;
 
-  // Result holds the result (stdout) of a script template
+  // Result holds the result (stdout) of a script or container template, or the response body of an HTTP template
   optional string result = 3;
 
   // ExitCode holds the exit code of a script template

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -4780,7 +4780,7 @@ func schema_pkg_apis_workflow_v1alpha1_Outputs(ref common.ReferenceCallback) com
 					},
 					"result": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Result holds the result (stdout) of a script template",
+							Description: "Result holds the result (stdout) of a script or container template, or the response body of an HTTP template",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1479,7 +1479,7 @@ type Outputs struct {
 	// +patchMergeKey=name
 	Artifacts Artifacts `json:"artifacts,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=artifacts"`
 
-	// Result holds the result (stdout) of a script template
+	// Result holds the result (stdout) of a script or container template, or the response body of an HTTP template
 	Result *string `json:"result,omitempty" protobuf:"bytes,3,opt,name=result"`
 
 	// ExitCode holds the exit code of a script template

--- a/pkg/plugins/executor/swagger.yml
+++ b/pkg/plugins/executor/swagger.yml
@@ -2509,7 +2509,7 @@ definitions:
                     $ref: '#/definitions/Parameter'
                 type: array
             result:
-                description: Result holds the result (stdout) of a script template
+                description: Result holds the result (stdout) of a script or container template, or the response body of an HTTP template
                 type: string
         type: object
     OwnerReference:

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1Outputs.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1Outputs.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **artifacts** | [**List&lt;IoArgoprojWorkflowV1alpha1Artifact&gt;**](IoArgoprojWorkflowV1alpha1Artifact.md) | Artifacts holds the list of output artifacts produced by a step |  [optional]
 **exitCode** | **String** | ExitCode holds the exit code of a script template |  [optional]
 **parameters** | [**List&lt;IoArgoprojWorkflowV1alpha1Parameter&gt;**](IoArgoprojWorkflowV1alpha1Parameter.md) | Parameters holds the list of output parameters produced by a step |  [optional]
-**result** | **String** | Result holds the result (stdout) of a script template |  [optional]
+**result** | **String** | Result holds the result (stdout) of a script or container template, or the response body of an HTTP template |  [optional]
 
 
 

--- a/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_outputs.py
+++ b/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_outputs.py
@@ -151,7 +151,7 @@ class IoArgoprojWorkflowV1alpha1Outputs(ModelNormal):
             artifacts ([IoArgoprojWorkflowV1alpha1Artifact]): Artifacts holds the list of output artifacts produced by a step. [optional]  # noqa: E501
             exit_code (str): ExitCode holds the exit code of a script template. [optional]  # noqa: E501
             parameters ([IoArgoprojWorkflowV1alpha1Parameter]): Parameters holds the list of output parameters produced by a step. [optional]  # noqa: E501
-            result (str): Result holds the result (stdout) of a script template. [optional]  # noqa: E501
+            result (str): Result holds the result (stdout) of a script or container template, or the response body of an HTTP template. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -236,7 +236,7 @@ class IoArgoprojWorkflowV1alpha1Outputs(ModelNormal):
             artifacts ([IoArgoprojWorkflowV1alpha1Artifact]): Artifacts holds the list of output artifacts produced by a step. [optional]  # noqa: E501
             exit_code (str): ExitCode holds the exit code of a script template. [optional]  # noqa: E501
             parameters ([IoArgoprojWorkflowV1alpha1Parameter]): Parameters holds the list of output parameters produced by a step. [optional]  # noqa: E501
-            result (str): Result holds the result (stdout) of a script template. [optional]  # noqa: E501
+            result (str): Result holds the result (stdout) of a script or container template, or the response body of an HTTP template. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1Outputs.md
+++ b/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1Outputs.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **artifacts** | [**[IoArgoprojWorkflowV1alpha1Artifact]**](IoArgoprojWorkflowV1alpha1Artifact.md) | Artifacts holds the list of output artifacts produced by a step | [optional] 
 **exit_code** | **str** | ExitCode holds the exit code of a script template | [optional] 
 **parameters** | [**[IoArgoprojWorkflowV1alpha1Parameter]**](IoArgoprojWorkflowV1alpha1Parameter.md) | Parameters holds the list of output parameters produced by a step | [optional] 
-**result** | **str** | Result holds the result (stdout) of a script template | [optional] 
+**result** | **str** | Result holds the result (stdout) of a script or container template, or the response body of an HTTP template | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation
HTTP templates set `output.result` to the response body, but this wasn't documented: https://github.com/argoproj/argo-workflows/blob/1f304ba6780ee043ea5ecd74e06787bcba298f8f/workflow/executor/agent.go#L260

This has confused users (e.g. https://github.com/argoproj/argo-workflows/discussions/13950#discussioncomment-11404302). Additionally, the API docs for `result` only mention script templates, but container templates also set it.
### Modifications

Update relevant docs  

### Verification

Ran `make docs-serve`
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
