### PR TITLE
test: fix and optimize flaky cron tests. Partial fix for #10807

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1006,6 +1006,9 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
     podGC:
       strategy: OnPodCompletion

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argoproj/pkg/humanize"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -54,10 +52,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -67,11 +65,11 @@ spec:
           image: argoproj/argosay:v2`).
 			When().
 			CreateCronWorkflow().
-			Wait(1 * time.Minute).
+			WaitForWorkflow(fixtures.ToBeSucceeded).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
-				assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
+				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
 	s.Run("TestBasicTimezone", func() {
@@ -97,6 +95,9 @@ metadata:
 spec:
   schedule: "%s"
   timezone: "%s"
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
     entrypoint: whalesay
     templates:
@@ -105,11 +106,11 @@ spec:
           image: argoproj/argosay:v2`, scheduleInTestTimezone, testTimezone)).
 			When().
 			CreateCronWorkflow().
-			Wait(1 * time.Minute).
+			WaitForWorkflow(fixtures.ToBeSucceeded).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
-				assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
+				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
 	s.Run("TestSuspend", func() {
@@ -124,10 +125,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -155,10 +156,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -186,10 +187,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -200,11 +201,12 @@ spec:
           args: ["sleep", "300s"]`).
 			When().
 			CreateCronWorkflow().
-			Wait(2 * time.Minute).
+			WaitForWorkflow(fixtures.ToBeRunning).
+			Wait(time.Minute). // wait for next scheduled time to ensure it's skipped by concurrencyPolicy
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Len(t, cronWf.Status.Active, 1)
-				assert.True(t, cronWf.Status.LastScheduledTime.Time.Before(time.Now().Add(-1*time.Minute)))
+				assert.Less(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
 	s.Run("TestBasicAllow", func() {
@@ -221,10 +223,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -235,7 +237,7 @@ spec:
           args: ["sleep", "300s"]`).
 			When().
 			CreateCronWorkflow().
-			Wait(2 * time.Minute).
+			WaitForWorkflowListCount(3*time.Minute, 2).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Len(t, cronWf.Status.Active, 2)
@@ -253,10 +255,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -267,17 +269,17 @@ spec:
           args: ["sleep", "300s"]`).
 			When().
 			CreateCronWorkflow().
-			Wait(2*time.Minute + 20*time.Second).
+			WaitForWorkflow(fixtures.ToBeRunning).
+			WaitForNewWorkflow(fixtures.ToBeRunning).
+			WaitForCronWorkflow().
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Len(t, cronWf.Status.Active, 1)
 				require.NotNil(t, cronWf.Status.LastScheduledTime)
-				assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
+				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
 	s.Run("TestSuccessfulJobHistoryLimit", func() {
-		var listOptions v1.ListOptions
-		wfInformerListOptionsFunc(&listOptions, "test-cron-wf-succeed-1")
 		s.Given().
 			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -289,10 +291,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -302,16 +304,16 @@ spec:
           image: argoproj/argosay:v2`).
 			When().
 			CreateCronWorkflow().
-			Wait(2*time.Minute+25*time.Second).
+			WaitForWorkflow(fixtures.ToBeSucceeded).
+			WaitForNewWorkflow(fixtures.ToBeRunning).
+			WaitForWorkflowListCount(2*time.Minute, 1).
 			Then().
