### PR TITLE
fix: correct semaphore configmap keys for multiple semaphores

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -501,7 +501,7 @@ func (wf *Workflow) GetSemaphoreKeys() []string {
 	if wf.Spec.WorkflowTemplateRef == nil {
 		templates = wf.Spec.Templates
 		if wf.Spec.Synchronization != nil {
-			if configMapRef := wf.Spec.Synchronization.getSemaphoreConfigMapRef(); configMapRef != nil {
+			for _, configMapRef := range wf.Spec.Synchronization.getSemaphoreConfigMapRefs() {
 				key := fmt.Sprintf("%s/%s", namespace, configMapRef.Name)
 				keyMap[key] = true
 			}
@@ -509,7 +509,7 @@ func (wf *Workflow) GetSemaphoreKeys() []string {
 	} else if wf.Status.StoredWorkflowSpec != nil {
 		templates = wf.Status.StoredWorkflowSpec.Templates
 		if wf.Status.StoredWorkflowSpec.Synchronization != nil {
-			if configMapRef := wf.Status.StoredWorkflowSpec.Synchronization.getSemaphoreConfigMapRef(); configMapRef != nil {
+			for _, configMapRef := range wf.Status.StoredWorkflowSpec.Synchronization.getSemaphoreConfigMapRefs() {
 				key := fmt.Sprintf("%s/%s", namespace, configMapRef.Name)
 				keyMap[key] = true
 			}
@@ -518,7 +518,7 @@ func (wf *Workflow) GetSemaphoreKeys() []string {
 
 	for _, tmpl := range templates {
 		if tmpl.Synchronization != nil {
-			if configMapRef := tmpl.Synchronization.getSemaphoreConfigMapRef(); configMapRef != nil {
+			for _, configMapRef := range tmpl.Synchronization.getSemaphoreConfigMapRefs() {
 				key := fmt.Sprintf("%s/%s", namespace, configMapRef.Name)
 				keyMap[key] = true
 			}
@@ -1698,11 +1698,18 @@ type Synchronization struct {
 	Mutexes []*Mutex `json:"mutexes,omitempty" protobuf:"bytes,4,opt,name=mutexes"`
 }
 
-func (s *Synchronization) getSemaphoreConfigMapRef() *apiv1.ConfigMapKeySelector {
+func (s *Synchronization) getSemaphoreConfigMapRefs() []*apiv1.ConfigMapKeySelector {
+	selectors := make([]*apiv1.ConfigMapKeySelector, 0)
 	if s.Semaphore != nil && s.Semaphore.ConfigMapKeyRef != nil {
-		return s.Semaphore.ConfigMapKeyRef
+		selectors = append(selectors, s.Semaphore.ConfigMapKeyRef)
 	}
-	return nil
+
+	for _, semaphore := range s.Semaphores {
+		if semaphore.ConfigMapKeyRef != nil {
+			selectors = append(selectors, semaphore.ConfigMapKeyRef)
+		}
+	}
+	return selectors
 }
 
 // SemaphoreRef is a reference of Semaphore

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -1118,11 +1118,22 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 		{
 			Name: "t1",
 			Synchronization: &Synchronization{
-				Semaphore: &SemaphoreRef{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "template",
+				Semaphores: []*SemaphoreRef{
+					&SemaphoreRef{
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "template",
+							},
+						},
 					},
-				}},
+					&SemaphoreRef{
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "template-b",
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -1147,9 +1158,10 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 		},
 	}
 	keys = wf.GetSemaphoreKeys()
-	assert.Len(keys, 3)
+	assert.Len(keys, 4)
 	assert.Contains(keys, "test/test")
 	assert.Contains(keys, "test/template")
+	assert.Contains(keys, "test/template-b")
 	assert.Contains(keys, "test/template1")
 
 	spec := wf.Spec.DeepCopy()
@@ -1160,9 +1172,10 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 	}
 	wf.Status.StoredWorkflowSpec = spec
 	keys = wf.GetSemaphoreKeys()
-	assert.Len(keys, 3)
+	assert.Len(keys, 4)
 	assert.Contains(keys, "test/test")
 	assert.Contains(keys, "test/template")
+	assert.Contains(keys, "test/template-b")
 	assert.Contains(keys, "test/template1")
 }
 


### PR DESCRIPTION
No known bug reports around this so far

### Motivation

Whilst looking at deprecating single semaphores completely I discovered `getSemaphoreConfigMapRef()` was not multiple semaphore aware.

### Modifications

Rename `getSemaphoreConfigMapRef` to `getSemaphoreConfigMapRefs` and return a list of pointers instead of a pointer.

Make the caller of this iterate the list.

### Verification

Updated the test case that tests `GetSemaphoreKeys` which is the only user of `getSemaphoreConfigMapRefs` to test this and added an extra entry to be sure it can successfully manage a list.
 
### Documentation

Not relevant, internal code