### PR TITLE
fix: update upload-artifact and download-artifact

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,10 +64,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-    ignore:
-      # temporarily ignore until https://github.com/actions/download-artifact/issues/249 is resolved
-      - dependency-name: "actions/download-artifact"
-      - dependency-name: "actions/upload-artifact"
     # ignore all non-security updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
     open-pull-requests-limit: 0
     labels:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -205,7 +205,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Upload
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: ${{matrix.image}}_image.tar
           path: /tmp/${{matrix.image}}_image.tar
@@ -323,7 +323,7 @@ jobs:
           echo "    token: xxxxxx" >> $KUBECONFIG
           until kubectl cluster-info ; do sleep 10s ; done
       - name: Download images
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: '*_image.tar'
           path: /tmp

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,7 +40,7 @@ jobs:
         run: git diff --exit-code
       # Upload the site so reviewers see it.
       - name: Upload Docs Site
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: docs
           path: site


### PR DESCRIPTION
Fixes #12455

See also @agilgur5's commentary from #13027

### Motivation

The github actions `upload-artifact` and `download-artifact` are [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)  and will presumably stop working completely on the 30th of January 2025.

### Modifications

Update all uses of both actions to the latest releases by SHA, matching those introduced in #14012.

Remove the dependabot ignore for these actions so they get dependabot maintained.

### Verification

This is a "github only" change so CI for this PR and future working or failing are the only mechanisms to check it works.

This PR fixes the warning we were getting - see this run for the PR: https://github.com/argoproj/argo-workflows/actions/runs/12706995546?pr=14070 

Compare to a prior run: https://github.com/argoproj/argo-workflows/actions/runs/12703710249