### PR TITLE
fix: retry strategy being ignored by daemoned nodes. Fix #14715

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2178,7 +2178,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 		childNodeIDs, lastChildNode := getChildNodeIdsAndLastRetriedNode(retryParentNode, woc.wf.Status.Nodes)
 
 		// The retry node might have completed by now.
-		if retryParentNode.Fulfilled() && woc.childrenFulfilled(retryParentNode) { // if retry node is daemoned we want to check those explicitly
+		if retryParentNode.Fulfilled() && (woc.childrenFulfilled(retryParentNode) || (retryParentNode.IsDaemoned() && retryParentNode.FailedOrError())) { // if retry node is daemoned we want to check those explicitly
 			// If retry node has completed, set the output of the last child node to its output.
 			// Runtime parameters (e.g., `status`, `resourceDuration`) in the output will be used to emit metrics.
 			if lastChildNode != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14715

### Motivation

Whenever a daemon pod Fails/errors the retryStategy is being ignored. The current code logic will skip the retry, and The message “Node not set to be retried” shows on the logs. However:
- workflow controller is still creating a new daemon node, ignoring the retryStrategy rules
- that node is not copying the children (step 2 in picture below)
- the killed daemoned node is marked as fulfilled with success ( I think this is by design)
- the workflow is set as failed event though the new daemon node is running

This leaves a zombie pod (monitor(1)) and If the global retry strategy is set, the workflow is retried.

<img width="1600" height="500" alt="image" src="https://github.com/user-attachments/assets/b3df4041-ca5c-4bdc-b892-75ced52c5ada" />


### Modifications

No longer creates new children when a daemoned retry node was set as failed or errored, which only happens when woc.processNodeRetries() decides that is not to be retried.

### Verification

```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: daemon-example-
spec:
  entrypoint: main
  templates:
    - name: main
      steps:
        - - name: monitor
            template: monitor

        - - name: fail
            template: fail 

    - name: monitor
      daemon: true
      retryStrategy:
        limit: 2
      script:
        image: python:alpine3.6
        command: [ python ]
        source: |
          import time
          print("Daemon running successfully", flush=True)
          time.sleep(10)
          sys.exit(1) # exit with non-zero code to failed node

    - name: fail
      script:
        image: python:alpine3.6
        command: [ python ]
        source: |
          import time
          import sys
          time.sleep(20)
          sys.exit(1) # remove this to test successfull workflow
```

The daemon pod is always failing, which triggers a Failed node. Kill the pod (`kubectl kill pod <name>`) to test a Errored node.

With `retryPolicy: Always`

Daemon pods are retried twice. After the last failure, the workflow is marked as failed and daemon nodes marked as successful (this is by design, all daemoned containers are set as Succeeded.

<img width="1106" height="504" alt="image" src="https://github.com/user-attachments/assets/d7e71551-5ec9-40b8-ba01-9c4ce76e29b9" />

With `retryPolicy: OnFailure`

If pod is killed by outside it is marked as `Errored`, so no retry:

<img width="846" height="182" alt="image" src="https://github.com/user-attachments/assets/75d0b193-c867-4e67-ab2c-4042435e6ff0" />

If pod exits with `sys.exit(1)` it is marked as `Failed` so it retries:

<img width="938" height="310" alt="image" src="https://github.com/user-attachments/assets/63baee1a-1769-47a6-91f1-fc3de4e8de54" />


With a global retry strategy, workflow will retry if daemoned pod fails, even if all other steps succeed 

<img width="1182" height="306" alt="image" src="https://github.com/user-attachments/assets/e56e6317-efc8-4ca9-875d-5972700509fe" />

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
