### PR TITLE
fix: http template read response.Body after cancel(), sometimes it return a context canceled error

### DIFF
--- a/workflow/executor/agent.go
+++ b/workflow/executor/agent.go
@@ -249,7 +249,13 @@ func (ae *AgentExecutor) executeHTTPTemplate(ctx context.Context, tmpl wfv1.Temp
 	if tmpl.HTTP == nil {
 		return 0, nil
 	}
-
+	// Read response.Body after cancel(), sometimes it return a context canceled error
+	// For more detail  https://groups.google.com/g/golang-nuts/c/2FKwG6oEvos
+	var cancel context.CancelFunc
+	if tmpl.HTTP.TimeoutSeconds != nil {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(*tmpl.HTTP.TimeoutSeconds)*time.Second)
+		defer cancel()
+	}
 	response, err := ae.executeHTTPTemplateRequest(ctx, tmpl.HTTP)
 	if err != nil {
 		return 0, err
@@ -320,21 +326,13 @@ func (ae *AgentExecutor) executeHTTPTemplateRequest(ctx context.Context, httpTem
 	)
 	if httpTemplate.BodyFrom != nil {
 		if httpTemplate.BodyFrom.Bytes != nil {
-			request, err = http.NewRequest(httpTemplate.Method, httpTemplate.URL, bytes.NewBuffer(httpTemplate.BodyFrom.Bytes))
+			request, err = http.NewRequestWithContext(ctx, httpTemplate.Method, httpTemplate.URL, bytes.NewBuffer(httpTemplate.BodyFrom.Bytes))
 		}
 	} else {
-		request, err = http.NewRequest(httpTemplate.Method, httpTemplate.URL, bytes.NewBufferString(httpTemplate.Body))
+		request, err = http.NewRequestWithContext(ctx, httpTemplate.Method, httpTemplate.URL, bytes.NewBufferString(httpTemplate.Body))
 	}
 	if err != nil {
 		return nil, err
-	}
-
-	if httpTemplate.TimeoutSeconds != nil {
-		ctx, cancel := context.WithTimeout(ctx, time.Duration(*httpTemplate.TimeoutSeconds)*time.Second)
-		defer cancel()
-		request = request.WithContext(ctx)
-	} else {
-		request = request.WithContext(ctx)
 	}
 
 	for _, header := range httpTemplate.Headers {


### PR DESCRIPTION
### Motivation

http template read response.Body after cancel(), sometimes it return a context canceled error

### Modifications

Read response.Body after cancel(), sometimes it return a context canceled error
For more detail  https://groups.google.com/g/golang-nuts/c/2FKwG6oEvos

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
