### PR TITLE
fix: fetch sa in delegate namespace when no sa matched. Fixes:#14610

### DIFF
--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/argoproj/argo-workflows/v3/util/secrets"
 
@@ -291,7 +292,7 @@ func (s *gatekeeper) getClientsForServiceAccount(ctx context.Context, claims *ty
 func (s *gatekeeper) rbacAuthorization(ctx context.Context, claims *types.Claims, req interface{}) (*servertypes.Clients, error) {
 	ssoDelegationAllowed, ssoDelegated := false, false
 	loginAccount, err := s.getServiceAccount(claims, s.ssoNamespace)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "no service account rule matches") {
 		return nil, err
 	}
 	delegatedAccount := loginAccount
@@ -304,6 +305,9 @@ func (s *gatekeeper) rbacAuthorization(ctx context.Context, claims *types.Claims
 			delegatedAccount = namespaceAccount
 			ssoDelegated = true
 		}
+	}
+	if delegatedAccount == nil {
+		return nil, fmt.Errorf("no service account rule matches")
 	}
 	// important! write an audit entry (i.e. log entry) so we know which user performed an operation
 	log.WithFields(log.Fields{"serviceAccount": delegatedAccount.Name, "loginServiceAccount": loginAccount.Name, "subject": claims.Subject, "email": claims.Email, "ssoDelegationAllowed": ssoDelegationAllowed, "ssoDelegated": ssoDelegated}).Info("selected SSO RBAC service account for user")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Fetch sa in delegate namespace when no sa matched.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14610

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

When sa is not found in the sso namespace, 
search in the delegate namespace. 
If it is still not found, an error is returned.

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
