### PR TITLE
fix: merge template defaults before processing. Fixes #13691

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1942,6 +1942,12 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 		woc.updated = true
 	}
 
+	// Merge Template defaults to template
+	err = woc.mergedTemplateDefaultsInto(resolvedTmpl)
+	if err != nil {
+		return woc.initializeNodeOrMarkError(node, nodeName, templateScope, orgTmpl, opts.boundaryID, opts.nodeFlag, err), err
+	}
+
 	localParams := make(map[string]string)
 	// Inject the pod name. If the pod has a retry strategy, the pod name will be changed and will be injected when it
 	// is determined
@@ -1956,12 +1962,6 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	}
 
 	localParams["node.name"] = nodeName
-
-	// Merge Template defaults to template
-	err = woc.mergedTemplateDefaultsInto(resolvedTmpl)
-	if err != nil {
-		return woc.initializeNodeOrMarkError(node, nodeName, templateScope, orgTmpl, opts.boundaryID, opts.nodeFlag, err), err
-	}
 
 	// Inputs has been processed with arguments already, so pass empty arguments.
 	processedTmpl, err := common.ProcessArgs(resolvedTmpl, &args, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13961

### Motivation

<!-- TODO: Say why you made your changes. -->

`{{pod.name}}` variable is wrong when using `retryStrategy` within `templateDefaults`.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Merge template defaults to `resolvedTmpl` before we check if `resolvedTmpl` has a retry strategy.

### Verification

<!-- TODO: Say how you tested your changes. -->
```YAML
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: test-pod-name-
spec:
  entrypoint: main
  templateDefaults:
    retryStrategy:
        limit: '2'
  templates:
    - name: main
      dag:
        tasks:
          - name: get-pod-name
            template: get-pod-name
    - name: get-pod-name
      container:
        name: main
        image: busybox
        command: [sh, -c]
        args: ["echo {{pod.name}}"]
```
```shell
# argo get test-pod-name-pv5t9     
Name:                test-pod-name-pv5t9
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Succeeded
Conditions:          
 PodRunning          False
 Completed           True
Created:             Fri Mar 14 15:13:30 +0800 (40 seconds ago)
Started:             Fri Mar 14 15:13:30 +0800 (40 seconds ago)
Finished:            Fri Mar 14 15:13:38 +0800 (32 seconds ago)
Duration:            8 seconds
Progress:            1/1
ResourcesDuration:   0s*(1 cpu),3s*(100Mi memory)

STEP                       TEMPLATE      PODNAME                         DURATION  MESSAGE
 ✔ test-pod-name-pv5t9(0)  main                                                      
 └─✔ get-pod-name(0)       get-pod-name  test-pod-name-pv5t9-2748205058  5s

# argo logs test-pod-name-pv5t9           
test-pod-name-pv5t9-2748205058: time="2025-03-14T07:13:33.697Z" level=info msg="capturing logs" argo=true
test-pod-name-pv5t9-2748205058: test-pod-name-pv5t9-2748205058
test-pod-name-pv5t9-2748205058: time="2025-03-14T07:13:34.698Z" level=info msg="sub-process exited" argo=true error="<nil>"
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
