### PR TITLE
chore(test): run tests with gotestsum and retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ endif
 E2E_WAIT_TIMEOUT      ?= 90s # timeout for wait conditions
 E2E_PARALLEL          ?= 20
 E2E_SUITE_TIMEOUT     ?= 15m
-GOTEST                ?= go test -v -p 20
+GOTESTSUM             ?= $(TOOL_GOTESTSUM) --rerun-fails=3 --format=testname --
+GOTEST                ?= $(GOTESTSUM) -- -v -p 20
 ALL_BUILD_TAGS        ?= api,cli,cron,executor,examples,corefunctional,functional,plugins
 BENCHMARK_COUNT       ?= 6
 
@@ -123,6 +124,7 @@ TOOL_OPENAPI_GEN            := $(GOPATH)/bin/openapi-gen
 TOOL_SWAGGER                := $(GOPATH)/bin/swagger
 TOOL_GOIMPORTS              := $(GOPATH)/bin/goimports
 TOOL_GOLANGCI_LINT          := $(GOPATH)/bin/golangci-lint
+TOOL_GOTESTSUM              := $(GOPATH)/bin/gotestsum
 
 # npm bin -g will do this on later npms than we have
 NVM_BIN                     ?= $(shell npm config get prefix)/bin
@@ -400,6 +402,11 @@ $(TOOL_GOIMPORTS): Makefile
 ifneq ($(USE_NIX), true)
 	go install golang.org/x/tools/cmd/goimports@v0.1.7
 endif
+$(TOOL_GOTESTSUM): Makefile
+# update this in Nix when upgrading it here
+ifneq ($(USE_NIX), true)
+	go install gotest.tools/gotestsum@v1.12.3
+endif
 
 $(TOOL_CLANG_FORMAT):
 ifeq (, $(shell which clang-format))
@@ -523,7 +530,7 @@ lint: ui/dist/app/index.html $(TOOL_GOLANGCI_LINT)
 
 # for local we have a faster target that prints to stdout, does not use json, and can cache because it has no coverage
 .PHONY: test
-test: ui/dist/app/index.html util/telemetry/metrics_list.go util/telemetry/attributes.go
+test: ui/dist/app/index.html util/telemetry/metrics_list.go util/telemetry/attributes.go $(TOOL_GOTESTSUM)
 	go build ./...
 	env KUBECONFIG=/dev/null $(GOTEST) ./...
 	# marker file, based on it's modification time, we know how long ago this target was run
@@ -647,18 +654,18 @@ mysql-dump:
 
 test-cli: ./dist/argo
 
-test-%:
-	E2E_WAIT_TIMEOUT=$(E2E_WAIT_TIMEOUT) go test -failfast -v -timeout $(E2E_SUITE_TIMEOUT) -count 1 --tags $* -parallel $(E2E_PARALLEL) ./test/e2e
+test-%: $(TOOL_GOTESTSUM)
+	E2E_WAIT_TIMEOUT=$(E2E_WAIT_TIMEOUT) $(GOTESTSUM) -failfast -v -timeout $(E2E_SUITE_TIMEOUT) -count 1 --tags $* -parallel $(E2E_PARALLEL) ./test/e2e
 
 .PHONY: test-%-sdk
 test-%-sdk:
 	make --directory sdks/$* install test -B
 
-Test%:
-	E2E_WAIT_TIMEOUT=$(E2E_WAIT_TIMEOUT) go test -failfast -v -timeout $(E2E_SUITE_TIMEOUT) -count 1 --tags $(ALL_BUILD_TAGS) -parallel $(E2E_PARALLEL) ./test/e2e  -run='.*/$*'
+Test%: $(TOOL_GOTESTSUM)
+	E2E_WAIT_TIMEOUT=$(E2E_WAIT_TIMEOUT) $(GOTESTSUM) -failfast -v -timeout $(E2E_SUITE_TIMEOUT) -count 1 --tags $(ALL_BUILD_TAGS) -parallel $(E2E_PARALLEL) ./test/e2e  -run='.*/$*'
 
-Benchmark%:
-	go test --tags $(ALL_BUILD_TAGS) ./test/e2e -run='$@' -benchmem -count=$(BENCHMARK_COUNT) -bench .
+Benchmark%: $(TOOL_GOTESTSUM)
+	$(GOTESTSUM) --tags $(ALL_BUILD_TAGS) ./test/e2e -run='$@' -benchmem -count=$(BENCHMARK_COUNT) -bench .
 
 # clean
 


### PR DESCRIPTION
Fixes #TODO

### Motivation

Two reasons:

We have flaky tests, and I'd like to adopt https://github.com/ctrf-io/github-test-reporter to help us understand them better and focus fixes. This is a step towards adopting that tool.

Our tests runs are hard to read, and Argo CD's are not.

### Modifications

Adopt [`gotestsum`](https://github.com/gotestyourself/gotestsum) as a runner for the tests which provides a much neater looking output, especially for successful tests. The failing tests can be read easily as the output doesn't change. There is a summary at the bottom. See the test runs from the CI to witness what it looks like. I've chosen the format `testname` to display the results, matching ArgoCD. See the main readme for a video of the options if you want.

ArgoCD already uses this tool: https://github.com/argoproj/argo-cd/blob/master/hack/test.sh

I have enabled 3 retries for flaky tests, hopefully helping everyone.

### Verification

Locally run `make test` and an e2e test (functional).

See CI.

### Documentation

None required, just DevX