### PR TITLE
docs(field reference): add support for strikethrough syntax in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ markdown_extensions:
   - md_in_html
   - pymdownx.details
   - pymdownx.snippets
+  - pymdownx.tilde
   - pymdownx.superfences:
       custom_fences:
         # support mermaid diagrams per https://squidfunk.github.io/mkdocs-material/reference/diagrams/#configuration


### PR DESCRIPTION
### Modifications

I noticed that, in the field reference part of the docs, text enclosed by two `~~` does not render a strikethrough correctly:

![image](https://github.com/user-attachments/assets/1388c03e-2403-47c1-a244-b4e2ee0aacae)

When adding the `pymdownx.tilde` extension in mkdocs the strikethrough are rendered correctly:

![image](https://github.com/user-attachments/assets/f0c5b527-2e14-4566-9640-3936e4104f88)

### Verification

```
make docs
make docs-serve
```
