### PR TITLE
feat: automated backport robot and /test command

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: true

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - "main"
+      - "release-*"
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,6 +22,15 @@ permissions:
 jobs:
   changed-files:
     name: Get changed files
+    if: >
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        github.event.comment.author_association == 'MEMBER' &&
+        github.event.comment.body == '/test'
+      ) || (
+        github.event_name != 'issue_comment'
+      )
     outputs:
       # reference: https://github.com/tj-actions/changed-files#outputs-
       tests: ${{ steps.changed-files.outputs.tests_any_modified == 'true' }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+      - release/*
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +21,15 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-24.04
+    if: >
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        github.event.comment.author_association == 'MEMBER' &&
+        github.event.comment.body == '/test'
+      ) || (
+        github.event_name != 'issue_comment'
+      )
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,6 +134,16 @@ Subsequently, if there is still no response, it will be automatically closed as 
 
 See the [Stale Action configuration](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/stale.yaml) for more details.
 
+## Automated actions
+
+As a member (see [roles](https://github.com/argoproj/argoproj/blob/main/community/membership.md)) of the argo-project you can use the following comments on PRs to trigger actions:
+
+* `/retest` - re-run any failing test cases
+* `/test` - trigger the full test suite.
+Only use this for PRs where the test suite has not automatically triggered - this is almost always wasteful and will not make things pass that `/retest` doesn't pass.
+* `/cherry-pick <branchname>` - will [attempt to cherry-pick](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot) this commit after it has been merged to the target branch.
+This can be used prior to merging and the PR will be created after the merge, or commented after merging for an immediate attempt.
+
 ## Sustainability Effort
 
 Argo Workflows is seeking more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -56,15 +56,7 @@ this was successful.
 ## Update Changelog
 
 Once the tag is published, GitHub Actions will automatically open a PR to update the changelog. Once the PR is ready,
-you can approve it, enable auto-merge, and then run the following to force trigger the CI build:
-
-```bash
-git branch -D create-pull-request/changelog
-git fetch upstream
-git checkout --track upstream/create-pull-request/changelog
-git commit -s --allow-empty -m "chore: Force trigger CI"
-git push upstream create-pull-request/changelog
-```
+you can approve it, enable auto-merge, and comment `/test` to run CI on it.
 
 ## Announce on Slack
 


### PR DESCRIPTION
Part of #12592

### Motivation

Maintaining released versions of argo-workflows is not automated. This will help by allowing the backporting of commits as they are merged rather than by the release manager at the time of release.

Each PR can be CI tested independently then, and only those that pass get merged.

### Modifications

Enabled CI on release branch PRs. 

Added a new backport action, triggered on `closed` PRs and comment creation. This uses [`korthout/backport-action`](https://github.com/korthout/backport-action) to do the backport. After considering various canned actions this was chosen as it does a decent job, and many others are unmaintained. [`nixpkgs`](https://github.com/NixOS/nixpkgs/blob/a83d658bc5baa767086daec1c013b643281246b2/.github/workflows/backport.yml#L34) uses this action, and as one of the most prolific repos it seemed prudent to follow.
* Configured to use labels of the form `backport/<branchname>` to match our other labels.

We would need to add labels `backport/release-3.5` and `backport/release-3.6` to allow this to be used.

### Verification

I have setup my fork to run this and done some merges there and then asked the action to backport them.

### Documentation

Added documentation for how to use the labels, `/backport` and `/test`, and for the other comment based command which already existed `/retest`