### PR TITLE
fix(api/jsonschema): use unchanging JSON Schema version

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "http://workflows.argoproj.io/workflows.json",
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "definitions": {
     "eventsource.CreateEventSourceRequest": {
       "properties": {

--- a/hack/api/jsonschema/main.go
+++ b/hack/api/jsonschema/main.go
@@ -40,7 +40,7 @@ func main() {
 		}
 		schema := obj{
 			"$id":     "http://workflows.argoproj.io/workflows.json", // don't really know what this should be
-			"$schema": "http://json-schema.org/schema#",
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
 			"type":    "object",
 			"oneOf": []interface{}{
 				obj{"$ref": "#/definitions/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate"},


### PR DESCRIPTION
### Motivation

The current value of `$schema` in `api/jsonschema/schema.json` refers to a schema version that changes over time, which means that there's a possibility that the keywords used in the schema might change meaning unexpectedly when a new version is released.

### Modifications

This PR fixes the schema version to the current latest version, avoiding this potential issue by locking in the expected JSON Schema semantics and meaning that any would-be interpreter does not have to make a network request to find out what version is intended.

### Verification

I checked that the new schema validates OK in a JSON schema checker.

### Aside

A passing remark with regard to this comment in `hack/api/jsonschema/main.go`:

```
"$id":     "http://workflows.argoproj.io/workflows.json", // don't really know what this should be
```

It seems relatively common to use a working URL for JSON schemas URIs so this could potentially be changed to:

```
"$id":     "https://raw.githubusercontent.com/argoproj/argo-workflows/HEAD/api/jsonschema/schema.json",
```
