### PR TITLE
fix: change non-root image to use tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,13 @@ jobs:
           GIT_TAG=$(git describe --exact-match --tags --abbrev=0  2> /dev/null || echo untagged)
           GIT_TREE_STATE=$(if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
           tag_suffix=$(echo $PLATFORM | sed -r "s/\//-/g")
-          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
+
+          # Special handling for argoexec-nonroot to create argoexec:tag-nonroot-platform instead
+          if [ "$TARGET" = "argoexec-nonroot" ]; then
+            image_name="${DOCKERIO_ORG}/argoexec:${tag}-nonroot-${tag_suffix}"
+          else
+            image_name="${DOCKERIO_ORG}/${TARGET}:${tag}-${tag_suffix}"
+          fi
 
           docker buildx build \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
@@ -181,11 +187,15 @@ jobs:
 
           targets="workflow-controller argoexec argoexec-nonroot argocli"
           for target in $targets; do
-            image_name="${docker_org}/${target}:${tag}"
-
-            if [ $target = "argoexec" ]; then
+            if [ "$target" = "argoexec-nonroot" ]; then
+              # Special handling for argoexec-nonroot: create argoexec:tag-nonroot manifest
+              image_name="${docker_org}/argoexec:${tag}-nonroot"
+              docker manifest create quay.io/$image_name quay.io/${docker_org}/argoexec:${tag}-nonroot-linux-arm64 quay.io/${docker_org}/argoexec:${tag}-nonroot-linux-amd64
+            elif [ "$target" = "argoexec" ]; then
+              image_name="${docker_org}/${target}:${tag}"
               docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64 quay.io/${image_name}-windows
             else
+              image_name="${docker_org}/${target}:${tag}"
               docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64
             fi
 
@@ -229,7 +239,11 @@ jobs:
             tag="latest"
           fi
 
-          image_name="${DOCKERIO_ORG}/${TARGET}:${tag}"
+          if [ "$TARGET" = "argoexec-nonroot" ]; then
+            image_name="${DOCKERIO_ORG}/argoexec:${tag}-nonroot"
+          else
+            image_name="${DOCKERIO_ORG}/${TARGET}:${tag}"
+          fi
           docker pull quay.io/$image_name
 
   test-images-windows:
@@ -309,7 +323,7 @@ jobs:
       - run: bom generate --image quay.io/argoproj/workflow-controller:$VERSION -o dist/workflow-controller.spdx
       - run: bom generate --image quay.io/argoproj/argocli:$VERSION -o dist/argocli.spdx
       - run: bom generate --image quay.io/argoproj/argoexec:$VERSION -o dist/argoexec.spdx
-      - run: bom generate --image quay.io/argoproj/argoexec-nonroot:$VERSION -o dist/argoexec-nonroot.spdx
+      - run: bom generate --image quay.io/argoproj/argoexec:$VERSION-nonroot -o dist/argoexec-nonroot.spdx
       # pack the boms into one file to make it easy to download
       - run: tar -zcf dist/sbom.tar.gz dist/*.spdx
       - run: make release-notes VERSION=$VERSION

--- a/docs/workflow-pod-security-context.md
+++ b/docs/workflow-pod-security-context.md
@@ -43,7 +43,7 @@ This is not the default executor for backwards compatibility, but using it is be
 Use this image when your security policies restrict pulling images that run as root.
 You can run this image as root by specifying `runAsUser: 0`.
 
-The image is available at `quay.io/argoproj/argoexec-nonroot:<version>`.
+The image is available at `quay.io/argoproj/argoexec:<version>-nonroot`.
 
 You can configure this as the default executor image in the [workflow-controller-configmap](workflow-controller-configmap.yaml):
 
@@ -54,5 +54,5 @@ metadata:
   name: workflow-controller-configmap
 data:
   executor: |
-    image: quay.io/argoproj/argoexec-nonroot:<version>
+    image: quay.io/argoproj/argoexec:<version>-nonroot
 ```


### PR DESCRIPTION
Fixes release 3.6.8

### Motivation

No-one seems to have access to docker-hub so 3.6 cannot be released with the nonroot image as we can't create the repo there. I'd like to sort this before 3.7 hits so it's not getting in the way, so keeping trying here.

### Modifications

In discussion with @isubasinghe we agreed we should have used the tag instead of the image name all along, so switching that here. Makes the code slightly messier.

### Verification

Make argoexec-nonroot-image locally. Can't test CI except at a release.

### Documentation

Updated with new image names
