### PR TITLE
chore: move e2e test content from literals to files

### DIFF
--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -22,41 +22,7 @@ type AgentSuite struct {
 
 func (s *AgentSuite) TestParallel() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: http-template-par-
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: one
-            template: http
-            arguments:
-              parameters: [{name: url, value: "https://argoproj.github.io"}]
-          - name: two
-            template: http
-            arguments:
-              parameters: [{name: url, value: "https://argoproj.github.io"}]
-          - name: three
-            template: http
-            arguments:
-              parameters: [{name: url, value: "https://argoproj.github.io"}]
-          - name: four
-            template: http
-            arguments:
-              parameters: [{name: url, value: "https://argoproj.github.io"}]
-    - name: http
-      inputs:
-        parameters:
-          - name: url
-      http:
-        url: "{{inputs.parameters.url}}"
-`).
+		Workflow("@functional/http-template-par.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted).
@@ -94,49 +60,7 @@ spec:
 
 func (s *AgentSuite) TestStatusCondition() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: http-template-condition-
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: http-status-is-201-fails
-            template: http-status-is-201
-            arguments:
-              parameters: [{name: url, value: "http://httpbin:9100/status/200"}]
-          - name: http-status-is-201-succeeds
-            template: http-status-is-201
-            arguments:
-              parameters: [{name: url, value: "http://httpbin:9100/status/201"}]
-          - name: http-body-contains-google-fails
-            template: http-body-contains-google
-            arguments:
-              parameters: [{name: url, value: "http://httpbin:9100/status/200"}]
-          - name: http-body-contains-google-succeeds
-            template: http-body-contains-google
-            arguments:
-              parameters: [{name: url, value: "https://google.com"}]
-    - name: http-status-is-201
-      inputs:
-        parameters:
-          - name: url
-      http:
-        successCondition: "response.statusCode == 201"
-        url: "{{inputs.parameters.url}}"
-    - name: http-body-contains-google
-      inputs:
-        parameters:
-          - name: url
-      http:
-        successCondition: "response.body contains \"google\""
-        url: "{{inputs.parameters.url}}"
-`).
+		Workflow("@functional/http-template-condition.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(2 * time.Minute).

--- a/test/e2e/api/archie-7.yaml
+++ b/test/e2e/api/archie-7.yaml
@@ -1,0 +1,11 @@
+metadata:
+  generateName: archie-
+  labels:
+    foo: 1
+spec:
+  entrypoint: run-archie
+  templates:
+    - name: run-archie
+      container:
+        image: argoproj/argosay:v2
+        args: [echo, "hello \\u0001F44D"]

--- a/test/e2e/api/archie.yaml
+++ b/test/e2e/api/archie.yaml
@@ -1,0 +1,11 @@
+metadata:
+  generateName: archie-
+  labels:
+    foo: 1
+spec:
+  entrypoint: run-archie
+  templates:
+    - name: run-archie
+      container:
+        image: argoproj/argosay:v2
+        args: [echo, "hello \u0000"]

--- a/test/e2e/api/betty.yaml
+++ b/test/e2e/api/betty.yaml
@@ -1,0 +1,10 @@
+metadata:
+  generateName: betty-
+  labels:
+    foo: 2
+spec:
+  entrypoint: run-betty
+  templates:
+    - name: run-betty
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/api/event-consumer-2.yaml
+++ b/test/e2e/api/event-consumer-2.yaml
@@ -1,0 +1,13 @@
+metadata:
+  name: event-consumer
+spec:
+  event:
+    selector: payload.appellation != "" && metadata["x-argo-e2e"] == ["true"]
+  submit:
+    workflowTemplateRef:
+      name: event-consumer
+    arguments:
+      parameters:
+        - name: appellation
+          valueFrom:
+            event: payload.appellation

--- a/test/e2e/api/event-consumer-3.yaml
+++ b/test/e2e/api/event-consumer-3.yaml
@@ -1,0 +1,31 @@
+metadata:
+  name: event-consumer
+spec:
+  entrypoint: main
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  arguments:
+    parameters:
+      - name: salutation
+        value: "hello"
+  templates:
+    - name: main
+      steps:
+      - - name: a
+          template: argosay
+          arguments:
+            parameters:
+            - name: salutation
+              value: "{{workflow.parameters.salutation}}"
+            - name: appellation
+              value: "{{workflow.parameters.appellation}}"
+
+    - name: argosay
+      inputs:
+        parameters:
+          - name: salutation
+          - name: appellation
+      container:
+         image: argoproj/argosay:v2
+         args: [echo, "{{inputs.parameters.salutation}} {{inputs.parameters.appellation}}"]

--- a/test/e2e/api/event-consumer.yaml
+++ b/test/e2e/api/event-consumer.yaml
@@ -1,0 +1,9 @@
+metadata:
+  name: event-consumer
+spec:
+  event:
+    selector: true
+  submit:
+    workflowTemplateRef:
+      name: event-consumer
+      clusterScope: true

--- a/test/e2e/api/github-webhook-0.yaml
+++ b/test/e2e/api/github-webhook-0.yaml
@@ -1,0 +1,8 @@
+metadata:
+  name: github-webhook
+spec:
+  event:
+    selector: metadata["x-github-event"] == ["push"]
+  submit:
+    workflowTemplateRef:
+      name: github-webhook

--- a/test/e2e/api/github-webhook.yaml
+++ b/test/e2e/api/github-webhook.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: github-webhook
+spec:
+  entrypoint: main
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  templates:
+    - name: main
+      container:
+         image: argoproj/argosay:v2

--- a/test/e2e/api/jughead.yaml
+++ b/test/e2e/api/jughead.yaml
@@ -1,0 +1,12 @@
+metadata:
+  generateName: jughead-
+  labels:
+    foo: 3
+spec:
+  entrypoint: run-jughead
+  templates:
+    - name: run-jughead
+      container:
+        image: argoproj/argosay:v2
+        command: [sh, -c]
+        args: ["echo intentional failure; exit 1"]

--- a/test/e2e/api/malformed.yaml
+++ b/test/e2e/api/malformed.yaml
@@ -1,0 +1,2 @@
+metadata:
+  name: malformed

--- a/test/e2e/api/test-cron-wf-basic.yaml
+++ b/test/e2e/api/test-cron-wf-basic.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2
+          imagePullPolicy: IfNotPresent
+          command: ["sh", -c]
+          args: ["echo hello"]

--- a/test/e2e/cli/suspend-template.yaml
+++ b/test/e2e/cli/suspend-template.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: suspend-template-
+spec:
+  entrypoint: suspend
+  templates:
+  - name: suspend
+    steps:
+    - - name: approve
+        template: approve
+      - name: approve-no-vars
+        template: approve-no-vars
+    - - name: release
+        template: whalesay
+        arguments:
+          parameters:
+            - name: message
+              value: "{{steps.approve.outputs.parameters.message}}"
+
+  - name: approve
+    suspend: {}
+    outputs:
+      parameters:
+        - name: message
+          valueFrom:
+            supplied: {}
+
+  - name: approve-no-vars
+    suspend: {}
+
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: message
+    container:
+      image: argoproj/argosay:v2
+      args: ["echo", "{{inputs.parameters.message}}"]

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1838,46 +1838,7 @@ func (s *CLISuite) TestArchiveLabel() {
 
 func (s *CLISuite) TestArgoSetOutputs() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: suspend-template-
-spec:
-  entrypoint: suspend
-  templates:
-  - name: suspend
-    steps:
-    - - name: approve
-        template: approve
-      - name: approve-no-vars
-        template: approve-no-vars
-    - - name: release
-        template: whalesay
-        arguments:
-          parameters:
-            - name: message
-              value: "{{steps.approve.outputs.parameters.message}}"
-
-  - name: approve
-    suspend: {}
-    outputs:
-      parameters:
-        - name: message
-          valueFrom:
-            supplied: {}
-
-  - name: approve-no-vars
-    suspend: {}
-
-  - name: whalesay
-    inputs:
-      parameters:
-        - name: message
-    container:
-      image: argoproj/argosay:v2
-      args: ["echo", "{{inputs.parameters.message}}"]
-`).
+		Workflow("@cli/suspend-template.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToStart).

--- a/test/e2e/cluster_workflow_template_test.go
+++ b/test/e2e/cluster_workflow_template_test.go
@@ -21,24 +21,7 @@ func (s *ClusterWorkflowTemplateSuite) TestNestedClusterWorkflowTemplate() {
 		ClusterWorkflowTemplate("@smoke/cluster-workflow-template-whalesay-template.yaml").
 		When().CreateClusterWorkflowTemplates().
 		Given().
-		Workflow(`
-metadata:
-  generateName: cwft-wf-
-spec:
-  entrypoint: whalesay
-  templates:
-  - name: whalesay
-    steps:
-    - - name: call-whalesay-template
-        templateRef:
-          name: cluster-workflow-template-nested-template 
-          template: whalesay-template
-          clusterScope: true
-        arguments:
-          parameters:
-          - name: message
-            value: hello from nested
-`).When().
+		Workflow("@functional/cwft-wf.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded)
 }

--- a/test/e2e/corefunctional/basic.yaml
+++ b/test/e2e/corefunctional/basic.yaml
@@ -1,0 +1,10 @@
+metadata:
+  generateName: basic-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+      # ordering of the containers in the next line is intentionally reversed
+      podSpecPatch: '{"terminationGracePeriodSeconds":5, "containers":[{"name":"main", "resources":{"limits":{"cpu": "100m"}}}, {"name":"wait", "resources":{"limits":{"cpu": "101m"}}}]}'

--- a/test/e2e/corefunctional/containerset-no-retry-fail.yaml
+++ b/test/e2e/corefunctional/containerset-no-retry-fail.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: containerset-no-retry-fail-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      containerSet:
+        containers:
+          - name: a
+            image: argoproj/argosay:v2
+            command: [sh, -c]
+            args: ['FILE=test.yml; EXITCODE=1; if test -f "$FILE"; then EXITCODE=0; else touch $FILE; fi; exit $EXITCODE']

--- a/test/e2e/corefunctional/containerset-retry-success.yaml
+++ b/test/e2e/corefunctional/containerset-retry-success.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: containerset-retry-success-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      containerSet:
+        containers:
+          - name: a
+            image: argoproj/argosay:v2
+            command: [sh, -c]
+            args: ['FILE=test.yml; EXITCODE=1; if test -f "$FILE"; then EXITCODE=0; else touch $FILE; fi; exit $EXITCODE']
+        retryStrategy:
+          retries: 2
+          duration: "5s"

--- a/test/e2e/corefunctional/continue-on-fail.yaml
+++ b/test/e2e/corefunctional/continue-on-fail.yaml
@@ -1,0 +1,31 @@
+metadata:
+  generateName: continue-on-fail-
+spec:
+  entrypoint: main
+  parallelism: 2
+  templates:
+  - name: main
+    steps:
+    - - name: A
+        template: whalesay
+      - name: B
+        template: boom
+        continueOn:
+          failed: true
+    - - name: C
+        template: whalesay
+
+  - name: boom
+    dag:
+      tasks:
+      - name: B-1
+        template: whalesplosion
+
+  - name: whalesay
+    container:
+      image: argoproj/argosay:v2
+
+  - name: whalesplosion
+    container:
+      image: argoproj/argosay:v2
+      args: [ exit, "1" ]

--- a/test/e2e/corefunctional/continue-on-failed-dag.yaml
+++ b/test/e2e/corefunctional/continue-on-failed-dag.yaml
@@ -1,0 +1,26 @@
+metadata:
+  generateName: continue-on-failed-dag-
+spec:
+  entrypoint: workflow-ignore
+  templates:
+    - name: workflow-ignore
+      dag:
+        failFast: false
+        tasks:
+          - name: F
+            template: fail
+            continueOn:
+              failed: true
+          - name: P
+            template: pass
+            dependencies:
+              - F
+
+    - name: pass
+      container:
+        image: argoproj/argosay:v2
+
+    - name: fail
+      container:
+        image: argoproj/argosay:v2
+        args: [ exit, "1" ]

--- a/test/e2e/corefunctional/dag-memoize-noout.yaml
+++ b/test/e2e/corefunctional/dag-memoize-noout.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-memoize-noout-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+    - name: hello-hello-hello
+      steps:
+        - - name: hello1
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+        - - name: hello2a
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+    - name: memostep
+      inputs:
+        parameters:
+        - name: message
+      memoize:
+        key: "{{inputs.parameters.message}}"
+        maxAge: "10s"
+        cache:
+          configMap:
+            name: my-config-memo-dag
+      dag:
+        tasks:
+        - name: cache
+          template: whalesay
+          arguments:
+            parameters: [{name: message, value: "{{inputs.parameters.message}}"}]
+    - name: whalesay
+      inputs:
+        parameters:
+        - name: message
+      container:
+        image: argoproj/argosay:v2
+        command: [echo]
+        args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/corefunctional/dag-memoize.yaml
+++ b/test/e2e/corefunctional/dag-memoize.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-memoize-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+    - name: hello-hello-hello
+      steps:
+        - - name: hello1
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+        - - name: hello2a
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+    - name: memostep
+      inputs:
+        parameters:
+        - name: message
+      memoize:
+        key: "{{inputs.parameters.message}}"
+        maxAge: "10s"
+        cache:
+          configMap:
+            name: my-config-memo-dag
+      dag:
+        tasks:
+        - name: cache
+          template: whalesay
+          arguments:
+            parameters: [{name: message, value: "{{inputs.parameters.message}}"}]
+      outputs:
+        parameters:
+        - name: output
+          valueFrom:
+            Parameter: "{{tasks.cache.outputs.result}}"
+    - name: whalesay
+      inputs:
+        parameters:
+        - name: message
+      container:
+        image: argoproj/argosay:v2
+        command: [echo]
+        args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/corefunctional/metadata.yaml
+++ b/test/e2e/corefunctional/metadata.yaml
@@ -1,0 +1,16 @@
+metadata:
+  generateName: metadata-
+spec:
+  arguments:
+    parameters:
+      - name: foo
+        value: bar
+  workflowMetadata:
+    labelsFrom:
+      my-label:
+        expression: workflow.parameters.foo
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/corefunctional/param-ads.yaml
+++ b/test/e2e/corefunctional/param-ads.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: param-ads-
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: ads
+        value: "5"
+  templates:
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: ads
+    activeDeadlineSeconds: "{{inputs.parameters.ads}}"
+    container:
+      image: argoproj/argosay:v2
+      args: [sleep, 10s]

--- a/test/e2e/corefunctional/param-limit.yaml
+++ b/test/e2e/corefunctional/param-limit.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: param-limit-
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: limit
+        value: "1"
+  templates:
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: limit
+    retryStrategy:
+      limit: "{{inputs.parameters.limit}}"
+    container:
+      image: argoproj/argosay:v2
+      args: [exit, 1]

--- a/test/e2e/corefunctional/pending-retry-workflow-with-retry-strategy.yaml
+++ b/test/e2e/corefunctional/pending-retry-workflow-with-retry-strategy.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: pending-retry-workflow-with-retry-strategy-
+spec:
+  entrypoint: dag
+  templates:
+  - name: cowsay
+    retryStrategy:
+      limit: 1
+    container:
+      image: argoproj/argosay:v2
+      args: ["echo", "a"]
+      resources:
+        limits:
+          memory: 128M
+  - name: dag
+    dag:
+      tasks:
+      - name: a
+        template: cowsay
+      - name: b
+        template: cowsay

--- a/test/e2e/corefunctional/pending-retry-workflow.yaml
+++ b/test/e2e/corefunctional/pending-retry-workflow.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: pending-retry-workflow-
+spec:
+  entrypoint: dag
+  templates:
+  - name: cowsay
+    container:
+      image: argoproj/argosay:v2
+      args: ["echo", "a"]
+      resources:
+        limits:
+          memory: 128M
+  - name: dag
+    dag:
+      tasks:
+      - name: a
+        template: cowsay
+      - name: b
+        template: cowsay

--- a/test/e2e/corefunctional/script-nonroot.yaml
+++ b/test/e2e/corefunctional/script-nonroot.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: script-nonroot-
+spec:
+  entrypoint: whalesay
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+  templates:
+    - name: whalesay
+      script:
+        image: argoproj/argosay:v2
+        command: ["bash"]
+        source: |
+          ls -l /argo/staging
+          cat /argo/stahing/script
+          sleep 10s

--- a/test/e2e/corefunctional/steps-memoize-noout.yaml
+++ b/test/e2e/corefunctional/steps-memoize-noout.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-memoize-noout-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+    - name: hello-hello-hello
+      steps:
+        - - name: hello1
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+        - - name: hello2a
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+    - name: memostep
+      inputs:
+        parameters:
+        - name: message
+      memoize:
+        key: "{{inputs.parameters.message}}"
+        maxAge: "10s"
+        cache:
+          configMap:
+            name: my-config-memo-step-no-out
+      steps:
+      - - name: cache
+          template: whalesay
+          arguments:
+            parameters: [{name: message, value: "{{inputs.parameters.message}}"}]
+    - name: whalesay
+      inputs:
+        parameters:
+        - name: message
+      container:
+        image: argoproj/argosay:v2
+        command: [echo]
+        args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/corefunctional/steps-memoize.yaml
+++ b/test/e2e/corefunctional/steps-memoize.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-memoize-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+    - name: hello-hello-hello
+      steps:
+        - - name: hello1
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+        - - name: hello2a
+            template: memostep
+            arguments:
+              parameters: [{name: message, value: "hello1"}]
+    - name: memostep
+      inputs:
+        parameters:
+        - name: message
+      memoize:
+        key: "{{inputs.parameters.message}}"
+        maxAge: "10s"
+        cache:
+          configMap:
+            name: my-config-memo-step
+      steps:
+      - - name: cache
+          template: whalesay
+          arguments:
+            parameters: [{name: message, value: "{{inputs.parameters.message}}"}]
+      outputs:
+        parameters:
+        - name: output
+          valueFrom:
+            Parameter: "{{steps.cache.outputs.result}}"
+    - name: whalesay
+      inputs:
+        parameters:
+        - name: message
+      container:
+        image: argoproj/argosay:v2
+        command: [echo]
+        args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/corefunctional/steps-tmpl-timeout-12.yaml
+++ b/test/e2e/corefunctional/steps-tmpl-timeout-12.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-tmpl-timeout-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+  - name: hello-hello-hello
+    steps:
+    - - name: hello1
+        template: whalesay
+        arguments:
+          parameters: [{name: message, value: "5s"}]
+      - name: hello2a
+        template: whalesay
+        arguments:
+          parameters: [{name: message, value: "10s"}]
+      - name: hello2b
+        template: whalesay
+        arguments:
+          parameters: [{name: message, value: "15s"}]
+
+  - name: whalesay
+    timeout: "{{inputs.parameters.message}}"
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: argoproj/argosay:v2
+      args: [sleep, 30s]

--- a/test/e2e/corefunctional/steps-tmpl-timeout.yaml
+++ b/test/e2e/corefunctional/steps-tmpl-timeout.yaml
@@ -1,0 +1,31 @@
+metadata:
+  generateName: steps-tmpl-timeout-
+spec:
+  entrypoint: hello-hello-hello
+  templates:
+  - name: hello-hello-hello
+    steps:
+    - - name: hello1
+        template: whalesay
+        arguments:
+          parameters: [{name: message, value: "5s"}]
+      - name: hello2a
+        template: whalesay
+        arguments:
+          parameters: [{name: message, value: "10s"}]
+      - name: hello2b
+        template: whalesay
+        arguments:
+          parameters: [{name: message, value: "15s"}]
+
+  - name: whalesay
+    resources:
+      limits:
+        memory: 145M
+    timeout: "{{inputs.parameters.message}}"
+    inputs:
+      parameters:
+      - name: message
+    container:
+      image: argoproj/argosay:v2
+      args: [sleep, 30s]

--- a/test/e2e/corefunctional/test-exit-handler-6.yaml
+++ b/test/e2e/corefunctional/test-exit-handler-6.yaml
@@ -1,0 +1,5 @@
+metadata:
+  generateName: test-exit-handler-
+spec:
+  workflowTemplateRef:
+    name: test-exit-handler

--- a/test/e2e/corefunctional/test-exit-handler-7.yaml
+++ b/test/e2e/corefunctional/test-exit-handler-7.yaml
@@ -1,0 +1,14 @@
+metadata:
+  name: test-exit-handler
+spec:
+  entrypoint: main
+  onExit: exit-handler
+  templates:
+    - name: main
+      container:
+        name: main
+        image: argoproj/argosay:v2
+    - name: exit-handler
+      templateRef:
+        name: nonexistent
+        template: exit-handler

--- a/test/e2e/corefunctional/test-exit-handler.yaml
+++ b/test/e2e/corefunctional/test-exit-handler.yaml
@@ -1,0 +1,13 @@
+metadata:
+  name: test-exit-handler
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        parameters:
+        - name: message
+      container:
+        image: argoproj/argosay:v2
+        command: [cowsay]
+        args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/corefunctional/test-lifecycle-hook.yaml
+++ b/test/e2e/corefunctional/test-lifecycle-hook.yaml
@@ -1,0 +1,17 @@
+metadata:
+  generateName: test-lifecycle-hook-
+spec:
+  entrypoint: hooks-exit-test
+  templates:
+  - name: hooks-exit-test
+    container:
+      image: argoproj/argosay:v2
+    hooks:
+      exit:
+        templateRef:
+          name: test-exit-handler
+          template: main
+        arguments:
+          parameters:
+            - name: message
+              value: "hello world"

--- a/test/e2e/corefunctional/workflow-ttl.yaml
+++ b/test/e2e/corefunctional/workflow-ttl.yaml
@@ -1,0 +1,10 @@
+metadata:
+  generateName: workflow-ttl-
+spec:
+  ttlStrategy:
+    secondsAfterCompletion: 0
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/cron/test-cron-wf-basic-allow.yaml
+++ b/test/e2e/cron/test-cron-wf-basic-allow.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic-allow
+  labels:
+
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2
+          args: ["sleep", "300s"]

--- a/test/e2e/cron/test-cron-wf-basic-forbid.yaml
+++ b/test/e2e/cron/test-cron-wf-basic-forbid.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic-forbid
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2
+          args: ["sleep", "300s"]

--- a/test/e2e/cron/test-cron-wf-basic-replace.yaml
+++ b/test/e2e/cron/test-cron-wf-basic-replace.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic-replace
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Replace"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2
+          args: ["sleep", "300s"]

--- a/test/e2e/cron/test-cron-wf-basic-resume.yaml
+++ b/test/e2e/cron/test-cron-wf-basic-resume.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic-resume
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2

--- a/test/e2e/cron/test-cron-wf-basic-suspend.yaml
+++ b/test/e2e/cron/test-cron-wf-basic-suspend.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic-suspend
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2

--- a/test/e2e/cron/test-cron-wf-basic.yaml
+++ b/test/e2e/cron/test-cron-wf-basic.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-basic
+spec:
+  schedules:
+    -  "* * * * *"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2

--- a/test/e2e/cron/test-cron-wf-fail-1.yaml
+++ b/test/e2e/cron/test-cron-wf-fail-1.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-fail-1
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 1
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2
+          args: ["exit", "1"]

--- a/test/e2e/cron/test-cron-wf-stop-condition-failed.yaml
+++ b/test/e2e/cron/test-cron-wf-stop-condition-failed.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-stop-condition-failed
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Allow"
+  stopStrategy:
+    expression: "cronworkflow.failed >= 1"
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2
+          args: ["exit", "1"]

--- a/test/e2e/cron/test-cron-wf-stop-condition-succeeded.yaml
+++ b/test/e2e/cron/test-cron-wf-stop-condition-succeeded.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-stop-condition-succeeded
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  stopStrategy:
+    expression: "cronworkflow.succeeded >= 1"
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+            image: argoproj/argosay:v2
+            command: [/argosay]

--- a/test/e2e/cron/test-cron-wf-succeed-1.yaml
+++ b/test/e2e/cron/test-cron-wf-succeed-1.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-cron-wf-succeed-1
+spec:
+  schedules:
+    - "* * * * *"
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2

--- a/test/e2e/cron/test-multiple-with-timezone.yaml
+++ b/test/e2e/cron/test-multiple-with-timezone.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: test-multiple-with-timezone
+spec:
+  schedules:
+    - "* * * * *"
+    - "0 1 * * *"
+  timezone: "America/Los_Angeles"
+  concurrencyPolicy: "Allow"
+  startingDeadlineSeconds: 0
+  successfulJobsHistoryLimit: 4
+  failedJobsHistoryLimit: 2
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+  workflowSpec:
+    podGC:
+      strategy: OnPodCompletion
+    entrypoint: whalesay
+    templates:
+      - name: whalesay
+        container:
+          image: argoproj/argosay:v2

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -36,28 +36,7 @@ func (s *CronSuite) TearDownSubTest() {
 func (s *CronSuite) TestBasic() {
 	s.Run("TestBasic", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-basic
-spec:
-  schedules:
-    -  "* * * * *"
-  concurrencyPolicy: "Allow"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2`).
+			CronWorkflow("@cron/test-cron-wf-basic.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -111,28 +90,7 @@ spec:
 	})
 	s.Run("TestSuspend", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-basic-suspend
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Allow"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2`).
+			CronWorkflow("@cron/test-cron-wf-basic-suspend.yaml").
 			When().
 			CreateCronWorkflow().
 			SuspendCronWorkflow().
@@ -143,28 +101,7 @@ spec:
 	})
 	s.Run("TestResume", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-basic-resume
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Allow"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2`).
+			CronWorkflow("@cron/test-cron-wf-basic-resume.yaml").
 			When().
 			CreateCronWorkflow().
 			ResumeCronWorkflow("test-cron-wf-basic-resume").
@@ -175,29 +112,7 @@ spec:
 	})
 	s.Run("TestBasicForbid", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-basic-forbid
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Forbid"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2
-          args: ["sleep", "300s"]`).
+			CronWorkflow("@cron/test-cron-wf-basic-forbid.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflow(fixtures.ToBeRunning).
@@ -210,31 +125,7 @@ spec:
 	})
 	s.Run("TestBasicAllow", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-basic-allow
-  labels:
-
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Allow"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2
-          args: ["sleep", "300s"]`).
+			CronWorkflow("@cron/test-cron-wf-basic-allow.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflowListCount(3*time.Minute, 2).
@@ -245,29 +136,7 @@ spec:
 	})
 	s.Run("TestBasicReplace", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-basic-replace
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Replace"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2
-          args: ["sleep", "300s"]`).
+			CronWorkflow("@cron/test-cron-wf-basic-replace.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflow(fixtures.ToBeRunning).
@@ -282,28 +151,7 @@ spec:
 	})
 	s.Run("TestSuccessfulJobHistoryLimit", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-succeed-1
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Forbid"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2`).
+			CronWorkflow("@cron/test-cron-wf-succeed-1.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -317,29 +165,7 @@ spec:
 	})
 	s.Run("TestFailedJobHistoryLimit", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-fail-1
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Forbid"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 1
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2
-          args: ["exit", "1"]`).
+			CronWorkflow("@cron/test-cron-wf-fail-1.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflow(fixtures.ToBeFailed).
@@ -353,31 +179,7 @@ spec:
 	})
 	s.Run("TestStoppingConditionWithSucceeded", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-stop-condition-succeeded
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Allow"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  stopStrategy:
-    expression: "cronworkflow.succeeded >= 1"
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-            image: argoproj/argosay:v2
-            command: [/argosay]`).
+			CronWorkflow("@cron/test-cron-wf-stop-condition-succeeded.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForCronWorkflowCompleted(3 * time.Minute).
@@ -391,28 +193,7 @@ spec:
 	})
 	s.Run("TestStoppingConditionWithFailed", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-cron-wf-stop-condition-failed
-spec:
-  schedules:
-    - "* * * * *"
-  concurrencyPolicy: "Allow"
-  stopStrategy:
-    expression: "cronworkflow.failed >= 1"
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2
-          args: ["exit", "1"]`).
+			CronWorkflow("@cron/test-cron-wf-stop-condition-failed.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForCronWorkflowCompleted(3 * time.Minute).
@@ -426,30 +207,7 @@ spec:
 	})
 	s.Run("TestMultipleWithTimezone", func() {
 		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
-kind: CronWorkflow
-metadata:
-  name: test-multiple-with-timezone
-spec:
-  schedules:
-    - "* * * * *"
-    - "0 1 * * *"
-  timezone: "America/Los_Angeles"
-  concurrencyPolicy: "Allow"
-  startingDeadlineSeconds: 0
-  successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
-  workflowMetadata:
-    labels:
-      workflows.argoproj.io/test: "true"
-  workflowSpec:
-    podGC:
-      strategy: OnPodCompletion
-    entrypoint: whalesay
-    templates:
-      - name: whalesay
-        container:
-          image: argoproj/argosay:v2`).
+			CronWorkflow("@cron/test-multiple-with-timezone.yaml").
 			When().
 			CreateCronWorkflow().
 			WaitForWorkflow(fixtures.ToBeSucceeded).