-			ExpectWorkflowList(listOptions, func(t *testing.T, wfList *wfv1.WorkflowList) {
+			ExpectWorkflowListFromCronWorkflow(func(t *testing.T, wfList *wfv1.WorkflowList) {
 				assert.Len(t, wfList.Items, 1)
-				assert.True(t, wfList.Items[0].Status.FinishedAt.Time.After(time.Now().Add(-1*time.Minute)))
+				assert.Greater(t, wfList.Items[0].Status.FinishedAt.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
 	s.Run("TestFailedJobHistoryLimit", func() {
-		var listOptions v1.ListOptions
-		wfInformerListOptionsFunc(&listOptions, "test-cron-wf-fail-1")
 		s.Given().
 			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -323,10 +325,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 1
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -337,11 +339,13 @@ spec:
           args: ["exit", "1"]`).
 			When().
 			CreateCronWorkflow().
-			Wait(2*time.Minute+25*time.Second).
+			WaitForWorkflow(fixtures.ToBeFailed).
+			WaitForNewWorkflow(fixtures.ToBeRunning).
+			WaitForWorkflowListCount(2*time.Minute, 1).
 			Then().
-			ExpectWorkflowList(listOptions, func(t *testing.T, wfList *wfv1.WorkflowList) {
+			ExpectWorkflowListFromCronWorkflow(func(t *testing.T, wfList *wfv1.WorkflowList) {
 				assert.Len(t, wfList.Items, 1)
-				assert.True(t, wfList.Items[0].Status.FinishedAt.Time.After(time.Now().Add(-1*time.Minute)))
+				assert.Greater(t, wfList.Items[0].Status.FinishedAt.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
 	s.Run("TestStoppingConditionWithSucceeded", func() {
@@ -358,10 +362,10 @@ spec:
   failedJobsHistoryLimit: 2
   stopStrategy:
     expression: "cronworkflow.succeeded >= 1"
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -372,7 +376,7 @@ spec:
             command: [/argosay]`).
 			When().
 			CreateCronWorkflow().
-			Wait(2 * time.Minute). // wait to be scheduled 2 times, but only runs once
+			WaitForCronWorkflowCompleted(3 * time.Minute).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Equal(t, int64(0), cronWf.Status.Failed)
@@ -392,10 +396,10 @@ spec:
   concurrencyPolicy: "Allow"
   stopStrategy:
     expression: "cronworkflow.failed >= 1"
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -406,7 +410,7 @@ spec:
           args: ["exit", "1"]`).
 			When().
 			CreateCronWorkflow().
-			Wait(2 * time.Minute). // wait to be scheduled 2 times, but only runs once
+			WaitForCronWorkflowCompleted(3 * time.Minute).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Equal(t, int64(0), cronWf.Status.Succeeded)
@@ -430,10 +434,10 @@ spec:
   startingDeadlineSeconds: 0
   successfulJobsHistoryLimit: 4
   failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: whalesay
@@ -443,24 +447,21 @@ spec:
           image: argoproj/argosay:v2`).
 			When().
 			CreateCronWorkflow().
-			Wait(1 * time.Minute).
+			WaitForWorkflow(fixtures.ToBeSucceeded).
 			Then().
 			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 				assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
-				assert.True(t, cronWf.Status.LastScheduledTime.Time.After(time.Now().Add(-1*time.Minute)))
+				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 			})
 	})
-}
-
-func wfInformerListOptionsFunc(options *v1.ListOptions, cronWfName string) {
-	options.LabelSelector = common.LabelKeyCronWorkflow + "=" + cronWfName
 }
 
 func (s *CronSuite) TestMalformedCronWorkflow() {
 	s.Given().
 		Exec("kubectl", []string{"apply", "-f", "testdata/malformed/malformed-cronworkflow.yaml"}, fixtures.NoError).
-		Exec("kubectl", []string{"apply", "-f", "testdata/wellformed/wellformed-cronworkflow.yaml"}, fixtures.NoError).
+		CronWorkflow("@testdata/wellformed/wellformed-cronworkflow.yaml").
 		When().
+		CreateCronWorkflow().
 		WaitForWorkflow(2*time.Minute).
 		Then().
 		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *wfv1.WorkflowStatus) {
@@ -479,15 +480,5 @@ func (s *CronSuite) TestMalformedCronWorkflow() {
 }
 
 func TestCronSuite(t *testing.T) {
-	// To ensure consistency, always start at the next 30 second mark
-	_, _, sec := time.Now().Clock()
-	var toWait time.Duration
-	if sec <= 30 {
-		toWait = time.Duration(30-sec) * time.Second
-	} else {
-		toWait = time.Duration(90-sec) * time.Second
-	}
-	log.Infof("Waiting %s to start", humanize.Duration(toWait))
-	time.Sleep(toWait)
 	suite.Run(t, new(CronSuite))
 }

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -129,6 +129,15 @@ func (t *Then) ExpectCron(block func(t *testing.T, cronWf *wfv1.CronWorkflow)) *
 	return t
 }
 
