### PR TITLE
feat: more granular caching options for argoKubeClient informer

### DIFF
--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -41,15 +41,27 @@ type ArgoKubeOpts struct {
 	// Closing caching channel will stop caching informers
 	CachingCloseCh chan struct{}
 
-	// Whether to cache WorkflowTemplates, ClusterWorkflowTemplates and Workflows
-	// This improves performance of reading
-	// It is especially visible during validating templates,
+	// Whether to cache Workflows
+	// This improves performance of reading Workflows, but it increases memory usage and startup time
+	//
+	// Workflow caching uses in-memory SQLite DB and it provides full capabilities
+	CacheWorkflows bool
+
+	// Whether to cache WorkflowTemplates
+	// This improves performance of reading WorkflowTemplates, but it increases memory usage and startup time
+	// It is especially visible during validating templates with many references,
 	//
 	// Note that templates caching currently uses informers, so not all template
 	// get/list can use it, since informer has limited capabilities (such as filtering)
+	CacheWorkflowTemplates bool
+
+	// Whether to cache ClusterWorkflowTemplates
+	// This improves performance of reading ClusterWorkflowTemplates, but it increases memory usage and startup time
+	// It is especially visible during validating templates with many references,
 	//
-	// Workflow caching uses in-memory SQLite DB and it provides full capabilities
-	UseCaching bool
+	// Note that templates caching currently uses informers, so not all template
+	// get/list can use it, since informer has limited capabilities (such as filtering)
+	CacheClusterWorkflowTemplates bool
 }
 
 type argoKubeClient struct {
@@ -125,28 +137,36 @@ func newArgoKubeClient(ctx context.Context, opts ArgoKubeOpts, clientConfig clie
 }
 
 func (a *argoKubeClient) startStores(restConfig *restclient.Config, namespace string) error {
-	if a.opts.UseCaching {
-		wftmplInformer, err := workflowtemplateserver.NewInformer(restConfig, namespace)
-		if err != nil {
-			return err
-		}
-		cwftmplInformer, err := clusterworkflowtmplserver.NewInformer(restConfig)
-		if err != nil {
-			return err
-		}
+	if a.opts.CacheWorkflows {
 		wfStore, err := store.NewSQLiteStore(a.instanceIDService)
 		if err != nil {
 			return err
 		}
-		wftmplInformer.Run(a.opts.CachingCloseCh)
-		cwftmplInformer.Run(a.opts.CachingCloseCh)
 		a.wfStore = wfStore
 		a.wfLister = wfStore
-		a.wfTmplStore = wftmplInformer
-		a.cwfTmplStore = cwftmplInformer
 	} else {
 		a.wfLister = store.NewKubeLister(a.wfClient)
+	}
+
+	if a.opts.CacheWorkflowTemplates {
+		wftmplInformer, err := workflowtemplateserver.NewInformer(restConfig, namespace)
+		if err != nil {
+			return err
+		}
+		wftmplInformer.Run(a.opts.CachingCloseCh)
+		a.wfTmplStore = wftmplInformer
+	} else {
 		a.wfTmplStore = workflowtemplateserver.NewWorkflowTemplateClientStore()
+	}
+
+	if a.opts.CacheClusterWorkflowTemplates {
+		cwftmplInformer, err := clusterworkflowtmplserver.NewInformer(restConfig)
+		if err != nil {
+			return err
+		}
+		cwftmplInformer.Run(a.opts.CachingCloseCh)
+		a.cwfTmplStore = cwftmplInformer
+	} else {
 		a.cwfTmplStore = clusterworkflowtmplserver.NewClusterWorkflowTemplateClientStore()
 	}
 	return nil


### PR DESCRIPTION
separate config for workflows, templates and cluster workflow templates

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

Enable argoKubeClient more glanural caching by separate switch for `Workflow`, `WorkflowTemplate` and `ClusterWorkflowTemplate`

This is a follow up #13672 

### Modifications

Changes to `ArgoKubeOpts` - replace single toggle with per-resource toggle.  
While this could be a breaking change for SDK users it's changing part of the SDK interface that is not released yet. 

### Verification

Used it in our dev cluster. 
Why no automated tests? The SDK clients doesn't have tests. While this should be fixed, it's not in scope of such small change to implement testing strategy for this part of the code. 

### Documentation

Documentation: godoc
This change is for users implementing programatic access to workflows - the main documentation is in the godoc. 

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
