### PR TITLE
fix(ci): python sdk release process (release-3.6)

### DIFF
--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -11,7 +11,7 @@ DOCKER = docker run --rm --user $(shell id -u):$(shell id -g) -v $(WD):/wd --wor
 CHOWN = chown -R $(shell id -u):$(shell id -g)
 
 publish: generate
-	pip install setuptools twine build
+	pip install -U packaging setuptools twine build
 	python -m build --sdist --wheel --outdir client/dist/ client
 	twine check client/dist/*
 	twine upload client/dist/* -u __token__ -p ${PYPI_API_TOKEN}
@@ -44,7 +44,7 @@ else
 		--model-name-suffix '' \
 		--artifact-id argo-python-client \
 		--global-property modelTests=false \
- 		--global-property packageName=argo_workflows \
+		--global-property packageName=argo_workflows \
 		--generate-alias-as-model
 	# https://vsupalov.com/docker-shared-permissions/#set-the-docker-user-when-running-your-container
 	$(CHOWN) $(WD) || sudo $(CHOWN) $(WD)


### PR DESCRIPTION
Fixes #14159

### Motivation

SDK releases are failing since 3.6.3 and 3.5.14

### Modifications

See https://github.com/pypa/twine/issues/1216 - the suggestions there are either to upgrade packaging or fiddle with setuptools.

Python SDK is deprecated so this code should end up being removed soon.

### Verification

I cannot reproduce the problem locally in devcontainer, so this is a speculative fix.

### Documentation

None needed.