### PR TITLE
docs: clarify that container templates have an automatic result output

### DIFF
--- a/docs/walk-through/scripts-and-results.md
+++ b/docs/walk-through/scripts-and-results.md
@@ -58,6 +58,6 @@ spec:
 The `script` keyword allows the specification of the script body using the `source` tag.
 This creates a temporary file containing the script body and then passes the name of the temporary file as the final parameter to `command`, which should be an interpreter that executes the script body.
 
-In the same way as `container` tempalates do, the use of the `script` feature also assigns the standard output of running the script to a special output parameter named `result`.
+In the same way as `container` templates do, the use of the `script` feature also assigns the standard output of running the script to a special output parameter named `result`.
 This allows you to use the result of running the script itself in the rest of the workflow spec.
 In this example, the result is simply echoed by the print-message template.

--- a/docs/walk-through/scripts-and-results.md
+++ b/docs/walk-through/scripts-and-results.md
@@ -55,6 +55,9 @@ spec:
       args: ["echo result was: {{inputs.parameters.message}}"]
 ```
 
-The `script` keyword allows the specification of the script body using the `source` tag. This creates a temporary file containing the script body and then passes the name of the temporary file as the final parameter to `command`, which should be an interpreter that executes the script body.
+The `script` keyword allows the specification of the script body using the `source` tag.
+This creates a temporary file containing the script body and then passes the name of the temporary file as the final parameter to `command`, which should be an interpreter that executes the script body.
 
-The use of the `script` feature also assigns the standard output of running the script to a special output parameter named `result`. This allows you to use the result of running the script itself in the rest of the workflow spec. In this example, the result is simply echoed by the print-message template.
+In the same way as `container` tempalates do, the use of the `script` feature also assigns the standard output of running the script to a special output parameter named `result`.
+This allows you to use the result of running the script itself in the rest of the workflow spec.
+In this example, the result is simply echoed by the print-message template.

--- a/docs/workflow-concepts.md
+++ b/docs/workflow-concepts.md
@@ -50,7 +50,7 @@ These templates _define_ work to be done, usually in a Container.
 
 Perhaps the most common template type, it will schedule a Container.
 The spec of the template is the same as the [Kubernetes container spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container), so you can define a container here the same way you do anywhere else in Kubernetes.
-The result of the container is automatically exported into an [Argo variable](./variables.md) either `{{tasks.<NAME>.outputs.result}}` or `{{steps.<NAME>.outputs.result}}`, depending how it was called.
+The standard output of the container is automatically exported into an [Argo variable](./variables.md) either `{{tasks.<NAME>.outputs.result}}` or `{{steps.<NAME>.outputs.result}}`, depending how it was called.
 
 Example:
 
@@ -67,7 +67,7 @@ Example:
 A convenience wrapper around a `container`.
 The spec is the same as a container, but adds the `source:` field which allows you to define a script in-place.
 The script will be saved into a file and executed for you.
-The result of the script is automatically exported into an [Argo variable](./variables.md) in the same way as a Container Template.
+The standard output of the script is automatically exported into an [Argo variable](./variables.md) in the same way as a Container Template.
 
 Example:
 

--- a/docs/workflow-concepts.md
+++ b/docs/workflow-concepts.md
@@ -50,6 +50,7 @@ These templates _define_ work to be done, usually in a Container.
 
 Perhaps the most common template type, it will schedule a Container.
 The spec of the template is the same as the [Kubernetes container spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container), so you can define a container here the same way you do anywhere else in Kubernetes.
+The result of the container is automatically exported into an [Argo variable](./variables.md) either `{{tasks.<NAME>.outputs.result}}` or `{{steps.<NAME>.outputs.result}}`, depending how it was called.
 
 Example:
 
@@ -66,7 +67,7 @@ Example:
 A convenience wrapper around a `container`.
 The spec is the same as a container, but adds the `source:` field which allows you to define a script in-place.
 The script will be saved into a file and executed for you.
-The result of the script is automatically exported into an [Argo variable](./variables.md) either `{{tasks.<NAME>.outputs.result}}` or `{{steps.<NAME>.outputs.result}}`, depending how it was called.
+The result of the script is automatically exported into an [Argo variable](./variables.md) in the same way as a Container Template.
 
 Example:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation

People lean into `script` templates for their automatic output capabilities, which `container` templates also offer. Wanted to make this more clear in the docs.


### Verification

`make docs`



<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
