### PR TITLE
fix: only init Informers if SA has apropriate RBAC access. Fixes #14688

### DIFF
--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -28,6 +28,7 @@ import (
 	workflowtemplateserver "github.com/argoproj/argo-workflows/v3/server/workflowtemplate"
 	"github.com/argoproj/argo-workflows/v3/util/help"
 	"github.com/argoproj/argo-workflows/v3/util/instanceid"
+	rbacutil "github.com/argoproj/argo-workflows/v3/util/rbac"
 )
 
 var (
@@ -71,6 +72,7 @@ type argoKubeClient struct {
 	wfLister          store.WorkflowLister
 	wfStore           store.WorkflowStore
 	namespace         string
+	kubeClient        *kubernetes.Clientset
 }
 
 var _ Client = &argoKubeClient{}
@@ -122,6 +124,7 @@ func newArgoKubeClient(ctx context.Context, opts ArgoKubeOpts, clientConfig clie
 		instanceIDService: instanceIDService,
 		wfClient:          wfClient,
 		namespace:         namespace,
+		kubeClient:        kubeClient,
 	}
 	err = client.startStores(ctx, restConfig)
 	if err != nil {
@@ -154,16 +157,19 @@ func (a *argoKubeClient) startStores(ctx context.Context, restConfig *restclient
 		a.wfTmplStore = workflowtemplateserver.NewWorkflowTemplateClientStore()
 	}
 
-	if a.opts.CacheClusterWorkflowTemplates {
-		cwftmplInformer, err := clusterworkflowtmplserver.NewInformer(restConfig)
-		if err != nil {
-			return err
+	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, a.kubeClient, a.namespace) {
+		if a.opts.CacheClusterWorkflowTemplates {
+			cwftmplInformer, err := clusterworkflowtmplserver.NewInformer(restConfig)
+			if err != nil {
+				return err
+			}
+			cwftmplInformer.Run(ctx, a.opts.CachingCloseCh)
+			a.cwfTmplStore = cwftmplInformer
+		} else {
+			a.cwfTmplStore = clusterworkflowtmplserver.NewClusterWorkflowTemplateClientStore()
 		}
-		cwftmplInformer.Run(ctx, a.opts.CachingCloseCh)
-		a.cwfTmplStore = cwftmplInformer
-	} else {
-		a.cwfTmplStore = clusterworkflowtmplserver.NewClusterWorkflowTemplateClientStore()
 	}
+
 	return nil
 }
 

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -1,0 +1,25 @@
+package rbac
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+
+	authutil "github.com/argoproj/argo-workflows/v3/util/auth"
+	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
+)
+
+func HasAccessToClusterWorkflowTemplates(ctx context.Context, kubeclientset kubernetes.Interface, namespace string) bool {
+	cwftGetAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "get", "clusterworkflowtemplates", namespace, "")
+	errorsutil.CheckError(ctx, err)
+	cwftListAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "list", "clusterworkflowtemplates", namespace, "")
+	errorsutil.CheckError(ctx, err)
+	cwftWatchAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "watch", "clusterworkflowtemplates", namespace, "")
+	errorsutil.CheckError(ctx, err)
+
+	if !cwftGetAllowed || !cwftListAllowed || !cwftWatchAllowed {
+		return false
+	}
+
+	return true
+}

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -1,0 +1,57 @@
+package rbac
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/argoproj/argo-workflows/v3/util/logging"
+)
+
+func TestRBAC_AccessClusterWorkflowTemplates(t *testing.T) {
+
+	t.Run("has full access", func(t *testing.T) {
+		kubeclientset := &kubefake.Clientset{}
+		allowedVerbs := []string{"get", "list", "watch"}
+		kubeclientset.AddReactor("create", "selfsubjectaccessreviews", reactionFuncWithAllowedVerbs(allowedVerbs))
+		ctx := logging.TestContext(t.Context())
+		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, "")
+		assert.True(t, allowed)
+	})
+
+	t.Run("only has get and list access", func(t *testing.T) {
+		kubeclientset := &kubefake.Clientset{}
+		allowedVerbs := []string{"get", "list"}
+		kubeclientset.AddReactor("create", "selfsubjectaccessreviews", reactionFuncWithAllowedVerbs(allowedVerbs))
+		ctx := logging.TestContext(t.Context())
+		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, "")
+		assert.False(t, allowed)
+	})
+
+	t.Run("only has get access", func(t *testing.T) {
+		kubeclientset := &kubefake.Clientset{}
+		allowedVerbs := []string{"get"}
+		kubeclientset.AddReactor("create", "selfsubjectaccessreviews", reactionFuncWithAllowedVerbs(allowedVerbs))
+		ctx := logging.TestContext(t.Context())
+		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, "")
+		assert.False(t, allowed)
+	})
+}
+
+func reactionFuncWithAllowedVerbs(allowedVerbs []string) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		selfSubjectAccessReview := reflect.ValueOf(action).FieldByName("Object").Elem().Elem().Field(2).Field(0).Elem()
+		resource := selfSubjectAccessReview.FieldByName("Resource").String()
+		verb := selfSubjectAccessReview.FieldByName("Verb").String()
+		allowed := resource == "clusterworkflowtemplates" && slices.Contains(allowedVerbs, verb)
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: allowed},
+		}, nil
+	}
+}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -44,11 +44,11 @@ import (
 	"github.com/argoproj/argo-workflows/v3/pkg/client/informers/externalversions"
 	wfextvv1alpha1 "github.com/argoproj/argo-workflows/v3/pkg/client/informers/externalversions/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/pkg/plugins/spec"
-	authutil "github.com/argoproj/argo-workflows/v3/util/auth"
 	wfctx "github.com/argoproj/argo-workflows/v3/util/context"
 	"github.com/argoproj/argo-workflows/v3/util/deprecation"
 	"github.com/argoproj/argo-workflows/v3/util/env"
 	"github.com/argoproj/argo-workflows/v3/util/errors"
+	rbacutil "github.com/argoproj/argo-workflows/v3/util/rbac"
 	"github.com/argoproj/argo-workflows/v3/util/retry"
 	"github.com/argoproj/argo-workflows/v3/util/telemetry"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
@@ -337,7 +337,17 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		go wfc.runConfigMapWatcher(ctx)
 	}
 
