### PR TITLE
fix: semaphore configmap retry on transient error. Fixes #14335

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -389,13 +389,13 @@ func (wfc *WorkflowController) createSynchronizationManager(ctx context.Context)
 		if err != nil {
 			return 0, err
 		}
-        configmapsIf := wfc.kubeclientset.CoreV1().ConfigMaps(lockName.Namespace)
-        var configMap *apiv1.ConfigMap
-        err = waitutil.Backoff(retry.DefaultRetry, func() (bool, error) {
-                var err error
-                configMap, err = configmapsIf.Get(ctx, lockName.ResourceName, metav1.GetOptions{})
-                return !errorsutil.IsTransientErr(err), err
-        })
+		configmapsIf := wfc.kubeclientset.CoreV1().ConfigMaps(lockName.Namespace)
+		var configMap *apiv1.ConfigMap
+		err = waitutil.Backoff(retry.DefaultRetry, func() (bool, error) {
+			var err error
+			configMap, err = configmapsIf.Get(ctx, lockName.ResourceName, metav1.GetOptions{})
+			return !errorsutil.IsTransientErr(err), err
+		})
 		if err != nil {
 			return 0, err
 		}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -48,7 +48,10 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/deprecation"
 	"github.com/argoproj/argo-workflows/v3/util/env"
 	"github.com/argoproj/argo-workflows/v3/util/errors"
+	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
+	"github.com/argoproj/argo-workflows/v3/util/retry"
 	"github.com/argoproj/argo-workflows/v3/util/telemetry"
+	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 	"github.com/argoproj/argo-workflows/v3/workflow/artifactrepositories"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	controllercache "github.com/argoproj/argo-workflows/v3/workflow/controller/cache"
@@ -386,7 +389,13 @@ func (wfc *WorkflowController) createSynchronizationManager(ctx context.Context)
 		if err != nil {
 			return 0, err
 		}
-		configMap, err := wfc.kubeclientset.CoreV1().ConfigMaps(lockName.Namespace).Get(ctx, lockName.ResourceName, metav1.GetOptions{})
+        configmapsIf := wfc.kubeclientset.CoreV1().ConfigMaps(lockName.Namespace)
+        var configMap *apiv1.ConfigMap
+        err = waitutil.Backoff(retry.DefaultRetry, func() (bool, error) {
+                var err error
+                configMap, err = configmapsIf.Get(ctx, lockName.ResourceName, metav1.GetOptions{})
+                return !errorsutil.IsTransientErr(err), err
+        })
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14335 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

- The code change is same as [executor configmap retry](https://github.com/argoproj/argo-workflows/blob/main/workflow/executor/executor.go#L708-L712)
- We don't see the error reoccur in our production env after deploy the change

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
