### PR TITLE
fix: gcs fix list a file. Fixes #2841

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -196,6 +196,11 @@ func listByPrefix(client *storage.Client, bucket, prefix, delim string) ([]strin
 		if err != nil {
 			return nil, err
 		}
+		// prefix is a file
+		if  attrs.Name == prefix {
+			results = []string{attrs.Name}
+			return results, nil
+		}
 		// skip "folder" path like objects
 		// note that we still download content (including "subfolders")
 		// this is just a consequence of how objects are stored in GCS (no real hierarchy)

--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -197,7 +197,7 @@ func listByPrefix(client *storage.Client, bucket, prefix, delim string) ([]strin
 			return nil, err
 		}
 		// prefix is a file
-		if  attrs.Name == prefix {
+		if attrs.Name == prefix {
 			results = []string{attrs.Name}
 			return results, nil
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #2841 

### Motivation

<!-- TODO: Say why you made your changes. -->

Currently if our gcs has the following structure.
```
/test/abc
/test/abcd
```
specifying `key: /test/abc` in input artifact would cause failure due current list funciton will return 
```
/test/abc
/test/abcd
```
The list function should only return `/test/abc`

### Modifications

If the iterator returns a object that matches with our prefix, this indicate the object is a file instead of a directory, we return the file straightaway
- in gcs iterator, a directory will have suffix `/`, it won't match with the cleaned prefix
- in gcs, we can't have a file and a directory with the same name, we won't skip directory if its indeed a directory

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested with
```
metadata:
  name: test
  namespace: default
spec:
  templates:
    - name: artifact-example
      steps:
        - - name: generate-artifact
            template: hello-world-to-file
        - - name: generate-artifact2
            template: hello-world-to-file2
        - - name: consume-artifact
            template: print-message-from-file
    - name: hello-world-to-file
      outputs:
        artifacts:
          - name: hello-art
            path: /tmp/hello_world.txt
            gcs:
              key: argo-artifacts/test1/abc
      container:
        name: ''
        image: busybox
        command:
          - sh
          - '-c'
        args:
          - sleep 1; echo hello world | tee /tmp/hello_world.txt
    - name: hello-world-to-file2
      outputs:
        artifacts:
          - name: hello-art
            path: /tmp/hello_world.txt
            gcs:
              key: argo-artifacts/test12/abcd
      container:
        name: ''
        image: busybox
        command:
          - sh
          - '-c'
        args:
          - sleep 1; echo hello | tee /tmp/hello_world.txt
    - name: print-message-from-file
      inputs:
        artifacts:
          - name: message
            path: /tmp/message
            gcs:
              key: argo-artifacts/test1
      container:
        name: ''
        image: alpine:latest
        command:
          - sh
          - '-c'
        args:
          - cat /tmp/message
  entrypoint: artifact-example
```

Failed before the change
Succeeded after the change
In addition, our production workflow runs without issue

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
