### PR TITLE
feat(ui): add warning message when deleting CronWorkflow about orphaned Workflows

### DIFF
--- a/ui/src/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/cron-workflows/cron-workflow-details.tsx
@@ -152,7 +152,7 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
                 iconClassName: 'fa fa-trash',
                 disabled: edited,
                 action: () => {
-                    popup.confirm('confirm', 'Are you sure you want to delete this cron workflow?').then(yes => {
+                    popup.confirm('confirm', 'Are you sure you want to delete this cron workflow? (This also deletes all Workflows it spawned)').then(yes => {
                         if (yes) {
                             services.cronWorkflows
                                 .delete(name, namespace)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Refs #14679 

### Motivation

When a user deletes a CronWorkflow (CronSchedule) from the Workflows UI, any associated Workflow resources are also garbage collected by Kubernetes. However, this behavior isn’t clearly communicated in the UI, which could result in accidental data loss.

To improve clarity, I’ve added an informational message to the delete confirmation modal to let users know that Workflows created by the CronSchedule will also be deleted. This is the first step toward eventually adding an option to retain orphaned Workflows in a future release.

### Modifications
- Added a warning message to the delete confirmation modal for CronWorkflows.
- The message informs users that all Workflows created by the CronWorkflow will also be deleted.
- UI/UX change only — no functional logic added yet.

<img width="1027" height="228" alt="image" src="https://github.com/user-attachments/assets/201b66c4-2232-431c-832d-c97dced3d768" />

### Verification
- Manually tested the delete modal in the Workflows UI.

### Documentation
- Not required at this point.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
