### PR TITLE
fix: watch for dynamic changes to the Controller ConfigMap in its installation namespace. Fixes #14673

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -464,29 +464,44 @@ func (wfc *WorkflowController) runConfigMapWatcher(ctx context.Context) {
 	defer runtimeutil.HandleCrashWithContext(ctx, runtimeutil.PanicHandlers...)
 	logger := logging.GetLoggerFromContext(ctx).WithField("component", "configmap_watcher")
 	ctx = logging.WithLogger(ctx, logger)
-	retryWatcher, err := apiwatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.managedNamespace).Watch(ctx, metav1.ListOptions{})
+	configWatcher, err := apiwatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.namespace).Watch(ctx, metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("metadata.name=%s", wfc.configController.GetName()),
+			})
 		},
 	})
 	if err != nil {
 		panic(err)
 	}
-	defer retryWatcher.Stop()
+	defer configWatcher.Stop()
+	semaphoreConfigWatcher, err := apiwatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.GetManagedNamespace()).Watch(ctx, metav1.ListOptions{})
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer semaphoreConfigWatcher.Stop()
 
 	for {
 		select {
-		case event := <-retryWatcher.ResultChan():
+		case event := <-configWatcher.ResultChan():
 			cm, ok := event.Object.(*apiv1.ConfigMap)
 			if !ok {
 				logger.Error(ctx, "invalid config map object received in config watcher. Ignored processing")
 				continue
 			}
-			logger.Debugf(ctx, "received config map %s/%s update", cm.Namespace, cm.Name)
-			if cm.GetName() == wfc.configController.GetName() && wfc.namespace == cm.GetNamespace() {
-				logger.Infof(ctx, "Received Workflow Controller config map %s/%s update", cm.Namespace, cm.Name)
-				wfc.UpdateConfig(ctx)
+			logger.Infof(ctx, "Received Workflow Controller config map %s/%s update", cm.Namespace, cm.Name)
+			wfc.UpdateConfig(ctx)
+		case event := <-semaphoreConfigWatcher.ResultChan():
+			cm, ok := event.Object.(*apiv1.ConfigMap)
+			if !ok {
+				logger.Error(ctx, "invalid config map object received in semaphore config watcher. Ignored processing")
+				continue
 			}
+			logger.Debugf(ctx, "received config map %s/%s update", cm.Namespace, cm.Name)
 			wfc.notifySemaphoreConfigUpdate(ctx, cm)
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14673 

### Motivation

<!-- TODO: Say why you made your changes. -->
Argo: both the Workflow Controller and Argo Server use a managed namespace install:
 
- Argo install in namespace `argo` and enable `--namespaced`
- `--managed-namespace` is set to `workflow`

https://github.com/argoproj/argo-workflows/blob/ac0a63cc41f212e2b8200cb449d20a4ef28004c7/workflow/controller/controller.go#L469

Workflow Controller only watchs ConfigMaps in managed namespace `workflow`, but it is installed in namespace `argo`.


### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
Watch for dynamic changes to the Controller ConfigMap in its installation namespace, not the managed namespace.

### Verification

<!-- TODO: Say how you tested your changes. -->
Local Test:
- Argo install in namespace `argo` and enable `--namespaced`
- `--managed-namespace` is set to `workflow`

Modify the Controller Configmap after the workflow controller started, see logs as below:
```shell
# tail -f logs/controller.log | grep configmap_watcher
time=2025-07-22T17:10:56.507+08:00 level=INFO msg="Received Workflow Controller config map argo/workflow-controller-configmap update" component=configmap_watcher
time=2025-07-22T17:10:56.513+08:00 level=INFO msg="Configuration:\nartifactRepository:\n  s3:\n    accessKeySecret:\n      key: accesskey\n      name: my-minio-cred\n    bucket: my-bucket\n    endpoint: minio:9000\n    insecure: true\n    secretKeySecret:\n      key: secretkey\n      name: my-minio-cred\ncolumns:\n- key: workflows.argoproj.io/completed\n  name: Workflow Completed\n  type: label\nexecutor:\n  imagePullPolicy: IfNotPresent\n  name: \"\"\n  resources:\n    limits:\n      cpu: 500m\n      memory: 256Mi\n    requests:\n      cpu: 100m\n      memory: 64Mi\nimages:\n  docker/whalesay:latest:\n    cmd:\n    - cowsay\ninitialDelay: 0s\nlinks:\n- name: Workflow Link\n  scope: workflow\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Pod Link\n  scope: pod\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Pod Logs Link\n  scope: pod-logs\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Event Source Logs Link\n  scope: event-source-logs\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Sensor Logs Link\n  scope: sensor-logs\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Completed Workflows\n  scope: workflow-list\n  target: \"\"\n  url: http://workflows?label=workflows.argoproj.io/completed=true\nmetricsConfig:\n  enabled: true\n  path: /metrics\n  port: 9090\nnamespaceParallelism: 10\nnodeEvents: {}\npodSpecLogStrategy: {}\nretentionPolicy:\n  completed: 10\n  errored: 2\n  failed: 2\nsso:\n  clientId:\n    key: \"\"\n  clientSecret:\n    key: \"\"\n  issuer: \"\"\n  redirectUrl: \"\"\n  sessionExpiry: 0s\ntelemetryConfig: {}\nworkflowDefaults:\n  metadata:\n    creationTimestamp: null\n  spec:\n    activeDeadlineSeconds: 300\n    arguments: {}\n    podSpecPatch: |\n      terminationGracePeriodSeconds: 3\n    workflowMetadata:\n      labels:\n        default-label: thisLabelIsFromWorkflowDefaults\n  status:\n    finishedAt: null\n    startedAt: null\nworkflowEvents: {}\n" component=configmap_watcher
time=2025-07-22T17:10:56.513+08:00 level=INFO msg="Persistence configuration disabled" component=configmap_watcher
time=2025-07-22T17:10:56.513+08:00 level=INFO msg="" executorImage=quay.io/argoproj/argoexec:latest executorImagePullPolicy=IfNotPresent managedNamespace=workflow component=configmap_watcher
time=2025-07-22T17:11:32.616+08:00 level=INFO msg="Received Workflow Controller config map argo/workflow-controller-configmap update" component=configmap_watcher
time=2025-07-22T17:11:32.620+08:00 level=INFO msg="Configuration:\nartifactRepository:\n  s3:\n    accessKeySecret:\n      key: accesskey\n      name: my-minio-cred\n    bucket: my-bucket-1\n    endpoint: minio:9000\n    insecure: true\n    secretKeySecret:\n      key: secretkey\n      name: my-minio-cred\ncolumns:\n- key: workflows.argoproj.io/completed\n  name: Workflow Completed\n  type: label\nexecutor:\n  imagePullPolicy: IfNotPresent\n  name: \"\"\n  resources:\n    limits:\n      cpu: 500m\n      memory: 256Mi\n    requests:\n      cpu: 100m\n      memory: 64Mi\nimages:\n  docker/whalesay:latest:\n    cmd:\n    - cowsay\ninitialDelay: 0s\nlinks:\n- name: Workflow Link\n  scope: workflow\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Pod Link\n  scope: pod\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Pod Logs Link\n  scope: pod-logs\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Event Source Logs Link\n  scope: event-source-logs\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Sensor Logs Link\n  scope: sensor-logs\n  target: \"\"\n  url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}\n- name: Completed Workflows\n  scope: workflow-list\n  target: \"\"\n  url: http://workflows?label=workflows.argoproj.io/completed=true\nmetricsConfig:\n  enabled: true\n  path: /metrics\n  port: 9090\nnamespaceParallelism: 10\nnodeEvents: {}\npodSpecLogStrategy: {}\nretentionPolicy:\n  completed: 10\n  errored: 2\n  failed: 2\nsso:\n  clientId:\n    key: \"\"\n  clientSecret:\n    key: \"\"\n  issuer: \"\"\n  redirectUrl: \"\"\n  sessionExpiry: 0s\ntelemetryConfig: {}\nworkflowDefaults:\n  metadata:\n    creationTimestamp: null\n  spec:\n    activeDeadlineSeconds: 300\n    arguments: {}\n    podSpecPatch: |\n      terminationGracePeriodSeconds: 3\n    workflowMetadata:\n      labels:\n        default-label: thisLabelIsFromWorkflowDefaults\n  status:\n    finishedAt: null\n    startedAt: null\nworkflowEvents: {}\n" component=configmap_watcher
time=2025-07-22T17:11:32.620+08:00 level=INFO msg="Persistence configuration disabled" component=configmap_watcher
time=2025-07-22T17:11:32.620+08:00 level=INFO msg="" component=configmap_watcher executorImage=quay.io/argoproj/argoexec:latest executorImagePullPolicy=IfNotPresent managedNamespace=workflow
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