+func (t *Then) ExpectWorkflowListFromCronWorkflow(block func(t *testing.T, wfList *wfv1.WorkflowList)) *Then {
+	t.t.Helper()
+	if t.cronWf == nil {
+		t.t.Fatal("No cron workflow to match against")
+	}
+	labelSelector := common.LabelKeyCronWorkflow + "=" + t.cronWf.Name
+	return t.ExpectWorkflowList(metav1.ListOptions{LabelSelector: labelSelector}, block)
+}
+
 func (t *Then) ExpectWorkflowList(listOptions metav1.ListOptions, block func(t *testing.T, wfList *wfv1.WorkflowList)) *Then {
 	t.t.Helper()
 	_, _ = fmt.Println("Listing workflows")

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -159,7 +159,6 @@ spec:
 }
 
 func (s *FunctionalSuite) TestWorkflowRetention() {
-	listOptions := metav1.ListOptions{LabelSelector: "workflows.argoproj.io/phase=Failed"}
 	s.Given().
 		Workflow("@testdata/exit-1.yaml").
 		When().
@@ -175,9 +174,7 @@ func (s *FunctionalSuite) TestWorkflowRetention() {
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
-		WaitForWorkflowList(listOptions, func(list []wfv1.Workflow) bool {
-			return len(list) == 2
-		})
+		WaitForWorkflowListFailedCount(2)
 }
 
 // in this test we create a poi quota, and then  we create a workflow that needs one more pod than the quota allows

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -99,7 +99,7 @@ func (s *MetricsSuite) TestDeprecatedCronSchedule() {
 		CronWorkflow(`@testdata/cronworkflow-deprecated-schedule.yaml`).
 		When().
 		CreateCronWorkflow().
-		Wait(1 * time.Minute). // This pattern is used in cron_test.go too
+		WaitForWorkflow(fixtures.ToBeRunning).
 		Then().
 		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 			s.e(s.T()).GET("").
@@ -184,7 +184,8 @@ func (s *MetricsSuite) TestCronCountersForbid() {
 		CronWorkflow(`@testdata/cronworkflow-metrics-forbid.yaml`).
 		When().
 		CreateCronWorkflow().
-		Wait(2 * time.Minute). // This pattern is used in cron_test.go too
+		WaitForWorkflow(fixtures.ToBeRunning).
+		Wait(time.Minute). // This pattern is used in cron_test.go too
 		Then().
 		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 			s.e(s.T()).GET("").
@@ -201,7 +202,8 @@ func (s *MetricsSuite) TestCronCountersReplace() {
 		CronWorkflow(`@testdata/cronworkflow-metrics-replace.yaml`).
 		When().
 		CreateCronWorkflow().
-		Wait(2 * time.Minute). // This pattern is used in cron_test.go too
+		WaitForWorkflow(fixtures.ToBeRunning).
+		WaitForNewWorkflow(fixtures.ToBeRunning).
 		Then().
 		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
 			s.e(s.T()).GET("").

--- a/test/e2e/testdata/cronworkflow-deprecated-schedule.yaml
+++ b/test/e2e/testdata/cronworkflow-deprecated-schedule.yaml
@@ -7,10 +7,10 @@ spec:
     - "* * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: sleep

--- a/test/e2e/testdata/cronworkflow-metrics-forbid.yaml
+++ b/test/e2e/testdata/cronworkflow-metrics-forbid.yaml
@@ -7,10 +7,10 @@ spec:
     - "* * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: sleep

--- a/test/e2e/testdata/cronworkflow-metrics-replace.yaml
+++ b/test/e2e/testdata/cronworkflow-metrics-replace.yaml
@@ -7,10 +7,10 @@ spec:
     - "* * * * *"
   concurrencyPolicy: "Replace"
   startingDeadlineSeconds: 0
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: sleep

--- a/test/e2e/testdata/cronworkflow_deprecated_schedule.yaml
+++ b/test/e2e/testdata/cronworkflow_deprecated_schedule.yaml
@@ -7,10 +7,10 @@ spec:
     - "* * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
   workflowSpec:
-    metadata:
-      labels:
-        workflows.argoproj.io/test: "true"
     podGC:
       strategy: OnPodCompletion
     entrypoint: sleep


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #10807

### Motivation

The cron tests have been some of the slowest and flakiest for awhile now, mostly due to using `time.Sleep()` to wait a fixed amount of time. The `TestCronSuite` function tries to workaround the flakiness by running the suite at the 30 second mark, but this is only effective for the first test in the suite.


### Modifications

This changes nearly all the cron tests to remove the `time.Sleep()` calls and instead use the API to poll for changes. The two tests I couldn't fix to stop using `time.Sleep()` are `TestBasicForbid` and `TestCronCountersForbid`, since I don't know of any way of verifying the `concurrencyPolicy` is respected without sleeping.

Also, most of the cron fixture data wasn't specifying workflow metadata properly using [workflowMetadata](https://argo-workflows.readthedocs.io/en/latest/fields/#cronworkflowspec), which meant they weren't being cleaned up automatically, so I fixed that too.

### Verification

Ran `make test-cron` locally

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
