### PR TITLE
fix: don't need to add workflow to pending queue when running.

### DIFF
--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -110,7 +110,13 @@ func (m *multiThrottler) Add(key Key, priority int32, creationTime time.Time) {
 	if err != nil {
 		return
 	}
-	_, ok := m.pending[namespace]
+
+	_, ok := m.running[key]
+	if ok {
+		return
+	}
+
+	_, ok = m.pending[namespace]
 	if !ok {
 		m.pending[namespace] = &priorityQueue{itemByKey: make(map[string]*item)}
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Don't need to add to pending queue when running.

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

We have seen cases where a single workflow has been moved from the pending queue to the running queue multiple times. I believe this operation is unnecessary. 

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
