### PR TITLE
fix: GC realtime metrics after workflow completed. Fixes #14694

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1030,7 +1030,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 		DeleteFunc: func(obj interface{}) {
 			wf, ok := obj.(*unstructured.Unstructured)
 			if ok { // maybe cache.DeletedFinalStateUnknown
-				wfc.metrics.StopRealtimeMetricsForWfUID(string(wf.GetUID()))
+				wfc.metrics.DeleteRealtimeMetricsForWfUID(string(wf.GetUID()))
 			}
 		},
 	})

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -813,7 +813,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 
 	// Make sure the workflow completed.
 	if woc.wf.Status.Fulfilled() {
-		woc.controller.metrics.StopRealtimeMetricsForWfUID(string(woc.wf.GetUID()))
+		woc.controller.metrics.CompleteRealtimeMetricsForWfUID(string(woc.wf.GetUID()))
 		if err := woc.deleteTaskResults(ctx); err != nil {
 			woc.log.WithError(err).Warn(ctx, "failed to delete task-results")
 		}

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -125,17 +125,19 @@ func TestRealtimeMetricGC(t *testing.T) {
 		func() float64 { return 1.0 },
 	)
 	require.NoError(t, err)
-	assert.Len(t, m.realtimeWorkflows[wfKey], 1)
+	userData, ok := m.GetCustomMetric(name).GetUserdata().(*customMetricUserData)
+	assert.True(t, ok)
+	assert.Len(t, userData.values, 1)
 
 	go m.customMetricsGC(ctx, config.TTL)
 
 	// simulate workflow is still running.
 	// ensure we get at least one TTL run
 	time.Sleep(time.Second * 2)
-	assert.Len(t, m.realtimeWorkflows[wfKey], 1)
+	assert.Len(t, userData.values, 1)
 
 	// simulate workflow is completed.
-	m.StopRealtimeMetricsForWfUID(wfKey)
+	m.CompleteRealtimeMetricsForWfUID(wfKey)
 	timeoutTime := time.Now().Add(time.Second * 2)
 	// Ensure we get at least one TTL run
 	for time.Now().Before(timeoutTime) {
@@ -146,7 +148,7 @@ func TestRealtimeMetricGC(t *testing.T) {
 		// Sleep to prevent overloading test worker CPU.
 		time.Sleep(100 * time.Millisecond)
 	}
-	assert.Empty(t, m.realtimeWorkflows[wfKey])
+	assert.Empty(t, userData.values)
 }
 
 func TestWorkflowQueueMetrics(t *testing.T) {
@@ -184,7 +186,7 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// We've not yet fed a metric in for 123
-	m.StopRealtimeMetricsForWfUID("123")
+	m.DeleteRealtimeMetricsForWfUID("123")
 	assert.Empty(t, m.realtimeWorkflows["123"])
 
 	const key string = `metric`
@@ -207,7 +209,7 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	baseCm := m.GetCustomMetric(key)
 	assert.NotNil(t, baseCm)
 
-	m.StopRealtimeMetricsForWfUID("456")
+	m.DeleteRealtimeMetricsForWfUID("456")
 	assert.Empty(t, m.realtimeWorkflows["456"])
 
 	cm := customUserData(baseCm, true)
@@ -215,7 +217,7 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 	assert.Len(t, cm.values, 1)
 	assert.Len(t, m.realtimeWorkflows["123"], 1)
 
-	m.StopRealtimeMetricsForWfUID("123")
+	m.DeleteRealtimeMetricsForWfUID("123")
 	assert.Empty(t, m.realtimeWorkflows["123"])
 	assert.Empty(t, cm.values)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14694

### Motivation

<!-- TODO: Say why you made your changes. -->
Realtime metrics may be cleaned up, even if the workflow is still running.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
- Adding boolean value: `complete` in metric to indicate whether the metric is completed.
- Adding two functions: `CompleteRealtimeMetricsForWfUID` and `DeleteRealtimeMetricsForWfUID` to clearly distinguish whether to directly clean realtime metrics or only mark them as completed.
- Enable realtime metric gc only after its workflow is completed.

### Verification

<!-- TODO: Say how you tested your changes. -->
local test and UT


### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
