### PR TITLE
fix: allow query parameters for DELETE method and disable body marshaling. Fixes #14753

### DIFF
--- a/pkg/apiclient/http1/facade.go
+++ b/pkg/apiclient/http1/facade.go
@@ -93,7 +93,7 @@ func (h Facade) EventStreamReader(ctx context.Context, in interface{}, path stri
 func (h Facade) do(ctx context.Context, in interface{}, out interface{}, method string, path string) error {
 	log := logging.RequireLoggerFromContext(ctx)
 	var data []byte
-	if method != "GET" {
+	if method != "GET" && method != "DELETE" {
 		var err error
 		data, err = json.Marshal(in)
 		if err != nil {
@@ -148,7 +148,7 @@ func (h Facade) url(method, path string, in interface{}) (*url.URL, error) {
 		x := "{" + s + "}"
 		if strings.Contains(path, x) {
 			path = strings.Replace(path, x, v, 1)
-		} else if method == "GET" {
+		} else if method == "GET" || method == "DELETE" {
 			query.Set(s, v)
 		}
 	}

--- a/pkg/apiclient/http1/facade_test.go
+++ b/pkg/apiclient/http1/facade_test.go
@@ -13,4 +13,8 @@ func TestFacade_do(t *testing.T) {
 	u, err := f.url("GET", "/{namespace}/{name}", &metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{"foo": "1"}})
 	require.NoError(t, err)
 	assert.Equal(t, "http://my-url/my-ns/?labels.foo=1", u.String())
+
+	u, err = f.url("DELETE", "/{namespace}/{name}", &metav1.ObjectMeta{Namespace: "my-ns", Labels: map[string]string{"foo": "1"}})
+	require.NoError(t, err)
+	assert.Equal(t, "http://my-url/my-ns/?labels.foo=1", u.String())
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14753

### Motivation
As described in issue #14753, query parameters are not passed when using a DELETE request. Code generated by `grpc-gateway` only allows path and query parameters for a `DELETE` request, so the `facade` code is updated to accommodate that. In general, the body can be used, but the command for generating the code needs to be updated.

https://github.com/grpc-ecosystem/grpc-gateway/blob/main/protoc-gen-openapiv2/main.go#L22

### Modifications
Allowed

### Verification
- manual testing
- added unit test


<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
