### PR TITLE
fix(controller): step group stuck on running when exit hook has illegal expression

### DIFF
--- a/util/expr/argoexpr/eval_test.go
+++ b/util/expr/argoexpr/eval_test.go
@@ -58,6 +58,17 @@ func TestEvalBool(t *testing.T) {
 			want:    true,
 			wantErr: false,
 		},
+		{
+			name: "test null expression",
+			args: args{
+				input: "steps[\"prepare\"].outputs != null",
+				env: map[string]interface{}{"steps": map[string]interface{}{
+					"prepare": map[string]interface{}{"outputs": "msg"},
+				}},
+			},
+			want:    false,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -109,7 +109,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 
 		sgNode, err := woc.executeStepGroup(ctx, stepGroup.Steps, sgNodeName, &stepsCtx)
 		if err != nil {
-			return nil, err
+			return woc.markNodeError(sgNodeName, err), nil
 		}
 		if !sgNode.Fulfilled() {
 			woc.log.Infof("Workflow step group node %s not yet completed", sgNode.ID)
@@ -330,8 +330,12 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 			completed = false
 		} else if childNode.Completed() {
 			hasOnExitNode, onExitNode, err := woc.runOnExitNode(ctx, step.GetExitHook(woc.execWf.Spec.Arguments), childNode, stepsCtx.boundaryID, stepsCtx.tmplCtx, "steps."+step.Name, stepsCtx.scope)
-			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled() || err != nil) {
-				// The onExit node is either not complete or has errored out, return.
+			// see https://github.com/argoproj/argo-workflows/issues/14031,
+			// we should return error otherwise the node will get stuck
+			if err != nil {
+				return node, err
+			}
+			if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled()) {
 				completed = false
 			}
 		}


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes #14031

### Motivation
The  error handling logic for `stepGroup` on `exithook` with illegal expressions should be consistent with `Dag`.

https://github.com/argoproj/argo-workflows/blob/27a59385f62de98b7bddc0087b03df90af29e87e/workflow/controller/dag.go#L289-L300

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
