### PR TITLE
fix: process aggregate outputs for steps node with retries. Fixes #14647

### DIFF
--- a/test/e2e/functional/parameter-aggregation-steps-with-retry.yaml
+++ b/test/e2e/functional/parameter-aggregation-steps-with-retry.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: parameter-aggregation-steps-with-retry
+spec:
+  retryStrategy:
+    limit: 1
+  entrypoint: fanout-steps-with-output
+  templates:
+    - name: echo-value
+      inputs:
+        parameters:
+          - name: message
+      container:
+        image: argoproj/argosay:v2
+      outputs:
+        parameters:
+          - name: dummy-output
+            value: '{{inputs.parameters.message}}'
+    - name: fanout-steps-with-output
+      steps:
+        - - name: echo-list
+            template: echo-value
+            arguments:
+              parameters:
+                - name: message
+                  value: '{{item}}'
+            withItems: [1, 2, 3]
+      outputs:
+        parameters:
+          - name: dummy-steps-output
+            valueFrom:
+              parameter: '{{steps.echo-list.outputs.parameters.dummy-output}}'

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -610,6 +610,24 @@ func (s *FunctionalSuite) TestParameterAggregationDAGWithRetry() {
 		})
 }
 
+func (s *FunctionalSuite) TestParameterAggregationStepsWithRetry() {
+	s.Given().
+		Workflow("@functional/parameter-aggregation-steps-with-retry.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(time.Second * 90).
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			nodeStatus := status.Nodes.FindByDisplayName("parameter-aggregation-steps-with-retry(0)")
+			require.NotNil(t, nodeStatus)
+			assert.Equal(t, wfv1.NodeSucceeded, nodeStatus.Phase)
+			require.NotNil(t, nodeStatus.Outputs)
+			assert.Len(t, nodeStatus.Outputs.Parameters, 1)
+			assert.Equal(t, `["1","2","3"]`, nodeStatus.Outputs.Parameters[0].Value.String())
+		})
+}
+
 func (s *FunctionalSuite) TestDAGDepends() {
 	s.Given().
 		Workflow("@functional/dag-depends.yaml").

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -673,10 +673,6 @@ func (woc *wfOperationCtx) buildLocalScopeFromTask(ctx context.Context, dagCtx *
 			var ancestorNodes []wfv1.NodeStatus
 			for _, node := range woc.wf.Status.Nodes {
 				if node.BoundaryID == dagCtx.boundaryID && strings.HasPrefix(node.Name, ancestorNode.Name+"(") {
-					// Filter retried nodes and only aggregate outputs of their parent nodes.
-					if node.NodeFlag != nil && node.NodeFlag.Retried {
-						continue
-					}
 					ancestorNodes = append(ancestorNodes, node)
 				}
 			}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3368,10 +3368,10 @@ func (woc *wfOperationCtx) processAggregateNodeOutputs(scope *wfScope, prefix st
 	if len(childNodes) == 0 {
 		return nil
 	}
-	// Some of the children may be hooks, only keep those that aren't
+	// Some of the children may be hooks and some of the children may be retried nodes, only keep those that aren't
 	nodeIdx := 0
 	for i := range childNodes {
-		if childNodes[i].NodeFlag == nil || !childNodes[i].NodeFlag.Hooked {
+		if childNodes[i].NodeFlag == nil || (!childNodes[i].NodeFlag.Hooked && !childNodes[i].NodeFlag.Retried) {
 			childNodes[nodeIdx] = childNodes[i]
 			nodeIdx++
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14647

### Motivation

<!-- TODO: Say why you made your changes. -->


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

 Filter retried nodes and only aggregate outputs of their parent nodes.

### Verification

<!-- TODO: Say how you tested your changes. -->
E2E test and local test

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
