### PR TITLE
fix: correct type of pods_total_count metric

### DIFF
--- a/util/telemetry/builder/values.yaml
+++ b/util/telemetry/builder/values.yaml
@@ -222,7 +222,7 @@ metrics:
       The `reason` attribute is the value from the Reason message before the `:` in the message.
       This is not directly controlled by the workflow controller, so it is possible for some pod pending states to be missed.
     unit: "{pod}"
-    type: Int64ObservableGauge
+    type: Int64Counter
   - name: QueueAddsCount
     description: A counter of additions to the work queues inside the controller
     extendedDescription: The rate of this shows how busy that area of the controller is

--- a/util/telemetry/metrics_list.go
+++ b/util/telemetry/metrics_list.go
@@ -194,7 +194,7 @@ var InstrumentPodsTotalCount = BuiltinInstrument{
 	name:        "pods_total_count",
 	description: "Total number of pods that have entered each phase",
 	unit:        "{pod}",
-	instType:    Int64ObservableGauge,
+	instType:    Int64Counter,
 	attributes: []BuiltinAttribute{
 		{
 			name: AttribPodPhase,


### PR DESCRIPTION
Fixes `pod_total_count` metric

### Motivation

In  #13943 this metric was incorrectly made an ObservableGauge and is broken by this change
### Modifications

Just update the type to be correct so it works again

### Verification

Observed it counting pods again.

It would be good if this was tested, but it never has been.

### Documentation

None required.