### PR TITLE
fix: ci step titles MySQL->Database

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -389,13 +389,13 @@ jobs:
       - name: Failure debug - k3s logs
         if: ${{ failure() }}
         run: journalctl -u k3s
-      - name: Failure debug - describe MinIO/MySQL deployment
+      - name: Failure debug - describe MinIO/Database deployment
         if: ${{ failure() }}
         run: |
           set -eux
           kubectl get deploy
           kubectl describe deploy
-      - name: Failure debug - describe MinIO/MySQL pods
+      - name: Failure debug - describe MinIO/Database pods
         if: ${{ failure() }}
         run: |
           set -eux


### PR DESCRIPTION
The describe and logs step in CI show up as "MySQL" when it actually means MySQL or Postgres (or neither if none was deployed for this test suite). This PR simply changes the word MySQL to Database.