### PR TITLE
feat: non-root argoexec

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         platform: [ linux/amd64, linux/arm64 ]
-        target: [ workflow-controller, argocli, argoexec ]
+        target: [ workflow-controller, argocli, argoexec, argoexec-nonroot ]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -179,7 +179,7 @@ jobs:
             tag="latest"
           fi
 
-          targets="workflow-controller argoexec argocli"
+          targets="workflow-controller argoexec argoexec-nonroot argocli"
           for target in $targets; do
             image_name="${docker_org}/${target}:${tag}"
 
@@ -203,7 +203,7 @@ jobs:
     strategy:
       matrix:
         platform: [ linux/amd64 ]
-        target: [ workflow-controller, argocli, argoexec ]
+        target: [ workflow-controller, argocli, argoexec, argoexec-nonroot ]
     steps:
       - name: Docker Login
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
@@ -309,6 +309,7 @@ jobs:
       - run: bom generate --image quay.io/argoproj/workflow-controller:$VERSION -o dist/workflow-controller.spdx
       - run: bom generate --image quay.io/argoproj/argocli:$VERSION -o dist/argocli.spdx
       - run: bom generate --image quay.io/argoproj/argoexec:$VERSION -o dist/argoexec.spdx
+      - run: bom generate --image quay.io/argoproj/argoexec-nonroot:$VERSION -o dist/argoexec-nonroot.spdx
       # pack the boms into one file to make it easy to download
       - run: tar -zcf dist/sbom.tar.gz dist/*.spdx
       - run: make release-notes VERSION=$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,12 +80,26 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 
 ####################################################################################################
 
-FROM gcr.io/distroless/static as argoexec
+FROM gcr.io/distroless/static as argoexec-base
 
-COPY --from=argoexec-build /go/src/github.com/argoproj/argo-workflows/dist/argoexec /bin/
 COPY --from=argoexec-build /etc/mime.types /etc/mime.types
 COPY hack/ssh_known_hosts /etc/ssh/
 COPY hack/nsswitch.conf /etc/
+
+####################################################################################################
+
+FROM argoexec-base as argoexec-nonroot
+
+USER 8737
+
+COPY --chown=8737 --from=argoexec-build /go/src/github.com/argoproj/argo-workflows/dist/argoexec /bin/
+
+ENTRYPOINT [ "argoexec" ]
+
+####################################################################################################
+FROM argoexec-base as argoexec
+
+COPY --from=argoexec-build /go/src/github.com/argoproj/argo-workflows/dist/argoexec /bin/
 
 ENTRYPOINT [ "argoexec" ]
 

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ else
 endif
 
 argoexec-image:
+argoexec-nonroot-image:
 
 %-image:
 	[ ! -e dist/$* ] || mv dist/$* .

--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -1,8 +1,8 @@
 # Workflow Executors
 
-A workflow executor runs in the pods that execute your workloads.
+A Workflow executor runs in the Pods that execute your workloads.
 It runs as both an init container and as a sidecar to the container you specify.
-It allows Argo to perform certain actions like monitoring pod logs, providing and collecting artifacts, and managing container life-cycles.
+It allows Argo to perform certain actions like monitoring Pod logs, providing and collecting artifacts, and managing container life-cycles.
 
 Historically there were multiple available executor types, but as of 3.4 the only available executor is called `emissary`.
 
@@ -26,7 +26,8 @@ Historically there were multiple available executor types, but as of 3.4 the onl
 You can determine the default command for a container image using:
 
 ```bash
-docker image inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}' argoproj/argosay:v2
+docker pull alpine:latest
+docker image inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}' alpine:latest
 ```
 
 [Learn more about command and args](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes)

--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -1,32 +1,29 @@
 # Workflow Executors
 
-A workflow executor is a process that conforms to a specific interface that allows Argo to perform certain actions like monitoring pod logs, collecting artifacts, managing container life-cycles, etc.
+A workflow executor runs in the pods that execute your workloads.
+It runs as both an init container and as a sidecar to the container you specify.
+It allows Argo to perform certain actions like monitoring pod logs, providing and collecting artifacts, and managing container life-cycles.
 
-## Emissary (emissary)
+Historically there were multiple available executor types, but as of 3.4 the only available executor is called `emissary`.
 
-> v3.1 and after
-
-Default in >= v3.3.
-Only option in >= v3.4.
-
-This is the most fully featured executor.
+## Emissary Executor
 
 * Reliability:
     * Works on GKE Autopilot
-    * Does not require `init` process to kill sub-processes.
-* More secure:
+    * Does not require `init` process to kill sub-processes
+* Security:
     * No `privileged` access
     * Cannot escape the privileges of the pod's service account
-    * Can [`runAsNonRoot`](workflow-pod-security-context.md).
-* Scalable:
-    * It reads and writes to and from the container's disk and typically does not use any network APIs unless resource
-    type template is used.
+    * Supports [running as non-root](workflow-pod-security-context.md)
+* Scalability:
+    * Reads and writes to and from the container's disk
+    * Typically does not use network APIs unless resource type template is used
 * Artifacts:
-    * Output artifacts can be located on the base layer (e.g. `/tmp`).
-* Configuration:
-    * `command` should be specified for containers.
+    * Output artifacts can be located on the base layer (e.g. `/tmp`)
 
-You can determine values as follows:
+### Container Command
+
+You can determine the default command for a container image using:
 
 ```bash
 docker image inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}' argoproj/argosay:v2
@@ -36,11 +33,18 @@ docker image inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}' argoproj/argosa
 
 ### Image Index/Cache
 
-If you don't provide command to run, the emissary will grab it from container image. You can also specify it using the workflow spec or emissary will look it up in the **image index**. This is nothing more fancy than
-a [configuration item](workflow-controller-configmap.yaml).
+The emissary executor determines the command to run in this order:
 
-Emissary will create a cache entry, using image with version as key and command as value, and it will reuse it for specific image/version.
+1. Command specified in the workflow spec
+2. Command from the image index cache
+3. Command from the container image
 
-### Exit Code 64
+The image index is a [configuration item](workflow-controller-configmap.yaml), called `images`.
 
-The emissary will exit with code 64 if it fails. This may indicate a bug in the emissary.
+The controller creates a cache entry using the image with version as key and command as value.
+It reuses this cache for specific image:version combinations, so you may get surprising behavior if you update the command in an image without changing its version tag.
+
+### Troubleshooting
+
+The emissary will exit with code 64 if it fails.
+This may indicate a bug in the emissary.

--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -1,8 +1,8 @@
 # Workflow Pod Security Context
 
-This document explains how to configure security context for workflow pods in Argo Workflows.
+This document explains how to configure security context for Workflow Pods in Argo Workflows.
 
-Running workflow pods as non-root is best practice for security.
+Running Workflow Pods as non-root is best practice for security.
 
 You may need to do this if:
 
@@ -11,11 +11,11 @@ You may need to do this if:
 
 ## Basic Configuration
 
-By default, all workflow pods run as root.
+By default, all Workflow Pods run as root.
 
-You can configure the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for your workflow pod.
+You can configure the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for your Workflow Pod.
 
-Here's a basic example that runs the pod as a non-root user:
+Here's a basic example that runs the Pod as a non-root user:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -1,12 +1,21 @@
 # Workflow Pod Security Context
 
+This document explains how to configure security context for workflow pods in Argo Workflows.
+
+Running workflow pods as non-root is best practice for security.
+
+You may need to do this if:
+
+* Your cluster requires [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards), as enforced by [PSA](https://kubernetes.io/docs/concepts/security/pod-security-admission/) or other means.
+* You need to comply with security policies that restrict root access.
+
+## Basic Configuration
+
 By default, all workflow pods run as root.
 
-You can run your workflow pods more securely by configuring the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for your workflow pod.
+You can configure the [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for your workflow pod.
 
-This is likely to be necessary if pod security standards ([PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards)) are enforced by
-[PSA](https://kubernetes.io/docs/concepts/security/pod-security-admission/) or other means, or if you have a
-[pod security policy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) (deprecated).
+Here's a basic example that runs the pod as a non-root user:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -16,10 +25,34 @@ metadata:
 spec:
   securityContext:
     runAsNonRoot: true
-    runAsUser: 8737 #; any non-root user
+    runAsUser: 8737 #; or any non-root user
 ```
-
-You can configure this globally using [workflow defaults](default-workflow-specs.md).
 
 !!! Warning "It is easy to make a workflow need root unintentionally"
     You may find that user's workflows have been written to require root with seemingly innocuous code. E.g. `mkdir /my-dir` would require root.
+
+## Global Configuration
+
+You can set these security context settings globally using [workflow defaults](default-workflow-specs.md).
+
+## Non-root Executor Image
+
+Argo provides a non-root executor image that runs by default as user 8737.
+
+This is not the default executor for backwards compatibility, but using it is best practice.
+Use this image when your security policies restrict pulling images that run as root.
+You can run this image as root by specifying `runAsUser: 0`.
+
+The image is available at `quay.io/argoproj/argoexec-nonroot:<version>`.
+
+You can configure this as the default executor image in the [workflow-controller-configmap](workflow-controller-configmap.yaml):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow-controller-configmap
+data:
+  executor: |
+    image: quay.io/argoproj/argoexec-nonroot:<version>
+```

--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -25,7 +25,7 @@ metadata:
 spec:
   securityContext:
     runAsNonRoot: true
-    runAsUser: 8737 #; or any non-root user
+    runAsUser: 8737 # or any non-root user
 ```
 
 !!! Warning "It is easy to make a workflow need root unintentionally"


### PR DESCRIPTION
As discussed at Feb 17th 2025 contributor meeting

### Motivation

Security policies for some companies do not like having images where the user is `0` or root.
`argoexec` defaults to running as root, but changing this is likely to break a lot of users workflows.

### Modifications

Supplement this with an `argoexec-nonroot` image which runs as the user 8737, the same user as the rest of the images.

Also update the documentation around this, and remove references executor choices.

### Verification

Built the image using the Makefile, and ran it in production for a week at pipekit.

### Documentation

Update the executor documentation to match the style guide better, and remove references to choices around the executor. I've retained the `Features` list mostly even though it feels a bit redundant.

Update the workflow pod security context documentation to prefer using this as best practice and encourage good pod security practice overall