### PR TITLE
fix: remove `/test` command comment

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,8 +9,6 @@ on:
     branches:
       - "main"
       - "release-*"
-  issue_comment:
-    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,15 +20,6 @@ permissions:
 jobs:
   changed-files:
     name: Get changed files
-    if: >
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request != null &&
-        github.event.comment.author_association == 'MEMBER' &&
-        github.event.comment.body == '/test'
-      ) || (
-        github.event_name != 'issue_comment'
-      )
     outputs:
       # reference: https://github.com/tj-actions/changed-files#outputs-
       tests: ${{ steps.changed-files.outputs.tests_any_modified == 'true' }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
       - release/*
-  issue_comment:
-    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,15 +19,6 @@ permissions:
 jobs:
   docs:
     runs-on: ubuntu-24.04
-    if: >
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request != null &&
-        github.event.comment.author_association == 'MEMBER' &&
-        github.event.comment.body == '/test'
-      ) || (
-        github.event_name != 'issue_comment'
-      )
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -139,8 +139,6 @@ See the [Stale Action configuration](https://github.com/argoproj/argo-workflows/
 As a member (see [roles](https://github.com/argoproj/argoproj/blob/main/community/membership.md)) of the argo-project you can use the following comments on PRs to trigger actions:
 
 * `/retest` - re-run any failing test cases
-* `/test` - trigger the full test suite.
-Only use this for PRs where the test suite has not automatically triggered - this is almost always wasteful and will not make things pass that `/retest` doesn't pass.
 * `/cherry-pick <branchname>` - will [attempt to cherry-pick](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot) this commit after it has been merged to the target branch.
 This can be used prior to merging and the PR will be created after the merge, or commented after merging for an immediate attempt.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -56,7 +56,15 @@ this was successful.
 ## Update Changelog
 
 Once the tag is published, GitHub Actions will automatically open a PR to update the changelog. Once the PR is ready,
-you can approve it, enable auto-merge, and comment `/test` to run CI on it.
+you can approve it, enable auto-merge, and then run the following to force trigger the CI build:
+
+```bash
+git branch -D create-pull-request/changelog
+git fetch upstream
+git checkout --track upstream/create-pull-request/changelog
+git commit -s --allow-empty -m "chore: Force trigger CI"
+git push upstream create-pull-request/changelog
+```
 
 ## Announce on Slack
 


### PR DESCRIPTION
Partial revert of #14151

Fixes [/test command not showing in github checks](https://github.com/argoproj/argo-workflows/pull/14151#issuecomment-2643256922) and [extra CI jobs running](https://github.com/argoproj/argo-workflows/pull/14151#issuecomment-2644729397)

### Motivation

The `/test` command isn't as important as the rest of #14151, so just remove it for now as it doesn't work as well as hoped and has issues

### Modifications

Remove `issue_comment` from the actions and associated `if`

### Verification

Untested as github action code, and changes are a revert.

### Documentation

Reverted documentation for releasing process to use the old manual push, and removed docs on `/test`
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
