### PR TITLE
fix(controller): support string type result for item

### DIFF
--- a/pkg/apis/workflow/v1alpha1/marshall_test.go
+++ b/pkg/apis/workflow/v1alpha1/marshall_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ func TestMustUnmarshalClusterWorkflowTemplate(t *testing.T) {
 		if r := recover(); r == nil {
 			t.Fatalf("The code did not panic but should have")
 		} else {
-			assert.Equal(t, "no text to unmarshal", r.(string))
+			assert.Equal(t, fmt.Errorf("no text to unmarshal"), r)
 		}
 	}()
 	_ = MustUnmarshalClusterWorkflowTemplate([]byte(""))

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3338,7 +3338,7 @@ func (woc *wfOperationCtx) processAggregateNodeOutputs(scope *wfScope, prefix st
 		if node.Outputs.Result != nil {
 			// Support the case where item may be a map
 			var item wfv1.Item
-			err := json.Unmarshal([]byte(*node.Outputs.Result), &item)
+			err := wfv1.Unmarshal([]byte(*node.Outputs.Result), &item)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes #14439

### Motivation
Support the case where item may be a map/string

### Modifications
use wfv1.Unmarshal instead of json.Unmarshal
