### PR TITLE
chore: remove a missed `onExit` in example

### DIFF
--- a/examples/exit-handler-step-level.yaml
+++ b/examples/exit-handler-step-level.yaml
@@ -24,7 +24,6 @@ spec:
               exit:
                 template: exit
           - name: hello2b
-            onExit: exit
             template: print-message
             arguments:
               parameters: [{ name: message, value: "hello2b" }]


### PR DESCRIPTION
### Motivation

One liner for a line missed in #14127
