### PR TITLE
docs(artifacts): add missing metadata field in finalizer example

### DIFF
--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -247,6 +247,7 @@ If the user needs to delete the Workflow and its child CRD objects, they will ne
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
+metadata:
   finalizers:
   - workflows.argoproj.io/artifact-gc
 ```


### PR DESCRIPTION
Minor fix to artifact docs, omitting any other info here (from the PR template).