### PR TITLE
fix(examples): map-reduce parts artifact path. Fixes #14091

### DIFF
--- a/examples/map-reduce.yaml
+++ b/examples/map-reduce.yaml
@@ -69,7 +69,7 @@ spec:
             archive:
               none: { }
             s3:
-              key: "{{workflow.name}}/parts"
+              key: "{{workflow.name}}/parts/"
     # One `map` per part ID is started. Finds its own "part file" under `/mnt/in/part.json`.
     # Each `map` task has an output artifact saved with a unique name for the part into to a common "results directory".
     - name: map


### PR DESCRIPTION
Added trailing slash after parts artifact path to treat it as a folder. Fixes artifactGC leaving it behind.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14091 

### Motivation

Parts folder remains dangling in S3 after garbage collection.

### Modifications

Added a trailing slash to the parts artifact path to signal that it's a folder.

### Verification

I have ran the modified workflow and observed that `parts` was visualized as a folder (with listed contents) in the UI and it was properly garbage collected after the workflow is deleted.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