--- a/test/e2e/executor/artifact-volume-claim.yaml
+++ b/test/e2e/executor/artifact-volume-claim.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: artifact-volume-claim-
+spec:
+  entrypoint: artifact-volume-claim
+  volumeClaimTemplates:
+    - metadata:
+        name: vol
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Mi
+  templates:
+  - name: artifact-volume-claim
+    inputs:
+      artifacts:
+      - name: artifact-volume-claim
+        path: /tmp/input/input.txt
+        raw:
+          data: abc
+    container:
+      image: argoproj/argosay:v2
+      command: [sh, -c]
+      args: ["ls -l"]
+      workingDir: /tmp
+      volumeMounts:
+      - name: vol
+        mountPath: /tmp

--- a/test/e2e/executor/containerset-logs.yaml
+++ b/test/e2e/executor/containerset-logs.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: containerset-logs-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      containerSet:
+        containers:
+          - name: a
+            image: argoproj/argosay:v2
+          - name: b
+            image: argoproj/argosay:v2

--- a/test/e2e/executor/default-params.yaml
+++ b/test/e2e/executor/default-params.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: default-params-
+spec:
+  entrypoint: start
+  templates:
+  - name: start
+    steps:
+      - - name: generate-1
+          template: generate
+      - - name: generate-2
+          when: "True == False"
+          template: generate
+    outputs:
+      parameters:
+        - name: nested-out-parameter
+          valueFrom:
+            default: "Default value"
+            parameter: "{{steps.generate-2.outputs.parameters.out-parameter}}"
+
+  - name: generate
+    container:
+      image: argoproj/argosay:v2
+      args: [echo, my-output-parameter, /tmp/my-output-parameter.txt]
+    outputs:
+      parameters:
+      - name: out-parameter
+        valueFrom:
+          path: /tmp/my-output-parameter.txt

