### PR TITLE
test: fix intermittent cron failures due to parallelism limit

### DIFF
--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -21,19 +21,16 @@ type CronSuite struct {
 	fixtures.E2ESuite
 }
 
-func (s *CronSuite) SetupSuite() {
-	s.E2ESuite.SetupSuite()
-	// Since tests run in parallel, delete all cron resources before the test suite is run
+func (s *CronSuite) TearDownSubTest() {
+	// Delete all CronWorkflows after every subtest (as opposed to after each
+	// test, which is the default) to avoid workflows from accumulating and
+	// causing intermittent failures due to the controller reaching the
+	// parallelism limit. When that happens, workflows can be postponed long
+	// enough to reach the test timeout, and you'll see the following in the logs:
+	//    time="2025-02-23T06:11:00.023Z" level=info msg="Workflow processing has been postponed due to max parallelism limit" key=argo/test-cron-wf-succeed-1-1740291060
+	//    time="2025-02-23T06:11:00.023Z" level=info msg="Updated phase  -> Pending" namespace=argo workflow=test-cron-wf-succeed-1-1740291060
+	//    time="2025-02-23T06:11:00.023Z" level=info msg="Updated message  -> Workflow processing has been postponed because too many workflows are already running" namespace=argo workflow=test-cron-wf-succeed-1-1740291060
 	s.E2ESuite.DeleteResources()
-}
-
-func (s *CronSuite) BeforeTest(suiteName, testName string) {
-	s.E2ESuite.BeforeTest(suiteName, testName)
-}
-
-func (s *CronSuite) TearDownSuite() {
-	s.E2ESuite.DeleteResources()
-	s.E2ESuite.TearDownSuite()
 }
 
 func (s *CronSuite) TestBasic() {


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

Occasionally, the cron E2E suite fails and you'll see the following in the output ([example](
https://github.com/argoproj/argo-workflows/actions/runs/13480065787/job/37664515754?pr=13747)):
>  ◷ test-cron-wf-fail-1-1740291060 Workflow 0s      Workflow processing has been postponed because too many workflows are already running

I think this is happening because the `E2ESuite.DeleteResources()` method that's supposed to clean up `CronWorkflow`s from previous tests isn't being run for subtests, and nearly all the tests in `test/e2e/cron_test.go` are subtests. 

### Modifications
This adds a `TearDownSubTest` method to cleanup all resources after every subtest. Docs:
https://pkg.go.dev/github.com/stretchr/testify/suite#TearDownSubTest

I also deleted the redundant `BeforeTest()` and `TearDownSuite()` methods.

### Verification
Ran `make test-cron` locally

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
