### PR TITLE
fix: remove UID from securitycontext, redundant to UID in Dockerfile Fixes #14279

### DIFF
--- a/workflow/common/security_context.go
+++ b/workflow/common/security_context.go
@@ -10,7 +10,7 @@ func MinimalCtrSC() *corev1.SecurityContext {
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		Privileged:               ptr.To(false),
 		RunAsNonRoot:             ptr.To(true),
-		RunAsUser:                ptr.To(int64(8737)),
+		RunAsUser:                nil,
 		ReadOnlyRootFilesystem:   ptr.To(true),
 		AllowPrivilegeEscalation: ptr.To(false),
 		SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
@@ -20,7 +20,7 @@ func MinimalCtrSC() *corev1.SecurityContext {
 func MinimalPodSC() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
 		RunAsNonRoot:   ptr.To(true),
-		RunAsUser:      ptr.To(int64(8737)),
+		RunAsUser:      nil,
 		SeccompProfile: &corev1.SeccompProfile{Type: "RuntimeDefault"},
 	}
 }


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14279

### Motivation

<!-- TODO: Say why you made your changes. -->

Argo should work easily in OpenShift and non-OpenShift environment. Currently, the UID 8737 is hard-coded in code, both in Dockerfile and in YAML resource to apply. This is redundant, and makes it fail in OpenShift, where a pod policy such as "UID must be in range 10000000-10010000" . This pod policy can also be dynamic, per OpenShift project, so another one might says "UID must be in range 20000000-20010000". So it is a nightmare to deploy ARGO and specifies each UID, while NOT settting the runAsUser UID in YAML resource, allows Kubernetes to use the default one in Dockerfile in non-OpenShift environment, and use the default high UID in the range in OpenShift environment.

### Modifications

<!-- TODO: Say what changes you made. -->
Just removed the UID in runAsUser by setting it to `nil`.
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
This changes nothing in use, and override of this UID for artgc pod has not yet been documented I believe. But from the other issue I found, the override with PodSpecPatch (described in my issue #14279 workaround) works before and after this pullrequest.
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
