### PR TITLE
fix: search and replace null bytes for postgres only.Fixes #13711

### DIFF
--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -1,8 +1,10 @@
 package sqldb
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -20,8 +22,9 @@ import (
 )
 
 const (
-	archiveTableName       = "argo_archived_workflows"
-	archiveLabelsTableName = archiveTableName + "_labels"
+	archiveTableName        = "argo_archived_workflows"
+	archiveLabelsTableName  = archiveTableName + "_labels"
+	postgresNullReplacement = "ARGO_POSTGRES_NULL_REPLACEMENT"
 )
 
 type archivedWorkflowMetadata struct {
@@ -102,6 +105,9 @@ func (r *workflowArchive) ArchiveWorkflow(wf *wfv1.Workflow) error {
 	workflow, err := json.Marshal(wf)
 	if err != nil {
 		return err
+	}
+	if r.dbType == Postgres {
+		workflow = bytes.ReplaceAll(workflow, []byte("\\u0000"), []byte(postgresNullReplacement))
 	}
 	return r.session.Tx(func(sess db.Session) error {
 		_, err := sess.SQL().
@@ -387,6 +393,9 @@ func (r *workflowArchive) GetWorkflow(uid string, namespace string, name string)
 		return nil, err
 	}
 	var wf *wfv1.Workflow
+	if r.dbType == Postgres {
+		archivedWf.Workflow = strings.ReplaceAll(archivedWf.Workflow, postgresNullReplacement, "\\u0000")
+	}
 	err = json.Unmarshal([]byte(archivedWf.Workflow), &wf)
 	if err != nil {
 		return nil, err

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -2135,6 +2135,42 @@ func (s *ArgoServerSuite) TestRateLimitHeader() {
 	})
 }
 
+func (s *ArgoServerSuite) TestPostgresNullBytes() {
+	// only meaningful for postgres, but shouldn't fail  for mysql.
+	var uid types.UID
+	_ = uid
+
+	s.Given().
+		Workflow(`
+metadata:
+  generateName: archie-
+  labels:
+    foo: 1
+spec:
+  entrypoint: run-archie
+  templates:
+    - name: run-archie
+      container:
+        image: argoproj/argosay:v2
+        args: [echo, "hello \u0000"]`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeArchived).
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			uid = metadata.UID
+		})
+
+	j := s.e().GET("/api/v1/archived-workflows/{uid}", uid).
+		Expect().
+		Status(200).
+		JSON()
+	j.
+		Path("$.spec.templates[0].container.args[1]").
+		IsEqual("hello \u0000")
+
+}
+
 func TestArgoServerSuite(t *testing.T) {
 	suite.Run(t, new(ArgoServerSuite))
 }


### PR DESCRIPTION
# Motivation
Unfortunately postgres does not handle NULL bytes in the json, this is as a result of a non-compliant implementation of JSON that exists in postgres. See  more details about this limitation [here](https://github.com/argoproj/argo-workflows/issues/13711#issuecomment-2507193576). 

# Modifications
This attempts a search and replace in postgres, it does this by reserving a special phrase for replacement of null bytes. 
On the `GetWorkflows` path, this special phrase is replaced with a null byte.

# Verification
This has tests and additionally been verified by checking postgres.