### PR TITLE
fix(test): change `createdAfter` to UTC time. Fixes #14346

### DIFF
--- a/server/workflow/store/sqlite_store_test.go
+++ b/server/workflow/store/sqlite_store_test.go
@@ -175,43 +175,43 @@ func TestStoreOperation(t *testing.T) {
 	})
 	t.Run("TestListWorkflows finishedBefore", func(t *testing.T) {
 		// Finished before today
-		wfList, err := store.ListWorkflows(context.Background(), "argo", "", "", metav1.NewTime(time.Now()).Format(time.RFC3339), metav1.ListOptions{})
+		wfList, err := store.ListWorkflows(context.Background(), "argo", "", "", time.Now().Format(time.RFC3339), metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, wfList.Items, 9)
 
 		// Finished before 1 day ago
-		wfList, err = store.ListWorkflows(context.Background(), "argo", "", "", metav1.NewTime(time.Now().Add(-24*time.Hour)).Format(time.RFC3339), metav1.ListOptions{})
+		wfList, err = store.ListWorkflows(context.Background(), "argo", "", "", time.Now().Add(-24*time.Hour).Format(time.RFC3339), metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, wfList.Items, 8)
 
 		// Finished before 5 days ago
-		wfList, err = store.ListWorkflows(context.Background(), "argo", "", "", metav1.NewTime(time.Now().Add(-5*24*time.Hour)).Format(time.RFC3339), metav1.ListOptions{})
+		wfList, err = store.ListWorkflows(context.Background(), "argo", "", "", time.Now().Add(-5*24*time.Hour).Format(time.RFC3339), metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, wfList.Items, 4)
 
 		// Finished before 10 days ago
-		wfList, err = store.ListWorkflows(context.Background(), "argo", "", "", metav1.NewTime(time.Now().Add(-24*10*time.Hour)).Format(time.RFC3339), metav1.ListOptions{})
+		wfList, err = store.ListWorkflows(context.Background(), "argo", "", "", time.Now().Add(-24*10*time.Hour).Format(time.RFC3339), metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Empty(t, wfList.Items)
 	})
 	t.Run("TestListWorkflows createdAfter", func(t *testing.T) {
 		// Created after today
-		wfList, err := store.ListWorkflows(context.Background(), "argo", "", time.Now().Format(time.RFC3339), "", metav1.ListOptions{})
+		wfList, err := store.ListWorkflows(context.Background(), "argo", "", time.Now().UTC().Format(time.RFC3339), "", metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Empty(t, wfList.Items)
 
 		// Created after 1 day ago
-		wfList, err = store.ListWorkflows(context.Background(), "argo", "", time.Now().Add(-24*time.Hour).Format(time.RFC3339), "", metav1.ListOptions{})
+		wfList, err = store.ListWorkflows(context.Background(), "argo", "", time.Now().UTC().Add(-24*time.Hour).Format(time.RFC3339), "", metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, wfList.Items, 1)
 
 		// Created after 3 days ago
-		wfList, err = store.ListWorkflows(context.Background(), "argo", "", time.Now().Add(-3*24*time.Hour).Format(time.RFC3339), "", metav1.ListOptions{})
+		wfList, err = store.ListWorkflows(context.Background(), "argo", "", time.Now().UTC().Add(-3*24*time.Hour).Format(time.RFC3339), "", metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, wfList.Items, 3)
 
 		// Created after 10 days ago
-		wfList, err = store.ListWorkflows(context.Background(), "argo", "", time.Now().Add(-10*24*time.Hour).Format(time.RFC3339), "", metav1.ListOptions{})
+		wfList, err = store.ListWorkflows(context.Background(), "argo", "", time.Now().UTC().Add(-10*24*time.Hour).Format(time.RFC3339), "", metav1.ListOptions{})
 		require.NoError(t, err)
 		assert.Len(t, wfList.Items, 9)
 	})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14346

### Motivation

`make test` fails as below:
```
--- FAIL: TestStoreOperation (0.00s)
    --- PASS: TestStoreOperation/TestAddWorkflow (0.00s)
    --- PASS: TestStoreOperation/TestUpdateWorkflow (0.00s)
    --- PASS: TestStoreOperation/TestDeleteWorkflow (0.00s)
    --- PASS: TestStoreOperation/TestListWorkflows (0.00s)
    --- PASS: TestStoreOperation/TestListWorkflows_name (0.00s)
    --- PASS: TestStoreOperation/TestListWorkflows_namePrefix (0.00s)
    --- PASS: TestStoreOperation/TestListWorkflows_namePattern (0.00s)
    --- PASS: TestStoreOperation/TestListWorkflows_finishedBefore (0.00s)
    --- FAIL: TestStoreOperation/TestListWorkflows_createdAfter (0.00s)
```

Local TimeZone: CST

`TestListWorkflows createdAfter` list workflows with query:
```SQL
select workflow from argo_workflows
where instanceid = ?
 and namespace = ? and json_extract(workflow, '$.metadata.creationTimestamp') >= ? order by startedat desc limit ? offset ?
```

`metadata.creationTimestamp` is UTC time, but the query input parameter is not.
https://github.com/argoproj/argo-workflows/blob/9b7c0c4c4ce1ecb8e1d27df95d14ccef09cffe0f/server/workflow/store/sqlite_store_test.go#L199


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

change `createdAfter` to UTC time

### Verification

<!-- TODO: Say how you tested your changes. -->
UT

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
