### PR TITLE
fix(controller): check optional artifacts in node output validation

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -645,6 +645,18 @@ func (s *FunctionalSuite) TestOptionalInputArtifacts() {
 		})
 }
 
+func (s *FunctionalSuite) TestOptionalOutputArtifacts() {
+	s.Given().
+		Workflow("@functional/output-artifact-optional.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(time.Second * 90).
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+		})
+}
+
 func (s *FunctionalSuite) TestWorkflowTemplateRefWithExitHandler() {
 	s.Given().
 		WorkflowTemplate("@smoke/workflow-template-whalesay-template.yaml").

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1518,12 +1518,24 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	}
 
 	// If the node template has outputs Parameters/Artifacts/Result, we should not change the phase to Succeeded until the outputs are set.
-	if tmpl != nil && tmpl.Outputs.HasOutputs() && new.Outputs != nil && new.Phase == wfv1.NodeSucceeded &&
-		((tmpl.Outputs.Parameters != nil && new.Outputs.Parameters == nil) ||
-			(tmpl.Outputs.Artifacts != nil && new.Outputs.Artifacts == nil) ||
-			(tmpl.Outputs.Result != nil && new.Outputs.Result == nil)) {
-		woc.log.WithField("new.phase", new.Phase).Info(ctx, "leaving phase un-changed: outputs are not yet set")
-		new.Phase = old.Phase
+	if tmpl != nil && tmpl.Outputs.HasOutputs() && new.Outputs != nil && new.Phase == wfv1.NodeSucceeded {
+		outputsNotReady := false
+		// Check Parameters - all parameters are considered required
+		if tmpl.Outputs.Parameters != nil && new.Outputs.Parameters == nil {
+			outputsNotReady = true
+		}
+		// Check Artifacts - only check if there are required (non-optional) artifacts
+		if hasRequiredArtifacts(tmpl.Outputs.Artifacts) && new.Outputs.Artifacts == nil {
+			outputsNotReady = true
+		}
+		// Check Result
+		if tmpl.Outputs.Result != nil && new.Outputs.Result == nil {
+			outputsNotReady = true
+		}
+		if outputsNotReady {
+			woc.log.WithField("new.phase", new.Phase).Info(ctx, "leaving phase un-changed: required outputs are not yet set")
+			new.Phase = old.Phase
+		}
 	}
 
 	// if we are transitioning from Pending to a different state (except Fail or Error), clear out unchanged message
@@ -1550,6 +1562,19 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	woc.log.WithField("nodeID", old.ID).
 		Debug(ctx, "node unchanged")
 	return nil
+}
+
+// hasRequiredArtifacts checks if there are any required (non-optional) artifacts
+func hasRequiredArtifacts(artifacts []wfv1.Artifact) bool {
+	if artifacts == nil {
+		return false
+	}
+	for _, artifact := range artifacts {
+		if !artifact.Optional {
+			return true
+		}
+	}
+	return false
 }
 
 func getExitCode(pod *apiv1.Pod) *int32 {


### PR DESCRIPTION
Fixes #14775

### Motivation
The original code had a logical flaw: when a template defined artifact outputs, it would prevent nodes from being marked as succeeded regardless of whether those artifacts were marked as Optional: true, until artifact outputs were present. This caused nodes to fail to complete normally even when all artifacts were optional.

When artifact is optional, it will not written to `WorkflowTaskResult` because of this PR:https://github.com/argoproj/argo-workflows/pull/13678
<!-- TODO: Say why you made your changes. -->

### Modifications
1. Added helper function hasRequiredArtifacts:
    - Checks if any artifact in the array has Optional: false
    - Returns false if all artifacts are optional
  2. Refactored output validation logic:
     - Used clear outputsNotReady boolean variable
  3. Optimized artifact checking:
     - Only performs checks when required (non-optional) artifacts exist
     - Allows nodes with only optional artifacts to succeed without artifact outputs
<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
local test
<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
