### PR TITLE
fix: avoid deleting from the throttle queue when reapply fails.

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -83,6 +83,8 @@ const (
 	// * `Persisted` - has been archived and retrieved from db
 	// See also `LabelKeyCompleted`.
 	LabelKeyWorkflowArchivingStatus = workflow.WorkflowFullName + "/workflow-archiving-status"
+	// LabelKeyReApplyFailed is the pod metadata label to indicate if the pod re-apply failed
+	LabelKeyReApplyFailed = workflow.WorkflowFullName + "/reapply"
 	// LabelKeyWorkflow is the pod metadata label to indicate the associated workflow name
 	LabelKeyWorkflow = workflow.WorkflowFullName + "/workflow"
 	// LabelKeyComponent determines what component within a workflow, intentionally similar to app.kubernetes.io/component.

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -763,7 +763,7 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 	// make sure this is removed from the throttler is complete
 	defer func() {
 		// must be done with woc
-		if !reconciliationNeeded(woc.wf) {
+		if !reconciliationNeeded(woc.wf) && !reapplyFailed(woc.wf) {
 			wfc.throttler.Remove(key)
 		}
 	}()
@@ -825,6 +825,10 @@ func (wfc *WorkflowController) getWorkflowByKey(ctx context.Context, key string)
 
 func reconciliationNeeded(wf metav1.Object) bool {
 	return wf.GetLabels()[common.LabelKeyCompleted] != "true" || slices.Contains(wf.GetFinalizers(), common.FinalizerArtifactGC)
+}
+
+func reapplyFailed(wf metav1.Object) bool {
+	return wf.GetLabels()[common.LabelKeyReApplyFailed] == "true"
 }
 
 // enqueueWfFromPodLabel will extract the workflow name from pod label and

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -774,7 +774,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.log.Info(ctx, "Re-applying updates on latest version and retrying update")
 		wf, err := woc.reapplyUpdate(ctx, wfClient, nodes)
 		if err != nil {
-			woc.wf.ObjectMeta.Labels[common.LabelKeyReApplyFailed] = "true"
+			woc.wf.Labels[common.LabelKeyReApplyFailed] = "true"
 			woc.log.WithError(err).Info(ctx, "Failed to re-apply update")
 			return
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -774,6 +774,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.log.Info(ctx, "Re-applying updates on latest version and retrying update")
 		wf, err := woc.reapplyUpdate(ctx, wfClient, nodes)
 		if err != nil {
+			woc.wf.ObjectMeta.Labels[common.LabelKeyReApplyFailed] = "true"
 			woc.log.WithError(err).Info(ctx, "Failed to re-apply update")
 			return
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->
 
Avoid deleting from the throttle queue when reapply fails.

When a running  workflow want to update to Succeeded, but it meet reapply failed. In this time, if is was remove from throttle queue, the workflow will be running forever. 
Because the admit function will prevent it from reconceil while not in running queue. 
And the 20min resync will not add it in pending queue because the resourceVersion not change.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
