### PR TITLE
docs: Added doc for GC directory

### DIFF
--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -155,11 +155,11 @@ spec:
 
 Consider parameterizing your S3 keys by {{workflow.uid}}, etc (as shown in the example above) if there's a possibility that you could have concurrent Workflows of the same spec. This would be to avoid a scenario in which the artifact from one Workflow is being deleted while the same S3 key is being generated for a different Workflow.
 
-In the case of having a whole directory as S3 key, please pay attention of the key value:
-- (A) and changing the default archive option to none (see example below), it is important that it ends with a "/". Otherwise, the directory will be created in S3 but the GC pod won't be able to remove it.
-- (B) and keeping the default archive option to tgz (see example below), the it is import that it does NOT end with "/". Otherwise Argo will fail to create the archive file.
+In the case of having a whole directory as S3 key, please pay attention to the key value. Here are two examples:
+- (A) When changing the default archive option to none, it is important that it ends with a "/". Otherwise, the directory will be created in S3 but the GC pod won't be able to remove it.
+- (B) When keeping the default archive option to `.tgz`, in this case, it is important that it does NOT end with "/". Otherwise, Argo will fail to create the archive file.
 
-Example (A) without packaging as tgz
+Example (A) without packaging as `.tgz`
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -193,7 +193,7 @@ spec:
               key: "{{workflow.name}}/directory/" # IMPORTANT! ends with "/"
 ```
 
-Example (B) with packaging as tgz
+Example (B) with packaging as `.tgz`
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1

--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -156,6 +156,7 @@ spec:
 Consider parameterizing your S3 keys by {{workflow.uid}}, etc (as shown in the example above) if there's a possibility that you could have concurrent Workflows of the same spec. This would be to avoid a scenario in which the artifact from one Workflow is being deleted while the same S3 key is being generated for a different Workflow.
 
 In the case of having a whole directory as S3 key, please pay attention to the key value. Here are two examples:
+
 - (A) When changing the default archive option to none, it is important that it ends with a "/". Otherwise, the directory will be created in S3 but the GC pod won't be able to remove it.
 - (B) When keeping the default archive option to `.tgz`, in this case, it is important that it does NOT end with "/". Otherwise, Argo will fail to create the archive file.
 
@@ -224,9 +225,8 @@ spec:
               tar:
                 compressionLevel: 1
             s3:
-              key: "{{workflow.name}}/archive.tgz" # IMPORTANT! must not ends with "/"
+              key: "{{workflow.name}}/archive.tgz" # IMPORTANT! must not end with "/"
 ```
-
 
 ### Service Accounts and Annotations
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes [14565](https://github.com/argoproj/argo-workflows/issues/14565)

### Motivation

This PR makes clearer the way of using the artifact GC when the S3 key is a whole directory. Comes from a problem stated at [14565](https://github.com/argoproj/argo-workflows/issues/14565)

### Modifications

Added documentation so this case is clear.

### Verification
Verified in the specified issue [14565](https://github.com/argoproj/argo-workflows/issues/14565)

### Documentation

Added
