### PR TITLE
fix: correct finding the closest ancestor retry node. Fixes #14517

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -1779,6 +1779,10 @@ func (in Nodes) FindByName(name string) *NodeStatus {
 	return in.Find(NodeWithName(name))
 }
 
+func (n Nodes) FindByChild(childId string) *NodeStatus {
+	return n.Find(NodeWithChild(childId))
+}
+
 func (in Nodes) Any(f func(NodeStatus) bool) bool {
 	return in.Find(f) != nil
 }
@@ -1856,6 +1860,12 @@ func NodeWithName(name string) func(n NodeStatus) bool {
 
 func NodeWithDisplayName(name string) func(n NodeStatus) bool {
 	return func(n NodeStatus) bool { return n.DisplayName == name }
+}
+
+func NodeWithChild(childID string) func(n NodeStatus) bool {
+	return func(n NodeStatus) bool {
+		return n.HasChild(childID)
+	}
 }
 
 func FailedPodNode(n NodeStatus) bool {

--- a/workflow/controller/retry_tweak_test.go
+++ b/workflow/controller/retry_tweak_test.go
@@ -15,23 +15,23 @@ func TestFindRetryNode(t *testing.T) {
 			Type:         wfv1.NodeTypeSteps,
 			Phase:        wfv1.NodeRunning,
 			BoundaryID:   "",
-			Children:     []string{"B1", "B2"},
+			Children:     []string{"B1", "B2", "B3"},
 			TemplateName: "tmpl1",
 		},
 		"B1": wfv1.NodeStatus{
 			ID:           "B1",
 			Type:         wfv1.NodeTypeSkipped,
 			Phase:        wfv1.NodeSkipped,
-			BoundaryID:   "",
+			BoundaryID:   "A1",
 			Children:     []string{},
 			TemplateName: "tmpl2",
 		},
-		// retry node
+		// retry node containing steps
 		"B2": wfv1.NodeStatus{
 			ID:           "B2",
 			Type:         wfv1.NodeTypeRetry,
 			Phase:        wfv1.NodeRunning,
-			BoundaryID:   "",
+			BoundaryID:   "A1",
 			Children:     []string{"C1"},
 			TemplateName: "tmpl1",
 		},
@@ -39,7 +39,7 @@ func TestFindRetryNode(t *testing.T) {
 			ID:           "C1",
 			Type:         wfv1.NodeTypeSteps,
 			Phase:        wfv1.NodeRunning,
-			BoundaryID:   "",
+			BoundaryID:   "A1",
 			Children:     []string{"D1", "D2"},
 			TemplateName: "tmpl2",
 		},
@@ -47,7 +47,7 @@ func TestFindRetryNode(t *testing.T) {
 			ID:           "D1",
 			Type:         wfv1.NodeTypeSkipped,
 			Phase:        wfv1.NodeSkipped,
-			BoundaryID:   "A1",
+			BoundaryID:   "C1",
 			Children:     []string{},
 			TemplateName: "tmpl2",
 		},
@@ -55,26 +55,27 @@ func TestFindRetryNode(t *testing.T) {
 			ID:           "D2",
 			Type:         wfv1.NodeTypePod,
 			Phase:        wfv1.NodeRunning,
-			BoundaryID:   "A1",
+			BoundaryID:   "C1",
 			Children:     []string{},
 			TemplateName: "tmpl2",
 		},
-		"E1": wfv1.NodeStatus{
-			ID:         "E1",
+		// retry node containing single step and templteRef
+		"B3": wfv1.NodeStatus{
+			ID:         "B3",
 			Type:       wfv1.NodeTypeRetry,
 			Phase:      wfv1.NodeRunning,
 			BoundaryID: "A1",
-			Children:   []string{},
+			Children:   []string{"C2"},
 			TemplateRef: &wfv1.TemplateRef{
 				Name:     "tmpl1",
 				Template: "tmpl3",
 			},
 		},
-		"E2": wfv1.NodeStatus{
-			ID:           "E2",
+		"C2": wfv1.NodeStatus{
+			ID:           "C2",
 			Type:         wfv1.NodeTypePod,
 			Phase:        wfv1.NodeRunning,
-			BoundaryID:   "E1",
+			BoundaryID:   "A1",
 			Children:     []string{},
 			TemplateName: "tmpl2",
 		},
@@ -88,7 +89,7 @@ func TestFindRetryNode(t *testing.T) {
 		assert.Nil(t, a)
 	})
 	t.Run("Expect to find retry node has TemplateRef", func(t *testing.T) {
-		node := allNodes["E1"]
-		assert.Equal(t, FindRetryNode(allNodes, "E2"), &node)
+		node := allNodes["B3"]
+		assert.Equal(t, FindRetryNode(allNodes, "C2"), &node)
 	})
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1169,9 +1169,7 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 		if node.FailedOrError() && isExecutionNodeType(node.Type) {
 			// Check its parent if current node is retry node
 			if node.NodeFlag != nil && node.NodeFlag.Retried {
-				node = *wf.Status.Nodes.Find(func(nodeStatus wfv1.NodeStatus) bool {
-					return nodeStatus.HasChild(node.ID)
-				})
+				node = *wf.Status.Nodes.FindByChild(nodeID)
 			}
 			if !isDescendantNodeSucceeded(wf, node, deleteNodesMap) {
 				failed[nodeID] = true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14517

### Motivation

<!-- TODO: Say why you made your changes. -->
RetryNodeAntiAffinity does not work in most cases.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
1. Correct finding the closest ancestor retry node, including UT.
2. Only enable `RetryNodeAntiAffinity` when `NodeAntiAffinity` is set.

### Verification

<!-- TODO: Say how you tested your changes. -->
```YAML
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  name: retry-with-affinity
spec:
  entrypoint: main
  templates:
    - name: main
      steps:
        - - name: fail-with-affinity
            template: fail-with-affinity
          - name: fail-steps-with-affinity
            template: fail-steps-with-affinity
          - name: fail-dag-with-affinity
            template: fail-dag-with-affinity
    - name: fail-steps-with-affinity
      retryStrategy:
        limit: "1"
        affinity:
          nodeAntiAffinity: { }
      steps:
        - - name: fail
            template: fail
    - name: fail-dag-with-affinity
      retryStrategy:
        limit: "1"
        affinity:
          nodeAntiAffinity: { }
      dag:
        tasks:
          - name: fail
            template: fail
    - name: fail
      container:
        image: alpine:latest
        command: [ sh, -c ]
        args: [ "exit 1" ]
    - name: fail-with-affinity
      retryStrategy:
        limit: "1"
        affinity:
          nodeAntiAffinity: { }
      container:
        image: alpine:latest
        command: [ sh, -c ]
        args: [ "exit 1" ]
```

```shell
# argo get retry-with-affinity
Name:                retry-with-affinity
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Running
Conditions:          
 PodRunning          False
 Completed           False
Created:             Wed Jun 18 10:56:53 +0800 (41 minutes ago)
Started:             Wed Jun 18 11:38:19 +0800 (30 seconds ago)
Duration:            30 seconds
Progress:            0/6
ResourcesDuration:   0s*(1 cpu),9s*(100Mi memory)

STEP                                  TEMPLATE                  PODNAME                         DURATION  MESSAGE
 ● retry-with-affinity                main                                                                                                                                                                                                                                                
 └─┬─✖ fail-dag-with-affinity         fail-dag-with-affinity                                              No more retries left                                                                                                                                                            
   │ ├─● fail-dag-with-affinity(0)    fail-dag-with-affinity                                                                                                                                                                                                                              
   │ ├─✖ fail-dag-with-affinity(1)    fail-dag-with-affinity                                                                                                                                                                                                                              
   │ │ └─✖ fail                       fail                      retry-with-affinity-861157032   6s        main: Error (exit code 1)                                                                                                                                                       
   │ └─● fail-dag-with-affinity(2)    fail-dag-with-affinity                                                                                                                                                                                                                              
   │   └─◷ fail                       fail                      retry-with-affinity-2013563541  4s        Unschedulable: 0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..  
   ├─✖ fail-steps-with-affinity       fail-steps-with-affinity                                            No more retries left                                                                                                                                                            
   │ ├─● fail-steps-with-affinity(0)  fail-steps-with-affinity                                                                                                                                                                                                                            
   │ ├─✖ fail-steps-with-affinity(1)  fail-steps-with-affinity                                            child 'retry-with-affinity-3759446571' failed                                                                                                                                   
   │ │ └───✖ fail                     fail                      retry-with-affinity-3759446571  6s        main: Error (exit code 1)                                                                                                                                                       
   │ └─● fail-steps-with-affinity(2)  fail-steps-with-affinity                                                                                                                                                                                                                            
   │   └───◷ fail                     fail                      retry-with-affinity-3349964740  4s        Unschedulable: 0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..  
   └─● fail-with-affinity             fail-with-affinity                                                                                                                                                                                                                                  
     ├─✖ fail-with-affinity(0)        fail-with-affinity        retry-with-affinity-3769946992  6s        main: Error (exit code 1)                                                                                                                                                       
     └─◷ fail-with-affinity(1)        fail-with-affinity        retry-with-affinity-3434247517  4s        Unschedulable: 0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
