### PR TITLE
fix(build): downgrade dev container image due to Python issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
-  "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04",
+  // TODO: Bump to ubuntu-24.04 once Python issues are fixed: https://github.com/argoproj/argo-workflows/pull/14302#issuecomment-2742883052
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04",
   "appPort": 8080,
   "features": {
     "ghcr.io/devcontainers/features/go:1": {


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation


https://github.com/argoproj/argo-workflows/pull/14302 changed the dev container image from
`mcr.microsoft.com/vscode/devcontainers/base:ubuntu` to `mcr.microsoft.com/vscode/devcontainers/base:ubuntu-24.04`. Per [the official docs](https://github.com/devcontainers/images/tree/main/src/base-ubuntu), the former is supposed to correspond to the latest LTS release, but it's currently pointing to the previous LTS release (22.04). In any case, `make docs` currently doesn't work in Ubuntu 24.04 due to Python-related issues, as reported in https://github.com/argoproj/argo-workflows/pull/14302#issuecomment-2742883052

### Modifications


This changes the image to `mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04`, which is currently identical to
`mcr.microsoft.com/vscode/devcontainers/base:ubuntu`, though that's certain to change in the future:
```
$ docker image ls --filter=reference=mcr.microsoft.com/vscode/devcontainers/base
REPOSITORY                                    TAG            IMAGE ID       CREATED        SIZE
mcr.microsoft.com/vscode/devcontainers/base   ubuntu         3a38a75d10aa   5 days ago     701MB
mcr.microsoft.com/vscode/devcontainers/base   ubuntu-22.04   3a38a75d10aa   5 days ago     701MB
mcr.microsoft.com/vscode/devcontainers/base   ubuntu-24.04   0b460ab3f47c   5 months ago   731MB
```

### Verification

Rebuilt the devcontainer using "Dev Containers: Rebuild Container Without Cache" and verified `make docs` works now:
<details>
<summary>Click here for output</summary>

```
$ make docs
GIT_COMMIT=33bd0ca0543efb6d91427870331df3095d10a3a0 GIT_BRANCH=build-ubuntu-22-04 GIT_TAG=untagged GIT_TREE_STATE=dirty RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-k3s-default K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
python -m pip install --no-cache-dir -r docs/requirements.txt
Defaulting to user installation because normal site-packages is not writeable
Collecting mkdocs-material==9.*
  Downloading mkdocs_material-9.6.9-py3-none-any.whl (8.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.7/8.7 MB 44.7 MB/s eta 0:00:00
Collecting mkdocs-redirects==1.*
  Downloading mkdocs_redirects-1.2.2-py3-none-any.whl (6.1 kB)
Collecting colorama~=0.4
  Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting markdown~=3.2
  Downloading Markdown-3.7-py3-none-any.whl (106 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 106.3/106.3 KB 690.0 MB/s eta 0:00:00
Collecting backrefs~=5.7.post1
  Downloading backrefs-5.8-py310-none-any.whl (380 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 380.3/380.3 KB 226.2 MB/s eta 0:00:00
Collecting pymdown-extensions~=10.2
  Downloading pymdown_extensions-10.14.3-py3-none-any.whl (264 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 264.5/264.5 KB 256.4 MB/s eta 0:00:00
Collecting mkdocs~=1.6
  Downloading mkdocs-1.6.1-py3-none-any.whl (3.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.9/3.9 MB 110.5 MB/s eta 0:00:00
Collecting paginate~=0.5
  Downloading paginate-0.5.7-py2.py3-none-any.whl (13 kB)
Collecting pygments~=2.16
  Downloading pygments-2.19.1-py3-none-any.whl (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 119.9 MB/s eta 0:00:00
Collecting jinja2~=3.0
  Downloading jinja2-3.1.6-py3-none-any.whl (134 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.9/134.9 KB 590.1 MB/s eta 0:00:00
Collecting mkdocs-material-extensions~=1.3
  Downloading mkdocs_material_extensions-1.3.1-py3-none-any.whl (8.7 kB)
Collecting requests~=2.26
  Downloading requests-2.32.3-py3-none-any.whl (64 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.9/64.9 KB 442.4 MB/s eta 0:00:00
Collecting babel~=2.10
  Downloading babel-2.17.0-py3-none-any.whl (10.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.2/10.2 MB 96.2 MB/s eta 0:00:00
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (20 kB)
Collecting mkdocs-get-deps>=0.2.0
  Downloading mkdocs_get_deps-0.2.0-py3-none-any.whl (9.5 kB)
Collecting click>=7.0
  Downloading click-8.1.8-py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.2/98.2 KB 646.3 MB/s eta 0:00:00
Collecting ghp-import>=1.0
  Downloading ghp_import-2.1.0-py3-none-any.whl (11 kB)
Collecting packaging>=20.5
  Downloading packaging-24.2-py3-none-any.whl (65 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.5/65.5 KB 513.8 MB/s eta 0:00:00
Collecting mergedeep>=1.3.4
  Downloading mergedeep-1.3.4-py3-none-any.whl (6.4 kB)
Collecting watchdog>=2.0
  Downloading watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl (79 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79.1/79.1 KB 628.9 MB/s eta 0:00:00
Collecting pyyaml-env-tag>=0.1
  Downloading pyyaml_env_tag-0.1-py3-none-any.whl (3.9 kB)
Collecting pathspec>=0.11.1
  Downloading pathspec-0.12.1-py3-none-any.whl (31 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (751 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 751.2/751.2 KB 122.0 MB/s eta 0:00:00
Collecting charset-normalizer<4,>=2
  Downloading charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (146 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 146.1/146.1 KB 611.5 MB/s eta 0:00:00
Collecting idna<4,>=2.5
  Downloading idna-3.10-py3-none-any.whl (70 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 70.4/70.4 KB 505.1 MB/s eta 0:00:00
Collecting urllib3<3,>=1.21.1
  Downloading urllib3-2.3.0-py3-none-any.whl (128 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 128.4/128.4 KB 680.6 MB/s eta 0:00:00
Collecting certifi>=2017.4.17
  Downloading certifi-2025.1.31-py3-none-any.whl (166 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 166.4/166.4 KB 629.6 MB/s eta 0:00:00
Collecting python-dateutil>=2.8.1
  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 229.9/229.9 KB 338.3 MB/s eta 0:00:00
Collecting platformdirs>=2.2.0
  Downloading platformdirs-4.3.7-py3-none-any.whl (18 kB)
Collecting six>=1.5
  Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: paginate, watchdog, urllib3, six, pyyaml, pygments, platformdirs, pathspec, packaging, mkdocs-material-extensions, mergedeep, MarkupSafe, markdown, idna, colorama, click, charset-normalizer, certifi, backrefs, babel, requests, pyyaml-env-tag, python-dateutil, pymdown-extensions, mkdocs-get-deps, jinja2, ghp-import, mkdocs, mkdocs-redirects, mkdocs-material
Successfully installed MarkupSafe-3.0.2 babel-2.17.0 backrefs-5.8 certifi-2025.1.31 charset-normalizer-3.4.1 click-8.1.8 colorama-0.4.6 ghp-import-2.1.0 idna-3.10 jinja2-3.1.6 markdown-3.7 mergedeep-1.3.4 mkdocs-1.6.1 mkdocs-get-deps-0.2.0 mkdocs-material-9.6.9 mkdocs-material-extensions-1.3.1 mkdocs-redirects-1.2.2 packaging-24.2 paginate-0.5.7 pathspec-0.12.1 platformdirs-4.3.7 pygments-2.19.1 pymdown-extensions-10.14.3 python-dateutil-2.9.0.post0 pyyaml-6.0.2 pyyaml-env-tag-0.1 requests-2.32.3 six-1.17.0 urllib3-2.3.0 watchdog-6.0.0
npm list -g markdown-spellcheck@1.3.1 > /dev/null || npm i -g markdown-spellcheck@1.3.1
npm notice
npm notice New major version of npm available! 10.8.2 -> 11.2.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.2.0
npm notice To update run: npm install -g npm@11.2.0
npm notice
npm warn deprecated samsam@1.1.2: This package has been deprecated in favour of @sinonjs/samsam
npm warn deprecated formatio@1.1.1: This package is unmaintained. Use @sinonjs/formatio instead
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated sinon@1.17.7: 16.1.1

added 114 packages in 3s

19 packages are looking for funding
  run `npm fund` for details
Rebuilding docs/metrics.md
go run ./util/telemetry/builder --metricsDocs docs/metrics.md
go: downloading github.com/nao1215/markdown v0.6.0
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading github.com/karrick/godirwalk v1.17.0
go: downloading github.com/mattn/go-runewidth v0.0.15
go: downloading github.com/rivo/uniseg v0.4.4
# check docs for spelling mistakes
mdspell --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report docs/http-template.md docs/windows.md docs/workflow-pod-security-context.md docs/running-at-massive-scale.md docs/running-nix.md docs/managed-namespace.md docs/CONTRIBUTING.md docs/running-locally.md docs/async-pattern.md docs/disaster-recovery.md docs/client-libraries.md docs/links.md docs/installation.md docs/estimated-duration.md docs/inline-templates.md docs/ide-setup.md docs/debug-pause.md docs/environment-variables.md docs/plugins.md docs/metrics.md docs/workflow-events.md docs/workflow-inputs.md docs/workflow-concepts.md docs/cron-workflows.md docs/container-set-template.md docs/events.md docs/intermediate-inputs.md docs/configure-artifact-repository.md docs/argo-server.md docs/kubectl.md docs/workflow-rbac.md docs/workflow-archive.md docs/empty-dir.md docs/rest-api.md docs/tls.md docs/conditional-artifacts-parameters.md docs/cluster-workflow-templates.md docs/quick-start.md docs/data-sourcing-and-transformation.md docs/high-availability.md docs/variables.md docs/architecture.md docs/stress-testing.md docs/memoization.md docs/faq.md docs/releases.md docs/proposals/makefile-improvement-proposal.md docs/proposals/artifact-gc-proposal.md docs/proposals/cron-wf-improvement-proposal.md docs/work-avoidance.md docs/cron-backfill.md docs/doc-changes.md docs/cost-optimisation.md docs/training.md docs/parallelism.md docs/suspend-template.md docs/use-cases/ci-cd.md docs/use-cases/stream-processing.md docs/use-cases/machine-learning.md docs/use-cases/data-processing.md docs/use-cases/other.md docs/use-cases/infrastructure-automation.md docs/swagger.md docs/title-and-description.md docs/sidecar-injection.md docs/artifact-repository-ref.md docs/lifecyclehook.md docs/argo-server-sso-argocd.md docs/workflow-of-workflows.md docs/artifact-visualization.md docs/public-api.md docs/workflow-restrictions.md docs/static-code-analysis.md docs/access-token.md docs/workflow-creator.md docs/workflow-notifications.md docs/offloading-large-workflows.md docs/widgets.md docs/security.md docs/resource-duration.md docs/walk-through/parameters.md docs/walk-through/argo-cli.md docs/walk-through/dag.md docs/walk-through/hardwired-artifacts.md docs/walk-through/timeouts.md docs/walk-through/artifacts.md docs/walk-through/annotations.md docs/walk-through/kubernetes-resources.md docs/walk-through/output-parameters.md docs/walk-through/custom-template-variable-reference.md docs/walk-through/volumes.md docs/walk-through/index.md docs/walk-through/scripts-and-results.md docs/walk-through/conditionals.md docs/walk-through/retrying-failed-or-errored-steps.md docs/walk-through/suspending.md docs/walk-through/sidecars.md docs/walk-through/daemon-containers.md docs/walk-through/exit-handlers.md docs/walk-through/loops.md docs/walk-through/continuous-integration-examples.md docs/walk-through/hello-world.md docs/walk-through/docker-in-docker-using-sidecars.md docs/walk-through/the-structure-of-workflow-specs.md docs/walk-through/secrets.md docs/walk-through/recursion.md docs/walk-through/steps.md docs/new-features.md docs/argo-server-auth-mode.md docs/key-only-artifacts.md docs/progress.md docs/executor_plugins.md docs/plugin-directory.md docs/deprecations.md docs/webhdfs.md docs/service-account-secrets.md docs/argo-server-sso.md docs/node-field-selector.md docs/template-defaults.md docs/roadmap.md docs/webhooks.md docs/default-workflow-specs.md docs/workflow-templates.md docs/service-accounts.md docs/retries.md docs/workflow-submitting-workflow.md docs/enhanced-depends-logic.md docs/releasing.md docs/resource-template.md docs/workflow-controller-configmap.md docs/rest-examples.md docs/synchronization.md docs/scaling.md docs/tolerating-pod-deletion.md docs/survey-data-privacy.md docs/workflow-executors.md docs/configure-archive-logs.md
>> 137 files are free from spelling errors
# alphabetize spelling file -- ignore first line (comment), then sort the rest case-sensitive and remove duplicates
npm list -g markdownlint-cli@0.33.0 > /dev/null || npm i -g markdownlint-cli@0.33.0
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@8.0.3: Glob versions prior to v9 are no longer supported

added 27 packages in 859ms

5 packages are looking for funding
  run `npm fund` for details
# lint docs
markdownlint docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md --ignore docs/tested-kubernetes-versions.md
# docs-linkcheck
# copy README.md to docs/README.md
./hack/docs/copy-readme.sh
# check environment-variables.md contains all variables mentioned in the code
./hack/docs/check-env-doc.sh
Checking docs/environment-variables.md for completeness...
✅ Success - all environment variables appear to be documented
# build the docs
TZ=UTC mkdocs build --strict
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/vscode/go/src/github.com/argoproj/argo-workflows/site
INFO    -  Doc file 'container-set-template.md' contains a link '#️-resource-requests', but there is no such anchor on this page.
INFO    -  Doc file 'executor_swagger.md' contains a link '#interface', but there is no such anchor on this page.
INFO    -  Doc file 'metrics.md' contains a link 'deprecations.md#cronworkflow_schedule', but the doc 'deprecations.md' does not contain an anchor '#cronworkflow_schedule'.
INFO    -  Doc file 'metrics.md' contains a link 'deprecations.md#synchronization_mutex', but the doc 'deprecations.md' does not contain an anchor '#synchronization_mutex'.
INFO    -  Doc file 'metrics.md' contains a link 'deprecations.md#synchronization_semaphore', but the doc 'deprecations.md' does not contain an anchor '#synchronization_semaphore'.
INFO    -  Doc file 'metrics.md' contains a link 'deprecations.md#workflow_podpriority', but the doc 'deprecations.md' does not contain an anchor '#workflow_podpriority'.
INFO    -  Doc file 'new-features.md' contains a link 'upgrading.md#upgrading_to_v3.6', but the doc 'upgrading.md' does not contain an anchor '#upgrading_to_v3.6'.
INFO    -  Doc file 'new-features.md' contains a link 'upgrading.md#metrics_changes', but the doc 'upgrading.md' does not contain an anchor '#metrics_changes'.
INFO    -  Documentation built in 4.54 seconds
# tell the user the fastest way to edit docs
ℹ️ If you want to preview your docs, open site/index.html. If you want to edit them with hot-reload, run 'make docs-serve' to start mkdocs on port 8000
```
</details>

### Documentation
N/A
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
