### PR TITLE
fix(api/jsonschema): use working `$id`

### DIFF
--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://workflows.argoproj.io/workflows.json",
+  "$id": "https://raw.githubusercontent.com/argoproj/argo-workflows/HEAD/api/jsonschema/schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "definitions": {
     "eventsource.CreateEventSourceRequest": {

--- a/hack/api/jsonschema/main.go
+++ b/hack/api/jsonschema/main.go
@@ -39,7 +39,7 @@ func main() {
 			props["kind"].(obj)["const"] = kind
 		}
 		schema := obj{
-			"$id":     "http://workflows.argoproj.io/workflows.json", // don't really know what this should be
+			"$id":     "https://raw.githubusercontent.com/argoproj/argo-workflows/HEAD/api/jsonschema/schema.json",
 			"$schema": "https://json-schema.org/draft/2020-12/schema",
 			"type":    "object",
 			"oneOf": []interface{}{


### PR DESCRIPTION
As suggested in #14092, it's fairly conventional for JSON Schema ID URIs to be working URLs too. Change the schema to use a URL that works and returns the latest tip version.
