### PR TITLE
chore: revert fix: ignore ALPN by using the env variable hack (#14588)

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -176,7 +176,6 @@ gitops
 goroutine
 goroutines
 govaluate
-grpc
 gzipped
 i.e.
 idempotence

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,8 +123,6 @@ USER 8737
 
 WORKDIR /home/argo
 
-# Temporary workaround for https://github.com/grpc/grpc-go/issues/434
-ENV GRPC_ENFORCE_ALPN_ENABLED=false
 COPY hack/ssh_known_hosts /etc/ssh/
 COPY hack/nsswitch.conf /etc/
 COPY --from=argocli-build /go/src/github.com/argoproj/argo-workflows/dist/argo /bin/

--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -181,7 +181,3 @@ You can access additional information through the following headers.
 * `X-Rate-Limit-Remaining` - the number of requests left for the current rate-limit window.
 * `X-Rate-Limit-Reset` - the time at which the rate limit resets, specified in UTC time.
 * `Retry-After` - indicate when a client should retry requests (when the rate limit expires), in UTC time.
-
-### GRPC ALPN
-
-The grpc library wants to enforce ALPN, but we are not prepared for this so the argo-server binary is built with `GRPC_ENFORCE_ALPN_ENABLED` set to `false` in the docker image as a short term workaround, as documented in https://github.com/grpc/grpc-go/issues/434


### PR DESCRIPTION
This reverts commit ce1b4471a64b4f20305d44fbbe2f3a9f242c8dcb.

With #14567 now in we can revert this