### PR TITLE
feat: cache latest resourceversion to avoid reconcile outdated workflow. Fixes: #14833

### DIFF
--- a/.features/pending/cache-latest-resourceversion.md
+++ b/.features/pending/cache-latest-resourceversion.md
@@ -1,0 +1,4 @@
+Component: General
+Issues: 13114
+Description: Cache latest resource version to avoid reconcile outdated workflow.
+Author: [Shuangkun Tian](https://github.com/shuangkun)

--- a/.features/pending/cache-latest-resourceversion.md
+++ b/.features/pending/cache-latest-resourceversion.md
@@ -2,3 +2,5 @@ Component: General
 Issues: 13114
 Description: Cache latest resource version to avoid reconcile outdated workflow.
 Author: [Shuangkun Tian](https://github.com/shuangkun)
+
+Cache latest resource version to avoid reconcile outdated workflow.

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -927,6 +927,9 @@ func (wfc *WorkflowController) recordCompletedWorkflow(key string) {
 func (wfc *WorkflowController) recordWorkflowResourceVersion(key string, resourceVersion string) {
 	wfc.workflowRecentResourceVersion.mutex.Lock()
 	defer wfc.workflowRecentResourceVersion.mutex.Unlock()
+	if wfc.workflowRecentResourceVersion.workflowRecentResourceVersionMap == nil {
+		wfc.workflowRecentResourceVersion.workflowRecentResourceVersionMap = make(map[string]string)
+	}
 	wfc.workflowRecentResourceVersion.workflowRecentResourceVersionMap[key] = resourceVersion
 }
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -235,6 +235,8 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		return nil, err
 	}
 
+	wfc.workflowRecentResourceVersion.workflowRecentResourceVersionMap = make(map[string]string)
+
 	deprecation.Initialize(wfc.metrics.DeprecatedFeature)
 	wfc.entrypoint = entrypoint.New(kubeclientset, wfc.Config.Images)
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -808,6 +808,10 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		time.Sleep(1 * time.Second)
 	}
 
+	key := wf.Namespace + "/" + wf.Name
+	// Record the latest workflow resource version
+	woc.controller.recordWorkflowResourceVersion(key, woc.wf.ResourceVersion)
+
 	// Make sure the workflow completed.
 	if woc.wf.Status.Fulfilled() {
 		woc.controller.metrics.CompleteRealtimeMetricsForWfUID(string(woc.wf.GetUID()))

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1614,3 +1614,22 @@ func FindWaitCtrIndex(pod *apiv1.Pod) (int, error) {
 	}
 	return waitCtrIndex, nil
 }
+
+// OutDateResourceVersion checks whether the resourceVersion is outdated
+func OutDateResourceVersion(currentRV, cachedRV string) bool {
+	// Parse both resourceVersions as integers
+	current, err2 := strconv.ParseInt(currentRV, 10, 64)
+	cached, err1 := strconv.ParseInt(cachedRV, 10, 64)
+
+	// If either is invalid, assume currentRV is outdated
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	// If cached RV is much larger than current, then current is old
+	if current < cached {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Cache latest resourceversion to avoid reconcile outdate workflow

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14833

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
