### PR TITLE
fix: only reset failed or error retry node. Fixes #14796

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1070,7 +1070,7 @@ func resetPath(allNodes []*dagNode, startNode string) (map[string]bool, map[stri
 				return nil, nil, err
 			}
 			continue
-		case curr.n.Type == wfv1.NodeTypeRetry:
+		case curr.n.Type == wfv1.NodeTypeRetry && curr.n.FailedOrError():
 			addToReset(curr.n.ID)
 		case curr.n.Type == wfv1.NodeTypeContainer:
 			curr, err = resetPod(curr, addToReset, addToDelete)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14796

### Motivation

<!-- TODO: Say why you made your changes. -->
`Succeeded` retry nodes are reset to `Running` after manual retry.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
Only reset failed or error retry node.

### Verification

<!-- TODO: Say how you tested your changes. -->
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: retry-reopens-upstream-
spec:
  entrypoint: main
  podGC:
    strategy: OnPodCompletion
  templates:
  # Shared template with a Retry wrapper (crucial to reproduce)
  - name: runner
    inputs:
      parameters:
        - name: name
        - name: script
    retryStrategy:
      limit: 3
      retryPolicy: OnTransientError
    container:
      image: alpine:3.19
      command: [sh, -c]
      args:
        - |
          echo "TASK={{inputs.parameters.name}}"
          echo "SCRIPT={{inputs.parameters.script}}"
          eval "{{inputs.parameters.script}}"

  - name: main
    dag:
      tasks:
        # root
        - name: apply
          template: runner
          arguments:
            parameters:
              - { name: name,   value: apply }
              - { name: script, value: "echo apply && exit 0" }

        # two siblings after root
        - name: a
          dependencies: [apply]
          template: runner
          arguments:
            parameters:
              - { name: name,   value: a }
              - { name: script, value: "echo a && exit 0" }

        - name: b
          dependencies: [apply]
          template: runner
          arguments:
            parameters:
              - { name: name,   value: b }
              - { name: script, value: "echo b && exit 0" }

        # downstream that fails deterministically
        - name: c
          dependencies: [a, b]
          template: runner
          arguments:
            parameters:
              - { name: name,   value: c }
              - { name: script, value: "echo c failing && exit 1" }
```
Behavior before the fix (incorrect):
<img width="420" height="844" alt="image" src="https://github.com/user-attachments/assets/c9c1065e-8bf4-48d8-a8cb-e4a440beafa2" />

Behavior after the fix (correct)
<img width="326" height="836" alt="Clipboard_Screenshot_1756696123" src="https://github.com/user-attachments/assets/c84c0a9d-c78b-435d-92b6-6bf28c685781" />


### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
