### PR TITLE
docs: Correct sub-optimal burst value for resourceRateLimit

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -85,11 +85,11 @@ To mitigate this, you can set rate limit how many Pods the Workflow Controller r
   # parallel nodes.
   resourceRateLimit: |
     limit: 10
-    burst: 1
+    burst: 25
 ```
 
 - `limit`: This sets the average number of Pod creation requests per second..
-- `burst`: This sets the number of Pods per second the Controller can create before it starts enforcing the `limit`.
+- `burst`: This sets the number of Pods per second the Controller can create before it starts enforcing the `limit`. Typically, burst should be greater than the limit.
 
 By using cluster-wide observability tooling, you can determine whether or not your Kubernetes API server can handle more Pod creation requests.
 It is important to note that increasing these values can increase the load on the Kubernetes API server and that you must observe your Kubernetes API under load in order to determine whether or not the values you have chosen are correct for your needs.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -54,7 +54,8 @@ You can increase the rate limits by adjusting the `--qps` and `--burst` argument
 - `--qps`: This argument sets the average number of queries per second allowed by the Kubernetes client.
 The default value is 20.
 - `--burst`: This argument sets the number of queries per second the client can send before it starts enforcing the qps limit.
-The default value is 30. Typically, burst should be greater than qps.
+The default value is 30.
+Typically, burst should be greater than qps.
 
 By increasing these values, you can allow the Controller to send more requests to the API server, reducing the likelihood of throttling.
 
@@ -89,7 +90,8 @@ To mitigate this, you can set rate limit how many Pods the Workflow Controller r
 ```
 
 - `limit`: This sets the average number of Pod creation requests per second..
-- `burst`: This sets the number of Pods per second the Controller can create before it starts enforcing the `limit`. Typically, burst should be greater than the limit.
+- `burst`: This sets the number of Pods per second the Controller can create before it starts enforcing the `limit`.
+Typically, burst should be greater than the limit.
 
 By using cluster-wide observability tooling, you can determine whether or not your Kubernetes API server can handle more Pod creation requests.
 It is important to note that increasing these values can increase the load on the Kubernetes API server and that you must observe your Kubernetes API under load in order to determine whether or not the values you have chosen are correct for your needs.

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -31,7 +31,7 @@ data:
   # parallel nodes.
   resourceRateLimit: |
     limit: 10
-    burst: 1
+    burst: 25
 
   # Whether or not to emit events on node completion. These can take a up a lot of space in
   # k8s (typically etcd) resulting in errors when trying to create new events:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation

In both the example configmap and the docs, the `resourceRateLimit` `burst` was set to a value lower than the `limit`.  Even worse, it was set to `1`. This means that the `limit` would be perpetually in place even when not needed.

### Modifications

- Update the docs to explain burst a little clearer. Update the example
- Update the example controller configmap to match the docs.
- Added a missing line break

### Verification

`make docs`



<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
