### PR TITLE
chore(migrate): mockery codegen to use packages

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,0 +1,40 @@
+# global config
+filename: "{{.InterfaceName}}.go"
+dir: "{{.InterfaceDir}}/mocks"
+outpkg: "mocks"
+mockname: "{{.InterfaceName}}"
+with-expecter: false
+# individual interface config
+
+packages:
+  github.com/argoproj/argo-workflows/v3/persist/sqldb:
+    interfaces:
+      WorkflowArchive:
+
+  github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflow:
+    interfaces:
+      WorkflowServiceClient:
+
+  github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate:
+    interfaces:
+      WorkflowTemplateServiceClient:
+
+  github.com/argoproj/argo-workflows/v3/server/auth:
+    interfaces:
+      Gatekeeper:
+
+  github.com/argoproj/argo-workflows/v3/server/auth/sso:
+    interfaces:
+      Interface:
+
+  github.com/argoproj/argo-workflows/v3/workflow/artifactrepositories:
+    interfaces:
+      Interface:
+
+  github.com/argoproj/argo-workflows/v3/workflow/executor:
+    interfaces:
+      ContainerRuntimeExecutor:
+  
+  github.com/argoproj/argo-workflows/v3/workflow/sync:
+    interfaces:
+      Throttler:

--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ argoexec-nonroot-image:
 .PHONY: codegen
 codegen: types swagger manifests $(TOOL_MOCKERY) $(GENERATED_DOCS)
 	go generate ./...
+	$(TOOL_MOCKERY) --config .mockery.yaml
  	# The generated markdown contains links to nowhere for interfaces, so remove them
 	sed -i.bak 's/\[interface{}\](#interface)/`interface{}`/g' docs/executor_swagger.md && rm -f docs/executor_swagger.md.bak
 	make --directory sdks/java USE_NIX=$(USE_NIX) generate

--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -67,8 +67,6 @@ type archivedWorkflowCount struct {
 	Total uint64 `db:"total,omitempty" json:"total"`
 }
 
-//go:generate mockery --name=WorkflowArchive
-
 type WorkflowArchive interface {
 	ArchiveWorkflow(ctx context.Context, wf *wfv1.Workflow) error
 	// list workflows, with the most recently started workflows at the beginning (i.e. index 0 is the most recent)

--- a/pkg/apiclient/workflow/workflow.go
+++ b/pkg/apiclient/workflow/workflow.go
@@ -1,3 +1,1 @@
 package workflow
-
-//go:generate mockery --name=WorkflowServiceClient

--- a/pkg/apiclient/workflowtemplate/workflowtemplate.go
+++ b/pkg/apiclient/workflowtemplate/workflowtemplate.go
@@ -1,3 +1,1 @@
 package workflowtemplate
-
-//go:generate mockery --name=WorkflowTemplateServiceClient

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -44,8 +44,6 @@ const (
 	ClaimsKey  ContextKey = "types.Claims"
 )
 
-//go:generate mockery --name=Gatekeeper
-
 type Gatekeeper interface {
 	ContextWithRequest(ctx context.Context, req interface{}) (context.Context, error)
 	Context(ctx context.Context) (context.Context, error)

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -42,8 +42,6 @@ const (
 // Matches //, /\ and both of these with whitespace in between (eg / / or / \).
 var invalidRedirectRegex = regexp.MustCompile(`[/\\](?:[\s\v]*|\.{1,2})[/\\]`)
 
-//go:generate mockery --name=Interface
-
 type Interface interface {
 	Authorize(authorization string) (*types.Claims, error)
 	HandleRedirect(writer http.ResponseWriter, request *http.Request)

--- a/workflow/artifactrepositories/artifactrepositories.go
+++ b/workflow/artifactrepositories/artifactrepositories.go
@@ -18,8 +18,6 @@ import (
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
 )
 
-//go:generate mockery --name=Interface
-
 type Interface interface {
 	// Resolve Figures out the correct repository to for a workflow.
 	Resolve(ctx context.Context, ref *wfv1.ArtifactRepositoryRef, workflowNamespace string) (*wfv1.ArtifactRepositoryRefStatus, error)

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -91,8 +91,6 @@ type Initializer interface {
 	Init(tmpl wfv1.Template) error
 }
 
-//go:generate mockery --name=ContainerRuntimeExecutor
-
 // ContainerRuntimeExecutor is the interface for interacting with a container runtime
 type ContainerRuntimeExecutor interface {
 	// GetFileContents returns the file contents of a file in a container as a string

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -10,8 +10,6 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
-//go:generate mockery --name=Throttler
-
 // Throttler allows the controller to limit number of items it is processing in parallel.
 // Items are processed in priority order, and one processing starts, other items (including higher-priority items)
 // will be kept pending until the processing is complete.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14691 

### Motivation

<!-- TODO: Say why you made your changes. -->
Migrating from mockery v2 to v3 involves multiple stages of changes.

### Modifications

<!-- TODO: Say what changes you made. -->
I have migrated from using go:generate to generate mocks to using the packages approach for mock generation.
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
![mockery](https://github.com/user-attachments/assets/08a08139-5687-46c3-b087-6d3ac8927f47)

left is `go:generate`
righit is `use package`

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

The functionality is now integrated as a Makefile target, so users can run the existing codegen command without referring to separate documentation.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
