### PR TITLE
fix(server/auth/webhook): update GitHub webhook events list and library version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-git/go-git/v5 v5.16.0
 	github.com/go-jose/go-jose/v3 v3.0.4
 	github.com/go-openapi/jsonreference v0.21.0
+	github.com/go-playground/webhooks/v6 v6.4.0
 	github.com/go-sql-driver/mysql v1.9.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
+github.com/go-playground/webhooks/v6 v6.4.0 h1:KLa6y7bD19N48rxJDHM0DpE3T4grV7GxMy1b/aHMWPY=
+github.com/go-playground/webhooks/v6 v6.4.0/go.mod h1:5lBxopx+cAJiBI4+kyRbuHrEi+hYRDdRHuRR4Ya5Ums=
 github.com/go-sql-driver/mysql v1.9.2 h1:4cNKDYQ1I84SXslGddlsrMhc8k4LeDVj6Ad6WRjiHuU=
 github.com/go-sql-driver/mysql v1.9.2/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/server/auth/webhook/github.go
+++ b/server/auth/webhook/github.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"net/http"
 
-	"gopkg.in/go-playground/webhooks.v5/github"
+	"github.com/go-playground/webhooks/v6/github"
 )
 
 func githubMatch(secret string, r *http.Request) bool {
@@ -14,12 +14,16 @@ func githubMatch(secret string, r *http.Request) bool {
 	_, err = hook.Parse(r,
 		github.CheckRunEvent,
 		github.CheckSuiteEvent,
+		github.CodeScanningAlertEvent,
 		github.CommitCommentEvent,
 		github.CreateEvent,
 		github.DeleteEvent,
+		github.DependabotAlertEvent,
+		github.DeployKeyEvent,
 		github.DeploymentEvent,
 		github.DeploymentStatusEvent,
 		github.ForkEvent,
+		github.GitHubAppAuthorizationEvent,
 		github.GollumEvent,
 		github.InstallationEvent,
 		github.InstallationRepositoriesEvent,
@@ -52,6 +56,9 @@ func githubMatch(secret string, r *http.Request) bool {
 		github.TeamEvent,
 		github.TeamAddEvent,
 		github.WatchEvent,
+		github.WorkflowDispatchEvent,
+		github.WorkflowJobEvent,
+		github.WorkflowRunEvent,
 	)
 	return err == nil
 }

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -60,7 +60,7 @@ func TestInterceptor(t *testing.T) {
 	t.Run("Github", func(t *testing.T) {
 		r, _ := intercept("POST", "/api/v1/events/my-ns/my-d", map[string]string{
 			"X-Github-Event":      "push",
-			"X-Hub-Signature-256": "00000ba880174336fbe22d4723a67ba5c4c356ec9c696",
+			"X-Hub-Signature-256": "sha256=323b66bd8d05fc4ee07c06c999097af9a462b551a04ba0860d6fb3fdc521a558",
 		})
 		assert.Equal(t, []string{"Bearer my-github-token"}, r.Header["Authorization"])
 	})

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -60,7 +60,7 @@ func TestInterceptor(t *testing.T) {
 	t.Run("Github", func(t *testing.T) {
 		r, _ := intercept("POST", "/api/v1/events/my-ns/my-d", map[string]string{
 			"X-Github-Event":      "push",
-			"X-Hub-Signature-256": "sha256=323b66bd8d05fc4ee07c06c999097af9a462b551a04ba0860d6fb3fdc521a558",
+			"X-Hub-Signature-256": "757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17",
 		})
 		assert.Equal(t, []string{"Bearer my-github-token"}, r.Header["Authorization"])
 	})

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -59,8 +59,8 @@ func TestInterceptor(t *testing.T) {
 	})
 	t.Run("Github", func(t *testing.T) {
 		r, _ := intercept("POST", "/api/v1/events/my-ns/my-d", map[string]string{
-			"X-Github-Event":  "push",
-			"X-Hub-Signature": "00000ba880174336fbe22d4723a67ba5c4c356ec9c696",
+			"X-Github-Event":      "push",
+			"X-Hub-Signature-256": "00000ba880174336fbe22d4723a67ba5c4c356ec9c696",
 		})
 		assert.Equal(t, []string{"Bearer my-github-token"}, r.Header["Authorization"])
 	})

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -60,7 +60,7 @@ func TestInterceptor(t *testing.T) {
 	t.Run("Github", func(t *testing.T) {
 		r, _ := intercept("POST", "/api/v1/events/my-ns/my-d", map[string]string{
 			"X-Github-Event":      "push",
-			"X-Hub-Signature-256": "757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17",
+			"X-Hub-Signature-256": "sha256=926ceeb8dcd67d5979fd7d726e3905af6d220f7fd6b2d8cce946906f7cf35963",
 		})
 		assert.Equal(t, []string{"Bearer my-github-token"}, r.Header["Authorization"])
 	})

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -182,7 +182,7 @@ spec:
 			s.e().
 				POST("/api/v1/events/argo/").
 				WithHeader("X-Github-Event", "push").
-				WithHeader("X-Hub-Signature", "sha1=c09e61386e81c2669e015049350500448148205c").
+				WithHeader("X-Hub-Signature-256", "sha1=c09e61386e81c2669e015049350500448148205c").
 				WithBytes(data).
 				Expect().
 				Status(200)

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -182,7 +182,7 @@ spec:
 			s.e().
 				POST("/api/v1/events/argo/").
 				WithHeader("X-Github-Event", "push").
-				WithHeader("X-Hub-Signature-256", "sha1=c09e61386e81c2669e015049350500448148205c").
+				WithHeader("X-Hub-Signature-256", "sha256=323b66bd8d05fc4ee07c06c999097af9a462b551a04ba0860d6fb3fdc521a558").
 				WithBytes(data).
 				Expect().
 				Status(200)

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -182,7 +182,7 @@ spec:
 			s.e().
 				POST("/api/v1/events/argo/").
 				WithHeader("X-Github-Event", "push").
-				WithHeader("X-Hub-Signature-256", "sha256=323b66bd8d05fc4ee07c06c999097af9a462b551a04ba0860d6fb3fdc521a558").
+				WithHeader("X-Hub-Signature-256", "sha256=dd6f6b41f6d0cb9523d6459032e164e220853b683a5e87892145b0eb0b84e0cd").
 				WithBytes(data).
 				Expect().
 				Status(200)


### PR DESCRIPTION
Fixes #14388

### Motivation
GitHub has expanded their webhook events system to include newer event types such as `workflow_run`, `workflow_dispatch`, and `workflow_job`. Currently, Argo Workflows doesn't recognize these newer event types in its GitHub webhook authentication mechanism, causing `401` authentication failures when these events are sent. This PR updates the list of supported GitHub webhook event types to align with GitHub's current list of events (within the newest version of the used library).

### Modifications
Updated the `githubMatch` function in `server/auth/webhook/github.go` to include the missing GitHub webhook event types:
- CodeScanningAlertEvent
- DependabotAlertEvent
- DeployKeyEvent
- GitHubAppAuthorizationEvent
- WorkflowDispatchEvent
- WorkflowJobEvent
- WorkflowRunEvent

Additionally, the updated webhook library (`go-playground/webhooks/v6`) now uses SHA-256 instead of SHA-1 for GitHub webhook signature validation. This required updating the test cases to use the `X-Hub-Signature-256` header with the `sha256=` prefix format instead of the previous SHA-1 format.

These changes ensure that Argo Workflows can properly authenticate and process both existing and newer event types from GitHub webhooks, while maintaining compatibility with GitHub's current security standards.

### Verification
I verified the changes by:
- Deploying the updated code to our Argo Workflows instance
- Configuring a GitHub webhook to send both release and `workflow_run` events
- Setting up WorkflowEventBindings for both event types
- Triggering both events from GitHub
- Confirming that both event types were properly authenticated and processed

Before the fix, the `workflow_run` events were being rejected with a `401` error, while `release` events were processed correctly. After the fix, both event types are properly authenticated and processed.

### Documentation
No documentation updates are required as this is a bug fix that aligns the code with expected behavior.