### PR TITLE
fix!: Adjust parameter value overriding. Fixes #14426

### DIFF
--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -340,6 +340,7 @@ func newController(options ...interface{}) (context.CancelFunc, *WorkflowControl
 		go wfc.taskResultInformer.Run(ctx.Done())
 		wfc.cwftmplInformer = informerFactory.Argoproj().V1alpha1().ClusterWorkflowTemplates()
 		go wfc.cwftmplInformer.Informer().Run(ctx.Done())
+		go wfc.configMapInformer.Run(ctx.Done())
 		// wfc.waitForCacheSync() takes minimum 100ms, we can be faster
 		for _, c := range []cache.SharedIndexInformer{
 			wfc.wfInformer,
@@ -349,6 +350,7 @@ func newController(options ...interface{}) (context.CancelFunc, *WorkflowControl
 			wfc.wfTaskSetInformer.Informer(),
 			wfc.artGCTaskInformer.Informer(),
 			wfc.taskResultInformer,
+			wfc.configMapInformer,
 		} {
 			for !c.HasSynced() {
 				time.Sleep(5 * time.Millisecond)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -643,7 +643,9 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 		woc.globalParams[common.GlobalVarWorkflowParametersJSON] = string(workflowParameters)
 	}
 	for _, param := range executionParameters.Parameters {
-		if param.ValueFrom != nil && param.ValueFrom.ConfigMapKeyRef != nil {
+		if param.Value != nil {
+			woc.globalParams["workflow.parameters."+param.Name] = param.Value.String()
+		} else if param.ValueFrom != nil && param.ValueFrom.ConfigMapKeyRef != nil {
 			cmValue, err := common.GetConfigMapValue(woc.controller.configMapInformer.GetIndexer(), woc.wf.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
 			if err != nil {
 				if param.ValueFrom.Default != nil {
@@ -655,8 +657,6 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 			} else {
 				woc.globalParams["workflow.parameters."+param.Name] = cmValue
 			}
-		} else if param.Value != nil {
-			woc.globalParams["workflow.parameters."+param.Name] = param.Value.String()
 		} else {
 			return fmt.Errorf("either value or valueFrom must be specified in order to set global parameter %s", param.Name)
 		}

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -265,8 +265,8 @@ func TestWorkflowTemplateRefValueFromParamOverwrite(t *testing.T) {
 		ctx := context.Background()
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
-		assert.Equal(t, wf.Spec.Arguments.Parameters, woc.wf.Spec.Arguments.Parameters)
-		assert.Equal(t, "configmap argument overwrite with argument", woc.wf.Spec.Arguments.Parameters[0].Value.String())
+		assert.Equal(t, wf.Spec.Arguments.Parameters, woc.execWf.Spec.Arguments.Parameters)
+		assert.Equal(t, "configmap argument overwrite with argument", woc.execWf.Spec.Arguments.Parameters[0].Value.String())
 	})
 }
 
@@ -334,9 +334,9 @@ func TestWorkflowTemplateRefValueParamOverwrite(t *testing.T) {
 		require.NoError(t, err)
 		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
-		assert.Equal(t, wf.Spec.Arguments.Parameters, woc.wf.Spec.Arguments.Parameters)
-		assert.Equal(t, "config-properties", woc.wf.Spec.Arguments.Parameters[0].ValueFrom.ConfigMapKeyRef.Name)
-		assert.Equal(t, "message", woc.wf.Spec.Arguments.Parameters[0].ValueFrom.ConfigMapKeyRef.Key)
+		assert.Equal(t, wf.Spec.Arguments.Parameters, woc.execWf.Spec.Arguments.Parameters)
+		assert.Equal(t, "config-properties", woc.execWf.Spec.Arguments.Parameters[0].ValueFrom.ConfigMapKeyRef.Name)
+		assert.Equal(t, "message", woc.execWf.Spec.Arguments.Parameters[0].ValueFrom.ConfigMapKeyRef.Key)
 	})
 }
 

--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -101,7 +101,7 @@ func JoinWorkflowSpec(wfSpec, wftSpec, wfDefaultSpec *wfv1.WorkflowSpec) (*wfv1.
 	// However, if Value, ValueFrom and Default are set in different places,
 	// i.e. the Workflow, WorflowTemplate and WorkflowDefault, we should only keep the one with the greatest priority.
 	wfParamsMap := parametersToMapByName(wfSpec)
-	wftParamsMap := parametersToMapByName(wfSpec)
+	wftParamsMap := parametersToMapByName(wftSpec)
 	for index, parameter := range targetWf.Spec.Arguments.Parameters {
 		if parameter.HasValue() {
 			if param, ok := wfParamsMap[parameter.Name]; ok {

--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -97,7 +97,34 @@ func JoinWorkflowSpec(wfSpec, wftSpec, wfDefaultSpec *wfv1.WorkflowSpec) (*wfv1.
 	if wfSpec.Suspend != targetWf.Spec.Suspend {
 		targetWf.Spec.Suspend = wfSpec.Suspend
 	}
+	// The value of an argument should respect the priority order of the merge.
+	// However, if Value, ValueFrom and Default are set in different places,
+	// i.e. the Workflow, WorflowTemplate and WorkflowDefault, we should only keep the one with the greatest priority.
+	wfParamsMap := parametersToMapByName(wfSpec)
+	wftParamsMap := parametersToMapByName(wfSpec)
+	for index, parameter := range targetWf.Spec.Arguments.Parameters {
+		if parameter.HasValue() {
+			if param, ok := wfParamsMap[parameter.Name]; ok {
+				targetWf.Spec.Arguments.Parameters[index] = *param.DeepCopy()
+			} else if param, ok := wftParamsMap[parameter.Name]; ok {
+				targetWf.Spec.Arguments.Parameters[index] = *param.DeepCopy()
+			}
+			// If none of the above conditions are met, we can safely assume that the parameter is set from the wfDefaultSpec.
+		}
+	}
 	return &targetWf, nil
+}
+
+func parametersToMapByName(spec *wfv1.WorkflowSpec) map[string]wfv1.Parameter {
+	parameterMap := make(map[string]wfv1.Parameter)
+	if spec != nil {
+		for _, param := range spec.Arguments.Parameters {
+			if param.HasValue() {
+				parameterMap[param.Name] = param
+			}
+		}
+	}
+	return parameterMap
 }
 
 // mergeMetadata will merge the labels and annotations into the target metadata.

--- a/workflow/util/merge_test.go
+++ b/workflow/util/merge_test.go
@@ -267,6 +267,7 @@ spec:
   arguments:
     parameters:
       - name: PARAM1
+        value: WorkflowTemplate value 1 ignored
       - name: PARAM2
       - name: PARAM3
         value: WorkflowTemplate value 3
@@ -382,6 +383,15 @@ func TestJoinWfSpecArguments(t *testing.T) {
 	result := wfv1.MustUnmarshalWorkflow(wfArgumentsResult)
 
 	targetWf, err := JoinWorkflowSpec(&wf.Spec, wft.GetWorkflowSpec(), nil)
+	require.NoError(t, err)
+	assert.Equal(result.Spec.Arguments, targetWf.Spec.Arguments)
+}
+
+func TestJoinWfSpecArgumentsWithNil(t *testing.T) {
+	assert := assert.New(t)
+	wf := wfv1.MustUnmarshalWorkflow(wfArguments)
+	result := wfv1.MustUnmarshalWorkflow(wfArguments)
+	targetWf, err := JoinWorkflowSpec(&wf.Spec, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(result.Spec.Arguments, targetWf.Spec.Arguments)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14426 

### Motivation

See the related issue description. It fixes the Inconsistent behavior for Workflow Arguments vs Template inputs to prioritise Value over ConfigMapKeyRef problem, and more in general the way the merge over the parameters containing values is performed.

### Modifications

* Modified the spec merge functionality `JoinWorkflowSpec` inside `workflow/util/merge.go`:
   * Arguments.Parameters has patch strategy `merge`
   * However when we merge the `Value`, `ValueFrom`, `Default` can conflict if they come from Wf, Wft or DefaultWf
   * The change aims of removing this ambiguity, so that the resulting `execWf` uses the proper value given the priority Wf -> Wft -> DefaultWf.
* No UI changes.

### Verification

Add unit tests to verify the changes. Tested with the given reproducible example from the issue and verified:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-properties
  namespace: argo
  labels:
    workflows.argoproj.io/configmap-type: Parameter
data:
  message: "message from config map"
---
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: wf-template-echo
  namespace: argo
spec:
  entrypoint: echo
  arguments:
    parameters:
      - name: message
        valueFrom:
          configMapKeyRef:
            name: config-properties
            key: message
  templates:
    - name: echo
      container:
        image: busybox
        command: [echo]
        args: ["{{workflow.parameters.message}}"]
---
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: wf-parameter-overwrite-
  namespace: argo
spec:
  entrypoint: echo
  arguments:
    parameters:
      - name: message
        value: "configmap argument overwrite with argument"
  workflowTemplateRef:
    name: wf-template-echo
```    

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
