### PR TITLE
fix: prevent thundering herd on cache save/load. Fixes #14701

### DIFF
--- a/workflow/controller/cache/cache.go
+++ b/workflow/controller/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"regexp"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,7 @@ type cacheFactory struct {
 	caches     map[string]MemoizationCache
 	kubeclient kubernetes.Interface
 	namespace  string
+	lock       sync.RWMutex
 }
 
 type Factory interface {
@@ -62,6 +64,7 @@ func NewCacheFactory(ki kubernetes.Interface, ns string) Factory {
 		make(map[string]MemoizationCache),
 		ki,
 		ns,
+		sync.RWMutex{},
 	}
 }
 
@@ -74,10 +77,22 @@ const (
 
 // Returns a cache if it exists and creates it otherwise
 func (cf *cacheFactory) GetCache(ct CacheType, name string) MemoizationCache {
+	cf.lock.RLock()
+
 	idx := string(ct) + "." + name
+	if c := cf.caches[idx]; c != nil {
+		cf.lock.RUnlock()
+		return c
+	}
+	cf.lock.RUnlock()
+
+	cf.lock.Lock()
+	defer cf.lock.Unlock()
+
 	if c := cf.caches[idx]; c != nil {
 		return c
 	}
+
 	switch ct {
 	case ConfigMapCache:
 		c := NewConfigMapCache(cf.namespace, cf.kubeclient, name)

--- a/workflow/controller/cache/configmap_cache.go
+++ b/workflow/controller/cache/configmap_cache.go
@@ -74,7 +74,7 @@ func (c *configMapCache) Load(ctx context.Context, key string) (*Entry, error) {
 		Steps:    5,
 		Cap:      30 * time.Second,
 	}, func(err error) bool {
-		return argoerr.IsTransientErr(ctx, err) || (apierr.IsConflict(err) && strings.Contains(err.Error(), ""))
+		return argoerr.IsTransientErr(ctx, err) || (apierr.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on configmaps"))
 	}, func() error {
 		var innerErr error
 		entry, innerErr = c.load(ctx, key)

--- a/workflow/controller/cache/configmap_cache.go
+++ b/workflow/controller/cache/configmap_cache.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -74,7 +73,7 @@ func (c *configMapCache) Load(ctx context.Context, key string) (*Entry, error) {
 		Steps:    5,
 		Cap:      30 * time.Second,
 	}, func(err error) bool {
-		return argoerr.IsTransientErr(ctx, err) || (apierr.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on configmaps"))
+		return argoerr.IsTransientErr(ctx, err) || apierr.IsConflict(err)
 	}, func() error {
 		var innerErr error
 		entry, innerErr = c.load(ctx, key)
@@ -141,9 +140,9 @@ func (c *configMapCache) Save(ctx context.Context, key string, nodeID string, va
 		Steps:    5,
 		Cap:      30 * time.Second,
 	}, func(err error) bool {
-		return argoerr.IsTransientErr(ctx, err) || (apierr.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on configmaps"))
+		return argoerr.IsTransientErr(ctx, err) || apierr.IsConflict(err)
 	}, func() error {
-		var innerErr = c.save(ctx, key, nodeID, value)
+		innerErr := c.save(ctx, key, nodeID, value)
 		return innerErr
 	})
 	return err

--- a/workflow/controller/cache/configmap_cache.go
+++ b/workflow/controller/cache/configmap_cache.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,8 +13,12 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	argoerr "github.com/argoproj/argo-workflows/v3/util/errors"
 	"github.com/argoproj/argo-workflows/v3/util/logging"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
@@ -61,6 +66,24 @@ func (c *configMapCache) validateConfigmap(ctx context.Context, cm *apiv1.Config
 }
 
 func (c *configMapCache) Load(ctx context.Context, key string) (*Entry, error) {
+	var entry *Entry
+	err := retry.OnError(kwait.Backoff{
+		Duration: time.Second,
+		Factor:   2,
+		Jitter:   0.1,
+		Steps:    5,
+		Cap:      30 * time.Second,
+	}, func(err error) bool {
+		return argoerr.IsTransientErr(ctx, err) || (apierr.IsConflict(err) && strings.Contains(err.Error(), ""))
+	}, func() error {
+		var innerErr error
+		entry, innerErr = c.load(ctx, key)
+		return innerErr
+	})
+	return entry, err
+}
+
+func (c *configMapCache) load(ctx context.Context, key string) (*Entry, error) {
 	if !cacheKeyRegex.MatchString(key) {
 		return nil, fmt.Errorf("invalid cache key: %s", key)
 	}
@@ -74,13 +97,11 @@ func (c *configMapCache) Load(ctx context.Context, key string) (*Entry, error) {
 			c.logError(ctx, err, logging.Fields{}, "config map cache miss: config map does not exist")
 			return nil, nil
 		}
-		c.logError(ctx, err, logging.Fields{}, "Error loading config map cache")
-		return nil, fmt.Errorf("could not load config map cache: %w", err)
-	} else {
-		err := c.validateConfigmap(ctx, cm)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+	err = c.validateConfigmap(ctx, cm)
+	if err != nil {
+		return nil, err
 	}
 
 	c.logInfo(ctx, logging.Fields{}, "config map cache loaded")
@@ -107,14 +128,28 @@ func (c *configMapCache) Load(ctx context.Context, key string) (*Entry, error) {
 
 	_, err = c.kubeClient.CoreV1().ConfigMaps(c.namespace).Update(ctx, cm, metav1.UpdateOptions{})
 	if err != nil {
-		c.logError(ctx, err, logging.Fields{}, "Error updating last hit timestamp on cache")
-		return nil, fmt.Errorf("error updating last hit timestamp on cache: %w", err)
+		return nil, err
 	}
-
 	return &entry, nil
 }
 
 func (c *configMapCache) Save(ctx context.Context, key string, nodeID string, value *wfv1.Outputs) error {
+	err := retry.OnError(kwait.Backoff{
+		Duration: time.Second,
+		Factor:   2,
+		Jitter:   0.1,
+		Steps:    5,
+		Cap:      30 * time.Second,
+	}, func(err error) bool {
+		return argoerr.IsTransientErr(ctx, err) || (apierr.IsConflict(err) && strings.Contains(err.Error(), "Operation cannot be fulfilled on configmaps"))
+	}, func() error {
+		var innerErr = c.save(ctx, key, nodeID, value)
+		return innerErr
+	})
+	return err
+}
+
+func (c *configMapCache) save(ctx context.Context, key string, nodeID string, value *wfv1.Outputs) error {
 	if !cacheKeyRegex.MatchString(key) {
 		errString := fmt.Sprintf("invalid cache key: %s", key)
 		err := errors.New(errString)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14701

### Motivation
Empirical data shows a thundering herd problem on configmaps when workflows are highly parallel. 

### Modifications

We do not gain exclusive access to configmaps on load/save operations despite the current code suggesting that we do. I believe this is a result of many `MemoizationCache` objects being created. This change ensures that we obtain a lock on the cacheFactory before a call to `GetCache`, this should ensure only one cache. 

I've also added a retry block on save/load operations, treating conflict errors as transient errors. 
The decision to not add to the TransientError function was deliberate. I think conflict errors being treated as transient
errors are somewhat context dependent, hence the omission. 

This was a small fix, I think the ideal fix for these sort of issues is much more work. We should have a priortised queue along with batching for these type of updates to k8s objects. It doesn't really make sense to perform `Load` 10000 times because 10000 parallel nodes used the cache, we can also batch updates to a configmap since the data is partitioned by key. This fix was what I initially wanted to attempt when I found this problem, but I found it to be:
a) too time consuming, realistically take a week or more
b) hard to get right, the merge strategy becomes complicated when duplicate values are present for the same key. 

So I gave up on this idea.

### Verification

None needed, no semantic change to how configmaps work.

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
