### PR TITLE
fix: correctly release all mutexes when multiple mutexes are held. FIxes #14461

### DIFF
--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -524,7 +524,9 @@ func (sm *Manager) ReleaseAll(wf *wfv1.Workflow) bool {
 	}
 
 	if wf.Status.Synchronization.Mutex != nil {
-		for _, holding := range wf.Status.Synchronization.Mutex.Holding {
+		h := make([]wfv1.MutexHolding, len(wf.Status.Synchronization.Mutex.Holding))
+		copy(h, wf.Status.Synchronization.Mutex.Holding)
+		for _, holding := range h {
 			syncLockHolder := sm.syncLockMap[holding.Mutex]
 			if syncLockHolder == nil {
 				continue

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -475,6 +475,84 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		syncManager.ReleaseAll(wf3)
 		assert.Empty(t, sema.pending.items)
 	})
+
+	t.Run("WorkflowLevelSemaphoreAcquireAndReleaseWithMultipleSemaphores", func(t *testing.T) {
+		// Create ConfigMap with multiple semaphore limits
+		cm := v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multiple-sema-config",
+				Namespace: "default",
+			},
+			Data: map[string]string{
+				"sem1": "1",
+				"sem2": "1",
+				"sem3": "1",
+			},
+		}
+		_, err := kube.CoreV1().ConfigMaps("default").Create(ctx, &cm, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		syncManager := NewLockManager(ctx, kube, "", nil, syncLimitFunc, func(key string) {
+			// nextKey = key
+		}, WorkflowExistenceFunc)
+
+		// Create two workflows that both need all semaphores
+		wf1 := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
+		wf1.Name = "wf1"
+		wf1.Spec.Synchronization.Semaphores = []*wfv1.SemaphoreRef{
+			{
+				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "multiple-sema-config"},
+					Key:                  "sem1",
+				},
+			},
+			{
+				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "multiple-sema-config"},
+					Key:                  "sem2",
+				},
+			},
+			{
+				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{Name: "multiple-sema-config"},
+					Key:                  "sem3",
+				},
+			},
+		}
+
+		wf2 := wf1.DeepCopy()
+		wf2.Name = "wf2"
+
+		// First workflow should acquire all semaphores
+		status, wfUpdate, msg, failedLockName, err := syncManager.TryAcquire(ctx, wf1, "", wf1.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.Empty(t, msg)
+		assert.Empty(t, failedLockName)
+		assert.True(t, status)
+		assert.True(t, wfUpdate)
+		require.NotNil(t, wf1.Status.Synchronization)
+		require.NotNil(t, wf1.Status.Synchronization.Semaphore)
+		require.NotNil(t, wf1.Status.Synchronization.Semaphore.Holding)
+		assert.Len(t, wf1.Status.Synchronization.Semaphore.Holding, 3)
+
+		// Release all semaphores from first workflow
+		syncManager.ReleaseAll(wf1)
+
+		// Second workflow should now be able to acquire all semaphores
+		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf2, "", wf2.Spec.Synchronization)
+		require.NoError(t, err)
+		assert.Empty(t, msg)
+		assert.Empty(t, failedLockName)
+		assert.True(t, status)
+		assert.True(t, wfUpdate)
+		require.NotNil(t, wf2.Status.Synchronization)
+		require.NotNil(t, wf2.Status.Synchronization.Semaphore)
+		require.NotNil(t, wf2.Status.Synchronization.Semaphore.Holding)
+		assert.Len(t, wf2.Status.Synchronization.Semaphore.Holding, 3)
+
+		// Clean up
+		syncManager.ReleaseAll(wf2)
+	})
 }
 
 func TestResizeSemaphoreSize(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fix #14461

### Motivation

Fix the issue where some mutexes are not properly released when multiple mutexes are used in a workflow. This ensures all held mutexes are released correctly after execution.

### Modifications

The issue occurred because the logic inside the loop modified the original `MutexHolding` array while iterating over it. To fix this, we create a copy of the `MutexHolding` array and operate on the copy instead. This guarantees that all mutexes are properly released.

### Verification

Added a test case named `WorkflowLevelMutexAcquireAndReleaseWithMultipleMutex` in `sync_manager_test.go` to verify that all mutexes are correctly acquired and released.

### Documentation

No documentation needed

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