-	go wfc.nsInformer.Run(ctx.Done())
+	// namespace informer only works if has RBAC access
+	var nsInformerHasSynced func() bool
+	if wfc.nsInformer != nil {
+		go wfc.nsInformer.Run(ctx.Done())
+		nsInformerHasSynced = wfc.nsInformer.HasSynced
+	} else {
+		nsInformerHasSynced = func() bool {
+			return true
+		}
+	}
+
 	go wfc.wfInformer.Run(ctx.Done())
 	go wfc.wftmplInformer.Informer().Run(ctx.Done())
 	go wfc.configMapInformer.Run(ctx.Done())
@@ -351,7 +361,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	if !cache.WaitForCacheSync(
 		ctx.Done(),
 		wfc.wfInformer.HasSynced,
-		wfc.nsInformer.HasSynced,
+		nsInformerHasSynced,
 		wfc.wftmplInformer.Informer().HasSynced,
 		wfc.PodController.HasSynced(),
 		wfc.configMapInformer.HasSynced,
@@ -506,15 +516,8 @@ func (wfc *WorkflowController) notifySemaphoreConfigUpdate(ctx context.Context, 
 
 // Check if the controller has RBAC access to ClusterWorkflowTemplates
 func (wfc *WorkflowController) createClusterWorkflowTemplateInformer(ctx context.Context) {
-	cwftGetAllowed, err := authutil.CanIArgo(ctx, wfc.kubeclientset, "get", "clusterworkflowtemplates", wfc.namespace, "")
-	errors.CheckError(ctx, err)
-	cwftListAllowed, err := authutil.CanIArgo(ctx, wfc.kubeclientset, "list", "clusterworkflowtemplates", wfc.namespace, "")
-	errors.CheckError(ctx, err)
-	cwftWatchAllowed, err := authutil.CanIArgo(ctx, wfc.kubeclientset, "watch", "clusterworkflowtemplates", wfc.namespace, "")
-	errors.CheckError(ctx, err)
-
 	logger := logging.RequireLoggerFromContext(ctx)
-	if cwftGetAllowed && cwftListAllowed && cwftWatchAllowed {
+	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, wfc.kubeclientset, wfc.namespace) {
 		wfc.cwftmplInformer = informer.NewTolerantClusterWorkflowTemplateInformer(wfc.dynamicInterface, clusterWorkflowTemplateResyncPeriod)
 		go wfc.cwftmplInformer.Informer().Run(ctx.Done())
 

--- a/workflow/controller/ns_watcher.go
+++ b/workflow/controller/ns_watcher.go
@@ -36,6 +36,7 @@ func (wfc *WorkflowController) newNamespaceInformer(ctx context.Context, kubecli
 	can, _ := authutil.CanI(ctx, wfc.kubeclientset, []string{"get", "watch", "list"}, "", metav1.NamespaceAll, "namespaces")
 	if !can {
 		log.Warn(ctx, "was unable to get permissions for get/watch/list verbs on the namespace resource, per-namespace parallelism will not work")
+		return nil, nil
 	}
 	c := kubeclientset.CoreV1().Namespaces()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/14688

### Motivation

Currently Argo Server is always starting the ClusterWorkflowTemplateInformer even when running on namespace mode (without RBAC access to ClusterWorkflowTemplates).

Workflow controller is also creating the informer for namespaces, which also needs RBAC. This was introduced in https://github.com/argoproj/argo-workflows/pull/14188

### Modifications

Updated the Argo Server startup to only init the ClusterWorkflowTemplateInformer if it has RBAC access.

Updated the Workflow controller to only init namespace innformer when it has RBAC access.

Also created a new util/rbac package to hold the function HasAccessToClusterWorkflowTemplates because it is used by argo-server, workflow controller and apiclient. Let me know if you think that creating a new package is not necessary.

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

Run with [namespace-install.yaml](https://github.com/argoproj/argo-workflows/releases/download/v3.7.0/namespace-install.yaml).

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
