### PR TITLE
fix: silence noisy "Ignoring duplicate key error" messages. Fixes #14344

### DIFF
--- a/persist/sqldb/offload_node_status_repo.go
+++ b/persist/sqldb/offload_node_status_repo.go
@@ -93,7 +93,7 @@ func (wdc *nodeOffloadRepo) Save(uid, namespace string, nodes wfv1.Nodes) (strin
 		if !isDuplicateKeyError(err) {
 			return "", err
 		}
-		logCtx.WithField("err", err).Info("Ignoring duplicate key error")
+		logCtx.WithField("err", err).Debug("Ignoring duplicate key error")
 	}
 	// Don't need to clean up the old records here, we have a scheduled cleanup mechanism.
 	// If we clean them up here, when we update, if there is an update conflict, we will not be able to go back.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14344

### Motivation

When offloading a workflow, it's possible for multiple workers to concurrently call `Save()` with the same workflow, which leads to `ERROR: duplicate key value violates unique constraint "argo_workflows_pkey"` messages in the logs, along with a stack trace.

These messages are cluttering the logs and confusing users. Duplicate key errors are harmless: `Save()` detects them automatically and will return the `version` hash. Since `version` is part of the primary key of the `argo_workflows` table, that means it's guaranteed to be identical to the previously-inserted row.

### Modifications


This decreases the log level of that message to `DEBUG` so that it doesn't clutter the logs. I thought about removing it entirely, but I figured it's worth keeping just in case there's an edge case we need to debug.

### Verification


I wasn't able to reproduce the error locally, but I verified workflow offloading works by following these steps:
1. Start with PostgreSQL and `ALWAYS_OFFLOAD_NODE_STATUS` enabled: `make start PROFILE=postgres UI=true ALWAYS_OFFLOAD_NODE_STATUS=true`
2. Submit an example workflow through the UI
3. Verify it got inserted into the DB:
```console
$ make postgres-cli
GIT_COMMIT=a5de57b4bd4dd95f79fc7ff0fa95ba94cfacb91d GIT_BRANCH=fix-loglevel GIT_TAG=untagged GIT_TREE_STATE=clean RELEASE_TAG=false DEV_BRANCH=true VERSION=latest
KUBECTX=k3d-k3s-default K3D=true DOCKER_PUSH=false TARGET_PLATFORM=linux/amd64
RUN_MODE=local PROFILE=minimal AUTH_MODE=hybrid SECURE=false  STATIC_FILES=false ALWAYS_OFFLOAD_NODE_STATUS=false UPPERIO_DB_DEBUG=0 LOG_LEVEL=debug NAMESPACED=true
kubectl exec -ti svc/postgres -- psql -U postgres
psql (12.14)
Type "help" for help.

postgres=# select * from argo_workflows limit 1;
                 uid                  | namespace | clustername |    version     |                                                                                                                                                                                    nodes                                    
                                                                                                                                                |         updatedat          
--------------------------------------+-----------+-------------+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------
 c4239bc5-8d90-4ca2-9f1a-323a62fb9ee3 | argo      | default     | fnv:2543912711 | {"sparkly-poochenheimer":{"id":"sparkly-poochenheimer","name":"sparkly-poochenheimer","displayName":"sparkly-poochenheimer","type":"Pod","templateName":"argosay","templateScope":"local/sparkly-poochenheimer","phase":"Pen
ding","startedAt":"2025-04-04T23:29:23Z","finishedAt":null,"progress":"0/1","inputs":{"parameters":[{"name":"message","value":"hello argo"}]}}} | 2025-04-04 23:29:23.084941
(1 row)
```

### Documentation

N/A

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
