### PR TITLE
fix: update TLS config to support ALPN. Fixes #14422

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,6 @@ USER 8737
 
 WORKDIR /home/argo
 
-# Temporary workaround for https://github.com/grpc/grpc-go/issues/434
-ENV GRPC_ENFORCE_ALPN_ENABLED=false
 COPY hack/ssh_known_hosts /etc/ssh/
 COPY hack/nsswitch.conf /etc/
 COPY --from=argocli-build /go/src/github.com/argoproj/argo-workflows/dist/argo /bin/

--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -178,7 +178,3 @@ Argo Server by default rate limits to 1000 per IP per minute, you can configure 
 * `X-Rate-Limit-Remaining` - the number of requests left for the current rate-limit window.
 * `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC time.
 * `Retry-After` - indicate when a client should retry requests (when the rate limit expires), in UTC time.
-
-### GRPC ALPN
-
-The grpc library wants to enforce ALPN, but we are not prepared for this so the argo-server binary is built with `GRPC_ENFORCE_ALPN_ENABLED` set to `false` in the docker image as a short term workaround, as documented in https://github.com/grpc/grpc-go/issues/434

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -125,6 +125,7 @@ func GenerateX509KeyPairTLSConfig(tlsMinVersion uint16) (*tls.Config, error) {
 		Certificates:       []tls.Certificate{*cer},
 		MinVersion:         uint16(tlsMinVersion),
 		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
 	}, nil
 }
 
@@ -147,5 +148,6 @@ func GetServerTLSConfigFromSecret(ctx context.Context, kubectlConfig kubernetes.
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		MinVersion:   uint16(tlsMinVersion),
+		NextProtos:   []string{"h2"},
 	}, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14422

### Motivation
As explained at #14422, any attempt to access the Argo server fails with an ALPN error. Example using curl:
```
$ curl -kv https://localhost:2746/api/v1/workflow-templates/argo 2>&1 | grep ALPN
* ALPN: curl offers h2,http/1.1
* ALPN: server did not agree on a protocol. Uses default.
{"code":14,"message":"connection error: desc = \"transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property. If you upgraded from a grpc-go version earlier than 1.67, your TLS connections may have stopped working due to ALPN enforcement. For more details, see: https://github.com/grpc/grpc-go/issues/434\""}
```

Despite appearances, this isn't actually a client-side issue. The problem is that  Go's `net/http` server requires explicitly enabling HTTP/2 in the TLS configuration, otherwise it won't return any negotiated protocols during the handshake. Here's the code that controls this: https://github.com/golang/go/blob/1e756dc5f73dc19eb1cbf038807d18ef1cc54ebc/src/net/http/server.go#L3399-L3406

More details:
* https://github.com/grpc-ecosystem/grpc-gateway/issues/220#issuecomment-250008004
* https://github.com/grpc/grpc-go/issues/434#issuecomment-1905093829



### Modifications

First, I reverted #14433, since that workaround is no longer necessary. The actual fix is the same as in https://github.com/philips/grpc-gateway-example/commit/e1dfd2244c42e44a2220bfc28393f3a7d25ddc0d. Note that even though only `h2` is in the list, HTTP/1.1 connections still work (see below).

### Verification

Tested locally by running `make start UI=true SECURE=true`, then running the following commands to verify both HTTP/2 and HTTP/1.1 requests work:
```
$ curl --http1.1 -kv https://localhost:2746/api/v1/workflow-templates/argo 2>&1 | grep ALPN
* ALPN: curl offers http/1.1
* ALPN: server accepted http/1.1

$ curl -kv https://localhost:2746/api/v1/workflow-templates/argo 2>&1 | grep ALPN
* ALPN: curl offers h2,http/1.1
* ALPN: server accepted h2
```

I also verified http://localhost:8080/workflows loads properly, as well as https://localhost:8080/workflows when using `make start UI_SECURE=true SECURE=true`.
 
### Documentation

N/A
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
