### PR TITLE
chore: fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,12 +297,12 @@ argoexec-nonroot-image:
 		-t $$image_name \
 		--target $* \
 		--load \
-		 .
-	[ ! -e $* ] || mv $* dist/
-	docker run --rm -t $$image_name version
+		.; \
+	[ ! -e $* ] || mv $* dist/; \
+	docker run --rm -t $$image_name version; \
 	if [ $(K3D) = true ]; then \
 		k3d image import -c $(K3D_CLUSTER_NAME) $$image_name; \
-	fi
+	fi; \
 	if [ $(DOCKER_PUSH) = true ] && [ $(IMAGE_NAMESPACE) != argoproj ] ; then \
 		docker push $$image_name; \
 	fi


### PR DESCRIPTION
This is already pushed to `release/3.6` (cherry picked from commit 459c19db6e9dd86dd757c21644404cb784863fae)

#14530 introduced the `image_name` variable to this Makefile rule, without ensuring that it all happened in one shell invocation. This means `$image_name` is not actually defined past it's first use making the rule not work.

This PR fixes that.
