### PR TITLE
fix: moved off deprecated bitnami Docker images. Fixes 14785

### DIFF
--- a/test/e2e/expectedfailures/pod-termination-failure.yaml
+++ b/test/e2e/expectedfailures/pod-termination-failure.yaml
@@ -37,7 +37,7 @@ spec:
         args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]
     - name: check-status
       script:
-        image: bitnami/kubectl:1.15.3-ol-7-r165
+        image: bitnamilegacy/kubectl:1.15.3-ol-7-r165
         command: [bash]
         source: |
           host=`hostname`;
@@ -55,7 +55,7 @@ spec:
         parameters:
           - name: pod
       container:
-        image: bitnami/kubectl:1.15.3-ol-7-r165
+        image: bitnamilegacy/kubectl:1.15.3-ol-7-r165
         command: [bash, -c]
         args: ["kubectl delete po {{inputs.parameters.pod}}"]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14785 

### Motivation

Bitnami images are paywalled this Thursday, Thursday, August 28, 2025.

### Modifications

Moved to `bitnamylegacy` Docker images in the meantime, they will be available but will not receive any more updates.

### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
