### PR TITLE
fix: Make the phase of the node unchange when the pod is completed and outputs are not set in the status.node

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1515,6 +1515,15 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		woc.wf.Status.MarkTaskResultComplete(nodeID)
 	}
 
+	// If the node template has outputs Parameters/Artifacts/Result, we should not change the phase to Succeeded until the outputs are set.
+	if tmpl != nil && tmpl.Outputs.HasOutputs() && new.Outputs != nil && new.Phase == wfv1.NodeSucceeded &&
+		((tmpl.Outputs.Parameters != nil && new.Outputs.Parameters == nil) ||
+			(tmpl.Outputs.Artifacts != nil && new.Outputs.Artifacts == nil) ||
+			(tmpl.Outputs.Result != nil && new.Outputs.Result == nil)) {
+		woc.log.WithField("new.phase", new.Phase).Info("leaving phase un-changed: outputs are not yet set")
+		new.Phase = old.Phase
+	}
+
 	// if we are transitioning from Pending to a different state (except Fail or Error), clear out unchanged message
 	if old.Phase == wfv1.NodePending && new.Phase != wfv1.NodePending && new.Phase != wfv1.NodeFailed && new.Phase != wfv1.NodeError && old.Message == new.Message {
 		new.Message = ""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14497 

### Motivation

This issue is difficult to reproduce. The scenario occurs when:

1. During taskResultReconciliation() execution, the Pod has either not yet finished running, or the Pod has finished but the task result cache has not been synced in time. As a result, the outputs parameters in taskResult are not set in status.nodes.

2. However, when podReconciliation() executes, the Pod has already completed, and the node is marked as Succeeded. This causes the workflow to proceed further. When the outputs of the node is required by other node, that would lead to an error.


### Modifications

Make the phase of the node unchange when the pod is completed and outputs are not set in the status.node

### Verification

local test

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
