### PR TITLE
fix: make conflict errors be treated as transient errors.

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -16,13 +16,6 @@ import (
 	argoerrs "github.com/argoproj/argo-workflows/v3/errors"
 )
 
-func IgnoreContainerNotFoundErr(err error) error {
-	if err != nil && strings.Contains(err.Error(), "container not found") {
-		return nil
-	}
-	return err
-}
-
 // IsTransientErr reports whether the error is transient and logs it.
 func IsTransientErr(err error) bool {
 	isTransient := IsTransientErrQuiet(err)
@@ -49,7 +42,7 @@ func isTransientErr(err error) bool {
 	err = argoerrs.Cause(err)
 	return isExceededQuotaErr(err) ||
 		apierr.IsTooManyRequests(err) ||
-		isResourceQuotaConflictErr(err) ||
+		apierr.IsConflict(err) ||
 		isResourceQuotaTimeoutErr(err) ||
 		isTransientNetworkErr(err) ||
 		apierr.IsServerTimeout(err) ||
@@ -73,10 +66,6 @@ func matchTransientErrPattern(err error) bool {
 
 func isExceededQuotaErr(err error) bool {
 	return apierr.IsForbidden(err) && strings.Contains(err.Error(), "exceeded quota")
-}
-
-func isResourceQuotaConflictErr(err error) bool {
-	return apierr.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on resourcequota")
 }
 
 func isResourceQuotaTimeoutErr(err error) bool {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

Conflict errors are being ignored in `errorsutil.IsTransientErr`.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
`isResourceQuotaConflictErr(err)` should be replaced with `apierr.IsConflict(err)`.
ps. leftover codes are also removed.

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
