### PR TITLE
docs: Pod Security Context: Volumes aren't required in >= v3.3 and runAsNonRoot

### DIFF
--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -24,5 +24,7 @@ You can configure this globally using [workflow defaults](default-workflow-specs
 !!! Warning "It is easy to make a workflow need root unintentionally"
     You may find that user's workflows have been written to require root with seemingly innocuous code. E.g. `mkdir /my-dir` would require root.
 
-!!! Note "You must use volumes for output artifacts"
-    If you use `runAsNonRoot` - you cannot have output artifacts on base layer (e.g. `/tmp`). You must use a volume (e.g. [empty dir](empty-dir.md)).
+!!! Note "You must use volumes for output artifacts (v3.3 or earlier)"
+    If you use `runAsNonRoot` in versions v3.3 or earlier, you cannot have output artifacts on base layer (e.g. `/tmp`). You must use a volume (e.g. [empty dir](empty-dir.md)).
+    In versions later than v3.3, the [Emissary executor](https://argo-workflows.readthedocs.io/en/latest/workflow-executors/#emissary-emissary)
+    allows artifacts on the base layer with `runAsNonRoot`.

--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -23,8 +23,3 @@ You can configure this globally using [workflow defaults](default-workflow-specs
 
 !!! Warning "It is easy to make a workflow need root unintentionally"
     You may find that user's workflows have been written to require root with seemingly innocuous code. E.g. `mkdir /my-dir` would require root.
-
-!!! Note "You must use volumes for output artifacts (v3.3 or earlier)"
-    If you use `runAsNonRoot` in versions v3.3 or earlier, you cannot have output artifacts on base layer (e.g. `/tmp`). You must use a volume (e.g. [empty dir](empty-dir.md)).
-    In versions later than v3.3, the [Emissary executor](workflow-executors.md#emissary-emissary)
-    allows artifacts on the base layer with `runAsNonRoot`.

--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -26,5 +26,5 @@ You can configure this globally using [workflow defaults](default-workflow-specs
 
 !!! Note "You must use volumes for output artifacts (v3.3 or earlier)"
     If you use `runAsNonRoot` in versions v3.3 or earlier, you cannot have output artifacts on base layer (e.g. `/tmp`). You must use a volume (e.g. [empty dir](empty-dir.md)).
-    In versions later than v3.3, the [Emissary executor](https://argo-workflows.readthedocs.io/en/latest/workflow-executors/#emissary-emissary)
+    In versions later than v3.3, the [Emissary executor](workflow-executors.md#emissary-emissary)
     allows artifacts on the base layer with `runAsNonRoot`.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Motivation

A note regarding volumes being required for `runAsNonRoot` took me down an incorrect path before I saw that was unnecessary in newer versions. I'm hoping this will save other developers a couple of hours of going down the same path.

### Modifications

Based on the PR discussion, I removed the note since v3.3 is no longer supported.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
