### PR TITLE
build: optimize `Makefile` and fix infinite loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ endif
 # * `kubernetes` run the workflow-controller and argo-server on the Kubernetes cluster
 RUN_MODE              := local
 KUBECTX               := $(shell [[ "`which kubectl`" != '' ]] && kubectl config current-context || echo none)
-DOCKER_DESKTOP        := $(shell [[ "$(KUBECTX)" == "docker-desktop" ]] && echo true || echo false)
 K3D                   := $(shell [[ "$(KUBECTX)" == "k3d-"* ]] && echo true || echo false)
 ifeq ($(PROFILE),prometheus)
 RUN_MODE              := kubernetes
@@ -93,7 +92,7 @@ AUTH_MODE                     := sso
 endif
 
 $(info GIT_COMMIT=$(GIT_COMMIT) GIT_BRANCH=$(GIT_BRANCH) GIT_TAG=$(GIT_TAG) GIT_TREE_STATE=$(GIT_TREE_STATE) RELEASE_TAG=$(RELEASE_TAG) DEV_BRANCH=$(DEV_BRANCH) VERSION=$(VERSION))
-$(info KUBECTX=$(KUBECTX) DOCKER_DESKTOP=$(DOCKER_DESKTOP) K3D=$(K3D) DOCKER_PUSH=$(DOCKER_PUSH) TARGET_PLATFORM=$(TARGET_PLATFORM))
+$(info KUBECTX=$(KUBECTX) K3D=$(K3D) DOCKER_PUSH=$(DOCKER_PUSH) TARGET_PLATFORM=$(TARGET_PLATFORM))
 $(info RUN_MODE=$(RUN_MODE) PROFILE=$(PROFILE) AUTH_MODE=$(AUTH_MODE) SECURE=$(SECURE) STATIC_FILES=$(STATIC_FILES) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) LOG_LEVEL=$(LOG_LEVEL) NAMESPACED=$(NAMESPACED))
 
 override LDFLAGS += \
@@ -107,11 +106,14 @@ override LDFLAGS += -X github.com/argoproj/argo-workflows/v3.gitTag=${GIT_TAG}
 endif
 
 ifndef $(GOPATH)
-	GOPATH=$(shell go env GOPATH)
+	GOPATH:=$(shell go env GOPATH)
 	export GOPATH
 endif
 
 # -- file lists
+# These variables are only used as prereqs for the below targets, and we don't want to run them for other targets
+# because the "go list" calls are very slow
+ifneq (,$(filter dist/argoexec dist/workflow-controller dist/argo dist/argo-% docs/cli/argo.md,$(MAKECMDGOALS)))
 HACK_PKG_FILES_AS_PKGS ?= false
 ifeq ($(HACK_PKG_FILES_AS_PKGS),false)
 	ARGOEXEC_PKG_FILES        := $(shell go list -f '{{ join .Deps "\n" }}' ./cmd/argoexec/ |  grep 'argoproj/argo-workflows/v3/' | xargs go list -f '{{ range $$file := .GoFiles }}{{ print $$.ImportPath "/" $$file "\n" }}{{ end }}' | cut -c 39-)
@@ -123,6 +125,11 @@ else
 	ARGOEXEC_PKG_FILES    := $(shell echo cmd/argoexec            && go list -f '{{ join .Deps "\n" }}' ./cmd/argoexec/            | grep 'argoproj/argo-workflows/v3/' | cut -c 39-)
 	CLI_PKG_FILES         := $(shell echo cmd/argo                && go list -f '{{ join .Deps "\n" }}' ./cmd/argo/                | grep 'argoproj/argo-workflows/v3/' | cut -c 39-)
 	CONTROLLER_PKG_FILES  := $(shell echo cmd/workflow-controller && go list -f '{{ join .Deps "\n" }}' ./cmd/workflow-controller/ | grep 'argoproj/argo-workflows/v3/' | cut -c 39-)
+endif
+else
+	ARGOEXEC_PKG_FILES    :=
+	CLI_PKG_FILES         :=
+	CONTROLLER_PKG_FILES  :=
 endif
 
 TYPES := $(shell find pkg/apis/workflow/v1alpha1 -type f -name '*.go' -not -name openapi_generated.go -not -name '*generated*' -not -name '*test.go')
@@ -651,6 +658,7 @@ pkg/apis/workflow/v1alpha1/openapi_generated.go: $(GOPATH)/bin/openapi-gen $(TYP
 
 
 # generates many other files (listers, informers, client etc).
+.PRECIOUS: pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go
 pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go: $(GOPATH)/bin/go-to-protobuf $(TYPES)
 	# These files are generated on a v3/ folder by the tool. Link them to the root folder
 	[ -e ./v3 ] || ln -s . v3


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

This makes some improvements to the `Makefile` to speed up local development and avoid a common race condition when building.

### Modifications

1. Remove `DOCKER_DESKTOP` because nothing uses it
2. Set `GOPATH` as a [simply expanded variable](https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html) so `go env GOPATH` isn't executed multiple times
3. Don't run the commands associated with the `ARGOEXEC_PKG_FILES`/`CLI_PKG_FILES`/`CONTROLLER_PKG_FILES` variables unless the target(s) needs them, because they're very slow. This speeds up `make` by ~1.5s for me. Before. 
    ```
    $ time make check-pwd 
    GIT_COMMIT=f796449df96888538af873bd6871374c2156db7b GIT_BRANCH=main GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
    KUBECTX=k3d-k3s-default DOCKER_DESKTOP=false K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64 
    RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=true ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true make: Nothing to be done for 'check-pwd'.

    real    0m1.764s
    user    0m4.382s
    sys     0m0.857s
    ```
    After:
    ```
    $ time make check-pwd
    GIT_COMMIT=f796449df96888538af873bd6871374c2156db7b GIT_BRANCH=main GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
    KUBECTX=k3d-k3s-default K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
    RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=true ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
    make: Nothing to be done for 'check-pwd'.

    real    0m0.117s
    user    0m0.060s
    sys     0m0.073s
    ```
5. Fix issue where `pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go` is deleted during a build and it causes Kit to enter an infinite loop. This is a race condition triggered when running something like `kit pre-up`. During that, as soon as `util/telemetry/attributes.go` is regenerated, this triggers Kit to abort the `make ./dist/argo` command. If that command is in the middle of regenerating `pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go`, then `make` deletes it:

    ```
    waiting for mutex "build"
    make: *** Deleting file 'pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go'
    make: *** [Makefile:657: pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go] Terminated
    signal: terminated
    ```

    This tells `make` not to delete it using the special [.PRECIOUS target](https://www.gnu.org/software/make/manual/html_node/Special-Targets.html#index-precious-targets).


### Verification
Ran `kit pre-up` and a bunch of other commands

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
