### PR TITLE
chore: Enable nilness checker in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,8 @@ linters:
         - "-ST1005"
         # Receiver names
         - "-ST1016"
+    govet:
+      enable: [nilness]
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION

### Motivation

Adds nilness detection to Go vet configuration to catch potential nil pointer dereferences during static analysis.

### Modifications

Modified `golangci-lint` configuration in `.golangci.yml` to use additional nilness linter checks.

### Verification

Enabled it and found #14442. Once it has been merged, this needs a rebase. Until then the CI pipeline will fail on this PR.

### Documentation

No changes needed.