### PR TITLE
fix: use Index data instead of directly requesting Apiserver to improve processing speed(Fixes #14791) 

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -981,7 +981,8 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 					// key function.
 
 					// Remove finalizers from Pods if they exist before deletion
-					podObjs, err := wfc.PodController.GetPodsByIndex(indexes.WorkflowIndex, indexes.WorkflowIndexValue(wfc.GetManagedNamespace(), obj.(*unstructured.Unstructured).GetName()))
+					wf := obj.(*unstructured.Unstructured)
+					podObjs, err := wfc.PodController.GetPodsByIndex(indexes.WorkflowIndex, indexes.WorkflowIndexValue(wf.GetNamespace(), wf.GetName()))
 					if err != nil {
 						logger.WithError(err).Error(ctx, "Failed to get pods by index")
 					}

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -110,7 +110,13 @@ func (m *multiThrottler) Add(key Key, priority int32, creationTime time.Time) {
 	if err != nil {
 		return
 	}
-	_, ok := m.pending[namespace]
+
+	_, ok := m.running[key]
+	if ok {
+		return
+	}
+
+	_, ok = m.pending[namespace]
 	if !ok {
 		m.pending[namespace] = &priorityQueue{itemByKey: make(map[string]*item)}
 	}


### PR DESCRIPTION
Fixes #14791 

### Motivation

Try to fix #14791
Some performance issues were encountered during production. Controller processing performance degrades significantly when running workflows at scale. Adding a throttling queue doesn't significantly improve speed.

### Modifications

Modify `DeleteFunc` in `controller.go`
Use Index data instead of directly requesting Apiserver to improve processing speed
```
DeleteFunc: func(obj interface{}) {
					//pods := wfc.kubeclientset.CoreV1().Pods(wfc.GetManagedNamespace())
					//podList, err := pods.List(ctx, metav1.ListOptions{
					//	LabelSelector: fmt.Sprintf("%s=%s", common.LabelKeyWorkflow, obj.(*unstructured.Unstructured).GetName()),
					//})
					//if err != nil {
					//	logger.WithError(err).Error(ctx, "Failed to list pods")
					//}
					//for _, p := range podList.Items {
					//	if slices.Contains(p.Finalizers, common.FinalizerPodStatus) {
					//		wfc.PodController.RemoveFinalizer(ctx, p.Namespace, p.Name)
					//	}
					//}

					podObjs, err := wfc.PodController.GetPodsByIndex(indexes.WorkflowIndex, indexes.WorkflowIndexValue(wfc.GetManagedNamespace(), obj.(*unstructured.Unstructured).GetName()))
					if err != nil {
						logger.WithError(err).Error(ctx, "Failed to get pods by index")
					}
					for _, podObj := range podObjs {
						p, ok := podObj.(*apiv1.Pod)
						if !ok {
							logger.WithError(err).Error(ctx, "expected \"*apiv1.Pod\", got "+reflect.TypeOf(podObj).String())
							continue
						}
						if slices.Contains(p.Finalizers, common.FinalizerPodStatus) {
							wfc.PodController.RemoveFinalizer(ctx, p.Namespace, p.Name)
						}
					}
					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
					if err == nil {
						wfc.releaseAllWorkflowLocks(ctx, obj)
						wfc.recordCompletedWorkflow(key)
						wfc.throttler.Remove(key)
					}
				}
```


### Documentation
In `shared_informer.go`, a single coroutine traverses `nextCh` and executes `AddFunc`, `UpdateFunc`, and `DeleteFunc`. In `DeleteFunc`, if the `pods.List` request is slow, then the next element of `nextCh` will be delayed, which will naturally block `AddFunc` and `UpdateFunc`.

```
func (p *processorListener) run() {
	sleepAfterCrash := false
	for next := range p.nextCh {
		if sleepAfterCrash {
			time.Sleep(time.Second)
		}
		func() {
			sleepAfterCrash = true
			defer utilruntime.HandleCrashWithLogger(p.logger)

			switch notification := next.(type) {
			case updateNotification:
				p.handler.OnUpdate(notification.oldObj, notification.newObj)
			case addNotification:
				p.handler.OnAdd(notification.newObj, notification.isInInitialList)
				if notification.isInInitialList {
					p.syncTracker.Finished()
				}
			case deleteNotification:
				p.handler.OnDelete(notification.oldObj)
			default:
				utilruntime.HandleErrorWithLogger(p.logger, nil, "unrecognized notification", "notificationType", fmt.Sprintf("%T", next))
			}
			sleepAfterCrash = false
		}()
	}
}

```