### PR TITLE
ci: add step to validate release manifests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -362,6 +362,8 @@ jobs:
             POD_STATUS_CAPTURE_FINALIZER=true 2>&1 | tee /tmp/argo.log &
           make wait PROFILE=${{matrix.profile}} API=${{matrix.use-api}}
         timeout-minutes: 5
+      - name: Validate release manifests
+        run: make manifests-validate
       - name: Run tests ${{matrix.test}}
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=20m STATIC_FILES=false
 

--- a/Makefile
+++ b/Makefile
@@ -447,6 +447,10 @@ dist/manifests/%: manifests/%
 
 # lint/test/etc
 
+.PHONE: manifests-validate
+manifests-validate:
+	kubectl apply --server-side --validate=strict --dry-run=server -f 'manifests/*.yaml'
+
 $(GOPATH)/bin/golangci-lint: Makefile
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.61.0
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->
### Motivation
As requested in https://github.com/argoproj/argo-workflows/pull/14044#discussion_r1917576753, this adds a simple step to each E2E suite that validates the release manifests using server-side field validation. This is very fast (~2s) and is intended to catch syntactic issues, e.g. bugs in `hack/manifests/crds.go`.
### Modifications
Add `make manifests-validate` that runs [kubectl apply](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/) with `--dry-run=server` to validate the manifests without actually applying them.
### Verification

Edited `manifests/quick-start-minimal.yaml` and changed this line: https://github.com/argoproj/argo-workflows/blob/b1a65e79fe583134117c33814b54dcaba40c4238/manifests/quick-start-minimal.yaml#L23

to `type: TYPO`, then ran `make manifests-validate` to ensure it correctly caught the issue:
```
$ make manifests-validate
<SNIP>
deployment.apps/postgres serverside-applied (server dry run)
The CustomResourceDefinition "clusterworkflowtemplates.argoproj.io" is invalid:
* spec.validation.openAPIV3Schema.properties[apiVersion].type: Invalid value: "TYPO": must be string
* spec.validation.openAPIV3Schema.properties[apiVersion].type: Unsupported value: "TYPO": supported values: "array", "boolean", "integer", "number", "object", "string"
make: *** [Makefile:452: manifests-validate] Error 1
```


<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
