### PR TITLE
fix: ensure variable sub and processing is performed. Fixes #12941

### DIFF
--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -237,7 +237,6 @@ func SubstituteParams(tmpl *wfv1.Template, globalParams, localParams Parameters)
 		return nil, errors.InternalWrapError(err)
 	}
 	// Now replace the rest of substitutions (the ones that can be made) in the template
-	replaceMap = make(map[string]string)
 	for _, inParam := range globalReplacedTmpl.Inputs.Parameters {
 		if inParam.Value == nil && inParam.ValueFrom == nil {
 			return nil, errors.InternalErrorf("inputs.parameters.%s had no value", inParam.Name)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -1266,3 +1266,73 @@ func TestWorkflowWithLongArguments(t *testing.T) {
 	assert.True(t, controller.PodController.TestingProcessNextItem(ctx))
 	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
 }
+
+const podSpecPatchTemplateLevelWf = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: wf-
+spec:
+  entrypoint: wf
+  templates:
+  - name: wf
+    steps:
+
+    - - name: run-task1
+        template: run-task
+        arguments:
+          parameters:
+            - name: memreqnum
+              value: '25'
+            - name: memrequnit
+              value: Mi
+            - name: message
+              value: "hello from run-task1"
+  - name: run-task
+    inputs:
+      parameters:
+        - name: memreqnum
+        - name: memrequnit
+        - name: message
+    retryStrategy:
+      limit: "2"
+      retryPolicy: "Always"
+      expression: 'lastRetry.status == "Error" or (lastRetry.status == "Failed" and asInt(lastRetry.exitCode) not in [1,2,127])'
+    podSpecPatch: |
+      containers:
+      - name: main
+        resources:
+          requests:
+            memory: "{{=(sprig.int(retries)+1)*sprig.int(inputs.parameters.memreqnum)}}{{inputs.parameters.memrequnit}}"
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]
+`
+
+func TestPodSpecPatchTemplateLevel(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(podSpecPatchTemplateLevelWf)
+	cancel, controller := newController(wf)
+	defer cancel()
+
+	ctx := context.Background()
+	assert.True(t, controller.processNextItem(ctx))
+
+	woc := newWorkflowOperationCtx(wf, controller)
+	woc.operate(ctx)
+	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+
+	podcs := woc.controller.kubeclientset.CoreV1().Pods(woc.wf.GetNamespace())
+	pods, err := podcs.List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, pods.Items, 1)
+
+	pod := pods.Items[0]
+	var mainContainer apiv1.Container
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "main" {
+			mainContainer = container
+		}
+	}
+	require.NotNil(t, mainContainer)
+	assert.Equal(t, mainContainer.Resources.Requests.Memory().String(), "25Mi")
+}

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -1334,5 +1334,5 @@ func TestPodSpecPatchTemplateLevel(t *testing.T) {
 		}
 	}
 	require.NotNil(t, mainContainer)
-	assert.Equal(t, mainContainer.Resources.Requests.Memory().String(), "25Mi")
+	assert.Equal(t, "25Mi", mainContainer.Resources.Requests.Memory().String())
 }

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -79,6 +79,33 @@ type createWorkflowPodOpts struct {
 	executionDeadline   time.Time
 }
 
+func (woc *wfOperationCtx) processPodSpecPatch(tmpl *wfv1.Template, pod *apiv1.Pod) ([]string, error) {
+	podSpecPatches := []string{}
+	localParams := make(map[string]string)
+	if tmpl.IsPodType() {
+		localParams[common.LocalVarPodName] = pod.Name
+	}
+	toProcess := []string{}
+	if woc.execWf.Spec.HasPodSpecPatch() {
+		toProcess = append(toProcess, woc.execWf.Spec.PodSpecPatch)
+	}
+	if tmpl.HasPodSpecPatch() {
+		toProcess = append(toProcess, tmpl.PodSpecPatch)
+	}
+
+	for _, patch := range toProcess {
+		newTmpl := tmpl.DeepCopy()
+		newTmpl.PodSpecPatch = patch
+		processedTmpl, err := common.ProcessArgs(newTmpl, &wfv1.Arguments{}, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())
+		if err != nil {
+			return nil, errors.Wrap(err, "", "Failed to substitute the PodSpecPatch variables")
+		}
+		podSpecPatches = append(podSpecPatches, processedTmpl.PodSpecPatch)
+	}
+	return podSpecPatches, nil
+
+}
+
 func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName string, mainCtrs []apiv1.Container, tmpl *wfv1.Template, opts *createWorkflowPodOpts) (*apiv1.Pod, error) {
 	nodeID := woc.wf.NodeID(nodeName)
 
@@ -361,32 +388,9 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 
 	// Apply the patch string from workflow and template
 	var podSpecPatchs []string
-	if woc.execWf.Spec.HasPodSpecPatch() {
-		// Final substitution for workflow level PodSpecPatch
-		localParams := make(map[string]string)
-		if tmpl.IsPodType() {
-			localParams[common.LocalVarPodName] = pod.Name
-		}
-		newTmpl := tmpl.DeepCopy()
-		newTmpl.PodSpecPatch = woc.execWf.Spec.PodSpecPatch
-		processedTmpl, err := common.ProcessArgs(newTmpl, &wfv1.Arguments{}, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())
-		if err != nil {
-			return nil, errors.Wrap(err, "", "Failed to substitute the PodSpecPatch variables")
-		}
-		podSpecPatchs = append(podSpecPatchs, processedTmpl.PodSpecPatch)
-	}
-	if tmpl.HasPodSpecPatch() {
-		localParams := make(map[string]string)
-		if tmpl.IsPodType() {
-			localParams[common.LocalVarPodName] = pod.Name
-		}
-		newTmpl := tmpl.DeepCopy()
-		newTmpl.PodSpecPatch = tmpl.PodSpecPatch
-		processedTmpl, err := common.ProcessArgs(newTmpl, &wfv1.Arguments{}, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())
-		if err != nil {
-			return nil, errors.Wrap(err, "", "Failed to substitute the PodSpecPatch variables")
-		}
-		podSpecPatchs = append(podSpecPatchs, processedTmpl.PodSpecPatch)
+	podSpecPatchs, err = woc.processPodSpecPatch(tmpl, pod)
+	if err != nil {
+		return nil, err
 	}
 	if len(podSpecPatchs) > 0 {
 		patchedPodSpec, err := util.ApplyPodSpecPatch(pod.Spec, podSpecPatchs...)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->



Fixes #12941

### Motivation
This makes the behaviour  of the podSpec patch consistent by processing it via ProcessArgs in the case of template level expressions existing. It also fixes an issue where the replaceMap was emptied out for no reason. 

### Modifications
Performs the same processing applied to workflow level pod spec strategy.

### Verification
Unit test was added and additionally manual testing was performed.

### Documentation
