### PR TITLE
fix: added pagination to the workflow and pod listings. Fixes #14374

### DIFF
--- a/util/unstructured/unstructured.go
+++ b/util/unstructured/unstructured.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const workflowPaginationLimit = 500
+
 // NewUnstructuredInformer constructs a new informer for Unstructured type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
@@ -32,7 +34,29 @@ func NewFilteredUnstructuredInformer(resource schema.GroupVersionResource, clien
 				if tweakListRequestListOptions != nil {
 					tweakListRequestListOptions(&options)
 				}
-				return client.Resource(resource).Namespace(namespace).List(ctx, options)
+				var allWorkflows []unstructured.Unstructured
+				continueTok := ""
+				options.Limit = workflowPaginationLimit
+				for {
+					options.Continue = continueTok
+					unList, err := client.Resource(resource).Namespace(namespace).List(ctx, options)
+					if err != nil {
+						return nil, err
+					}
+					allWorkflows = append(allWorkflows, unList.Items...)
+
+					if unList.GetContinue() == "" {
+						break
+					}
+					continueTok = unList.GetContinue()
+				}
+				return &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "List",
+					},
+					Items: allWorkflows,
+				}, nil
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakWatchRequestListOptions != nil {

--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	podResyncPeriod = 30 * time.Minute
+	podResyncPeriod    = 30 * time.Minute
+	podPaginationLimit = 500
 )
 
 var (
@@ -292,7 +293,22 @@ func newWorkflowPodWatch(ctx context.Context, clientSet kubernetes.Interface, in
 
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		options.LabelSelector = labelSelector.String()
-		return c.List(ctx, options)
+		var allPods []v1.Pod
+		continueTok := ""
+		options.Limit = podPaginationLimit
+		for {
+			options.Continue = continueTok
+			podList, err := c.List(ctx, options)
+			if err != nil {
+				return nil, err
+			}
+			allPods = append(allPods, podList.Items...)
+			if podList.Continue == "" {
+				break
+			}
+			continueTok = podList.Continue
+		}
+		return &v1.PodList{Items: allPods}, nil
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		options.Watch = true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14374

### Motivation

This change ensures that pagination happens in our list calls to both pod and workflows. This is needed because when k8s has a large number of resources, it is generally better to perform some amount of pagination. 

### Modifications

Simple change that modified the list calls to use 'continue on' tokens.

### Verification

Tested to ensure the k8s api calls function as is.