### PR TITLE
docs: fix Buildkit template

### DIFF
--- a/docs/walk-through/docker-in-docker-using-sidecars.md
+++ b/docs/walk-through/docker-in-docker-using-sidecars.md
@@ -2,7 +2,7 @@
 
 !!! Note "Alternatives"
     Alternative methods of building containers, such as [Kaniko](https://github.com/GoogleContainerTools/kaniko) or [Buildkit](https://github.com/moby/buildkit) can be simpler and more secure.
-    See the [Buildkit template](https://github.com/argoproj/argo-workflows/main/examples/buildkit-template.yaml) as an example.
+    See the [Buildkit template](https://github.com/argoproj/argo-workflows/blob/main/examples/buildkit-template.yaml) as an example.
 
 You can use [sidecars](sidecars.md) to implement Docker-in-Docker (DIND).
 You can use DIND to run Docker commands inside a container, such as to build and push a container image.


### PR DESCRIPTION
# PR Summary
This small PR simply fixes the Buildkit template broken reference. Relevant page: https://argo-workflows.readthedocs.io/en/stable/walk-through/docker-in-docker-using-sidecars/