### PR TITLE
fix: ensure pod used container templates are copies

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3018,7 +3018,8 @@ func (woc *wfOperationCtx) executeContainer(ctx context.Context, nodeName string
 	}
 
 	woc.log.WithFields(logging.Fields{"nodeName": nodeName, "template": tmpl.Name}).Debug(ctx, "Executing node with container template")
-	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*tmpl.Container}, tmpl, &createWorkflowPodOpts{
+	ctr := tmpl.Container.DeepCopy()
+	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*ctr}, tmpl, &createWorkflowPodOpts{
 		includeScriptOutput: includeScriptOutput,
 		onExitPod:           opts.onExitTemplate,
 		executionDeadline:   opts.executionDeadline,
@@ -3235,7 +3236,7 @@ func (woc *wfOperationCtx) executeScript(ctx context.Context, nodeName string, t
 		return node, err
 	}
 
-	mainCtr := tmpl.Script.Container
+	mainCtr := *tmpl.Script.Container.DeepCopy()
 	if len(tmpl.Script.Source) == 0 {
 		woc.log.Warn(ctx, "'script.source' is empty, suggest change template into 'container'")
 	} else {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3236,13 +3236,13 @@ func (woc *wfOperationCtx) executeScript(ctx context.Context, nodeName string, t
 		return node, err
 	}
 
-	mainCtr := *tmpl.Script.Container.DeepCopy()
+	mainCtr := tmpl.Script.Container.DeepCopy()
 	if len(tmpl.Script.Source) == 0 {
 		woc.log.Warn(ctx, "'script.source' is empty, suggest change template into 'container'")
 	} else {
 		mainCtr.Args = append(mainCtr.Args, common.ExecutorScriptSourcePath)
 	}
-	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{mainCtr}, tmpl, &createWorkflowPodOpts{
+	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*mainCtr}, tmpl, &createWorkflowPodOpts{
 		includeScriptOutput: includeScriptOutput,
 		onExitPod:           opts.onExitTemplate,
 		executionDeadline:   opts.executionDeadline,


### PR DESCRIPTION
### Motivation

During a highly parallel workflow re-using the same template in a massive fan out it's been seen that you can get a panic, trimmed here:
```
fatal error: concurrent map iterarion and map write

encoding/json.Marshal({0x24148c0, 0xc16e8a1408})
	/opt/bb/libexec/go/src/encoding/json/encode.go:175 +0xbe
github.com/argoproj/argo-workflows/v3/workflow/controller.substitutePodParams(0xc16e8a1408, 0xc00204d4d0, 0xc20e4006c8)
	/go/src/github.com/argoproj/argo-workflows/workflow/controller/workflowpod.go:586 +0x290
```
### Modifications

Ensure templates which come from the common template store are copied before modification

### Verification

This is very hard to reproduce, so not really tested.

### Documentation

None, just a bug fix
