### PR TITLE
docs: fix all links and prevent invalid links/anchors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ argoexec-nonroot-image:
 codegen: types swagger manifests $(TOOL_MOCKERY) docs/fields.md docs/cli/argo.md
 	go generate ./...
  	# The generated markdown contains links to nowhere for interfaces, so remove them
-	sed -i 's/\[interface{}\](#interface)/`interface{}`/g' docs/executor_swagger.md
+	sed -i.bak 's/\[interface{}\](#interface)/`interface{}`/g' docs/executor_swagger.md && rm -f docs/executor_swagger.md.bak
 	make --directory sdks/java USE_NIX=$(USE_NIX) generate
 	make --directory sdks/python USE_NIX=$(USE_NIX) generate
 

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,8 @@ argoexec-nonroot-image:
 .PHONY: codegen
 codegen: types swagger manifests $(TOOL_MOCKERY) docs/fields.md docs/cli/argo.md
 	go generate ./...
+ 	# The generated markdown contains links to nowhere for interfaces, so remove them
+	sed -i 's/\[interface{}\](#interface)/`interface{}`/g' docs/executor_swagger.md
 	make --directory sdks/java USE_NIX=$(USE_NIX) generate
 	make --directory sdks/python USE_NIX=$(USE_NIX) generate
 

--- a/docs/container-set-template.md
+++ b/docs/container-set-template.md
@@ -55,7 +55,7 @@ spec:
 There are a few caveats:
 
 1. You cannot use [enhanced depends logic](enhanced-depends-logic.md).
