### PR TITLE
test: fix TestReadinessProbe due to conflict

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -72,8 +72,7 @@ func (s *ArgoServerSuite) TestReadinessProbe() {
 		response := s.e().GET("/").
 			WithProto("HTTP/1.1").
 			Expect().
-			Status(200).
-			HasContentType("text/html")
+			Status(200)
 		s.Equal("HTTP/1.1", response.Raw().Proto) //nolint:bodyclose
 	})
 
@@ -82,8 +81,7 @@ func (s *ArgoServerSuite) TestReadinessProbe() {
 			WithProto("HTTP/2.0").
 			WithClient(http2Client).
 			Expect().
-			Status(200).
-			HasContentType("text/html")
+			Status(200)
 		s.Equal("HTTP/2.0", response.Raw().Proto) //nolint:bodyclose
 	})
 }


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation
On `release-3.6`, the `TestArgoServerSuite/TestReadinessProbe` test is failing with `invalid "Content-Type" response header`. Example: https://github.com/argoproj/argo-workflows/actions/runs/16828111449/job/47669457916

That test was backported in https://github.com/argoproj/argo-workflows/pull/14742, but it's conflicting with the changes in https://github.com/argoproj/argo-workflows/pull/11707, which haven't been backported to `release-3.6`. The latter PR changed the behavior of the server when `STATIC_FILES` is disabled. Before that change, the response for the root path won't have `Content-Type: text/html`, but aftewards it does, even though the response body is empty (since `index.html` will be an empty file when `STATIC_FILES=false`).

Before:
```
$ curl http://localhost:2746 -v
* Host localhost:2746 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:2746...
* Connected to localhost (::1) port 2746
> GET / HTTP/1.1
> Host: localhost:2746
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Security-Policy: default-src 'self' 'unsafe-inline'; img-src 'self' data:
< X-Frame-Options: SAMEORIGIN
< X-Ratelimit-Limit: 1000
< X-Ratelimit-Remaining: 999
< X-Ratelimit-Reset: Sat, 09 Aug 2025 02:19:43 UTC
< Date: Sat, 09 Aug 2025 02:19:43 GMT
< Content-Length: 0
<
* Connection #0 to host localhost left intact
```

After:
```
 $ curl http://localhost:2746 -v
* Host localhost:2746 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:2746...
* Connected to localhost (::1) port 2746
> GET / HTTP/1.1
> Host: localhost:2746
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Length: 0
< Content-Security-Policy: default-src 'self' 'unsafe-inline'; img-src 'self' data:
< Content-Type: text/html; charset=utf-8
< Last-Modified: Sat, 09 Aug 2025 02:33:08 GMT
< X-Frame-Options: SAMEORIGIN
< X-Ratelimit-Limit: 1000
< X-Ratelimit-Remaining: 999
< X-Ratelimit-Reset: Sat, 09 Aug 2025 02:33:08 UTC
< Date: Sat, 09 Aug 2025 02:33:08 GMT
 ```


### Modifications

The fix is simply removing the `HasContentType()` assertion, though alternatively we could backport https://github.com/argoproj/argo-workflows/pull/11707.
### Verification

Ran `make TestReadinessProbe` locally

### Documentation

N/A
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
