### PR TITLE
build: workaround for segfaults when building dev container

### DIFF
--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -26,11 +26,15 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'argoproj/argo-workflows'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+        with:
+          # Workaround for segfaults under arm64:
+          # https://github.com/docker/setup-qemu-action/issues/198#issuecomment-2653791775
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Login to registry
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation
After https://github.com/argoproj/argo-workflows/pull/14341 was merged, the "Dev Container" workflow on the "main" branch is failing with segfaults when building the image for `arm64` ([example](https://github.com/argoproj/argo-workflows/actions/runs/15206127255/job/42769554389)):
```
[2025-05-23T08:46:25.854Z] #38 39.17 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
[2025-05-23T08:46:26.082Z] #38 39.55 Segmentation fault (core dumped)
[2025-05-23T08:46:26.226Z] #38 39.56 dpkg: error processing package libc-bin (--configure):
[2025-05-23T08:46:26.331Z] : Sub-process /usr/bin/dpkg returned an error code (1)
```

### Modifications


The root cause appears to be a kernel bug (https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782/), but I'm not sure. There are reports that downgrading Ubuntu and binfmt fixes it (https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2653281724), so hopefully this works.

### Verification

Run for this PR passed: https://github.com/argoproj/argo-workflows/actions/runs/15230576937/job/42837955903?pr=14500

### Documentation
N/A
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
