### PR TITLE
fix: validate template of the same name. Fixes #13763

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -479,13 +479,14 @@ func (ctx *templateValidationCtx) validateTemplate(tmpl *wfv1.Template, tmplCtx 
 
 	}
 
+	templateScope := tmplCtx.GetTemplateScope()
 	tmplID := getTemplateID(tmpl)
-	_, ok := ctx.results[tmplID]
+	_, ok := ctx.results[templateScope+tmplID]
 	if ok {
 		// we can skip the rest since it has been validated.
 		return nil
 	}
-	ctx.results[tmplID] = true
+	ctx.results[templateScope+tmplID] = true
 
 	for globalVar, val := range ctx.globalParams {
 		scope[globalVar] = val

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -1538,6 +1538,56 @@ func TestNestedTemplateRef(t *testing.T) {
 	require.NoError(t, err)
 }
 
+var templateRefTargetWithInput = `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: template-ref-target-with-input
+spec:
+  templates:
+  - name: A
+    inputs:
+      parameters:
+        - name: message
+    container:
+      image: alpine:3.11
+      command: [sh, -c]
+      args: ["echo {{inputs.parameters.message}}"]
+`
+
+var nestedTemplateRefWithError = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: template-ref-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+      - - name: call-A
+          templateRef:
+            name: template-ref-target
+            template: A
+      - - name: call-A-input
+          template: A
+  - name: A
+    steps:
+      - - name: call-B
+          templateRef:
+            name: template-ref-target-with-input
+            template: A
+`
+
+func TestNestedTemplateRefWithError(t *testing.T) {
+	err := createWorkflowTemplateFromSpec(templateRefTarget)
+	require.NoError(t, err)
+	err = createWorkflowTemplateFromSpec(templateRefTargetWithInput)
+	require.NoError(t, err)
+	err = validate(nestedTemplateRefWithError)
+	require.EqualError(t, err, "templates.main.steps[1].call-A-input templates.A.steps[0].call-B templates.A inputs.parameters.message was not supplied")
+}
+
 var undefinedTemplateRef = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13763

### Motivation

<!-- TODO: Say why you made your changes. -->

Validate template even if they use the same name (happened in nested template situation).
So that all templates are validated and cached in `storedTemplate` upon workflow submission

### Modifications

Include templateScope in validation cache,
so that the validation is aware which `workflowTemplate` is the current `template` coming from, and `template` of the same name from different `workflowTemplate` will not skip validation

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Added unit test, test failed
Added code change, unit test passed

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
