### PR TITLE
fix: workflow-controller to identify outdated workflow status. Fixes #13986

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -57,6 +57,7 @@ This document outlines environment variables that can be used to customize behav
 | `SEMAPHORE_NOTIFY_DELAY`                 | `time.Duration`     | `1s`                                                                                        | Tuning Delay when notifying semaphore waiters about availability in the semaphore                                                                                                                                                                                        |
 | `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS` | `bool` | `true` | Whether to watch the Controller's ConfigMap and semaphore ConfigMaps for run-time changes. When disabled, the Controller will only read these ConfigMaps once and will have to be manually restarted to pick up new changes. |
 | `SKIP_WORKFLOW_DURATION_ESTIMATION` | `bool` | `false` | Whether to lookup resource usage from prior workflows to estimate usage for new workflows. |
+| `PROCESSED_WORKFLOW_VERSIONS_TTL` | `time.Duration` | `10s` | How long the workflow versions cache stores. Should be set as the max workflow informer delay anticipated to avoid processing the same workflow version multiple times. |
 
 CLI parameters of the Controller can be specified as environment variables with the `ARGO_` prefix.
 For example:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/TwiN/go-color v1.4.1
+	github.com/TwiN/gocache/v2 v2.2.2
 	github.com/alibabacloud-go/tea v1.3.9
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible
 	github.com/aliyun/credentials-go v1.4.6
@@ -46,6 +47,7 @@ require (
 	github.com/prometheus/common v0.64.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sethvargo/go-limiter v1.0.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
@@ -92,7 +94,6 @@ require (
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBi
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/TwiN/go-color v1.4.1 h1:mqG0P/KBgHKVqmtL5ye7K0/Gr4l6hTksPgTgMk3mUzc=
 github.com/TwiN/go-color v1.4.1/go.mod h1:WcPf/jtiW95WBIsEeY1Lc/b8aaWoiqQpu5cf8WFxu+s=
+github.com/TwiN/gocache/v2 v2.2.2 h1:4HToPfDV8FSbaYO5kkbhLpEllUYse5rAf+hVU/mSsuI=
+github.com/TwiN/gocache/v2 v2.2.2/go.mod h1:WfIuwd7GR82/7EfQqEtmLFC3a2vqaKbs4Pe6neB7Gyc=
 github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2 h1:ZBbLwSJqkHBuFDA6DUhhse0IGJ7T5bemHyNILUjvOq4=
 github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2/go.mod h1:VSw57q4QFiWDbRnjdX8Cb3Ow0SFncRw+bA/ofY6Q83w=
 github.com/UnnoTed/fileb0x v1.1.4/go.mod h1:X59xXT18tdNk/D6j+KZySratBsuKJauMtVuJ9cgOiZs=

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -300,6 +300,7 @@ func newController(ctx context.Context, options ...interface{}) (context.CancelF
 		progressPatchTickDuration: envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:  envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
 		maxStackDepth:             maxAllowedStackDepth,
+		workflowVersionChecker:    NewWorkflowVersionChecker(NoExpiration),
 	}
 
 	for _, opt := range options {

--- a/workflow/controller/workflow_version_checker.go
+++ b/workflow/controller/workflow_version_checker.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/TwiN/gocache/v2"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// workflowVersionChecker is a cache used to check if a workflow status is outdated.
+// It stores outdated versions of workflows, use the namespace/workflow:version as the key, value is nil.
+// Set the ttl as the max delay of the informer you anticipate.
+type workflowVersionChecker struct {
+	cache *gocache.Cache
+}
+
+const NoExpiration = gocache.NoExpiration
+
+func NewWorkflowVersionChecker(ttl time.Duration) *workflowVersionChecker {
+	log.WithFields(log.Fields{"ttl": ttl}).Info("Starting workflow version checker")
+	cache := gocache.NewCache().WithDefaultTTL(ttl).WithMaxSize(gocache.NoMaxSize).WithMaxMemoryUsage(gocache.NoMaxMemoryUsage).WithEvictionPolicy(gocache.LeastRecentlyUsed)
+	if err := cache.StartJanitor(); err != nil {
+		log.WithError(err).Warn("Failed to start cache janitor, TTL functionality will be disabled")
+	}
+	return &workflowVersionChecker{cache: cache}
+}
+
+func (c *workflowVersionChecker) IsOutdated(wf metav1.Object) bool {
+	_, exist := c.cache.Get(toProcessedVersionKey(wf, wf.GetResourceVersion()))
+	return exist
+}
+
+func (c *workflowVersionChecker) UpdateOutdatedVersion(wf metav1.Object) {
+	c.cache.Set(toProcessedVersionKey(wf, wf.GetResourceVersion()), nil)
+	log.WithFields(log.Fields{"workflow": wf.GetName(), "version": wf.GetResourceVersion()}).Info("Workflow version checker: logged outdated version")
+}
+
+func toProcessedVersionKey(wf metav1.Object, version string) string {
+	key, _ := cache.MetaNamespaceKeyFunc(wf)
+	return fmt.Sprintf("%s:%s", key, version)
+}

--- a/workflow/controller/workflow_version_checker_test.go
+++ b/workflow/controller/workflow_version_checker_test.go
@@ -1,0 +1,120 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testWorkflow struct {
+	metav1.ObjectMeta
+}
+
+func (t *testWorkflow) GetResourceVersion() string {
+	return t.ResourceVersion
+}
+
+func TestWorkflowVersionChecker(t *testing.T) {
+	checker := NewWorkflowVersionChecker(NoExpiration)
+
+	// Test outdated version tracking
+	wf1 := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-workflow",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+
+	// Mark version 1 as outdated
+	checker.UpdateOutdatedVersion(wf1)
+
+	// Verify version 1 is marked as outdated
+	assert.True(t, checker.IsOutdated(wf1), "Version 1 should be marked as outdated")
+
+	// Test different workflow
+	wf2 := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-workflow",
+			Namespace:       "default",
+			ResourceVersion: "2",
+		},
+	}
+	assert.False(t, checker.IsOutdated(wf2), "Version 2 should not be marked as outdated")
+}
+
+func TestWorkflowVersionCheckerWithDifferentNamespaces(t *testing.T) {
+	checker := NewWorkflowVersionChecker(10 * time.Minute)
+
+	// Create workflows in different namespaces
+	wf1 := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-workflow",
+			Namespace:       "namespace1",
+			ResourceVersion: "1",
+		},
+	}
+	wf2 := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-workflow",
+			Namespace:       "namespace2",
+			ResourceVersion: "1",
+		},
+	}
+
+	// Mark version 1 in namespace1 as outdated
+	checker.UpdateOutdatedVersion(wf1)
+
+	// Check that they don't interfere with each other
+	assert.True(t, checker.IsOutdated(wf1), "Workflow in namespace1 should be marked as outdated")
+	assert.False(t, checker.IsOutdated(wf2), "Workflow in namespace2 should not be marked as outdated")
+}
+
+func TestWorkflowVersionCheckerWithDifferentNames(t *testing.T) {
+	checker := NewWorkflowVersionChecker(10 * time.Minute)
+
+	// Create workflows with different names
+	wf1 := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "workflow1",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+	wf2 := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "workflow2",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+
+	// Mark workflow1 version 1 as outdated
+	checker.UpdateOutdatedVersion(wf1)
+
+	// Check that they don't interfere with each other
+	assert.True(t, checker.IsOutdated(wf1), "workflow1 should be marked as outdated")
+	assert.False(t, checker.IsOutdated(wf2), "workflow2 should not be marked as outdated")
+}
+
+func TestWorkflowVersionCheckerTTL(t *testing.T) {
+	checker := NewWorkflowVersionChecker(time.Millisecond)
+
+	// Create and mark a workflow version as outdated
+	wf := &testWorkflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-workflow",
+			Namespace:       "default",
+			ResourceVersion: "1",
+		},
+	}
+	checker.UpdateOutdatedVersion(wf)
+
+	// Wait for TTL to expire
+	time.Sleep(time.Millisecond * 2)
+
+	// Verify it's no longer marked as outdated
+	assert.False(t, checker.IsOutdated(wf), "Version should no longer be marked as outdated after TTL")
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13986

