### PR TITLE
chore(manifest): update to postgres-16 in quick start manifest

### DIFF
--- a/manifests/components/postgres/postgres-deployment.yaml
+++ b/manifests/components/postgres/postgres-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: main
-          image: quay.io/fedora/postgresql-12@sha256:055c8bd433e3e6617e9ecbf0fe1ab1d611582cb0102aac64e42724af5f43cbac
+          image: quay.io/fedora/postgresql-16@sha256:06d566b4be3ba0542690382c2586c5e7e033005cc09a689a5c1f5c1fe7c6cc96
           env:
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: password

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -5988,7 +5988,7 @@ spec:
       - env:
         - name: POSTGRESQL_ADMIN_PASSWORD
           value: password
-        image: quay.io/fedora/postgresql-12@sha256:055c8bd433e3e6617e9ecbf0fe1ab1d611582cb0102aac64e42724af5f43cbac
+        image: quay.io/fedora/postgresql-16@sha256:06d566b4be3ba0542690382c2586c5e7e033005cc09a689a5c1f5c1fe7c6cc96
         name: main
         ports:
         - containerPort: 5432


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

No related issue

### Motivation

Bump to postgres 16, because 12 is no longer supported ([link](https://www.postgresql.org/support/versioning/)).

### Modifications

Updated version of postgres image in the postgres quick start manifest.

### Verification

```
make manifest
make manifest-validate
```

Install the quick start manifest, submit workflow and verify that the workflow is archived:

```
kubectl -n argo apply -f manifests/quick-start-postgres.yaml 
argo submit -n argo --watch https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/hello-world.yaml
kubectl exec -n argo postgres-7cc545668d-rzb5f -- psql -c "select phase from argo_archived_workflows;"
```

### Documentation

