### PR TITLE
feat: support filter node type in retry expression. Fixes: #13990

### DIFF
--- a/.features/pending/13990-node-type-variable.md
+++ b/.features/pending/13990-node-type-variable.md
@@ -1,0 +1,16 @@
+Description: Add a `node.type` variable available to all templates, usable in `retryStrategy.expression` to filter retries by node type
+Authors: [shuangkun](https://github.com/shuangkun)
+Component: General
+Issues: 13990
+
+The `node.type` variable exposes the type of the current node (`Pod`, `Steps`, `DAG`, `Suspend`, `HTTP`, `Plugin`) to every template, alongside the existing `node.name`.
+
+Because retry expressions have access to all-template variables, this lets a `retryStrategy.expression` decide whether to retry based on the node type.
+For example, only retry pod nodes:
+
+```yaml
+retryStrategy:
+  expression: node.type == "Pod"
+```
+
+Inside a retry expression, `node.type` is the type of the node being retried.

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -117,6 +117,12 @@ This is an [expr expression](variables.md#expression) with access to the followi
     expression: lastRetry.message matches 'imminent node shutdown|pod deleted'
     ```
 
+- `node.type`: The type of the node being retried: `Pod`, `Steps`, `DAG`, etc. (see [all-template variables](variables.md#all-templates))
+
+    ```yaml
+    expression: node.type == "Pod" # only retry Pod nodes
+    ```
+
 If `expression` evaluates to false, the step will not be retried.
 
 The `expression` result will be logical *and* with the `retryPolicy`. Both must be true to retry.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -136,6 +136,7 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `inputs.parameters`| All input parameters to a template as a JSON string |
 | `inputs.artifacts.<NAME>` | Input artifact to a template |
 | `node.name` | Full name of the node |
+| `node.type` | Type of the node: `Pod`, `Steps`, `DAG`, `Suspend`, `HTTP`, `Plugin` |
 
 ### Steps Templates
 

--- a/util/variables/keys/nodectx.go
+++ b/util/variables/keys/nodectx.go
@@ -17,6 +17,7 @@ var (
 	// exit-handler template whose body is itself container/script/resource.
 	PodName   = nodeCtx("pod.name", "Computed pod name for pod-producing templates", podKindsOnExit)
 	NodeName  = nodeCtx("node.name", "Full node name", anyTmpl)
+	NodeType  = nodeCtx("node.type", "Node type of the current node: Pod, Steps, DAG, Suspend, HTTP, Plugin", anyTmpl)
 	StepsName = nodeCtx("steps.name", "Name of the current step (inside a Steps template body)", []v.TemplateKind{v.TmplSteps})
 	TasksName = nodeCtx("tasks.name", "Name of the current task (inside a DAG template body)", []v.TemplateKind{v.TmplDAG})
 )

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2126,6 +2126,7 @@ func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[s
 	localScope[varkeys.RetriesLastStatus.Template()] = string(lastChildNode.Phase)
 	localScope[varkeys.RetriesLastDuration.Template()] = fmt.Sprint(lastChildNode.GetDuration().Seconds())
 	localScope[varkeys.RetriesLastMessage.Template()] = lastChildNode.Message
+	localScope[varkeys.NodeType.Template()] = string(lastChildNode.Type)
 
 	return localScope
 }
@@ -2212,6 +2213,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	localParams[varkeys.NodeName.Template()] = nodeName
+	localParams[varkeys.NodeType.Template()] = string(resolvedTmpl.GetNodeType())
 
 	// Inputs has been processed with arguments already, so pass empty arguments.
 	processedTmpl, err := common.ProcessArgs(ctx, resolvedTmpl, &args, woc.globalParams(), localParams, false, woc.wf.Namespace, woc.controller.typedConfigMapInformer.GetIndexer())

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -9985,12 +9985,13 @@ func TestBuildRetryStrategyLocalScope(t *testing.T) {
 
 	localScope := buildRetryStrategyLocalScope(retryNode, wf.Status.Nodes)
 
-	assert.Len(t, localScope, 5)
+	assert.Len(t, localScope, 6)
 	assert.Equal(t, "1", localScope[varkeys.Retries.Template()])
 	assert.Equal(t, "1", localScope[varkeys.RetriesLastExitCode.Template()])
 	assert.Equal(t, string(wfv1.NodeFailed), localScope[varkeys.RetriesLastStatus.Template()])
 	assert.Equal(t, "6", localScope[varkeys.RetriesLastDuration.Template()])
 	assert.Equal(t, "Error (exit code 1)", localScope[varkeys.RetriesLastMessage.Template()])
+	assert.Equal(t, string(wfv1.NodeTypePod), localScope[varkeys.NodeType.Template()])
 }
 
 const operatorRetryExpressionError = `

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -813,6 +813,7 @@ func resolveAllVariables(scope map[string]any, globalParams map[string]string, t
 			case strings.HasPrefix(trimmedTag, varkeys.TasksName.Template()):
 			case strings.HasPrefix(trimmedTag, varkeys.StepsName.Template()):
 			case strings.HasPrefix(trimmedTag, varkeys.NodeName.Template()):
+			case strings.HasPrefix(trimmedTag, varkeys.NodeType.Template()):
 			case strings.HasPrefix(trimmedTag, varkeys.WorkflowParametersAll.Template()) && workflowTemplateValidation:
 				// If we are simply validating a WorkflowTemplate in isolation, some of the parameters may come from the Workflow that uses it
 			default:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

I hope to configure the global retryStrategy uniformly, but I don't want the Step/DAG type retry to cause the task to be re-run.

https://github.com/argoproj/argo-workflows/issues/13990#issuecomment-2540339821

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13990 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

UT and Local test
For Workflow
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: test01-fail-
spec:
  entrypoint: step-entrypoint
  templates:
  - name: step-entrypoint
    steps:
    - - name: step-a
        template: a
    - - name: step-b
        template: dag-b

  - name: dag-b
    dag:
      tasks:
      - name: dag-b
        template: b

  - name: a
    container:
      image: busybox:latest
      command: [sh, -c]
      args: ["echo a step && sleep 5"]

  - name: b
    container:
      image: busybox:latest
      command: [sh, -c]
      args: ["echo b step && sleep 5 && exit 1"]
```
template b always failed.

With global RetryStrategy in workflow-controller-configmap:
```
        retryStrategy:
          limit: 4
```
![image](https://github.com/user-attachments/assets/b1c40e64-fcaa-4ce2-8dfc-4ef5ae983c3a)


After add the feature, and with global RetryStrategy in workflow-controller-configmap:
```
        retryStrategy:
          limit: 4
          expression: "retry.nodeType == 'Pod'"
```
![image](https://github.com/user-attachments/assets/38d3a8c0-9e87-4b9a-8c6d-938c35b69410)


### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

add "retry.nodeType" in docs/retries.md and docs/variables.md

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the all-template variable `node.type`, exposing the current node type.
  * Retry expressions can now conditionally retry nodes based on type, such as retrying only `Pod` nodes.

* **Documentation**
  * Documented `node.type` and added conditional retry examples to the variable and retry references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->