-1. The ContainerSet uses the sum total of all resource requests, which may cost more than using the same DAG template. This can be problematic if your [resource requests](#️-resource-requests) are already high.
+1. The ContainerSet uses the sum total of all resource requests, which may cost more than using the same DAG template. This can be problematic if your [resource requests](#resource-requests) are already high.
 1. ContainerSet templates can only run container templates.
 
 You can arrange the containers as a graph by specifying dependencies.
@@ -73,9 +73,9 @@ This may not always be practical.
 
 Instead, use a workspace volume and ensure all artifact paths are on that volume.
 
-## ⚠️ Resource Requests
+## Resource Requests
 
-A ContainerSet starts all containers, and the [workflow executor](workflow-executors.md#emissary-emissary) only starts the main container process when the containers it depends on have completed.
+A ContainerSet starts all containers, and the [workflow executor](workflow-executors.md#emissary-executor) only starts the main container process when the containers it depends on have completed.
 
 This means that even though the container is doing no useful work, it still consumes resources and you are still billed for them.
 

--- a/docs/debug-pause.md
+++ b/docs/debug-pause.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-The `debug pause` feature makes it possible to pause individual workflow steps for debugging before, after or both and then release the steps from the paused state. Currently this feature is only supported when using the [Emissary Executor](workflow-executors.md#emissary-emissary)
+The `debug pause` feature makes it possible to pause individual workflow steps for debugging before, after or both and then release the steps from the paused state. Currently this feature is only supported when using the [Emissary Executor](workflow-executors.md#emissary-executor)
 
 In order to pause a container env variables are used:
 

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -113,7 +113,7 @@ ownership management and SELinux relabeling.
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="any-string"></span> AnyString
 
@@ -1116,7 +1116,7 @@ can be used as map keys in json.
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="empty-dir-volume-source"></span> EmptyDirVolumeSource
 
@@ -1309,7 +1309,7 @@ The exact format is defined in sigs.k8s.io/structured-merge-diff
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="flex-volume-source"></span> FlexVolumeSource
 
@@ -1861,7 +1861,7 @@ ISCSI volumes support ownership management and SELinux relabeling.
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="key-to-path"></span> KeyToPath
 
@@ -2347,7 +2347,7 @@ save/load the directory appropriately.
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="o-auth2-auth"></span> OAuth2Auth
 
@@ -2523,7 +2523,7 @@ be cluster-scoped, so there is no namespace field.
 
   
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="parameter"></span> Parameter
 
@@ -2683,7 +2683,7 @@ type of volume that is owned by someone else (the system).
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="pod-affinity"></span> PodAffinity
 
@@ -3037,7 +3037,7 @@ cause implementors to also use a fixed point implementation.
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="quobyte-volume-source"></span> QuobyteVolumeSource
 
@@ -3247,7 +3247,7 @@ cause implementors to also use a fixed point implementation.
 
 
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="retry-policy"></span> RetryPolicy
 
@@ -3718,7 +3718,7 @@ of the first container processes are calculated.
 
   
 
-[interface{}](#interface)
+`interface{}`
 
 ### <span id="suspend-template"></span> SuspendTemplate
 
@@ -4349,4 +4349,4 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 
 
-[interface{}](#interface)
+`interface{}`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -277,10 +277,10 @@ Deprecated features are [explained here](deprecations.md).
 
 `feature` will be one of:
 
-- [`cronworkflow schedule`](deprecations.md#cronworkflow_schedule)
-- [`synchronization mutex`](deprecations.md#synchronization_mutex)
-- [`synchronization semaphore`](deprecations.md#synchronization_semaphore)
-- [`workflow podpriority`](deprecations.md#workflow_podpriority)
+- [`cronworkflow schedule`](deprecations.md#cronworkflow-schedule)
+- [`synchronization mutex`](deprecations.md#synchronization-mutex)
+- [`synchronization semaphore`](deprecations.md#synchronization-semaphore)
+- [`workflow podpriority`](deprecations.md#workflow-podpriority)
 
 #### `error_count`
 

--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -3,7 +3,7 @@
 This is a concise list of new features.
 For a more detailed list, see the [3.6 blog post](https://blog.argoproj.io/argo-workflows-3-6-aa037cd782be).
 
-See [the upgrade notes](upgrading.md#upgrading_to_v3.6) for information on breaking changes and deprecations.
+See [the upgrade notes](upgrading.md#upgrading-to-v36) for information on breaking changes and deprecations.
 
 ## UI
 
@@ -26,7 +26,7 @@ See [the upgrade notes](upgrading.md#upgrading_to_v3.6) for information on break
 * [#13265](https://github.com/argoproj/argo-workflows/pull/13265): The workflow controller can now emit metrics over OpenTelemetry GRPC protocol
     * [#13267](https://github.com/argoproj/argo-workflows/pull/13267): with selectable temporality
     * [#13268](https://github.com/argoproj/argo-workflows/pull/13268): configuration of what is emitted
-* Many of the metrics have been updated which will require you [to change how you use them](upgrading.md#metrics_changes) and there are some new ones:
+* Many of the metrics have been updated which will require you [to change how you use them](upgrading.md#metrics-changes) and there are some new ones:
     * [#13269](https://github.com/argoproj/argo-workflows/pull/13269): Version information in the controller
     * [#13270](https://github.com/argoproj/argo-workflows/pull/13270): Is this controller the leader
     * [#13271](https://github.com/argoproj/argo-workflows/pull/13271): Kubernetes API calls duration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,8 +51,9 @@ plugins:
   - search # re-include the default: https://www.mkdocs.org/user-guide/configuration/#plugins,
 validation:
   omitted_files: warn
-  absolute_links: warn
+  absolute_links: relative_to_docs
   unrecognized_links: warn
+  anchors: warn
 exclude_docs: |
   /proposals/
   /requirements.txt

--- a/util/telemetry/builder/values.yaml
+++ b/util/telemetry/builder/values.yaml
@@ -112,10 +112,10 @@ metrics:
     notes: |
       `feature` will be one of:
 
-      - [`cronworkflow schedule`](deprecations.md#cronworkflow_schedule)
-      - [`synchronization mutex`](deprecations.md#synchronization_mutex)
-      - [`synchronization semaphore`](deprecations.md#synchronization_semaphore)
-      - [`workflow podpriority`](deprecations.md#workflow_podpriority)
+      - [`cronworkflow schedule`](deprecations.md#cronworkflow-schedule)
+      - [`synchronization mutex`](deprecations.md#synchronization-mutex)
+      - [`synchronization semaphore`](deprecations.md#synchronization-semaphore)
+      - [`workflow podpriority`](deprecations.md#workflow-podpriority)
     attributes:
       - name: DeprecatedFeature
       - name: WorkflowNamespace


### PR DESCRIPTION
### Motivation

mkdocs has been emitting warnings on invalid links which are broken in our docs.
Fix all of them, and reconfigure it to prevent this in the future.

### Modifications

Added configuration of `anchors: warn` to mkdocs.yaml to make missing anchors cause a warning, and because of mkdocs running with `--strict` convert that to a CI failure.
Fix up all broken anchors. Two of note:
* `#interface` in executor_swagger.md really doesn't have anywhere to go, so remove the links with a nasty bit of `sed`. (We already depend on sed)
* The links to an emoji prefixed "Resource requests" title breaks wither mkdocs or markdown-linkcheck whatever you do, so remove the emoji for a full on 90s web experience and a happy developer.

`absolute_links` was changed to [`relative_to_docs`](https://www.mkdocs.org/user-guide/configuration/#validation-of-absolute-links) as the recommended setting, although we don't use either.

### Verification

`make codegen` and `make docs`

### Documentation

This fixes the documentation, but otherwise is a developer facing improvement which will shout at them at build time with the appropriate words when things are wrong.