### PR TITLE
chore(lint): update golangci-lint to 2.1.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
-# https://golangci-lint.run/usage/quick-start/
+version: "2"
 run:
-  timeout: 12m
   build-tags:
     - api
     - cli
@@ -17,13 +16,7 @@ linters:
     - bodyclose
     - copyloopvar
     - errcheck
-    - goimports
-    # only minor issues
-    # - errorlint
-    # seems to have bugs in recent version, also slow
-    # - gci
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -34,34 +27,70 @@ linters:
     - sqlclosecheck
     - staticcheck
     - testifylint
-    - typecheck
     - unparam
     - unused
-linters-settings:
-  goimports:
-    local-prefixes: github.com/argoproj/argo-workflows/
-  gosec:
-    includes:
-      - G304
-      - G307
-    excludes:
-      # G106: Use of ssh InsecureIgnoreHostKey should be audited
-      - G106
-      # G402: TLS InsecureSkipVerify set true
-      - G402
-      # G601: Implicit memory aliasing in for loop.
-      - G601
-issues:
-  exclude-rules:
-    - path: server/artifacts/artifact_server_test.go
-      text: "response body must be closed"
-  exclude-dirs:
-    - dist
-    - docs
-    - examples
-    - hack
-    - manifests
-    - pkg/client
-    - sdks
-    - ui
-    - vendor
+  settings:
+    gosec:
+      includes:
+        - G304
+        - G307
+      excludes:
+        # G106: Use of ssh InsecureIgnoreHostKey should be audited
+        - G106
+        # G402: TLS InsecureSkipVerify set true
+        - G402
+    staticcheck:
+      checks:
+        - all
+        # Capitalised variable names
+        - "-ST1003"
+        # Capitalised error strings
+        - "-ST1005"
+        # Receiver names
+        - "-ST1016"
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: server/artifacts/artifact_server_test.go
+        text: response body must be closed
+    paths:
+      - dist
+      - docs
+      - examples
+      - hack
+      - manifests
+      - pkg/client
+      - sdks
+      - ui
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/argoproj/argo-workflows/
+  exclusions:
+    generated: lax
+    paths:
+      - dist
+      - docs
+      - examples
+      - hack
+      - manifests
+      - pkg/client
+      - sdks
+      - ui
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,7 @@ manifests-validate:
 	kubectl apply --server-side --validate=strict --dry-run=server -f 'manifests/*.yaml'
 
 $(TOOL_GOLANGCI_LINT): Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v1.61.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.1.1
 
 .PHONY: lint
 lint: ui/dist/app/index.html $(TOOL_GOLANGCI_LINT)

