### PR TITLE
docs: fix kubernetes versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -762,7 +762,7 @@ docs: /usr/local/bin/mkdocs \
 	# check environment-variables.md contains all variables mentioned in the code
 	./hack/docs/check-env-doc.sh
 	# build the docs
-ifeq ($(RELEASE_TAG),true)
+ifeq ($(shell echo $(GIT_BRANCH) | head -c 8),release-)
 	./hack/docs/tested-versions.sh > docs/tested-kubernetes-versions.md
 endif
 	TZ=UTC mkdocs build --strict


### PR DESCRIPTION
Fixes kubernetes versions in documentation - this doesn't work as hoped from #14176 

### Motivation

Docs get rebuilt on every push to a branch, so `RELEASE_TAG` isn't usable

### Modifications

Use the `GIT_BRANCH` variable and check we're on an appropriate branch

### Verification

`make docs`

### Documentation

Not needed