### PR TITLE
fix: remove unnecessary init container status checks. Fixes #14495

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1486,14 +1486,6 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		new.Outputs.ExitCode = ptr.To(fmt.Sprint(*exitCode))
 	}
 
-	for _, c := range pod.Status.InitContainerStatuses {
-		if c.State.Terminated != nil && int(c.State.Terminated.ExitCode) != 0 {
-			new.Phase = wfv1.NodeFailed
-			woc.log.WithField("new.phase", new.Phase).Info("marking node as failed since init container has non-zero exit code")
-			break
-		}
-	}
-
 	waitContainerCleanedUp := true
 	// We cannot fail the node if the wait container is still running because it may be busy saving outputs, and these
 	// would not get captured successfully.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14495

### Motivation

Workflow stucks `Running` when initContainer in containerSet fails.

### Modifications

Remove unnecessary init container status checks because pod will turn to `Failed` if init container fails.
All nodes including container node will be `Failed` if pod fails.

### Verification

```YAML
metadata:
  name: hello-world-containerset-initcontainerfails
spec:
  entrypoint: hello-world
  templates:
    - name: hello-world
      dag:
        tasks:
          - name: containerset
            template: containerset
    - name: containerset
      containerSet:
        containers:
          - name: hello
            image: alpine:latest
            command: [sh, -c]
            args: ["echo hello"]
          - name: world
            image: alpine:latest
            command: [sh, -c]
            args: ["echo world"]
      initContainers:
        - name: setup
          image: alpine:latest
          command: [sh, -c]
          args: ["echo intentional failure; exit 1"]
```

![Clipboard_Screenshot_1748335986](https://github.com/user-attachments/assets/f5f9cf93-4e9b-433b-a15f-13c948965956)

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
