### PR TITLE
fix: Remove nil ConfigMap reference in cache gc

### DIFF
--- a/workflow/controller/cache_gc.go
+++ b/workflow/controller/cache_gc.go
@@ -34,7 +34,7 @@ func (wfc *WorkflowController) syncAllCacheForGC(ctx context.Context) {
 	for _, obj := range configMaps {
 		cm, ok := obj.(*apiv1.ConfigMap)
 		if !ok {
-			log.WithField("configMap", cm.Name).Error("Unable to convert object to configmap when syncing ConfigMaps")
+			log.Error("Unable to convert object to configmap when syncing ConfigMaps")
 			continue
 		}
 		if err := wfc.cleanupUnusedCache(ctx, cm); err != nil {


### PR DESCRIPTION
### Motivation

Prevents `nil` pointer dereference when attempting to log invalid objects during ConfigMap cache garbage collection.

### Modifications

Changed the error log from `log.WithField().Error()` to `log.Error()` as there's no additional fields to be added.

### Verification

`make test` passes locally.

I've also prepared a lint rule change in #14443.

### Documentation

No documentation changes needed.