--- a/cmd/argo/commands/archive/get.go
+++ b/cmd/argo/commands/archive/get.go
@@ -70,8 +70,8 @@ func printWorkflow(wf *wfv1.Workflow, output string) {
 		fmt.Println(string(output))
 	default:
 		const fmtStr = "%-20s %v\n"
-		fmt.Printf(fmtStr, "Name:", wf.ObjectMeta.Name)
-		fmt.Printf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)
+		fmt.Printf(fmtStr, "Name:", wf.Name)
+		fmt.Printf(fmtStr, "Namespace:", wf.Namespace)
 		serviceAccount := wf.GetExecSpec().ServiceAccountName
 		if serviceAccount == "" {
 			// if serviceAccountName was not specified in a submitted Workflow, we will
@@ -85,7 +85,7 @@ func printWorkflow(wf *wfv1.Workflow, output string) {
 		if wf.Status.Message != "" {
 			fmt.Printf(fmtStr, "Message:", wf.Status.Message)
 		}
-		fmt.Printf(fmtStr, "Created:", humanize.Timestamp(wf.ObjectMeta.CreationTimestamp.Time))
+		fmt.Printf(fmtStr, "Created:", humanize.Timestamp(wf.CreationTimestamp.Time))
 		if !wf.Status.StartedAt.IsZero() {
 			fmt.Printf(fmtStr, "Started:", humanize.Timestamp(wf.Status.StartedAt.Time))
 		}

--- a/cmd/argo/commands/clustertemplate/list.go
+++ b/cmd/argo/commands/clustertemplate/list.go
@@ -48,7 +48,7 @@ func NewListCommand() *cobra.Command {
 				printTable(cwftmplList.Items)
 			case "name":
 				for _, cwftmp := range cwftmplList.Items {
-					fmt.Println(cwftmp.ObjectMeta.Name)
+					fmt.Println(cwftmp.Name)
 				}
 			default:
 				return fmt.Errorf("Unknown output mode: %s", output.String())
@@ -65,7 +65,7 @@ func printTable(wfList []wfv1.ClusterWorkflowTemplate) {
 	_, _ = fmt.Fprint(w, "NAME")
 	_, _ = fmt.Fprint(w, "\n")
 	for _, wf := range wfList {
-		_, _ = fmt.Fprintf(w, "%s\t", wf.ObjectMeta.Name)
+		_, _ = fmt.Fprintf(w, "%s\t", wf.Name)
 		_, _ = fmt.Fprintf(w, "\n")
 	}
 	_ = w.Flush()

--- a/cmd/argo/commands/clustertemplate/util.go
+++ b/cmd/argo/commands/clustertemplate/util.go
@@ -57,7 +57,7 @@ func unmarshalClusterWorkflowTemplates(wfBytes []byte, strict bool) ([]wfv1.Clus
 func printClusterWorkflowTemplate(wf *wfv1.ClusterWorkflowTemplate, outFmt string) {
 	switch outFmt {
 	case "name":
-		fmt.Println(wf.ObjectMeta.Name)
+		fmt.Println(wf.Name)
 	case "json":
 		outBytes, _ := json.MarshalIndent(wf, "", "    ")
 		fmt.Println(string(outBytes))
@@ -73,6 +73,6 @@ func printClusterWorkflowTemplate(wf *wfv1.ClusterWorkflowTemplate, outFmt strin
 
 func printClusterWorkflowTemplateHelper(wf *wfv1.ClusterWorkflowTemplate) {
 	const fmtStr = "%-20s %v\n"
-	fmt.Printf(fmtStr, "Name:", wf.ObjectMeta.Name)
-	fmt.Printf(fmtStr, "Created:", humanize.Timestamp(wf.ObjectMeta.CreationTimestamp.Time))
+	fmt.Printf(fmtStr, "Name:", wf.Name)
+	fmt.Printf(fmtStr, "Created:", humanize.Timestamp(wf.CreationTimestamp.Time))
 }

--- a/cmd/argo/commands/common/get.go
+++ b/cmd/argo/commands/common/get.go
@@ -52,8 +52,8 @@ func (g GetFlags) shouldPrint(node wfv1.NodeStatus) bool {
 func PrintWorkflowHelper(wf *wfv1.Workflow, getArgs GetFlags) string {
 	const fmtStr = "%-20s %v\n"
 	out := ""
-	out += fmt.Sprintf(fmtStr, "Name:", wf.ObjectMeta.Name)
-	out += fmt.Sprintf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)
+	out += fmt.Sprintf(fmtStr, "Name:", wf.Name)
+	out += fmt.Sprintf(fmtStr, "Namespace:", wf.Namespace)
 	serviceAccount := wf.GetExecSpec().ServiceAccountName
 	if serviceAccount == "" {
 		// if serviceAccountName was not specified in a submitted Workflow, we will
@@ -74,7 +74,7 @@ func PrintWorkflowHelper(wf *wfv1.Workflow, getArgs GetFlags) string {
 	if len(wf.Status.Conditions) > 0 {
 		out += wf.Status.Conditions.DisplayString(fmtStr, WorkflowConditionIconMap)
 	}
-	out += fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(wf.ObjectMeta.CreationTimestamp.Time))
+	out += fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(wf.CreationTimestamp.Time))
 	if !wf.Status.StartedAt.IsZero() {
 		out += fmt.Sprintf(fmtStr, "Started:", humanize.Timestamp(wf.Status.StartedAt.Time))
 	}
@@ -139,7 +139,7 @@ func PrintWorkflowHelper(wf *wfv1.Workflow, getArgs GetFlags) string {
 	printTree := true
 	if wf.Status.Nodes == nil {
 		printTree = false
-	} else if _, ok := wf.Status.Nodes[wf.ObjectMeta.Name]; !ok {
+	} else if _, ok := wf.Status.Nodes[wf.Name]; !ok {
 		printTree = false
 	}
 	if printTree {
@@ -159,13 +159,13 @@ func PrintWorkflowHelper(wf *wfv1.Workflow, getArgs GetFlags) string {
 		roots := convertToRenderTrees(wf)
 
 		// Print main and onExit Trees
-		mainRoot := roots[wf.ObjectMeta.Name]
+		mainRoot := roots[wf.Name]
 		if mainRoot == nil {
 			panic("failed to get the entrypoint node")
 		}
 		mainRoot.renderNodes(w, wf, 0, " ", " ", getArgs)
 
-		onExitID := wf.NodeID(wf.ObjectMeta.Name + "." + onExitSuffix)
+		onExitID := wf.NodeID(wf.Name + "." + onExitSuffix)
 		if onExitRoot, ok := roots[onExitID]; ok {
 			_, _ = fmt.Fprintf(w, "\t\t\t\t\t\n")
 			onExitRoot.renderNodes(w, wf, 0, " ", " ", getArgs)
@@ -523,7 +523,7 @@ func (nodeInfo *boundaryNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflow
 	filtered, childIndent := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
 		version := util.GetWorkflowPodNameVersion(wf)
-		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs, version)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.Name, nodePrefix, getArgs, version)
 	}
 
 	for i, nInfo := range nodeInfo.boundaryContained {
@@ -537,7 +537,7 @@ func (nodeInfo *nonBoundaryParentNode) renderNodes(w *tabwriter.Writer, wf *wfv1
 	filtered, childIndent := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
 		version := util.GetWorkflowPodNameVersion(wf)
-		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs, version)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.Name, nodePrefix, getArgs, version)
 	}
 
 	for i, nInfo := range nodeInfo.children {
@@ -551,7 +551,7 @@ func (nodeInfo *executionNode) renderNodes(w *tabwriter.Writer, wf *wfv1.Workflo
 	filtered, _ := filterNode(nodeInfo.getNodeStatus(wf), getArgs)
 	if !filtered {
 		version := util.GetWorkflowPodNameVersion(wf)
-		printNode(w, nodeInfo.getNodeStatus(wf), wf.ObjectMeta.Name, nodePrefix, getArgs, version)
+		printNode(w, nodeInfo.getNodeStatus(wf), wf.Name, nodePrefix, getArgs, version)
 	}
 }
 

--- a/cmd/argo/commands/common/submit.go
+++ b/cmd/argo/commands/common/submit.go
@@ -41,7 +41,7 @@ func WaitWatchOrLog(ctx context.Context, serviceClient workflowpkg.WorkflowServi
 		}
 	}
 	if cliSubmitOpts.Wait {
-		WaitWorkflows(ctx, serviceClient, namespace, workflowNames, false, !(cliSubmitOpts.Output.String() == "" || cliSubmitOpts.Output.String() == "wide"))
+		WaitWorkflows(ctx, serviceClient, namespace, workflowNames, false, cliSubmitOpts.Output.String() != "" && cliSubmitOpts.Output.String() != "wide")
 	} else if cliSubmitOpts.Watch {
 		for _, workflow := range workflowNames {
 			if err := WatchWorkflow(ctx, serviceClient, namespace, workflow, cliSubmitOpts.GetArgs); err != nil {

--- a/cmd/argo/commands/cron/backfill.go
+++ b/cmd/argo/commands/cron/backfill.go
@@ -201,10 +201,10 @@ const backfillWf = `{
 func CreateMonitorWf(ctx context.Context, wf, namespace, cronWFName string, scheTime []string, wfClient workflow.WorkflowServiceClient, cliOps backfillOpts) error {
 	var monitorWfObj v1alpha1.Workflow
 	err := json.Unmarshal([]byte(backfillWf), &monitorWfObj)
-	if monitorWfObj.ObjectMeta.Labels == nil {
-		monitorWfObj.ObjectMeta.Labels = make(map[string]string)
+	if monitorWfObj.Labels == nil {
+		monitorWfObj.Labels = make(map[string]string)
 	}
-	monitorWfObj.ObjectMeta.Labels[common.LabelKeyCronWorkflowBackfill] = cronWFName
+	monitorWfObj.Labels[common.LabelKeyCronWorkflowBackfill] = cronWFName
 	if err != nil {
 		return err
 	}

--- a/cmd/argo/commands/cron/create.go
+++ b/cmd/argo/commands/cron/create.go
@@ -73,13 +73,13 @@ func CreateCronWorkflows(ctx context.Context, filePaths []string, cliOpts *cliCr
 		// We have only copied the workflow spec to the cron workflow but not the metadata
 		// that includes name and generateName. Here we copy the metadata to the cron
 		// workflow's metadata and remove the unnecessary and mutually exclusive part.
-		if generateName := newWf.ObjectMeta.GenerateName; generateName != "" {
-			cronWf.ObjectMeta.GenerateName = generateName
-			cronWf.ObjectMeta.Name = ""
+		if generateName := newWf.GenerateName; generateName != "" {
+			cronWf.GenerateName = generateName
+			cronWf.Name = ""
 		}
-		if name := newWf.ObjectMeta.Name; name != "" {
-			cronWf.ObjectMeta.Name = name
-			cronWf.ObjectMeta.GenerateName = ""
+		if name := newWf.Name; name != "" {
+			cronWf.Name = name
+			cronWf.GenerateName = ""
 		}
 		if cronWf.Namespace == "" {
 			cronWf.Namespace = client.Namespace()

--- a/cmd/argo/commands/cron/list.go
+++ b/cmd/argo/commands/cron/list.go
@@ -57,7 +57,7 @@ func NewListCommand() *cobra.Command {
 				printTable(ctx, cronWfList.Items, &listArgs)
 			case "name":
 				for _, cronWf := range cronWfList.Items {
-					fmt.Println(cronWf.ObjectMeta.Name)
+					fmt.Println(cronWf.Name)
 				}
 			default:
 				return fmt.Errorf("Unknown output mode: %s", listArgs.output.String())
@@ -80,7 +80,7 @@ func printTable(ctx context.Context, wfList []wfv1.CronWorkflow, listArgs *listF
 	_, _ = fmt.Fprint(w, "\n")
 	for _, cwf := range wfList {
 		if listArgs.allNamespaces {
-			_, _ = fmt.Fprintf(w, "%s\t", cwf.ObjectMeta.Namespace)
+			_, _ = fmt.Fprintf(w, "%s\t", cwf.Namespace)
 		}
 		var cleanLastScheduledTime string
 		if cwf.Status.LastScheduledTime != nil {
@@ -94,7 +94,7 @@ func printTable(ctx context.Context, wfList []wfv1.CronWorkflow, listArgs *listF
 		} else {
 			cleanNextScheduledTime = "N/A"
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%t", cwf.ObjectMeta.Name, humanize.RelativeDurationShort(cwf.ObjectMeta.CreationTimestamp.Time, time.Now()), cleanLastScheduledTime, cleanNextScheduledTime, cwf.Spec.GetScheduleString(), cwf.Spec.Timezone, cwf.Spec.Suspend)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%t", cwf.Name, humanize.RelativeDurationShort(cwf.CreationTimestamp.Time, time.Now()), cleanLastScheduledTime, cleanNextScheduledTime, cwf.Spec.GetScheduleString(), cwf.Spec.Timezone, cwf.Spec.Suspend)
 		_, _ = fmt.Fprintf(w, "\n")
 	}
 	_ = w.Flush()

--- a/cmd/argo/commands/cron/util.go
+++ b/cmd/argo/commands/cron/util.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/util/humanize"
 	argoJson "github.com/argoproj/argo-workflows/v3/util/json"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
@@ -58,15 +57,15 @@ func generateCronWorkflows(filePaths []string, strict bool) []v1alpha1.CronWorkf
 }
 
 // unmarshalCronWorkflows unmarshals the input bytes as either json or yaml
-func unmarshalCronWorkflows(wfBytes []byte, strict bool) []wfv1.CronWorkflow {
-	var cronWf wfv1.CronWorkflow
+func unmarshalCronWorkflows(wfBytes []byte, strict bool) []v1alpha1.CronWorkflow {
+	var cronWf v1alpha1.CronWorkflow
 	var jsonOpts []argoJson.JSONOpt
 	if strict {
 		jsonOpts = append(jsonOpts, argoJson.DisallowUnknownFields)
 	}
 	err := argoJson.Unmarshal(wfBytes, &cronWf, jsonOpts...)
 	if err == nil {
-		return []wfv1.CronWorkflow{cronWf}
+		return []v1alpha1.CronWorkflow{cronWf}
 	}
 	yamlWfs, err := common.SplitCronWorkflowYAMLFile(wfBytes, strict)
 	if err == nil {
@@ -76,10 +75,10 @@ func unmarshalCronWorkflows(wfBytes []byte, strict bool) []wfv1.CronWorkflow {
 	return nil
 }
 
-func printCronWorkflow(ctx context.Context, wf *wfv1.CronWorkflow, outFmt string) {
+func printCronWorkflow(ctx context.Context, wf *v1alpha1.CronWorkflow, outFmt string) {
 	switch outFmt {
 	case "name":
-		fmt.Println(wf.ObjectMeta.Name)
+		fmt.Println(wf.Name)
 	case "json":
 		outBytes, _ := json.MarshalIndent(wf, "", "    ")
 		fmt.Println(string(outBytes))
@@ -93,13 +92,13 @@ func printCronWorkflow(ctx context.Context, wf *wfv1.CronWorkflow, outFmt string
 	}
 }
 
-func getCronWorkflowGet(ctx context.Context, cwf *wfv1.CronWorkflow) string {
+func getCronWorkflowGet(ctx context.Context, cwf *v1alpha1.CronWorkflow) string {
 	const fmtStr = "%-30s %v\n"
 
 	out := ""
-	out += fmt.Sprintf(fmtStr, "Name:", cwf.ObjectMeta.Name)
-	out += fmt.Sprintf(fmtStr, "Namespace:", cwf.ObjectMeta.Namespace)
-	out += fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(cwf.ObjectMeta.CreationTimestamp.Time))
+	out += fmt.Sprintf(fmtStr, "Name:", cwf.Name)
+	out += fmt.Sprintf(fmtStr, "Namespace:", cwf.Namespace)
+	out += fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(cwf.CreationTimestamp.Time))
 	out += fmt.Sprintf(fmtStr, "Schedules:", cwf.Spec.GetScheduleString())
 	out += fmt.Sprintf(fmtStr, "Suspended:", cwf.Spec.Suspend)
 	if cwf.Spec.Timezone != "" {
@@ -128,7 +127,7 @@ func getCronWorkflowGet(ctx context.Context, cwf *wfv1.CronWorkflow) string {
 		out += fmt.Sprintf(fmtStr, "Active Workflows:", strings.Join(activeWfNames, ", "))
 	}
 	if len(cwf.Status.Conditions) > 0 {
-		out += cwf.Status.Conditions.DisplayString(fmtStr, map[wfv1.ConditionType]string{wfv1.ConditionTypeSubmissionError: "✖"})
+		out += cwf.Status.Conditions.DisplayString(fmtStr, map[v1alpha1.ConditionType]string{v1alpha1.ConditionTypeSubmissionError: "✖"})
 	}
 	if len(cwf.Spec.WorkflowSpec.Arguments.Parameters) > 0 {
 		out += fmt.Sprintf(fmtStr, "Workflow Parameters:", "")

--- a/cmd/argo/commands/get.go
+++ b/cmd/argo/commands/get.go
@@ -65,7 +65,7 @@ func NewGetCommand() *cobra.Command {
 func printWorkflow(wf *wfv1.Workflow, getArgs common.GetFlags) error {
 	switch getArgs.Output.String() {
 	case "name":
-		fmt.Println(wf.ObjectMeta.Name)
+		fmt.Println(wf.Name)
 	case "json":
 		outBytes, _ := json.MarshalIndent(wf, "", "    ")
 		fmt.Println(string(outBytes))

--- a/cmd/argo/commands/list.go
+++ b/cmd/argo/commands/list.go
@@ -179,7 +179,7 @@ func listWorkflows(ctx context.Context, serviceClient workflowpkg.WorkflowServic
 	}
 	workflows = workflows.
 		Filter(func(wf wfv1.Workflow) bool {
-			return strings.HasPrefix(wf.ObjectMeta.Name, flags.prefix)
+			return strings.HasPrefix(wf.Name, flags.prefix)
 		})
 	if flags.createdSince != "" && flags.finishedBefore != "" {
 		startTime, err := argotime.ParseSince(flags.createdSince)

--- a/cmd/argo/commands/template/create.go
+++ b/cmd/argo/commands/template/create.go
@@ -55,7 +55,7 @@ func CreateWorkflowTemplates(ctx context.Context, filePaths []string, cliOpts *c
 			Template:  &wftmpl,
 		})
 		if err != nil {
-			return fmt.Errorf("Failed to create workflow template: %v", err)
+			return fmt.Errorf("failed to create workflow template: %v", err)
 		}
 		printWorkflowTemplate(created, cliOpts.output.String())
 	}

--- a/cmd/argo/commands/template/list.go
+++ b/cmd/argo/commands/template/list.go
@@ -59,7 +59,7 @@ func NewListCommand() *cobra.Command {
 				printTable(wftmplList.Items, &listArgs)
 			case "name":
 				for _, wftmp := range wftmplList.Items {
-					fmt.Println(wftmp.ObjectMeta.Name)
+					fmt.Println(wftmp.Name)
 				}
 			default:
 				return fmt.Errorf("Unknown output mode: %s", listArgs.output)
@@ -82,9 +82,9 @@ func printTable(wfList []wfv1.WorkflowTemplate, listArgs *listFlags) {
 	_, _ = fmt.Fprint(w, "\n")
 	for _, wf := range wfList {
 		if listArgs.allNamespaces {
-			_, _ = fmt.Fprintf(w, "%s\t", wf.ObjectMeta.Namespace)
+			_, _ = fmt.Fprintf(w, "%s\t", wf.Namespace)
 		}
-		_, _ = fmt.Fprintf(w, "%s\t", wf.ObjectMeta.Name)
+		_, _ = fmt.Fprintf(w, "%s\t", wf.Name)
 		_, _ = fmt.Fprintf(w, "\n")
 	}
 	_ = w.Flush()

--- a/cmd/argo/commands/template/util.go
+++ b/cmd/argo/commands/template/util.go
@@ -55,7 +55,7 @@ func unmarshalWorkflowTemplates(wfBytes []byte, strict bool) []wfv1.WorkflowTemp
 func printWorkflowTemplate(wf *wfv1.WorkflowTemplate, outFmt string) {
 	switch outFmt {
 	case "name":
-		fmt.Println(wf.ObjectMeta.Name)
+		fmt.Println(wf.Name)
 	case "json":
 		outBytes, _ := json.MarshalIndent(wf, "", "    ")
 		fmt.Println(string(outBytes))
@@ -71,7 +71,7 @@ func printWorkflowTemplate(wf *wfv1.WorkflowTemplate, outFmt string) {
 
 func printWorkflowTemplateHelper(wf *wfv1.WorkflowTemplate) {
 	const fmtStr = "%-20s %v\n"
-	fmt.Printf(fmtStr, "Name:", wf.ObjectMeta.Name)
-	fmt.Printf(fmtStr, "Namespace:", wf.ObjectMeta.Namespace)
-	fmt.Printf(fmtStr, "Created:", humanize.Timestamp(wf.ObjectMeta.CreationTimestamp.Time))
+	fmt.Printf(fmtStr, "Name:", wf.Name)
+	fmt.Printf(fmtStr, "Namespace:", wf.Namespace)
+	fmt.Printf(fmtStr, "Created:", humanize.Timestamp(wf.CreationTimestamp.Time))
 }

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -228,7 +228,7 @@ func startCommand(name string, args []string, template *wfv1.Template) (*exec.Cm
 	command := exec.Command(name, args...)
 	command.Env = os.Environ()
 
-	var closer func() = func() {}
+	var closer = func() {}
 	var stdout io.Writer = os.Stdout
 	var stderr io.Writer = os.Stderr
 

--- a/persist/sqldb/explosive_offload_node_status_repo.go
+++ b/persist/sqldb/explosive_offload_node_status_repo.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	ExplosiveOffloadNodeStatusRepo OffloadNodeStatusRepo = &explosiveOffloadNodeStatusRepo{}
-	OffloadNotSupportedError                             = fmt.Errorf("offload node status is not supported")
+	ErrOffloadNotSupported                               = fmt.Errorf("offload node status is not supported")
 )
 
 type explosiveOffloadNodeStatusRepo struct{}
@@ -18,21 +18,21 @@ func (n *explosiveOffloadNodeStatusRepo) IsEnabled() bool {
 }
 
 func (n *explosiveOffloadNodeStatusRepo) Save(string, string, wfv1.Nodes) (string, error) {
-	return "", OffloadNotSupportedError
+	return "", ErrOffloadNotSupported
 }
 
 func (n *explosiveOffloadNodeStatusRepo) Get(string, string) (wfv1.Nodes, error) {
-	return nil, OffloadNotSupportedError
+	return nil, ErrOffloadNotSupported
 }
 
 func (n *explosiveOffloadNodeStatusRepo) List(string) (map[UUIDVersion]wfv1.Nodes, error) {
-	return nil, OffloadNotSupportedError
+	return nil, ErrOffloadNotSupported
 }
 
 func (n *explosiveOffloadNodeStatusRepo) Delete(string, string) error {
-	return OffloadNotSupportedError
+	return ErrOffloadNotSupported
 }
 
 func (n *explosiveOffloadNodeStatusRepo) ListOldOffloads(string) (map[string][]string, error) {
-	return nil, OffloadNotSupportedError
+	return nil, ErrOffloadNotSupported
 }

--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -102,7 +102,7 @@ func NewWorkflowArchive(session db.Session, clusterName, managedNamespace string
 func (r *workflowArchive) ArchiveWorkflow(wf *wfv1.Workflow) error {
 	logCtx := log.WithFields(log.Fields{"uid": wf.UID, "labels": wf.GetLabels()})
 	logCtx.Debug("Archiving workflow")
-	wf.ObjectMeta.Labels[common.LabelKeyWorkflowArchivingStatus] = "Persisted"
+	wf.Labels[common.LabelKeyWorkflowArchivingStatus] = "Persisted"
 	workflow, err := json.Marshal(wf)
 	if err != nil {
 		return err
@@ -402,7 +402,7 @@ func (r *workflowArchive) GetWorkflow(uid string, namespace string, name string)
 		return nil, err
 	}
 	// For backward compatibility, we should label workflow retrieved from DB as Persisted.
-	wf.ObjectMeta.Labels[common.LabelKeyWorkflowArchivingStatus] = "Persisted"
+	wf.Labels[common.LabelKeyWorkflowArchivingStatus] = "Persisted"
 	return wf, nil
 }
 

--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/server/types"
 	workflowserver "github.com/argoproj/argo-workflows/v3/server/workflow"
 	"github.com/argoproj/argo-workflows/v3/server/workflow/store"
-	workflowstore "github.com/argoproj/argo-workflows/v3/server/workflow/store"
 	workflowtemplateserver "github.com/argoproj/argo-workflows/v3/server/workflowtemplate"
 	"github.com/argoproj/argo-workflows/v3/util/help"
 	"github.com/argoproj/argo-workflows/v3/util/instanceid"
@@ -34,7 +33,7 @@ import (
 
 var (
 	argoKubeOffloadNodeStatusRepo = sqldb.ExplosiveOffloadNodeStatusRepo
-	NoArgoServerErr               = fmt.Errorf("this is impossible if you are not using the Argo Server, see %s", help.CLI())
+	ErrNoArgoServer               = fmt.Errorf("this is impossible if you are not using the Argo Server, see %s", help.CLI())
 )
 
 type ArgoKubeOpts struct {
@@ -58,8 +57,8 @@ type argoKubeClient struct {
 	wfClient          workflow.Interface
 	wfTmplStore       types.WorkflowTemplateStore
 	cwfTmplStore      types.ClusterWorkflowTemplateStore
-	wfLister          workflowstore.WorkflowLister
-	wfStore           workflowstore.WorkflowStore
+	wfLister          store.WorkflowLister
+	wfStore           store.WorkflowStore
 }
 
 var _ Client = &argoKubeClient{}
@@ -166,11 +165,11 @@ func (a *argoKubeClient) NewWorkflowTemplateServiceClient() (workflowtemplate.Wo
 }
 
 func (a *argoKubeClient) NewArchivedWorkflowServiceClient() (workflowarchivepkg.ArchivedWorkflowServiceClient, error) {
-	return nil, NoArgoServerErr
+	return nil, ErrNoArgoServer
 }
 
 func (a *argoKubeClient) NewInfoServiceClient() (infopkg.InfoServiceClient, error) {
-	return nil, NoArgoServerErr
+	return nil, ErrNoArgoServer
 }
 
 func (a *argoKubeClient) NewClusterWorkflowTemplateServiceClient() (clusterworkflowtemplate.ClusterWorkflowTemplateServiceClient, error) {

--- a/pkg/apiclient/offline-client.go
+++ b/pkg/apiclient/offline-client.go
@@ -35,7 +35,7 @@ type offlineClient struct {
 	namespacedWorkflowTemplateGetterMap offlineWorkflowTemplateGetterMap
 }
 
-var OfflineErr = fmt.Errorf("not supported when you are in offline mode")
+var ErrOffline = fmt.Errorf("not supported when you are in offline mode")
 
 var _ Client = &offlineClient{}
 
@@ -129,11 +129,11 @@ func (c *offlineClient) NewClusterWorkflowTemplateServiceClient() (clusterworkfl
 }
 
 func (c *offlineClient) NewArchivedWorkflowServiceClient() (workflowarchivepkg.ArchivedWorkflowServiceClient, error) {
-	return nil, NoArgoServerErr
+	return nil, ErrNoArgoServer
 }
 
 func (c *offlineClient) NewInfoServiceClient() (infopkg.InfoServiceClient, error) {
-	return nil, NoArgoServerErr
+	return nil, ErrNoArgoServer
 }
 
 type offlineWorkflowTemplateNamespacedGetter struct {

--- a/pkg/apiclient/offline-cluster-workflow-template-service-client.go
+++ b/pkg/apiclient/offline-cluster-workflow-template-service-client.go
@@ -19,23 +19,23 @@ type OfflineClusterWorkflowTemplateServiceClient struct {
 var _ clusterworkflowtmplpkg.ClusterWorkflowTemplateServiceClient = &OfflineClusterWorkflowTemplateServiceClient{}
 
 func (o OfflineClusterWorkflowTemplateServiceClient) CreateClusterWorkflowTemplate(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateCreateRequest, opts ...grpc.CallOption) (*v1alpha1.ClusterWorkflowTemplate, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineClusterWorkflowTemplateServiceClient) GetClusterWorkflowTemplate(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateGetRequest, opts ...grpc.CallOption) (*v1alpha1.ClusterWorkflowTemplate, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineClusterWorkflowTemplateServiceClient) ListClusterWorkflowTemplates(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateListRequest, opts ...grpc.CallOption) (*v1alpha1.ClusterWorkflowTemplateList, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineClusterWorkflowTemplateServiceClient) UpdateClusterWorkflowTemplate(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateUpdateRequest, opts ...grpc.CallOption) (*v1alpha1.ClusterWorkflowTemplate, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineClusterWorkflowTemplateServiceClient) DeleteClusterWorkflowTemplate(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateDeleteRequest, opts ...grpc.CallOption) (*clusterworkflowtmplpkg.ClusterWorkflowTemplateDeleteResponse, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineClusterWorkflowTemplateServiceClient) LintClusterWorkflowTemplate(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateLintRequest, opts ...grpc.CallOption) (*v1alpha1.ClusterWorkflowTemplate, error) {

--- a/pkg/apiclient/offline-cron-workflow-service-client.go
+++ b/pkg/apiclient/offline-cron-workflow-service-client.go
@@ -27,29 +27,29 @@ func (o OfflineCronWorkflowServiceClient) LintCronWorkflow(ctx context.Context, 
 }
 
 func (o OfflineCronWorkflowServiceClient) CreateCronWorkflow(ctx context.Context, req *cronworkflow.CreateCronWorkflowRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineCronWorkflowServiceClient) ListCronWorkflows(ctx context.Context, req *cronworkflow.ListCronWorkflowsRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflowList, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineCronWorkflowServiceClient) GetCronWorkflow(ctx context.Context, req *cronworkflow.GetCronWorkflowRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineCronWorkflowServiceClient) UpdateCronWorkflow(ctx context.Context, req *cronworkflow.UpdateCronWorkflowRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineCronWorkflowServiceClient) DeleteCronWorkflow(ctx context.Context, req *cronworkflow.DeleteCronWorkflowRequest, _ ...grpc.CallOption) (*cronworkflow.CronWorkflowDeletedResponse, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineCronWorkflowServiceClient) ResumeCronWorkflow(ctx context.Context, req *cronworkflow.CronWorkflowResumeRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineCronWorkflowServiceClient) SuspendCronWorkflow(ctx context.Context, req *cronworkflow.CronWorkflowSuspendRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }

--- a/pkg/apiclient/offline-workflow-service-client.go
+++ b/pkg/apiclient/offline-workflow-service-client.go
@@ -19,55 +19,55 @@ type OfflineWorkflowServiceClient struct {
 var _ workflowpkg.WorkflowServiceClient = &OfflineWorkflowServiceClient{}
 
 func (o OfflineWorkflowServiceClient) CreateWorkflow(context.Context, *workflowpkg.WorkflowCreateRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) GetWorkflow(context.Context, *workflowpkg.WorkflowGetRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) ListWorkflows(context.Context, *workflowpkg.WorkflowListRequest, ...grpc.CallOption) (*wfv1.WorkflowList, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) WatchWorkflows(context.Context, *workflowpkg.WatchWorkflowsRequest, ...grpc.CallOption) (workflowpkg.WorkflowService_WatchWorkflowsClient, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) WatchEvents(context.Context, *workflowpkg.WatchEventsRequest, ...grpc.CallOption) (workflowpkg.WorkflowService_WatchEventsClient, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) DeleteWorkflow(context.Context, *workflowpkg.WorkflowDeleteRequest, ...grpc.CallOption) (*workflowpkg.WorkflowDeleteResponse, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) RetryWorkflow(context.Context, *workflowpkg.WorkflowRetryRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) ResubmitWorkflow(context.Context, *workflowpkg.WorkflowResubmitRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) ResumeWorkflow(context.Context, *workflowpkg.WorkflowResumeRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) SuspendWorkflow(context.Context, *workflowpkg.WorkflowSuspendRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) TerminateWorkflow(context.Context, *workflowpkg.WorkflowTerminateRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) StopWorkflow(context.Context, *workflowpkg.WorkflowStopRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) SetWorkflow(context.Context, *workflowpkg.WorkflowSetRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) LintWorkflow(_ context.Context, req *workflowpkg.WorkflowLintRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
@@ -79,13 +79,13 @@ func (o OfflineWorkflowServiceClient) LintWorkflow(_ context.Context, req *workf
 }
 
 func (o OfflineWorkflowServiceClient) PodLogs(context.Context, *workflowpkg.WorkflowLogRequest, ...grpc.CallOption) (workflowpkg.WorkflowService_PodLogsClient, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) WorkflowLogs(context.Context, *workflowpkg.WorkflowLogRequest, ...grpc.CallOption) (workflowpkg.WorkflowService_WorkflowLogsClient, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowServiceClient) SubmitWorkflow(context.Context, *workflowpkg.WorkflowSubmitRequest, ...grpc.CallOption) (*wfv1.Workflow, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }

--- a/pkg/apiclient/offline-workflow-template-service-client.go
+++ b/pkg/apiclient/offline-workflow-template-service-client.go
@@ -19,23 +19,23 @@ type OfflineWorkflowTemplateServiceClient struct {
 var _ workflowtemplatepkg.WorkflowTemplateServiceClient = &OfflineWorkflowTemplateServiceClient{}
 
 func (o OfflineWorkflowTemplateServiceClient) CreateWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateCreateRequest, _ ...grpc.CallOption) (*v1alpha1.WorkflowTemplate, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowTemplateServiceClient) GetWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateGetRequest, _ ...grpc.CallOption) (*v1alpha1.WorkflowTemplate, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowTemplateServiceClient) ListWorkflowTemplates(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateListRequest, _ ...grpc.CallOption) (*v1alpha1.WorkflowTemplateList, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowTemplateServiceClient) UpdateWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateUpdateRequest, _ ...grpc.CallOption) (*v1alpha1.WorkflowTemplate, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowTemplateServiceClient) DeleteWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateDeleteRequest, _ ...grpc.CallOption) (*workflowtemplatepkg.WorkflowTemplateDeleteResponse, error) {
-	return nil, OfflineErr
+	return nil, ErrOffline
 }
 
 func (o OfflineWorkflowTemplateServiceClient) LintWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateLintRequest, _ ...grpc.CallOption) (*v1alpha1.WorkflowTemplate, error) {

--- a/pkg/apis/workflow/v1alpha1/anystring_test.go
+++ b/pkg/apis/workflow/v1alpha1/anystring_test.go
@@ -20,7 +20,7 @@ func TestAnyString(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, AnyStringPtr(""), i)
 
-		assert.Equal(t, "", i.String(), "string value does not have quotes")
+		assert.Empty(t, i.String(), "string value does not have quotes")
 	})
 	t.Run("String", func(t *testing.T) {
 		x := AnyStringPtr("my-string")

--- a/pkg/apis/workflow/v1alpha1/cluster_workflow_template_types.go
+++ b/pkg/apis/workflow/v1alpha1/cluster_workflow_template_types.go
@@ -25,7 +25,7 @@ func (w ClusterWorkflowTemplates) Len() int {
 }
 
 func (w ClusterWorkflowTemplates) Less(i, j int) bool {
-	return strings.Compare(w[j].ObjectMeta.Name, w[i].ObjectMeta.Name) > 0
+	return strings.Compare(w[j].Name, w[i].Name) > 0
 }
 
 func (w ClusterWorkflowTemplates) Swap(i, j int) {

--- a/pkg/apis/workflow/v1alpha1/item_test.go
+++ b/pkg/apis/workflow/v1alpha1/item_test.go
@@ -34,7 +34,7 @@ func runItemTest(t *testing.T, data string, expectedType Type) {
 	assert.Equal(t, expectedType, itm.GetType())
 	jsonBytes, err := json.Marshal(itm)
 	require.NoError(t, err)
-	assert.Equal(t, data, string(jsonBytes), "marshalling is symmetric")
+	assert.JSONEq(t, data, string(jsonBytes), "marshalling is symmetric")
 	if strings.HasPrefix(data, `"`) {
 		assert.Equal(t, data, fmt.Sprintf("\"%v\"", itm))
 		assert.Equal(t, data, fmt.Sprintf("\"%s\"", itm))

--- a/pkg/apis/workflow/v1alpha1/marshall.go
+++ b/pkg/apis/workflow/v1alpha1/marshall.go
@@ -20,18 +20,19 @@ func MustUnmarshal(text, v interface{}) {
 		if len(x) == 0 {
 			panic("no text to unmarshal")
 		}
-		if x[0] == '@' {
+		switch x[0] {
+		case '@':
 			filename := string(x[1:])
 			y, err := os.ReadFile(filepath.Clean(filename))
 			if err != nil {
 				panic(fmt.Errorf("failed to read file %s: %w", filename, err))
 			}
 			MustUnmarshal(y, v)
-		} else if x[0] == '{' {
+		case '{':
 			if err := json.Unmarshal(x, v); err != nil {
 				panic(fmt.Errorf("failed to unmarshal JSON %q: %w", string(x), err))
 			}
-		} else {
+		default:
 			if err := yaml.UnmarshalStrict(x, v); err != nil {
 				panic(fmt.Errorf("failed to unmarshal YAML %q: %w", string(x), err))
 			}

--- a/pkg/apis/workflow/v1alpha1/plugin_types.go
+++ b/pkg/apis/workflow/v1alpha1/plugin_types.go
@@ -18,7 +18,7 @@ func (p *Plugin) UnmarshalJSON(value []byte) error {
 	// by validating the structure in UnmarshallJSON, we prevent bad data entering the system at the point of
 	// parsing, which means we do not need validate
 	m := map[string]interface{}{}
-	if err := json.Unmarshal(p.Object.Value, &m); err != nil {
+	if err := json.Unmarshal(p.Value, &m); err != nil {
 		return err
 	}
 	numKeys := len(m)

--- a/pkg/apis/workflow/v1alpha1/workflow_template_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_template_types.go
@@ -24,7 +24,7 @@ func (w WorkflowTemplates) Len() int {
 }
 
 func (w WorkflowTemplates) Less(i, j int) bool {
-	return strings.Compare(w[j].ObjectMeta.Name, w[i].ObjectMeta.Name) > 0
+	return strings.Compare(w[j].Name, w[i].Name) > 0
 }
 
 func (w WorkflowTemplates) Swap(i, j int) {

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -162,9 +162,9 @@ type Workflows []Workflow
 func (w Workflows) Len() int      { return len(w) }
 func (w Workflows) Swap(i, j int) { w[i], w[j] = w[j], w[i] }
 func (w Workflows) Less(i, j int) bool {
-	iStart := w[i].ObjectMeta.CreationTimestamp
+	iStart := w[i].CreationTimestamp
 	iFinish := w[i].Status.FinishedAt
-	jStart := w[j].ObjectMeta.CreationTimestamp
+	jStart := w[j].CreationTimestamp
 	jFinish := w[j].Status.FinishedAt
 	if iFinish.IsZero() && jFinish.IsZero() {
 		return !iStart.Before(&jStart)
@@ -230,7 +230,7 @@ func (w *Workflow) GetArtifactGCStrategy(a *Artifact) ArtifactGCStrategy {
 var (
 	WorkflowCreatedAfter = func(t time.Time) WorkflowPredicate {
 		return func(wf Workflow) bool {
-			return wf.ObjectMeta.CreationTimestamp.After(t)
+			return wf.CreationTimestamp.After(t)
 		}
 	}
 	WorkflowFinishedBefore = func(t time.Time) WorkflowPredicate {
@@ -240,7 +240,7 @@ var (
 	}
 	WorkflowRanBetween = func(startTime time.Time, endTime time.Time) WorkflowPredicate {
 		return func(wf Workflow) bool {
-			return wf.ObjectMeta.CreationTimestamp.After(startTime) && !wf.Status.FinishedAt.IsZero() && wf.Status.FinishedAt.Time.Before(endTime)
+			return wf.CreationTimestamp.After(startTime) && !wf.Status.FinishedAt.IsZero() && wf.Status.FinishedAt.Time.Before(endTime)
 		}
 	}
 )
@@ -2416,7 +2416,7 @@ func (ws *WorkflowStatus) GetDuration() time.Duration {
 	if ws.FinishedAt.IsZero() {
 		return 0
 	}
-	return ws.FinishedAt.Time.Sub(ws.StartedAt.Time)
+	return ws.FinishedAt.Sub(ws.StartedAt.Time)
 }
 
 // Pending returns whether or not the node is in pending state
@@ -3474,12 +3474,12 @@ func (wf *Workflow) GetWorkflowSpec() WorkflowSpec {
 
 // NodeID creates a deterministic node ID based on a node name
 func (wf *Workflow) NodeID(name string) string {
-	if name == wf.ObjectMeta.Name {
-		return wf.ObjectMeta.Name
+	if name == wf.Name {
+		return wf.Name
 	}
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(name))
-	return fmt.Sprintf("%s-%v", wf.ObjectMeta.Name, h.Sum32())
+	return fmt.Sprintf("%s-%v", wf.Name, h.Sum32())
 }
 
 // GetStoredTemplate retrieves a template from stored templates of the workflow.

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -204,7 +204,7 @@ func TestArtifact_ValidatePath(t *testing.T) {
 		a1 := Artifact{Name: "a1", Path: ""}
 		err := a1.CleanPath()
 		require.EqualError(t, err, "Artifact 'a1' did not specify a path")
-		assert.Equal(t, "", a1.Path)
+		assert.Empty(t, a1.Path)
 	})
 
 	t.Run("directory traversal above safe base dir fails", func(t *testing.T) {
@@ -607,7 +607,7 @@ func TestArtifactRepositoryRef_GetConfigMapOr(t *testing.T) {
 
 func TestArtifactRepositoryRef_GetKeyOr(t *testing.T) {
 	var r *ArtifactRepositoryRef
-	assert.Equal(t, "", r.GetKeyOr(""))
+	assert.Empty(t, r.GetKeyOr(""))
 	assert.Equal(t, "my-key", (&ArtifactRepositoryRef{}).GetKeyOr("my-key"))
 	assert.Equal(t, "my-key", (&ArtifactRepositoryRef{Key: "my-key"}).GetKeyOr(""))
 }
@@ -754,7 +754,7 @@ func TestNestedChildren(t *testing.T) {
 			assert.False(t, ok, "got %s", child.Name)
 			found[child.Name] = true
 		}
-		assert.Equal(t, len(nodes), len(found))
+		assert.Len(t, found, len(nodes))
 	})
 }
 
@@ -967,7 +967,7 @@ func TestWorkflow_SearchArtifacts(t *testing.T) {
 	countArtifactName := func(ars ArtifactSearchResults, name string) int {
 		count := 0
 		for _, ar := range ars {
-			if ar.Artifact.Name == name {
+			if ar.Name == name {
 				count++
 			}
 		}
@@ -1022,7 +1022,7 @@ func TestWorkflow_SearchArtifacts(t *testing.T) {
 	queriedArtifactSearchResults = wf.SearchArtifacts(query)
 	assert.NotNil(t, queriedArtifactSearchResults)
 	assert.Len(t, queriedArtifactSearchResults, 1)
-	assert.Equal(t, "artifact-foobar", queriedArtifactSearchResults[0].Artifact.Name)
+	assert.Equal(t, "artifact-foobar", queriedArtifactSearchResults[0].Name)
 	assert.Equal(t, "node-bar", queriedArtifactSearchResults[0].NodeID)
 
 	// artifact name
@@ -1031,7 +1031,7 @@ func TestWorkflow_SearchArtifacts(t *testing.T) {
 	queriedArtifactSearchResults = wf.SearchArtifacts(query)
 	assert.NotNil(t, queriedArtifactSearchResults)
 	assert.Len(t, queriedArtifactSearchResults, 1)
-	assert.Equal(t, "artifact-foo", queriedArtifactSearchResults[0].Artifact.Name)
+	assert.Equal(t, "artifact-foo", queriedArtifactSearchResults[0].Name)
 	assert.Equal(t, "node-foo", queriedArtifactSearchResults[0].NodeID)
 
 	// node id
@@ -1058,7 +1058,7 @@ func TestWorkflow_SearchArtifacts(t *testing.T) {
 	queriedArtifactSearchResults = wf.SearchArtifacts(query)
 	assert.NotNil(t, queriedArtifactSearchResults)
 	assert.Len(t, queriedArtifactSearchResults, 1)
-	assert.Equal(t, "artifact-foo", queriedArtifactSearchResults[0].Artifact.Name)
+	assert.Equal(t, "artifact-foo", queriedArtifactSearchResults[0].Name)
 	assert.Equal(t, "node-foo", queriedArtifactSearchResults[0].NodeID)
 }
 
@@ -1103,7 +1103,7 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 		},
 		Spec: WorkflowSpec{
 			Synchronization: &Synchronization{
-				Semaphores: []*SemaphoreRef{&SemaphoreRef{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				Semaphores: []*SemaphoreRef{{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "test",
 					},
@@ -1119,14 +1119,14 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 			Name: "t1",
 			Synchronization: &Synchronization{
 				Semaphores: []*SemaphoreRef{
-					&SemaphoreRef{
+					{
 						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "template",
 							},
 						},
 					},
-					&SemaphoreRef{
+					{
 						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "template-b",
@@ -1139,7 +1139,7 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 		{
 			Name: "t1",
 			Synchronization: &Synchronization{
-				Semaphores: []*SemaphoreRef{&SemaphoreRef{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				Semaphores: []*SemaphoreRef{{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "template1",
 					},
@@ -1149,7 +1149,7 @@ func TestWorkflow_GetSemaphoreKeys(t *testing.T) {
 		{
 			Name: "t2",
 			Synchronization: &Synchronization{
-				Semaphores: []*SemaphoreRef{&SemaphoreRef{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				Semaphores: []*SemaphoreRef{{ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "template",
 					},
@@ -1393,7 +1393,7 @@ func TestDAGTask_GetExitTemplate(t *testing.T) {
 	}
 	task := DAGTask{
 		Hooks: map[LifecycleEvent]LifecycleHook{
-			ExitLifecycleEvent: LifecycleHook{
+			ExitLifecycleEvent: {
 				Template:  "test",
 				Arguments: args,
 			},
@@ -1421,7 +1421,7 @@ func TestStep_GetExitTemplate(t *testing.T) {
 	}
 	task := WorkflowStep{
 		Hooks: map[LifecycleEvent]LifecycleHook{
-			ExitLifecycleEvent: LifecycleHook{
+			ExitLifecycleEvent: {
 				Template:  "test",
 				Arguments: args,
 			},
@@ -1620,7 +1620,7 @@ func TestInlineStore(t *testing.T) {
 						{
 							Name: "step-template",
 							Steps: []ParallelSteps{
-								ParallelSteps{
+								{
 									[]WorkflowStep{
 										{
 											Name: "hello1",

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -154,10 +154,7 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	isInput := false
-	if direction == Inputs {
-		isInput = true
-	}
+	isInput := direction == Inputs
 
 	artifact, driver, err := a.getArtifactAndDriver(ctx, nodeId, artifactName, isInput, wf, fileName)
 	if err != nil {
@@ -211,7 +208,7 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 
 		dirs := map[string]bool{} // to de-dupe sub-dirs
 
-		_, _ = w.Write([]byte(fmt.Sprintf("<li><a href=\"%s\">%s</a></li>\n", "..", "..")))
+		_, _ = fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>\n", "..", "..")
 
 		for _, object := range objects {
 
@@ -220,11 +217,11 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 
 			// if dir is empty string, we are in the root dir
 			if dir == "" {
-				_, _ = w.Write([]byte(fmt.Sprintf("<li><a href=\"%s\">%s</a></li>\n", file, file)))
+				_, _ = fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>\n", file, file)
 			} else if dirs[dir] {
 				continue
 			} else {
-				_, _ = w.Write([]byte(fmt.Sprintf("<li><a href=\"%s\">%s</a></li>\n", dir, dir)))
+				_, _ = fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>\n", dir, dir)
 				dirs[dir] = true
 			}
 		}

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -79,7 +79,7 @@ var bucketsOfKeys = map[string][]string{
 func (a *fakeArtifactDriver) OpenStream(artifact *wfv1.Artifact) (io.ReadCloser, error) {
 	//fmt.Printf("deletethis: artifact=%+v\n", artifact)
 
-	key, err := artifact.ArtifactLocation.GetKey()
+	key, err := artifact.GetKey()
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 					// verify that the files are contained in the listing we got back
 					assert.Len(t, tt.directoryFiles, strings.Count(string(all), "<li>"))
 					for _, file := range tt.directoryFiles {
-						assert.True(t, strings.Contains(string(all), file))
+						assert.Contains(t, string(all), file)
 					}
 				} else {
 					assert.Equal(t, "my-data", string(all))

--- a/server/auth/authorizing_server_stream.go
+++ b/server/auth/authorizing_server_stream.go
@@ -35,7 +35,7 @@ func (l *authorizingServerStream) RecvMsg(m interface{}) error {
 	if err != nil {
 		return err
 	}
-	ctx, err := l.Gatekeeper.ContextWithRequest(l.ctx, m)
+	ctx, err := l.ContextWithRequest(l.ctx, m)
 	if err != nil {
 		return err
 	}

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -351,7 +351,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(cookie.Value, prefix) {
 		redirect = cookie.Value
 	}
-	http.Redirect(w, r, redirect, 302)
+	http.Redirect(w, r, redirect, http.StatusFound)
 }
 
 // authorize verifies a bearer token and pulls user information form the claims.

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -70,7 +70,7 @@ func TestLoadSsoClientIdFromSecret(t *testing.T) {
 	assert.Equal(t, "sso-client-id-value", ssoObject.config.ClientID)
 	assert.Equal(t, "sso-client-secret-value", ssoObject.config.ClientSecret)
 	assert.Equal(t, "argo_groups", ssoObject.customClaimName)
-	assert.Equal(t, "", config.IssuerAlias)
+	assert.Empty(t, config.IssuerAlias)
 	assert.Equal(t, 10*time.Hour, ssoObject.expiry)
 }
 

--- a/server/auth/types/claims.go
+++ b/server/auth/types/claims.go
@@ -38,7 +38,7 @@ func init() {
 // json.Unmarshal to mash every claim into a custom map
 func (c *Claims) UnmarshalJSON(data []byte) error {
 	type claimAlias Claims
-	var localClaim claimAlias = claimAlias(*c)
+	var localClaim = claimAlias(*c)
 
 	// Populate the claims struct as much as possible
 	err := json.Unmarshal(data, &localClaim)

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -36,7 +36,7 @@ func TestInterceptor(t *testing.T) {
 		assert.Empty(t, r.Header["Authorization"])
 		// we check the status code here - because we get a 403
 		assert.Equal(t, 403, w.Code)
-		assert.Equal(t, `{"message": "failed to process webhook request"}`, w.Body.String())
+		assert.JSONEq(t, `{"message": "failed to process webhook request"}`, w.Body.String())
 	})
 	t.Run("NoDiscriminator", func(t *testing.T) {
 		r, _ := intercept("POST", "/api/v1/events/my-ns/", nil)

--- a/server/info/info_server_test.go
+++ b/server/info/info_server_test.go
@@ -53,9 +53,9 @@ func Test_infoServer_GetInfo(t *testing.T) {
 		i := &infoServer{}
 		info, err := i.GetInfo(context.TODO(), nil)
 		require.NoError(t, err)
-		assert.Equal(t, "", info.ManagedNamespace)
+		assert.Empty(t, info.ManagedNamespace)
 		assert.Empty(t, info.Links)
 		assert.Empty(t, info.Columns)
-		assert.Equal(t, "", info.NavColor)
+		assert.Empty(t, info.NavColor)
 	})
 }

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -759,7 +759,7 @@ func getLatestWorkflow(ctx context.Context, wfClient versioned.Interface, namesp
 	}
 	latest := wfList.Items[0]
 	for _, wf := range wfList.Items {
-		if latest.ObjectMeta.CreationTimestamp.Before(&wf.ObjectMeta.CreationTimestamp) {
+		if latest.CreationTimestamp.Before(&wf.CreationTimestamp) {
 			latest = wf
 		}
 	}

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -248,8 +248,8 @@ func (w *archivedWorkflowServer) RetryArchivedWorkflow(ctx context.Context, req 
 			return nil, sutils.ToStatusError(err, codes.Internal)
 		}
 
-		wf.ObjectMeta.ResourceVersion = ""
-		wf.ObjectMeta.UID = ""
+		wf.ResourceVersion = ""
+		wf.UID = ""
 		result, err := wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
 		if err != nil {
 			return nil, sutils.ToStatusError(err, codes.Internal)

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/persist/sqldb/mocks"
 	workflowarchivepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowarchive"
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	argofake "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo-workflows/v3/server/auth"
 	sutils "github.com/argoproj/argo-workflows/v3/server/utils"
@@ -54,31 +53,31 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		}, nil
 	})
 	// two pages of results for limit 1
-	repo.On("ListWorkflows", sutils.ListOptions{Limit: 2, Offset: 0}).Return(wfv1.Workflows{{}, {}}, nil)
-	repo.On("ListWorkflows", sutils.ListOptions{Limit: 2, Offset: 1}).Return(wfv1.Workflows{{}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}, {}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Limit: 2, Offset: 1}).Return(v1alpha1.Workflows{{}}, nil)
 	minStartAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	maxStartAt, _ := time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
 	createdTime := metav1.Time{Time: time.Now().UTC()}
 	finishedTime := metav1.Time{Time: createdTime.Add(time.Second * 2)}
-	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(wfv1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(wfv1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(wfv1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(wfv1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0, ShowRemainingItemCount: true}).Return(wfv1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "user-ns", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 2, Offset: 0}).Return(wfv1.Workflows{{}, {}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0, ShowRemainingItemCount: true}).Return(v1alpha1.Workflows{{}}, nil)
+	repo.On("ListWorkflows", sutils.ListOptions{Namespace: "user-ns", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}, {}}, nil)
 	repo.On("CountWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(int64(5), nil)
 	repo.On("CountWorkflows", sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0, ShowRemainingItemCount: true}).Return(int64(5), nil)
 	repo.On("GetWorkflow", "", "", "").Return(nil, nil)
-	repo.On("GetWorkflow", "my-uid", "", "").Return(&wfv1.Workflow{
+	repo.On("GetWorkflow", "my-uid", "", "").Return(&v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-name"},
-		Spec: wfv1.WorkflowSpec{
+		Spec: v1alpha1.WorkflowSpec{
 			Entrypoint: "my-entrypoint",
-			Templates: []wfv1.Template{
+			Templates: []v1alpha1.Template{
 				{Name: "my-entrypoint", Container: &apiv1.Container{}},
 			},
 		},
 	}, nil)
-	repo.On("GetWorkflow", "failed-uid", "", "").Return(&wfv1.Workflow{
+	repo.On("GetWorkflow", "failed-uid", "", "").Return(&v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "failed-wf",
 			Labels: map[string]string{
@@ -86,44 +85,44 @@ func Test_archivedWorkflowServer(t *testing.T) {
 				common.LabelKeyWorkflowArchivingStatus: "Pending",
 			},
 		},
-		Status: wfv1.WorkflowStatus{
-			Phase:      wfv1.WorkflowFailed,
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
 			StartedAt:  createdTime,
 			FinishedAt: finishedTime,
-			Nodes: map[string]wfv1.NodeStatus{
-				"failed-node":    {Name: "failed-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: wfv1.NodeFailed, Message: "failed"},
-				"succeeded-node": {Name: "succeeded-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: wfv1.NodeSucceeded, Message: "succeeded"}},
+			Nodes: map[string]v1alpha1.NodeStatus{
+				"failed-node":    {Name: "failed-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: v1alpha1.NodeFailed, Message: "failed"},
+				"succeeded-node": {Name: "succeeded-node", StartedAt: createdTime, FinishedAt: finishedTime, Phase: v1alpha1.NodeSucceeded, Message: "succeeded"}},
 		},
 	}, nil)
-	repo.On("GetWorkflow", "resubmit-uid", "", "").Return(&wfv1.Workflow{
+	repo.On("GetWorkflow", "resubmit-uid", "", "").Return(&v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "resubmit-wf"},
-		Spec: wfv1.WorkflowSpec{
+		Spec: v1alpha1.WorkflowSpec{
 			Entrypoint: "my-entrypoint",
-			Templates: []wfv1.Template{
+			Templates: []v1alpha1.Template{
 				{Name: "my-entrypoint", Container: &apiv1.Container{Image: "docker/whalesay:latest"}},
 			},
 		},
 	}, nil)
 	wfClient.AddReactor("create", "workflows", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &wfv1.Workflow{
+		return true, &v1alpha1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-name-resubmitted"},
 		}, nil
 	})
 	repo.On("DeleteWorkflow", "my-uid").Return(nil)
-	repo.On("ListWorkflowsLabelKeys").Return(&wfv1.LabelKeys{
+	repo.On("ListWorkflowsLabelKeys").Return(&v1alpha1.LabelKeys{
 		Items: []string{"foo", "bar"},
 	}, nil)
-	repo.On("ListWorkflowsLabelValues", "my-key").Return(&wfv1.LabelValues{
+	repo.On("ListWorkflowsLabelValues", "my-key").Return(&v1alpha1.LabelValues{
 		Items: []string{"my-key=foo", "my-key=bar"},
 	}, nil)
-	repo.On("RetryWorkflow", "failed-uid").Return(&wfv1.Workflow{
+	repo.On("RetryWorkflow", "failed-uid").Return(&v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "failed-wf"},
 	}, nil)
-	repo.On("ResubmitWorkflow", "my-uid").Return(&wfv1.Workflow{
+	repo.On("ResubmitWorkflow", "my-uid").Return(&v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-name"},
-		Spec: wfv1.WorkflowSpec{
+		Spec: v1alpha1.WorkflowSpec{
 			Entrypoint: "my-entrypoint",
-			Templates: []wfv1.Template{
+			Templates: []v1alpha1.Template{
 				{Name: "my-entrypoint", Container: &apiv1.Container{}},
 			},
 		},
@@ -162,7 +161,7 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{FieldSelector: "metadata.name=my-name,spec.startedAt>2020-01-01T00:00:00Z,spec.startedAt<2020-01-02T00:00:00Z,ext.showRemainingItemCount=true", Limit: 1}, NamePrefix: "my-"})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, int64(4), *resp.ListMeta.RemainingItemCount)
+		assert.Equal(t, int64(4), *resp.RemainingItemCount)
 		assert.Empty(t, resp.Continue)
 		/////// Currently, for the purpose of backward compatibility, namespace is supported both as its own query parameter and as part of the field selector
 		/////// need to test both
@@ -199,11 +198,11 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, wf)
 
-		repo.On("GetWorkflow", "", "my-ns", "my-name").Return(&wfv1.Workflow{
+		repo.On("GetWorkflow", "", "my-ns", "my-name").Return(&v1alpha1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-name", Namespace: "my-ns"},
-			Spec: wfv1.WorkflowSpec{
+			Spec: v1alpha1.WorkflowSpec{
 				Entrypoint: "my-entrypoint",
-				Templates: []wfv1.Template{
+				Templates: []v1alpha1.Template{
 					{Name: "my-entrypoint", Container: &apiv1.Container{}},
 				},
 			},

--- a/server/workflowtemplate/workflow_template_server.go
+++ b/server/workflowtemplate/workflow_template_server.go
@@ -116,7 +116,7 @@ func cursorPaginationByResourceVersion(items []v1alpha1.WorkflowTemplate, resour
 	// For the next pagination, the resourceVersion of the last item is set in the Continue field.
 	if limit != 0 && len(wfList.Items) == int(limit) {
 		lastIndex := len(wfList.Items) - 1
-		wfList.ListMeta.Continue = wfList.Items[lastIndex].ResourceVersion
+		wfList.Continue = wfList.Items[lastIndex].ResourceVersion
 	}
 }
 
@@ -151,7 +151,7 @@ func (wts *WorkflowTemplateServer) ListWorkflowTemplates(ctx context.Context, re
 	var items []v1alpha1.WorkflowTemplate
 	if req.NamePattern != "" {
 		for _, item := range wfList.Items {
-			if strings.Contains(item.ObjectMeta.Name, req.NamePattern) {
+			if strings.Contains(item.Name, req.NamePattern) {
 				items = append(items, item)
 			}
 		}

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1410,14 +1410,14 @@ func (s *CLISuite) TestCronCommands() {
 	s.Run("Create Name Override", func() {
 		s.Given().RunCli([]string{"cron", "create", "cron/basic.yaml", "--name", "basic-cron-wf-overridden-name", "-l", "workflows.argoproj.io/test=true"}, func(t *testing.T, output string, err error) {
 			require.NoError(t, err)
-			assert.Contains(t, strings.Replace(output, " ", "", -1), "Name:basic-cron-wf-overridden-name")
+			assert.Contains(t, strings.ReplaceAll(output, " ", ""), "Name:basic-cron-wf-overridden-name")
 		})
 	})
 
 	s.Run("Create GenerateName Override", func() {
 		s.Given().RunCli([]string{"cron", "create", "cron/basic.yaml", "--generate-name", "basic-cron-wf-overridden-generate-name-", "-l", "workflows.argoproj.io/test=true"}, func(t *testing.T, output string, err error) {
 			require.NoError(t, err)
-			assert.Contains(t, strings.Replace(output, " ", "", -1), "Name:basic-cron-wf-overridden-generate-name-")
+			assert.Contains(t, strings.ReplaceAll(output, " ", ""), "Name:basic-cron-wf-overridden-generate-name-")
 		})
 	})
 

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -30,7 +30,7 @@ func (s *CronSuite) TearDownSubTest() {
 	//    time="2025-02-23T06:11:00.023Z" level=info msg="Workflow processing has been postponed due to max parallelism limit" key=argo/test-cron-wf-succeed-1-1740291060
 	//    time="2025-02-23T06:11:00.023Z" level=info msg="Updated phase  -> Pending" namespace=argo workflow=test-cron-wf-succeed-1-1740291060
 	//    time="2025-02-23T06:11:00.023Z" level=info msg="Updated message  -> Workflow processing has been postponed because too many workflows are already running" namespace=argo workflow=test-cron-wf-succeed-1-1740291060
-	s.E2ESuite.DeleteResources()
+	s.DeleteResources()
 }
 
 func (s *CronSuite) TestBasic() {

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -42,7 +41,7 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 			assert.Equal(t, &apiv1.PodSecurityContext{
 				RunAsUser:      ptr.To(int64(8737)),
 				RunAsNonRoot:   ptr.To(true),
-				SeccompProfile: &v1.SeccompProfile{Type: "RuntimeDefault"},
+				SeccompProfile: &apiv1.SeccompProfile{Type: "RuntimeDefault"},
 			}, spec.SecurityContext)
 			require.Len(t, spec.Volumes, 4)
 			assert.Contains(t, spec.Volumes[0].Name, "kube-api-access-")
@@ -72,7 +71,7 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 					ReadOnlyRootFilesystem:   ptr.To(true),
 					Privileged:               ptr.To(false),
 					Capabilities:             &apiv1.Capabilities{Drop: []apiv1.Capability{"ALL"}},
-					SeccompProfile:           &v1.SeccompProfile{Type: "RuntimeDefault"},
+					SeccompProfile:           &apiv1.SeccompProfile{Type: "RuntimeDefault"},
 				}, agent.SecurityContext)
 			}
 		}).

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -212,7 +212,7 @@ func (t *Then) ExpectPVCDeleted() *Then {
 			return t
 		default:
 			num := len(t.wf.Status.PersistentVolumeClaims)
-			pvcClient := t.kubeClient.CoreV1().PersistentVolumeClaims(t.wf.ObjectMeta.Namespace)
+			pvcClient := t.kubeClient.CoreV1().PersistentVolumeClaims(t.wf.Namespace)
 			for _, p := range t.wf.Status.PersistentVolumeClaims {
 				_, err := pvcClient.Get(ctx, p.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 				if err == nil {

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
@@ -894,9 +893,10 @@ spec:
 		ExpectWorkflowNode(wfv1.SucceededPodNode, func(t *testing.T, n *wfv1.NodeStatus, p *apiv1.Pod) {
 			assert.Equal(t, int64(5), *p.Spec.TerminationGracePeriodSeconds)
 			for _, c := range p.Spec.Containers {
-				if c.Name == "main" {
+				switch c.Name {
+				case "main":
 					assert.Equal(t, "100m", c.Resources.Limits.Cpu().String())
-				} else if c.Name == "wait" {
+				case "wait":
 					assert.Equal(t, "101m", c.Resources.Limits.Cpu().String())
 				}
 			}
@@ -1371,7 +1371,7 @@ func (s *FunctionalSuite) TestTerminateWorkflowWhileOnExitHandlerRunning() {
 		ShutdownWorkflow(wfv1.ShutdownStrategyTerminate).
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *wfv1.WorkflowStatus) {
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			for _, node := range status.Nodes {
 				if node.Type == wfv1.NodeTypeStepGroup || node.Type == wfv1.NodeTypeSteps {
 					assert.Equal(t, wfv1.NodeFailed, node.Phase)
@@ -1390,7 +1390,7 @@ func (s *FunctionalSuite) TestWorkflowExitHandlerCrashEnsureNodeIsPresent() {
 		WaitForWorkflow(fixtures.ToBeRunning).
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *wfv1.WorkflowStatus) {
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			var hasExitNode bool
 			var exitNodeName string
 
@@ -1421,7 +1421,7 @@ func (s *FunctionalSuite) TestWorkflowParallelismStepFailFast() {
 		WaitForWorkflow(fixtures.ToBeRunning).
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *wfv1.WorkflowStatus) {
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, "template has failed or errored children and failFast enabled", status.Message)
 			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("[0]").Phase)
 			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("step1").Phase)
@@ -1437,7 +1437,7 @@ func (s *FunctionalSuite) TestWorkflowParallelismDAGFailFast() {
 		WaitForWorkflow(fixtures.ToBeRunning).
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *wfv1.WorkflowStatus) {
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
 			assert.Equal(t, "template has failed or errored children and failFast enabled", status.Message)
 			assert.Equal(t, wfv1.NodeFailed, status.Nodes.FindByDisplayName("task1").Phase)
 			assert.Equal(t, wfv1.NodeSucceeded, status.Nodes.FindByDisplayName("task2").Phase)

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
 )
 
@@ -45,8 +44,8 @@ spec:
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowPhase("Failed"), status.Phase)
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowPhase("Failed"), status.Phase)
 			assert.Equal(t, "No more retries left", status.Message)
 			assert.Equal(t, v1alpha1.Progress("0/1"), status.Progress)
 		}).
@@ -88,8 +87,8 @@ spec:
 		SubmitWorkflow().
 		WaitForWorkflow(time.Second * 90).
 		Then().
-		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowPhase("Failed"), status.Phase)
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowPhase("Failed"), status.Phase)
 			assert.LessOrEqual(t, len(status.Nodes), 10)
 		})
 	s.Given().
@@ -114,8 +113,8 @@ spec:
 		SubmitWorkflow().
 		WaitForWorkflow(time.Second * 90).
 		Then().
-		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowPhase("Failed"), status.Phase)
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowPhase("Failed"), status.Phase)
 			assert.LessOrEqual(t, len(status.Nodes), 10)
 		})
 }
@@ -135,8 +134,8 @@ spec:
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowFailed, status.Phase)
 		}).
 		// Success, no need retry
 		ExpectContainerLogs("c1", func(t *testing.T, logs string) {
@@ -183,13 +182,13 @@ spec:
 		WaitForWorkflow(fixtures.ToHaveFailedPod).
 		Wait(5 * time.Second).
 		Then().
-		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			if status.Phase == wfv1.WorkflowFailed {
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			if status.Phase == v1alpha1.WorkflowFailed {
 				nodeStatus := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(0)")
 				nodeStatusRetry := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(1)")
 				assert.NotEqual(t, nodeStatus.HostNodeName, nodeStatusRetry.HostNodeName)
 			}
-			if status.Phase == wfv1.WorkflowRunning {
+			if status.Phase == v1alpha1.WorkflowRunning {
 				nodeStatus := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(0)")
 				nodeStatusRetry := status.Nodes.FindByDisplayName("test-nodeantiaffinity-strategy(1)")
 				assert.Contains(t, nodeStatusRetry.Message, "didn't match Pod's node affinity/selector")

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
-	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
@@ -66,11 +65,11 @@ spec:
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed, time.Minute*11).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowFailed, status.Phase)
 			for _, node := range status.Nodes {
-				if node.Type == wfv1.NodeTypePod {
-					assert.Equal(t, wfv1.NodeFailed, node.Phase)
+				if node.Type == v1alpha1.NodeTypePod {
+					assert.Equal(t, v1alpha1.NodeFailed, node.Phase)
 					assert.Contains(t, node.Message, "Pod was active on the node longer than the specified deadline")
 				}
 			}
@@ -147,8 +146,8 @@ spec:
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted, time.Minute*1).
 		Then().
-		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+		ExpectWorkflow(func(t *testing.T, metadata *metav1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
 		}).
 		ExpectWorkflowNode(func(status v1alpha1.NodeStatus) bool {
 			return strings.Contains(status.Name, "a")

--- a/util/json/fix.go
+++ b/util/json/fix.go
@@ -4,8 +4,8 @@ import "strings"
 
 func Fix(s string) string {
 	// https://stackoverflow.com/questions/28595664/how-to-stop-json-marshal-from-escaping-and/28596225
-	s = strings.Replace(s, "\\u003c", "<", -1)
-	s = strings.Replace(s, "\\u003e", ">", -1)
-	s = strings.Replace(s, "\\u0026", "&", -1)
+	s = strings.ReplaceAll(s, "\\u003c", "<")
+	s = strings.ReplaceAll(s, "\\u003e", ">")
+	s = strings.ReplaceAll(s, "\\u0026", "&")
 	return s
 }

--- a/util/printer/workflow-printer.go
+++ b/util/printer/workflow-printer.go
@@ -31,7 +31,7 @@ func PrintWorkflows(workflows wfv1.Workflows, out io.Writer, opts PrintOpts) err
 		printCostOptimizationNudges(workflows, out)
 	case "name":
 		for _, wf := range workflows {
-			_, _ = fmt.Fprintln(out, wf.ObjectMeta.Name)
+			_, _ = fmt.Fprintln(out, wf.Name)
 		}
 	case "json":
 		output, err := json.MarshalIndent(workflows, "", "  ")
@@ -74,17 +74,17 @@ func printTable(wfList []wfv1.Workflow, out io.Writer, opts PrintOpts) {
 		_, _ = fmt.Fprint(w, "\n")
 	}
 	for _, wf := range wfList {
-		ageStr := humanize.RelativeDurationShort(wf.ObjectMeta.CreationTimestamp.Time, time.Now())
+		ageStr := humanize.RelativeDurationShort(wf.CreationTimestamp.Time, time.Now())
 		durationStr := humanize.RelativeDurationShort(wf.Status.StartedAt.Time, wf.Status.FinishedAt.Time)
 		messageStr := wf.Status.Message
 		if opts.Namespace {
-			_, _ = fmt.Fprintf(w, "%s\t", wf.ObjectMeta.Namespace)
+			_, _ = fmt.Fprintf(w, "%s\t", wf.Namespace)
 		}
 		var priority int
 		if wf.Spec.Priority != nil {
 			priority = int(*wf.Spec.Priority)
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s", wf.ObjectMeta.Name, WorkflowStatus(&wf), ageStr, durationStr, priority, messageStr)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s", wf.Name, WorkflowStatus(&wf), ageStr, durationStr, priority, messageStr)
 		if opts.Output == "wide" {
 			pending, running, completed := countPendingRunningCompletedNodes(&wf)
 			_, _ = fmt.Fprintf(w, "\t%d/%d/%d", pending, running, completed)
@@ -186,7 +186,7 @@ func WorkflowStatus(wf *wfv1.Workflow) string {
 			return "Failed (Terminated)"
 		}
 	case wfv1.WorkflowUnknown, wfv1.WorkflowPending:
-		if !wf.ObjectMeta.CreationTimestamp.IsZero() {
+		if !wf.CreationTimestamp.IsZero() {
 			return "Pending"
 		}
 		return "Unknown"

--- a/util/resource/summary.go
+++ b/util/resource/summary.go
@@ -15,7 +15,7 @@ type Summary struct {
 
 func (s Summary) age() time.Duration {
 	if s.ContainerState.Terminated != nil {
-		return s.ContainerState.Terminated.FinishedAt.Time.Sub(s.ContainerState.Terminated.StartedAt.Time)
+		return s.ContainerState.Terminated.FinishedAt.Sub(s.ContainerState.Terminated.StartedAt.Time)
 	} else {
 		return 0
 	}

--- a/util/template/simple_template.go
+++ b/util/template/simple_template.go
@@ -30,7 +30,7 @@ func simpleReplace(w io.Writer, tag string, replaceMap map[string]interface{}, a
 		if allowUnresolved {
 			// just write the same string back
 			log.WithError(errors.InternalError("unresolved")).Debug("unresolved is allowed ")
-			return w.Write([]byte(fmt.Sprintf("{{%s}}", tag)))
+			return fmt.Fprintf(w, "{{%s}}", tag)
 		}
 		return 0, errors.Errorf(errors.CodeBadRequest, "failed to resolve {{%s}}", tag)
 	}

--- a/util/template/template.go
+++ b/util/template/template.go
@@ -32,7 +32,7 @@ type impl struct {
 
 func (t *impl) Replace(replaceMap map[string]interface{}, allowUnresolved bool) (string, error) {
 	replacedTmpl := &bytes.Buffer{}
-	_, err := t.Template.ExecuteFunc(replacedTmpl, func(w io.Writer, tag string) (int, error) {
+	_, err := t.ExecuteFunc(replacedTmpl, func(w io.Writer, tag string) (int, error) {
 		kind, expression := parseTag(tag)
 		switch kind {
 		case kindExpression:

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -62,7 +62,7 @@ func TestRecoverWorkflowNameFromSelectorString(t *testing.T) {
 		})
 	}
 	name := RecoverWorkflowNameFromSelectorStringIfAny("whatever=whalesay")
-	assert.Equal(t, "", name)
+	assert.Empty(t, name)
 	assert.NotPanics(t, func() {
 		_ = RecoverWorkflowNameFromSelectorStringIfAny("whatever")
 	})

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -48,7 +48,7 @@ func TestDetermineAccountName(t *testing.T) {
 		require.NoError(t, err)
 		accountName, err := determineAccountName(u)
 		require.Error(t, err)
-		assert.Equal(t, "", accountName)
+		assert.Empty(t, accountName)
 	}
 }
 
@@ -66,7 +66,7 @@ func TestArtifactDriver_WithServiceKey_DownloadDirectory_Subdir(t *testing.T) {
 	require.NoError(t, err)
 	_, err = containerClient.Create(context.Background(), nil)
 	var responseError *azcore.ResponseError
-	if err != nil && !(errors.As(err, &responseError) && responseError.ErrorCode == "ContainerAlreadyExists") {
+	if err != nil && (!errors.As(err, &responseError) || responseError.ErrorCode != "ContainerAlreadyExists") {
 		require.NoError(t, err)
 	}
 

--- a/workflow/artifacts/common/load_to_stream_test.go
+++ b/workflow/artifacts/common/load_to_stream_test.go
@@ -116,7 +116,7 @@ func TestLoadToStream(t *testing.T) {
 				if err != nil {
 					panic(err)
 				}
-				assert.Equal(t, len(filesBefore), len(filesAfter))
+				assert.Len(t, filesAfter, len(filesBefore))
 			} else {
 				require.Error(t, err)
 				assert.Equal(t, tc.errMsg, err.Error())

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -469,11 +469,12 @@ func NewS3Client(ctx context.Context, opts S3ClientOpts) (S3Client, error) {
 	}
 
 	var bucketLookupType minio.BucketLookupType
-	if s3cli.AddressingStyle == PathStyle {
+	switch s3cli.AddressingStyle {
+	case PathStyle:
 		bucketLookupType = minio.BucketLookupPath
-	} else if s3cli.AddressingStyle == VirtualHostedStyle {
+	case VirtualHostedStyle:
 		bucketLookupType = minio.BucketLookupDNS
-	} else {
+	default:
 		bucketLookupType = minio.BucketLookupAuto
 	}
 	minioOpts := &minio.Options{Creds: credentials, Secure: s3cli.Secure, Transport: opts.Transport, Region: s3cli.Region, BucketLookup: bucketLookupType}

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -138,7 +138,7 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 		"Success": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art.tar.gz",
 					},
 				},
@@ -164,7 +164,7 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 		"No such key": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -181,7 +181,7 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 		"Is Directory": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -198,7 +198,7 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 		"Test Directory Failed": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -258,7 +258,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		"Success": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art.tar.gz",
 					},
 				},
@@ -286,7 +286,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		"No such key": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -304,7 +304,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		"Is Directory": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -322,7 +322,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		"Get File Other Transient Error": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -340,7 +340,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		"Test Directory Failed": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -361,7 +361,7 @@ func TestLoadS3Artifact(t *testing.T) {
 		"Get Directory Failed": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art-2.tar.gz",
 					},
 				},
@@ -398,7 +398,7 @@ func TestLoadS3Artifact(t *testing.T) {
 			if err != nil {
 				assert.Equal(t, tc.errMsg, err.Error())
 			} else {
-				assert.Equal(t, "", tc.errMsg)
+				assert.Empty(t, tc.errMsg)
 			}
 		})
 	}
@@ -435,7 +435,7 @@ func TestSaveS3Artifact(t *testing.T) {
 		"Success as Directory": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{},
+					"my-bucket": {},
 				},
 				map[string]error{}),
 			bucket:    "my-bucket",
@@ -532,7 +532,7 @@ func TestSaveS3Artifact(t *testing.T) {
 			if err != nil {
 				assert.Equal(t, tc.errMsg, err.Error())
 			} else {
-				assert.Equal(t, "", tc.errMsg)
+				assert.Empty(t, tc.errMsg)
 			}
 		})
 	}
@@ -551,7 +551,7 @@ func TestListObjects(t *testing.T) {
 		"Found objects": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder/hello-art.tar.gz",
 					},
 				},
@@ -564,7 +564,7 @@ func TestListObjects(t *testing.T) {
 		"Empty directory": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder",
 					},
 				},
@@ -577,7 +577,7 @@ func TestListObjects(t *testing.T) {
 		"Non-existent directory": {
 			s3client: newMockS3Client(
 				map[string][]string{
-					"my-bucket": []string{
+					"my-bucket": {
 						"/folder",
 					},
 				},

--- a/workflow/common/convert.go
+++ b/workflow/common/convert.go
@@ -30,7 +30,7 @@ func ConvertCronWorkflowToWorkflow(cronWf *wfv1.CronWorkflow) *wfv1.Workflow {
 }
 
 func ConvertCronWorkflowToWorkflowWithProperties(cronWf *wfv1.CronWorkflow, name string, scheduledTime time.Time) *wfv1.Workflow {
-	cronWfLabels := cronWf.ObjectMeta.GetLabels()
+	cronWfLabels := cronWf.GetLabels()
 	wfLabels := make(map[string]string)
 	for _, k := range labelsToPropagate {
 		v, ok := cronWfLabels[k]
@@ -79,14 +79,14 @@ func toWorkflow(cronWf wfv1.CronWorkflow, objectMeta metav1.ObjectMeta) *wfv1.Wo
 	wf := &wfv1.Workflow{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       workflow.WorkflowKind,
-			APIVersion: cronWf.TypeMeta.APIVersion,
+			APIVersion: cronWf.APIVersion,
 		},
 		ObjectMeta: objectMeta,
 		Spec:       cronWf.Spec.WorkflowSpec,
 	}
 
-	if instanceId, ok := cronWf.ObjectMeta.GetLabels()[LabelKeyControllerInstanceID]; ok {
-		wf.ObjectMeta.GetLabels()[LabelKeyControllerInstanceID] = instanceId
+	if instanceId, ok := cronWf.GetLabels()[LabelKeyControllerInstanceID]; ok {
+		wf.GetLabels()[LabelKeyControllerInstanceID] = instanceId
 	}
 
 	wf.Labels[LabelKeyCronWorkflow] = cronWf.Name

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -67,7 +67,7 @@ func assessAgentPodStatus(pod *apiv1.Pod) (wfv1.NodePhase, string) {
 		message = pod.Status.Message
 	default:
 		newPhase = wfv1.NodeError
-		message = fmt.Sprintf("Unexpected pod phase for %s: %s", pod.ObjectMeta.Name, pod.Status.Phase)
+		message = fmt.Sprintf("Unexpected pod phase for %s: %s", pod.Name, pod.Status.Phase)
 	}
 	return newPhase, message
 }
@@ -195,7 +195,7 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	pod = &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
-			Namespace: woc.wf.ObjectMeta.Namespace,
+			Namespace: woc.wf.Namespace,
 			Labels: map[string]string{
 				common.LabelKeyWorkflow:  woc.wf.Name, // Allows filtering by pods related to specific workflow
 				common.LabelKeyCompleted: "false",     // Allows filtering by incomplete workflow pods
@@ -239,7 +239,7 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	}
 
 	if woc.controller.Config.InstanceID != "" {
-		pod.ObjectMeta.Labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
+		pod.Labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
 	}
 
 	log.Debug("Creating Agent pod")

--- a/workflow/controller/agent_test.go
+++ b/workflow/controller/agent_test.go
@@ -136,7 +136,7 @@ status:
 		for _, pod := range pods.Items {
 			assert.NotNil(t, pod)
 			assert.True(t, strings.HasSuffix(pod.Name, "-agent"))
-			assert.Equal(t, "testID", pod.ObjectMeta.Labels[common.LabelKeyControllerInstanceID])
+			assert.Equal(t, "testID", pod.Labels[common.LabelKeyControllerInstanceID])
 			assert.Equal(t, "virtual-node", pod.Spec.NodeName)
 		}
 	})
@@ -149,7 +149,7 @@ func TestAssessAgentPodStatus(t *testing.T) {
 		}
 		nodeStatus, msg := assessAgentPodStatus(pod1)
 		assert.Equal(t, wfv1.NodeFailed, nodeStatus)
-		assert.Equal(t, "", msg)
+		assert.Empty(t, msg)
 	})
 	t.Run("Running", func(t *testing.T) {
 		pod1 := &apiv1.Pod{
@@ -158,7 +158,7 @@ func TestAssessAgentPodStatus(t *testing.T) {
 
 		nodeStatus, msg := assessAgentPodStatus(pod1)
 		assert.Equal(t, wfv1.NodePhase(""), nodeStatus)
-		assert.Equal(t, "", msg)
+		assert.Empty(t, msg)
 	})
 	t.Run("Success", func(t *testing.T) {
 		pod1 := &apiv1.Pod{
@@ -166,7 +166,7 @@ func TestAssessAgentPodStatus(t *testing.T) {
 		}
 		nodeStatus, msg := assessAgentPodStatus(pod1)
 		assert.Equal(t, wfv1.NodePhase(""), nodeStatus)
-		assert.Equal(t, "", msg)
+		assert.Empty(t, msg)
 	})
 
 }

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -478,10 +478,10 @@ func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv
 		pod.Spec.ServiceAccountName = podInfo.serviceAccount
 	}
 	for label, labelVal := range podInfo.podMetadata.Labels {
-		pod.ObjectMeta.Labels[label] = labelVal
+		pod.Labels[label] = labelVal
 	}
 	for annotation, annotationVal := range podInfo.podMetadata.Annotations {
-		pod.ObjectMeta.Annotations[annotation] = annotationVal
+		pod.Annotations[annotation] = annotationVal
 	}
 
 	if v := woc.controller.Config.InstanceID; v != "" {

--- a/workflow/controller/cache_test.go
+++ b/workflow/controller/cache_test.go
@@ -59,7 +59,7 @@ func TestConfigMapCacheLoadHit(t *testing.T) {
 
 	entry, err := c.Load(ctx, "hi-there-world")
 	require.NoError(t, err)
-	assert.True(t, entry.LastHitTimestamp.Time.After(entry.CreationTimestamp.Time))
+	assert.True(t, entry.LastHitTimestamp.After(entry.CreationTimestamp.Time))
 
 	outputs := entry.Outputs
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestConfigMapCacheLoadMiss(t *testing.T) {
 }
 
 func TestConfigMapCacheSave(t *testing.T) {
-	var MockParamValue string = "Hello world"
+	var MockParamValue = "Hello world"
 	MockParam := wfv1.Parameter{
 		Name:  "hello",
 		Value: wfv1.AnyStringPtr(MockParamValue),

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -219,7 +219,7 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 			WorkflowCondition: wfc.getWorkflowConditionMetrics,
 			IsLeader:          wfc.IsLeader,
 		})
-	deprecation.Initialize(wfc.metrics.Metrics.DeprecatedFeature)
+	deprecation.Initialize(wfc.metrics.DeprecatedFeature)
 
 	if err != nil {
 		return nil, err
@@ -700,7 +700,7 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		return true
 	}
 
-	if wf.Status.Phase != "" && wfc.checkRecentlyCompleted(wf.ObjectMeta.Name) {
+	if wf.Status.Phase != "" && wfc.checkRecentlyCompleted(wf.Name) {
 		log.WithFields(log.Fields{"name": wf.ObjectMeta.Name}).Warn("Cache: Rejecting recently deleted")
 		return true
 	}
@@ -710,7 +710,7 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 
 	woc := newWorkflowOperationCtx(wf, wfc)
 
-	if !(woc.GetShutdownStrategy().Enabled() && woc.GetShutdownStrategy() == wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) {
+	if (!woc.GetShutdownStrategy().Enabled() || woc.GetShutdownStrategy() != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) {
 		log.WithField("key", key).Info("Workflow processing has been postponed due to max parallelism limit")
 		if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
 			woc.markWorkflowPhase(ctx, wfv1.WorkflowPending, "Workflow processing has been postponed because too many workflows are already running")
@@ -795,7 +795,7 @@ func (wfc *WorkflowController) enqueueWfFromPodLabel(pod *apiv1.Pod) error {
 		// Ignore pods unrelated to workflow (this shouldn't happen unless the watch is setup incorrectly)
 		return fmt.Errorf("Watch returned pod unrelated to any workflow")
 	}
-	wfc.wfQueue.AddRateLimited(pod.ObjectMeta.Namespace + "/" + workflowName)
+	wfc.wfQueue.AddRateLimited(pod.Namespace + "/" + workflowName)
 	return nil
 }
 
@@ -1288,5 +1288,5 @@ func (wfc *WorkflowController) newArtGCTaskInformer() wfextvv1alpha1.WorkflowArt
 
 func (wfc *WorkflowController) IsLeader() bool {
 	// the wfc.wfInformer is nil if it is not the leader
-	return !(wfc.wfInformer == nil)
+	return wfc.wfInformer != nil
 }

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -223,7 +223,7 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		return nil, err
 	}
 
-	deprecation.Initialize(wfc.metrics.Metrics.DeprecatedFeature)
+	deprecation.Initialize(wfc.metrics.DeprecatedFeature)
 	wfc.entrypoint = entrypoint.New(kubeclientset, wfc.Config.Images)
 
 	workqueue.SetProvider(wfc.metrics) // must execute SetProvider before we create the queues

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -1242,7 +1242,7 @@ func TestWorkflowWithLongArguments(t *testing.T) {
 	woc.operate(ctx)
 	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 
-	cms, err := controller.kubeclientset.CoreV1().ConfigMaps(woc.wf.ObjectMeta.Namespace).List(ctx, metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + woc.wf.ObjectMeta.Name})
+	cms, err := controller.kubeclientset.CoreV1().ConfigMaps(woc.wf.ObjectMeta.Namespace).List(ctx, metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + woc.wf.Name})
 	require.NoError(t, err)
 	assert.Len(t, cms.Items, 1)
 	assert.Contains(t, cms.Items[0].Data, common.EnvVarTemplate)

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -858,7 +858,7 @@ func (d *dagContext) evaluateDependsLogic(taskName string) (bool, bool, error) {
 			return false, false, nil
 		}
 
-		evalTaskName := strings.Replace(taskName, "-", "_", -1)
+		evalTaskName := strings.ReplaceAll(taskName, "-", "_")
 		if _, ok := evalScope[evalTaskName]; ok {
 			continue
 		}
@@ -894,7 +894,7 @@ func (d *dagContext) evaluateDependsLogic(taskName string) (bool, bool, error) {
 		}
 	}
 
-	evalLogic := strings.Replace(d.GetTaskDependsLogic(taskName), "-", "_", -1)
+	evalLogic := strings.ReplaceAll(d.GetTaskDependsLogic(taskName), "-", "_")
 	execute, err := argoexpr.EvalBool(evalLogic, evalScope)
 	if err != nil {
 		return false, false, fmt.Errorf("unable to evaluate expression '%s': %s", evalLogic, err)

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -106,7 +106,7 @@ func TestSingleDependency(t *testing.T) {
 		ctx := context.Background()
 		wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 		require.NoError(t, err)
-		wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+		wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 		require.NoError(t, err)
 		woc := newWorkflowOperationCtx(wf, controller)
 

--- a/workflow/controller/hooks.go
+++ b/workflow/controller/hooks.go
@@ -19,7 +19,7 @@ func (woc *wfOperationCtx) executeWfLifeCycleHook(ctx context.Context, tmplCtx *
 		if hookName == wfv1.ExitLifecycleEvent {
 			continue
 		}
-		hookNodeName := generateLifeHookNodeName(woc.wf.ObjectMeta.Name, string(hookName))
+		hookNodeName := generateLifeHookNodeName(woc.wf.Name, string(hookName))
 		// To check a node was triggered.
 		hookedNode, _ := woc.wf.GetNodeByName(hookNodeName)
 		if hook.Expression == "" {

--- a/workflow/controller/ns_watcher.go
+++ b/workflow/controller/ns_watcher.go
@@ -118,7 +118,7 @@ func nsFromObj(obj interface{}) (*apiv1.Namespace, error) {
 func limitChanged(old *apiv1.Namespace, newNS *apiv1.Namespace) bool {
 	oldLimit := old.GetLabels()[common.LabelParallelismLimit]
 	newLimit := newNS.GetLabels()[common.LabelParallelismLimit]
-	return !(oldLimit == newLimit)
+	return oldLimit != newLimit
 }
 
 func extractLimit(ns *apiv1.Namespace) (int, error) {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -156,8 +156,8 @@ func newWorkflowOperationCtx(wf *wfv1.Workflow, wfc *WorkflowController) *wfOper
 		execWf:  wfCopy,
 		updated: false,
 		log: log.WithFields(log.Fields{
-			"workflow":  wf.ObjectMeta.Name,
-			"namespace": wf.ObjectMeta.Namespace,
+			"workflow":  wf.Name,
+			"namespace": wf.Namespace,
 		}),
 		controller:             wfc,
 		globalParams:           make(map[string]string),
@@ -365,7 +365,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		woc.markWorkflowRunning(ctx)
 	}
 
-	node, err := woc.executeTemplate(ctx, woc.wf.ObjectMeta.Name, &wfv1.WorkflowStep{Template: woc.execWf.Spec.Entrypoint}, tmplCtx, woc.execWf.Spec.Arguments, &executeTemplateOpts{})
+	node, err := woc.executeTemplate(ctx, woc.wf.Name, &wfv1.WorkflowStep{Template: woc.execWf.Spec.Entrypoint}, tmplCtx, woc.execWf.Spec.Arguments, &executeTemplateOpts{})
 	if err != nil {
 		woc.log.WithError(err).Error("error in entry template execution")
 		// we wrap this error up to report a clear message
@@ -443,7 +443,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	var onExitNode *wfv1.NodeStatus
 	if woc.execWf.Spec.HasExitHook() {
 		woc.log.Infof("Running OnExit handler: %s", woc.execWf.Spec.OnExit)
-		onExitNodeName := common.GenerateOnExitNodeName(woc.wf.ObjectMeta.Name)
+		onExitNodeName := common.GenerateOnExitNodeName(woc.wf.Name)
 		onExitNode, _ = woc.execWf.GetNodeByName(onExitNodeName)
 		if onExitNode != nil || woc.GetShutdownStrategy().ShouldExecute(true) {
 			exitHook := woc.execWf.Spec.GetExitHook(woc.execWf.Spec.Arguments)
@@ -511,7 +511,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 	default:
 		// NOTE: we should never make it here because if the node was 'Running' we should have
 		// returned earlier.
-		err = errors.InternalErrorf("Unexpected node phase %s: %+v", woc.wf.ObjectMeta.Name, err)
+		err = errors.InternalErrorf("Unexpected node phase %s: %+v", woc.wf.Name, err)
 		woc.markWorkflowError(ctx, err)
 	}
 
@@ -615,13 +615,13 @@ func (woc *wfOperationCtx) getWorkflowDeadline() *time.Time {
 
 // setGlobalParameters sets the globalParam map with global parameters
 func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Arguments) error {
-	woc.globalParams[common.GlobalVarWorkflowName] = woc.wf.ObjectMeta.Name
-	woc.globalParams[common.GlobalVarWorkflowNamespace] = woc.wf.ObjectMeta.Namespace
+	woc.globalParams[common.GlobalVarWorkflowName] = woc.wf.Name
+	woc.globalParams[common.GlobalVarWorkflowNamespace] = woc.wf.Namespace
 	woc.globalParams[common.GlobalVarWorkflowMainEntrypoint] = woc.execWf.Spec.Entrypoint
 	woc.globalParams[common.GlobalVarWorkflowServiceAccountName] = woc.execWf.Spec.ServiceAccountName
-	woc.globalParams[common.GlobalVarWorkflowUID] = string(woc.wf.ObjectMeta.UID)
-	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp] = woc.wf.ObjectMeta.CreationTimestamp.Format(time.RFC3339)
-	if annotation := woc.wf.ObjectMeta.GetAnnotations(); annotation != nil {
+	woc.globalParams[common.GlobalVarWorkflowUID] = string(woc.wf.UID)
+	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp] = woc.wf.CreationTimestamp.Format(time.RFC3339)
+	if annotation := woc.wf.GetAnnotations(); annotation != nil {
 		val, ok := annotation[common.AnnotationKeyCronWfScheduledTime]
 		if ok {
 			woc.globalParams[common.GlobalVarWorkflowCronScheduleTime] = val
@@ -633,10 +633,10 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 	}
 	for char := range strftime.FormatChars {
 		cTimeVar := fmt.Sprintf("%s.%s", common.GlobalVarWorkflowCreationTimestamp, string(char))
-		woc.globalParams[cTimeVar] = strftime.Format("%"+string(char), woc.wf.ObjectMeta.CreationTimestamp.Time)
+		woc.globalParams[cTimeVar] = strftime.Format("%"+string(char), woc.wf.CreationTimestamp.Time)
 	}
-	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp+".s"] = strconv.FormatInt(woc.wf.ObjectMeta.CreationTimestamp.Time.Unix(), 10)
-	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp+".RFC3339"] = woc.wf.ObjectMeta.CreationTimestamp.Format(time.RFC3339)
+	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp+".s"] = strconv.FormatInt(woc.wf.CreationTimestamp.Unix(), 10)
+	woc.globalParams[common.GlobalVarWorkflowCreationTimestamp+".RFC3339"] = woc.wf.CreationTimestamp.Format(time.RFC3339)
 
 	if workflowParameters, err := json.Marshal(woc.execWf.Spec.Arguments.Parameters); err == nil {
 		woc.globalParams[common.GlobalVarWorkflowParameters] = string(workflowParameters)
@@ -644,7 +644,7 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 	}
 	for _, param := range executionParameters.Parameters {
 		if param.ValueFrom != nil && param.ValueFrom.ConfigMapKeyRef != nil {
-			cmValue, err := common.GetConfigMapValue(woc.controller.configMapInformer.GetIndexer(), woc.wf.ObjectMeta.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
+			cmValue, err := common.GetConfigMapValue(woc.controller.configMapInformer.GetIndexer(), woc.wf.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
 			if err != nil {
 				if param.ValueFrom.Default != nil {
 					woc.globalParams["workflow.parameters."+param.Name] = param.ValueFrom.Default.String()
@@ -678,18 +678,18 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 
 	md := woc.execWf.Spec.WorkflowMetadata
 
-	if workflowAnnotations, err := json.Marshal(woc.wf.ObjectMeta.Annotations); err == nil {
+	if workflowAnnotations, err := json.Marshal(woc.wf.Annotations); err == nil {
 		woc.globalParams[common.GlobalVarWorkflowAnnotations] = string(workflowAnnotations)
 		woc.globalParams[common.GlobalVarWorkflowAnnotationsJSON] = string(workflowAnnotations)
 	}
-	for k, v := range woc.wf.ObjectMeta.Annotations {
+	for k, v := range woc.wf.Annotations {
 		woc.globalParams["workflow.annotations."+k] = v
 	}
-	if workflowLabels, err := json.Marshal(woc.wf.ObjectMeta.Labels); err == nil {
+	if workflowLabels, err := json.Marshal(woc.wf.Labels); err == nil {
 		woc.globalParams[common.GlobalVarWorkflowLabels] = string(workflowLabels)
 		woc.globalParams[common.GlobalVarWorkflowLabelsJSON] = string(workflowLabels)
 	}
-	for k, v := range woc.wf.ObjectMeta.Labels {
+	for k, v := range woc.wf.Labels {
 		// if the Label will get overridden by a LabelsFrom expression later, don't set it now
 		if md != nil {
 			_, existsLabelsFrom := md.LabelsFrom[k]
@@ -736,7 +736,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 	if woc.orig.ResourceVersion != woc.wf.ResourceVersion {
 		woc.log.Panic("cannot persist updates with mismatched resource versions")
 	}
-	wfClient := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows(woc.wf.ObjectMeta.Namespace)
+	wfClient := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows(woc.wf.Namespace)
 	// try and compress nodes if needed
 	nodes := woc.wf.Status.Nodes
 	err := woc.controller.hydrator.Dehydrate(woc.wf)
@@ -890,7 +890,7 @@ func (woc *wfOperationCtx) reapplyUpdate(ctx context.Context, wfClient v1alpha1.
 	// Next get latest version of the workflow, apply the patch and retry the update
 	attempt := 1
 	for {
-		currWf, err := wfClient.Get(ctx, woc.wf.ObjectMeta.Name, metav1.GetOptions{})
+		currWf, err := wfClient.Get(ctx, woc.wf.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -1372,7 +1372,7 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		new.Message = getPendingReason(pod)
 		new.Daemoned = nil
 		if old.Phase != new.Phase || old.Message != new.Message {
-			woc.controller.metrics.ChangePodPending(ctx, new.Message, pod.ObjectMeta.Namespace)
+			woc.controller.metrics.ChangePodPending(ctx, new.Message, pod.Namespace)
 		}
 	case apiv1.PodSucceeded:
 		new.Phase = wfv1.NodeSucceeded
@@ -1414,10 +1414,10 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		}
 	default:
 		new.Phase = wfv1.NodeError
-		new.Message = fmt.Sprintf("Unexpected pod phase for %s: %s", pod.ObjectMeta.Name, pod.Status.Phase)
+		new.Message = fmt.Sprintf("Unexpected pod phase for %s: %s", pod.Name, pod.Status.Phase)
 	}
 	if old.Phase != new.Phase {
-		woc.controller.metrics.ChangePodPhase(ctx, string(new.Phase), pod.ObjectMeta.Namespace)
+		woc.controller.metrics.ChangePodPhase(ctx, string(new.Phase), pod.Namespace)
 	}
 
 	// if it's ContainerSetTemplate pod then the inner container names should match to some node names,
@@ -1688,7 +1688,7 @@ func (woc *wfOperationCtx) inferFailedReason(pod *apiv1.Pod, tmpl *wfv1.Template
 }
 
 func (woc *wfOperationCtx) createPVCs(ctx context.Context) error {
-	if !(woc.wf.Status.Phase == wfv1.WorkflowPending || woc.wf.Status.Phase == wfv1.WorkflowRunning) {
+	if woc.wf.Status.Phase != wfv1.WorkflowPending && woc.wf.Status.Phase != wfv1.WorkflowRunning {
 		// Only attempt to create PVCs if workflow is in Pending or Running state
 		// (e.g. passed validation, or didn't already complete)
 		return nil
@@ -1698,21 +1698,21 @@ func (woc *wfOperationCtx) createPVCs(ctx context.Context) error {
 		// This will also handle the case where workflow has no volumeClaimTemplates.
 		return nil
 	}
-	pvcClient := woc.controller.kubeclientset.CoreV1().PersistentVolumeClaims(woc.wf.ObjectMeta.Namespace)
+	pvcClient := woc.controller.kubeclientset.CoreV1().PersistentVolumeClaims(woc.wf.Namespace)
 	for i, pvcTmpl := range woc.execWf.Spec.VolumeClaimTemplates {
-		if pvcTmpl.ObjectMeta.Name == "" {
+		if pvcTmpl.Name == "" {
 			return errors.Errorf(errors.CodeBadRequest, "volumeClaimTemplates[%d].metadata.name is required", i)
 		}
 		pvcTmpl = *pvcTmpl.DeepCopy()
 		// PVC name will be <workflowname>-<volumeclaimtemplatename>
-		refName := pvcTmpl.ObjectMeta.Name
-		pvcName := fmt.Sprintf("%s-%s", woc.wf.ObjectMeta.Name, pvcTmpl.ObjectMeta.Name)
+		refName := pvcTmpl.Name
+		pvcName := fmt.Sprintf("%s-%s", woc.wf.Name, pvcTmpl.Name)
 		woc.log.Infof("Creating pvc %s", pvcName)
-		pvcTmpl.ObjectMeta.Name = pvcName
-		if pvcTmpl.ObjectMeta.Labels == nil {
-			pvcTmpl.ObjectMeta.Labels = make(map[string]string)
+		pvcTmpl.Name = pvcName
+		if pvcTmpl.Labels == nil {
+			pvcTmpl.Labels = make(map[string]string)
 		}
-		pvcTmpl.ObjectMeta.Labels[common.LabelKeyWorkflow] = woc.wf.ObjectMeta.Name
+		pvcTmpl.Labels[common.LabelKeyWorkflow] = woc.wf.Name
 		pvcTmpl.OwnerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(woc.wf, wfv1.SchemeGroupVersion.WithKind(workflow.WorkflowKind)),
 		}
@@ -1745,7 +1745,7 @@ func (woc *wfOperationCtx) createPVCs(ctx context.Context) error {
 			Name: refName,
 			VolumeSource: apiv1.VolumeSource{
 				PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvc.ObjectMeta.Name,
+					ClaimName: pvc.Name,
 				},
 			},
 		}
@@ -1775,7 +1775,7 @@ func (woc *wfOperationCtx) deletePVCs(ctx context.Context) error {
 		// PVC list already empty. nothing to do
 		return nil
 	}
-	pvcClient := woc.controller.kubeclientset.CoreV1().PersistentVolumeClaims(woc.wf.ObjectMeta.Namespace)
+	pvcClient := woc.controller.kubeclientset.CoreV1().PersistentVolumeClaims(woc.wf.Namespace)
 	newPVClist := make([]apiv1.Volume, 0)
 	// Attempt to delete all PVCs. Record first error encountered
 	var firstErr error
@@ -1819,7 +1819,7 @@ func (woc *wfOperationCtx) deletePVCs(ctx context.Context) error {
 
 // Check if we have a retry node which wasn't memoized and return that if we do
 func (woc *wfOperationCtx) possiblyGetRetryChildNode(node *wfv1.NodeStatus) *wfv1.NodeStatus {
-	if node.Type == wfv1.NodeTypeRetry && !(node.MemoizationStatus != nil && node.MemoizationStatus.Hit) {
+	if node.Type == wfv1.NodeTypeRetry && (node.MemoizationStatus == nil || !node.MemoizationStatus.Hit) {
 		// If a retry node has hooks, the hook nodes will also become its children,
 		// so we need to filter out the hook nodes when finding the last child node of the retry node.
 		for i := len(node.Children) - 1; i >= 0; i-- {
@@ -2359,13 +2359,13 @@ func (woc *wfOperationCtx) checkTemplateTimeout(tmpl *wfv1.Template, node *wfv1.
 // recordWorkflowPhaseChange stores the metrics associated with the workflow phase changing
 func (woc *wfOperationCtx) recordWorkflowPhaseChange(ctx context.Context) {
 	phase := metrics.ConvertWorkflowPhase(woc.wf.Status.Phase)
-	woc.controller.metrics.ChangeWorkflowPhase(ctx, phase, woc.wf.ObjectMeta.Namespace)
+	woc.controller.metrics.ChangeWorkflowPhase(ctx, phase, woc.wf.Namespace)
 	if woc.wf.Spec.WorkflowTemplateRef != nil { // not-woc-misuse
-		woc.controller.metrics.CountWorkflowTemplate(ctx, phase, woc.wf.Spec.WorkflowTemplateRef.Name, woc.wf.ObjectMeta.Namespace, woc.wf.Spec.WorkflowTemplateRef.ClusterScope) // not-woc-misuse
+		woc.controller.metrics.CountWorkflowTemplate(ctx, phase, woc.wf.Spec.WorkflowTemplateRef.Name, woc.wf.Namespace, woc.wf.Spec.WorkflowTemplateRef.ClusterScope) // not-woc-misuse
 		switch woc.wf.Status.Phase {
 		case wfv1.WorkflowSucceeded, wfv1.WorkflowFailed, wfv1.WorkflowError:
 			duration := time.Since(woc.wf.Status.StartedAt.Time)
-			woc.controller.metrics.RecordWorkflowTemplateTime(ctx, duration, woc.wf.Spec.WorkflowTemplateRef.Name, woc.wf.ObjectMeta.Namespace, woc.wf.Spec.WorkflowTemplateRef.ClusterScope) // not-woc-misuse
+			woc.controller.metrics.RecordWorkflowTemplateTime(ctx, duration, woc.wf.Spec.WorkflowTemplateRef.Name, woc.wf.Namespace, woc.wf.Spec.WorkflowTemplateRef.ClusterScope) // not-woc-misuse
 			log.Warnf("Recording template time")
 		}
 	}
@@ -2391,12 +2391,12 @@ func (woc *wfOperationCtx) markWorkflowPhase(ctx context.Context, phase wfv1.Wor
 		woc.updated = true
 		woc.wf.Status.Phase = phase
 		woc.recordWorkflowPhaseChange(ctx)
-		if woc.wf.ObjectMeta.Labels == nil {
-			woc.wf.ObjectMeta.Labels = make(map[string]string)
+		if woc.wf.Labels == nil {
+			woc.wf.Labels = make(map[string]string)
 		}
-		woc.wf.ObjectMeta.Labels[common.LabelKeyPhase] = string(phase)
-		if _, ok := woc.wf.ObjectMeta.Labels[common.LabelKeyCompleted]; !ok {
-			woc.wf.ObjectMeta.Labels[common.LabelKeyCompleted] = "false"
+		woc.wf.Labels[common.LabelKeyPhase] = string(phase)
+		if _, ok := woc.wf.Labels[common.LabelKeyCompleted]; !ok {
+			woc.wf.Labels[common.LabelKeyCompleted] = "false"
 		}
 		if woc.controller.Config.WorkflowEvents.IsEnabled() {
 			switch phase {
@@ -2421,14 +2421,14 @@ func (woc *wfOperationCtx) markWorkflowPhase(ctx context.Context, phase wfv1.Wor
 	}
 
 	if phase == wfv1.WorkflowError {
-		entryNode, err := woc.wf.Status.Nodes.Get(woc.wf.ObjectMeta.Name)
+		entryNode, err := woc.wf.Status.Nodes.Get(woc.wf.Name)
 		if err != nil {
-			woc.log.Errorf("was unable to obtain node for %s", woc.wf.ObjectMeta.Name)
+			woc.log.Errorf("was unable to obtain node for %s", woc.wf.Name)
 		}
 		if (err == nil) && entryNode.Phase == wfv1.NodeRunning {
 			entryNode.Phase = wfv1.NodeError
 			entryNode.Message = "Workflow operation error"
-			woc.wf.Status.Nodes.Set(woc.wf.ObjectMeta.Name, *entryNode)
+			woc.wf.Status.Nodes.Set(woc.wf.Name, *entryNode)
 			woc.updated = true
 		}
 	}
@@ -2438,15 +2438,15 @@ func (woc *wfOperationCtx) markWorkflowPhase(ctx context.Context, phase wfv1.Wor
 		woc.log.Info("Marking workflow completed")
 		woc.wf.Status.FinishedAt = metav1.Time{Time: time.Now().UTC()}
 		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", woc.wf.Status.FinishedAt.Sub(woc.wf.Status.StartedAt.Time).Seconds())
-		if woc.wf.ObjectMeta.Labels == nil {
-			woc.wf.ObjectMeta.Labels = make(map[string]string)
+		if woc.wf.Labels == nil {
+			woc.wf.Labels = make(map[string]string)
 		}
-		woc.wf.ObjectMeta.Labels[common.LabelKeyCompleted] = "true"
+		woc.wf.Labels[common.LabelKeyCompleted] = "true"
 		woc.wf.Status.Conditions.UpsertCondition(wfv1.Condition{Status: metav1.ConditionTrue, Type: wfv1.ConditionTypeCompleted})
 		err := woc.deletePDBResource(ctx)
 		if err != nil {
 			woc.wf.Status.Phase = wfv1.WorkflowError
-			woc.wf.ObjectMeta.Labels[common.LabelKeyPhase] = string(wfv1.NodeError)
+			woc.wf.Labels[common.LabelKeyPhase] = string(wfv1.NodeError)
 			woc.updated = true
 			woc.wf.Status.Message = err.Error()
 		}
@@ -3173,12 +3173,12 @@ func (woc *wfOperationCtx) buildLocalScope(scope *wfScope, prefix string, node *
 
 	if !node.StartedAt.Time.IsZero() {
 		key := fmt.Sprintf("%s.startedAt", prefix)
-		scope.addParamToScope(key, node.StartedAt.Time.Format(time.RFC3339))
+		scope.addParamToScope(key, node.StartedAt.Format(time.RFC3339))
 	}
 
 	if !node.FinishedAt.Time.IsZero() {
 		key := fmt.Sprintf("%s.finishedAt", prefix)
-		scope.addParamToScope(key, node.FinishedAt.Time.Format(time.RFC3339))
+		scope.addParamToScope(key, node.FinishedAt.Format(time.RFC3339))
 	}
 
 	if node.PodIP != "" {
@@ -3806,7 +3806,7 @@ func (woc *wfOperationCtx) computeMetrics(ctx context.Context, metricList []*wfv
 
 		proceed, err := shouldExecute(metricTmpl.When)
 		if err != nil {
-			woc.reportMetricEmissionError(fmt.Sprintf("unable to compute 'when' clause for metric '%s': %s", woc.wf.ObjectMeta.Name, err))
+			woc.reportMetricEmissionError(fmt.Sprintf("unable to compute 'when' clause for metric '%s': %s", woc.wf.Name, err))
 			continue
 		}
 		if !proceed {
@@ -3816,7 +3816,7 @@ func (woc *wfOperationCtx) computeMetrics(ctx context.Context, metricList []*wfv
 		if metricTmpl.IsRealtime() {
 			// Finally substitute value parameters
 			value := metricTmpl.Gauge.Value
-			if !(strings.HasPrefix(value, "{{") && strings.HasSuffix(value, "}}")) {
+			if !strings.HasPrefix(value, "{{") || !strings.HasSuffix(value, "}}") {
 				woc.reportMetricEmissionError("real time metrics can only be used with metric variables")
 				continue
 			}

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -1119,7 +1119,7 @@ spec:
 
 	// Make job-1's pod succeed
 	makePodsPhase(ctx, woc, apiv1.PodSucceeded, func(pod *apiv1.Pod, _ *wfOperationCtx) {
-		if pod.ObjectMeta.Name == "job-1" {
+		if pod.Name == "job-1" {
 			pod.Status.Phase = apiv1.PodSucceeded
 		}
 	})

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -508,7 +508,7 @@ func TestVolumeGCStrategy(t *testing.T) {
 			wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
 			woc := newWorkflowOperationCtx(wf, controller)
 			woc.operate(ctx)
-			wf, err := wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+			wf, err := wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 			require.NoError(t, err)
 			assert.Len(t, wf.Status.PersistentVolumeClaims, tt.expectedVolumesRemaining)
 		})
@@ -948,7 +948,7 @@ func TestProcessNodeRetriesWithExpression(t *testing.T) {
 	require.NoError(t, err)
 	// The parent node also gets marked as Succeeded.
 	assert.Equal(t, wfv1.NodeSucceeded, n.Phase)
-	assert.Equal(t, "", n.Message)
+	assert.Empty(t, n.Message)
 
 	// Mark the parent node as running again and the lastChild as errored.
 	n = woc.markNodePhase(n.Name, wfv1.NodeRunning)
@@ -1022,14 +1022,14 @@ func TestProcessNodeRetriesMessageOrder(t *testing.T) {
 	n, _, err = woc.processNodeRetries(n, retries, &executeTemplateOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.NodeRunning, n.Phase)
-	assert.Equal(t, "", n.Message)
+	assert.Empty(t, n.Message)
 
 	// No retry related message for succeeded node
 	woc.markNodePhase(lastChild.Name, wfv1.NodeSucceeded)
 	n, _, err = woc.processNodeRetries(n, retries, &executeTemplateOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.NodeSucceeded, n.Phase)
-	assert.Equal(t, "", n.Message)
+	assert.Empty(t, n.Message)
 
 	// workflow mark shutdown, no retry is evaluated
 	woc.wf.Spec.Shutdown = wfv1.ShutdownStrategyStop
@@ -1059,7 +1059,7 @@ func TestProcessNodeRetriesMessageOrder(t *testing.T) {
 	n, err = woc.wf.GetNodeByName(nodeName)
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.NodeError, n.Phase)
-	assert.Equal(t, "", n.Message)
+	assert.Empty(t, n.Message)
 
 	// Node status aligns with retrypolicy, should evaluate expression
 	retries.RetryPolicy = wfv1.RetryPolicyOnFailure
@@ -1347,7 +1347,7 @@ func TestBackoffMessage(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, proceed)
 	// New node is started, message should be clear
-	assert.Equal(t, "", newRetryNode.Message)
+	assert.Empty(t, newRetryNode.Message)
 }
 
 var retriesVariableTemplate = `
@@ -2020,7 +2020,7 @@ func TestWorkflowStepRetry(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(workflowStepRetry)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -2030,7 +2030,7 @@ func TestWorkflowStepRetry(t *testing.T) {
 
 	// complete the first pod
 	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc = newWorkflowOperationCtx(wf, controller)
 	nodeID := woc.nodeID(&pods.Items[0])
@@ -2039,7 +2039,7 @@ func TestWorkflowStepRetry(t *testing.T) {
 
 	// fail the second pod
 	makePodsPhase(ctx, woc, apiv1.PodFailed)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc = newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -2148,7 +2148,7 @@ func TestStepsTemplateParallelismLimit(t *testing.T) {
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	woc := newWorkflowOperationCtx(wf, controller)
@@ -2159,7 +2159,7 @@ func TestStepsTemplateParallelismLimit(t *testing.T) {
 
 	// operate again and make sure we don't schedule any more pods
 	makePodsPhase(ctx, woc, apiv1.PodRunning)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	// wfBytes, _ := json.MarshalIndent(wf, "", "  ")
 	// log.Printf("%s", wfBytes)
@@ -2293,7 +2293,7 @@ func TestNestedTemplateParallelismLimit(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(nestedParallelism)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -2348,9 +2348,9 @@ func TestSuspendResume(t *testing.T) {
 
 	// suspend the workflow
 	ctx := context.Background()
-	err := util.SuspendWorkflow(ctx, wfcset, wf.ObjectMeta.Name)
+	err := util.SuspendWorkflow(ctx, wfcset, wf.Name)
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, *wf.Spec.Suspend)
 
@@ -2362,9 +2362,9 @@ func TestSuspendResume(t *testing.T) {
 	assert.Empty(t, pods.Items)
 
 	// resume the workflow and operate again. two pods should be able to be scheduled
-	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.ObjectMeta.Name, "")
+	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.Name, "")
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Nil(t, wf.Spec.Suspend)
 	woc = newWorkflowOperationCtx(wf, controller)
@@ -2399,7 +2399,7 @@ func TestSuspendWithDeadline(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
@@ -2453,7 +2453,7 @@ func TestSuspendInputsResolution(t *testing.T) {
 	assert.Equal(t, wfv1.NodeRunning, node.Phase)
 
 	assert.Equal(t, "param1", node.Inputs.Parameters[0].Name)
-	assert.Equal(t, "{\"enum\": [\"one\", \"two\", \"three\"]}", node.Inputs.Parameters[0].Value.String())
+	assert.JSONEq(t, "{\"enum\": [\"one\", \"two\", \"three\"]}", node.Inputs.Parameters[0].Value.String())
 	assert.Len(t, node.Inputs.Parameters[0].Enum, 3)
 	assert.Equal(t, "one", node.Inputs.Parameters[0].Enum[0].String())
 	assert.Equal(t, "two", node.Inputs.Parameters[0].Enum[1].String())
@@ -2508,10 +2508,11 @@ func TestSequence(t *testing.T) {
 	found100 := false
 	found101 := false
 	for _, node := range updatedWf.Status.Nodes {
-		if node.DisplayName == "step1(0:100)" {
+		switch node.DisplayName {
+		case "step1(0:100)":
 			assert.Equal(t, "100", node.Inputs.Parameters[0].Value.String())
 			found100 = true
-		} else if node.DisplayName == "step1(1:101)" {
+		case "step1(1:101)":
 			assert.Equal(t, "101", node.Inputs.Parameters[0].Value.String())
 			found101 = true
 		}
@@ -2571,8 +2572,8 @@ func TestInputParametersAsJson(t *testing.T) {
 	found := false
 	for _, node := range updatedWf.Status.Nodes {
 		if node.Type == wfv1.NodeTypePod {
-			expectedJson := `Workflow: [{"name":"parameter1","value":"value1"}]. Template: [{"name":"parameter1","value":"value1"},{"name":"parameter2","value":"template2"}]`
-			assert.Equal(t, expectedJson, node.Inputs.Parameters[0].Value.String())
+			expected := `Workflow: [{"name":"parameter1","value":"value1"}]. Template: [{"name":"parameter1","value":"value1"},{"name":"parameter2","value":"template2"}]`
+			assert.Equal(t, expected, node.Inputs.Parameters[0].Value.String())
 			found = true
 		}
 	}
@@ -2723,7 +2724,7 @@ func TestSuspendTemplate(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
@@ -2735,9 +2736,9 @@ func TestSuspendTemplate(t *testing.T) {
 	assert.Empty(t, pods.Items)
 
 	// resume the workflow. verify resume workflow edits nodestatus correctly
-	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.ObjectMeta.Name, "")
+	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.Name, "")
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.False(t, util.IsWorkflowSuspended(wf))
 
@@ -2761,7 +2762,7 @@ func TestSuspendTemplateWithFailedResume(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
@@ -2773,9 +2774,9 @@ func TestSuspendTemplateWithFailedResume(t *testing.T) {
 	assert.Empty(t, pods.Items)
 
 	// resume the workflow. verify resume workflow edits nodestatus correctly
-	err = util.StopWorkflow(ctx, wfcset, controller.hydrator, wf.ObjectMeta.Name, "inputs.parameters.param1.value=value1", "Step failed!")
+	err = util.StopWorkflow(ctx, wfcset, controller.hydrator, wf.Name, "inputs.parameters.param1.value=value1", "Step failed!")
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.False(t, util.IsWorkflowSuspended(wf))
 
@@ -2800,7 +2801,7 @@ func TestSuspendTemplateWithFilteredResume(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
@@ -2812,7 +2813,7 @@ func TestSuspendTemplateWithFilteredResume(t *testing.T) {
 	assert.Empty(t, pods.Items)
 
 	// resume the workflow, but with non-matching selector
-	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.ObjectMeta.Name, "inputs.paramaters.param1.value=value2")
+	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.Name, "inputs.paramaters.param1.value=value2")
 	require.Error(t, err)
 
 	// operate the workflow. nothing should have happened
@@ -2824,9 +2825,9 @@ func TestSuspendTemplateWithFilteredResume(t *testing.T) {
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
 	// resume the workflow, but with matching selector
-	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.ObjectMeta.Name, "inputs.parameters.param1.value=value1")
+	err = util.ResumeWorkflow(ctx, wfcset, controller.hydrator, wf.Name, "inputs.parameters.param1.value=value1")
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.False(t, util.IsWorkflowSuspended(wf))
 
@@ -2876,7 +2877,7 @@ func TestSuspendResumeAfterTemplate(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
@@ -2910,7 +2911,7 @@ func TestSuspendResumeAfterTemplateNoWait(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.True(t, util.IsWorkflowSuspended(wf))
 
@@ -3269,7 +3270,7 @@ func TestParamSubstitutionWithArtifact(t *testing.T) {
 	woc := newWoc(*wf)
 	ctx := context.Background()
 	woc.operate(ctx)
-	wf, err := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows("").Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows("").Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
 	pods, err := listPods(woc)
@@ -3282,7 +3283,7 @@ func TestGlobalParamSubstitutionWithArtifact(t *testing.T) {
 	woc := newWoc(*wf)
 	ctx := context.Background()
 	woc.operate(ctx)
-	wf, err := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows("").Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows("").Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
 	pods, err := listPods(woc)
@@ -3395,7 +3396,7 @@ func TestMetadataPassing(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(metadataTemplate)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -3646,7 +3647,7 @@ func TestResourceTemplate(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
 
@@ -3658,7 +3659,7 @@ func TestResourceTemplate(t *testing.T) {
 	err = yaml.Unmarshal([]byte(tmpl.Resource.Manifest), &cm)
 	require.NoError(t, err)
 	assert.Equal(t, "resource-cm", cm.Name)
-	assert.Empty(t, cm.ObjectMeta.OwnerReferences)
+	assert.Empty(t, cm.OwnerReferences)
 }
 
 var resourceWithOwnerReferenceTemplate = `
@@ -3729,7 +3730,7 @@ func TestResourceWithOwnerReferenceTemplate(t *testing.T) {
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
 
@@ -3841,7 +3842,7 @@ func TestStepWFGetNodeName(t *testing.T) {
 	assert.False(t, hasOutputResultRef("print-message", &wf.Spec.Templates[0]))
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	for _, node := range wf.Status.Nodes {
 		if strings.Contains(node.Name, "generate") {
@@ -3866,7 +3867,7 @@ func TestDAGWFGetNodeName(t *testing.T) {
 	assert.False(t, hasOutputResultRef("B", &wf.Spec.Templates[0]))
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	for _, node := range wf.Status.Nodes {
 		if strings.Contains(node.Name, ".A") {
@@ -3888,7 +3889,7 @@ spec:
   arguments:
     parameters:
     - name: input
-      value: '[[1,2],[3,4],[4,5],[6,7]]'
+      value: '[[1,2],[3,4],[4,5],[106,7]]'
   templates:
   - name: expand-with-items
     steps:
@@ -4597,7 +4598,7 @@ func TestRetryNodeOutputs(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(retryNodeOutputs)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 
@@ -7046,7 +7047,7 @@ func TestStorageQuota(t *testing.T) {
 	cancel, controller := newController(wf)
 	defer cancel()
 
-	controller.kubeclientset.(*fake.Clientset).BatchV1().(*batchfake.FakeBatchV1).Fake.PrependReactor("create", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	controller.kubeclientset.(*fake.Clientset).BatchV1().(*batchfake.FakeBatchV1).PrependReactor("create", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierr.NewForbidden(schema.GroupResource{Group: "test", Resource: "test1"}, "test", errors.New("exceeded quota"))
 	})
 
@@ -7056,7 +7057,7 @@ func TestStorageQuota(t *testing.T) {
 	assert.Equal(t, wfv1.WorkflowPending, woc.wf.Status.Phase)
 	assert.Contains(t, woc.wf.Status.Message, "Waiting for a PVC to be created.")
 
-	controller.kubeclientset.(*fake.Clientset).BatchV1().(*batchfake.FakeBatchV1).Fake.PrependReactor("create", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	controller.kubeclientset.(*fake.Clientset).BatchV1().(*batchfake.FakeBatchV1).PrependReactor("create", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierr.NewBadRequest("BadRequest")
 	})
 
@@ -7679,7 +7680,7 @@ func TestRetryOnDiffHost(t *testing.T) {
 	assert.Equal(t, wfv1.NodeRunning, n.Phase)
 
 	// Ensure related fields are not set
-	assert.Equal(t, "", lastChild.HostNodeName)
+	assert.Empty(t, lastChild.HostNodeName)
 
 	// Set host name
 	n, err = woc.wf.GetNodeByName(nodeName)
@@ -8585,7 +8586,7 @@ func TestMutexWfPendingWithNoPod(t *testing.T) {
 	}, workflowExistenceFunc)
 
 	// preempt lock
-	_, _, _, _, err := controller.syncManager.TryAcquire(ctx, wf, "test", &wfv1.Synchronization{Mutexes: []*wfv1.Mutex{&wfv1.Mutex{Name: "welcome"}}})
+	_, _, _, _, err := controller.syncManager.TryAcquire(ctx, wf, "test", &wfv1.Synchronization{Mutexes: []*wfv1.Mutex{{Name: "welcome"}}})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 
@@ -8594,9 +8595,9 @@ func TestMutexWfPendingWithNoPod(t *testing.T) {
 	assert.Equal(t, wfv1.NodePending, woc.wf.Status.Nodes.FindByDisplayName("hello-world-mpdht").Phase)
 	assert.Equal(t, "Waiting for argo/Mutex/welcome lock. Lock status: 0/1", woc.wf.Status.Nodes.FindByDisplayName("hello-world-mpdht").Message)
 
-	woc.controller.syncManager.Release(ctx, wf, "test", &wfv1.Synchronization{Mutexes: []*wfv1.Mutex{&wfv1.Mutex{Name: "welcome"}}})
+	woc.controller.syncManager.Release(ctx, wf, "test", &wfv1.Synchronization{Mutexes: []*wfv1.Mutex{{Name: "welcome"}}})
 	woc.operate(ctx)
-	assert.Equal(t, "", woc.wf.Status.Nodes.FindByDisplayName("hello-world-mpdht").Message)
+	assert.Empty(t, woc.wf.Status.Nodes.FindByDisplayName("hello-world-mpdht").Message)
 }
 
 var wfGlobalArtifactNil = `apiVersion: argoproj.io/v1alpha1
@@ -9630,7 +9631,7 @@ func TestSetWFPodNamesAnnotation(t *testing.T) {
 		woc := newWorkflowOperationCtx(wf, controller)
 
 		woc.operate(ctx)
-		annotations := woc.wf.ObjectMeta.GetAnnotations()
+		annotations := woc.wf.GetAnnotations()
 		assert.Equal(t, annotations[common.AnnotationKeyPodNameVersion], tt.podNameVersion)
 	}
 }
@@ -10335,6 +10336,10 @@ spec:
           path: /tmp/hello_world.txt
 `
 
+func nodeWithTemplateName(name string) func(n wfv1.NodeStatus) bool {
+	return func(n wfv1.NodeStatus) bool { return n.TemplateName == name }
+}
+
 func TestMemoizationTemplateLevelCacheWithStepWithoutCache(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(workflowWithTemplateLevelMemoizationAndChildStep)
 
@@ -10351,16 +10356,15 @@ func TestMemoizationTemplateLevelCacheWithStepWithoutCache(t *testing.T) {
 
 	// Expect both workflowTemplate and the step to be executed
 	for _, node := range woc.wf.Status.Nodes {
-		if node.TemplateName == "entrypoint" {
-			assert.True(t, true, "Entrypoint node does not exist")
-			assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-			assert.False(t, node.MemoizationStatus.Hit)
-		}
-		if node.Name == "whalesay" {
-			assert.True(t, true, "Whalesay step does not exist")
-			assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-		}
+		t.Logf("%+v", node)
 	}
+	node := woc.wf.Status.Nodes.Find(nodeWithTemplateName("entrypoint"))
+	require.NotNil(t, node, "Entrypoint should exist")
+	assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
+	assert.False(t, node.MemoizationStatus.Hit)
+	node = woc.wf.Status.Nodes.Find(nodeWithTemplateName("whalesay"))
+	require.NotNil(t, node, "Whalesay step should exist")
+	assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
 }
 
 func TestMemoizationTemplateLevelCacheWithStepWithCache(t *testing.T) {
@@ -10399,17 +10403,12 @@ func TestMemoizationTemplateLevelCacheWithStepWithCache(t *testing.T) {
 	woc.operate(ctx)
 
 	// Only parent node should exist and it should be a memoization cache hit
-	for _, node := range woc.wf.Status.Nodes {
-		t.Log(node)
-		if node.TemplateName == "entrypoint" {
-			assert.True(t, true, "Entrypoint node does not exist")
-			assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-			assert.True(t, node.MemoizationStatus.Hit)
-		}
-		if node.Name == "whalesay" {
-			assert.False(t, true, "Whalesay step should not have been executed")
-		}
-	}
+	node := woc.wf.Status.Nodes.Find(nodeWithTemplateName("entrypoint"))
+	require.NotNil(t, node, "Entrypoint should exist")
+	assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
+	assert.True(t, node.MemoizationStatus.Hit)
+	node = woc.wf.Status.Nodes.Find(nodeWithTemplateName("whalesay"))
+	require.Nil(t, node, "Whalesay step should not have been executed")
 }
 
 var workflowWithTemplateLevelMemoizationAndChildDag = `
@@ -10465,17 +10464,13 @@ func TestMemoizationTemplateLevelCacheWithDagWithoutCache(t *testing.T) {
 	woc.operate(ctx)
 
 	// Expect both workflowTemplate and the dag to be executed
-	for _, node := range woc.wf.Status.Nodes {
-		if node.TemplateName == "entrypoint" {
-			assert.True(t, true, "Entrypoint node does not exist")
-			assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-			assert.False(t, node.MemoizationStatus.Hit)
-		}
-		if node.Name == "whalesay" {
-			assert.True(t, true, "Whalesay dag does not exist")
-			assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-		}
-	}
+	node := woc.wf.Status.Nodes.Find(nodeWithTemplateName("entrypoint"))
+	require.NotNil(t, node, "Entrypoint should exist")
+	assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
+	assert.False(t, node.MemoizationStatus.Hit)
+	node = woc.wf.Status.Nodes.Find(nodeWithTemplateName("whalesay"))
+	require.NotNil(t, node, "Whalesay dag should exist")
+	assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
 }
 
 func TestMemoizationTemplateLevelCacheWithDagWithCache(t *testing.T) {
@@ -10514,17 +10509,12 @@ func TestMemoizationTemplateLevelCacheWithDagWithCache(t *testing.T) {
 	woc.operate(ctx)
 
 	// Only parent node should exist and it should be a memoization cache hit
-	for _, node := range woc.wf.Status.Nodes {
-		t.Log(node)
-		if node.TemplateName == "entrypoint" {
-			assert.True(t, true, "Entrypoint node does not exist")
-			assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
-			assert.True(t, node.MemoizationStatus.Hit)
-		}
-		if node.Name == "whalesay" {
-			assert.False(t, true, "Whalesay dag should not have been executed")
-		}
-	}
+	node := woc.wf.Status.Nodes.Find(nodeWithTemplateName("entrypoint"))
+	require.NotNil(t, node, "Entrypoint should exist")
+	assert.Equal(t, wfv1.NodeSucceeded, node.Phase)
+	assert.True(t, node.MemoizationStatus.Hit)
+	node = woc.wf.Status.Nodes.Find(nodeWithTemplateName("whalesay"))
+	require.Nil(t, node, "Whalesay dag should not have been executed")
 }
 
 var maxDepth = `
@@ -10821,7 +10811,7 @@ status:
 
 	ctx := context.Background()
 
-	controller.kubeclientset.(*fake.Clientset).CoreV1().(*corefake.FakeCoreV1).Fake.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	controller.kubeclientset.(*fake.Clientset).CoreV1().(*corefake.FakeCoreV1).PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		createAction, ok := action.(k8stesting.CreateAction)
 		assert.True(t, ok)
 
@@ -10907,7 +10897,7 @@ func TestWorkflowNeedReconcile(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(needReconcileWorklfow)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -10917,7 +10907,7 @@ func TestWorkflowNeedReconcile(t *testing.T) {
 
 	// complete the first pod
 	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc = newWorkflowOperationCtx(wf, controller)
 	for _, node := range woc.wf.Status.Nodes {
@@ -10948,7 +10938,7 @@ func TestWorkflowNeedReconcile(t *testing.T) {
 
 	// complete the second pod
 	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc = newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -11249,7 +11239,7 @@ func TestContainerSetWhenPodDeleted(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(wfHasContainerSet)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)
@@ -11333,7 +11323,7 @@ func TestContainerSetWithDependenciesWhenPodDeleted(t *testing.T) {
 	wf := wfv1.MustUnmarshalWorkflow(wfHasContainerSetWithDependencies)
 	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
 	require.NoError(t, err)
-	wf, err = wfcset.Get(ctx, wf.ObjectMeta.Name, metav1.GetOptions{})
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	woc := newWorkflowOperationCtx(wf, controller)
 	woc.operate(ctx)

--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	apiv1 "k8s.io/api/core/v1"
-
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -142,7 +140,7 @@ func (c *Controller) GetPodPhaseMetrics() map[string]int64 {
 }
 
 // Check if owned pod's workflow no longer exists or workflow is in deletion
-func (c *Controller) podOrphaned(pod *v1.Pod) bool {
+func (c *Controller) podOrphaned(pod *apiv1.Pod) bool {
 	controllerRef := metav1.GetControllerOf(pod)
 	// Pod had no owner
 	if controllerRef == nil ||
@@ -171,8 +169,8 @@ func (c *Controller) podOrphaned(pod *v1.Pod) bool {
 	return wf.DeletionTimestamp != nil
 }
 
-func podGCFromPod(pod *v1.Pod) wfv1.PodGC {
-	if val, ok := pod.ObjectMeta.Annotations[common.AnnotationKeyPodGCStrategy]; ok {
+func podGCFromPod(pod *apiv1.Pod) wfv1.PodGC {
+	if val, ok := pod.Annotations[common.AnnotationKeyPodGCStrategy]; ok {
 		parts := strings.Split(val, "/")
 		return wfv1.PodGC{Strategy: wfv1.PodGCStrategy(parts[0]), DeleteDelayDuration: parts[1]}
 	}
@@ -180,7 +178,7 @@ func podGCFromPod(pod *v1.Pod) wfv1.PodGC {
 }
 
 // Returns time.IsZero if no last transition
-func podLastTransition(pod *v1.Pod) time.Time {
+func podLastTransition(pod *apiv1.Pod) time.Time {
 	lastTransition := time.Time{}
 	for _, condition := range pod.Status.Conditions {
 		if condition.LastTransitionTime.After(lastTransition) {
@@ -191,7 +189,7 @@ func podLastTransition(pod *v1.Pod) time.Time {
 }
 
 // A common handler for
-func (c *Controller) commonPodEvent(pod *v1.Pod, deleting bool) {
+func (c *Controller) commonPodEvent(pod *apiv1.Pod, deleting bool) {
 	// All pods here are not marked completed
 	action := noAction
 	minimumDelay := time.Duration(0)
@@ -237,7 +235,7 @@ func (c *Controller) commonPodEvent(pod *v1.Pod, deleting bool) {
 	}
 }
 
-func (c *Controller) addPodEvent(pod *v1.Pod) {
+func (c *Controller) addPodEvent(pod *apiv1.Pod) {
 	c.log.WithField("pod", pod.Name).Info("add pod event")
 	err := c.callBack(pod)
 	if err != nil {
@@ -246,7 +244,7 @@ func (c *Controller) addPodEvent(pod *v1.Pod) {
 	c.commonPodEvent(pod, false)
 }
 
-func (c *Controller) updatePodEvent(old *v1.Pod, new *v1.Pod) {
+func (c *Controller) updatePodEvent(old *apiv1.Pod, new *apiv1.Pod) {
 	// This is only called for actual updates, where there are "significant changes"
 	c.log.WithField("pod", old.Name).Info("update pod event")
 	err := c.callBack(new)
@@ -256,7 +254,6 @@ func (c *Controller) updatePodEvent(old *v1.Pod, new *v1.Pod) {
 	c.commonPodEvent(new, false)
 }
 
-// func (c *Controller) deletePodEvent(pod *v1.Pod) {
 func (c *Controller) deletePodEvent(obj interface{}) {
 	pod, err := podFromObj(obj)
 	if err != nil {

--- a/workflow/controller/pod/queue.go
+++ b/workflow/controller/pod/queue.go
@@ -39,7 +39,7 @@ func (c *Controller) getPodCleanupPatch(pod *apiv1.Pod, labelPodCompleted bool) 
 			func(s string) bool { return s == common.FinalizerPodStatus })
 		if len(finalizers) != len(pod.Finalizers) {
 			un.SetFinalizers(finalizers)
-			un.SetResourceVersion(pod.ObjectMeta.ResourceVersion)
+			un.SetResourceVersion(pod.ResourceVersion)
 		}
 	}
 

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -77,10 +77,11 @@ func (woc *wfOperationCtx) taskResultReconciliation() {
 
 		label := result.Labels[common.LabelKeyReportOutputsCompleted]
 		// If the task result is completed, set the state to true.
-		if label == "true" {
+		switch label {
+		case "true":
 			woc.log.Debugf("Marking task result complete %s", resultName)
 			woc.wf.Status.MarkTaskResultComplete(resultName)
-		} else if label == "false" {
+		case "false":
 			woc.log.Debugf("Marking task result incomplete %s", resultName)
 			woc.wf.Status.MarkTaskResultIncomplete(resultName)
 		}

--- a/workflow/controller/taskset_test.go
+++ b/workflow/controller/taskset_test.go
@@ -110,7 +110,7 @@ spec:
 		for _, pod := range pods.Items {
 			assert.NotNil(t, pod)
 			assert.True(t, strings.HasSuffix(pod.Name, "-agent"))
-			assert.Equal(t, "testID", pod.ObjectMeta.Labels[common.LabelKeyControllerInstanceID])
+			assert.Equal(t, "testID", pod.Labels[common.LabelKeyControllerInstanceID])
 		}
 	})
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -164,10 +164,10 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	pod := &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      util.GeneratePodName(woc.wf.Name, nodeName, tmpl.Name, nodeID, util.GetWorkflowPodNameVersion(woc.wf)),
-			Namespace: woc.wf.ObjectMeta.Namespace,
+			Namespace: woc.wf.Namespace,
 			Labels: map[string]string{
-				common.LabelKeyWorkflow:  woc.wf.ObjectMeta.Name, // Allows filtering by pods related to specific workflow
-				common.LabelKeyCompleted: "false",                // Allows filtering by incomplete workflow pods
+				common.LabelKeyWorkflow:  woc.wf.Name, // Allows filtering by pods related to specific workflow
+				common.LabelKeyCompleted: "false",     // Allows filtering by incomplete workflow pods
 			},
 			Annotations: map[string]string{
 				common.AnnotationKeyNodeName: nodeName,
@@ -186,12 +186,12 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	}
 
 	if os.Getenv(common.EnvVarPodStatusCaptureFinalizer) == "true" {
-		pod.ObjectMeta.Finalizers = append(pod.ObjectMeta.Finalizers, common.FinalizerPodStatus)
+		pod.Finalizers = append(pod.Finalizers, common.FinalizerPodStatus)
 	}
 
 	if opts.onExitPod {
 		// This pod is part of an onExit handler, label it so
-		pod.ObjectMeta.Labels[common.LabelKeyOnExit] = "true"
+		pod.Labels[common.LabelKeyOnExit] = "true"
 	}
 
 	if woc.execWf.Spec.HostNetwork != nil {
@@ -201,7 +201,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	woc.addDNSConfig(pod)
 
 	if woc.controller.Config.InstanceID != "" {
-		pod.ObjectMeta.Labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
+		pod.Labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
 	}
 
 	woc.addArchiveLocation(tmpl)
@@ -234,10 +234,10 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 			break
 		}
 	}
-	pod.ObjectMeta.Annotations[common.AnnotationKeyDefaultContainer] = defaultContainer
+	pod.Annotations[common.AnnotationKeyDefaultContainer] = defaultContainer
 
 	if podGC := woc.execWf.Spec.PodGC; podGC != nil {
-		pod.ObjectMeta.Annotations[common.AnnotationKeyPodGCStrategy] = fmt.Sprintf("%s/%s", podGC.GetStrategy(), woc.getPodGCDelay(podGC))
+		pod.Annotations[common.AnnotationKeyPodGCStrategy] = fmt.Sprintf("%s/%s", podGC.GetStrategy(), woc.getPodGCDelay(podGC))
 	}
 
 	// Add init container only if it needs input artifacts. This is also true for
@@ -249,7 +249,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 	woc.addMetadata(pod, tmpl)
 
 	// Set initial progress from pod metadata if exists.
-	if x, ok := pod.ObjectMeta.Annotations[common.AnnotationKeyProgress]; ok {
+	if x, ok := pod.Annotations[common.AnnotationKeyProgress]; ok {
 		if p, ok := wfv1.ParseProgress(x); ok {
 			node, err := woc.wf.Status.Nodes.Get(nodeID)
 			if err != nil {
@@ -436,9 +436,9 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 		cm := &apiv1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cmName,
-				Namespace: woc.wf.ObjectMeta.Namespace,
+				Namespace: woc.wf.Namespace,
 				Labels: map[string]string{
-					common.LabelKeyWorkflow: woc.wf.ObjectMeta.Name,
+					common.LabelKeyWorkflow: woc.wf.Name,
 				},
 				Annotations: map[string]string{
 					common.AnnotationKeyNodeName: nodeName,
@@ -736,18 +736,18 @@ func (woc *wfOperationCtx) addMetadata(pod *apiv1.Pod, tmpl *wfv1.Template) {
 	if woc.execWf.Spec.PodMetadata != nil {
 		// add workflow-level pod annotations and labels
 		for k, v := range woc.execWf.Spec.PodMetadata.Annotations {
-			pod.ObjectMeta.Annotations[k] = v
+			pod.Annotations[k] = v
 		}
 		for k, v := range woc.execWf.Spec.PodMetadata.Labels {
-			pod.ObjectMeta.Labels[k] = v
+			pod.Labels[k] = v
 		}
 	}
 
 	for k, v := range tmpl.Metadata.Annotations {
-		pod.ObjectMeta.Annotations[k] = v
+		pod.Annotations[k] = v
 	}
 	for k, v := range tmpl.Metadata.Labels {
-		pod.ObjectMeta.Labels[k] = v
+		pod.Labels[k] = v
 	}
 }
 

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -450,13 +450,13 @@ func TestMetadata(t *testing.T) {
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
 	assert.NotNil(t, pod.ObjectMeta)
-	assert.NotNil(t, pod.ObjectMeta.Annotations)
-	assert.NotNil(t, pod.ObjectMeta.Labels)
+	assert.NotNil(t, pod.Annotations)
+	assert.NotNil(t, pod.Labels)
 	for k, v := range woc.execWf.Spec.Templates[0].Metadata.Annotations {
-		assert.Equal(t, pod.ObjectMeta.Annotations[k], v)
+		assert.Equal(t, pod.Annotations[k], v)
 	}
 	for k, v := range woc.execWf.Spec.Templates[0].Metadata.Labels {
-		assert.Equal(t, pod.ObjectMeta.Labels[k], v)
+		assert.Equal(t, pod.Labels[k], v)
 	}
 }
 
@@ -830,7 +830,7 @@ func TestOutOfCluster(t *testing.T) {
 		assert.Len(t, pods.Items, 1)
 		pod := pods.Items[0]
 		assert.Equal(t, "kubeconfig", pod.Spec.Volumes[0].Name)
-		assert.Equal(t, "foo", pod.Spec.Volumes[0].VolumeSource.Secret.SecretName)
+		assert.Equal(t, "foo", pod.Spec.Volumes[0].Secret.SecretName)
 
 		waitCtr := pod.Spec.Containers[0]
 		verifyKubeConfigVolume(waitCtr, "kubeconfig", "/kube/config")
@@ -856,7 +856,7 @@ func TestOutOfCluster(t *testing.T) {
 		assert.Len(t, pods.Items, 1)
 		pod := pods.Items[0]
 		assert.Equal(t, "kube-config-secret", pod.Spec.Volumes[0].Name)
-		assert.Equal(t, "foo", pod.Spec.Volumes[0].VolumeSource.Secret.SecretName)
+		assert.Equal(t, "foo", pod.Spec.Volumes[0].Secret.SecretName)
 
 		// kubeconfig volume is the last one
 		waitCtr := pod.Spec.Containers[0]
@@ -1760,17 +1760,17 @@ func TestPodMetadata(t *testing.T) {
 	woc := newWoc(*wf)
 	mainCtr := woc.execWf.Spec.Templates[0].Container
 	pod, _ := woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
-	assert.Equal(t, "foo", pod.ObjectMeta.Annotations["workflow-level-pod-annotation"])
-	assert.Equal(t, "bar", pod.ObjectMeta.Labels["workflow-level-pod-label"])
+	assert.Equal(t, "foo", pod.Annotations["workflow-level-pod-annotation"])
+	assert.Equal(t, "bar", pod.Labels["workflow-level-pod-label"])
 
 	wf = wfv1.MustUnmarshalWorkflow(wfWithPodMetadataAndTemplateMetadata)
 	woc = newWoc(*wf)
 	mainCtr = woc.execWf.Spec.Templates[0].Container
 	pod, _ = woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
-	assert.Equal(t, "fizz", pod.ObjectMeta.Annotations["workflow-level-pod-annotation"])
-	assert.Equal(t, "buzz", pod.ObjectMeta.Labels["workflow-level-pod-label"])
-	assert.Equal(t, "hello", pod.ObjectMeta.Annotations["template-level-pod-annotation"])
-	assert.Equal(t, "world", pod.ObjectMeta.Labels["template-level-pod-label"])
+	assert.Equal(t, "fizz", pod.Annotations["workflow-level-pod-annotation"])
+	assert.Equal(t, "buzz", pod.Labels["workflow-level-pod-label"])
+	assert.Equal(t, "hello", pod.Annotations["template-level-pod-annotation"])
+	assert.Equal(t, "world", pod.Labels["template-level-pod-label"])
 }
 
 var wfWithContainerSet = `
@@ -1802,13 +1802,13 @@ func TestPodDefaultContainer(t *testing.T) {
 	woc := newWoc(*wf)
 	template := woc.execWf.Spec.Templates[0]
 	pod, _ := woc.createWorkflowPod(ctx, wf.Name, template.ContainerSet.GetContainers(), &wf.Spec.Templates[0], &createWorkflowPodOpts{})
-	assert.Equal(t, common.MainContainerName, pod.ObjectMeta.Annotations[common.AnnotationKeyDefaultContainer])
+	assert.Equal(t, common.MainContainerName, pod.Annotations[common.AnnotationKeyDefaultContainer])
 
 	wf = wfv1.MustUnmarshalWorkflow(wfWithContainerSet)
 	woc = newWoc(*wf)
 	template = woc.execWf.Spec.Templates[0]
 	pod, _ = woc.createWorkflowPod(ctx, wf.Name, template.ContainerSet.GetContainers(), &template, &createWorkflowPodOpts{})
-	assert.Equal(t, "b", pod.ObjectMeta.Annotations[common.AnnotationKeyDefaultContainer])
+	assert.Equal(t, "b", pod.Annotations[common.AnnotationKeyDefaultContainer])
 }
 
 func TestGetDeadline(t *testing.T) {
@@ -1856,10 +1856,10 @@ func TestPodMetadataWithWorkflowDefaults(t *testing.T) {
 	require.NoError(t, err)
 	mainCtr := woc.execWf.Spec.Templates[0].Container
 	pod, _ := woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
-	assert.Equal(t, "annotation-value", pod.ObjectMeta.Annotations["controller-level-pod-annotation"])
-	assert.Equal(t, "set-by-controller", pod.ObjectMeta.Annotations["workflow-level-pod-annotation"])
-	assert.Equal(t, "label-value", pod.ObjectMeta.Labels["controller-level-pod-label"])
-	assert.Equal(t, "set-by-controller", pod.ObjectMeta.Labels["workflow-level-pod-label"])
+	assert.Equal(t, "annotation-value", pod.Annotations["controller-level-pod-annotation"])
+	assert.Equal(t, "set-by-controller", pod.Annotations["workflow-level-pod-annotation"])
+	assert.Equal(t, "label-value", pod.Labels["controller-level-pod-label"])
+	assert.Equal(t, "set-by-controller", pod.Labels["workflow-level-pod-label"])
 	cancel() // need to cancel to spin up pods with the same name
 
 	cancel, controller = newController()
@@ -1879,10 +1879,10 @@ func TestPodMetadataWithWorkflowDefaults(t *testing.T) {
 	require.NoError(t, err)
 	mainCtr = woc.execWf.Spec.Templates[0].Container
 	pod, _ = woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
-	assert.Equal(t, "foo", pod.ObjectMeta.Annotations["workflow-level-pod-annotation"])
-	assert.Equal(t, "bar", pod.ObjectMeta.Labels["workflow-level-pod-label"])
-	assert.Equal(t, "annotation-value", pod.ObjectMeta.Annotations["controller-level-pod-annotation"])
-	assert.Equal(t, "label-value", pod.ObjectMeta.Labels["controller-level-pod-label"])
+	assert.Equal(t, "foo", pod.Annotations["workflow-level-pod-annotation"])
+	assert.Equal(t, "bar", pod.Labels["workflow-level-pod-label"])
+	assert.Equal(t, "annotation-value", pod.Annotations["controller-level-pod-annotation"])
+	assert.Equal(t, "label-value", pod.Labels["controller-level-pod-label"])
 	cancel()
 }
 
@@ -1906,11 +1906,11 @@ func TestPodExists(t *testing.T) {
 
 	// Sleep 1 second to wait for informer getting pod info
 	time.Sleep(time.Second)
-	existingPod, doesExist, err := woc.podExists(pod.ObjectMeta.Name)
+	existingPod, doesExist, err := woc.podExists(pod.Name)
 	require.NoError(t, err)
 	assert.NotNil(t, existingPod)
 	assert.True(t, doesExist)
-	assert.EqualValues(t, pod, existingPod)
+	assert.Equal(t, pod, existingPod)
 }
 
 func TestPodFinalizerExits(t *testing.T) {

--- a/workflow/events/event_recorder_manager_test.go
+++ b/workflow/events/event_recorder_manager_test.go
@@ -13,8 +13,8 @@ const aggregationWithAnnotationsEnvKey = "EVENT_AGGREGATION_WITH_ANNOTATIONS"
 func TestCustomEventAggregatorFuncWithAnnotations(t *testing.T) {
 	event := apiv1.Event{}
 	key, msg := customEventAggregatorFuncWithAnnotations(&event)
-	assert.Equal(t, "", key)
-	assert.Equal(t, "", msg)
+	assert.Empty(t, key)
+	assert.Empty(t, msg)
 
 	event.Source = apiv1.EventSource{Component: "component1", Host: "host1"}
 	event.InvolvedObject.Name = "name1"
@@ -25,7 +25,7 @@ func TestCustomEventAggregatorFuncWithAnnotations(t *testing.T) {
 	assert.Equal(t, "message1", msg)
 
 	// Test default behavior where annotations are not used for aggregation
-	event.ObjectMeta.Annotations = map[string]string{"key1": "val1", "key2": "val2"}
+	event.Annotations = map[string]string{"key1": "val1", "key2": "val2"}
 	key, msg = customEventAggregatorFuncWithAnnotations(&event)
 	assert.Equal(t, "component1host1name1", key)
 	assert.Equal(t, "message1", msg)
@@ -37,7 +37,7 @@ func TestCustomEventAggregatorFuncWithAnnotations(t *testing.T) {
 
 	// Test annotations with values in different order
 	t.Setenv(aggregationWithAnnotationsEnvKey, "true")
-	event.ObjectMeta.Annotations = map[string]string{"key2": "val2", "key1": "val1"}
+	event.Annotations = map[string]string{"key2": "val2", "key1": "val1"}
 	key, msg = customEventAggregatorFuncWithAnnotations(&event)
 	assert.Equal(t, "component1host1name1val1val2", key)
 	assert.Equal(t, "message1", msg)

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -230,7 +230,7 @@ func TestDefaultParametersEmptyString(t *testing.T) {
 	ctx := context.Background()
 	err := we.SaveParameters(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, "", we.Template.Outputs.Parameters[0].Value.String())
+	assert.Empty(t, we.Template.Outputs.Parameters[0].Value.String())
 }
 
 func TestIsTarball(t *testing.T) {

--- a/workflow/gccontroller/heap_test.go
+++ b/workflow/gccontroller/heap_test.go
@@ -51,10 +51,10 @@ metadata:
 	heap.Push(queue, wf)
 	assert.Equal(t, 3, queue.Len())
 	first := heap.Pop(queue).(*unstructured.Unstructured)
-	assert.Equal(t, now.Add(-time.Second).Unix(), first.GetCreationTimestamp().Time.Unix())
+	assert.Equal(t, now.Add(-time.Second).Unix(), first.GetCreationTimestamp().Unix())
 	assert.Equal(t, "bad-baseline-oldest", first.GetName())
-	assert.Equal(t, now.Unix(), heap.Pop(queue).(*unstructured.Unstructured).GetCreationTimestamp().Time.Unix())
-	assert.Equal(t, now.Add(time.Second).Unix(), heap.Pop(queue).(*unstructured.Unstructured).GetCreationTimestamp().Time.Unix())
+	assert.Equal(t, now.Unix(), heap.Pop(queue).(*unstructured.Unstructured).GetCreationTimestamp().Unix())
+	assert.Equal(t, now.Add(time.Second).Unix(), heap.Pop(queue).(*unstructured.Unstructured).GetCreationTimestamp().Unix())
 	assert.Equal(t, 0, queue.Len())
 }
 

--- a/workflow/hydrator/hydrator_test.go
+++ b/workflow/hydrator/hydrator_test.go
@@ -68,7 +68,7 @@ func TestHydrator(t *testing.T) {
 		})
 		t.Run("WorkflowTooLargeButOffloadNotSupported", func(t *testing.T) {
 			offloadNodeStatusRepo := &sqldbmocks.OffloadNodeStatusRepo{}
-			offloadNodeStatusRepo.On("Save", "my-uid", "my-ns", mock.Anything).Return("my-offload-version", sqldb.OffloadNotSupportedError)
+			offloadNodeStatusRepo.On("Save", "my-uid", "my-ns", mock.Anything).Return("my-offload-version", sqldb.ErrOffloadNotSupported)
 			hydrator := New(offloadNodeStatusRepo)
 			wf := &wfv1.Workflow{
 				ObjectMeta: metav1.ObjectMeta{UID: "my-uid", Namespace: "my-ns"},
@@ -96,7 +96,7 @@ func TestHydrator(t *testing.T) {
 		})
 		t.Run("OffloadingDisabled", func(t *testing.T) {
 			offloadNodeStatusRepo := &sqldbmocks.OffloadNodeStatusRepo{}
-			offloadNodeStatusRepo.On("Get", "my-uid", "my-offload-version").Return(nil, sqldb.OffloadNotSupportedError)
+			offloadNodeStatusRepo.On("Get", "my-uid", "my-offload-version").Return(nil, sqldb.ErrOffloadNotSupported)
 			hydrator := New(offloadNodeStatusRepo)
 			wf := &wfv1.Workflow{
 				ObjectMeta: metav1.ObjectMeta{UID: "my-uid"},

--- a/workflow/sync/multi_throttler_test.go
+++ b/workflow/sync/multi_throttler_test.go
@@ -129,7 +129,7 @@ status:
 	assert.False(t, throttler.Admit("default/d"))
 
 	throttler.Remove("default/a")
-	assert.Equal(t, "", queuedKey)
+	assert.Empty(t, queuedKey)
 	assert.False(t, throttler.Admit("default/c"))
 	assert.False(t, throttler.Admit("default/d"))
 

--- a/workflow/sync/syncitems_test.go
+++ b/workflow/sync/syncitems_test.go
@@ -19,7 +19,7 @@ func TestNoDuplicates(t *testing.T) {
 		{
 			name: "single",
 			items: []*syncItem{
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "alpha",
 					},
@@ -29,12 +29,12 @@ func TestNoDuplicates(t *testing.T) {
 		{
 			name: "two",
 			items: []*syncItem{
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "alpha",
 					},
 				},
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "beta",
 					},
@@ -44,13 +44,13 @@ func TestNoDuplicates(t *testing.T) {
 		{
 			name: "different namespace mutex",
 			items: []*syncItem{
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name:      "alpha",
 						Namespace: "foo",
 					},
 				},
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name:      "alpha",
 						Namespace: "bar",
@@ -75,12 +75,12 @@ func TestExpectDuplicates(t *testing.T) {
 		{
 			name: "simple duplicate mutex",
 			items: []*syncItem{
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "alpha",
 					},
 				},
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "alpha",
 					},
@@ -90,7 +90,7 @@ func TestExpectDuplicates(t *testing.T) {
 		{
 			name: "simple duplicate semaphore",
 			items: []*syncItem{
-				&syncItem{
+				{
 					semaphore: &v1alpha1.SemaphoreRef{
 						ConfigMapKeyRef: &apiv1.ConfigMapKeySelector{
 							LocalObjectReference: apiv1.LocalObjectReference{
@@ -100,7 +100,7 @@ func TestExpectDuplicates(t *testing.T) {
 						},
 					},
 				},
-				&syncItem{
+				{
 					semaphore: &v1alpha1.SemaphoreRef{
 						ConfigMapKeyRef: &apiv1.ConfigMapKeySelector{
 							LocalObjectReference: apiv1.LocalObjectReference{
@@ -115,17 +115,17 @@ func TestExpectDuplicates(t *testing.T) {
 		{
 			name: "another duplicate mutex",
 			items: []*syncItem{
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "alpha",
 					},
 				},
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "beta",
 					},
 				},
-				&syncItem{
+				{
 					mutex: &v1alpha1.Mutex{
 						Name: "alpha",
 					},

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -167,8 +167,8 @@ func ToUnstructured(wf *wfv1.Workflow) (*unstructured.Unstructured, error) {
 
 // IsWorkflowCompleted returns whether or not a workflow is considered completed
 func IsWorkflowCompleted(wf *wfv1.Workflow) bool {
-	if wf.ObjectMeta.Labels != nil {
-		return wf.ObjectMeta.Labels[common.LabelKeyCompleted] == "true"
+	if wf.Labels != nil {
+		return wf.Labels[common.LabelKeyCompleted] == "true"
 	}
 	return false
 }
@@ -290,10 +290,10 @@ func ApplySubmitOpts(wf *wfv1.Workflow, opts *wfv1.SubmitOpts) error {
 		return err
 	}
 	if opts.GenerateName != "" {
-		wf.ObjectMeta.GenerateName = opts.GenerateName
+		wf.GenerateName = opts.GenerateName
 	}
 	if opts.Name != "" {
-		wf.ObjectMeta.Name = opts.Name
+		wf.Name = opts.Name
 	}
 	if opts.OwnerReference != nil {
 		wf.SetOwnerReferences(append(wf.GetOwnerReferences(), *opts.OwnerReference))
@@ -639,10 +639,10 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 	newWF.TypeMeta = wf.TypeMeta
 
 	// Resubmitted workflow will use generated names
-	if wf.ObjectMeta.GenerateName != "" {
-		newWF.ObjectMeta.GenerateName = wf.ObjectMeta.GenerateName
+	if wf.GenerateName != "" {
+		newWF.GenerateName = wf.GenerateName
 	} else {
-		newWF.ObjectMeta.GenerateName = wf.ObjectMeta.Name + "-"
+		newWF.GenerateName = wf.Name + "-"
 	}
 	// When resubmitting workflow with memoized nodes, we need to use a predetermined workflow name
 	// in order to formulate the node statuses. Which means we cannot reuse metadata.generateName
@@ -653,7 +653,7 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 		default:
 			return nil, errors.Errorf(errors.CodeBadRequest, "workflow must be Failed/Error to resubmit in memoized mode")
 		}
-		newWF.ObjectMeta.Name = newWF.ObjectMeta.GenerateName + RandSuffix()
+		newWF.Name = newWF.GenerateName + RandSuffix()
 	}
 
 	// carry over the unmodified spec
@@ -667,16 +667,16 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 	newWF.Spec.Shutdown = ""
 
 	// carry over user labels and annotations from previous workflow.
-	if newWF.ObjectMeta.Labels == nil {
-		newWF.ObjectMeta.Labels = make(map[string]string)
+	if newWF.Labels == nil {
+		newWF.Labels = make(map[string]string)
 	}
-	for key, val := range wf.ObjectMeta.Labels {
+	for key, val := range wf.Labels {
 		switch key {
 		case common.LabelKeyCreator, common.LabelKeyCreatorEmail, common.LabelKeyCreatorPreferredUsername,
 			common.LabelKeyPhase, common.LabelKeyCompleted, common.LabelKeyWorkflowArchivingStatus:
 			// ignore
 		default:
-			newWF.ObjectMeta.Labels[key] = val
+			newWF.Labels[key] = val
 		}
 	}
 	// Apply creator labels based on the authentication information of the current request,
@@ -684,12 +684,12 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 	creator.LabelCreator(ctx, &newWF)
 	// Append an additional label so it's easy for user to see the
 	// name of the original workflow that has been resubmitted.
-	newWF.ObjectMeta.Labels[common.LabelKeyPreviousWorkflowName] = wf.ObjectMeta.Name
-	if newWF.ObjectMeta.Annotations == nil {
-		newWF.ObjectMeta.Annotations = make(map[string]string)
+	newWF.Labels[common.LabelKeyPreviousWorkflowName] = wf.Name
+	if newWF.Annotations == nil {
+		newWF.Annotations = make(map[string]string)
 	}
-	for key, val := range wf.ObjectMeta.Annotations {
-		newWF.ObjectMeta.Annotations[key] = val
+	for key, val := range wf.Annotations {
+		newWF.Annotations[key] = val
 	}
 
 	// Setting OwnerReference from original Workflow
@@ -697,7 +697,7 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 
 	// Override parameters
 	if parameters != nil {
-		if _, ok := wf.ObjectMeta.Labels[common.LabelKeyPreviousWorkflowName]; ok || memoized {
+		if _, ok := wf.Labels[common.LabelKeyPreviousWorkflowName]; ok || memoized {
 			log.Warnln("Overriding parameters on memoized or resubmitted workflows may have unexpected results")
 		}
 		err := overrideParameters(&newWF, parameters)
@@ -711,9 +711,9 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 	}
 
 	// Iterate the previous nodes.
-	replaceRegexp := regexp.MustCompile("^" + wf.ObjectMeta.Name)
+	replaceRegexp := regexp.MustCompile("^" + wf.Name)
 	newWF.Status.Nodes = make(map[string]wfv1.NodeStatus)
-	onExitNodeName := wf.ObjectMeta.Name + ".onExit"
+	onExitNodeName := wf.Name + ".onExit"
 	err := packer.DecompressWorkflow(wf)
 	if err != nil {
 		log.Panic(err)
@@ -724,7 +724,7 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 			continue
 		}
 		originalID := node.ID
-		newNode.Name = replaceRegexp.ReplaceAllString(node.Name, newWF.ObjectMeta.Name)
+		newNode.Name = replaceRegexp.ReplaceAllString(node.Name, newWF.Name)
 		newNode.ID = newWF.NodeID(newNode.Name)
 		if node.BoundaryID != "" {
 			newNode.BoundaryID = convertNodeID(&newWF, replaceRegexp, node.BoundaryID, wf.Status.Nodes)
@@ -774,7 +774,7 @@ func FormulateResubmitWorkflow(ctx context.Context, wf *wfv1.Workflow, memoized 
 // convertNodeID converts an old nodeID to a new nodeID
 func convertNodeID(newWf *wfv1.Workflow, regex *regexp.Regexp, oldNodeID string, oldNodes map[string]wfv1.NodeStatus) string {
 	node := oldNodes[oldNodeID]
-	newNodeName := regex.ReplaceAllString(node.Name, newWf.ObjectMeta.Name)
+	newNodeName := regex.ReplaceAllString(node.Name, newWf.Name)
 	return newWf.NodeID(newNodeName)
 }
 
@@ -810,7 +810,7 @@ func createNewRetryWorkflow(wf *wfv1.Workflow, parameters []string) (*wfv1.Workf
 	delete(newWF.Labels, common.LabelKeyCompleted)
 	delete(newWF.Labels, common.LabelKeyWorkflowArchivingStatus)
 	newWF.Status.Conditions.UpsertCondition(wfv1.Condition{Status: metav1.ConditionFalse, Type: wfv1.ConditionTypeCompleted})
-	newWF.ObjectMeta.Labels[common.LabelKeyPhase] = string(wfv1.NodeRunning)
+	newWF.Labels[common.LabelKeyPhase] = string(wfv1.NodeRunning)
 	newWF.Status.Phase = wfv1.WorkflowRunning
 	newWF.Status.Nodes = make(wfv1.Nodes)
 	newWF.Status.Message = ""
@@ -827,7 +827,7 @@ func createNewRetryWorkflow(wf *wfv1.Workflow, parameters []string) (*wfv1.Workf
 	}
 	// Override parameters
 	if parameters != nil {
-		if _, ok := wf.ObjectMeta.Labels[common.LabelKeyPreviousWorkflowName]; ok {
+		if _, ok := wf.Labels[common.LabelKeyPreviousWorkflowName]; ok {
 			log.Warnln("Overriding parameters on resubmitted workflows may have unexpected results")
 		}
 		err := overrideParameters(newWF, parameters)
@@ -861,7 +861,7 @@ func newWorkflowsDag(wf *wfv1.Workflow) ([]*dagNode, error) {
 
 	for _, wfNode := range wf.Status.Nodes {
 		parentWfNode, ok := parentsMap[wfNode.ID]
-		if !ok && wfNode.Name != wf.Name && !strings.HasPrefix(wfNode.Name, wf.ObjectMeta.Name+".onExit") {
+		if !ok && wfNode.Name != wf.Name && !strings.HasPrefix(wfNode.Name, wf.Name+".onExit") {
 			return nil, fmt.Errorf("couldn't find parent node for %s", wfNode.ID)
 		}
 
@@ -1084,11 +1084,7 @@ func resetPath(allNodes []*dagNode, startNode string) (map[string]bool, map[stri
 	}
 
 	findBoundaries := false
-	for {
-
-		if curr == nil {
-			break
-		}
+	for curr != nil {
 
 		switch curr.n.Type {
 		case wfv1.NodeTypePod:
@@ -1220,14 +1216,14 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 	switch wf.Status.Phase {
 	case wfv1.WorkflowFailed, wfv1.WorkflowError:
 	case wfv1.WorkflowSucceeded:
-		if !(restartSuccessful && len(nodeFieldSelector) > 0) {
+		if !restartSuccessful || len(nodeFieldSelector) <= 0 {
 			return nil, nil, errors.Errorf(errors.CodeBadRequest, "To retry a succeeded workflow, set the options restartSuccessful and nodeFieldSelector")
 		}
 	default:
 		return nil, nil, errors.Errorf(errors.CodeBadRequest, "Cannot retry a workflow in phase %s", wf.Status.Phase)
 	}
 
-	onExitNodeName := wf.ObjectMeta.Name + ".onExit"
+	onExitNodeName := wf.Name + ".onExit"
 
 	newWf, err := createNewRetryWorkflow(wf, parameters)
 	if err != nil {

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -76,7 +76,7 @@ func TestResubmitWorkflowWithOnExit(t *testing.T) {
 	wf.Status.Nodes.Set(onExitID, onExitNode)
 	newWF, err := FormulateResubmitWorkflow(context.Background(), &wf, true, nil)
 	require.NoError(t, err)
-	newWFOnExitName := newWF.ObjectMeta.Name + ".onExit"
+	newWFOnExitName := newWF.Name + ".onExit"
 	newWFOneExitID := newWF.NodeID(newWFOnExitName)
 	_, ok := newWF.Status.Nodes[newWFOneExitID]
 	assert.False(t, ok)
@@ -112,7 +112,7 @@ func TestReadFromSingleorMultiplePath(t *testing.T) {
 				}
 			}
 			body, err := ReadFromFilePathsOrUrls(filePaths...)
-			assert.Equal(t, len(body), len(filePaths))
+			assert.Len(t, filePaths, len(body))
 			require.NoError(t, err)
 			for i := range body {
 				assert.Equal(t, body[i], []byte(tc.contents[i]))
@@ -266,7 +266,7 @@ func TestResumeWorkflowByNodeName(t *testing.T) {
 		wf, err = wfIf.Get(ctx, "suspend", metav1.GetOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes.FindByDisplayName("approve").Phase)
-		assert.Equal(t, "", wf.Status.Nodes.FindByDisplayName("approve").Message)
+		assert.Empty(t, wf.Status.Nodes.FindByDisplayName("approve").Message)
 	})
 
 	t.Run("With user info", func(t *testing.T) {

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -206,8 +206,8 @@ func ValidateWorkflow(wftmplGetter templateresolution.WorkflowTemplateNamespaced
 		}
 	}
 
-	annotationSources := [][]string{maps.Keys(wf.ObjectMeta.Annotations)}
-	labelSources := [][]string{maps.Keys(wf.ObjectMeta.Labels)}
+	annotationSources := [][]string{maps.Keys(wf.Annotations)}
+	labelSources := [][]string{maps.Keys(wf.Labels)}
 	if wf.Spec.WorkflowMetadata != nil {
 		annotationSources = append(annotationSources, maps.Keys(wf.Spec.WorkflowMetadata.Annotations))
 		labelSources = append(labelSources, maps.Keys(wf.Spec.WorkflowMetadata.Labels), maps.Keys(wf.Spec.WorkflowMetadata.LabelsFrom))
@@ -342,8 +342,8 @@ func ValidateWorkflowTemplate(wftmplGetter templateresolution.WorkflowTemplateNa
 
 	wf := &wfv1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Labels:      wftmpl.ObjectMeta.Labels,
-			Annotations: wftmpl.ObjectMeta.Annotations,
+			Labels:      wftmpl.Labels,
+			Annotations: wftmpl.Annotations,
 		},
 		Spec: wftmpl.Spec,
 	}
@@ -360,8 +360,8 @@ func ValidateClusterWorkflowTemplate(wftmplGetter templateresolution.WorkflowTem
 
 	wf := &wfv1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Labels:      cwftmpl.ObjectMeta.Labels,
-			Annotations: cwftmpl.ObjectMeta.Annotations,
+			Labels:      cwftmpl.Labels,
+			Annotations: cwftmpl.Annotations,
 		},
 		Spec: cwftmpl.Spec,
 	}
@@ -410,7 +410,7 @@ func ValidateCronWorkflow(ctx context.Context, wftmplGetter templateresolution.W
 
 func (ctx *templateValidationCtx) validateInitContainers(containers []wfv1.UserContainer) error {
 	for _, container := range containers {
-		if len(container.Container.Name) == 0 {
+		if len(container.Name) == 0 {
 			return errors.Errorf(errors.CodeBadRequest, "initContainers must all have container name")
 		}
 	}
@@ -759,11 +759,11 @@ func (ctx *templateValidationCtx) validateLeaf(scope map[string]interface{}, tmp
 		if tmpl.Container.Image == "" {
 			switch baseTemplate := tmplCtx.GetCurrentTemplateBase().(type) {
 			case *wfv1.Workflow:
-				if !(baseTemplate.Spec.TemplateDefaults != nil && baseTemplate.Spec.TemplateDefaults.Container != nil && baseTemplate.Spec.TemplateDefaults.Container.Image != "") {
+				if baseTemplate.Spec.TemplateDefaults == nil || baseTemplate.Spec.TemplateDefaults.Container == nil || baseTemplate.Spec.TemplateDefaults.Container.Image == "" {
 					return errors.Errorf(errors.CodeBadRequest, "templates.%s.container.image may not be empty", tmpl.Name)
 				}
 			case *wfv1.WorkflowTemplate:
-				if !(baseTemplate.Spec.TemplateDefaults != nil && baseTemplate.Spec.TemplateDefaults.Container != nil && baseTemplate.Spec.TemplateDefaults.Container.Image != "") {
+				if baseTemplate.Spec.TemplateDefaults == nil || baseTemplate.Spec.TemplateDefaults.Container == nil || baseTemplate.Spec.TemplateDefaults.Container.Image == "" {
 					return errors.Errorf(errors.CodeBadRequest, "templates.%s.container.image may not be empty", tmpl.Name)
 				}
 			default:
@@ -830,11 +830,11 @@ func (ctx *templateValidationCtx) validateLeaf(scope map[string]interface{}, tmp
 		if tmpl.Script.Image == "" {
 			switch baseTemplate := tmplCtx.GetCurrentTemplateBase().(type) {
 			case *wfv1.Workflow:
-				if !(baseTemplate.Spec.TemplateDefaults != nil && baseTemplate.Spec.TemplateDefaults.Script != nil && baseTemplate.Spec.TemplateDefaults.Script.Image != "") {
+				if baseTemplate.Spec.TemplateDefaults == nil || baseTemplate.Spec.TemplateDefaults.Script == nil || baseTemplate.Spec.TemplateDefaults.Script.Image == "" {
 					return errors.Errorf(errors.CodeBadRequest, "templates.%s.script.image may not be empty", tmpl.Name)
 				}
 			case *wfv1.WorkflowTemplate:
-				if !(baseTemplate.Spec.TemplateDefaults != nil && baseTemplate.Spec.TemplateDefaults.Script != nil && baseTemplate.Spec.TemplateDefaults.Script.Image != "") {
+				if baseTemplate.Spec.TemplateDefaults == nil || baseTemplate.Spec.TemplateDefaults.Script == nil || baseTemplate.Spec.TemplateDefaults.Script.Image == "" {
 					return errors.Errorf(errors.CodeBadRequest, "templates.%s.script.image may not be empty", tmpl.Name)
 				}
 			default:


### PR DESCRIPTION
Pre-requisite for bumping to golang 1.24 - #14385

### Motivation

In order to upgrade to golang 1.24 we need to update golangci-lint to one that supports it.

It is also good practice to keep linters up to date.

### Modifications

Bumped golangci-lint to latest (2.1.1) from 1.61.0. This bumps over the v2 boundary, so I've run the migrate command from https://golangci-lint.run/product/migration-guide/.

This didn't bring across the full `staticcheck` merged config correctly. I have enabled this and disabled some select tests from it - some of which we should enable, just not in this PR as it's already big enough. These are the disabled linters in this odd syntax where you `-ST1003` to disable that linter.
```
    staticcheck:
      checks:
        - all
        # Capitalised variable names
        - "-ST1003"
        # Capitalised error strings
        - "-ST1005"
        # Receiver names
        - "-ST1016"
```

I dropped G601 as this is no longer something golang does.

I then ran the linter which did a lot of autofixing.
* Removal of unnecessary sub-struct referencing (`ObjectMeta`)
* All the testify `assert`/`require` changes
* Write(Sprintf())->FPrintf
* Unnecessary types in `var` or struct usage
* `if` {} `else` {} -> `switch`
* strings.Replace -> ReplaceAll
* Some logical tests simplified via logical equivalence (examples at the end of the PR in workflow/validate/validate.go)

I then manually fixed:
* Same library imported more than once in some files
* Some const Errors not starting with `Err`. This could probably be disabled as a linter, I don't think this is a new style thing, I think I've just enabled it.
* `operator_test.go` L 2574 - the expected isn't JSON, but as it was the converter assumed it was because it was called expectedJson, and wanted to assert.JSONeq the result, which made it sad
* Memoization tests in operator_test.go (L10359 onwards) made some bizarre asserts in loops which may not actually find nodes. Rewritten these asserts to do the right thing in my opinion. Please review these 4 tests carefully.

### Verification

CI

### Documentation

Not applicable
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
