### PR TITLE
fix: set creator when use X509 client certificates. Fixes: #14578

### DIFF
--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -25,7 +25,7 @@ func ClaimSetFor(restConfig *rest.Config) (*types.Claims, error) {
 		return ClaimSetWithBearerToken(restConfig)
 	}
 
-        if restConfig.CertFile != "" || len(restConfig.CertData) > 0 {
+	if restConfig.CertFile != "" || len(restConfig.CertData) > 0 {
 		return ClaimSetWithX509(restConfig)
 	}
 	return nil, nil

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -81,7 +80,7 @@ func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 		cert, _ = x509.ParseCertificate(block.Bytes)
 	} else if restConfig.TLSClientConfig.CertFile != "" {
 		// Load certificate from file
-		data, err := ioutil.ReadFile(restConfig.TLSClientConfig.CertFile)
+		data, err := os.ReadFile(restConfig.TLSClientConfig.CertFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read certificate file: %w", err)
 		}

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -84,7 +84,7 @@ func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate: %w", err)
 		}
-	} else if restConfig.CertFile != "" {
+	} else {
 		// Load certificate from file
 		data, err := os.ReadFile(restConfig.CertFile)
 		if err != nil {
@@ -98,8 +98,6 @@ func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate: %w", err)
 		}
-	} else {
-		return nil, nil // No certificate info available
 	}
 
 	if cert == nil {

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -71,16 +71,16 @@ func ClaimSetWithBearerToken(restConfig *rest.Config) (*types.Claims, error) {
 func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 	var cert *x509.Certificate
 
-	if len(restConfig.TLSClientConfig.CertData) > 0 {
+	if len(restConfig.CertData) > 0 {
 		// Decode certificate from memory data
-		block, _ := pem.Decode(restConfig.TLSClientConfig.CertData)
+		block, _ := pem.Decode(restConfig.CertData)
 		if block == nil || block.Type != "CERTIFICATE" {
 			return nil, fmt.Errorf("failed to parse certificate PEM")
 		}
 		cert, _ = x509.ParseCertificate(block.Bytes)
-	} else if restConfig.TLSClientConfig.CertFile != "" {
+	} else if restConfig.CertFile != "" {
 		// Load certificate from file
-		data, err := os.ReadFile(restConfig.TLSClientConfig.CertFile)
+		data, err := os.ReadFile(restConfig.CertFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read certificate file: %w", err)
 		}

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -70,17 +70,20 @@ func ClaimSetWithBearerToken(restConfig *rest.Config) (*types.Claims, error) {
 
 func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 	var cert *x509.Certificate
-
-	if len(restConfig.CertData) > 0 {
+	var err error
+	if len(restConfig.TLSClientConfig.CertData) > 0 {
 		// Decode certificate from memory data
-		block, _ := pem.Decode(restConfig.CertData)
+		block, _ := pem.Decode(restConfig.TLSClientConfig.CertData)
 		if block == nil || block.Type != "CERTIFICATE" {
 			return nil, fmt.Errorf("failed to parse certificate PEM")
 		}
-		cert, _ = x509.ParseCertificate(block.Bytes)
-	} else if restConfig.CertFile != "" {
+		cert, err = x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
+	} else if restConfig.TLSClientConfig.CertFile != "" {
 		// Load certificate from file
-		data, err := os.ReadFile(restConfig.CertFile)
+		data, err := os.ReadFile(restConfig.TLSClientConfig.CertFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read certificate file: %w", err)
 		}
@@ -88,7 +91,10 @@ func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 		if block == nil || block.Type != "CERTIFICATE" {
 			return nil, fmt.Errorf("failed to parse certificate PEM")
 		}
-		cert, _ = x509.ParseCertificate(block.Bytes)
+		cert, err = x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse certificate: %w", err)
+		}
 	} else {
 		return nil, nil // No certificate info available
 	}

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -71,9 +71,9 @@ func ClaimSetWithBearerToken(restConfig *rest.Config) (*types.Claims, error) {
 func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 	var cert *x509.Certificate
 	var err error
-	if len(restConfig.TLSClientConfig.CertData) > 0 {
+	if len(restConfig.CertData) > 0 {
 		// Decode certificate from memory data
-		block, _ := pem.Decode(restConfig.TLSClientConfig.CertData)
+		block, _ := pem.Decode(restConfig.CertData)
 		if block == nil || block.Type != "CERTIFICATE" {
 			return nil, fmt.Errorf("failed to parse certificate PEM")
 		}
@@ -81,9 +81,9 @@ func ClaimSetWithX509(restConfig *rest.Config) (*types.Claims, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate: %w", err)
 		}
-	} else if restConfig.TLSClientConfig.CertFile != "" {
+	} else if restConfig.CertFile != "" {
 		// Load certificate from file
-		data, err := os.ReadFile(restConfig.TLSClientConfig.CertFile)
+		data, err := os.ReadFile(restConfig.CertFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read certificate file: %w", err)
 		}

--- a/server/auth/serviceaccount/claims.go
+++ b/server/auth/serviceaccount/claims.go
@@ -25,7 +25,10 @@ func ClaimSetFor(restConfig *rest.Config) (*types.Claims, error) {
 		return ClaimSetWithBearerToken(restConfig)
 	}
 
-	return ClaimSetWithX509(restConfig)
+        if restConfig.CertFile != "" || len(restConfig.CertData) > 0 {
+		return ClaimSetWithX509(restConfig)
+	}
+	return nil, nil
 }
 
 func ClaimSetWithBearerToken(restConfig *rest.Config) (*types.Claims, error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Set creator when use X509 client certificates.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14578 

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Loccal Test:
When use an alibaba cloud  ACK cluster kubeconfig.
![image](https://github.com/user-attachments/assets/e0761a94-cc9d-428d-8020-4a8130899bab)
You can see that after the update, there is creator. So do a local k3d cluster.

