### PR TITLE
fix: try to stop .spelling from getting deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ sdks/python/client/dist/*
 /v3/
 /cmd/argoexec/commands/test.txt
 /db-dumps/
+.spelling.tmp
 
 # Do not commit rendered installation manifests since they are misleading to users.
 manifests/install.yaml

--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,7 @@ docs-spellcheck: $(TOOL_MDSPELL) docs/metrics.md
 	# check docs for spelling mistakes
 	$(TOOL_MDSPELL) --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name workflow-controller-configmap.md -not -name upgrading.md -not -name executor_swagger.md -not -path '*/cli/*' -not -name tested-kubernetes-versions.md)
 	# alphabetize spelling file -- ignore first line (comment), then sort the rest case-sensitive and remove duplicates
-	$(shell cat .spelling | awk 'NR<2{ print $0; next } { print $0 | "LC_COLLATE=C sort" }' | uniq | tee .spelling > /dev/null)
+	$(shell cat .spelling | awk 'NR<2{ print $0; next } { print $0 | "LC_COLLATE=C sort" }' | uniq > .spelling.tmp && mv .spelling.tmp .spelling)
 
 $(TOOL_MARKDOWN_LINK_CHECK): Makefile
 # update this in Nix when upgrading it here


### PR DESCRIPTION
Sometimes `.spelling` seems to end up empty. This tries to prevent that from happening.
