### PR TITLE
fix(ui): add tooltips to WORKFLOW TEMPLATE and CRON WORKFLOW dropdowns

### DIFF
--- a/ui/src/shared/components/data-loader-dropdown.tsx
+++ b/ui/src/shared/components/data-loader-dropdown.tsx
@@ -1,24 +1,86 @@
 import {DataLoader} from 'argo-ui/src/components/data-loader';
 import {Select, SelectOption} from 'argo-ui/src/components/select/select';
 import * as React from 'react';
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 export function DataLoaderDropdown(props: {load: () => Promise<(string | SelectOption)[]>; onChange: (value: string) => void; placeholder?: string}) {
     const [selected, setSelected] = useState('');
+    const selectRef = useRef<HTMLDivElement>(null);
+    const [options, setOptions] = useState<(string | SelectOption)[]>([]);
+
+    const enhanceOptionsWithTitles = (options: (string | SelectOption)[]) => {
+        setOptions(options);
+        return options.map(option => {
+            if (typeof option === 'string') {
+                return {
+                    value: option,
+                    title: option
+                };
+            } else {
+                return option;
+            }
+        });
+    };
+
+    useEffect(() => {
+        const addTitleAttributes = () => {
+            setTimeout(() => {
+                const optionElements = document.querySelectorAll('.select__option');
+                optionElements.forEach(element => {
+                    const text = element.textContent || '';
+                    if (text) {
+                        element.setAttribute('title', text);
+                    }
+                });
+            }, 100);
+        };
+
+        if (options.length > 0) {
+            addTitleAttributes();
+        }
+    }, [options]);
+
+    useEffect(() => {
+        const handleDropdownOpen = () => {
+            const observer = new MutationObserver(mutations => {
+                mutations.forEach(mutation => {
+                    if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+                        const optionElements = document.querySelectorAll('.select__option');
+                        optionElements.forEach(element => {
+                            const text = element.textContent || '';
+                            if (text) {
+                                element.setAttribute('title', text);
+                            }
+                        });
+                    }
+                });
+            });
+
+            observer.observe(document.body, {childList: true, subtree: true});
+
+            return () => {
+                observer.disconnect();
+            };
+        };
+
+        handleDropdownOpen();
+    }, []);
 
     return (
-        <DataLoader load={props.load}>
-            {list => (
-                <Select
-                    placeholder={props.placeholder}
-                    options={list}
-                    value={selected}
-                    onChange={x => {
-                        setSelected(x.value);
-                        props.onChange(x.value);
-                    }}
-                />
-            )}
-        </DataLoader>
+        <div ref={selectRef}>
+            <DataLoader load={props.load}>
+                {list => (
+                    <Select
+                        placeholder={props.placeholder}
+                        options={enhanceOptionsWithTitles(list)}
+                        value={selected}
+                        onChange={x => {
+                            setSelected(x.value);
+                            props.onChange(x.value);
+                        }}
+                    />
+                )}
+            </DataLoader>
+        </div>
     );
 }

--- a/ui/src/workflows/components/workflow-filters/workflow-filters.scss
+++ b/ui/src/workflows/components/workflow-filters/workflow-filters.scss
@@ -37,3 +37,24 @@
 #top-bar__filter-list {
     column-count: 1;
 }
+
+.select__option {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    position: relative;
+}
+
+.select__option:hover::after {
+    content: attr(title);
+    position: absolute;
+    left: 0;
+    top: -30px;
+    background: #333;
+    color: white;
+    padding: 5px;
+    border-radius: 3px;
+    white-space: nowrap;
+    z-index: 1000;
+    font-size: 12px;
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14770 

### Motivation
The current implementation of WORKFLOW TEMPLATE and CRON WORKFLOW dropdowns in the Workflows tab has a usability issue. When template or workflow names are long, the text gets truncated without any way to view the full content. This makes it difficult for users to identify and select the correct template or workflow, especially when there are multiple items with similar names.

Users need to be able to see the full name of templates and workflows in the dropdown lists, even when those names are long. Currently, hovering over truncated text does not display any tooltip or additional information.

<!-- TODO: Say why you made your changes. -->

### Modifications
This PR implements the following changes to improve the user experience:

1. Implement logic in the DataLoaderDropdown component to add a title attribute to each option. Set the title attribute for static option lists and use MutationObserver to set the title attribute for dynamically added option elements as well. 

2. Improve how long text is displayed in the workflow filter stylesheet by showing overflowed text with an ellipsis (text-overflow: ellipsis) and displaying the full text as a tooltip on hover.


Screenshots after the changes:

<img width="400" height="600" alt="スクリーンショット 2025-08-19 13 04 14" src="https://github.com/user-attachments/assets/ea0bb5cf-ff3a-41d8-83ca-f4eb5be71550" />
<img width="400" height="600" alt="スクリーンショット 2025-08-19 13 04 09" src="https://github.com/user-attachments/assets/7d8a877d-be5a-4435-ba06-4401fbb77523" />


<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
The changes have been tested with the following scenarios:

1. Created workflow templates with very long names
2. Verified that long names are properly truncated with ellipsis in the dropdown
3. Confirmed that hovering over truncated text displays a tooltip with the full name
4. Verified that the functionality works for both WORKFLOW TEMPLATE and CRON WORKFLOW dropdowns

<!-- TODO: Say how you tested your changes. -->

### Documentation
No documentation updates are required for this change as it's a UI improvement that doesn't introduce new features or change existing functionality. The behavior (showing tooltips on hover) follows standard web UI patterns that users are already familiar with.

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
