### PR TITLE
fix(ui): Add multibyte character support tests for pod name generation

### DIFF
--- a/ui/src/shared/pod-name.test.ts
+++ b/ui/src/shared/pod-name.test.ts
@@ -1,12 +1,23 @@
+import {TextEncoder} from 'util';
+
 import {ANNOTATION_KEY_POD_NAME_VERSION} from './annotations';
 import {NodeStatus, Workflow} from './models';
 import {createFNVHash, ensurePodNamePrefixLength, getPodName, getTemplateNameFromNode, k8sNamingHashLength, maxK8sResourceNameLength, POD_NAME_V1, POD_NAME_V2} from './pod-name';
+
+global.TextEncoder = TextEncoder;
 
 describe('pod names', () => {
     test('createFNVHash', () => {
         expect(createFNVHash('hello')).toEqual(1335831723);
         expect(createFNVHash('world')).toEqual(933488787);
         expect(createFNVHash('You cannot alter your fate. However, you can rise to meet it.')).toEqual(827171719);
+    });
+
+    test('createFNVHash with multibyte characters', () => {
+        expect(createFNVHash('こんにちは')).toEqual(486186189);
+        expect(createFNVHash('ワークフロー')).toEqual(1626941668);
+        expect(createFNVHash('テスト用の日本語文字列')).toEqual(1519251954);
+        expect(createFNVHash('🚀✨🔥')).toEqual(2133319838); // Emoji test
     });
 
     // note: the below is intended to be equivalent to the server-side Go code in workflow/util/pod_name_test.go
@@ -24,6 +35,24 @@ describe('pod names', () => {
         expected = `${longWfName}-${longTemplateName}`;
         const actual = ensurePodNamePrefixLength(expected);
         expect(actual.length).toEqual(maxK8sResourceNameLength - k8sNamingHashLength - 1);
+    });
+
+    test('ensurePodNamePrefixLength with multibyte characters', () => {
+        const multibyteWfName = '日本語ワークフロー名';
+        const multibyteTemplateName = 'テンプレート名サンプル';
+
+        let expected = `${multibyteWfName}-${multibyteTemplateName}`;
+        expect(ensurePodNamePrefixLength(expected)).toEqual(expected);
+
+        const longMultibyteWfName = '非常に長い日本語のワークフロー名で色々な文字を含んでいます例えば記号や絵文字なども含まれています🚀✨🔥';
+        const longMultibyteTemplateName = 'こちらも非常に長いテンプレート名でマルチバイト文字をたくさん使っています全角スペースも　含まれています';
+
+        expected = `${longMultibyteWfName}-${longMultibyteTemplateName}`;
+        const actual = ensurePodNamePrefixLength(expected);
+        expect(actual.length).toBeLessThanOrEqual(maxK8sResourceNameLength - k8sNamingHashLength - 1);
+        if (expected.length > maxK8sResourceNameLength - k8sNamingHashLength - 1) {
+            expect(actual.length).toBeLessThanOrEqual(maxK8sResourceNameLength - k8sNamingHashLength - 1);
+        }
     });
 
     test('getPodName', () => {
@@ -57,6 +86,44 @@ describe('pod names', () => {
         node.templateName = longTemplateName;
         const name = getPodName(wf, node);
         expect(name.length).toEqual(maxK8sResourceNameLength);
+    });
+
+    test('getPodName with multibyte characters', () => {
+        const multibyteWfName = '日本語ワークフロー';
+        const multibyteTemplateName = 'テンプレート名';
+        const multibyteNodeName = 'ノード名サンプル';
+
+        const node = {
+            name: multibyteNodeName,
+            id: '1',
+            templateName: multibyteTemplateName
+        } as unknown as NodeStatus;
+
+        const wf = {
+            metadata: {
+                name: multibyteWfName,
+                annotations: {
+                    [ANNOTATION_KEY_POD_NAME_VERSION]: POD_NAME_V2
+                }
+            }
+        } as unknown as Workflow;
+
+        const expectedPodName = `${multibyteWfName}-${multibyteTemplateName}-${createFNVHash(multibyteNodeName)}`;
+        expect(getPodName(wf, node)).toEqual(expectedPodName);
+
+        const longMultibyteWfName = '非常に長い日本語のワークフロー名で色々な文字を含んでいます例えば記号や絵文字なども含まれています🚀✨🔥';
+        const longMultibyteTemplateName = 'こちらも非常に長いテンプレート名でマルチバイト文字をたくさん使っています全角スペースも　含まれています';
+
+        wf.metadata.name = longMultibyteWfName;
+        node.templateName = longMultibyteTemplateName;
+
+        const name = getPodName(wf, node);
+        expect(name.length).toBeLessThanOrEqual(maxK8sResourceNameLength);
+
+        const containerSetNodeName = `${multibyteNodeName}.コンテナ名`;
+        expect(getPodName(wf, {...node, name: containerSetNodeName, type: 'Container'})).toEqual(
+            `${ensurePodNamePrefixLength(`${longMultibyteWfName}-${longMultibyteTemplateName}`)}-${createFNVHash(multibyteNodeName)}`
+        );
     });
 
     test('getTemplateNameFromNode', () => {

--- a/ui/src/shared/pod-name.ts
+++ b/ui/src/shared/pod-name.ts
@@ -48,9 +48,12 @@ export function ensurePodNamePrefixLength(prefix: string): string {
 export function createFNVHash(input: string): number {
     let hashint = 2166136261;
 
-    for (let i = 0; i < input.length; i++) {
-        const character = input.charCodeAt(i);
-        hashint = hashint ^ character;
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(input);
+
+    for (let i = 0; i < bytes.length; i++) {
+        const byte = bytes[i];
+        hashint = hashint ^ byte;
         hashint += (hashint << 1) + (hashint << 4) + (hashint << 7) + (hashint << 8) + (hashint << 24);
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14652 

### Motivation

<!-- TODO: Say why you made your changes. -->
When specifying a multibyte string with withParam, it returns the name of a POD that does not exist on k8s.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
- Supports multibyte character strings
- Add a test

### Verification

<!-- TODO: Say how you tested your changes. -->
#### Before
<img width="1266" height="523" alt="スクリーンショット 2025-07-14 17 28 13" src="https://github.com/user-attachments/assets/891b4745-6d9c-4652-bfe2-85939291e8f5" />

```
% k get po -n argo with-multibyte-smnwv-cat-612121745
Error from server (NotFound): pods "with-multibyte-smnwv-cat-612121745" not found

 % k get po -n argo
NAME                                   READY   STATUS      RESTARTS      AGE
with-multibyte-smnwv-cat-4115705801    0/2     Completed   0             10s
```

#### After
<img width="1266" height="523" alt="スクリーンショット 2025-07-14 17 59 59" src="https://github.com/user-attachments/assets/86df7087-c806-410b-82c1-97f8e21f1527" />

```
% k get po -n argo with-multibyte-vg86n-cat-1799227071
NAME                                  READY   STATUS      RESTARTS   AGE
with-multibyte-vg86n-cat-1799227071   0/2     Completed   0          11s

argo: % k get po -n argo
NAME                                  READY   STATUS      RESTARTS      AGE
with-multibyte-vg86n-cat-1799227071   0/2     Completed   0             13s
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
