### PR TITLE
fix: disable ALPN in argo-server as a workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,8 @@ USER 8737
 
 WORKDIR /home/argo
 
+# Temporary workaround for https://github.com/grpc/grpc-go/issues/434
+ENV GRPC_ENFORCE_ALPN_ENABLED=false
 COPY hack/ssh_known_hosts /etc/ssh/
 COPY hack/nsswitch.conf /etc/
 COPY --from=argocli-build /go/src/github.com/argoproj/argo-workflows/dist/argo /bin/

--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -178,3 +178,7 @@ Argo Server by default rate limits to 1000 per IP per minute, you can configure 
 * `X-Rate-Limit-Remaining` - the number of requests left for the current rate-limit window.
 * `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC time.
 * `Retry-After` - indicate when a client should retry requests (when the rate limit expires), in UTC time.
+
+### GRPC ALPN
+
+The grpc library wants to enforce ALPN, but we are not prepared for this so the argo-server binary is built with `GRPC_ENFORCE_ALPN_ENABLED` set to `false` in the docker image as a short term workaround, as documented in https://github.com/grpc/grpc-go/issues/434


### PR DESCRIPTION
### Motivation

Upgrading from 3.6.5 to 3.6.6 will probably cause you to see ALPN errors as per https://github.com/grpc/grpc-go/issues/434 and #14422.
### Modifications

This bakes the disabling flag into the docker image for this warning as a workaround for 3.6.

### Verification

Built image and substituted it into a running 3.6.6 and found the error went away

### Documentation

Added some notes to the argo server page to document this. I will also highlight this in slack.