### PR TITLE
fix(controller): task progress with mutexes not updated. Fixes #14148

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -256,7 +256,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 			woc.markWorkflowFailed(ctx, fmt.Sprintf("Failed to acquire the synchronization lock. %s", err.Error()))
 			return
 		}
-		woc.updated = wfUpdate
+		woc.updated = woc.updated || wfUpdate
 		if !acquired {
 			if !woc.releaseLocksForPendingShuttingdownWfs(ctx) {
 				woc.log.Warn("Workflow processing has been postponed due to concurrency limit")


### PR DESCRIPTION
Fixes #14148

### Motivation

wait container updated progress, and the controller has detected the change in task result, but it was overridden by syncManager's `wfUpdate`.

