### PR TITLE
chore: longer unit tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -112,7 +112,7 @@ jobs:
     needs: [ changed-files ]
     if: ${{ needs.changed-files.outputs.tests == 'true' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0


### PR DESCRIPTION
Unit tests are timing out, probably due to the database tests for synchronisation. Let's increase the timeout