### PR TITLE
feat: SSO support for Argo Workflows CLI

### DIFF
--- a/cmd/argo/commands/auth/root.go
+++ b/cmd/argo/commands/auth/root.go
@@ -13,5 +13,6 @@ func NewAuthCommand() *cobra.Command {
 		},
 	}
 	command.AddCommand(NewTokenCommand())
+	command.AddCommand(NewSsoCommand())
 	return command
 }

--- a/cmd/argo/commands/auth/sso.go
+++ b/cmd/argo/commands/auth/sso.go
@@ -1,0 +1,213 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
+
+	"github.com/argoproj/argo-workflows/v3/cmd/argo/commands/client"
+	pkgrand "github.com/argoproj/argo-workflows/v3/util/rand"
+)
+
+func NewSsoCommand() *cobra.Command {
+	var ssoPort int
+
+	cmd := &cobra.Command{
+		Use:   "sso",
+		Short: "Authenticate with SSO",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSsoFlow(ssoPort)
+		},
+	}
+
+	cmd.Flags().IntVar(&ssoPort, "sso-port", 8085, "Port to listen for the callback")
+	return cmd
+}
+
+func runSsoFlow(port int) error {
+	if client.ArgoServerOpts.URL == "" {
+		return fmt.Errorf("argo server URL is required")
+	}
+
+	argoURL, err := url.Parse(client.ArgoServerOpts.URL)
+	if err != nil {
+		return fmt.Errorf("invalid argo server URL: %w", err)
+	}
+
+	state, err := pkgrand.RandString(10)
+	if err != nil {
+		return fmt.Errorf("failed to generate random state: %w", err)
+	}
+
+	baseURL := fmt.Sprintf("%s://%s%s", argoURL.Scheme, argoURL.Host, strings.TrimRight(argoURL.Path, "/"))
+	callbackURL := fmt.Sprintf("http://localhost:%d/oauth/callback", port)
+	finalRedirectURL := fmt.Sprintf("%s/oauth2/redirect?redirect=%s&cli=true&cli_state=%s", baseURL, url.QueryEscape(callbackURL), url.QueryEscape(state))
+	exchangeURL := fmt.Sprintf("%s/oauth2/cli/exchange", baseURL)
+
+	fmt.Printf("Opening browser for SSO login: %s\n", finalRedirectURL)
+
+	completion := make(chan string)
+
+	// HTTP server setup
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/callback", makeCallbackHandler(exchangeURL, state, completion))
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf("localhost:%d", port),
+		Handler: mux,
+	}
+
+	go func() {
+		fmt.Printf("Listening on %s for OAuth2 callback...\n", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("HTTP server error: %v", err)
+		}
+	}()
+
+	// Open browser for login
+	if err := open.Start(finalRedirectURL); err != nil {
+		return fmt.Errorf("failed to open browser: %w", err)
+	}
+
+	// Wait for callback
+	errMsg := <-completion
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx)
+
+	if errMsg != "" {
+		return fmt.Errorf("authentication failed: %s", errMsg)
+	}
+
+	fmt.Println("✅ Authentication successful")
+	return nil
+}
+
+func makeCallbackHandler(exchangeURL string, state string, done chan<- string) http.HandlerFunc {
+	handleErr := func(w http.ResponseWriter, errMsg string) {
+		http.Error(w, html.EscapeString(errMsg), http.StatusBadRequest)
+		done <- errMsg
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("🔐 Received SSO callback")
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			handleErr(w, "no code received in callback")
+			return
+		}
+
+		fmt.Printf("Code: %s\n", code)
+
+		tokenStr, err := exchangeCode(exchangeURL, code, state)
+		if err != nil {
+			handleErr(w, fmt.Sprintf("failed to exchange code: %v", err))
+			return
+		}
+
+		viper.Set("token", strings.TrimSpace(tokenStr))
+
+		configFile := viper.ConfigFileUsed()
+		if configFile == "" {
+			// store token in ~/.argo/config
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				handleErr(w, fmt.Sprintf("failed to get home directory: %v", err))
+				return
+			}
+			configFile = filepath.Join(homeDir, ".argo", "config.yaml")
+		}
+		// load yaml from config file
+		config := make(map[string]interface{})
+		if _, err := os.Stat(configFile); err == nil {
+			data, err := os.ReadFile(configFile)
+			if err != nil {
+				handleErr(w, fmt.Sprintf("failed to read config file: %v", err))
+				return
+			}
+			if err := yaml.Unmarshal(data, &config); err != nil {
+				handleErr(w, fmt.Sprintf("failed to unmarshal config file: %v", err))
+				return
+			}
+		}
+		// set token in config
+		config["token"] = viper.Get("token")
+		// marshal config to yaml
+		data, err := yaml.Marshal(config)
+		if err != nil {
+			handleErr(w, fmt.Sprintf("failed to marshal config file: %v", err))
+			return
+		}
+		// write config to file
+		if err := os.MkdirAll(filepath.Dir(configFile), os.ModePerm); err != nil {
+			handleErr(w, fmt.Sprintf("failed to create config directory: %v", err))
+			return
+		}
+		if err := os.WriteFile(configFile, data, os.ModePerm); err != nil {
+			handleErr(w, fmt.Sprintf("failed to write config file: %v", err))
+			return
+		}
+
+		successPage := `
+		<div style="height:100px; width:100%!; display:flex; flex-direction: column; justify-content: center; align-items:center; background-color:#2ecc71; color:white; font-size:22"><div>Authentication successful!</div></div>
+		<p style="margin-top:20px; font-size:18; text-align:center">Authentication was successful, you can now return to CLI.</p>
+		`
+		fmt.Fprint(w, successPage)
+
+		fmt.Println("✅ Code exchanged and saved successfully")
+		done <- ""
+	}
+}
+
+func exchangeCode(exUrl, code, state string) (string, error) {
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	jsonData, err := json.Marshal(map[string]string{"code": code, "state": state})
+	if err != nil {
+		return "", err
+	}
+	// send code via POST request to not leak it in the URL
+	resp, err := httpClient.Post(exUrl, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	jsonToken := make(map[string]string)
+	_ = json.NewDecoder(resp.Body).Decode(&jsonToken)
+
+	token := jsonToken["token"]
+	if token == "" {
+		return "", fmt.Errorf("no token received in response")
+	}
+
+	return token, nil
+}

--- a/cmd/argo/commands/client/conn.go
+++ b/cmd/argo/commands/client/conn.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -96,6 +97,12 @@ func GetAuthString() (string, error) {
 	if ok {
 		return token, nil
 	}
+
+	token = viper.GetString("token")
+	if token != "" {
+		return token, nil
+	}
+
 	restConfig, err := GetConfig().ClientConfig()
 	if err != nil {
 		return "", err

--- a/docs/cli/argo.md
+++ b/docs/cli/argo.md
@@ -79,6 +79,7 @@ argo [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive.md
+++ b/docs/cli/argo_archive.md
@@ -25,6 +25,7 @@ argo archive [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_delete.md
+++ b/docs/cli/argo_archive_delete.md
@@ -33,6 +33,7 @@ argo archive delete UID... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_get.md
+++ b/docs/cli/argo_archive_get.md
@@ -37,6 +37,7 @@ argo archive get UID [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_list-label-keys.md
+++ b/docs/cli/argo_archive_list-label-keys.md
@@ -25,6 +25,7 @@ argo archive list-label-keys [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_list-label-values.md
+++ b/docs/cli/argo_archive_list-label-values.md
@@ -26,6 +26,7 @@ argo archive list-label-values [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_list.md
+++ b/docs/cli/argo_archive_list.md
@@ -45,6 +45,7 @@ argo archive list [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_resubmit.md
+++ b/docs/cli/argo_archive_resubmit.md
@@ -67,6 +67,7 @@ argo archive resubmit [WORKFLOW...] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_archive_retry.md
+++ b/docs/cli/argo_archive_retry.md
@@ -67,6 +67,7 @@ argo archive retry [WORKFLOW...] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_auth.md
+++ b/docs/cli/argo_auth.md
@@ -25,6 +25,7 @@ argo auth [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level
@@ -50,5 +51,6 @@ argo auth [flags]
 ### SEE ALSO
 
 * [argo](argo.md)	 - argo is the command line interface to Argo
+* [argo auth sso](argo_auth_sso.md)	 - Authenticate with SSO
 * [argo auth token](argo_auth_token.md)	 - Print the auth token
 

--- a/docs/cli/argo_auth_sso.md
+++ b/docs/cli/argo_auth_sso.md
@@ -1,15 +1,16 @@
-## argo cron suspend
+## argo auth sso
 
-suspend zero or more cron workflows
+Authenticate with SSO
 
 ```
-argo cron suspend CRON_WORKFLOW... [flags]
+argo auth sso [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for suspend
+  -h, --help           help for sso
+      --sso-port int   Port to listen for the callback (default 8085)
 ```
 
 ### Options inherited from parent commands
@@ -50,5 +51,5 @@ argo cron suspend CRON_WORKFLOW... [flags]
 
 ### SEE ALSO
 
-* [argo cron](argo_cron.md)	 - manage cron workflows
+* [argo auth](argo_auth.md)	 - manage authentication settings
 

--- a/docs/cli/argo_auth_token.md
+++ b/docs/cli/argo_auth_token.md
@@ -25,6 +25,7 @@ argo auth token [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template.md
+++ b/docs/cli/argo_cluster-template.md
@@ -25,6 +25,7 @@ argo cluster-template [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template_create.md
+++ b/docs/cli/argo_cluster-template_create.md
@@ -41,6 +41,7 @@ argo cluster-template create FILE1 FILE2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template_delete.md
+++ b/docs/cli/argo_cluster-template_delete.md
@@ -26,6 +26,7 @@ argo cluster-template delete WORKFLOW_TEMPLATE [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template_get.md
+++ b/docs/cli/argo_cluster-template_get.md
@@ -26,6 +26,7 @@ argo cluster-template get CLUSTER WORKFLOW_TEMPLATE... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template_lint.md
+++ b/docs/cli/argo_cluster-template_lint.md
@@ -27,6 +27,7 @@ argo cluster-template lint FILE... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template_list.md
+++ b/docs/cli/argo_cluster-template_list.md
@@ -40,6 +40,7 @@ argo cluster-template list [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cluster-template_update.md
+++ b/docs/cli/argo_cluster-template_update.md
@@ -41,6 +41,7 @@ argo cluster-template update FILE1 FILE2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_completion.md
+++ b/docs/cli/argo_completion.md
@@ -40,6 +40,7 @@ argo completion SHELL [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cp.md
+++ b/docs/cli/argo_cp.md
@@ -43,6 +43,7 @@ argo cp my-wf output-directory ... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron.md
+++ b/docs/cli/argo_cron.md
@@ -29,6 +29,7 @@ argo cron [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_backfill.md
+++ b/docs/cli/argo_cron_backfill.md
@@ -32,6 +32,7 @@ argo cron backfill cronwf [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_create.md
+++ b/docs/cli/argo_cron_create.md
@@ -35,6 +35,7 @@ argo cron create FILE1 FILE2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_delete.md
+++ b/docs/cli/argo_cron_delete.md
@@ -26,6 +26,7 @@ argo cron delete [CRON_WORKFLOW... | --all] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_get.md
+++ b/docs/cli/argo_cron_get.md
@@ -26,6 +26,7 @@ argo cron get CRON_WORKFLOW... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_lint.md
+++ b/docs/cli/argo_cron_lint.md
@@ -27,6 +27,7 @@ argo cron lint FILE... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_list.md
+++ b/docs/cli/argo_cron_list.md
@@ -28,6 +28,7 @@ argo cron list [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_resume.md
+++ b/docs/cli/argo_cron_resume.md
@@ -25,6 +25,7 @@ argo cron resume [CRON_WORKFLOW...] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_cron_update.md
+++ b/docs/cli/argo_cron_update.md
@@ -48,6 +48,7 @@ argo cron update FILE1 FILE2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_delete.md
+++ b/docs/cli/argo_delete.md
@@ -50,6 +50,7 @@ argo delete [--dry-run] [WORKFLOW...|[--all] [--older] [--completed] [--resubmit
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_executor-plugin.md
+++ b/docs/cli/argo_executor-plugin.md
@@ -25,6 +25,7 @@ argo executor-plugin [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_executor-plugin_build.md
+++ b/docs/cli/argo_executor-plugin_build.md
@@ -25,6 +25,7 @@ argo executor-plugin build DIR [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_get.md
+++ b/docs/cli/argo_get.md
@@ -42,6 +42,7 @@ argo get WORKFLOW... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_lint.md
+++ b/docs/cli/argo_lint.md
@@ -43,6 +43,7 @@ argo lint FILE... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_list.md
+++ b/docs/cli/argo_list.md
@@ -70,6 +70,7 @@ argo list [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_logs.md
+++ b/docs/cli/argo_logs.md
@@ -67,6 +67,7 @@ argo logs WORKFLOW [POD] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_node.md
+++ b/docs/cli/argo_node.md
@@ -42,6 +42,7 @@ argo node ACTION WORKFLOW FLAGS [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_resubmit.md
+++ b/docs/cli/argo_resubmit.md
@@ -75,6 +75,7 @@ argo resubmit [WORKFLOW...] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_resume.md
+++ b/docs/cli/argo_resume.md
@@ -47,6 +47,7 @@ argo resume WORKFLOW1 WORKFLOW2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_retry.md
+++ b/docs/cli/argo_retry.md
@@ -78,6 +78,7 @@ argo retry [WORKFLOW...] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_server.md
+++ b/docs/cli/argo_server.md
@@ -52,6 +52,7 @@ See https://argo-workflows.readthedocs.io/en/latest/argo-server/
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_stop.md
+++ b/docs/cli/argo_stop.md
@@ -55,6 +55,7 @@ argo stop WORKFLOW WORKFLOW2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_submit.md
+++ b/docs/cli/argo_submit.md
@@ -73,6 +73,7 @@ argo submit [FILE... | --from `kind/name] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_suspend.md
+++ b/docs/cli/argo_suspend.md
@@ -37,6 +37,7 @@ argo suspend WORKFLOW1 WORKFLOW2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template.md
+++ b/docs/cli/argo_template.md
@@ -25,6 +25,7 @@ argo template [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template_create.md
+++ b/docs/cli/argo_template_create.md
@@ -27,6 +27,7 @@ argo template create FILE1 FILE2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template_delete.md
+++ b/docs/cli/argo_template_delete.md
@@ -26,6 +26,7 @@ argo template delete WORKFLOW_TEMPLATE [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template_get.md
+++ b/docs/cli/argo_template_get.md
@@ -26,6 +26,7 @@ argo template get WORKFLOW_TEMPLATE... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template_lint.md
+++ b/docs/cli/argo_template_lint.md
@@ -27,6 +27,7 @@ argo template lint (DIRECTORY | FILE1 FILE2 FILE3...) [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template_list.md
+++ b/docs/cli/argo_template_list.md
@@ -28,6 +28,7 @@ argo template list [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_template_update.md
+++ b/docs/cli/argo_template_update.md
@@ -41,6 +41,7 @@ argo template update FILE1 FILE2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_terminate.md
+++ b/docs/cli/argo_terminate.md
@@ -53,6 +53,7 @@ argo terminate WORKFLOW WORKFLOW2... [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_version.md
+++ b/docs/cli/argo_version.md
@@ -26,6 +26,7 @@ argo version [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_wait.md
+++ b/docs/cli/argo_wait.md
@@ -39,6 +39,7 @@ argo wait [WORKFLOW...] [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/docs/cli/argo_watch.md
+++ b/docs/cli/argo_watch.md
@@ -40,6 +40,7 @@ argo watch WORKFLOW [flags]
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
+      --config string                  config file (default is $HOME/.argo/config.yaml)
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --gloglevel int                  Set the glog logging level

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
           - argo archive resubmit: cli/argo_archive_resubmit.md
           - argo archive retry: cli/argo_archive_retry.md
           - argo auth: cli/argo_auth.md
+          - argo auth sso: cli/argo_auth_sso.md
           - argo auth token: cli/argo_auth_token.md
           - argo cluster-template: cli/argo_cluster-template.md
           - argo cluster-template create: cli/argo_cluster-template_create.md

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -418,6 +418,7 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 	}
 	mux.Handle("/oauth2/redirect", handlers.ProxyHeaders(http.HandlerFunc(as.oAuth2Service.HandleRedirect)))
 	mux.Handle("/oauth2/callback", handlers.ProxyHeaders(http.HandlerFunc(as.oAuth2Service.HandleCallback)))
+	mux.Handle("/oauth2/cli/exchange", handlers.ProxyHeaders(http.HandlerFunc(as.oAuth2Service.HandleCliExchange)))
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		if os.Getenv("ARGO_SERVER_METRICS_AUTH") != "false" {
 			md := metadata.New(map[string]string{"authorization": r.Header.Get("Authorization")})

--- a/server/auth/sso/mocks/Interface.go
+++ b/server/auth/sso/mocks/Interface.go
@@ -50,6 +50,11 @@ func (_m *Interface) HandleCallback(writer http.ResponseWriter, request *http.Re
 	_m.Called(writer, request)
 }
 
+// HandleCliExchange provides a mock function with given fields: writer, request
+func (_m *Interface) HandleCliExchange(writer http.ResponseWriter, request *http.Request) {
+	_m.Called(writer, request)
+}
+
 // HandleRedirect provides a mock function with given fields: writer, request
 func (_m *Interface) HandleRedirect(writer http.ResponseWriter, request *http.Request) {
 	_m.Called(writer, request)

--- a/server/auth/sso/null_sso.go
+++ b/server/auth/sso/null_sso.go
@@ -26,3 +26,7 @@ func (n nullService) HandleRedirect(w http.ResponseWriter, _ *http.Request) {
 func (n nullService) HandleCallback(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
+
+func (n nullService) HandleCliExchange(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}


### PR DESCRIPTION
Support authentication in Argo Workflows CLI via SSO and store / reuse the token in further CLI calls.

The PR also adds support for file-based configuration via `Viper`.

New command is as follows:

```
$ argo auth sso
```

You can also optionally pass `--sso-port` variable for a custom local server port.

Help for the cmd:

```
$ argo auth sso --help
Authenticate with SSO

Usage:
  argo auth sso [flags]

Flags:
  -h, --help       help for sso
      --sso-port int   Port to listen for the callback (default 8085)
```

A [new global CLI option `--config`](https://github.com/argoproj/argo-workflows/pull/14471/files#diff-942e08d7ee20e2ecea58e1f1a8d5f3508d23ab95d33df4e587177fde120350e8R155) is added to load config from a custom file location. If omited - we use `$HOME/.argo/config.yaml` as the default config file location.

<!-- Does this PR fix an issue -->

### Motivation

In our company we have hundreds of users of Argo Workflows.
From time to time users use `argo` cli to test / update / trigger workflows simply because that's it's handier than UI and because you can script it however you need with predefined params.

The only downside to the approach is that users had to copy `ARGO_TOKEN` from workflows UI, manually store it somewhere then periodically update etc..
If we compare the workflow to ArgoCD CLI - we can clearly see advantages of using SSO within that CLI and automatically storing tokens.

This PR attempts to bring this functionality on par with `argocd` cli.

ArgoCD and Argo Workflows use slightly different mechanics underneath when it comes to SSO:
 - ArgoCD cli talks directly to dex and then uses the obtained token for ArgoCD requests
 - Argo Workflows further modifies dex token and wraps it into a custom encrypted JWT so our CLI needs to communicate with Argo Workflows in order to obtain the correct token.

### CLI Flow

```mermaid
sequenceDiagram
CLI->>Argo Server: GET /oauth2/redirect?redirect=<localhost>&state=<state>
Argo Server->>Cookie: stores <redirect url>, cli=true, cli_state=<state>
Argo Server->>DEX: redirects to server-side SSO flow
DEX-->>Argo Server: redirects back to /oauth2/callback with a token
Argo Server->>Cookie: parse cookie and generate temp <JWT>
Argo Server-->>CLI: redirect to <localhost> with <JWT>
CLI->>Argo Server: POST /oauth2/cli/exchange with <JWT> and <state>
Argo Server-->>CLI: validates and return long-lived token
```

### Modifications

In order to support CLI SSO Flow, I customized the `state` cookie within oauth flow to include besides redirect url some additional information:
 - `cli` flag to indicate that this is a CLI flow
 - `cli_state` variable to include state from CLI into temporary JWT token (`jti`) and validate it during JWT token exchange phase.

The above means that we need to encode the data to store it in a cookie.
For the purpose I encoded the data into `json` and then further encoded it into `base64` to encode invalid cookie characters.

When we are in the CLI flow within `/oauth2/callback` handler - then instead of storing auth token within Cookies 
[CLI then calls](https://github.com/argoproj/argo-workflows/pull/14471/files#diff-327c3dbb27b512b661c3231126081f1c1321e279c4ab81e662b3c9473cc232fdR188-R193) `POST /oauth2/cli/exchange` with the code and cli state in json body to [exchange the code](https://github.com/argoproj/argo-workflows/pull/14471/files#diff-e04d9d144b5da0d3c2f1333b1fa94be9c7520161f7226c41fd6dabfda563589fR255-R271) (temporary cli jwt) for authentication token (actual long-living jwt).
The token is then stored within `$HOME/.argo/config.yaml` file.

On server side to split token types I used JWT Audiences.
 - The temporary JWT token is issued with `cli-auth` audience and is not valid for anything besides cli exchange flow (the token is valid for just 10 seconds to minimise any potential security risks).
 - Long-living token is issued with `argo-session` audience and is used for normal operations (beforehand audience wasn't set at all).

In order to support token preloading from config file I [utilised `viper.ReadInConfig()` method](https://github.com/argoproj/argo-workflows/pull/14471/files#diff-942e08d7ee20e2ecea58e1f1a8d5f3508d23ab95d33df4e587177fde120350e8R159-R174).
Since you already using viper in your command parsing code it was logic choice.
I also moved viper configuration and flags override into `cobra.OnInitialize()` method since that is the correct way to update flags only after they were fully parsed.

And lastly, [I allowed `localhost`](https://github.com/argoproj/argo-workflows/pull/14471/files#diff-e04d9d144b5da0d3c2f1333b1fa94be9c7520161f7226c41fd6dabfda563589fR493-R496) in `redirect` value for `/oauth2/redirect` handler as otherwise we can't redirect to a local CLI server.

```bash
➜  argo-workflows git:(cli-sso-support) ls -l ~/.argo/
ls: /Users/vitali.deatlov/.argo/: No such file or directory
➜  argo-workflows git:(cli-sso-support) dist/argo auth sso -s https://localhost:8080
Opening browser for SSO login: https://localhost:8080/oauth2/redirect?redirect=http%3A%2F%2Flocalhost%3A8085%2Foauth%2Fcallback&cli=true&cli_state=b8b649353f
Listening on localhost:8085 for OAuth2 callback...
🔐 Received SSO callback
Code: eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIiwiemlwIjoiREVGIn0.NioWA9PXj3VY856d1CtNOqDFbKMSXuvUlxHVjXYWX6QWC5M_P7-mgzMV-AKQRe5FmXT_QmpNQOPEVBhB_MB4t_v14nSyd-4yE66kDgYrmfmLKeeLueByvPfgIiDf17-H0PAYFPoRfVVXJHXdneBBx3WaCwaaNPyCQrfVggW828V5YRcNVwZi2loz0k2iRxBe80a1vPFdCctWffNWlOsYjdU34Rf8L8VNHGLCp5xLhnb7S3t4YqozHnARQ-rU0RCmNpRnYK7gyvdhklNatBQGF5fAZebgLZduMMNXodIfiYCP0ncJX79MJgpY-FbILUuB8LscBl-JdRLVZueL4wmzEg.G3tBxgwnMAlzEVb9.0xFCrRwoq1rdQ_YQf8Alqoy3P4nn8RquzcaM66E_FJZW74zgxOdzR3Tn6reVs6-r-vMtUbIymZX_8-mRiCGnO_lkth64bg3hc_tcEXmATxx1HIaPmnJfoq7fq7Woe9iV-Z8Q7R7fyadkP91dMuTZpM3u6lowq0onFhDnF5OmDxQxfpCDGCy-tv2g41SE4dTVy3cZe4IxgNHudspSduSFu7Cj.avZ6q4uedktWaSKPGB_jKA
✅ Code exchanged and saved successfully
✅ Authentication successful
➜  argo-workflows git:(cli-sso-support) cat ~/.argo/config.yaml
token: Bearer v2:eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIiwiemlwIjoiREVGIn0.e-X_aYwYg1J01CQJF964fkDA9DhEpy0v_hPoGSOb0SRnFXh6c6SsDL2a7TScvQDHixCZOUkmyU_gsZU5zGXqjQ5b7Y86MwBhqmbWqBSljm1JDeSw4MOacqHlweqM41xwT0aEXpYzSKLdE_dhNv5d9qtVLZL7o2AJLEZKIu9LHr2fc-XgOs9uktLEC8QfPshd7fgTV-uz2ROTlOYRNoL7TdankNQEVlTgA6lHt0v-cOZ3cFAxfj8QuHtZmA0TPoDixudNdPq1QYac6RazevCRpIrsfRgtEDKHp6m8Pxm6p_bD_GBo4hdJn0nWGFbkkZ3WVgvUhzau3mUB6UQj-h-UMw.1JeCcTijyIsWUX-B.meAvrK564bY3j4VHuHrWaVML7XUJa6rt5wWJ6VWs70THpzvD5Tgh_3ZPzBUv684NvQaf04iOmXJJG060vusZTEbY0xH6YZQeK-p4qxFHoIJ9JHaRUJHFFfIBQ_lInoDGnVmemQ7RiCE6z9USCAEXJmEkTrRVmvIUnuyVPvgG8IlChNI32JEs.BoyBGsFBSWMgEJlV436z4Q
➜  argo-workflows git:(cli-sso-support) dist/argo auth token
Bearer v2:eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIiwiemlwIjoiREVGIn0.e-X_aYwYg1J01CQJF964fkDA9DhEpy0v_hPoGSOb0SRnFXh6c6SsDL2a7TScvQDHixCZOUkmyU_gsZU5zGXqjQ5b7Y86MwBhqmbWqBSljm1JDeSw4MOacqHlweqM41xwT0aEXpYzSKLdE_dhNv5d9qtVLZL7o2AJLEZKIu9LHr2fc-XgOs9uktLEC8QfPshd7fgTV-uz2ROTlOYRNoL7TdankNQEVlTgA6lHt0v-cOZ3cFAxfj8QuHtZmA0TPoDixudNdPq1QYac6RazevCRpIrsfRgtEDKHp6m8Pxm6p_bD_GBo4hdJn0nWGFbkkZ3WVgvUhzau3mUB6UQj-h-UMw.1JeCcTijyIsWUX-B.meAvrK564bY3j4VHuHrWaVML7XUJa6rt5wWJ6VWs70THpzvD5Tgh_3ZPzBUv684NvQaf04iOmXJJG060vusZTEbY0xH6YZQeK-p4qxFHoIJ9JHaRUJHFFfIBQ_lInoDGnVmemQ7RiCE6z9USCAEXJmEkTrRVmvIUnuyVPvgG8IlChNI32JEs.BoyBGsFBSWMgEJlV436z4Q
```

![Screenshot 2025-05-20 at 16 16 04](https://github.com/user-attachments/assets/349a9c30-d824-47d7-bf15-73eee43b49e2)

![Screenshot 2025-05-20 at 16 16 13](https://github.com/user-attachments/assets/9a2512d4-a56b-4e47-a893-eae3184c18f6)

![Screenshot 2025-05-20 at 16 16 21](https://github.com/user-attachments/assets/47507582-2da3-4e14-8a62-e617c44beaa4)

### Verification

Changes were successfully tested locally using Dev Containers.

### Documentation

Documentation was updated automatically when I ran `make pre-commit -B` 
I find the generated documentation sufficient. 
Users can discover the new feature simply by using `argo --help` or `argo auth --help`.