--- a/test/e2e/executor/git-depth.yaml
+++ b/test/e2e/executor/git-depth.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: git-depth-
+spec:
+  entrypoint: git-depth
+  templates:
+  - name: git-depth
+    inputs:
+      artifacts:
+      - name: git-repo
+        path: /tmp/git
+        git:
+          repo: https://github.com/argoproj-labs/go-git.git
+          revision: master
+          depth: 1
+    container:
+      image: argoproj/argosay:v2
+      command: [sh, -c]
+      args: ["ls -l"]
+      workingDir: /tmp/git

--- a/test/e2e/executor/k8s-resource-tmpl-with-artifact.yaml
+++ b/test/e2e/executor/k8s-resource-tmpl-with-artifact.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-resource-tmpl-with-artifact-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      inputs:
+        artifacts:
+        - name: manifest
+          path: /tmp/manifestfrom-path.yaml
+          raw:
+            data: |
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                generateName: k8s-pod-resource-
+              spec:
+                containers:
+                - name: argosay-container
+                  image: argoproj/argosay:v2
+                  command: ["/argosay"]
+                restartPolicy: Never
+      resource:
+        action: create
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase == Failed
+        manifestFrom:
+          artifact:
+            name: manifest

--- a/test/e2e/executor/k8s-resource-tmpl-with-automountservicetoken-disabled.yaml
+++ b/test/e2e/executor/k8s-resource-tmpl-with-automountservicetoken-disabled.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-resource-tmpl-with-automountservicetoken-disabled-
+spec:
+  serviceAccountName: argo
+  automountServiceAccountToken: false
+  executor:
+    serviceAccountName: default
+  entrypoint: main
+  templates:
+    - name: main
+      resource:
+        action: create
+        setOwnerReference: true
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase == Failed
+        manifest: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            generateName: k8s-wf-resource-
+          spec:
+            entrypoint: main
+            templates:
+              - name: main
+                container:
+                  image: argoproj/argosay:v2
+                  command: ["/argosay"]

--- a/test/e2e/executor/k8s-resource-tmpl-with-pod.yaml
+++ b/test/e2e/executor/k8s-resource-tmpl-with-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-resource-tmpl-with-pod-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      resource:
+        action: create
+        setOwnerReference: true
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase == Failed
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            generateName: k8s-pod-resource-
+          spec:
+            containers:
+            - name: argosay-container
+              image: argoproj/argosay:v2
+              command: ["/argosay"]
+            restartPolicy: Never

--- a/test/e2e/executor/k8s-resource-tmpl-with-wf.yaml
+++ b/test/e2e/executor/k8s-resource-tmpl-with-wf.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: k8s-resource-tmpl-with-wf-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      resource:
+        action: create
+        setOwnerReference: true
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase == Failed
+        manifest: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            generateName: k8s-wf-resource-
+          spec:
+            entrypoint: main
+            templates:
+              - name: main
+                container:
+                  image: argoproj/argosay:v2
+                  command: ["/argosay"]

--- a/test/e2e/executor/resource-tmpl-wf.yaml
+++ b/test/e2e/executor/resource-tmpl-wf.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: resource-tmpl-wf-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      resource:
+        action: create
+        successCondition: status.phase == Succeeded
+        setOwnerReference: true
+        manifest: |
+          apiVersion: argoproj.io/v1alpha1
+          kind: Workflow
+          metadata:
+            generateName: hello-world-
+            labels:
+              workflows.argoproj.io/test: "true"
+          spec:
+            entrypoint: whalesay
+            templates:
+              - name: whalesay
+                container:
+                  image: argoproj/argosay:v2
+                  command: [sh, -c]
+                  args: [echo, ":) Hello Argo!"]

