### PR TITLE
fix: cronOperator/serverResubmitWf retry create workflow on transient error. Fixes #13970

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -199,7 +199,7 @@ func SubmitWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, wfClie
 		err = waitutil.Backoff(retry.DefaultRetry, func() (bool, error) {
 			var err error
 			runWf, err = wfIf.Create(ctx, wf, metav1.CreateOptions{})
-			return !errorsutil.IsTransientErr(err), nil
+			return !errorsutil.IsTransientErr(err), err
 		})
 		return runWf, err
 	}

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -195,7 +195,13 @@ func SubmitWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, wfClie
 		}
 		return wf, err
 	} else {
-		return wfIf.Create(ctx, wf, metav1.CreateOptions{})
+		var runWf *wfv1.Workflow
+		err = waitutil.Backoff(retry.DefaultRetry, func() (bool, error) {
+			var err error
+			runWf, err = wfIf.Create(ctx, wf, metav1.CreateOptions{})
+			return !errorsutil.IsTransientErr(err), nil
+		})
+		return runWf, err
 	}
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13970 

### Motivation

<!-- TODO: Say why you made your changes. -->

To address issue where a cron intiated create workflow could failed due network issue

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Add retry to util.SubmitWorkflow

The `SubmitWorkflow` is used by `argo server.resubmit workflow` and `controller.cron operator`
The original issue was on cron operator, but having retry in the util function allows server to retry resubmit when there's an intermittent issue communicating with the controller, enabling a better user experience.

### Verification

The code style is identical to how other transient patterns are written.
We currently don't have a process to force k8s network error, thus hard to write additional test.
We do have a test for transient utility and a successful e2e test is an indication that no issue has been introduced

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
