### PR TITLE
docs: autogenerate tested k8s versions and centralize config (#14176) (release-3.6)

### DIFF
--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -1,19 +1,20 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eux
 
-# install kubernetes
+# install kubernetes using the minimum tested version
+. hack/k8s-versions.sh
 wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-k3d cluster get k3s-default || k3d cluster create --image rancher/k3s:v1.27.3-k3s1 --wait
+k3d cluster get k3s-default || k3d cluster create --image "rancher/k3s:${K8S_VERSIONS[min]}-k3s1" --wait
 k3d kubeconfig merge --kubeconfig-merge-default
 
 # install kubectl
-curl -LO https://dl.k8s.io/release/v1.27.3/bin/linux/$(go env GOARCH)/kubectl
+curl -LO "https://dl.k8s.io/release/${K8S_VERSIONS[min]}/bin/linux/$(go env GOARCH)/kubectl"
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 kubectl cluster-info
 
 # install kit
-make kit
+curl -q https://raw.githubusercontent.com/kitproj/kit/main/install.sh | sh
 
 # install protocol buffer compiler (protoc)
 sudo apt update

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -242,15 +242,15 @@ jobs:
             profile: minimal
             use-api: true
           - test: test-executor
-            install_k3s_version: v1.28.13+k3s1
+            k8s_version: min
             profile: minimal
             use-api: false
           - test: test-corefunctional
-            install_k3s_version: v1.28.13+k3s1
+            k8s_version: min
             profile: minimal
             use-api: false
           - test: test-functional
-            install_k3s_version: v1.28.13+k3s1
+            k8s_version: min
             profile: minimal
             use-api: false
     steps:
@@ -283,12 +283,11 @@ jobs:
           python-version: '3.x'
           cache: pip
       - name: Install and start K3S
+        env:
+          K8S_VERSION: ${{ matrix.k8s_version || 'max' }}
         run: |
-          if ! echo "${{ matrix.install_k3s_version }}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+\+k3s1$'; then
-            export INSTALL_K3S_VERSION=v1.31.0+k3s1
-          else
-            export INSTALL_K3S_VERSION=${{ matrix.install_k3s_version }}
-          fi
+          . hack/k8s-versions.sh
+          export INSTALL_K3S_VERSION="${K8S_VERSIONS[$K8S_VERSION]}+k3s1"
 
           curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=stable \
             INSTALL_K3S_EXEC="--docker --kubelet-arg=config=${GITHUB_WORKSPACE}/test/e2e/manifests/kubelet-configuration.yaml" \

--- a/.spelling
+++ b/.spelling
@@ -183,6 +183,7 @@ liveness
 localhost
 maxFailures
 maxSuccess
+md
 memoization
 memoized
 memoizing

--- a/Makefile
+++ b/Makefile
@@ -712,7 +712,7 @@ endif
 .PHONY: docs-spellcheck
 docs-spellcheck: /usr/local/bin/mdspell
 	# check docs for spelling mistakes
-	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name upgrading.md -not -name executor_swagger.md -not -path '*/cli/*')
+	mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name upgrading.md -not -name executor_swagger.md -not -path '*/cli/*' -not -name tested-kubernetes-versions.md)
 	# alphabetize spelling file -- ignore first line (comment), then sort the rest case-sensitive and remove duplicates
 	$(shell cat .spelling | awk 'NR<2{ print $0; next } { print $0 | "LC_COLLATE=C sort" }' | uniq | tee .spelling > /dev/null)
 
@@ -737,7 +737,7 @@ endif
 .PHONY: docs-lint
 docs-lint: /usr/local/bin/markdownlint
 	# lint docs
-	markdownlint docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md
+	markdownlint docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md --ignore docs/tested-kubernetes-versions.md
 
 /usr/local/bin/mkdocs:
 # update this in Nix when upgrading it here
@@ -756,6 +756,9 @@ docs: /usr/local/bin/mkdocs \
 	# check environment-variables.md contains all variables mentioned in the code
 	./hack/docs/check-env-doc.sh
 	# build the docs
+ifeq ($(RELEASE_TAG),true)
+	./hack/docs/tested-versions.sh > docs/tested-kubernetes-versions.md
+endif
 	TZ=UTC mkdocs build --strict
 	# tell the user the fastest way to edit docs
 	@echo "ℹ️ If you want to preview your docs, open site/index.html. If you want to edit them with hot-reload, run 'make docs-serve' to start mkdocs on port 8000"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -38,25 +38,16 @@ Otherwise, we typically release every two weeks:
 * Patch fixes for the current stable version.
 * The next RC, if we are currently in a release cycle.
 
-## Kubernetes Compatibility Matrix
+## Tested Versions
 
-| Argo Workflows \ Kubernetes | 1.28 | 1.29 | 1.30 | 1.31 |
-|-----------------------------|------|------|------|------|
-| **main**                    | `✓`  | `✓`  | `✓`  | `✓`  |
-| **3.6**                    | `✓`  | `✓`  | `✓`  | `✓`  |
-| **3.5**                     | `✓`  | `✓`  | `✓`  | `?`  |
-| **3.4**                     | `?`  | `?`  | `?`  | `?`  |
+--8<-- "docs/tested-kubernetes-versions.md"
 
-* `✓` Fully supported versions.
-* `?` Due to breaking changes might not work. Also, we haven't thoroughly tested against this version.
-* `✕` Unsupported versions.
+Use the version selector to view the tested Kubernetes versions for a specific Argo Workflows version.
 
 ### Notes on Compatibility
 
-Argo versions may be compatible with newer and older Kubernetes versions (indicated by `?`), but only three minor versions are tested unless otherwise noted.
+Argo versions may be compatible with newer and older Kubernetes versions, but only two minor versions are tested.
 
 Note that Kubernetes [is backward compatible with clients](https://github.com/kubernetes/client-go/tree/aa7909e7d7c0661792ba21b9e882f3cd6ad0ce53?tab=readme-ov-file#compatibility-client-go---kubernetes-clusters), so newer k8s versions are generally supported.
 The caveats with newer k8s versions are possible changes to experimental APIs and unused new features.
 Argo uses stable Kubernetes APIs such as Pods and ConfigMaps; see the Controller and Server RBAC of your [installation](installation.md) for a full list.
-
-The `main` branch is currently [tested on Kubernetes 1.28](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L228) and [1.31](https://github.com/argoproj/argo-workflows/blob/main/.github/workflows/ci-build.yaml#L263).

--- a/docs/tested-kubernetes-versions.md
+++ b/docs/tested-kubernetes-versions.md
@@ -1,0 +1,1 @@
+This section is only populated for released Argo Workflows versions.

--- a/hack/docs/tested-versions.sh
+++ b/hack/docs/tested-versions.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+. hack/k8s-versions.sh
+printf 'This version is tested under Kubernetes %s and %s.' "${K8S_VERSIONS[min]}" "${K8S_VERSIONS[max]}"

--- a/hack/k8s-versions.sh
+++ b/hack/k8s-versions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Centralized config to define the minimum and maximum tested Kubernetes versions.
+# This is used in the CI workflow for e2e tests, the devcontainer, and to generate docs.
+declare -A K8S_VERSIONS=(
+  [min]=v1.29.13
+  [max]=v1.32.1
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ validation:
 exclude_docs: |
   /proposals/
   /requirements.txt
+  /tested-kubernetes-versions.md
 
 nav:
   - Home: README.md


### PR DESCRIPTION
Signed-off-by: Mason Malone <651224+MasonM@users.noreply.github.com>
(cherry picked from commit f5d59e9a69460196545652f89b351ee60107db0e)

