### PR TITLE
chore: bump go to 1.24.4 as per main (release-3.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.24-alpine3.21 as builder
+FROM golang:1.24.4-alpine3.22 as builder
 
 # libc-dev to build openapi-gen
 RUN apk update && apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.24.2
+go 1.24.4
 
 require (
 	cloud.google.com/go/storage v1.55.0


### PR DESCRIPTION
Catching up golang like on main
