### PR TITLE
fix: incorrect description of value field in Workflow.Parameter

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -73,6 +73,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [DataRobot](https://www.datarobot.com/)
 1. [DataStax](https://www.datastax.com/)
 1. [DDEV](https://www.ddev.com/)
+1. [Deutsche Telekom AG](https://telekom.com)
 1. [DevSamurai](https://www.devsamurai.com/)
 1. [Devtron Labs](https://github.com/devtron-labs/devtron)
 1. [DLR](https://www.dlr.de/eoc/)

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -6246,7 +6246,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values",
+          "description": "Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value",
           "type": "string"
         },
         "valueFrom": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10344,7 +10344,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values",
+          "description": "Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value",
           "type": "string"
         },
         "valueFrom": {

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2380,7 +2380,7 @@ Parameter indicate a passed string parameter to a service template with an optio
 |`enum`|`Array< string >`|Enum holds a list of string values to choose from, for the actual value of the parameter|
 |`globalName`|`string`|GlobalName exports an output parameter to the global scope, making it available as '{{io.argoproj.workflow.v1alpha1.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters|
 |`name`|`string`|Name is the parameter name|
-|`value`|`string`|Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values|
+|`value`|`string`|Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value|
 |`valueFrom`|[`ValueFrom`](#valuefrom)|ValueFrom is the source for the output parameter's value|
 
 ## TemplateRef

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -1262,7 +1262,7 @@ message Parameter {
   optional string default = 2;
 
   // Value is the literal value to use for the parameter.
-  // If specified in the context of an input parameter, the value takes precedence over any passed values
+  // If specified in the context of an input parameter, any passed values take precedence over the specified value
   optional string value = 3;
 
   // ValueFrom is the source for the output parameter's value

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -4842,7 +4842,7 @@ func schema_pkg_apis_workflow_v1alpha1_Parameter(ref common.ReferenceCallback) c
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values",
+							Description: "Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -898,7 +898,7 @@ type Parameter struct {
 	Default *AnyString `json:"default,omitempty" protobuf:"bytes,2,opt,name=default"`
 
 	// Value is the literal value to use for the parameter.
-	// If specified in the context of an input parameter, the value takes precedence over any passed values
+	// If specified in the context of an input parameter, any passed values take precedence over the specified value
 	Value *AnyString `json:"value,omitempty" protobuf:"bytes,3,opt,name=value"`
 
 	// ValueFrom is the source for the output parameter's value

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1Parameter.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1Parameter.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **_enum** | **List&lt;String&gt;** | Enum holds a list of string values to choose from, for the actual value of the parameter |  [optional]
 **globalName** | **String** | GlobalName exports an output parameter to the global scope, making it available as &#39;{{io.argoproj.workflow.v1alpha1.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters |  [optional]
 **name** | **String** | Name is the parameter name | 
-**value** | **String** | Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values |  [optional]
+**value** | **String** | Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value |  [optional]
 **valueFrom** | [**IoArgoprojWorkflowV1alpha1ValueFrom**](IoArgoprojWorkflowV1alpha1ValueFrom.md) |  |  [optional]
 
 

--- a/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_parameter.py
+++ b/sdks/python/client/argo_workflows/model/io_argoproj_workflow_v1alpha1_parameter.py
@@ -159,7 +159,7 @@ class IoArgoprojWorkflowV1alpha1Parameter(ModelNormal):
             description (str): Description is the parameter description. [optional]  # noqa: E501
             enum ([str]): Enum holds a list of string values to choose from, for the actual value of the parameter. [optional]  # noqa: E501
             global_name (str): GlobalName exports an output parameter to the global scope, making it available as '{{io.argoproj.workflow.v1alpha1.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters. [optional]  # noqa: E501
-            value (str): Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values. [optional]  # noqa: E501
+            value (str): Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value. [optional]  # noqa: E501
             value_from (IoArgoprojWorkflowV1alpha1ValueFrom): [optional]  # noqa: E501
         """
 
@@ -250,7 +250,7 @@ class IoArgoprojWorkflowV1alpha1Parameter(ModelNormal):
             description (str): Description is the parameter description. [optional]  # noqa: E501
             enum ([str]): Enum holds a list of string values to choose from, for the actual value of the parameter. [optional]  # noqa: E501
             global_name (str): GlobalName exports an output parameter to the global scope, making it available as '{{io.argoproj.workflow.v1alpha1.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters. [optional]  # noqa: E501
-            value (str): Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values. [optional]  # noqa: E501
+            value (str): Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value. [optional]  # noqa: E501
             value_from (IoArgoprojWorkflowV1alpha1ValueFrom): [optional]  # noqa: E501
         """
 

--- a/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1Parameter.md
+++ b/sdks/python/client/docs/IoArgoprojWorkflowV1alpha1Parameter.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **description** | **str** | Description is the parameter description | [optional] 
 **enum** | **[str]** | Enum holds a list of string values to choose from, for the actual value of the parameter | [optional] 
 **global_name** | **str** | GlobalName exports an output parameter to the global scope, making it available as &#39;{{io.argoproj.workflow.v1alpha1.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters | [optional] 
-**value** | **str** | Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values | [optional] 
+**value** | **str** | Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value | [optional] 
 **value_from** | [**IoArgoprojWorkflowV1alpha1ValueFrom**](IoArgoprojWorkflowV1alpha1ValueFrom.md) |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 

--- a/ui/src/shared/models/workflows.ts
+++ b/ui/src/shared/models/workflows.ts
@@ -196,7 +196,7 @@ export interface Parameter {
      */
     name: string;
     /**
-     * Value is the literal value to use for the parameter. If specified in the context of an input parameter, the value takes precedence over any passed values
+     * Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value
      */
     value?: string;
     /**


### PR DESCRIPTION
### Motivation

The current description of the `value` field on `Workflow.Parameter` is confusing and suggests that parameters passed to the workflow will not be respected if a value has been set in the workflow definition.
The actual behavior is opposite: The specified value acts as a default and is overridden by any passed values.

### Modifications

- Updated the description to match the actual behavior
- Added *Deutsche Telekom AG* to the list of users

### Verification

Ran `make pre-commit -B`.