### PR TITLE
fix: don't print help. Fixes argoproj#14234

### DIFF
--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -55,6 +55,7 @@ func NewRootCommand() *cobra.Command {
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			initConfig()
+			cmd.SilenceUsage = true
 		},
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

The default behavior with Cobra is to print the help text for all errors, which can be tedious to scroll through.

### Modifications

This changes the CLI to only print the help text for argument validation errors.
Here are the related PRs.
https://github.com/argoproj/argo-workflows/pull/13831

### Verification
I have confirmed that the issue does not occur locally and no help error is shown.

### Documentation
