### PR TITLE
ci: improve performance by eliminating redundancies

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -355,9 +355,8 @@ jobs:
             LOG_LEVEL=info \
             API=${{matrix.use-api}} \
             UI=false \
-            POD_STATUS_CAPTURE_FINALIZER=true > /tmp/argo.log 2>&1 &
-      - name: Wait for controller to be up
-        run: make wait PROFILE=${{matrix.profile}} API=${{matrix.use-api}}
+            POD_STATUS_CAPTURE_FINALIZER=true 2>&1 | tee /tmp/argo.log &
+          make wait PROFILE=${{matrix.profile}} API=${{matrix.use-api}}
         timeout-minutes: 5
       - name: Run tests ${{matrix.test}}
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -280,8 +280,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
           printf "==> Available space after cleanup\n"
           df -h
-      - name: Install socat (needed by Kubernetes)
-        run: sudo apt-get -y install socat
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
@@ -300,6 +298,8 @@ jobs:
         with:
           python-version: '3.x'
           cache: pip
+      - name: Install socat (needed by Kubernetes) and kit
+        run: sudo apt-get -y install socat && make kit
       - name: Install and start K3S
         run: |
           if ! echo "${{ matrix.install_k3s_version }}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+\+k3s1$'; then
@@ -339,6 +339,8 @@ jobs:
         with:
           name: cli
           path: dist/
+      - name: Prepare binaries
+        run: chmod +x dist/* && make --touch dist/*
       - name: Set-up /etc/hosts
         run: |
           echo '127.0.0.1 dex'      | sudo tee -a /etc/hosts
@@ -346,8 +348,6 @@ jobs:
           echo '127.0.0.1 postgres' | sudo tee -a /etc/hosts
           echo '127.0.0.1 mysql'    | sudo tee -a /etc/hosts
           echo '127.0.0.1 azurite'  | sudo tee -a /etc/hosts
-      - name: Install manifests
-        run: make install PROFILE=${{matrix.profile}} STATIC_FILES=false
       - name: Start controller/API
         run: |
           make start PROFILE=${{matrix.profile}} \

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -299,6 +299,10 @@ jobs:
           python-version: '3.x'
           cache: pip
       - name: Install socat (needed by Kubernetes) and kit
+        # socat is needed for "kubectl port-forward" to work when using cri-dockerd: https://github.com/k3s-io/cri-dockerd/blob/4995f339edcffdf890406b3f1477d34e38477f18/streaming/streaming_others.go#L46
+        # Both cri-o and containerd removed it as a dependency awhile ago, but that hasn't been ported to cri-dockerd.
+        # Running "make kit" isn't strictly necessary, since it would be installed automatically by "make start",
+        # but it's noisy and makes the logs for "Start controller/API" hard to follow.
         run: sudo apt-get -y install socat && make kit
       - name: Install and start K3S
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "19"
+      # This is mainly here so the dependencies get saved to the cache by "actions/setup-go"
+      - name: Download go dependencies
+        run: go mod download
       # Use the same make target both locally and on CI to make it easier to debug failures.
       - name: Build & Lint docs
         run: make docs

--- a/Makefile
+++ b/Makefile
@@ -541,11 +541,7 @@ endif
 
 .PHONY: start
 ifeq ($(RUN_MODE),local)
-ifeq ($(API),true)
-start: install controller kit cli
-else
-start: install controller kit
-endif
+start: kit
 else
 start: install kit
 endif


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation
There's three sources of redundancy that are slowing down CI builds:
1. `make install` is being redundantly run three times for each E2E test:
    1. In the workflow: https://github.com/argoproj/argo-workflows/blob/6699ab396f830210f6dcac4f00a9328a629c142f/.github/workflows/ci-build.yaml#L349-L350
    2. As a prerequisite of `make start`: https://github.com/argoproj/argo-workflows/blob/6699ab396f830210f6dcac4f00a9328a629c142f/Makefile#L547
    3. As a dependency by Kit: https://github.com/argoproj/argo-workflows/blob/6699ab396f830210f6dcac4f00a9328a629c142f/tasks.yaml#L39
2.  Similarly, the changes in https://github.com/argoproj/argo-workflows/pull/14012 to centralize binary building aren't actually preventing the binaries from being rebuilt in the E2E tests because `controller` and `cli` are prerequisites of `make start`, and listed as prerequisites in Kit.
3. Go dependencies are being re-downloaded in every job. The [actions/setup-go](https://github.com/actions/setup-go) is supposed to prevent that by caching the contents of `GOMODCACHE`. I think the problem is the cache is usually populated by the `docs` workflow, which doesn't fetch all the Go dependencies ([example](https://github.com/argoproj/argo-workflows/actions/runs/12460536734/job/34778897761)), so they aren't included when `actions/setup-go` saves the cache.
![image](https://github.com/user-attachments/assets/808f8084-94f6-474f-aace-8555aae23b57)

### Modifications

This eliminates the first two redundancies by removing the unnecessary prerequisites from the `Makefile` and the redundant `make install` step in `ci-build.yaml`. Also, I added `make --touch dist/*` to mark everything as up-to-date so the binaries aren't rebuilt ([docs](https://www.gnu.org/software/make/manual/html_node/Instead-of-Execution.html)). For the issue with the go dependencies not being in the cache, I updated `docs.yaml` to run `go mod download` to ensure they're included.

Also, I consolidated `Start controller/API` and `Wait for controller to be up` steps so you can see everything Kit is doing in the logs for the former, which will help prevent these kind of oversights in the future. The reason I didn't catch the issue with binaries being rebuilt in https://github.com/argoproj/argo-workflows/pull/14012 is because the logs are discarded unless the build failed (in which case they were visible in the `Failure debug - Controller/API logs` step).
### Verification

Wait for E2E tests 

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
