### PR TITLE
chore: upgrade actions/cache to v4.2.0 (Fixes #14169) (#14170)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           version: v0.10.4
 
       - name: Cache Docker layers
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: cache
         with:
           path: /tmp/.buildx-cache
@@ -293,7 +293,7 @@ jobs:
         with:
           go-version: "1.23"
       - name: Restore node packages cache
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ui/node_modules
           key: ${{ runner.os }}-node-dep-v1-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Manually cherry-picked.

Cherry-picked chore: upgrade actions/cache to v4.2.0 (Fixes https://github.com/argoproj/argo-workflows/issues/14169) (https://github.com/argoproj/argo-workflows/pull/14170)