### PR TITLE
docs: Fixed broken bash script when installing on macos

### DIFF
--- a/hack/release-notes.md
+++ b/hack/release-notes.md
@@ -19,7 +19,7 @@ Available via `curl`
 ```bash
 # Detect OS
 ARGO_OS="darwin"
-if [[ uname -s != "Darwin" ]]; then
+if [[ "$(uname -s)" != "Darwin" ]]; then
   ARGO_OS="linux"
 fi
 


### PR DESCRIPTION
This is how I fixed bash script installing using cURL on my macbook.