### Motivation

We continuous encountered pod duplicate issue because workflow-controller can create duplicate pods due to informer delays.

### Modifications

Add a cache to store the latest workflow versions that are recently used but outdated. When the informer is delayed, the controller can use the cache to determine whether the workflow status from the informer is outdated, and skip the action for now if it is.
See the comment for more background:
https://github.com/argoproj/argo-workflows/issues/13986#issuecomment-2915950739

### Verification

For the current version, I only do happy path test with a hello-world workflow:
```
$ make clean
$ make start
$ kubectl create -f examples/hello-world.yaml
$ kubectl get workflow
NAME                STATUS      AGE     MESSAGE
hello-world-q7gz6   Succeeded   3m43s
```
However, I did a full test based on v3.6.2, which is the version we used in our production environment. 
I created a workflow-template massive-40 with 40 sequential steps [massive-40.txt](https://github.com/user-attachments/files/20584782/massive-40.txt). Each step has num of parallel nodes defined by the workflow.
Each node inserts a record to postgres DB. The last step then counts the number of records to see whether it matches the expectation. For example, the following workflow:
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  ...
spec:
  arguments:
    parameters:
    - name: nodes
      value: "10"
    - name: sleep
      value: 3s
    - name: batch-id
      value: stress-test-hwmfc
    - name: workflow-id
      value: stress-test-hwmfc-0
  workflowTemplateRef:
    name: massive-40
```
The last step expects to see 40 (sequential steps) * 10 (nodes per step) = 400 records. Otherwise the workflow would be failed.
I submit 50 such workflows in my cluster with PROCESSED_WORKFLOW_VERSIONS_TTL = 10m. Before the change (v3.6.2), all workflows were failed. After the change, all workflows were succeeded.

Here're the metrics comparison: (the left one is “before fix”, the right one is “after fix”)
- No failed workflow after fix
![Screenshot 2025-06-09 at 1 41 08 PM](https://github.com/user-attachments/assets/0158c341-8231-46e6-8dc3-64f617832cd5)
- No 409 error from workflow-controller
![Screenshot 2025-06-09 at 4 10 24 PM](https://github.com/user-attachments/assets/b7a48209-e655-4ae5-bae8-82b57a678af9)

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
Added description for PROCESSED_WORKFLOW_VERSIONS_TTL.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->


