### PR TITLE
chore: remove more log levels and implement speedups

### DIFF
--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -175,14 +175,14 @@ If your server is behind an ingress with a path (running "argo server --base-hre
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
 	if err := viper.BindPFlags(command.PersistentFlags()); err != nil {
-		log.Fatal(cctx, err.Error())
+		log.WithError(err).WithFatal().Error(cctx, "Failed to bind flags to env vars")
 	}
 	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
 	command.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)
 			if err := command.PersistentFlags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-				log.Fatal(cctx, err.Error())
+				log.WithError(err).WithFatal().Error(cctx, "Failed to set flag")
 			}
 		}
 	})

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -134,7 +134,7 @@ func NewRootCommand() *cobra.Command {
 			} else {
 				nodeID, ok := os.LookupEnv("LEADER_ELECTION_IDENTITY")
 				if !ok {
-					log.Fatal(ctx, "LEADER_ELECTION_IDENTITY must be set so that the workflow controllers can elect a leader")
+					log.WithFatal().Error(ctx, "LEADER_ELECTION_IDENTITY must be set so that the workflow controllers can elect a leader")
 				}
 
 				leaderName := "workflow-controller"

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -189,7 +189,7 @@ func NewRootCommand() *cobra.Command {
 			http.HandleFunc("/healthz", wfController.Healthz)
 
 			go func() {
-				log.Println(ctx, http.ListenAndServe(":6060", nil).Error())
+				log.Error(ctx, http.ListenAndServe(":6060", nil).Error())
 			}()
 
 			<-ctx.Done()

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -28,3 +28,10 @@ Argo Workflows exclusively uses quay.io now.
 Pull Request [#14462](https://github.com/argoproj/argo-workflows/pull/14462) made parameter value overriding consistent.
 This fix changes the priority in which the values are processed, meaning that a Workflow argument will now take priority.
 For more details see the example provided [here](https://github.com/argoproj/argo-workflows/issues/14426)
+
+## Upgrading to 4.0
+
+### Logging levels
+
+The logging levels available have been reduced to `debug`, `info`, `warn` and `error`.
+Other levels will be mapped to their equivalent if you use them, although they were previously undocumented.

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2516,7 +2516,7 @@ func (n *NodeStatus) IsPartOfExitHandler(ctx context.Context, nodes Nodes) bool 
 		}
 		boundaryNode, err := nodes.Get(currentNode.BoundaryID)
 		if err != nil {
-			log.Panicf(ctx, "was unable to obtain node for %s", currentNode.BoundaryID)
+			log.WithPanic().Errorf(ctx, "was unable to obtain node for %s", currentNode.BoundaryID)
 		}
 		currentNode = boundaryNode
 	}

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -61,7 +61,7 @@ func MustIsDir(ctx context.Context, filePath string) bool {
 	log := logging.GetLoggerFromContext(ctx)
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
-		log.Fatal(ctx, err.Error())
+		log.WithFatal().Error(ctx, err.Error())
 	}
 	return fileInfo.IsDir()
 }

--- a/util/cmd/log.go
+++ b/util/cmd/log.go
@@ -18,6 +18,8 @@ func SetLogLevel(logLevel string) {
 	switch logLevel {
 	case "trace":
 		logLevel = "debug"
+	case "print":
+		logLevel = "info"
 	}
 	logrusLevel, err := logrus.ParseLevel(logLevel)
 	if err != nil {

--- a/util/cmd/log.go
+++ b/util/cmd/log.go
@@ -20,6 +20,10 @@ func SetLogLevel(logLevel string) {
 		logLevel = "debug"
 	case "print":
 		logLevel = "info"
+	case "fatal":
+		logLevel = "error"
+	case "panic":
+		logLevel = "error"
 	}
 	logrusLevel, err := logrus.ParseLevel(logLevel)
 	if err != nil {

--- a/util/env/env.go
+++ b/util/env/env.go
@@ -16,7 +16,7 @@ func LookupEnvDurationOr(ctx context.Context, key string, o time.Duration) time.
 		if err != nil {
 			logger := logging.GetLoggerFromContext(ctx)
 			logger = logger.WithField(key, v).WithError(err)
-			logger.Panic(ctx, "failed to parse")
+			logger.WithPanic().Error(ctx, "failed to parse")
 		} else {
 			return d
 		}
@@ -31,7 +31,7 @@ func LookupEnvIntOr(ctx context.Context, key string, o int) int {
 		if err != nil {
 			logger := logging.GetLoggerFromContext(ctx)
 			logger = logger.WithField(key, v).WithError(err)
-			logger.Panic(ctx, "failed to convert to int")
+			logger.WithPanic().Error(ctx, "failed to convert to int")
 		} else {
 			return d
 		}
@@ -46,7 +46,7 @@ func LookupEnvFloatOr(ctx context.Context, key string, o float64) float64 {
 		if err != nil {
 			logger := logging.GetLoggerFromContext(ctx)
 			logger = logger.WithField(key, v).WithError(err)
-			logger.Panic(ctx, "failed to convert to float")
+			logger.WithPanic().Error(ctx, "failed to convert to float")
 		} else {
 			return d
 		}

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -165,6 +165,6 @@ func CheckError(ctx context.Context, err error) {
 		if logger == nil {
 			logger = logging.NewSlogLogger(logging.GetGlobalLevel(), logging.GetGlobalFormat())
 		}
-		logger.Fatal(ctx, err.Error())
+		logger.WithFatal().Error(ctx, err.Error())
 	}
 }

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -165,6 +165,6 @@ func CheckError(ctx context.Context, err error) {
 		if logger == nil {
 			logger = logging.NewSlogLogger(logging.GetGlobalLevel(), logging.GetGlobalFormat())
 		}
-		logger.WithFatal().Error(ctx, err.Error())
+		logger.WithError(err).WithFatal().Error(ctx, err.Error())
 	}
 }

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -165,6 +165,6 @@ func CheckError(ctx context.Context, err error) {
 		if logger == nil {
 			logger = logging.NewSlogLogger(logging.GetGlobalLevel(), logging.GetGlobalFormat())
 		}
-		logger.WithError(err).WithFatal().Error(ctx, err.Error())
+		logger.WithError(err).WithFatal().Error(ctx, "An error occurred during execution")
 	}
 }

--- a/util/file/fileutil.go
+++ b/util/file/fileutil.go
@@ -150,7 +150,7 @@ func WalkManifests(ctx context.Context, root string, fn func(path string, data [
 			defer func() {
 				if err := f.Close(); err != nil {
 					logger := logging.GetLoggerFromContext(ctx)
-					logger.Fatalf(ctx, "Error closing file[%s]: %v", path, err)
+					logger.WithFatal().Errorf(ctx, "Error closing file[%s]: %v", path, err)
 				}
 			}()
 			r = f

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -142,9 +142,6 @@ type Logger interface {
 	Debug(ctx context.Context, msg string)
 	Debugf(ctx context.Context, format string, args ...any)
 
-	Warning(ctx context.Context, msg string)
-	Warningf(ctx context.Context, format string, args ...any)
-
 	Panic(ctx context.Context, msg string)
 	Panicf(ctx context.Context, format string, args ...any)
 }

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 const (
@@ -27,6 +28,8 @@ const (
 )
 
 var (
+	lock = sync.RWMutex{}
+
 	globalLevel   = Info
 	globalFormat  = Text
 	defaultLogger = NewSlogLogger(globalLevel, globalFormat)
@@ -42,8 +45,8 @@ func SetGlobalLevel(level Level) {
 
 // GetGlobalLevel returns the current global log level
 func GetGlobalLevel() Level {
-	lock.Lock()
-	defer lock.Unlock()
+	lock.RLock()
+	defer lock.RUnlock()
 	return globalLevel
 }
 
@@ -57,15 +60,15 @@ func SetGlobalFormat(format LogType) {
 
 // GetGlobalFormat returns the current global log format
 func GetGlobalFormat() LogType {
-	lock.Lock()
-	defer lock.Unlock()
+	lock.RLock()
+	defer lock.RUnlock()
 	return globalFormat
 }
 
 // GetDefaultLogger returns the default logger configured with global settings
 func GetDefaultLogger() Logger {
-	lock.Lock()
-	defer lock.Unlock()
+	lock.RLock()
+	defer lock.RUnlock()
 	return defaultLogger
 }
 
@@ -84,10 +87,6 @@ const (
 	Warn Level = "warn"
 	// Error level events
 	Error Level = "error"
-	// Fatal level events
-	Fatal Level = "fatal"
-	// Panic level events
-	Panic Level = "panic"
 )
 
 // ParseLevel parses a string into a Level enum
@@ -100,16 +99,19 @@ func ParseLevel(s string) (Level, error) {
 		return Debug, nil
 	case "info":
 		return Info, nil
+	// legacy removed level
 	case "print":
 		return Info, nil
 	case "warn":
 		return Warn, nil
 	case "error":
 		return Error, nil
+	// legacy removed level
 	case "fatal":
-		return Fatal, nil
+		return Error, nil
+	// legacy removed level
 	case "panic":
-		return Panic, nil
+		return Error, nil
 	default:
 		return "", fmt.Errorf("invalid log level: %s", s)
 	}
@@ -127,23 +129,22 @@ type Logger interface {
 	WithField(name string, value any) Logger
 	WithError(err error) Logger
 
+	// When issuing Error, adding this will Panic
+	WithPanic() Logger
+	// When issuing Error, adding this will exit 1
+	WithFatal() Logger
+
+	Debug(ctx context.Context, msg string)
+	Debugf(ctx context.Context, format string, args ...any)
+
 	Info(ctx context.Context, msg string)
 	Infof(ctx context.Context, format string, args ...any)
 
 	Warn(ctx context.Context, msg string)
 	Warnf(ctx context.Context, format string, args ...any)
 
-	Fatal(ctx context.Context, msg string)
-	Fatalf(ctx context.Context, format string, args ...any)
-
 	Error(ctx context.Context, msg string)
 	Errorf(ctx context.Context, format string, args ...any)
-
-	Debug(ctx context.Context, msg string)
-	Debugf(ctx context.Context, format string, args ...any)
-
-	Panic(ctx context.Context, msg string)
-	Panicf(ctx context.Context, format string, args ...any)
 }
 
 // GetLoggerFromContext returns a logger from context, returns nil if not found

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -86,8 +86,6 @@ const (
 	Error Level = "error"
 	// Fatal level events
 	Fatal Level = "fatal"
-	// Print level events
-	Print Level = "print"
 	// Panic level events
 	Panic Level = "panic"
 )
@@ -102,14 +100,14 @@ func ParseLevel(s string) (Level, error) {
 		return Debug, nil
 	case "info":
 		return Info, nil
+	case "print":
+		return Info, nil
 	case "warn":
 		return Warn, nil
 	case "error":
 		return Error, nil
 	case "fatal":
 		return Fatal, nil
-	case "print":
-		return Print, nil
 	case "panic":
 		return Panic, nil
 	default:
@@ -146,9 +144,6 @@ type Logger interface {
 
 	Warning(ctx context.Context, msg string)
 	Warningf(ctx context.Context, format string, args ...any)
-
-	Println(ctx context.Context, msg string)
-	Printf(ctx context.Context, format string, args ...any)
 
 	Panic(ctx context.Context, msg string)
 	Panicf(ctx context.Context, format string, args ...any)

--- a/util/logging/slog.go
+++ b/util/logging/slog.go
@@ -235,22 +235,6 @@ func (s *slogLogger) Warningf(ctx context.Context, format string, args ...any) {
 	s.Warning(ctx, msg)
 }
 
-func (s *slogLogger) Println(ctx context.Context, msg string) {
-	s.mu.RLock()
-	hooks := s.hooks[Print]
-	s.mu.RUnlock()
-	if hooks == nil {
-		hooks = []Hook{}
-	}
-	s.executeHooks(ctx, hooks, Print, msg)
-	s.logger.LogAttrs(ctx, slog.LevelInfo, msg, fieldsToAttrs(s.fields)...)
-}
-
-func (s *slogLogger) Printf(ctx context.Context, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	s.Println(ctx, msg)
-}
-
 func (s *slogLogger) Panic(ctx context.Context, msg string) {
 	s.mu.RLock()
 	hooks := s.hooks[Panic]
@@ -281,8 +265,6 @@ func convertLevel(level Level) slog.Level {
 		return slog.LevelError
 	case Fatal:
 		return slog.LevelError
-	case Print:
-		return slog.LevelInfo
 	case Panic:
 		return slog.LevelError
 	default:

--- a/util/logging/slog.go
+++ b/util/logging/slog.go
@@ -9,9 +9,9 @@ import (
 )
 
 type slogLogger struct {
-	fields   Fields
-	logger   *slog.Logger
-	hooks    map[Level][]Hook
+	fields    Fields
+	logger    *slog.Logger
+	hooks     map[Level][]Hook
 	withPanic bool
 	withFatal bool
 }
@@ -73,9 +73,11 @@ func (s *slogLogger) WithFields(fields Fields) Logger {
 	}
 
 	return &slogLogger{
-		fields: newFields,
-		logger: s.logger,
-		hooks:  s.hooks,
+		fields:    newFields,
+		logger:    s.logger,
+		hooks:     s.hooks,
+		withFatal: s.withFatal,
+		withPanic: s.withPanic,
 	}
 }
 
@@ -89,29 +91,33 @@ func (s *slogLogger) WithField(name string, value any) Logger {
 	newFields[name] = value
 
 	return &slogLogger{
-		fields: newFields,
-		logger: s.logger,
-		hooks:  s.hooks,
+		fields:    newFields,
+		logger:    s.logger,
+		hooks:     s.hooks,
+		withFatal: s.withFatal,
+		withPanic: s.withPanic,
 	}
 }
 
 // Only works with Error()
 func (s *slogLogger) WithPanic() Logger {
 	return &slogLogger{
-		fields:   s.fields,
-		logger:   s.logger,
-		hooks:    s.hooks,
+		fields:    s.fields,
+		logger:    s.logger,
+		hooks:     s.hooks,
 		withPanic: true,
+		withFatal: s.withFatal,
 	}
 }
 
 // Only works with Error()
 func (s *slogLogger) WithFatal() Logger {
 	return &slogLogger{
-		fields:   s.fields,
-		logger:   s.logger,
-		hooks:    s.hooks,
+		fields:    s.fields,
+		logger:    s.logger,
+		hooks:     s.hooks,
 		withFatal: true,
+		withPanic: s.withPanic,
 	}
 }
 

--- a/util/logging/slog.go
+++ b/util/logging/slog.go
@@ -219,22 +219,6 @@ func (s *slogLogger) Debugf(ctx context.Context, format string, args ...any) {
 	s.Debug(ctx, msg)
 }
 
-func (s *slogLogger) Warning(ctx context.Context, msg string) {
-	s.mu.RLock()
-	hooks := s.hooks[Warn]
-	s.mu.RUnlock()
-	if hooks == nil {
-		hooks = []Hook{}
-	}
-	s.executeHooks(ctx, hooks, Warn, msg)
-	s.logger.LogAttrs(ctx, slog.LevelWarn, msg, fieldsToAttrs(s.fields)...)
-}
-
-func (s *slogLogger) Warningf(ctx context.Context, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	s.Warning(ctx, msg)
-}
-
 func (s *slogLogger) Panic(ctx context.Context, msg string) {
 	s.mu.RLock()
 	hooks := s.hooks[Panic]

--- a/util/logging/test_hook.go
+++ b/util/logging/test_hook.go
@@ -26,7 +26,7 @@ func NewTestHook() *TestHook {
 
 // Levels returns the levels this hook should fire on
 func (h *TestHook) Levels() []Level {
-	return []Level{Debug, Info, Warn, Error, Fatal, Panic}
+	return []Level{Debug, Info, Warn, Error}
 }
 
 // Fire is called when a log event is fired

--- a/util/logging/test_hook.go
+++ b/util/logging/test_hook.go
@@ -26,7 +26,7 @@ func NewTestHook() *TestHook {
 
 // Levels returns the levels this hook should fire on
 func (h *TestHook) Levels() []Level {
-	return []Level{Debug, Info, Warn, Error, Fatal, Print, Panic}
+	return []Level{Debug, Info, Warn, Error, Fatal, Panic}
 }
 
 // Fire is called when a log event is fired

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -492,7 +492,7 @@ func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv
 
 	if err != nil {
 		if apierr.IsAlreadyExists(err) {
-			woc.log.Warningf(ctx, "Artifact GC Pod %s already exists?", pod.Name)
+			woc.log.Warnf(ctx, "Artifact GC Pod %s already exists?", pod.Name)
 		} else {
 			return nil, fmt.Errorf("failed to create pod: %w", err)
 		}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -287,7 +287,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	// init DB after leader election (if enabled)
 	if err := wfc.initDB(ctx); err != nil {
 		logger := logging.GetLoggerFromContext(ctx)
-		logger.WithFatal().Errorf(ctx, "Failed to init db: %v", err)
+		logger.WithError(err).WithFatal().Error(ctx, "Failed to init db")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -311,7 +311,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.wfInformer = util.NewWorkflowInformer(wfc.dynamicInterface, wfc.GetManagedNamespace(), workflowResyncPeriod, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, indexers)
 	nsInformer, err := wfc.newNamespaceInformer(ctx, wfc.kubeclientset)
 	if err != nil {
-		logger.WithFatal().Error(ctx, err.Error())
+		logger.WithError(err).WithFatal().Error(ctx, "Failed to create namespace informer")
 	}
 	wfc.nsInformer = nsInformer
 	wfc.wftmplInformer = informer.NewTolerantWorkflowTemplateInformer(wfc.dynamicInterface, workflowTemplateResyncPeriod, wfc.managedNamespace)
@@ -321,7 +321,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.taskResultInformer = wfc.newWorkflowTaskResultInformer(ctx)
 	err = wfc.addWorkflowInformerHandlers(ctx)
 	if err != nil {
-		logger.WithFatal().Error(ctx, err.Error())
+		logger.WithError(err).WithFatal().Error(ctx, "Failed to add workflow informer handlers")
 	}
 	wfc.PodController = pod.NewController(ctx, &wfc.Config, wfc.restConfig, wfc.GetManagedNamespace(), wfc.kubeclientset, wfc.wfInformer, wfc.metrics, wfc.enqueueWfFromPodLabel)
 
@@ -333,7 +333,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.createSynchronizationManager(ctx)
 	// init managers: throttler and SynchronizationManager
 	if err := wfc.initManagers(ctx); err != nil {
-		logger.WithFatal().Error(ctx, err.Error())
+		logger.WithError(err).WithFatal().Error(ctx, "Failed to init managers")
 	}
 
 	if os.Getenv("WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS") != "false" {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -398,7 +398,7 @@ func (woc *wfOperationCtx) updateOutboundNodesForTargetTasks(ctx context.Context
 	for _, depName := range targetTasks {
 		depNode := dagCtx.getTaskNode(ctx, depName)
 		if depNode == nil {
-			woc.log.Println(ctx, depName)
+			woc.log.Info(ctx, depName)
 			continue
 		}
 		outboundNodeIDs := woc.getOutboundNodes(ctx, depNode.ID)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3068,7 +3068,7 @@ func (woc *wfOperationCtx) getOutboundNodes(ctx context.Context, nodeID string) 
 		for _, child := range node.Children {
 			childNode, err := woc.wf.Status.Nodes.Get(child)
 			if err != nil {
-				woc.log.WithPanic().Errorf(ctx, "was unable to obtain child node for %s", child)
+				woc.log.WithError(err).WithPanic().Errorf(ctx, "was unable to obtain child node for %s", child)
 			}
 			// child node has different boundaryID meaning current node is the deepest outbound node
 			if node.Type == wfv1.NodeTypeContainer && node.BoundaryID != childNode.BoundaryID {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -740,7 +740,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 	// * Fails the `reapplyUpdate` cannot work unless resource versions are different.
 	// * It will double the number of Kubernetes API requests.
 	if woc.orig.ResourceVersion != woc.wf.ResourceVersion {
-		woc.log.Panic(ctx, "cannot persist updates with mismatched resource versions")
+		woc.log.WithPanic().Error(ctx, "cannot persist updates with mismatched resource versions")
 	}
 	wfClient := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows(woc.wf.Namespace)
 	// try and compress nodes if needed
@@ -873,7 +873,7 @@ func (woc *wfOperationCtx) persistWorkflowSizeLimitErr(ctx context.Context, wfCl
 func (woc *wfOperationCtx) reapplyUpdate(ctx context.Context, wfClient v1alpha1.WorkflowInterface, nodes wfv1.Nodes) (*wfv1.Workflow, error) {
 	// if this condition is true, then this func will always error
 	if woc.orig.ResourceVersion != woc.wf.ResourceVersion {
-		woc.log.Panic(ctx, "cannot re-apply update with mismatched resource versions")
+		woc.log.WithPanic().Error(ctx, "cannot re-apply update with mismatched resource versions")
 	}
 	err := woc.controller.hydrator.Hydrate(ctx, woc.orig)
 	if err != nil {
@@ -2446,7 +2446,7 @@ func (woc *wfOperationCtx) markWorkflowPhase(ctx context.Context, phase wfv1.Wor
 	if woc.wf.Status.Phase != phase {
 		if woc.wf.Status.Fulfilled() {
 			woc.log.WithFields(logging.Fields{"fromPhase": woc.wf.Status.Phase, "toPhase": phase}).
-				Panic(ctx, "workflow is already fulfilled")
+				WithPanic().Error(ctx, "workflow is already fulfilled")
 		}
 		woc.log.Infof(ctx, "Updated phase %s -> %s", woc.wf.Status.Phase, phase)
 		woc.updated = true
@@ -3036,7 +3036,7 @@ func (woc *wfOperationCtx) executeContainer(ctx context.Context, nodeName string
 func (woc *wfOperationCtx) getOutboundNodes(ctx context.Context, nodeID string) []string {
 	node, err := woc.wf.Status.Nodes.Get(nodeID)
 	if err != nil {
-		woc.log.Panicf(ctx, "was unable to obtain node for %s", nodeID)
+		woc.log.WithPanic().Errorf(ctx, "was unable to obtain node for %s", nodeID)
 	}
 	switch node.Type {
 	case wfv1.NodeTypeSkipped, wfv1.NodeTypeSuspend, wfv1.NodeTypeHTTP, wfv1.NodeTypePlugin:
@@ -3068,7 +3068,7 @@ func (woc *wfOperationCtx) getOutboundNodes(ctx context.Context, nodeID string) 
 		for _, child := range node.Children {
 			childNode, err := woc.wf.Status.Nodes.Get(child)
 			if err != nil {
-				woc.log.Panicf(ctx, "was unable to obtain child node for %s", child)
+				woc.log.WithPanic().Errorf(ctx, "was unable to obtain child node for %s", child)
 			}
 			// child node has different boundaryID meaning current node is the deepest outbound node
 			if node.Type == wfv1.NodeTypeContainer && node.BoundaryID != childNode.BoundaryID {
@@ -3539,7 +3539,7 @@ func (woc *wfOperationCtx) addChildNode(ctx context.Context, parent string, chil
 	childID := woc.wf.NodeID(child)
 	node, err := woc.wf.Status.Nodes.Get(parentID)
 	if err != nil {
-		woc.log.Panicf(ctx, "was unable to obtain node for %s", parentID)
+		woc.log.WithPanic().Errorf(ctx, "was unable to obtain node for %s", parentID)
 	}
 	for _, nodeID := range node.Children {
 		if childID == nodeID {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2764,7 +2764,7 @@ func (woc *wfOperationCtx) updateAsCacheHitNode(ctx context.Context, node *wfv1.
 func (woc *wfOperationCtx) markNodePhase(ctx context.Context, nodeName string, phase wfv1.NodePhase, message ...string) *wfv1.NodeStatus {
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
-		woc.log.Warningf(ctx, "workflow '%s' node '%s' uninitialized when marking as %v: %s", woc.wf.Name, nodeName, phase, message)
+		woc.log.Warnf(ctx, "workflow '%s' node '%s' uninitialized when marking as %v: %s", woc.wf.Name, nodeName, phase, message)
 		node = &wfv1.NodeStatus{}
 	}
 	// if we not in a running state (not expecting task results)

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -353,7 +353,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 	for _, childNodeID := range node.Children {
 		childNode, err := woc.wf.Status.Nodes.Get(childNodeID)
 		if err != nil {
-			woc.log.WithPanic().Errorf(ctx, "Coudn't obtain child for %s, panicking", childNodeID)
+			woc.log.WithPanic().Errorf(ctx, "Couldn't obtain child for %s, panicking", childNodeID)
 		}
 		step := nodeSteps[childNode.Name]
 		if childNode.FailedOrError() && !step.ContinuesOn(childNode.Phase) {

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -46,7 +46,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 	defer func() {
 		nodePhase, err := woc.wf.Status.Nodes.GetPhase(node.ID)
 		if err != nil {
-			woc.log.Fatalf(ctx, "was unable to obtain nodePhase for %s", node.ID)
+			woc.log.WithFatal().Errorf(ctx, "was unable to obtain nodePhase for %s", node.ID)
 			panic(fmt.Sprintf("unable to obtain nodePhase for %s", node.ID))
 		}
 		if nodePhase.Fulfilled(node.TaskResultSynced) {
@@ -98,7 +98,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 					for _, outNodeID := range outboundNodeIDs {
 						outNodeName, err := woc.wf.Status.Nodes.GetName(outNodeID)
 						if err != nil {
-							woc.log.Fatalf(ctx, "was not able to obtain node name for %s", outNodeID)
+							woc.log.WithFatal().Errorf(ctx, "was not able to obtain node name for %s", outNodeID)
 							panic(fmt.Sprintf("could not obtain the out noden name for %s", outNodeID))
 						}
 						woc.addChildNode(ctx, outNodeName, sgNodeName)
@@ -353,7 +353,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 	for _, childNodeID := range node.Children {
 		childNode, err := woc.wf.Status.Nodes.Get(childNodeID)
 		if err != nil {
-			woc.log.Panicf(ctx, "Coudn't obtain child for %s, panicking", childNodeID)
+			woc.log.WithPanic().Errorf(ctx, "Coudn't obtain child for %s, panicking", childNodeID)
 		}
 		step := nodeSteps[childNode.Name]
 		if childNode.FailedOrError() && !step.ContinuesOn(childNode.Phase) {

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -120,7 +120,7 @@ func (woc *wfOperationCtx) nodeRequiresTaskSetReconciliation(ctx context.Context
 		// If any of the node's children need an HTTP reconciliation, the parent node will also need one
 		childNodeName, err := woc.wf.Status.Nodes.GetName(child)
 		if err != nil {
-			woc.log.Fatalf(ctx, "was unable to get child node name for %s", child)
+			woc.log.WithFatal().Errorf(ctx, "was unable to get child node name for %s", child)
 			panic("unable to obtain child node name")
 		}
 		if woc.nodeRequiresTaskSetReconciliation(ctx, childNodeName) {

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -281,7 +281,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 		if p, ok := wfv1.ParseProgress(x); ok {
 			node, err := woc.wf.Status.Nodes.Get(nodeID)
 			if err != nil {
-				woc.log.Panicf(ctx, "was unable to obtain node for %s", nodeID)
+				woc.log.WithPanic().Errorf(ctx, "was unable to obtain node for %s", nodeID)
 			}
 			node.Progress = p
 			woc.wf.Status.Nodes.Set(ctx, nodeID, *node)

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -71,7 +71,7 @@ func init() {
 	// this make sure we support timezones
 	_, err := time.Parse(time.RFC822, "17 Oct 07 14:03 PST")
 	if err != nil {
-		slog.Fatal(ctx, err.Error())
+		slog.WithFatal().Error(ctx, err.Error())
 	}
 	cronSyncPeriod = env.LookupEnvDurationOr(ctx, "CRON_SYNC_PERIOD", 10*time.Second)
 	slog.WithField("cronSyncPeriod", cronSyncPeriod).Info(ctx, "cron config")
@@ -117,7 +117,7 @@ func (cc *Controller) Run(ctx context.Context) {
 	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.CronWorkflowPlural})
 	err := cc.addCronWorkflowInformerHandler(ctx)
 	if err != nil {
-		cc.logger.Fatal(ctx, err.Error())
+		cc.logger.WithFatal().Error(ctx, err.Error())
 	}
 
 	wfInformer := util.NewWorkflowInformer(cc.dynamicInterface, cc.managedNamespace, cronWorkflowResyncPeriod,

--- a/workflow/gccontroller/gc_controller.go
+++ b/workflow/gccontroller/gc_controller.go
@@ -75,7 +75,7 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 		},
 	})
 	if err != nil {
-		log.Fatal(ctx, err.Error())
+		log.WithError(err).WithFatal().Error(ctx, "Failed to add event handler")
 	}
 
 	_, err = wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
@@ -93,7 +93,7 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 		},
 	})
 	if err != nil {
-		log.Fatal(ctx, err.Error())
+		log.WithFatal().Error(ctx, err.Error())
 	}
 	return controller
 }

--- a/workflow/gccontroller/gc_controller.go
+++ b/workflow/gccontroller/gc_controller.go
@@ -75,7 +75,7 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 		},
 	})
 	if err != nil {
-		log.WithError(err).WithFatal().Error(ctx, "Failed to add event handler")
+		log.WithError(err).WithFatal().Error(ctx, "Failed to add queue event handler")
 	}
 
 	_, err = wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
@@ -93,7 +93,7 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 		},
 	})
 	if err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.WithError(err).WithFatal().Error(ctx, "Failed to add retention event handler")
 	}
 	return controller
 }


### PR DESCRIPTION
Another follow on from #14527 and #14642.

This follows 14642 by removing print and warning from log levels (first two commits in the chain).

The third commit removes panic and fatal by adding WithPanic and WithFatal.

Whilst fixing up the callers of these methods I've improved them slightly by using WithError() for more structured logs.

This commit also implements https://github.com/argoproj/argo-workflows/pull/14527#discussion_r2163680318 by removing the mutex in the logger and all the hook copies, because they're now immutable for the lifetime of the parent logger.

With this we're down to the base `levels` from slog instead of the large number from logrus.

### Documentation

Upgrading notes added, but previously other log levels were never documented (not that I can find that if they were).
