### PR TITLE
fix: ensure no nulls in postgres. Fixes  #13711

### DIFF
--- a/persist/sqldb/raw_marshaller.go
+++ b/persist/sqldb/raw_marshaller.go
@@ -1,0 +1,79 @@
+// Package sqldb implements workflow archiving
+package sqldb
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+type pair struct {
+	k string
+	v interface{}
+}
+
+func convertStrings(m map[string]interface{}) (map[string]interface{}, error) {
+	for k, v := range m {
+		switch v := v.(type) {
+		case string:
+			tmp := strconv.QuoteToASCII(v)
+			tmp = tmp[1:]
+			tmp = tmp[:len(tmp)-1]
+			m[k] = tmp
+		case map[string]interface{}:
+			convertedInner, err := convertStrings(v)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = convertedInner
+		case []any:
+			newList := []any{}
+			for _, val := range v {
+				// bit of a hack to reuse code
+				valM := map[string]interface{}{"entry": val}
+				retVal, err := convertStrings(valM)
+				if err != nil {
+					return nil, err
+				}
+				newList = append(newList, retVal["entry"])
+			}
+			m[k] = newList
+		default:
+			m[k] = v
+		}
+	}
+	return m, nil
+}
+
+func convertMap(jsonObject any) (map[string]interface{}, error) {
+
+	bytes, err := json.Marshal(jsonObject)
+	if err != nil {
+		return nil, err
+	}
+	// we do this to handle json tags without explicitly programming this
+	// ourselves.
+	oldMap := make(map[string]interface{})
+	err = json.Unmarshal(bytes, &oldMap)
+	if err != nil {
+		return nil, err
+	}
+
+	newMap, err := convertStrings(oldMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return newMap, nil
+}
+
+func jsonMarshallRawStrings(jsonObject any) ([]byte, error) {
+	m, err := convertMap(jsonObject)
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}

--- a/persist/sqldb/raw_marshaller.go
+++ b/persist/sqldb/raw_marshaller.go
@@ -3,22 +3,20 @@ package sqldb
 
 import (
 	"encoding/json"
-	"strconv"
 )
-
-type pair struct {
-	k string
-	v interface{}
-}
 
 func convertStrings(m map[string]interface{}) (map[string]interface{}, error) {
 	for k, v := range m {
 		switch v := v.(type) {
 		case string:
-			tmp := strconv.QuoteToASCII(v)
+			ms, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			tmp := string(ms)
 			tmp = tmp[1:]
 			tmp = tmp[:len(tmp)-1]
-			m[k] = tmp
+			m[k] = string(tmp)
 		case map[string]interface{}:
 			convertedInner, err := convertStrings(v)
 			if err != nil {

--- a/persist/sqldb/raw_marshaller_test.go
+++ b/persist/sqldb/raw_marshaller_test.go
@@ -1,0 +1,52 @@
+package sqldb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type simpleStruct struct {
+	Val         string          `json:"val"`
+	Val2        *string         `json:"val2"`
+	Val3        *string         `json:"val3,omitempty"`
+	InnerSimple *simpleStruct   `json:"sstruct,omitempty"`
+	List        []string        `json:"list"`
+	List2       *[]simpleStruct `json:"list2,omitempty"`
+}
+
+func TestStrings(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	val2 := "val2 \uC582"
+	val3 := "val3 \uC583"
+	inner := simpleStruct{
+		Val: "inner val \uc589",
+	}
+	l := []simpleStruct{inner}
+	s := simpleStruct{
+		Val:         "hello \x00",
+		Val2:        &val2,
+		Val3:        &val3,
+		InnerSimple: &inner,
+		List2:       &l,
+	}
+
+	newMap, err := convertMap(s)
+	require.NoError(err)
+	assert.Contains(string(newMap["val"].(string)), "\\x00")
+	assert.Contains(string(newMap["val3"].(string)), "\\uc583")
+
+	innerMapI, ok := newMap["sstruct"]
+	require.True(ok)
+	innerMap, ok := innerMapI.(map[string]interface{})
+	require.True(ok)
+	assert.Contains(string((innerMap["val"]).(string)), "inner val \\uc589")
+
+	_, err = json.Marshal(newMap)
+	require.NoError(err)
+
+}

--- a/persist/sqldb/raw_marshaller_test.go
+++ b/persist/sqldb/raw_marshaller_test.go
@@ -37,14 +37,14 @@ func TestStrings(t *testing.T) {
 
 	newMap, err := convertMap(s)
 	require.NoError(err)
-	assert.Contains(string(newMap["val"].(string)), "\\x00")
-	assert.Contains(string(newMap["val3"].(string)), "\\uc583")
+	assert.Contains(string(newMap["val"].(string)), "\\u0000")
+	assert.Contains(string(newMap["val3"].(string)), "\uc583")
 
 	innerMapI, ok := newMap["sstruct"]
 	require.True(ok)
 	innerMap, ok := innerMapI.(map[string]interface{})
 	require.True(ok)
-	assert.Contains(string((innerMap["val"]).(string)), "inner val \\uc589")
+	assert.Contains(string((innerMap["val"]).(string)), "inner val \uc589")
 
 	_, err = json.Marshal(newMap)
 	require.NoError(err)

--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -99,9 +99,19 @@ func (r *workflowArchive) ArchiveWorkflow(wf *wfv1.Workflow) error {
 	logCtx := log.WithFields(log.Fields{"uid": wf.UID, "labels": wf.GetLabels()})
 	logCtx.Debug("Archiving workflow")
 	wf.ObjectMeta.Labels[common.LabelKeyWorkflowArchivingStatus] = "Persisted"
-	workflow, err := json.Marshal(wf)
-	if err != nil {
-		return err
+	var workflow []byte
+	var err error
+	if r.dbType == Postgres {
+		workflow, err = jsonMarshallRawStrings(wf)
+		if err != nil {
+			log.Errorf("was unable to marshal to json with raw strings: %s", err)
+			return err
+		}
+	} else {
+		workflow, err = json.Marshal(wf)
+		if err != nil {
+			return err
+		}
 	}
 	return r.session.Tx(func(sess db.Session) error {
 		_, err := sess.SQL().


### PR DESCRIPTION
# Motivation
Unfortunately postgres does not handle NULL bytes in the json, this is as a result of a non-compliant implementation of JSON that exists in postgres. See  more details about this limitation [here](https://github.com/argoproj/argo-workflows/issues/13711#issuecomment-2507193576). 

# Modifications
This is arguably hacky solution, but this fix attempts to resolve this by mutating the workflow. 

# Verification
This has tests and additionally been verified by checking postgres.