### PR TITLE
build: fix `mkdir /home/vscode/go/pkg: permission denied`

### DIFF
--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -12,9 +12,6 @@ chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 kubectl cluster-info
 
-# install kit
-make kit
-
 # install protocol buffer compiler (protoc)
 sudo apt update
 sudo apt install -y protobuf-compiler
@@ -23,6 +20,9 @@ sudo apt install -y protobuf-compiler
 sudo chown vscode:vscode /home/vscode/go || true
 sudo chown vscode:vscode /home/vscode/go/src || true
 sudo chown vscode:vscode /home/vscode/go/src/github.com || true
+
+# install kit
+make kit
 
 # download dependencies and do first-pass compile
 kit build


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

When rebuilding the dev container, I'm getting the following:
```
Running the postCreateCommand from devcontainer.json...

[12542 ms] Start: Run in container: /bin/sh -c .devcontainer/pre-build.sh
<SNIP>
+ make kit
GIT_COMMIT=a776b4583972625541a358b3c9a2e1fdc0925763 GIT_BRANCH=main GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=false VERSION=latest
KUBECTX=k3d-k3s-default K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=true ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
go install github.com/kitproj/kit@v0.1.79
go: go: could not create module cache: mkdir /home/vscode/go/pkg: permission denied
make: *** [Makefile:535: kit] Error 1
[21801 ms] postCreateCommand from devcontainer.json failed with exit code 2. Skipping any further user-provided commands.
```

This causes the rest of `pre-build.sh` to be skipped, which means the container will be missing `kit`
### Modifications

I think this was introduced with https://github.com/argoproj/argo-workflows/pull/14105, and the fix is to move `make kit` to be after the `chown` lines.
### Verification

Rebuilt dev container locally
### Documentation

N/A

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
