### PR TITLE
fix: avoid healthz check restart controller. Fixes: #14526

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -150,7 +150,8 @@ type WorkflowController struct {
 	executorPlugins          map[string]map[string]*spec.Plugin // namespace -> name -> plugin
 
 	recentCompletions recentCompletions
-	lastUnreconciled  map[string]*wfv1.Workflow
+	// lastUnreconciledWorkflows is a map of workflows that have been recently unreconciled
+	lastUnreconciledWorkflows map[string]*wfv1.Workflow
 }
 
 const (

--- a/workflow/controller/healthz.go
+++ b/workflow/controller/healthz.go
@@ -76,7 +76,7 @@ func (wfc *WorkflowController) Healthz(w http.ResponseWriter, r *http.Request) {
 			log.Info("healthz: workflows exceed max age")
 			// Check if there is progress by comparing with the last check:
 			// If all workflows from last time are still present, it means no progress
-			for key := range wfc.lastUnreconciled {
+			for key := range wfc.lastUnreconciledWorkflows {
 				if _, exists := unreconciledWorkflows[key]; !exists {
 					// At least one workflow has been reconciled, so there is progress
 					noProgress = false
@@ -84,13 +84,13 @@ func (wfc *WorkflowController) Healthz(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			if noProgress && len(wfc.lastUnreconciled) > 0 {
+			if noProgress && len(wfc.lastUnreconciledWorkflows) > 0 {
 				return fmt.Errorf("workflow exceeds max age and no progress: %s/%s", firstExceededWorkflow.Namespace, firstExceededWorkflow.Name)
 			}
 		}
 
 		// Update the cache for the next health check
-		wfc.lastUnreconciled = unreconciledWorkflows
+		wfc.lastUnreconciledWorkflows = unreconciledWorkflows
 
 		return nil
 	}()

--- a/workflow/controller/healthz_test.go
+++ b/workflow/controller/healthz_test.go
@@ -18,6 +18,10 @@ func TestHealthz(t *testing.T) {
 	veryOldUnreconciledWF.SetCreationTimestamp(metav1.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)) // a long time ago
 	veryOldUnreconciledWF.SetName(veryOldUnreconciledWF.Name + "-1")
 
+	veryOldUnreconciledWF2 := wfv1.MustUnmarshalWorkflow(helloWorldWf)
+	veryOldUnreconciledWF2.SetCreationTimestamp(metav1.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC)) // a long time ago
+	veryOldUnreconciledWF2.SetName(veryOldUnreconciledWF.Name + "-1")
+
 	newUnreconciledWF := wfv1.MustUnmarshalWorkflow(helloWorldWf)
 	newUnreconciledWF.SetCreationTimestamp(metav1.Now())
 	newUnreconciledWF.SetName(newUnreconciledWF.Name + "-2")
@@ -28,24 +32,46 @@ func TestHealthz(t *testing.T) {
 	veryOldReconciledWF.Labels = map[string]string{common.LabelKeyPhase: string(wfv1.WorkflowPending)}
 
 	tests := []struct {
-		workflows      []*wfv1.Workflow
-		expectedStatus int
+		workflows                []*wfv1.Workflow
+		expectedStatus           int
+		lastUnreconciledWorkflws map[string]*wfv1.Workflow
 	}{
 		{
 			[]*wfv1.Workflow{veryOldUnreconciledWF},
+			200,
+			nil,
+		},
+		{
+			[]*wfv1.Workflow{veryOldUnreconciledWF},
 			500,
+			map[string]*wfv1.Workflow{
+				veryOldUnreconciledWF.Namespace + "/" + veryOldUnreconciledWF.Name: veryOldUnreconciledWF,
+			},
+		},
+		{
+			[]*wfv1.Workflow{newUnreconciledWF, veryOldUnreconciledWF2},
+			200,
+			map[string]*wfv1.Workflow{
+				veryOldUnreconciledWF.Namespace + "/" + veryOldUnreconciledWF.Name:   veryOldUnreconciledWF,
+				veryOldUnreconciledWF2.Namespace + "/" + veryOldUnreconciledWF2.Name: veryOldUnreconciledWF2,
+			},
 		},
 		{
 			[]*wfv1.Workflow{newUnreconciledWF},
 			200,
+			nil,
 		},
 		{
 			[]*wfv1.Workflow{veryOldUnreconciledWF, newUnreconciledWF},
 			500,
+			map[string]*wfv1.Workflow{
+				veryOldUnreconciledWF.Namespace + "/" + veryOldUnreconciledWF.Name: veryOldUnreconciledWF,
+			},
 		},
 		{
 			[]*wfv1.Workflow{veryOldReconciledWF},
 			200,
+			nil,
 		},
 	}
 
@@ -56,7 +82,7 @@ func TestHealthz(t *testing.T) {
 		}
 		cancel, controller := newController(workflowsAsInterfaceSlice...)
 		defer cancel()
-
+		controller.lastUnreconciledWorkflows = tt.lastUnreconciledWorkflws
 		rr := httptest.NewRecorder()
 
 		handler := http.HandlerFunc(controller.Healthz)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->
avoid healthz check restart controller in large-scale scenarios.
<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14526 

### Motivation
When submitting large-scale workflows at one time (8000+), avoid frequent restarts of the workflow-controller due to healthz problems

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Add a cache of workflows that were not reconceiled last time.
If there are workflows that have not been reconceiled for more than 5 minutes, check whether the workflows in the cache have decreased.
If there are decreases, it means that the workflow-controller is still processing, but it is slow, and there is no need to restart.

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
