### PR TITLE
feat: add documentation section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,11 @@ Fixes #TODO
 
 <!-- TODO: Say how you tested your changes. -->
 
+### Documentation
+
+<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
+<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
+
 <!--
 ### Beyond this PR
 


### PR DESCRIPTION
In response to https://github.com/argoproj/argo-workflows/pull/14077#issuecomment-2599000634

### Motivation

I'd like to ensure that documentation is considered for each PR made.

### Modifications

Added a documentation section to the PR template to encourage people to consider it, document if they feel it's unnecessary, and always document `feat` PRs

### Verification

None, this is a github PR template update

### Documentation

This is self documenting