### PR TITLE
ci: add support for k8s 1.33 and drop 1.30

### DIFF
--- a/hack/k8s-versions.sh
+++ b/hack/k8s-versions.sh
@@ -3,6 +3,6 @@
 # Centralized config to define the minimum and maximum tested Kubernetes versions.
 # This is used in the CI workflow for e2e tests, the devcontainer, and to generate docs.
 declare -A K8S_VERSIONS=(
-  [min]=v1.30.9
-  [max]=v1.32.1
+  [min]=v1.31.9
+  [max]=v1.33.1
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

* Add testing for k8s 1.33 and drop support for EOL 1.30

### Modifications

* updated the min and max k8s versions

### Verification

e2e will verify

### Documentation

docs will be updated automatically

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
