### PR TITLE
docs: clarify which version markdown features are in

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -249,6 +249,7 @@ v3.4.
 v3.4.4
 v3.5
 v3.6
+v3.7
 validator
 vendored
 versioned

--- a/docs/title-and-description.md
+++ b/docs/title-and-description.md
@@ -80,7 +80,7 @@ The above examples will render as rows like the below image:
 
 ### For `ClusterWorkflowTemplates`
 
-> v3.6 and after
+> v3.7 and after
 
 You can also add the `workflows.argoproj.io/title` and `workflows.argoproj.io/description` annotations with embedded markdown to a `ClusterWorkflowTemplate` to display in the list:
 
@@ -101,7 +101,7 @@ The above manifest will render as a row like the below image:
 
 ### For `CronWorkflows`
 
-> v3.6 and after
+> v3.7 and after
 
 You can also add the `workflows.argoproj.io/title` and `workflows.argoproj.io/description` annotations with embedded markdown to a `CronWorkflow` to display in the list:
 
@@ -122,7 +122,7 @@ The above manifest will render as a row like the below image:
 
 ### For `WorkflowTemplates`
 
-> v3.6 and after
+> v3.7 and after
 
 You can also add the `workflows.argoproj.io/title` and `workflows.argoproj.io/description` annotations with embedded markdown to a `WorkflowTemplate` to display in the list:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


### Motivation

The docs erroneously stated that markdown features for titles/descriptions on things other than Workflows were available in 3.6. This will be a 3.7 feature: https://github.com/argoproj/argo-workflows/pull/12697


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
