### PR TITLE
fix: workflow DeleteFunc use Index data to improve processing speed(#14791)

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1026,22 +1026,9 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 					// IndexerInformer uses a delta queue, therefore for deletes we have to use this
 					// key function.
 
-					// Remove finalizers from Pods if they exist before deletion
-					pods := wfc.kubeclientset.CoreV1().Pods(wfc.GetManagedNamespace())
-					podList, err := pods.List(ctx, metav1.ListOptions{
-						LabelSelector: fmt.Sprintf("%s=%s", common.LabelKeyWorkflow, obj.(*unstructured.Unstructured).GetName()),
-					})
-					if err != nil {
-						logger.WithError(err).Error(ctx, "Failed to list pods")
-					}
-					for _, p := range podList.Items {
-						if slices.Contains(p.Finalizers, common.FinalizerPodStatus) {
-							wfc.PodController.RemoveFinalizer(ctx, p.Namespace, p.Name)
-						}
-					}
-
 					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 					if err == nil {
+						wfc.removeAllPodFinalizer(ctx, obj)
 						wfc.releaseAllWorkflowLocks(ctx, obj)
 						wfc.recordCompletedWorkflow(key)
 						// no need to add to the queue - this workflow is done
@@ -1291,6 +1278,25 @@ func (wfc *WorkflowController) getMetricsServerConfig() *telemetry.MetricsConfig
 		Temporality:  wfc.Config.MetricsConfig.GetTemporality(),
 	}
 	return &metricsConfig
+}
+
+func (wfc *WorkflowController) removeAllPodFinalizer(ctx context.Context, obj any) {
+	un, ok := obj.(*unstructured.Unstructured)
+	logger := logging.RequireLoggerFromContext(ctx)
+	if !ok {
+		logger.WithField("key", obj).Warn(ctx, "Key in index is not an unstructured")
+		return
+	}
+	wf, err := util.FromUnstructured(un)
+	if err != nil {
+		logger.WithField("key", obj).Warn(ctx, "Invalid workflow object")
+		return
+	}
+	for _, node := range wf.Status.Nodes {
+		if node.Type == wfv1.NodeTypePod {
+			wfc.PodController.RemoveFinalizer(ctx, wf.Namespace, node.ID)
+		}
+	}
 }
 
 func (wfc *WorkflowController) releaseAllWorkflowLocks(ctx context.Context, obj any) {


### PR DESCRIPTION
Fixes #14791 

### Motivation

Try to fix #14791
Some performance issues were encountered during production. Controller processing performance degrades significantly when running workflows at scale. Adding a throttling queue doesn't significantly improve speed.

### Modifications

Modify `DeleteFunc` in `controller.go`
Use Index data instead of directly requesting Apiserver to improve processing speed
```
DeleteFunc: func(obj interface{}) {
					//pods := wfc.kubeclientset.CoreV1().Pods(wfc.GetManagedNamespace())
					//podList, err := pods.List(ctx, metav1.ListOptions{
					//	LabelSelector: fmt.Sprintf("%s=%s", common.LabelKeyWorkflow, obj.(*unstructured.Unstructured).GetName()),
					//})
					//if err != nil {
					//	logger.WithError(err).Error(ctx, "Failed to list pods")
					//}
					//for _, p := range podList.Items {
					//	if slices.Contains(p.Finalizers, common.FinalizerPodStatus) {
					//		wfc.PodController.RemoveFinalizer(ctx, p.Namespace, p.Name)
					//	}
					//}

					wf := obj.(*unstructured.Unstructured)
					podObjs, err := wfc.PodController.GetPodsByIndex(indexes.WorkflowIndex, indexes.WorkflowIndexValue(wf.GetNamespace(), wf.GetName()))
					if err != nil {
						logger.WithError(err).Error(ctx, "Failed to get pods by index")
					}
					for _, podObj := range podObjs {
						p, ok := podObj.(*apiv1.Pod)
						if !ok {
							logger.WithError(err).Error(ctx, "expected \"*apiv1.Pod\", got "+reflect.TypeOf(podObj).String())
							continue
						}
						if slices.Contains(p.Finalizers, common.FinalizerPodStatus) {
							wfc.PodController.RemoveFinalizer(ctx, p.Namespace, p.Name)
						}
					}
					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
					if err == nil {
						wfc.releaseAllWorkflowLocks(ctx, obj)
						wfc.recordCompletedWorkflow(key)
						wfc.throttler.Remove(key)
					}
				}
```


### Documentation
In `shared_informer.go`, a single coroutine traverses `nextCh` and executes `AddFunc`, `UpdateFunc`, and `DeleteFunc`. In `DeleteFunc`, if the `pods.List` request is slow, then the next element of `nextCh` will be delayed, which will naturally block `AddFunc` and `UpdateFunc`.

```
func (p *processorListener) run() {
	sleepAfterCrash := false
	for next := range p.nextCh {
		if sleepAfterCrash {
			time.Sleep(time.Second)
		}
		func() {
			sleepAfterCrash = true
			defer utilruntime.HandleCrashWithLogger(p.logger)

			switch notification := next.(type) {
			case updateNotification:
				p.handler.OnUpdate(notification.oldObj, notification.newObj)
			case addNotification:
				p.handler.OnAdd(notification.newObj, notification.isInInitialList)
				if notification.isInInitialList {
					p.syncTracker.Finished()
				}
			case deleteNotification:
				p.handler.OnDelete(notification.oldObj)
			default:
				utilruntime.HandleErrorWithLogger(p.logger, nil, "unrecognized notification", "notificationType", fmt.Sprintf("%T", next))
			}
			sleepAfterCrash = false
		}()
	}
}

```