### PR TITLE
Cache semaphore limit lookup

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -59,7 +59,7 @@ func NewRootCommand() *cobra.Command {
 		podCleanupWorkers       int    // --pod-cleanup-workers
 		cronWorkflowWorkers     int    // --cron-workflow-workers
 		workflowArchiveWorkers  int    // --workflow-archive-workers
-		semaphoreCacheTTL       int    // --semaphore-cache-ttl
+		SemaphoreSizeCacheTTL   int    // --semaphore-size-cache-ttl
 		burst                   int
 		qps                     float32
 		namespaced              bool   // --namespaced
@@ -122,7 +122,7 @@ func NewRootCommand() *cobra.Command {
 				log.Info("Leader election is turned off. Running in single-instance mode")
 				log.WithField("id", "single-instance").Info("starting leading")
 
-				go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers, time.Second*time.Duration(semaphoreCacheTTL))
+				go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers, time.Second*time.Duration(SemaphoreSizeCacheTTL))
 				go wfController.RunPrometheusServer(ctx, false)
 			} else {
 				nodeID, ok := os.LookupEnv("LEADER_ELECTION_IDENTITY")
@@ -159,7 +159,7 @@ func NewRootCommand() *cobra.Command {
 						OnStartedLeading: func(ctx context.Context) {
 							dummyCancel()
 							wg.Wait()
-							go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers, time.Second*time.Duration(semaphoreCacheTTL))
+							go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers, time.Second*time.Duration(SemaphoreSizeCacheTTL))
 							wg.Add(1)
 							go func() {
 								wfController.RunPrometheusServer(ctx, false)
@@ -203,7 +203,7 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().IntVar(&podCleanupWorkers, "pod-cleanup-workers", 4, "Number of pod cleanup workers")
 	command.Flags().IntVar(&cronWorkflowWorkers, "cron-workflow-workers", 8, "Number of cron workflow workers")
 	command.Flags().IntVar(&workflowArchiveWorkers, "workflow-archive-workers", 8, "Number of workflow archive workers")
-	command.Flags().IntVar(&semaphoreCacheTTL, "semaphore-cache-ttl", 0, "Duration in seconds semaphore size will be cached for before refetching from configmap")
+	command.Flags().IntVar(&SemaphoreSizeCacheTTL, "semaphore-size-cache-ttl", 0, "Duration in seconds semaphore size will be cached for before refetching from configmap")
 	command.Flags().IntVar(&burst, "burst", 30, "Maximum burst for throttle.")
 	command.Flags().Float32Var(&qps, "qps", 20.0, "Queries per second")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run workflow-controller as namespaced mode")

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -59,6 +59,7 @@ func NewRootCommand() *cobra.Command {
 		podCleanupWorkers       int    // --pod-cleanup-workers
 		cronWorkflowWorkers     int    // --cron-workflow-workers
 		workflowArchiveWorkers  int    // --workflow-archive-workers
+		semaphoreCacheTTL       int    // --semaphore-cache-ttl
 		burst                   int
 		qps                     float32
 		namespaced              bool   // --namespaced
@@ -121,7 +122,7 @@ func NewRootCommand() *cobra.Command {
 				log.Info("Leader election is turned off. Running in single-instance mode")
 				log.WithField("id", "single-instance").Info("starting leading")
 
-				go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers)
+				go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers, time.Second*time.Duration(semaphoreCacheTTL))
 				go wfController.RunPrometheusServer(ctx, false)
 			} else {
 				nodeID, ok := os.LookupEnv("LEADER_ELECTION_IDENTITY")
@@ -158,7 +159,7 @@ func NewRootCommand() *cobra.Command {
 						OnStartedLeading: func(ctx context.Context) {
 							dummyCancel()
 							wg.Wait()
-							go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers)
+							go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers, time.Second*time.Duration(semaphoreCacheTTL))
 							wg.Add(1)
 							go func() {
 								wfController.RunPrometheusServer(ctx, false)
@@ -202,6 +203,7 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().IntVar(&podCleanupWorkers, "pod-cleanup-workers", 4, "Number of pod cleanup workers")
 	command.Flags().IntVar(&cronWorkflowWorkers, "cron-workflow-workers", 8, "Number of cron workflow workers")
 	command.Flags().IntVar(&workflowArchiveWorkers, "workflow-archive-workers", 8, "Number of workflow archive workers")
+	command.Flags().IntVar(&semaphoreCacheTTL, "semaphore-cache-ttl", 0, "Duration in seconds semaphore size will be cached for before refetching from configmap")
 	command.Flags().IntVar(&burst, "burst", 30, "Maximum burst for throttle.")
 	command.Flags().Float32Var(&qps, "qps", 20.0, "Queries per second")
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run workflow-controller as namespaced mode")

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -110,6 +110,12 @@ In order to protect users against infinite recursion, the controller has a defau
 
 This protection can be disabled with the [environment variable](environment-variables.md#controller) `DISABLE_MAX_RECURSION=true`
 
+### Caching Semaphore ConfigMap Requests
+
+By default the controller will reload the config map(s) referenced by a semaphore from kube every time that workflow is queued. If you notice high latency from queuing workflows leveraging semaphores you can cache semaphore sizes by setting `--semaphore-size-cache-ttl` (cache duration in seconds).
+
+Note that this will mean that Argo will not immediately pick up changes to your config map sizes.
+
 ## Miscellaneous
 
 See also [Running At Massive Scale](running-at-massive-scale.md).

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -274,7 +274,7 @@ var indexers = cache.Indexers{
 }
 
 // Run starts a Workflow resource controller
-func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, wfArchiveWorkers int, semaphoreCacheTTL time.Duration) {
+func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, wfArchiveWorkers int, SemaphoreSizeCacheTTL time.Duration) {
 	defer runtimeutil.HandleCrashWithContext(ctx, runtimeutil.PanicHandlers...)
 
 	// init DB after leader election (if enabled)
@@ -295,7 +295,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		WithField("podCleanup", podCleanupWorkers).
 		WithField("cronWorkflowWorkers", cronWorkflowWorkers).
 		WithField("workflowArchive", wfArchiveWorkers).
-		WithField("semaphoreCacheTTL", semaphoreCacheTTL).
+		WithField("SemaphoreSizeCacheTTL", SemaphoreSizeCacheTTL).
 		Info("Current Worker Numbers")
 
 	wfc.wfInformer = util.NewWorkflowInformer(wfc.dynamicInterface, wfc.GetManagedNamespace(), workflowResyncPeriod, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, indexers)
@@ -315,7 +315,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.configMapInformer = wfc.newConfigMapInformer()
 
 	// Create Synchronization Manager
-	wfc.createSynchronizationManager(ctx, semaphoreCacheTTL)
+	wfc.createSynchronizationManager(ctx, SemaphoreSizeCacheTTL)
 	// init managers: throttler and SynchronizationManager
 	if err := wfc.initManagers(ctx); err != nil {
 		log.Fatal(err)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -329,7 +329,7 @@ func newController(options ...interface{}) (context.CancelFunc, *WorkflowControl
 		wfc.PodController = pod.NewController(ctx, &wfc.Config, wfc.restConfig, "", wfc.kubeclientset, wfc.wfInformer, wfc.metrics, wfc.enqueueWfFromPodLabel)
 
 		wfc.configMapInformer = wfc.newConfigMapInformer()
-		wfc.createSynchronizationManager(ctx)
+		wfc.createSynchronizationManager(ctx, 0)
 		_ = wfc.initManagers(ctx)
 
 		go wfc.wfInformer.Run(ctx.Done())

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -163,7 +163,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -224,7 +224,7 @@ func TestSemaphoreScriptTmplLevel(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -284,7 +284,7 @@ func TestSemaphoreScriptConfigMapInDifferentNamespace(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -346,7 +346,7 @@ func TestSemaphoreResourceTmplLevel(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -408,7 +408,7 @@ func TestSemaphoreWithOutConfigMap(t *testing.T) {
 	defer cancel()
 
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 
 	t.Run("SemaphoreRefWithOutConfigMap", func(t *testing.T) {
@@ -464,7 +464,7 @@ func TestMutexInDAG(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	t.Run("MutexWithDAG", func(t *testing.T) {
 		wf := wfv1.MustUnmarshalWorkflow(DAGWithMutex)
@@ -536,7 +536,7 @@ func TestMutexInDAGWithInterpolation(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	t.Run("InterpolatedMutexWithDAG", func(t *testing.T) {
 		wf := wfv1.MustUnmarshalWorkflow(DAGWithInterpolatedMutex)
@@ -601,7 +601,7 @@ func TestSynchronizationWithRetry(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -809,7 +809,7 @@ func TestSynchronizationWithStep(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -886,7 +886,7 @@ func TestSynchronizationWithStepRetry(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 	var cm apiv1.ConfigMap
 	wfv1.MustUnmarshal([]byte(configMap), &cm)
@@ -950,7 +950,7 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 
 	t.Run("PendingShuttingdownTerminatingWf", func(t *testing.T) {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -8581,7 +8581,7 @@ func TestMutexWfPendingWithNoPod(t *testing.T) {
 	cancel, controller := newController(wf)
 	defer cancel()
 	ctx := context.Background()
-	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	controller.syncManager = sync.NewLockManager(GetSyncLimitFunc(ctx, controller.kubeclientset), 0, func(key string) {
 	}, workflowExistenceFunc)
 
 	// preempt lock

--- a/workflow/sync/common.go
+++ b/workflow/sync/common.go
@@ -13,5 +13,10 @@ type semaphore interface {
 	getCurrentPending() []string
 	getName() string
 	getLimit() int
+	getLimitTimestamp() time.Time
+	resetLimitTimestamp()
 	resize(n int) bool
 }
+
+// expose for overriding in tests
+var now = time.Now

--- a/workflow/sync/multiple_test.go
+++ b/workflow/sync/multiple_test.go
@@ -42,7 +42,7 @@ func TestMultipleMutexLock(t *testing.T) {
 	kube := fake.NewSimpleClientset()
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("MultipleMutex", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {},
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {},
 			WorkflowExistenceFunc)
 		wfall := templatedWorkflow("all",
 			`    mutexes:
@@ -122,7 +122,7 @@ func TestMultipleMutexLock(t *testing.T) {
 		assert.True(t, wfUpdate)
 	})
 	t.Run("MultipleMutexOrdering", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {},
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {},
 			WorkflowExistenceFunc)
 		wfall := templatedWorkflow("all",
 			`    mutexes:
@@ -204,7 +204,7 @@ func TestMutexAndSemaphore(t *testing.T) {
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("MutexSemaphore", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {},
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {},
 			WorkflowExistenceFunc)
 		wfmands1 := templatedWorkflow("mands1",
 			`    mutexes:
@@ -322,7 +322,7 @@ func TestPriority(t *testing.T) {
 	kube := fake.NewSimpleClientset()
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("Priority", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {},
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {},
 			WorkflowExistenceFunc)
 		wflow := templatedWorkflow("prioritylow",
 			`    mutexes:
@@ -399,7 +399,7 @@ func TestDuplicates(t *testing.T) {
 	kube := fake.NewSimpleClientset()
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("Mutex", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {},
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {},
 			WorkflowExistenceFunc)
 		wfdupmutex := templatedWorkflow("mutex",
 			`    mutexes:
@@ -410,7 +410,7 @@ func TestDuplicates(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("Semaphore", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {},
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {},
 			WorkflowExistenceFunc)
 		wfdupsemaphore := templatedWorkflow("semaphore",
 			`    semaphores:

--- a/workflow/sync/mutex_test.go
+++ b/workflow/sync/mutex_test.go
@@ -114,7 +114,7 @@ func TestMutexLock(t *testing.T) {
 	kube := fake.NewSimpleClientset()
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("InitializeSynchronization", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(mutexwfstatus)
 		wfclientset := fakewfclientset.NewSimpleClientset(wf)
@@ -127,7 +127,7 @@ func TestMutexLock(t *testing.T) {
 	})
 	t.Run("WfLevelMutexAcquireAndRelease", func(t *testing.T) {
 		var nextWorkflow string
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			nextWorkflow = key
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(mutexWf)
@@ -208,7 +208,7 @@ func TestMutexLock(t *testing.T) {
 
 	t.Run("WfLevelMutexOthernamespace", func(t *testing.T) {
 		var nextWorkflow string
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			nextWorkflow = key
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(mutexWfNamespaced)
@@ -399,7 +399,7 @@ func TestMutexTmplLevel(t *testing.T) {
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("TemplateLevelAcquireAndRelease", func(t *testing.T) {
 		// var nextKey string
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			// nextKey = key
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(mutexWfWithTmplLevel)

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
@@ -19,20 +20,22 @@ type (
 )
 
 type Manager struct {
-	syncLockMap  map[string]semaphore
-	lock         *sync.Mutex
-	nextWorkflow NextWorkflow
-	getSyncLimit GetSyncLimit
-	isWFDeleted  IsWorkflowDeleted
+	syncLockMap       map[string]semaphore
+	lock              *sync.Mutex
+	nextWorkflow      NextWorkflow
+	getSyncLimit      GetSyncLimit
+	syncLimitCacheTTL time.Duration
+	isWFDeleted       IsWorkflowDeleted
 }
 
-func NewLockManager(getSyncLimit GetSyncLimit, nextWorkflow NextWorkflow, isWFDeleted IsWorkflowDeleted) *Manager {
+func NewLockManager(getSyncLimit GetSyncLimit, syncLimitCacheTTL time.Duration, nextWorkflow NextWorkflow, isWFDeleted IsWorkflowDeleted) *Manager {
 	return &Manager{
-		syncLockMap:  make(map[string]semaphore),
-		lock:         &sync.Mutex{},
-		nextWorkflow: nextWorkflow,
-		getSyncLimit: getSyncLimit,
-		isWFDeleted:  isWFDeleted,
+		syncLockMap:       make(map[string]semaphore),
+		lock:              &sync.Mutex{},
+		nextWorkflow:      nextWorkflow,
+		getSyncLimit:      getSyncLimit,
+		syncLimitCacheTTL: syncLimitCacheTTL,
+		isWFDeleted:       isWFDeleted,
 	}
 }
 
@@ -459,12 +462,18 @@ func (sm *Manager) isSemaphoreSizeChanged(semaphore semaphore) (bool, int, error
 }
 
 func (sm *Manager) checkAndUpdateSemaphoreSize(semaphore semaphore) error {
+	if now().Sub(semaphore.getLimitTimestamp()) < sm.syncLimitCacheTTL {
+		return nil
+	}
+
 	changed, newLimit, err := sm.isSemaphoreSizeChanged(semaphore)
 	if err != nil {
 		return err
 	}
 	if changed {
 		semaphore.resize(newLimit)
+	} else {
+		semaphore.resetLimitTimestamp()
 	}
 	return nil
 }

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -337,7 +337,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("InitializeSynchronization", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(wfWithStatus)
 		wfclientset := fakewfclientset.NewSimpleClientset(wf)
@@ -348,7 +348,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		assert.Len(t, syncManager.syncLockMap, 1)
 	})
 	t.Run("InitializeSynchronizationWithInvalid", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(wfWithStatus)
 		invalidSync := []wfv1.SemaphoreHolding{{Semaphore: "default/configmap/my-config1/workflow", Holders: []string{"hello-world-vcrg5"}}}
@@ -362,7 +362,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 
 	t.Run("WfLevelAcquireAndRelease", func(t *testing.T) {
 		var nextKey string
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			nextKey = key
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
@@ -464,7 +464,7 @@ func TestResizeSemaphoreSize(t *testing.T) {
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("WfLevelAcquireAndRelease", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
 		wf.CreationTimestamp = metav1.Time{Time: time.Now()}
@@ -540,7 +540,7 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("TemplateLevelAcquireAndRelease", func(t *testing.T) {
 		// var nextKey string
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			// nextKey = key
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(wfWithTmplSemaphore)
@@ -590,6 +590,199 @@ func TestSemaphoreTmplLevel(t *testing.T) {
 	})
 }
 
+type mockGetSyncLimit struct {
+	callCount  int
+	outputSize int
+	outputErr  error
+}
+
+func (m *mockGetSyncLimit) getSyncLimit(s string) (int, error) {
+	m.callCount++
+	return m.outputSize, m.outputErr
+}
+
+func TestSemaphoreSizeCache(t *testing.T) {
+	ctx := context.Background()
+
+	mockedNow := time.Now()
+	now = func() time.Time {
+		return mockedNow
+	}
+	defer func() {
+		now = time.Now
+	}()
+
+	t.Run("WfLevelAcquireAndRelease", func(t *testing.T) {
+		mock := mockGetSyncLimit{}
+		mock.outputSize = 10
+
+		syncManager := NewLockManager(mock.getSyncLimit, 1, func(key string) {
+		}, WorkflowExistenceFunc)
+		wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
+		wf.CreationTimestamp = metav1.Time{Time: time.Now()}
+
+		status, wfUpdate, msg, failedLockName, err := syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.Empty(t, msg)
+		assert.Empty(t, failedLockName)
+		assert.True(t, status)
+		assert.True(t, wfUpdate)
+		assert.Equal(t, 1, mock.callCount)
+
+		semaphore := syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 1, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		// increase semaphore age to force update
+		semaphore.(*prioritySemaphore).limitTimestamp = mockedNow.Add(-1)
+
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 2, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		// semaphore age should be updated to now
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 2, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		// increase semaphore age to force update
+		semaphore.(*prioritySemaphore).limitTimestamp = mockedNow.Add(-1)
+		mock.outputSize = 20
+
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 3, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		assert.Equal(t, 20, semaphore.getLimit())
+
+		// semaphore age should be updated to now again
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 3, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		assert.Equal(t, 20, semaphore.getLimit())
+	})
+
+	t.Run("TemplateLevelAcquireAndRelease", func(t *testing.T) {
+		mock := mockGetSyncLimit{}
+		mock.outputSize = 10
+
+		syncManager := NewLockManager(mock.getSyncLimit, 1, func(key string) {
+		}, WorkflowExistenceFunc)
+		wf := wfv1.MustUnmarshalWorkflow(wfWithTmplSemaphore)
+		tmpl := wf.Spec.Templates[2]
+
+		status, wfUpdate, msg, failedLockName, err := syncManager.TryAcquire(ctx, wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
+		require.NoError(t, err)
+		assert.Empty(t, msg)
+		assert.Empty(t, failedLockName)
+		assert.True(t, status)
+		assert.True(t, wfUpdate)
+		assert.Equal(t, 1, mock.callCount)
+
+		semaphore := syncManager.syncLockMap["default/ConfigMap/my-config/template"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 1, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/template"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		// increase semaphore age to force update
+		semaphore.(*prioritySemaphore).limitTimestamp = mockedNow.Add(-1)
+
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 2, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/template"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		// semaphore age should be updated to now
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 2, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/template"]
+		assert.Equal(t, 10, semaphore.getLimit())
+
+		// increase semaphore age to force update
+		semaphore.(*prioritySemaphore).limitTimestamp = mockedNow.Add(-1)
+		mock.outputSize = 20
+
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 3, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/template"]
+		assert.Equal(t, 20, semaphore.getLimit())
+
+		// semaphore age should be updated to now again
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf, "semaphore-tmpl-level-xjvln-3448864205", tmpl.Synchronization)
+		require.NoError(t, err)
+		assert.True(t, status)
+		assert.Empty(t, failedLockName)
+		assert.False(t, wfUpdate)
+		assert.Empty(t, msg)
+		assert.Equal(t, 3, mock.callCount)
+
+		semaphore = syncManager.syncLockMap["default/ConfigMap/my-config/template"]
+		assert.Equal(t, 20, semaphore.getLimit())
+	})
+}
+
 func TestTriggerWFWithAvailableLock(t *testing.T) {
 	assert := assert.New(t)
 	kube := fake.NewSimpleClientset()
@@ -604,7 +797,7 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("TriggerWfsWithAvailableLocks", func(t *testing.T) {
 		triggerCount := 0
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			triggerCount++
 		}, WorkflowExistenceFunc)
 		var wfs []wfv1.Workflow
@@ -643,7 +836,7 @@ func TestMutexWfLevel(t *testing.T) {
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("WorkflowLevelMutexAcquireAndRelease", func(t *testing.T) {
 		// var nextKey string
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			// nextKey = key
 		}, WorkflowExistenceFunc)
 		wf := wfv1.MustUnmarshalWorkflow(wfWithMutex)
@@ -699,7 +892,7 @@ func TestCheckWorkflowExistence(t *testing.T) {
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 	t.Run("WorkflowDeleted", func(t *testing.T) {
-		syncManager := NewLockManager(syncLimitFunc, func(key string) {
+		syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 			// nextKey = key
 		}, func(s string) bool {
 			return strings.Contains(s, "test1")
@@ -868,7 +1061,7 @@ status:
 `)
 	syncLimitFunc := GetSyncLimitFunc(kube)
 
-	syncManager := NewLockManager(syncLimitFunc, func(key string) {
+	syncManager := NewLockManager(syncLimitFunc, 0, func(key string) {
 		// nextKey = key
 	}, WorkflowExistenceFunc)
 	t.Run("InitializeMutex", func(t *testing.T) {
@@ -1133,7 +1326,7 @@ func TestMutexMigration(t *testing.T) {
 
 	syncLimitFunc := GetSyncLimitFunc(kube)
 
-	syncMgr := NewLockManager(syncLimitFunc, func(key string) {
+	syncMgr := NewLockManager(syncLimitFunc, 0, func(key string) {
 	}, WorkflowExistenceFunc)
 
 	wfMutex := wfv1.MustUnmarshalWorkflow(wfWithMutex)
@@ -1173,7 +1366,7 @@ func TestMutexMigration(t *testing.T) {
 		assert.True(status)
 	})
 
-	syncMgr = NewLockManager(syncLimitFunc, func(key string) {
+	syncMgr = NewLockManager(syncLimitFunc, 0, func(key string) {
 	}, WorkflowExistenceFunc)
 
 	t.Run("RunMigrationTemplateLevel", func(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

This PR came out of the slack discussion [here](https://cloud-native.slack.com/archives/C01QW9QSSSK/p1739325430319219):

Each `semaphore` must acquire a universal lock on the `SyncManager` and reload the corresponding `ConfigMap` from the kube api on every operation call. This can result in a performance degradation when a large number of workflows with semaphores are queued as all workflows using synchronization will have to wait in this same queue for each get call.

### Modifications

Added a `--semaphore-size-cache-ttl` argument. When specified, `SyncManager` will wait the provided number of seconds before refetching the semaphore size from the `ConfigMap`.

### Verification

Added associated unit tests to verify the caching behavior.

### Documentation

Added a line in the scaling docs to explain the flag and its purpose.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