--- a/test/e2e/failed_main_test.go
+++ b/test/e2e/failed_main_test.go
@@ -16,17 +16,7 @@ type FailedMainSuite struct {
 
 func (s *FailedMainSuite) TestFailedMain() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: failed-main-
-spec:
-  entrypoint: main
-  templates:
-  - name: main
-    container:
-      image: argoproj/argosay:v2
-      args: [ exit, "1" ]
-`).
+		Workflow("@functional/failed-main.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed)

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -39,14 +39,11 @@ type Given struct {
 	config            *config.Config
 }
 
-// creates a workflow based on the parameter, this may be:
-//
-// 1. A file name if it starts with "@"
-// 2. Raw YAML.
-func (g *Given) Workflow(text string) *Given {
+// creates a workflow from a file path with @ prefix
+func (g *Given) Workflow(filename string) *Given {
 	g.t.Helper()
 	g.wf = &wfv1.Workflow{}
-	g.readResource(text, g.wf)
+	g.readResource(filename, g.wf)
 	g.checkImages(g.wf, false)
 	return g
 }
@@ -74,19 +71,7 @@ func (g *Given) readResource(text string, v metav1.Object) {
 	if strings.HasPrefix(text, "@") {
 		file = strings.TrimPrefix(text, "@")
 	} else {
-		f, err := os.CreateTemp("", "argo_e2e")
-		if err != nil {
-			g.t.Fatal(err)
-		}
-		_, err = f.Write([]byte(text))
-		if err != nil {
-			g.t.Fatal(err)
-		}
-		err = f.Close()
-		if err != nil {
-			g.t.Fatal(err)
-		}
-		file = f.Name()
+		g.t.Fatalf("literal YAML is no longer supported in %T, use @file notation instead", v)
 	}
 
 	{
@@ -175,26 +160,26 @@ func (g *Given) WorkflowName(name string) *Given {
 	return g
 }
 
-func (g *Given) WorkflowEventBinding(text string) *Given {
+func (g *Given) WorkflowEventBinding(filename string) *Given {
 	g.t.Helper()
 	g.wfeb = &wfv1.WorkflowEventBinding{}
-	g.readResource(text, g.wfeb)
+	g.readResource(filename, g.wfeb)
 	return g
 }
 
-func (g *Given) WorkflowTemplate(text string) *Given {
+func (g *Given) WorkflowTemplate(filename string) *Given {
 	g.t.Helper()
 	wfTemplate := &wfv1.WorkflowTemplate{}
-	g.readResource(text, wfTemplate)
+	g.readResource(filename, wfTemplate)
 	g.checkImages(wfTemplate, false)
 	g.wfTemplates = append(g.wfTemplates, wfTemplate)
 	return g
 }
 
-func (g *Given) CronWorkflow(text string) *Given {
+func (g *Given) CronWorkflow(filename string) *Given {
 	g.t.Helper()
 	g.cronWf = &wfv1.CronWorkflow{}
-	g.readResource(text, g.cronWf)
+	g.readResource(filename, g.cronWf)
 	g.checkImages(g.cronWf, false)
 	return g
 }
@@ -237,10 +222,10 @@ func (g *Given) RunCli(args []string, block func(t *testing.T, output string, er
 	return g.Exec("../../dist/argo", append([]string{"-n", Namespace}, args...), block)
 }
 
-func (g *Given) ClusterWorkflowTemplate(text string) *Given {
+func (g *Given) ClusterWorkflowTemplate(filename string) *Given {
 	g.t.Helper()
 	cwfTemplate := &wfv1.ClusterWorkflowTemplate{}
-	g.readResource(text, cwfTemplate)
+	g.readResource(filename, cwfTemplate)
 	g.cwfTemplates = append(g.cwfTemplates, cwfTemplate)
 	return g
 }

--- a/test/e2e/fixtures/given.go.bak
+++ b/test/e2e/fixtures/given.go.bak
@@ -1,0 +1,268 @@
+package fixtures
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
+
+	"github.com/argoproj/argo-workflows/v3/config"
+	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
+)
+
+type Given struct {
+	t                 *testing.T
+	client            v1alpha1.WorkflowInterface
+	wfebClient        v1alpha1.WorkflowEventBindingInterface
+	wfTemplateClient  v1alpha1.WorkflowTemplateInterface
+	wftsClient        v1alpha1.WorkflowTaskSetInterface
+	cwfTemplateClient v1alpha1.ClusterWorkflowTemplateInterface
+	cronClient        v1alpha1.CronWorkflowInterface
+	hydrator          hydrator.Interface
+	wf                *wfv1.Workflow
+	wfeb              *wfv1.WorkflowEventBinding
+	wfTemplates       []*wfv1.WorkflowTemplate
+	cwfTemplates      []*wfv1.ClusterWorkflowTemplate
+	cronWf            *wfv1.CronWorkflow
+	kubeClient        kubernetes.Interface
+	bearerToken       string
+	restConfig        *rest.Config
+	config            *config.Config
+}
+
+// creates a workflow based on the parameter, this may be:
+//
+// 1. A file name if it starts with "@"
+// 2. Raw YAML.
+func (g *Given) Workflow(text string) *Given {
+	g.t.Helper()
+	g.wf = &wfv1.Workflow{}
+	g.readResource(text, g.wf)
+	g.checkImages(g.wf, false)
+	return g
+}
+
+// Load parsed Workflow that's assumed to be from the "examples/" directory
+func (g *Given) ExampleWorkflow(wf *wfv1.Workflow) *Given {
+	g.t.Helper()
+	g.wf = wf
+	g.checkLabels(wf)
+	g.checkImages(g.wf, true)
+	return g
+}
+
+// Load created workflow
+func (g *Given) WorkflowWorkflow(wf *wfv1.Workflow) *Given {
+	g.t.Helper()
+	g.wf = wf
+	g.checkImages(g.wf, false)
+	return g
+}
+
+func (g *Given) readResource(text string, v metav1.Object) {
+	g.t.Helper()
+	var file string
+	if strings.HasPrefix(text, "@") {
+		file = strings.TrimPrefix(text, "@")
+	} else {
+		f, err := os.CreateTemp("", "argo_e2e")
+		if err != nil {
+			g.t.Fatal(err)
+		}
+		_, err = f.Write([]byte(text))
+		if err != nil {
+			g.t.Fatal(err)
+		}
+		err = f.Close()
+		if err != nil {
+			g.t.Fatal(err)
+		}
+		file = f.Name()
+	}
+
+	{
+		file, err := os.ReadFile(filepath.Clean(file))
+		if err != nil {
+			g.t.Fatal(err)
+		}
+		err = yaml.Unmarshal(file, v)
+		if err != nil {
+			g.t.Fatal(err)
+		}
+		g.checkLabels(v)
+	}
+}
+
+// Check if given Workflow, WorkflowTemplate, or CronWorkflow uses forbidden images.
+// Using an arbitrary image will result in slow and flakey tests as we can't really predict when they'll be
+// downloaded or evicted. To keep tests fast and reliable you must use allowed images.
+// Workflows from the examples/ folder are given special treatment and allowed to use a wider range of images.
+func (g *Given) checkImages(wf interface{}, isExample bool) {
+	g.t.Helper()
+	var defaultImage string
+	var templates []wfv1.Template
+	switch baseTemplate := wf.(type) {
+	case *wfv1.Workflow:
+		templates = baseTemplate.Spec.Templates
+		if baseTemplate.Spec.TemplateDefaults != nil && baseTemplate.Spec.TemplateDefaults.Container != nil && baseTemplate.Spec.TemplateDefaults.Container.Image != "" {
+			defaultImage = baseTemplate.Spec.TemplateDefaults.Container.Image
+		}
+	case *wfv1.WorkflowTemplate:
+		templates = baseTemplate.Spec.Templates
+		if baseTemplate.Spec.TemplateDefaults != nil && baseTemplate.Spec.TemplateDefaults.Container != nil && baseTemplate.Spec.TemplateDefaults.Container.Image != "" {
+			defaultImage = baseTemplate.Spec.TemplateDefaults.Container.Image
+		}
+	case *wfv1.CronWorkflow:
+		templates = baseTemplate.Spec.WorkflowSpec.Templates
+		if baseTemplate.Spec.WorkflowSpec.TemplateDefaults != nil && baseTemplate.Spec.WorkflowSpec.TemplateDefaults.Container != nil && baseTemplate.Spec.WorkflowSpec.TemplateDefaults.Container.Image != "" {
+			defaultImage = baseTemplate.Spec.WorkflowSpec.TemplateDefaults.Container.Image
+		}
+	default:
+		g.t.Fatalf("Unsupported checkImage workflow type: %s", wf)
+	}
+
+	allowed := func(image string) bool {
+		return strings.Contains(image, "argoexec:") ||
+			image == "argoproj/argosay:v1" ||
+			image == "argoproj/argosay:v2" ||
+			image == "quay.io/argoproj/argocli:latest" ||
+			(isExample && (image == "busybox" || image == "python:alpine3.6"))
+	}
+	for _, t := range templates {
+		container := t.Container
+		if container != nil {
+			var image string
+			if container.Image != "" {
+				image = container.Image
+			} else {
+				image = defaultImage
+			}
+			if !allowed(image) {
+				g.t.Fatalf("image not allowed in tests: %s", image)
+			}
+			// (⎈ |docker-desktop:argo)➜  ~ time docker run --rm argoproj/argosay:v2
+			// docker run --rm argoproj/argosay˜:v2  0.21s user 0.10s system 16% cpu 1.912 total
+			// docker run --rm argoproj/argosay:v1  0.17s user 0.08s system 31% cpu 0.784 total
+		}
+	}
+}
+
+func (g *Given) checkLabels(m metav1.Object) {
+	g.t.Helper()
+	if m.GetLabels() == nil {
+		m.SetLabels(map[string]string{})
+	}
+	if m.GetLabels()[Label] == "" {
+		m.GetLabels()[Label] = "true"
+	}
+	if m.GetLabels()[Label] == "" {
+		g.t.Fatalf("%s%s does not have %s label", m.GetName(), m.GetGenerateName(), Label)
+	}
+}
+
+func (g *Given) WorkflowName(name string) *Given {
+	g.t.Helper()
+	g.wf = &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	return g
+}
+
+func (g *Given) WorkflowEventBinding(text string) *Given {
+	g.t.Helper()
+	g.wfeb = &wfv1.WorkflowEventBinding{}
+	g.readResource(text, g.wfeb)
+	return g
+}
+
+func (g *Given) WorkflowTemplate(text string) *Given {
+	g.t.Helper()
+	wfTemplate := &wfv1.WorkflowTemplate{}
+	g.readResource(text, wfTemplate)
+	g.checkImages(wfTemplate, false)
+	g.wfTemplates = append(g.wfTemplates, wfTemplate)
+	return g
+}
+
+func (g *Given) CronWorkflow(text string) *Given {
+	g.t.Helper()
+	g.cronWf = &wfv1.CronWorkflow{}
+	g.readResource(text, g.cronWf)
+	g.checkImages(g.cronWf, false)
+	return g
+}
+
+var NoError = func(t *testing.T, output string, err error) {
+	t.Helper()
+	require.NoError(t, err, output)
+}
+
+var ErrorOutput = func(contains string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		t.Helper()
+		require.Error(t, err)
+		assert.Contains(t, output, contains)
+	}
+}
+
+var OutputRegexp = func(rx string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		t.Helper()
+		require.NoError(t, err, output)
+		assert.Regexp(t, rx, output)
+	}
+}
+
+func (g *Given) Exec(name string, args []string, block func(t *testing.T, output string, err error)) *Given {
+	g.t.Helper()
+	output, err := Exec(name, args...)
+	block(g.t, output, err)
+	return g
+}
+
+// Use Kubectl to server-side apply the given file
+func (g *Given) KubectlApply(file string, block func(t *testing.T, output string, err error)) *Given {
+	g.t.Helper()
+	return g.Exec("kubectl", append([]string{"-n", Namespace, "apply", "--server-side", "-f"}, file), block)
+}
+
+func (g *Given) RunCli(args []string, block func(t *testing.T, output string, err error)) *Given {
+	return g.Exec("../../dist/argo", append([]string{"-n", Namespace}, args...), block)
+}
+
+func (g *Given) ClusterWorkflowTemplate(text string) *Given {
+	g.t.Helper()
+	cwfTemplate := &wfv1.ClusterWorkflowTemplate{}
+	g.readResource(text, cwfTemplate)
+	g.cwfTemplates = append(g.cwfTemplates, cwfTemplate)
+	return g
+}
+
+func (g *Given) When() *When {
+	return &When{
+		t:                 g.t,
+		wf:                g.wf,
+		wfeb:              g.wfeb,
+		wfTemplates:       g.wfTemplates,
+		cwfTemplates:      g.cwfTemplates,
+		cronWf:            g.cronWf,
+		client:            g.client,
+		wfebClient:        g.wfebClient,
+		wfTemplateClient:  g.wfTemplateClient,
+		wftsClient:        g.wftsClient,
+		cwfTemplateClient: g.cwfTemplateClient,
+		cronClient:        g.cronClient,
+		hydrator:          g.hydrator,
+		kubeClient:        g.kubeClient,
+		bearerToken:       g.bearerToken,
+		restConfig:        g.restConfig,
+		config:            g.config,
+	}
+}

--- a/test/e2e/functional/active-deadline-fanout-template-level.yaml
+++ b/test/e2e/functional/active-deadline-fanout-template-level.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: active-deadline-fanout-template-level-
+  namespace: argo
+spec:
+  entrypoint: entrypoint
+  templates:
+  - name: entrypoint
+    steps:
+    - - name: fanout
+        template: echo
+        arguments:
+          parameters:
+            - name: item
+              value: "{{item}}"
+        withItems:
+          - 1
+          - 2
+          - 3
+          - 4
+  - name: echo
+    inputs:
+      parameters:
+        - name: item
+    container:
+      image: argoproj/argosay:v2
+      imagePullPolicy: Always
+      command:
+        - sh
+        - '-c'
+      args:
+        - echo
+        - 'workflow number {{inputs.parameters.item}}'
+        - sleep
+        - '20'
+    activeDeadlineSeconds: 2 # defined on template level, not workflow level !

--- a/test/e2e/functional/broken-pipeline.yaml
+++ b/test/e2e/functional/broken-pipeline.yaml
@@ -1,0 +1,18 @@
+metadata:
+  name: broken-pipeline
+spec:
+  entrypoint: main
+  templates:
+  - name: do-something
+    container:
+      image: argoproj/argosay:v2
+  - name: main
+    dag:
+      tasks:
+        - name: do-something
+          template: do-something
+        - name: run-tests-broken
+          depends: "do-something"
+          templateRef:
+            name: run-tests-broken
+            template: main

--- a/test/e2e/functional/cwft-wf.yaml
+++ b/test/e2e/functional/cwft-wf.yaml
@@ -1,0 +1,16 @@
+metadata:
+  generateName: cwft-wf-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    steps:
+    - - name: call-whalesay-template
+        templateRef:
+          name: cluster-workflow-template-nested-template 
+          template: whalesay-template
+          clusterScope: true
+        arguments:
+          parameters:
+          - name: message
+            value: hello from nested

--- a/test/e2e/functional/daemon-retry.yaml
+++ b/test/e2e/functional/daemon-retry.yaml
@@ -1,0 +1,34 @@
+metadata:
+  name: daemon-retry
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+        - name: daemoned
+          template: daemoned
+        - name: whale
+          dependencies: [daemoned]
+          template: whale-tmpl
+  - name: daemoned
+    retryStrategy:
+      limit: 2
+    daemon: true
+    container:
+      image: argoproj/argosay:v2
+      command: ["bash"]
+      args:
+        - "-c"
+        - |
+          echo "Attempt {{retries}}";
+          if [ "{{retries}}" -eq 0 ]; then
+            sleep 10 && exit 1;
+          else
+            sleep 120 && exit 1;
+          fi
+  - name: whale-tmpl
+    container:
+      image: argoproj/argosay:v2
+      command: ["bash"]
+      args: ["-c", "echo hi & sleep 15 && echo bye"]

--- a/test/e2e/functional/daemon.yaml
+++ b/test/e2e/functional/daemon.yaml
@@ -1,0 +1,21 @@
+metadata:
+  name: daemon
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+        - name: redis
+          template: redis-tmpl
+        - name: whale
+          dependencies: [redis]
+          template: whale-tmpl
+  - name: redis-tmpl
+    daemon: true
+    container:
+      image: argoproj/argosay:v2
+      args: ["sleep", "100s"]
+  - name: whale-tmpl
+    container:
+      image: argoproj/argosay:v2

--- a/test/e2e/functional/example-steps-simple-mutex.yaml
+++ b/test/e2e/functional/example-steps-simple-mutex.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: example-steps-simple-mutex
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: job
+            template: exit0
+            hooks:
+              running:
+                expression: steps['job'].status == "Running"
+                template: sleep
+              succeed:
+                expression: steps['job'].status == "Succeeded"
+                template: sleep
+    - name: sleep
+      synchronization:
+        mutexes:
+          - name: job
+      container:
+        image: argoproj/argosay:v2
+        args: ["sleep", "4"]
+    - name: exit0
+      container:
+        image: argoproj/argosay:v2
+        args: ["sleep", "2"]

--- a/test/e2e/functional/example-steps.yaml
+++ b/test/e2e/functional/example-steps.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: example-steps
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: job
+            template: argosay
+            hooks:
+              running:
+                expression: steps['job'].status == "Running"
+                template: argosay-sleep-2seconds
+              failed:
+                expression: steps['job'].status == "Failed"
+                template: argosay-sleep-2seconds
+
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 5; /argosay"]
+    - name: argosay-sleep-2seconds
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 2; /argosay"]

--- a/test/e2e/functional/exit-handler-with-workflow-level-deadline.yaml
+++ b/test/e2e/functional/exit-handler-with-workflow-level-deadline.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: exit-handler-with-workflow-level-deadline
+spec:
+  entrypoint: main
+  activeDeadlineSeconds: 1
+  hooks:
+    exit:
+      template: exit-handler
+  templates:
+    - name: main
+      steps:
+      - - name: sleep
+          template: sleep
+    - name: exit-handler
+      steps:
+      - - name: sleep
+          template: sleep
+    - name: sleep
+      container:
+        image: argoproj/argosay:v2
+        args: ["sleep", "5"]

--- a/test/e2e/functional/failed-main.yaml
+++ b/test/e2e/functional/failed-main.yaml
@@ -1,0 +1,9 @@
+metadata:
+  generateName: failed-main-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    container:
+      image: argoproj/argosay:v2
+      args: [ exit, "1" ]

--- a/test/e2e/functional/http-exit-handler-with-workflow-level-deadline.yaml
+++ b/test/e2e/functional/http-exit-handler-with-workflow-level-deadline.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: http-exit-handler-with-workflow-level-deadline
+spec:
+  entrypoint: main
+  activeDeadlineSeconds: 1
+  hooks:
+    exit:
+      template: exit-handler
+  templates:
+    - name: main
+      steps:
+      - - name: sleep
+          template: sleep
+    - name: sleep
+      container:
+        image: argoproj/argosay:v2
+        args: ["sleep", "5"]
+    - name: exit-handler
+      steps:
+      - - name: http
+          template: http
+    - name: http
+      http:
+        url: http://httpbin:9100/get

--- a/test/e2e/functional/http-template-condition.yaml
+++ b/test/e2e/functional/http-template-condition.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: http-template-condition-
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: http-status-is-201-fails
+            template: http-status-is-201
+            arguments:
+              parameters: [{name: url, value: "http://httpbin:9100/status/200"}]
+          - name: http-status-is-201-succeeds
+            template: http-status-is-201
+            arguments:
+              parameters: [{name: url, value: "http://httpbin:9100/status/201"}]
+          - name: http-body-contains-google-fails
+            template: http-body-contains-google
+            arguments:
+              parameters: [{name: url, value: "http://httpbin:9100/status/200"}]
+          - name: http-body-contains-google-succeeds
+            template: http-body-contains-google
+            arguments:
+              parameters: [{name: url, value: "https://google.com"}]
+    - name: http-status-is-201
+      inputs:
+        parameters:
+          - name: url
+      http:
+        successCondition: "response.statusCode == 201"
+        url: "{{inputs.parameters.url}}"
+    - name: http-body-contains-google
+      inputs:
+        parameters:
+          - name: url
+      http:
+        successCondition: "response.body contains \"google\""
+        url: "{{inputs.parameters.url}}"

--- a/test/e2e/functional/http-template-par.yaml
+++ b/test/e2e/functional/http-template-par.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: http-template-par-
+  workflowMetadata:
+    labels:
+      workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: one
+            template: http
+            arguments:
+              parameters: [{name: url, value: "https://argoproj.github.io"}]
+          - name: two
+            template: http
+            arguments:
+              parameters: [{name: url, value: "https://argoproj.github.io"}]
+          - name: three
+            template: http
+            arguments:
+              parameters: [{name: url, value: "https://argoproj.github.io"}]
+          - name: four
+            template: http
+            arguments:
+              parameters: [{name: url, value: "https://argoproj.github.io"}]
+    - name: http
+      inputs:
+        parameters:
+          - name: url
+      http:
+        url: "{{inputs.parameters.url}}"

--- a/test/e2e/functional/lifecycle-hook-0.yaml
+++ b/test/e2e/functional/lifecycle-hook-0.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-
+spec:
+  entrypoint: main
+  hooks:
+    running:
+      expression: workflow.status == "Running"
+      template: argosay
+    succeed:
+      expression: workflow.status == "Succeeded"
+      template: argosay
+
+  templates:
+    - name: main
+      steps:
+      - - name: step1
+          template: argosay
+
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]

--- a/test/e2e/functional/lifecycle-hook-1.yaml
+++ b/test/e2e/functional/lifecycle-hook-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-
+spec:
+  entrypoint: main
+  hooks:
+    running:
+      expression: workflow.status == "Running"
+      template: hook
+    failed:
+      expression: workflow.status == "Failed"
+      template: hook
+
+  templates:
+    - name: main
+      steps:
+      - - name: step1
+          template: argosay
+
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay; exit 1"]
+
+    - name: hook
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]

--- a/test/e2e/functional/lifecycle-hook-tmpl-level-2.yaml
+++ b/test/e2e/functional/lifecycle-hook-tmpl-level-2.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-tmpl-level-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: step-1
+            hooks:
+              running:
+                expression: steps["step-1"].status == "Running"
+                template: argosay
+              succeed:
+                expression: steps["step-1"].status == "Succeeded"
+                template: argosay
+            template: argosay
+        - - name: step-2
+            hooks:
+              running:
+                expression: steps["step-2"].status == "Running"
+                template: argosay
+              succeed:
+                expression: steps["step-2"].status == "Succeeded"
+                template: argosay
+            template: argosay
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]

--- a/test/e2e/functional/lifecycle-hook-tmpl-level-3.yaml
+++ b/test/e2e/functional/lifecycle-hook-tmpl-level-3.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-tmpl-level-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: step-1
+            hooks:
+              running:
+                expression: steps["step-1"].status == "Running"
+                template: hook
+              failed:
+                expression: steps["step-1"].status == "Failed"
+                template: hook
+            template: argosay
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay; exit 1"]
+    - name: hook
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]

--- a/test/e2e/functional/lifecycle-hook-tmpl-level-4.yaml
+++ b/test/e2e/functional/lifecycle-hook-tmpl-level-4.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-tmpl-level-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: step-1
+            hooks:
+              running:
+                expression: tasks["step-1"].status == "Running"
+                template: argosay
+              succeed:
+                expression: tasks["step-1"].status == "Succeeded"
+                template: argosay
+            template: argosay
+          - name: step-2
+            hooks:
+              running:
+                expression: tasks["step-2"].status == "Running"
+                template: argosay
+              succeed:
+                expression: tasks["step-2"].status == "Succeeded"
+                template: argosay
+            template: argosay
+            dependencies: [step-1]
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]

--- a/test/e2e/functional/lifecycle-hook-tmpl-level-5.yaml
+++ b/test/e2e/functional/lifecycle-hook-tmpl-level-5.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-tmpl-level-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: step-1
+            hooks:
+              running:
+                expression: tasks["step-1"].status == "Running"
+                template: hook
+              failed:
+                expression: tasks["step-1"].status == "Failed"
+                template: hook
+            template: argosay
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay; exit 1"]
+    - name: hook
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]

--- a/test/e2e/functional/lifecycle-hook-tmpl-level.yaml
+++ b/test/e2e/functional/lifecycle-hook-tmpl-level.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-tmpl-level-
+spec:
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: A
+            template: fail
+            hooks:
+              running:
+                template: hook
+                expression: tasks.A.status == "Running"
+              success:
+                template: hook
+                expression: tasks.A.status == "Succeeded"
+          - name: B
+            template: success
+            dependencies:
+              - A
+            hooks:
+              running:
+                template: hook
+                expression: tasks.B.status == "Running"
+              success:
+                template: hook
+                expression: tasks.B.status == "Succeeded"
+    - name: success
+      container:
+        name: ''
+        image: argoproj/argosay:v2
+        command:
+          - /bin/sh
+          - '-c'
+        args:
+          - /bin/sleep 1; /argosay; exit 0
+    - name: fail
+      container:
+        name: ''
+        image: argoproj/argosay:v2
+        command:
+          - /bin/sh
+          - '-c'
+        args:
+          - /bin/sleep 1; /argosay; exit 1
+    - name: hook
+      container:
+        name: ''
+        image: argoproj/argosay:v2
+        command:
+          - /bin/sh
+          - '-c'
+        args:
+          - /bin/sleep 1; /argosay
+  entrypoint: main

--- a/test/e2e/functional/lifecycle-hook.yaml
+++ b/test/e2e/functional/lifecycle-hook.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: lifecycle-hook-
+spec:
+  entrypoint: main
+  hooks:
+    running:
+      expression: workflow.status == "Running"
+      template: argosay-sleep-2seconds
+    # This hook never triggered by following test.
+    # To guarantee workflow does not wait forever for untriggered hooks.
+    failed:
+      expression: workflow.status == "Failed"
+      template: argosay-sleep-2seconds
+  templates:
+    - name: main
+      steps:
+      - - name: step1
+          template: argosay
+
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 1; /argosay"]
+    - name: argosay-sleep-2seconds
+      container:
+        image: argoproj/argosay:v2
+        command: ["/bin/sh", "-c"]
+        args: ["/bin/sleep 2; /argosay"]

--- a/test/e2e/functional/retries-with-hooks-and-artifact.yaml
+++ b/test/e2e/functional/retries-with-hooks-and-artifact.yaml
@@ -1,0 +1,72 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: retries-with-hooks-and-artifact
+  labels:
+    workflows.argoproj.io/test: "true"
+  annotations:
+    workflows.argoproj.io/description: |
+      when retries and hooks are both included, the workflow cannot resolve the artifact 
+    workflows.argoproj.io/version: '>= 3.5.0'
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: build
+            template: output-artifact
+            hooks:
+              started:
+                expression: steps["build"].status == "Running"
+                template: started
+              success:
+                expression: steps["build"].status == "Succeeded"
+                template: success
+              failed:
+                expression: steps["build"].status == "Failed" || steps["build"].status == "Error"
+                template: failed
+        - - name: print
+            template: print-artifact
+            arguments:
+              artifacts:
+                - name: message
+                  from: "{{steps.build.outputs.artifacts.result}}"
+
+    - name: output-artifact
+      script:
+        image: argoproj/argosay:v2
+        command: [/bin/sh]
+        source: |
+          sleep 1
+          echo 'Welcome' > result.txt
+          [ "{{retries}}" = "2" ]
+      retryStrategy: 
+        limit: 2
+      outputs:
+        artifacts:
+          - name: result
+            path: /result.txt
+
+    - name: started
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "STARTED!"]
+
+    - name: success
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "SUCCEEDED!"]
+
+    - name: failed
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "FAILED or ERROR!"]
+
+    - name: print-artifact
+      inputs:
+        artifacts:
+          - name: message
+            path: /tmp/message
+      container:
+        image: argoproj/argosay:v2
+        args: ["cat", "/tmp/message"]

--- a/test/e2e/functional/run-tests-broken.yaml
+++ b/test/e2e/functional/run-tests-broken.yaml
@@ -1,0 +1,20 @@
+metadata:
+  name: run-tests-broken
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+      - - name: postgres
+          template: postgres
+      - - name: run-tests-broken
+          template: run-tests-broken
+  - name: run-tests-broken
+    container:
+      image: argoproj/argosay:v2
+  - name: postgres
+    daemon: true
+    container:
+      image: argoproj/argosay:v2
+      args: ["sleep", "100s"]
+      name: database

--- a/test/e2e/functional/steps-inline.yaml
+++ b/test/e2e/functional/steps-inline.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-inline-
+  labels:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: a
+            inline:
+              container:
+                image: argoproj/argosay:v2
+                command:
+                  - cowsay
+                args:
+                  - "foo"

--- a/test/e2e/functional/suspend-node-timeout-with-default-value.yaml
+++ b/test/e2e/functional/suspend-node-timeout-with-default-value.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: suspend-node-timeout-with-default-value
+spec:
+  entrypoint: suspend
+  templates:
+  - name: suspend
+    steps:
+    - - name: approve
+        template: approve
+    - - name: release
+        template: whalesay
+        arguments:
+          parameters:
+            - name: message
+              value: "{{steps.approve.outputs.parameters.message}}"
+  - name: approve
+    suspend:
+      duration: 5s
+    outputs:
+      parameters:
+        - name: message
+          valueFrom:
+            default: default message
+            supplied: {}
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: message
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/functional/suspend-node-timeout-without-default-value.yaml
+++ b/test/e2e/functional/suspend-node-timeout-without-default-value.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: suspend-node-timeout-without-default-value
+spec:
+  entrypoint: suspend
+  templates:
+  - name: suspend
+    steps:
+    - - name: approve
+        template: approve
+    - - name: release
+        template: whalesay
+        arguments:
+          parameters:
+            - name: message
+              value: "{{steps.approve.outputs.parameters.message}}"
+  - name: approve
+    suspend:
+      duration: 5s
+    outputs:
+      parameters:
+        - name: message
+          valueFrom:
+            supplied: {}
+  - name: whalesay
+    inputs:
+      parameters:
+        - name: message
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["{{inputs.parameters.message}}"]

--- a/test/e2e/functional/test-backoff-strategy-1.yaml
+++ b/test/e2e/functional/test-backoff-strategy-1.yaml
@@ -1,0 +1,15 @@
+metadata:
+  generateName: test-backoff-strategy-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: '10'
+        backoff:
+          duration: 10s
+          maxDuration: 1m
+      container:
+          name: main
+          image: 'argoproj/argosay:v2'
+          args: [ exit, "1" ]

--- a/test/e2e/functional/test-backoff-strategy.yaml
+++ b/test/e2e/functional/test-backoff-strategy.yaml
@@ -1,0 +1,15 @@
+metadata:
+  generateName: test-backoff-strategy-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: 10
+        backoff:
+          duration: 10s
+          maxDuration: 1m
+      container:
+          name: main
+          image: 'argoproj/argosay:v2'
+          args: [ exit, "1" ]

--- a/test/e2e/functional/test-nodeantiaffinity-strategy.yaml
+++ b/test/e2e/functional/test-nodeantiaffinity-strategy.yaml
@@ -1,0 +1,15 @@
+metadata:
+  name: test-nodeantiaffinity-strategy
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: '1'
+        retryPolicy: "Always"
+        affinity:
+          nodeAntiAffinity: {}
+      container:
+          name: main
+          image: 'argoproj/argosay:v2'
+          args: [ exit, "1" ]

--- a/test/e2e/functional/test-pod-cleanup-0.yaml
+++ b/test/e2e/functional/test-pod-cleanup-0.yaml
@@ -1,0 +1,8 @@
+metadata:
+  generateName: test-pod-cleanup-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup-on-pod-completion-1.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-completion-1.yaml
@@ -1,0 +1,11 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-completion-
+spec:
+  podGC:
+    strategy: OnPodCompletion
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]

--- a/test/e2e/functional/test-pod-cleanup-on-pod-completion-label-selected-3.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-completion-label-selected-3.yaml
@@ -1,0 +1,17 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-completion-label-selected-
+spec:
+  podGC:
+    strategy: OnPodCompletion
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]
+      metadata:
+        labels:
+          evicted: true

--- a/test/e2e/functional/test-pod-cleanup-on-pod-completion-label-selected.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-completion-label-selected.yaml
@@ -1,0 +1,13 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-completion-label-selected-
+spec:
+  podGC:
+    strategy: OnPodCompletion
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup-on-pod-completion.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-completion.yaml
@@ -1,0 +1,10 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-completion-
+spec:
+  podGC:
+    strategy: OnPodCompletion
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup-on-pod-success-5.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-success-5.yaml
@@ -1,0 +1,11 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-success-
+spec:
+  podGC:
+    strategy: OnPodSuccess
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]

--- a/test/e2e/functional/test-pod-cleanup-on-pod-success-label-match-8.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-success-label-match-8.yaml
@@ -1,0 +1,14 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-success-label-match-
+spec:
+  podGC:
+    strategy: OnPodSuccess
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]

--- a/test/e2e/functional/test-pod-cleanup-on-pod-success-label-match.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-success-label-match.yaml
@@ -1,0 +1,16 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-success-label-match-
+spec:
+  podGC:
+    strategy: OnPodSuccess
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+      metadata:
+        labels:
+          evicted: true

--- a/test/e2e/functional/test-pod-cleanup-on-pod-success-label-not-match.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-success-label-not-match.yaml
@@ -1,0 +1,13 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-success-label-not-match-
+spec:
+  podGC:
+    strategy: OnPodSuccess
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup-on-pod-success.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-pod-success.yaml
@@ -1,0 +1,10 @@
+metadata:
+  generateName: test-pod-cleanup-on-pod-success-
+spec:
+  podGC:
+    strategy: OnPodSuccess
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup-on-workflow-completion-label-match.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-workflow-completion-label-match.yaml
@@ -1,0 +1,17 @@
+metadata:
+  generateName: test-pod-cleanup-on-workflow-completion-label-match-
+spec:
+  podGC:
+    strategy: OnWorkflowCompletion
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]
+      metadata:
+        labels:
+          evicted: true

--- a/test/e2e/functional/test-pod-cleanup-on-workflow-completion-label-not-match.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-workflow-completion-label-not-match.yaml
@@ -1,0 +1,14 @@
+metadata:
+  generateName: test-pod-cleanup-on-workflow-completion-label-not-match-
+spec:
+  podGC:
+    strategy: OnWorkflowCompletion
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]

--- a/test/e2e/functional/test-pod-cleanup-on-workflow-completion.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-workflow-completion.yaml
@@ -1,0 +1,11 @@
+metadata:
+  generateName: test-pod-cleanup-on-workflow-completion-
+spec:
+  podGC:
+    strategy: OnWorkflowCompletion
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+        args: [exit, 1]

--- a/test/e2e/functional/test-pod-cleanup-on-workflow-success-label-match.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-workflow-success-label-match.yaml
@@ -1,0 +1,16 @@
+metadata:
+  generateName: test-pod-cleanup-on-workflow-success-label-match-
+spec:
+  podGC:
+    strategy: OnWorkflowSuccess
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2
+      metadata:
+        labels:
+          evicted: true

--- a/test/e2e/functional/test-pod-cleanup-on-workflow-success-label-not-match.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-workflow-success-label-not-match.yaml
@@ -1,0 +1,13 @@
+metadata:
+  generateName: test-pod-cleanup-on-workflow-success-label-not-match-
+spec:
+  podGC:
+    strategy: OnWorkflowSuccess
+    labelSelector:
+      matchLabels:
+        evicted: true
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup-on-workflow-success.yaml
+++ b/test/e2e/functional/test-pod-cleanup-on-workflow-success.yaml
@@ -1,0 +1,10 @@
+metadata:
+  generateName: test-pod-cleanup-on-workflow-success-
+spec:
+  podGC:
+    strategy: OnWorkflowSuccess
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-pod-cleanup.yaml
+++ b/test/e2e/functional/test-pod-cleanup.yaml
@@ -1,0 +1,10 @@
+metadata:
+  name: test-pod-cleanup
+spec:
+  podGC:
+    strategy: OnWorkflowCompletion
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: argoproj/argosay:v2

--- a/test/e2e/functional/test-retry-limit.yaml
+++ b/test/e2e/functional/test-retry-limit.yaml
@@ -1,0 +1,16 @@
+metadata:
+  name: test-retry-limit
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      retryStrategy:
+        limit: 0
+        backoff:
+          duration: 2s
+          factor: 2
+          maxDuration: 5m
+      container:
+        name: main
+        image: 'argoproj/argosay:v2'
+        args: [ exit, "1" ]

--- a/test/e2e/functional/test-workflow-level-hooks-with-retry.yaml
+++ b/test/e2e/functional/test-workflow-level-hooks-with-retry.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: test-workflow-level-hooks-with-retry
+spec:
+  templates:
+    - name: argosay
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - /bin/sh
+          - '-c'
+        args:
+          - /bin/sleep 1; exit 1
+      retryStrategy:
+        limit: 1
+    - name: hook
+      container:
+        image: argoproj/argosay:v2
+        command:
+          - /bin/sh
+          - '-c'
+        args:
+          - /argosay
+  entrypoint: argosay
+  hooks:
+    failed:
+      template: hook
+      expression: workflow.status == "Failed"
+    running:
+      template: hook
+      expression: workflow.status == "Running"

--- a/test/e2e/functional/whalesay.yaml
+++ b/test/e2e/functional/whalesay.yaml
@@ -1,0 +1,21 @@
+metadata:
+  generateName: whalesay-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    dag:
+      tasks:
+        - name: redis
+          template: redis-tmpl
+        - name: whale
+          dependencies: [redis]
+          template: whale-tmpl
+  - name: redis-tmpl
+    daemon: true
+    container:
+      image: argoproj/argosay:v2
+      args: ["sleep", "100s"]
+  - name: whale-tmpl
+    container:
+      image: argoproj/argosay:v2

--- a/test/e2e/functional/workflow-inputs-overridable-wf-0.yaml
+++ b/test/e2e/functional/workflow-inputs-overridable-wf-0.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-inputs-overridable-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: message
+        value: arg-value
+  templates:
+    - name: whalesay
+      container:
+        image: argoproj/argosay:v2
+        args:
+        - echo
+        - "{{inputs.parameters.message}}"
+      inputs:
+        parameters:
+          - name: message
+            valueFrom:
+              configMapKeyRef:
+                name: cmref-parameters
+                key: cmref-key

--- a/test/e2e/functional/workflow-inputs-overridable-wf-1.yaml
+++ b/test/e2e/functional/workflow-inputs-overridable-wf-1.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-inputs-overridable-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: message
+        valueFrom:
+          configMapKeyRef:
+            name: new-cmref-parameters
+            key: cmref-key
+  templates:
+    - name: whalesay
+      container:
+        image: argoproj/argosay:v2
+        args:
+        - echo
+        - "{{inputs.parameters.message}}"
+      inputs:
+        parameters:
+          - name: message
+            valueFrom:
+              configMapKeyRef:
+                name: cmref-parameters
+                key: cmref-key

--- a/test/e2e/functional/workflow-inputs-overridable-wf.yaml
+++ b/test/e2e/functional/workflow-inputs-overridable-wf.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-inputs-overridable-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: message
+        valueFrom:
+          configMapKeyRef:
+            name: cmref-parameters
+            key: cmref-key
+  templates:
+    - name: whalesay
+      container:
+        image: argoproj/argosay:v2
+        args:
+        - echo
+        - "{{inputs.parameters.message}}"
+      inputs:
+        parameters:
+          - name: message
+            value: input-value

--- a/test/e2e/functional/workflow-template-cmkeyselector-wf-global-arg-default-param.yaml
+++ b/test/e2e/functional/workflow-template-cmkeyselector-wf-global-arg-default-param.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-cmkeyselector-wf-global-arg-default-param-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: simple-global-param
+        valueFrom:
+          default: "default value"
+          configMapKeyRef:
+            name: not-existing-cm
+            key: not-existing-key
+  templates:
+    - name: whalesay
+      container:
+        image: argoproj/argosay:v2
+        command: [sh, -c]
+        args: ["sleep 1; echo -n {{workflow.parameters.simple-global-param}} > /tmp/message.txt"]
+      outputs:
+        parameters:
+         - name: message
+           valueFrom:
+             path: /tmp/message.txt

--- a/test/e2e/functional/workflow-template-configmapkeyselector-wf-0.yaml
+++ b/test/e2e/functional/workflow-template-configmapkeyselector-wf-0.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-configmapkeyselector-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+    - name: message
+      value: msg
+  templates:
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+        valueFrom:
+          configMapKeyRef:
+            name: cmref-parameters
+            key: '{{ workflow.parameters.message }}'
+    container:
+      image: argoproj/argosay:v2
+      args:
+        - echo
+        - "{{inputs.parameters.message}}"

--- a/test/e2e/functional/workflow-template-configmapkeyselector-wf-1.yaml
+++ b/test/e2e/functional/workflow-template-configmapkeyselector-wf-1.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-configmapkeyselector-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+    - name: cm-name
+      value: cmref-parameters
+  templates:
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+        valueFrom:
+          configMapKeyRef:
+            name: '{{ workflow.parameters.cm-name}}'
+            key: msg
+    container:
+      image: argoproj/argosay:v2
+      args:
+        - echo
+        - "{{inputs.parameters.message}}"

--- a/test/e2e/functional/workflow-template-configmapkeyselector-wf-default-param.yaml
+++ b/test/e2e/functional/workflow-template-configmapkeyselector-wf-default-param.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-configmapkeyselector-wf-default-param-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+    - name: message
+      value: msg
+  templates:
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+        valueFrom:
+          default: "default-val"
+          configMapKeyRef:
+            name: cmref-parameters
+            key: not-existing-key
+    container:
+      image: argoproj/argosay:v2
+      args:
+        - echo
+        - "{{inputs.parameters.message}}"

--- a/test/e2e/functional/workflow-template-configmapkeyselector-wf.yaml
+++ b/test/e2e/functional/workflow-template-configmapkeyselector-wf.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-configmapkeyselector-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+    - name: cm-name
+      value: cmref-parameters
+  templates:
+  - name: whalesay
+    inputs:
+      parameters:
+      - name: message
+        valueFrom:
+          configMapKeyRef:
+            name: '{{ workflow.parameters.cm-name }}'
+            key: msg
+    container:
+      image: argoproj/argosay:v2
+      args:
+        - echo
+        - "{{inputs.parameters.message}}"

--- a/test/e2e/functional/workflow-template-containerset.yaml
+++ b/test/e2e/functional/workflow-template-containerset.yaml
@@ -1,0 +1,5 @@
+metadata:
+  name: workflow-template-containerset
+spec:
+  workflowTemplateRef:
+    name: containerset-with-retrystrategy

--- a/test/e2e/functional/workflow-template-hook.yaml
+++ b/test/e2e/functional/workflow-template-hook.yaml
@@ -1,0 +1,5 @@
+metadata:
+  generateName: workflow-template-hook-
+spec:
+  workflowTemplateRef:
+    name: hook

--- a/test/e2e/functional/workflow-template-invalid-entrypoint.yaml
+++ b/test/e2e/functional/workflow-template-invalid-entrypoint.yaml
@@ -1,0 +1,5 @@
+metadata:
+  generateName: workflow-template-invalid-entrypoint-
+spec:
+  workflowTemplateRef:
+    name: workflow-template-invalid-entrypoint

--- a/test/e2e/functional/workflow-template-invalid-onexit.yaml
+++ b/test/e2e/functional/workflow-template-invalid-onexit.yaml
@@ -1,0 +1,5 @@
+metadata:
+  generateName: workflow-template-invalid-onexit-
+spec:
+  workflowTemplateRef:
+    name: workflow-template-invalid-onexit

--- a/test/e2e/functional/workflow-template-nested.yaml
+++ b/test/e2e/functional/workflow-template-nested.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-nested-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    steps:
+      - - name: call-whalesay-template
+          templateRef:
+            name: workflow-template-nested-template
+            template: whalesay-template
+          arguments:
+            parameters:
+            - name: message
+              value: "hello from nested"

--- a/test/e2e/functional/workflow-template-wf.yaml
+++ b/test/e2e/functional/workflow-template-wf.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-wf-
+  label:
+    workflows.argoproj.io/test: "true"
+spec:
+  entrypoint: whalesay
+  arguments:
+    parameters:
+      - name: message
+        value: arg-value
+  templates:
+    - name: whalesay
+      container:
+        image: argoproj/argosay:v2
+        args:
+        - echo
+        - "{{inputs.parameters.message}}"
+      inputs:
+        parameters:
+          - name: message
+            value: input-value

--- a/test/e2e/hooks_test.go
+++ b/test/e2e/hooks_test.go
@@ -23,32 +23,7 @@ type HooksSuite struct {
 
 func (s *HooksSuite) TestWorkflowLevelHooksSuccessVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-
-spec:
-  entrypoint: main
-  hooks:
-    running:
-      expression: workflow.status == "Running"
-      template: argosay
-    succeed:
-      expression: workflow.status == "Succeeded"
-      template: argosay
-
-  templates:
-    - name: main
-      steps:
-      - - name: step1
-          template: argosay
-
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
@@ -67,38 +42,7 @@ spec:
 
 func (s *HooksSuite) TestWorkflowLevelHooksFailVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-
-spec:
-  entrypoint: main
-  hooks:
-    running:
-      expression: workflow.status == "Running"
-      template: hook
-    failed:
-      expression: workflow.status == "Failed"
-      template: hook
-
-  templates:
-    - name: main
-      steps:
-      - - name: step1
-          template: argosay
-
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay; exit 1"]
-        
-    - name: hook
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
@@ -117,39 +61,7 @@ spec:
 
 func (s *HooksSuite) TestTemplateLevelHooksStepSuccessVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-tmpl-level-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: step-1
-            hooks:
-              running:
-                expression: steps["step-1"].status == "Running"
-                template: argosay
-              succeed:
-                expression: steps["step-1"].status == "Succeeded"
-                template: argosay
-            template: argosay
-        - - name: step-2
-            hooks:
-              running:
-                expression: steps["step-2"].status == "Running"
-                template: argosay
-              succeed:
-                expression: steps["step-2"].status == "Succeeded"
-                template: argosay
-            template: argosay
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook-tmpl-level.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
@@ -180,35 +92,7 @@ spec:
 
 func (s *HooksSuite) TestTemplateLevelHooksStepFailVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-tmpl-level-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: step-1
-            hooks:
-              running:
-                expression: steps["step-1"].status == "Running"
-                template: hook
-              failed:
-                expression: steps["step-1"].status == "Failed"
-                template: hook
-            template: argosay
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay; exit 1"]
-    - name: hook
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook-tmpl-level.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
@@ -227,41 +111,7 @@ spec:
 
 func (s *HooksSuite) TestTemplateLevelHooksDagSuccessVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-tmpl-level-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      dag:
-        tasks:
-          - name: step-1
-            hooks:
-              running:
-                expression: tasks["step-1"].status == "Running"
-                template: argosay
-              succeed:
-                expression: tasks["step-1"].status == "Succeeded"
-                template: argosay
-            template: argosay
-          - name: step-2
-            hooks:
-              running:
-                expression: tasks["step-2"].status == "Running"
-                template: argosay
-              succeed:
-                expression: tasks["step-2"].status == "Succeeded"
-                template: argosay
-            template: argosay
-            dependencies: [step-1]
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook-tmpl-level.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
@@ -291,36 +141,7 @@ spec:
 
 func (s *HooksSuite) TestTemplateLevelHooksDagFailVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-tmpl-level-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      dag:
-        tasks:
-          - name: step-1
-            hooks:
-              running:
-                expression: tasks["step-1"].status == "Running"
-                template: hook
-              failed:
-                expression: tasks["step-1"].status == "Failed"
-                template: hook
-            template: argosay
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay; exit 1"]
-    - name: hook
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook-tmpl-level.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
@@ -339,64 +160,7 @@ spec:
 
 func (s *HooksSuite) TestTemplateLevelHooksDagHasDependencyVersion() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-tmpl-level-
-spec:
-  templates:
-    - name: main
-      dag:
-        tasks:
-          - name: A
-            template: fail
-            hooks:
-              running:
-                template: hook
-                expression: tasks.A.status == "Running"
-              success:
-                template: hook
-                expression: tasks.A.status == "Succeeded"
-          - name: B
-            template: success
-            dependencies:
-              - A
-            hooks:
-              running:
-                template: hook
-                expression: tasks.B.status == "Running"
-              success:
-                template: hook
-                expression: tasks.B.status == "Succeeded"
-    - name: success
-      container:
-        name: ''
-        image: argoproj/argosay:v2
-        command:
-          - /bin/sh
-          - '-c'
-        args:
-          - /bin/sleep 1; /argosay; exit 0
-    - name: fail
-      container:
-        name: ''
-        image: argoproj/argosay:v2
-        command:
-          - /bin/sh
-          - '-c'
-        args:
-          - /bin/sleep 1; /argosay; exit 1
-    - name: hook
-      container:
-        name: ''
-        image: argoproj/argosay:v2
-        command:
-          - /bin/sh
-          - '-c'
-        args:
-          - /bin/sleep 1; /argosay
-  entrypoint: main
-`).When().
+		Workflow("@functional/lifecycle-hook-tmpl-level.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
@@ -419,38 +183,7 @@ spec:
 
 func (s *HooksSuite) TestWorkflowLevelHooksWaitForTriggeredHook() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: lifecycle-hook-
-spec:
-  entrypoint: main
-  hooks:
-    running:
-      expression: workflow.status == "Running"
-      template: argosay-sleep-2seconds
-    # This hook never triggered by following test.
-    # To guarantee workflow does not wait forever for untriggered hooks.
-    failed:
-      expression: workflow.status == "Failed"
-      template: argosay-sleep-2seconds
-  templates:
-    - name: main
-      steps:
-      - - name: step1
-          template: argosay
-
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 1; /argosay"]
-    - name: argosay-sleep-2seconds
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 2; /argosay"]
-`).When().
+		Workflow("@functional/lifecycle-hook.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
@@ -468,37 +201,7 @@ spec:
 
 func (s *HooksSuite) TestTemplateLevelHooksWaitForTriggeredHook() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: example-steps
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: job
-            template: argosay
-            hooks:
-              running:
-                expression: steps['job'].status == "Running"
-                template: argosay-sleep-2seconds
-              failed:
-                expression: steps['job'].status == "Failed"
-                template: argosay-sleep-2seconds
-
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 5; /argosay"]
-    - name: argosay-sleep-2seconds
-      container:
-        image: argoproj/argosay:v2
-        command: ["/bin/sh", "-c"]
-        args: ["/bin/sleep 2; /argosay"]
-`).When().
+		Workflow("@functional/example-steps.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
@@ -516,37 +219,7 @@ spec:
 // Ref: https://github.com/argoproj/argo-workflows/issues/11117
 func (s *HooksSuite) TestTemplateLevelHooksWaitForTriggeredHookAndRespectSynchronization() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: example-steps-simple-mutex
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: job
-            template: exit0
-            hooks:
-              running:
-                expression: steps['job'].status == "Running"
-                template: sleep
-              succeed:
-                expression: steps['job'].status == "Succeeded"
-                template: sleep
-    - name: sleep
-      synchronization:
-        mutexes:
-          - name: job
-      container:
-        image: argoproj/argosay:v2
-        args: ["sleep", "4"]
-    - name: exit0
-      container:
-        image: argoproj/argosay:v2
-        args: ["sleep", "2"]
-`).When().
+		Workflow("@functional/example-steps-simple-mutex.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
 		Then().
@@ -568,40 +241,7 @@ spec:
 
 func (s *HooksSuite) TestWorkflowLevelHooksWithRetry() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  name: test-workflow-level-hooks-with-retry
-spec:
-  templates:
-    - name: argosay
-      container:
-        image: argoproj/argosay:v2
-        command:
-          - /bin/sh
-          - '-c'
-        args:
-          - /bin/sleep 1; exit 1
-      retryStrategy:
-        limit: 1
-    - name: hook
-      container:
-        image: argoproj/argosay:v2
-        command:
-          - /bin/sh
-          - '-c'
-        args:
-          - /argosay
-  entrypoint: argosay
-  hooks:
-    failed:
-      template: hook
-      expression: workflow.status == "Failed"
-    running:
-      template: hook
-      expression: workflow.status == "Running"
-`).When().
+		Workflow("@functional/test-workflow-level-hooks-with-retry.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
 		Then().
@@ -649,80 +289,7 @@ spec:
 func (s *HooksSuite) TestTemplateLevelHooksWithRetry() {
 	var children []string
 	(s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  name: retries-with-hooks-and-artifact
-  labels:
-    workflows.argoproj.io/test: "true"
-  annotations:
-    workflows.argoproj.io/description: |
-      when retries and hooks are both included, the workflow cannot resolve the artifact 
-    workflows.argoproj.io/version: '>= 3.5.0'
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: build
-            template: output-artifact
-            hooks:
-              started:
-                expression: steps["build"].status == "Running"
-                template: started
-              success:
-                expression: steps["build"].status == "Succeeded"
-                template: success
-              failed:
-                expression: steps["build"].status == "Failed" || steps["build"].status == "Error"
-                template: failed
-        - - name: print
-            template: print-artifact
-            arguments:
-              artifacts:
-                - name: message
-                  from: "{{steps.build.outputs.artifacts.result}}"
-    
-    - name: output-artifact
-      script:
-        image: argoproj/argosay:v2
-        command: [/bin/sh]
-        source: |
-          sleep 1
-          echo 'Welcome' > result.txt
-          [ "{{retries}}" = "2" ]
-      retryStrategy: 
-        limit: 2
-      outputs:
-        artifacts:
-          - name: result
-            path: /result.txt
-
-    - name: started
-      container:
-        image: argoproj/argosay:v2
-        args: ["echo", "STARTED!"]
-
-    - name: success
-      container:
-        image: argoproj/argosay:v2
-        args: ["echo", "SUCCEEDED!"]
-
-    - name: failed
-      container:
-        image: argoproj/argosay:v2
-        args: ["echo", "FAILED or ERROR!"]
-
-    - name: print-artifact
-      inputs:
-        artifacts:
-          - name: message
-            path: /tmp/message
-      container:
-        image: argoproj/argosay:v2
-        args: ["cat", "/tmp/message"]
-`).When().
+		Workflow("@functional/retries-with-hooks-and-artifact.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted).
 		Then().
@@ -766,30 +333,7 @@ spec:
 func (s *HooksSuite) TestExitHandlerWithWorkflowLevelDeadline() {
 	var onExitNodeName string
 	(s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  name: exit-handler-with-workflow-level-deadline
-spec:
-  entrypoint: main
-  activeDeadlineSeconds: 1
-  hooks:
-    exit:
-      template: exit-handler
-  templates:
-    - name: main
-      steps:
-      - - name: sleep
-          template: sleep
-    - name: exit-handler
-      steps:
-      - - name: sleep
-          template: sleep
-    - name: sleep
-      container:
-        image: argoproj/argosay:v2
-        args: ["sleep", "5"]
-`).When().
+		Workflow("@functional/exit-handler-with-workflow-level-deadline.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted, 2*time.Minute).
 		WaitForWorkflow(fixtures.Condition(func(wf *v1alpha1.Workflow) (bool, string) {
@@ -812,33 +356,7 @@ spec:
 func (s *HooksSuite) TestHttpExitHandlerWithWorkflowLevelDeadline() {
 	var onExitNodeName string
 	(s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  name: http-exit-handler-with-workflow-level-deadline
-spec:
-  entrypoint: main
-  activeDeadlineSeconds: 1
-  hooks:
-    exit:
-      template: exit-handler
-  templates:
-    - name: main
-      steps:
-      - - name: sleep
-          template: sleep
-    - name: sleep
-      container:
-        image: argoproj/argosay:v2
-        args: ["sleep", "5"]
-    - name: exit-handler
-      steps:
-      - - name: http
-          template: http
-    - name: http
-      http:
-        url: http://httpbin:9100/get
-`).When().
+		Workflow("@functional/http-exit-handler-with-workflow-level-deadline.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted).
 		WaitForWorkflow(fixtures.Condition(func(wf *v1alpha1.Workflow) (bool, string) {

--- a/test/e2e/pod_cleanup_test.go
+++ b/test/e2e/pod_cleanup_test.go
@@ -16,16 +16,7 @@ type PodCleanupSuite struct {
 
 func (s *PodCleanupSuite) TestNone() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+		Workflow("@functional/test-pod-cleanup.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodCompleted)
@@ -34,37 +25,14 @@ spec:
 func (s *PodCleanupSuite) TestOnPodCompletion() {
 	s.Run("FailedPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-completion-
-spec:
-  podGC:
-    strategy: OnPodCompletion
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-completion.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodDeleted)
 	})
 	s.Run("SucceededPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-completion-
-spec:
-  podGC:
-    strategy: OnPodCompletion
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-completion.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodDeleted)
@@ -74,46 +42,14 @@ spec:
 func (s *PodCleanupSuite) TestOnPodCompletionLabelSelected() {
 	s.Run("FailedPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-completion-label-selected-
-spec:
-  podGC:
-    strategy: OnPodCompletion
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-      metadata:
-        labels:
-          evicted: true
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-completion-label-selected.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodDeleted)
 	})
 	s.Run("SucceededPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-completion-label-selected-
-spec:
-  podGC:
-    strategy: OnPodCompletion
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-completion-label-selected.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodCompleted)
@@ -123,37 +59,14 @@ spec:
 func (s *PodCleanupSuite) TestOnPodSuccess() {
 	s.Run("FailedPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-success-
-spec:
-  podGC:
-    strategy: OnPodSuccess
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-success.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodCompleted)
 	})
 	s.Run("SucceededPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-success-
-spec:
-  podGC:
-    strategy: OnPodSuccess
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-success.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodDeleted)
@@ -162,21 +75,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnPodSuccessLabelNotMatch() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-success-label-not-match-
-spec:
-  podGC:
-    strategy: OnPodSuccess
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+		Workflow("@functional/test-pod-cleanup-on-pod-success-label-not-match.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodCompleted)
@@ -185,46 +84,14 @@ spec:
 func (s *PodCleanupSuite) TestOnPodSuccessLabelMatch() {
 	s.Run("FailedPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-success-label-match-
-spec:
-  podGC:
-    strategy: OnPodSuccess
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-success-label-match.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodCompleted)
 	})
 	s.Run("SucceededPod", func() {
 		s.Given().
-			Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-pod-success-label-match-
-spec:
-  podGC:
-    strategy: OnPodSuccess
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-      metadata:
-        labels:
-          evicted: true
-`).
+			Workflow("@functional/test-pod-cleanup-on-pod-success-label-match.yaml").
 			When().
 			SubmitWorkflow().
 			WaitForPod(fixtures.PodDeleted)
@@ -233,19 +100,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowCompletion() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-workflow-completion-
-spec:
-  podGC:
-    strategy: OnWorkflowCompletion
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-`).
+		Workflow("@functional/test-pod-cleanup-on-workflow-completion.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodDeleted)
@@ -253,22 +108,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowCompletionLabelNotMatch() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-workflow-completion-label-not-match-
-spec:
-  podGC:
-    strategy: OnWorkflowCompletion
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-`).
+		Workflow("@functional/test-pod-cleanup-on-workflow-completion-label-not-match.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodCompleted)
@@ -276,25 +116,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowCompletionLabelMatch() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-workflow-completion-label-match-
-spec:
-  podGC:
-    strategy: OnWorkflowCompletion
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-        args: [exit, 1]
-      metadata:
-        labels:
-          evicted: true
-`).
+		Workflow("@functional/test-pod-cleanup-on-workflow-completion-label-match.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodDeleted)
@@ -302,18 +124,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowSuccess() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-workflow-success-
-spec:
-  podGC:
-    strategy: OnWorkflowSuccess
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+		Workflow("@functional/test-pod-cleanup-on-workflow-success.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodDeleted)
@@ -321,21 +132,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowSuccessLabelNotMatch() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-workflow-success-label-not-match-
-spec:
-  podGC:
-    strategy: OnWorkflowSuccess
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+		Workflow("@functional/test-pod-cleanup-on-workflow-success-label-not-match.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodCompleted)
@@ -343,24 +140,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowSuccessLabelMatch() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-pod-cleanup-on-workflow-success-label-match-
-spec:
-  podGC:
-    strategy: OnWorkflowSuccess
-    labelSelector:
-      matchLabels:
-        evicted: true
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-      metadata:
-        labels:
-          evicted: true
-`).
+		Workflow("@functional/test-pod-cleanup-on-workflow-success-label-match.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForPod(fixtures.PodDeleted)
@@ -368,18 +148,7 @@ spec:
 
 func (s *PodCleanupSuite) TestOnWorkflowTemplate() {
 	s.Given().
-		WorkflowTemplate(`
-metadata:
-  name: test-pod-cleanup
-spec:
-  podGC:
-    strategy: OnWorkflowCompletion
-  entrypoint: main
-  templates:
-    - name: main
-      container:
-        image: argoproj/argosay:v2
-`).
+		WorkflowTemplate("@functional/test-pod-cleanup.yaml").
 		When().
 		CreateWorkflowTemplates().
 		SubmitWorkflowsFromWorkflowTemplates().

--- a/test/e2e/resource_template_test.go
+++ b/test/e2e/resource_template_test.go
@@ -20,33 +20,7 @@ type ResourceTemplateSuite struct {
 
 func (s *ResourceTemplateSuite) TestResourceTemplateWithWorkflow() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: k8s-resource-tmpl-with-wf-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      resource:
-        action: create
-        setOwnerReference: true
-        successCondition: status.phase == Succeeded
-        failureCondition: status.phase == Failed
-        manifest: |
-          apiVersion: argoproj.io/v1alpha1
-          kind: Workflow
-          metadata:
-            generateName: k8s-wf-resource-
-          spec:
-            entrypoint: main
-            templates:
-              - name: main
-                container:
-                  image: argoproj/argosay:v2
-                  command: ["/argosay"]
-`).
+		Workflow("@executor/k8s-resource-tmpl-with-wf.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow().
@@ -58,32 +32,7 @@ spec:
 
 func (s *ResourceTemplateSuite) TestResourceTemplateWithPod() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: k8s-resource-tmpl-with-pod-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      resource:
-        action: create
-        setOwnerReference: true
-        successCondition: status.phase == Succeeded
-        failureCondition: status.phase == Failed
-        manifest: |
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            generateName: k8s-pod-resource-
-          spec:
-            containers:
-            - name: argosay-container
-              image: argoproj/argosay:v2
-              command: ["/argosay"]
-            restartPolicy: Never
-`).
+		Workflow("@executor/k8s-resource-tmpl-with-pod.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow().
@@ -95,39 +44,7 @@ spec:
 
 func (s *ResourceTemplateSuite) TestResourceTemplateWithArtifact() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: k8s-resource-tmpl-with-artifact-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      inputs:
-        artifacts:
-        - name: manifest
-          path: /tmp/manifestfrom-path.yaml
-          raw:
-            data: |
-              apiVersion: v1
-              kind: Pod
-              metadata:
-                generateName: k8s-pod-resource-
-              spec:
-                containers:
-                - name: argosay-container
-                  image: argoproj/argosay:v2
-                  command: ["/argosay"]
-                restartPolicy: Never
-      resource:
-        action: create
-        successCondition: status.phase == Succeeded
-        failureCondition: status.phase == Failed
-        manifestFrom:
-          artifact:
-            name: manifest
-`).
+		Workflow("@executor/k8s-resource-tmpl-with-artifact.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow().
@@ -159,37 +76,7 @@ func (s *ResourceTemplateSuite) TestResourceTemplateWithOutputs() {
 
 func (s *ResourceTemplateSuite) TestResourceTemplateAutomountServiceAccountTokenDisabled() {
 	s.Given().
-		Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: k8s-resource-tmpl-with-automountservicetoken-disabled-
-spec:
-  serviceAccountName: argo
-  automountServiceAccountToken: false
-  executor:
-    serviceAccountName: default
-  entrypoint: main
-  templates:
-    - name: main
-      resource:
-        action: create
-        setOwnerReference: true
-        successCondition: status.phase == Succeeded
-        failureCondition: status.phase == Failed
-        manifest: |
-          apiVersion: argoproj.io/v1alpha1
-          kind: Workflow
-          metadata:
-            generateName: k8s-wf-resource-
-          spec:
-            entrypoint: main
-            templates:
-              - name: main
-                container:
-                  image: argoproj/argosay:v2
-                  command: ["/argosay"]
-`).
+		Workflow("@executor/k8s-resource-tmpl-with-automountservicetoken-disabled.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow().

--- a/test/e2e/retry_test.go
+++ b/test/e2e/retry_test.go
@@ -22,24 +22,7 @@ type RetryTestSuite struct {
 
 func (s *RetryTestSuite) TestRetryLimit() {
 	s.Given().
-		Workflow(`
-metadata:
-  name: test-retry-limit
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      retryStrategy:
-        limit: 0
-        backoff:
-          duration: 2s
-          factor: 2
-          maxDuration: 5m
-      container:
-        name: main
-        image: 'argoproj/argosay:v2'
-        args: [ exit, "1" ]
-`).
+		Workflow("@functional/test-retry-limit.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -66,23 +49,7 @@ spec:
 
 func (s *RetryTestSuite) TestRetryBackoff() {
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-backoff-strategy-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      retryStrategy:
-        limit: '10'
-        backoff:
-          duration: 10s
-          maxDuration: 1m
-      container:
-          name: main
-          image: 'argoproj/argosay:v2'
-          args: [ exit, "1" ]
-`).
+		Workflow("@functional/test-backoff-strategy.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(time.Second * 90).
@@ -92,23 +59,7 @@ spec:
 			assert.LessOrEqual(t, len(status.Nodes), 10)
 		})
 	s.Given().
-		Workflow(`
-metadata:
-  generateName: test-backoff-strategy-
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      retryStrategy:
-        limit: 10
-        backoff:
-          duration: 10s
-          maxDuration: 1m
-      container:
-          name: main
-          image: 'argoproj/argosay:v2'
-          args: [ exit, "1" ]
-`).
+		Workflow("@functional/test-backoff-strategy.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(time.Second * 90).
@@ -122,13 +73,7 @@ spec:
 func (s *RetryTestSuite) TestWorkflowTemplateWithRetryStrategyInContainerSet() {
 	s.Given().
 		WorkflowTemplate("@testdata/workflow-template-with-containerset.yaml").
-		Workflow(`
-metadata:
-  name: workflow-template-containerset
-spec:
-  workflowTemplateRef:
-    name: containerset-with-retrystrategy
-`).
+		Workflow("@functional/workflow-template-containerset.yaml").
 		When().
 		CreateWorkflowTemplates().
 		SubmitWorkflow().
@@ -160,23 +105,7 @@ spec:
 
 func (s *RetryTestSuite) TestRetryNodeAntiAffinity() {
 	s.Given().
-		Workflow(`
-metadata:
-  name: test-nodeantiaffinity-strategy
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      retryStrategy:
-        limit: '1'
-        retryPolicy: "Always"
-        affinity:
-          nodeAntiAffinity: {}
-      container:
-          name: main
-          image: 'argoproj/argosay:v2'
-          args: [ exit, "1" ]
-`).
+		Workflow("@functional/test-nodeantiaffinity-strategy.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToHaveFailedPod).

--- a/test/e2e/suspend_test.go
+++ b/test/e2e/suspend_test.go
@@ -19,41 +19,7 @@ type TestSuspendSitue struct {
 }
 
 func (s *TestSuspendSitue) TestSuspendNodeTimeoutWithoutDefaultValue() {
-	s.Given().Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  name: suspend-node-timeout-without-default-value
-spec:
-  entrypoint: suspend
-  templates:
-  - name: suspend
-    steps:
-    - - name: approve
-        template: approve
-    - - name: release
-        template: whalesay
-        arguments:
-          parameters:
-            - name: message
-              value: "{{steps.approve.outputs.parameters.message}}"
-  - name: approve
-    suspend:
-      duration: 5s
-    outputs:
-      parameters:
-        - name: message
-          valueFrom:
-            supplied: {}
-  - name: whalesay
-    inputs:
-      parameters:
-        - name: message
-    container:
-      image: docker/whalesay
-      command: [cowsay]
-      args: ["{{inputs.parameters.message}}"]
-`).
+	s.Given().Workflow("@functional/suspend-node-timeout-without-default-value.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed).
@@ -65,42 +31,7 @@ spec:
 }
 
 func (s *TestSuspendSitue) TestSuspendNodeTimeoutWithDefaultValue() {
-	s.Given().Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  name: suspend-node-timeout-with-default-value
-spec:
-  entrypoint: suspend
-  templates:
-  - name: suspend
-    steps:
-    - - name: approve
-        template: approve
-    - - name: release
-        template: whalesay
-        arguments:
-          parameters:
-            - name: message
-              value: "{{steps.approve.outputs.parameters.message}}"
-  - name: approve
-    suspend:
-      duration: 5s
-    outputs:
-      parameters:
-        - name: message
-          valueFrom:
-            default: default message
-            supplied: {}
-  - name: whalesay
-    inputs:
-      parameters:
-        - name: message
-    container:
-      image: docker/whalesay
-      command: [cowsay]
-      args: ["{{inputs.parameters.message}}"]
-`).
+	s.Given().Workflow("@functional/suspend-node-timeout-with-default-value.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).

--- a/test/e2e/workflow_configmap_substitution_test.go
+++ b/test/e2e/workflow_configmap_substitution_test.go
@@ -20,33 +20,7 @@ type WorkflowConfigMapSelectorSubstitutionSuite struct {
 
 func (s *WorkflowConfigMapSelectorSubstitutionSuite) TestKeySubstitution() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-configmapkeyselector-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-    - name: message
-      value: msg
-  templates:
-  - name: whalesay
-    inputs:
-      parameters:
-      - name: message
-        valueFrom:
-          configMapKeyRef:
-            name: cmref-parameters
-            key: '{{ workflow.parameters.message }}'
-    container:
-      image: argoproj/argosay:v2
-      args:
-        - echo
-        - "{{inputs.parameters.message}}"
-`).
+		Workflow("@functional/workflow-template-configmapkeyselector-wf.yaml").
 		When().
 		CreateConfigMap(
 			"cmref-parameters",
@@ -64,33 +38,7 @@ spec:
 
 func (s *WorkflowConfigMapSelectorSubstitutionSuite) TestNameSubstitution() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-configmapkeyselector-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-    - name: cm-name
-      value: cmref-parameters
-  templates:
-  - name: whalesay
-    inputs:
-      parameters:
-      - name: message
-        valueFrom:
-          configMapKeyRef:
-            name: '{{ workflow.parameters.cm-name}}'
-            key: msg
-    container:
-      image: argoproj/argosay:v2
-      args:
-        - echo
-        - "{{inputs.parameters.message}}"
-`).
+		Workflow("@functional/workflow-template-configmapkeyselector-wf.yaml").
 		When().
 		CreateConfigMap(
 			"cmref-parameters",
@@ -108,33 +56,7 @@ spec:
 
 func (s *WorkflowConfigMapSelectorSubstitutionSuite) TestInvalidNameParameterSubstitution() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-configmapkeyselector-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-    - name: cm-name
-      value: cmref-parameters
-  templates:
-  - name: whalesay
-    inputs:
-      parameters:
-      - name: message
-        valueFrom:
-          configMapKeyRef:
-            name: '{{ workflow.parameters.cm-name }}'
-            key: msg
-    container:
-      image: argoproj/argosay:v2
-      args:
-        - echo
-        - "{{inputs.parameters.message}}"
-`).
+		Workflow("@functional/workflow-template-configmapkeyselector-wf.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeErrored)
@@ -142,34 +64,7 @@ spec:
 
 func (s *WorkflowConfigMapSelectorSubstitutionSuite) TestDefaultParamValueWhenNotFound() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-configmapkeyselector-wf-default-param-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-    - name: message
-      value: msg
-  templates:
-  - name: whalesay
-    inputs:
-      parameters:
-      - name: message
-        valueFrom:
-          default: "default-val"
-          configMapKeyRef:
-            name: cmref-parameters
-            key: not-existing-key
-    container:
-      image: argoproj/argosay:v2
-      args:
-        - echo
-        - "{{inputs.parameters.message}}"
-`).
+		Workflow("@functional/workflow-template-configmapkeyselector-wf-default-param.yaml").
 		When().
 		CreateConfigMap(
 			"cmref-parameters",
@@ -187,34 +82,7 @@ spec:
 
 func (s *WorkflowConfigMapSelectorSubstitutionSuite) TestGlobalArgDefaultCMParamValueWhenNotFound() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-cmkeyselector-wf-global-arg-default-param-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-      - name: simple-global-param
-        valueFrom:
-          default: "default value"
-          configMapKeyRef:
-            name: not-existing-cm
-            key: not-existing-key
-  templates:
-    - name: whalesay
-      container:
-        image: argoproj/argosay:v2
-        command: [sh, -c]
-        args: ["sleep 1; echo -n {{workflow.parameters.simple-global-param}} > /tmp/message.txt"]
-      outputs:
-        parameters:
-         - name: message
-           valueFrom:
-             path: /tmp/message.txt
-`).
+		Workflow("@functional/workflow-template-cmkeyselector-wf-global-arg-default-param.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).

--- a/test/e2e/workflow_inputs_orverridable_test.go
+++ b/test/e2e/workflow_inputs_orverridable_test.go
@@ -20,33 +20,7 @@ type WorkflowInputsOverridableSuite struct {
 
 func (s *WorkflowInputsOverridableSuite) TestArgsValueParamsOverrideInputParamsValueFrom() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-inputs-overridable-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-      - name: message
-        value: arg-value
-  templates:
-    - name: whalesay
-      container:
-        image: argoproj/argosay:v2
-        args:
-        - echo
-        - "{{inputs.parameters.message}}"
-      inputs:
-        parameters:
-          - name: message
-            valueFrom:
-              configMapKeyRef:
-                name: cmref-parameters
-                key: cmref-key
-`).
+		Workflow("@functional/workflow-inputs-overridable-wf.yaml").
 		When().
 		CreateConfigMap(
 			"cmref-parameters",
@@ -65,36 +39,7 @@ spec:
 
 func (s *WorkflowInputsOverridableSuite) TestArgsValueFromParamsOverrideInputParamsValueFrom() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-inputs-overridable-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-      - name: message
-        valueFrom:
-          configMapKeyRef:
-            name: new-cmref-parameters
-            key: cmref-key
-  templates:
-    - name: whalesay
-      container:
-        image: argoproj/argosay:v2
-        args:
-        - echo
-        - "{{inputs.parameters.message}}"
-      inputs:
-        parameters:
-          - name: message
-            valueFrom:
-              configMapKeyRef:
-                name: cmref-parameters
-                key: cmref-key
-`).
+		Workflow("@functional/workflow-inputs-overridable-wf.yaml").
 		When().
 		CreateConfigMap(
 			"cmref-parameters",
@@ -118,30 +63,7 @@ spec:
 
 func (s *WorkflowInputsOverridableSuite) TestArgsValueParamsOverrideInputParamsValue() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-      - name: message
-        value: arg-value
-  templates:
-    - name: whalesay
-      container:
-        image: argoproj/argosay:v2
-        args:
-        - echo
-        - "{{inputs.parameters.message}}"
-      inputs:
-        parameters:
-          - name: message
-            value: input-value
-`).
+		Workflow("@functional/workflow-template-wf.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -154,33 +76,7 @@ spec:
 
 func (s *WorkflowInputsOverridableSuite) TestArgsValueFromParamsOverrideInputParamsValue() {
 	s.Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-inputs-overridable-wf-
-  label:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: whalesay
-  arguments:
-    parameters:
-      - name: message
-        valueFrom:
-          configMapKeyRef:
-            name: cmref-parameters
-            key: cmref-key
-  templates:
-    - name: whalesay
-      container:
-        image: argoproj/argosay:v2
-        args:
-        - echo
-        - "{{inputs.parameters.message}}"
-      inputs:
-        parameters:
-          - name: message
-            value: input-value
-`).
+		Workflow("@functional/workflow-inputs-overridable-wf.yaml").
 		When().
 		CreateConfigMap(
 			"cmref-parameters",

--- a/test/e2e/workflow_template_test.go
+++ b/test/e2e/workflow_template_test.go
@@ -26,24 +26,7 @@ func (s *WorkflowTemplateSuite) TestNestedWorkflowTemplate() {
 		When().
 		CreateWorkflowTemplates().
 		Given().
-		Workflow(`apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: workflow-template-nested-
-spec:
-  entrypoint: whalesay
-  templates:
-  - name: whalesay
-    steps:
-      - - name: call-whalesay-template
-          templateRef:
-            name: workflow-template-nested-template
-            template: whalesay-template
-          arguments:
-            parameters:
-            - name: message
-              value: "hello from nested"
-`).When().
+		Workflow("@functional/workflow-template-nested.yaml").When().
 		SubmitWorkflow().
 		WaitForWorkflow().
 		Then().
@@ -115,13 +98,7 @@ func (s *WorkflowTemplateSuite) TestSubmitWorkflowTemplateWithParallelStepsRequi
 func (s *WorkflowTemplateSuite) TestWorkflowTemplateInvalidOnExit() {
 	s.Given().
 		WorkflowTemplate("@testdata/workflow-template-invalid-onexit.yaml").
-		Workflow(`
-metadata:
-  generateName: workflow-template-invalid-onexit-
-spec:
-  workflowTemplateRef:
-    name: workflow-template-invalid-onexit
-`).
+		Workflow("@functional/workflow-template-invalid-onexit.yaml").
 		When().
 		CreateWorkflowTemplates().
 		SubmitWorkflow().
@@ -137,13 +114,7 @@ spec:
 func (s *WorkflowTemplateSuite) TestWorkflowTemplateWithHook() {
 	s.Given().
 		WorkflowTemplate("@testdata/workflow-templates/success-hook.yaml").
-		Workflow(`
-metadata:
-  generateName: workflow-template-hook-
-spec:
-  workflowTemplateRef:
-    name: hook
-`).
+		Workflow("@functional/workflow-template-hook.yaml").
 		When().
 		CreateWorkflowTemplates().
 		SubmitWorkflow().
@@ -167,13 +138,7 @@ spec:
 func (s *WorkflowTemplateSuite) TestWorkflowTemplateInvalidEntryPoint() {
 	s.Given().
 		WorkflowTemplate("@testdata/workflow-template-invalid-entrypoint.yaml").
-		Workflow(`
-metadata:
-  generateName: workflow-template-invalid-entrypoint-
-spec:
-  workflowTemplateRef:
-    name: workflow-template-invalid-entrypoint
-`).
+		Workflow("@functional/workflow-template-invalid-entrypoint.yaml").
 		When().
 		CreateWorkflowTemplates().
 		SubmitWorkflow().

--- a/test/e2e/workflow_test.go
+++ b/test/e2e/workflow_test.go
@@ -22,45 +22,7 @@ type WorkflowSuite struct {
 }
 
 func (s *WorkflowSuite) TestWorkflowFailedWhenAllPodSetFailedFromPending() {
-	(s.Given().Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: active-deadline-fanout-template-level-
-  namespace: argo
-spec:
-  entrypoint: entrypoint
-  templates:
-  - name: entrypoint
-    steps:
-    - - name: fanout
-        template: echo
-        arguments:
-          parameters:
-            - name: item
-              value: "{{item}}"
-        withItems:
-          - 1
-          - 2
-          - 3
-          - 4
-  - name: echo
-    inputs:
-      parameters:
-        - name: item
-    container:
-      image: argoproj/argosay:v2
-      imagePullPolicy: Always
-      command:
-        - sh
-        - '-c'
-      args:
-        - echo
-        - 'workflow number {{inputs.parameters.item}}'
-        - sleep
-        - '20'
-    activeDeadlineSeconds: 2 # defined on template level, not workflow level !
-`).
+	(s.Given().Workflow("@functional/active-deadline-fanout-template-level.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeFailed, time.Minute*11).
@@ -121,27 +83,7 @@ spec:
 }
 
 func (s *WorkflowSuite) TestWorkflowInlinePodName() {
-	s.Given().Workflow(`
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: steps-inline-
-  labels:
-    workflows.argoproj.io/test: "true"
-spec:
-  entrypoint: main
-  templates:
-    - name: main
-      steps:
-        - - name: a
-            inline:
-              container:
-                image: argoproj/argosay:v2
-                command:
-                  - cowsay
-                args:
-                  - "foo"
-`).
+	s.Given().Workflow("@functional/steps-inline.yaml").
 		When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeCompleted, time.Minute*1).


### PR DESCRIPTION
Part of #13610 

### Motivation

The .go files are too big.
Vibe coded a tool to move these, so hopefully this is sane and the content is necessarily identical.

### Modifications

Remove literal kubernetes objects from e2e tests and put them in files.
Only accept files from now on.

### Verification

CI will tell us if it's horridly broken

### Documentation

Developer experience only