### PR TITLE
fix: Add default value for creationtimestamp column addition. Fixes #…

### DIFF
--- a/persist/sqldb/migrate.go
+++ b/persist/sqldb/migrate.go
@@ -218,7 +218,7 @@ func Migrate(ctx context.Context, session db.Session, clusterName, tableName str
 		}),
 		sqldb.AnsiSQLChange(`create index argo_archived_workflows_i4 on argo_archived_workflows (clustername, startedat)`),
 		// add creationtimestamp column to argo_archived_workflows table
-		sqldb.AnsiSQLChange(`alter table argo_archived_workflows add column creationtimestamp timestamp`),
+		sqldb.AnsiSQLChange(`alter table argo_archived_workflows add column creationtimestamp timestamp null`),
 		sqldb.AnsiSQLChange(`update argo_archived_workflows set creationtimestamp = startedat where creationtimestamp is null`),
 		sqldb.ByType(dbType, sqldb.TypedChanges{
 			sqldb.MySQL:    sqldb.AnsiSQLChange(`alter table argo_archived_workflows modify column creationtimestamp timestamp not null default CURRENT_TIMESTAMP`),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14789

### Motivation

<!-- TODO: Say why you made your changes. -->
[The query in v3.7.1](https://github.com/argoproj/argo-workflows/blob/v3.7.1/persist/sqldb/migrate.go#L221) may fail to automatically assign default values when adding a column, depending on the database version or configuration, which can cause the DB migration to fail. 
From what I’ve found, this issue occurs with MySQL 5.7 but does not appear with MySQL 8.0 or PostgreSQL. 
MySQL 5.7 is officially end-of-life, so migrating to MySQL 8.0 is recommended. 
However, since Argo Workflows supports MySQL 5.7.8 and later from [Workflow Archive Doc](https://argo-workflows.readthedocs.io/en/stable/workflow-archive/), we likely need to address this.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Added a default value `null` explicitly when `creationtimestamp` column addition for `argo_workflow_history`. 
- Setting the value to `null` ensures that [the subsequent query](https://github.com/argoproj/argo-workflows/blob/v3.7.1/persist/sqldb/migrate.go#L222) will update the `creationtimestamp` value of existing records to the value of `startedat`.
- Because [subsequent queries](https://github.com/argoproj/argo-workflows/blob/v3.7.1/persist/sqldb/migrate.go#L223-L226) sets `creationtimestamp` to not null and default CURRENT_TIMESTAMP, there’s no impact on the final table schema or on inserting new records.


### Verification

<!-- TODO: Say how you tested your changes. -->

- Tested both on MySQL(5.7 and 8.0) and Postgres. And tested both on fresh installations and existing environment.
- Confirmed the `creationtimestamp` value of existing records are updated to the value of `startedat`.
- After DB migration, confirmed that the final table schema is the same and new records are correctly inserted.

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
