### PR TITLE
fix: gracefully handle invalid CronWorkflows and simplify logic. Fixes #14047

### DIFF
--- a/ui/src/cron-workflows/cron-workflow-editor.tsx
+++ b/ui/src/cron-workflows/cron-workflow-editor.tsx
@@ -8,7 +8,7 @@ import {WorkflowParametersEditor} from '../shared/components/editors/workflow-pa
 import {ObjectEditor} from '../shared/components/object-editor';
 import type {Lang} from '../shared/components/object-parser';
 import {CronWorkflow} from '../shared/models';
-import {CronWorkflowSpecEditor} from './cron-workflow-spec-editior';
+import {CronWorkflowSpecEditor} from './cron-workflow-spec-editor';
 import {CronWorkflowStatusViewer} from './cron-workflow-status-viewer';
 
 export function CronWorkflowEditor({

--- a/ui/src/cron-workflows/cron-workflow-row.tsx
+++ b/ui/src/cron-workflows/cron-workflow-row.tsx
@@ -38,28 +38,20 @@ export function CronWorkflowRow(props: CronWorkflowRowProps) {
                 <div className='columns small-2'>{wf.metadata.namespace}</div>
                 <div className='columns small-1'>{wf.spec.timezone}</div>
                 <div className='columns small-1'>
-                    {wf.spec.schedule != ''
-                        ? wf.spec.schedule
-                        : wf.spec.schedules.map(schedule => (
-                              <>
-                                  {schedule}
-                                  <br />
-                              </>
-                          ))}
+                    {wf.spec.schedules.map(schedule => (
+                        <>
+                            {schedule}
+                            <br />
+                        </>
+                    ))}
                 </div>
                 <div className='columns small-1'>
-                    {wf.spec.schedule != '' ? (
-                        <PrettySchedule schedule={wf.spec.schedule} />
-                    ) : (
+                    {wf.spec.schedules.map(schedule => (
                         <>
-                            {wf.spec.schedules.map(schedule => (
-                                <>
-                                    <PrettySchedule schedule={schedule} />
-                                    <br />
-                                </>
-                            ))}
+                            <PrettySchedule schedule={schedule} />
+                            <br />
                         </>
-                    )}
+                    ))}
                 </div>
                 <div className='columns small-2'>
                     <Timestamp date={wf.metadata.creationTimestamp} displayISOFormat={props.displayISOFormatCreation} />
@@ -77,10 +69,6 @@ export function CronWorkflowRow(props: CronWorkflowRowProps) {
 }
 
 function getCronNextScheduledTime(spec: CronWorkflowSpec): Date {
-    if (spec.schedule != '') {
-        return getNextScheduledTime(spec.schedule, spec.timezone);
-    }
-
     let out: Date;
     spec.schedules.forEach(schedule => {
         const next = getNextScheduledTime(schedule, spec.timezone);

--- a/ui/src/cron-workflows/cron-workflow-spec-editor.tsx
+++ b/ui/src/cron-workflows/cron-workflow-spec-editor.tsx
@@ -14,22 +14,12 @@ export function CronWorkflowSpecEditor({onChange, spec}: {spec: CronWorkflowSpec
                 <div className='row white-box__details-row'>
                     <div className='columns small-3'>Schedules</div>
                     <div className='columns small-9'>
-                        {(spec.schedule ?? '') != '' ? (
+                        {spec.schedules.map((schedule, index) => (
                             <>
-                                <TextInput value={spec.schedule} onChange={schedule => onChange({...spec, schedule})} />
-                                <ScheduleValidator schedule={spec.schedule} />
+                                <TextInput value={schedule} onChange={newSchedule => onChange({...spec, schedules: updateScheduleAtIndex(spec.schedules, index, newSchedule)})} />
+                                <ScheduleValidator schedule={schedule} />
                             </>
-                        ) : (
-                            spec.schedules.map((schedule, index) => (
-                                <>
-                                    <TextInput
-                                        value={schedule}
-                                        onChange={newSchedule => onChange({...spec, schedules: updateScheduleAtIndex(spec.schedules, index, newSchedule)})}
-                                    />
-                                    <ScheduleValidator schedule={schedule} />
-                                </>
-                            ))
-                        )}
+                        ))}
                     </div>
                 </div>
                 <div className='row white-box__details-row'>

--- a/ui/src/cron-workflows/cron-workflow-status-viewer.tsx
+++ b/ui/src/cron-workflows/cron-workflow-status-viewer.tsx
@@ -19,22 +19,12 @@ export function CronWorkflowStatusViewer({spec, status}: {spec: CronWorkflowSpec
                     {title: 'Active', value: status.active ? getCronWorkflowActiveWorkflowList(status.active) : <i>No Workflows Active</i>},
                     {
                         title: 'Schedules',
-                        value: (
+                        value: spec.schedules.map(schedule => (
                             <>
-                                {(spec.schedule ?? '') != '' ? (
-                                    <>
-                                        <code>{spec.schedule}</code> <PrettySchedule schedule={spec.schedule} />
-                                    </>
-                                ) : (
-                                    spec.schedules.map(schedule => (
-                                        <>
-                                            <code>{schedule}</code> <PrettySchedule schedule={schedule} />
-                                            <br />
-                                        </>
-                                    ))
-                                )}
+                                <code>{schedule}</code> <PrettySchedule schedule={schedule} />
+                                <br />
                             </>
-                        )
+                        ))
                     },
                     {title: 'Last Scheduled Time', value: <Timestamp date={status.lastScheduledTime} timestampKey={TIMESTAMP_KEYS.CRON_WORKFLOW_STATUS_LAST_SCHEDULED} />},
                     {title: 'Conditions', value: <ConditionsPanel conditions={status.conditions} />}

--- a/ui/src/shared/examples.ts
+++ b/ui/src/shared/examples.ts
@@ -84,7 +84,7 @@ export const exampleCronWorkflow = (namespace: string): CronWorkflow => ({
     },
     spec: {
         workflowMetadata: {labels},
-        schedule: '* * * * *',
+        schedules: ['* * * * *'],
         workflowSpec: {
             entrypoint,
             arguments: argumentz,

--- a/ui/src/shared/models/cron-workflows.ts
+++ b/ui/src/shared/models/cron-workflows.ts
@@ -15,7 +15,6 @@ export type ConcurrencyPolicy = 'Allow' | 'Forbid' | 'Replace';
 export interface CronWorkflowSpec {
     workflowSpec: WorkflowSpec;
     workflowMetadata?: kubernetes.ObjectMeta;
-    schedule: string;
     schedules?: string[];
     concurrencyPolicy?: ConcurrencyPolicy;
     suspend?: boolean;

--- a/ui/src/shared/services/cron-workflow-service.test.ts
+++ b/ui/src/shared/services/cron-workflow-service.test.ts
@@ -1,0 +1,113 @@
+import {exampleCronWorkflow} from '../examples';
+import {CronWorkflowService} from './cron-workflow-service';
+import requests from './requests';
+
+jest.mock('./requests');
+
+describe('cron workflow service', () => {
+    describe('create', () => {
+        test('with valid CronWorkflow', async () => {
+            const cronWf = exampleCronWorkflow('ns');
+            const request = {send: jest.fn().mockResolvedValue({body: cronWf})};
+            jest.spyOn(requests, 'post').mockReturnValue(request as any);
+
+            const result = await CronWorkflowService.create(cronWf, cronWf.metadata.namespace);
+
+            expect(result).toStrictEqual(cronWf);
+            expect(requests.post).toHaveBeenCalledWith('api/v1/cron-workflows/ns');
+        });
+    });
+
+    describe('list', () => {
+        test('with no results', async () => {
+            jest.spyOn(requests, 'get').mockResolvedValue({body: {}} as any);
+
+            const result = await CronWorkflowService.list('ns');
+
+            expect(result).toStrictEqual([]);
+            expect(requests.get).toHaveBeenCalledWith('api/v1/cron-workflows/ns?');
+        });
+
+        test('with multiple results', async () => {
+            const items = [exampleCronWorkflow('ns'), exampleCronWorkflow('ns')];
+            jest.spyOn(requests, 'get').mockResolvedValue({body: {items}} as any);
+
+            const result = await CronWorkflowService.list('ns', ['foo', 'bar']);
+
+            expect(result).toStrictEqual(items);
+            expect(requests.get).toHaveBeenCalledWith('api/v1/cron-workflows/ns?listOptions.labelSelector=foo,bar');
+        });
+    });
+
+    describe('get', () => {
+        test('with valid CronWorkflow', async () => {
+            const cronWf = exampleCronWorkflow('ns');
+            jest.spyOn(requests, 'get').mockResolvedValue({body: cronWf} as any);
+
+            const result = await CronWorkflowService.get(cronWf.metadata.name, 'ns');
+
+            expect(result).toStrictEqual(cronWf);
+            expect(requests.get).toHaveBeenCalledWith(`api/v1/cron-workflows/ns/${cronWf.metadata.name}`);
+        });
+
+        test('with old CronWorkflow using "schedule"', async () => {
+            const cronWf = exampleCronWorkflow('otherns') as any;
+            cronWf.spec.schedule = '* * * * *';
+            delete cronWf.spec.schedules;
+            jest.spyOn(requests, 'get').mockResolvedValue({body: cronWf} as any);
+
+            const result = await CronWorkflowService.get(cronWf.metadata.name, 'otherns');
+
+            expect(result.spec.schedules).toEqual(['* * * * *']);
+            expect(requests.get).toHaveBeenCalledWith(`api/v1/cron-workflows/otherns/${cronWf.metadata.name}`);
+        });
+
+        test('with invalid CronWorkflow missing "schedules"', async () => {
+            const cronWf = exampleCronWorkflow('otherns');
+            delete cronWf.spec.schedules;
+            jest.spyOn(requests, 'get').mockResolvedValue({body: cronWf} as any);
+
+            const result = await CronWorkflowService.get(cronWf.metadata.name, 'otherns');
+
+            expect(result.spec.schedules).toEqual([]);
+            expect(requests.get).toHaveBeenCalledWith(`api/v1/cron-workflows/otherns/${cronWf.metadata.name}`);
+        });
+    });
+
+    describe('update', () => {
+        test('with valid CronWorkflow', async () => {
+            const cronWf = exampleCronWorkflow('ns');
+            const request = {send: jest.fn().mockResolvedValue({body: cronWf})};
+            jest.spyOn(requests, 'put').mockReturnValue(request as any);
+
+            const result = await CronWorkflowService.update(cronWf, cronWf.metadata.name, cronWf.metadata.namespace);
+
+            expect(result).toStrictEqual(cronWf);
+            expect(requests.put).toHaveBeenCalledWith(`api/v1/cron-workflows/ns/${cronWf.metadata.name}`);
+        });
+    });
+
+    describe('suspend', () => {
+        test('with valid CronWorkflow', async () => {
+            const cronWf = exampleCronWorkflow('ns');
+            jest.spyOn(requests, 'put').mockResolvedValue({body: cronWf} as any);
+
+            const result = await CronWorkflowService.suspend(cronWf.metadata.name, 'ns');
+
+            expect(result).toStrictEqual(cronWf);
+            expect(requests.put).toHaveBeenCalledWith(`api/v1/cron-workflows/ns/${cronWf.metadata.name}/suspend`);
+        });
+    });
+
+    describe('resume', () => {
+        test('with valid CronWorkflow', async () => {
+            const cronWf = exampleCronWorkflow('ns');
+            jest.spyOn(requests, 'put').mockResolvedValue({body: cronWf} as any);
+
+            const result = await CronWorkflowService.resume(cronWf.metadata.name, 'ns');
+
+            expect(result).toStrictEqual(cronWf);
+            expect(requests.put).toHaveBeenCalledWith(`api/v1/cron-workflows/ns/${cronWf.metadata.name}/resume`);
+        });
+    });
+});

--- a/ui/src/shared/services/cron-workflow-service.ts
+++ b/ui/src/shared/services/cron-workflow-service.ts
@@ -2,30 +2,44 @@ import {CronWorkflow, CronWorkflowList} from '../models';
 import requests from './requests';
 import {queryParams} from './utils';
 
+// Handle CronWorkflows using the deprecated "schedule" field by automatically
+// migrating them to use "schedules".
+// Also, gracefully handle invalid CronWorkflows that are missing both
+// "schedule" and "schedules".
+function normalizeSchedules(cronWorkflow: any): CronWorkflow {
+    cronWorkflow.spec.schedules ??= [];
+    // TODO: Delete this once we drop support for "schedule"
+    if ((cronWorkflow.spec.schedule ?? '') != '') {
+        cronWorkflow.spec.schedules.push(cronWorkflow.spec.schedule);
+        delete cronWorkflow.spec.schedule;
+    }
+    return cronWorkflow as CronWorkflow;
+}
+
 export const CronWorkflowService = {
     create(cronWorkflow: CronWorkflow, namespace: string) {
         return requests
             .post(`api/v1/cron-workflows/${namespace}`)
             .send({cronWorkflow})
-            .then(res => res.body as CronWorkflow);
+            .then(res => normalizeSchedules(res.body));
     },
 
     list(namespace: string, labels: string[] = []) {
         return requests
             .get(`api/v1/cron-workflows/${namespace}?${queryParams({labels}).join('&')}`)
             .then(res => res.body as CronWorkflowList)
-            .then(list => list.items || []);
+            .then(list => (list.items || []).map(normalizeSchedules));
     },
 
     get(name: string, namespace: string) {
-        return requests.get(`api/v1/cron-workflows/${namespace}/${name}`).then(res => res.body as CronWorkflow);
+        return requests.get(`api/v1/cron-workflows/${namespace}/${name}`).then(res => normalizeSchedules(res.body));
     },
 
     update(cronWorkflow: CronWorkflow, name: string, namespace: string) {
         return requests
             .put(`api/v1/cron-workflows/${namespace}/${name}`)
             .send({cronWorkflow})
-            .then(res => res.body as CronWorkflow);
+            .then(res => normalizeSchedules(res.body));
     },
 
     delete(name: string, namespace: string) {
@@ -33,10 +47,10 @@ export const CronWorkflowService = {
     },
 
     suspend(name: string, namespace: string) {
-        return requests.put(`api/v1/cron-workflows/${namespace}/${name}/suspend`).then(res => res.body as CronWorkflow);
+        return requests.put(`api/v1/cron-workflows/${namespace}/${name}/suspend`).then(res => normalizeSchedules(res.body));
     },
 
     resume(name: string, namespace: string) {
-        return requests.put(`api/v1/cron-workflows/${namespace}/${name}/resume`).then(res => res.body as CronWorkflow);
+        return requests.put(`api/v1/cron-workflows/${namespace}/${name}/resume`).then(res => normalizeSchedules(res.body));
     }
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14047 and fixes #14009

### Motivation

If you have a `CronWorkflow` that's missing both `schedules` and `schedule`, or has `schedules` set to an empty array, you'll get an error in the UI when visiting `/cron-workflows`. This appears to have been introduced in https://github.com/argoproj/argo-workflows/pull/12616. You could argue this isn't a bug, since such `CronWorkflows` aren't valid, but multiple users have reported this, so we should gracefully handle it.

### Modifications


This updates the UI code that fetches `CronWorkflow`s from the API to normalize the response with a new `normalizeSchedules()` function that sets `schedules` to an empty array if it isn't present and automatically converts `schedule` to `schedules`: https://github.com/argoproj/argo-workflows/blob/8461afb4b276511ad88eeaa93e0d2c688ae07d04/ui/src/shared/services/cron-workflow-service.ts#L5-L17

 Then, I deleted all the logic for handling `schedule`, since everything can now safely assume that `schedules` is present and is a non-empty array. Once we drop support for `schedule` completely, we could delete the logic for converting that to `schedules`, but it's only a few lines of code. I also added some basic tests.

### Verification
First, I used `kubectl apply` to manually create three `CronWorkflow`s, one missing both `schedule` and `schedules`, one with `schedules` set to an empty array, and one with `schedule`:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: testschedulesmissinhg
spec:
  workflowSpec:
    entrypoint: main
    templates:
      - name: main
        container:
          image: argoproj/argosay:v2
---
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: testschedulesemptyarray
spec:
  schedules: []
  workflowSpec:
    entrypoint: main
    templates:
      - name: main
        container:
          image: argoproj/argosay:v2
---
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: testdeprecatedschedule
spec:
  schedule: "0 0 * * *"
  workflowSpec:
    entrypoint: main
    templates:
      - name: main
        container:
          image: argoproj/argosay:v2
```
I verified all three show up at http://localhost:8080/cron-workflows and can be edited:
![image](https://github.com/user-attachments/assets/29bcef16-9da1-43b5-87eb-6149372ccca3)

I also verified that "Create New CronWorkflow` works with the example `CronWorkflow`:
![image](https://github.com/user-attachments/assets/f1ea5445-e2a6-4022-9e41-8ea56a2918fa)
 
### Documentation

N/A

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
