### PR TITLE
fix: locking in metrics

### DIFF
--- a/test/e2e/testdata/cronworkflow-deprecated-schedule.yaml
+++ b/test/e2e/testdata/cronworkflow-deprecated-schedule.yaml
@@ -3,8 +3,7 @@ kind: CronWorkflow
 metadata:
   name: test-cron-deprecated-schedule
 spec:
-  schedules:
-    - "* * * * *"
+  schedule: "* * * * *"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
   workflowMetadata:

--- a/util/telemetry/instrument.go
+++ b/util/telemetry/instrument.go
@@ -17,7 +17,7 @@ type Instrument struct {
 }
 
 func (m *Metrics) preCreateCheck(name string) error {
-	if _, exists := m.AllInstruments[name]; exists {
+	if inst := m.GetInstrument(name); inst != nil {
 		return fmt.Errorf("Instrument called %s already exists", name)
 	}
 	return nil
@@ -69,8 +69,6 @@ func collectOptions(options ...instrumentOption) instrumentOptions {
 
 func (m *Metrics) CreateInstrument(instType instrumentType, name, desc, unit string, options ...instrumentOption) error {
 	opts := collectOptions(options...)
-	m.Mutex.Lock()
-	defer m.Mutex.Unlock()
 	err := m.preCreateCheck(name)
 	if err != nil {
 		return err
@@ -137,11 +135,11 @@ func (m *Metrics) CreateInstrument(instType instrumentType, name, desc, unit str
 	if err != nil {
 		return err
 	}
-	m.AllInstruments[name] = &Instrument{
+	m.AddInstrument(name, &Instrument{
 		name:        name,
 		description: desc,
 		otel:        instPtr,
-	}
+	})
 	return nil
 }
 

--- a/util/telemetry/operators.go
+++ b/util/telemetry/operators.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (m *Metrics) AddInt(ctx context.Context, name string, val int64, attribs InstAttribs) {
-	if instrument, ok := m.AllInstruments[name]; ok {
+	if instrument := m.GetInstrument(name); instrument != nil {
 		instrument.AddInt(ctx, val, attribs)
 	} else {
 		log.Errorf("Metrics addInt() to non-existent metric %s", name)
@@ -29,7 +29,7 @@ func (i *Instrument) AddInt(ctx context.Context, val int64, attribs InstAttribs)
 }
 
 func (m *Metrics) Record(ctx context.Context, name string, val float64, attribs InstAttribs) {
-	if instrument, ok := m.AllInstruments[name]; ok {
+	if instrument := m.GetInstrument(name); instrument != nil {
 		instrument.Record(ctx, val, attribs)
 	} else {
 		log.Errorf("Metrics record() to non-existent metric %s", name)

--- a/workflow/metrics/counter_log.go
+++ b/workflow/metrics/counter_log.go
@@ -16,7 +16,7 @@ func addLogCounter(ctx context.Context, m *Metrics) error {
 	err := m.CreateBuiltinInstrument(telemetry.InstrumentLogMessages)
 	name := telemetry.InstrumentLogMessages.Name()
 	lm := logMetric{
-		counter: m.AllInstruments[name],
+		counter: m.GetInstrument(name),
 	}
 	log.AddHook(lm)
 	for _, level := range lm.Levels() {

--- a/workflow/metrics/gauge_pod_phase.go
+++ b/workflow/metrics/gauge_pod_phase.go
@@ -26,9 +26,9 @@ func addPodPhaseGauge(ctx context.Context, m *Metrics) error {
 	if m.callbacks.PodPhase != nil {
 		ppGauge := podPhaseGauge{
 			callback: m.callbacks.PodPhase,
-			gauge:    m.AllInstruments[name],
+			gauge:    m.GetInstrument(name),
 		}
-		return m.AllInstruments[name].RegisterCallback(m.Metrics, ppGauge.update)
+		return ppGauge.gauge.RegisterCallback(m.Metrics, ppGauge.update)
 	}
 	return nil
 }

--- a/workflow/metrics/gauge_workflow_condition.go
+++ b/workflow/metrics/gauge_workflow_condition.go
@@ -26,9 +26,9 @@ func addWorkflowConditionGauge(_ context.Context, m *Metrics) error {
 	if m.callbacks.WorkflowCondition != nil {
 		wfcGauge := workflowConditionGauge{
 			callback: m.callbacks.WorkflowCondition,
-			gauge:    m.AllInstruments[telemetry.InstrumentWorkflowCondition.Name()],
+			gauge:    m.GetInstrument(telemetry.InstrumentWorkflowCondition.Name()),
 		}
-		return m.AllInstruments[telemetry.InstrumentWorkflowCondition.Name()].RegisterCallback(m.Metrics, wfcGauge.update)
+		return wfcGauge.gauge.RegisterCallback(m.Metrics, wfcGauge.update)
 	}
 	return nil
 	// TODO init all phases?

--- a/workflow/metrics/gauge_workflow_phase.go
+++ b/workflow/metrics/gauge_workflow_phase.go
@@ -26,9 +26,9 @@ func addWorkflowPhaseGauge(_ context.Context, m *Metrics) error {
 	if m.callbacks.WorkflowPhase != nil {
 		wfpGauge := workflowPhaseGauge{
 			callback: m.callbacks.WorkflowPhase,
-			gauge:    m.AllInstruments[name],
+			gauge:    m.GetInstrument(name),
 		}
-		return m.AllInstruments[name].RegisterCallback(m.Metrics, wfpGauge.update)
+		return wfpGauge.gauge.RegisterCallback(m.Metrics, wfpGauge.update)
 	}
 	return nil
 	// TODO init all phases?

--- a/workflow/metrics/leader.go
+++ b/workflow/metrics/leader.go
@@ -26,9 +26,9 @@ func addIsLeader(ctx context.Context, m *Metrics) error {
 	name := telemetry.InstrumentIsLeader.Name()
 	lGauge := leaderGauge{
 		callback: m.callbacks.IsLeader,
-		gauge:    m.AllInstruments[name],
+		gauge:    m.GetInstrument(name),
 	}
-	return m.AllInstruments[name].RegisterCallback(m.Metrics, lGauge.update)
+	return lGauge.gauge.RegisterCallback(m.Metrics, lGauge.update)
 }
 
 func (l *leaderGauge) update(_ context.Context, o metric.Observer) error {

--- a/workflow/metrics/metrics.go
+++ b/workflow/metrics/metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"sync"
 
 	"github.com/argoproj/argo-workflows/v3/util/telemetry"
 
@@ -12,6 +13,7 @@ type Metrics struct {
 	*telemetry.Metrics
 
 	callbacks         Callbacks
+	realtimeMutex     sync.Mutex
 	realtimeWorkflows map[string][]realtimeTracker
 }
 

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -74,22 +74,22 @@ func TestMetricGC(t *testing.T) {
 	baseCm := m.GetCustomMetric(key)
 	assert.NotNil(t, baseCm)
 
-	cm := customUserdata(baseCm, true)
-	assert.Len(t, cm, 1)
+	cm := customUserData(baseCm, true)
+	assert.NotNil(t, cm)
+	assert.Len(t, cm.values, 1)
 
 	// Ensure we get at least one TTL run
 	timeoutTime := time.Now().Add(time.Second * 2)
 	for time.Now().Before(timeoutTime) {
 		// Break if we know our test will pass.
-		if len(cm) == 0 {
+		if len(cm.values) == 0 {
 			break
 		}
 		// Sleep to prevent overloading test worker CPU.
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	assert.Empty(t, cm)
-
+	assert.Empty(t, cm.values)
 }
 
 func TestRealtimeMetricGC(t *testing.T) {
@@ -151,12 +151,12 @@ func TestWorkflowQueueMetrics(t *testing.T) {
 	wfQueue := m.RateLimiterWithBusyWorkers(m.Ctx, workqueue.DefaultTypedControllerRateLimiter[string](), "workflow_queue")
 	defer wfQueue.ShutDown()
 
-	assert.NotNil(t, m.AllInstruments[telemetry.InstrumentQueueDepthGauge.Name()])
-	assert.NotNil(t, m.AllInstruments[telemetry.InstrumentQueueLatency.Name()])
+	assert.NotNil(t, m.GetInstrument(telemetry.InstrumentQueueDepthGauge.Name()))
+	assert.NotNil(t, m.GetInstrument(telemetry.InstrumentQueueLatency.Name()))
 
 	wfQueue.Add("hello")
 
-	require.NotNil(t, m.AllInstruments[telemetry.InstrumentQueueAddsCount.Name()])
+	require.NotNil(t, m.GetInstrument(telemetry.InstrumentQueueAddsCount.Name()))
 	val, err := te.GetInt64CounterValue(telemetry.InstrumentQueueAddsCount.Name(), &attribs)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), val)
@@ -201,13 +201,14 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	m.StopRealtimeMetricsForWfUID("456")
 	assert.Empty(t, m.realtimeWorkflows["456"])
 
-	cm := customUserdata(baseCm, true)
-	assert.Len(t, cm, 1)
+	cm := customUserData(baseCm, true)
+	assert.NotNil(t, cm)
+	assert.Len(t, cm.values, 1)
 	assert.Len(t, m.realtimeWorkflows["123"], 1)
 
 	m.StopRealtimeMetricsForWfUID("123")
 	assert.Empty(t, m.realtimeWorkflows["123"])
-	assert.Empty(t, cm)
+	assert.Empty(t, cm.values)
 
 	err = m.UpsertCustomMetric(ctx, &wfv1.Prometheus{
 		Name:   key,
@@ -221,6 +222,6 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	}, "456", nil)
 	require.NoError(t, err)
 
-	assert.Len(t, cm, 1)
+	assert.Len(t, cm.values, 1)
 	assert.Len(t, m.realtimeWorkflows["456"], 1)
 }

--- a/workflow/metrics/work_queue.go
+++ b/workflow/metrics/work_queue.go
@@ -52,9 +52,10 @@ func addWorkQueueMetrics(_ context.Context, m *Metrics) error {
 		return err
 	}
 	unfinishedCallback := queueUserdata{
-		gauge: m.AllInstruments[telemetry.InstrumentQueueUnfinishedWork.Name()]}
-	m.AllInstruments[telemetry.InstrumentQueueUnfinishedWork.Name()].SetUserdata(&unfinishedCallback)
-	err = m.AllInstruments[telemetry.InstrumentQueueUnfinishedWork.Name()].RegisterCallback(m.Metrics, unfinishedCallback.update)
+		gauge: m.GetInstrument(telemetry.InstrumentQueueUnfinishedWork.Name()),
+	}
+	unfinishedCallback.gauge.SetUserdata(&unfinishedCallback)
+	err = unfinishedCallback.gauge.RegisterCallback(m.Metrics, unfinishedCallback.update)
 	if err != nil {
 		return err
 	}
@@ -64,10 +65,10 @@ func addWorkQueueMetrics(_ context.Context, m *Metrics) error {
 		return err
 	}
 	longestRunningCallback := queueUserdata{
-		gauge: m.AllInstruments[telemetry.InstrumentQueueLongestRunning.Name()],
+		gauge: m.GetInstrument(telemetry.InstrumentQueueLongestRunning.Name()),
 	}
-	m.AllInstruments[telemetry.InstrumentQueueLongestRunning.Name()].SetUserdata(&longestRunningCallback)
-	err = m.AllInstruments[telemetry.InstrumentQueueLongestRunning.Name()].RegisterCallback(m.Metrics, longestRunningCallback.update)
+	longestRunningCallback.gauge.SetUserdata(&longestRunningCallback)
+	err = longestRunningCallback.gauge.RegisterCallback(m.Metrics, longestRunningCallback.update)
 	if err != nil {
 		return err
 	}
@@ -78,7 +79,7 @@ func (m *Metrics) RateLimiterWithBusyWorkers(ctx context.Context, workQueue work
 	queue := workersBusyRateLimiterWorkQueue{
 		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(workQueue, workqueue.TypedRateLimitingQueueConfig[string]{Name: queueName}),
 		workerType:                 queueName,
-		busyGauge:                  m.AllInstruments[telemetry.InstrumentWorkersBusyCount.Name()],
+		busyGauge:                  m.GetInstrument(telemetry.InstrumentWorkersBusyCount.Name()),
 		ctx:                        ctx,
 	}
 	queue.newWorker(ctx)
@@ -167,7 +168,7 @@ func (m *Metrics) NewDepthMetric(name string) workqueue.GaugeMetric {
 	return queueMetric{
 		ctx:  m.Ctx,
 		name: name,
-		inst: m.AllInstruments[telemetry.InstrumentQueueDepthGauge.Name()],
+		inst: m.GetInstrument(telemetry.InstrumentQueueDepthGauge.Name()),
 	}
 }
 
@@ -175,7 +176,7 @@ func (m *Metrics) NewAddsMetric(name string) workqueue.CounterMetric {
 	return queueMetric{
 		ctx:  m.Ctx,
 		name: name,
-		inst: m.AllInstruments[telemetry.InstrumentQueueAddsCount.Name()],
+		inst: m.GetInstrument(telemetry.InstrumentQueueAddsCount.Name()),
 	}
 }
 
@@ -183,7 +184,7 @@ func (m *Metrics) NewLatencyMetric(name string) workqueue.HistogramMetric {
 	return queueMetric{
 		ctx:  m.Ctx,
 		name: name,
-		inst: m.AllInstruments[telemetry.InstrumentQueueLatency.Name()],
+		inst: m.GetInstrument(telemetry.InstrumentQueueLatency.Name()),
 	}
 }
 
@@ -191,7 +192,7 @@ func (m *Metrics) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
 	return queueMetric{
 		ctx:  m.Ctx,
 		name: name,
-		inst: m.AllInstruments[telemetry.InstrumentQueueDuration.Name()],
+		inst: m.GetInstrument(telemetry.InstrumentQueueDuration.Name()),
 	}
 }
 
@@ -199,7 +200,7 @@ func (m *Metrics) NewRetriesMetric(name string) workqueue.CounterMetric {
 	return queueMetric{
 		ctx:  m.Ctx,
 		name: name,
-		inst: m.AllInstruments[telemetry.InstrumentQueueRetries.Name()],
+		inst: m.GetInstrument(telemetry.InstrumentQueueRetries.Name()),
 	}
 }
 
@@ -207,7 +208,7 @@ func (m *Metrics) NewUnfinishedWorkSecondsMetric(name string) workqueue.Settable
 	metric := queueMetric{
 		ctx:   m.Ctx,
 		name:  name,
-		inst:  m.AllInstruments[telemetry.InstrumentQueueUnfinishedWork.Name()],
+		inst:  m.GetInstrument(telemetry.InstrumentQueueUnfinishedWork.Name()),
 		value: ptr.To(float64(0.0)),
 	}
 	ud := getQueueUserdata(metric.inst)
@@ -219,7 +220,7 @@ func (m *Metrics) NewLongestRunningProcessorSecondsMetric(name string) workqueue
 	metric := queueMetric{
 		ctx:   m.Ctx,
 		name:  name,
-		inst:  m.AllInstruments[telemetry.InstrumentQueueLongestRunning.Name()],
+		inst:  m.GetInstrument(telemetry.InstrumentQueueLongestRunning.Name()),
 		value: ptr.To(float64(0.0)),
 	}
 	ud := getQueueUserdata(metric.inst)


### PR DESCRIPTION
Fixes #14076

Also fixes my own bad test case (deprecated schedule test)

### Motivation

The golang map in the userdata for custom metrics was accessed under some circumstances from multiple go routines without an appropriate mutex - as can be seen from the stack trace and panic in #14076

### Modifications

Make the three maps which can be accessed have their own semaphore, instead of attempting to use the single top level one.

Make accessor functions for accessing `instruments` from util/telemetry/metrics so that locks there can be easily reasoned about. (Renamed from `AllInstruments`).

Make a separate lock for `realtimeWorkflows` from util/metrics/metrics and manually implement that.

Make a lock for custom_metric UserData, because that is needed in limited scenarios. Don't lock when this is accessed from test framework for cleanness in the framework. I don't believe the lock would be useful as the tests are not free running.

Fixed the deprecations metric test which only passed due to a different CronWorkflow using `schedule` not `schedules`.

### Verification

Ensure existing tests pass - all changes are just for code compatibility, not changes to the tests.