### PR TITLE
feat!: don't push to docker hub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,6 @@ jobs:
             --platform="${PLATFORM}" \
             --target $TARGET \
             --provenance=false \
-            --tag $image_name \
             --tag quay.io/$image_name .
 
   build-windows:
@@ -133,8 +132,6 @@ jobs:
               -t $image_name \
               -f Dockerfile.windows \
               .
-
-            docker push $image_name
 
             docker tag $image_name quay.io/$image_name
             docker push quay.io/$image_name
@@ -187,14 +184,11 @@ jobs:
             image_name="${docker_org}/${target}:${tag}"
 
             if [ $target = "argoexec" ]; then
-              docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64 ${image_name}-windows
               docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64 quay.io/${image_name}-windows
             else
-              docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64
               docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64
             fi
 
-            docker manifest push $image_name
             docker manifest push quay.io/$image_name
 
             cosign sign -y --key env://COSIGN_PRIVATE_KEY quay.io/$image_name
@@ -236,7 +230,6 @@ jobs:
           fi
 
           image_name="${DOCKERIO_ORG}/${TARGET}:${tag}"
-          docker pull $image_name
           docker pull quay.io/$image_name
 
   test-images-windows:
@@ -270,7 +263,6 @@ jobs:
           targets="argoexec"
           for target in $targets; do
             image_name="${docker_org}/${target}:${tag}"
-            docker pull $image_name
             docker pull quay.io/$image_name
           done
 

--- a/docs/access-token.md
+++ b/docs/access-token.md
@@ -95,7 +95,7 @@ docker run --rm -it \
   -e ARGO_HTTP1=true \
   -e KUBECONFIG=/dev/null \
   -e ARGO_NAMESPACE=$ARGO_NAMESPACE  \
-  argoproj/argocli:latest template list -v -e -k
+  quay.io/argoproj/argocli:latest template list -v -e -k
 ```
 
 ## Token Revocation

--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -119,7 +119,7 @@ spec:
         env:
           - name: ARGO_BASE_HREF
             value: /argo/
-        image: argoproj/argocli:latest
+        image: quay.io/argoproj/argocli:latest
         name: argo-server
 ...
 ```

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -169,7 +169,7 @@ spec:
       containers:
         - args:
             - server
-          image: argoproj/argocli:latest
+          image: quay.io/argoproj/argocli:latest
           name: argo-server
           env:
             - name: GRPC_MESSAGE_SIZE

--- a/docs/managed-namespace.md
+++ b/docs/managed-namespace.md
@@ -16,7 +16,7 @@ For example:
         - --configmap
         - workflow-controller-configmap
         - --executor-image
-        - argoproj/workflow-controller:v2.5.1
+        - quay.io/argoproj/workflow-controller:v3.6.7
         - --namespaced
         - --managed-namespace
         - default

--- a/examples/k8s-orchestration.yaml
+++ b/examples/k8s-orchestration.yaml
@@ -66,10 +66,10 @@ spec:
       parameters:
       - name: job-uid
     container:
-      image: argoproj/argoexec:latest
+      image: quay.io/argoproj/argoexec:latest
       command: [sh, -c]
       args: ["
-        for i in `kubectl get pods -l controller-uid={{inputs.parameters.job-uid}} -o name`; do 
+        for i in `kubectl get pods -l controller-uid={{inputs.parameters.job-uid}} -o name`; do
           kubectl logs $i;
         done
       "]


### PR DESCRIPTION
Fixes #13968

### Motivation

None of the rest of argoproj pushes to docker hub any more. With their rate limiting it makes it hard to use.

We have pushed to quay.io for years, so make that the only place we push to

### Modifications

Remove all the actions which push to docker hub.

Fix up a few docs which would attempt to pull from docker hub not quay.io

This is not a 100% purge of images in docker hub, there are still some references to things that don't mention a registry.

There is no intention to delete any old images, just to stop new ones going there.

I'm intending to backport this to 3.6, so comments around whether that is acceptable to reviewers would be helpful. This will allow me to test the release changes.

I have retained docker login within the codebase as our Dockerfile depends on images coming from dockerhub, and logging in should remove rate limiting.

I haven't renamed `DOCKERIO_ORG` (which == `argoproj`), just to reduce likelyhood of things going wrong. I'm unsure why this comes from a secret at all.

### Verification

There really has to be a release for the bulk of it to be tested.

### Documentation

None here, should be mentioned in the release notes. The image sources aren't mentioned in the current docs.

The official helm chart already pulls from quay, as do our manifests.