### PR TITLE
fix(ui): support base HREF in dev environment

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -214,6 +214,7 @@ parameterizing
 params
 pprof
 pre-commit
+proxying
 pytorch
 qps
 ray
@@ -279,6 +280,7 @@ versioning
 webHDFS
 webhook
 webhooks
+webpack-dev-server
 workflow-controller-configmap
 workqueue
 yaml

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,23 @@ endif
 ifeq ($(UI),true)
 TASKS                 := controller server ui
 endif
+
+# -- SSO options
+# Need to rewrite the SSO redirect URL referenced in ConfigMaps when UI_SECURE and/or BASE_HREF is set.
+# Can't use "kustomize" or "kubectl patch" because the SSO config is a YAML string in those ConfigMaps.
+SSO_REDIRECT_URL   := http
+ifeq ($(UI_SECURE),true)
+SSO_REDIRECT_URL   := https
+endif
+ifeq ($(BASE_HREF),)
+BASE_HREF          := /
+else
+# Ensure base URL has a single trailing/leading slash to match the logic in getIndexData() in server/static/static.go
+override BASE_HREF := /$(BASE_HREF:/%=%)
+override BASE_HREF := $(BASE_HREF:%/=%)/
+endif
+SSO_REDIRECT_URL   := $(SSO_REDIRECT_URL)://localhost:8080$(BASE_HREF)oauth2/callback
+
 # Which mode to run in:
 # * `local` run the workflow–controller and argo-server as single replicas on the local machine (default)
 # * `kubernetes` run the workflow-controller and argo-server on the Kubernetes cluster
@@ -157,7 +174,7 @@ TOOL_MKDOCS                 := $(TOOL_MKDOCS_DIR)/bin/mkdocs
 print-variables: ## Print Makefile variables
 	@echo GIT_COMMIT=$(GIT_COMMIT) GIT_BRANCH=$(GIT_BRANCH) GIT_TAG=$(GIT_TAG) GIT_TREE_STATE=$(GIT_TREE_STATE) RELEASE_TAG=$(RELEASE_TAG) DEV_BRANCH=$(DEV_BRANCH) VERSION=$(VERSION)
 	@echo KUBECTX=$(KUBECTX) K3D=$(K3D) DOCKER_PUSH=$(DOCKER_PUSH) TARGET_PLATFORM=$(TARGET_PLATFORM)
-	@echo RUN_MODE=$(RUN_MODE) PROFILE=$(PROFILE) AUTH_MODE=$(AUTH_MODE) SECURE=$(SECURE) STATIC_FILES=$(STATIC_FILES) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) LOG_LEVEL=$(LOG_LEVEL) NAMESPACED=$(NAMESPACED)
+	@echo RUN_MODE=$(RUN_MODE) PROFILE=$(PROFILE) AUTH_MODE=$(AUTH_MODE) SECURE=$(SECURE) STATIC_FILES=$(STATIC_FILES) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) LOG_LEVEL=$(LOG_LEVEL) NAMESPACED=$(NAMESPACED) BASE_HREF=$(BASE_HREF)
 
 override LDFLAGS += \
   -X github.com/argoproj/argo-workflows/v3.version=$(VERSION) \
@@ -574,12 +591,10 @@ install: githooks ## Install Argo to the current Kubernetes cluster
 	kubectl kustomize --load-restrictor=LoadRestrictionsNone test/e2e/manifests/$(PROFILE) \
 		| sed 's|quay.io/argoproj/|$(IMAGE_NAMESPACE)/|' \
 		| sed 's/namespace: argo/namespace: $(KUBE_NAMESPACE)/' \
+		| sed 's|http://localhost:8080/oauth2/callback|$(SSO_REDIRECT_URL)|' \
 		| KUBECTL_APPLYSET=true kubectl -n $(KUBE_NAMESPACE) apply --applyset=configmaps/install --server-side --prune -f -
 ifeq ($(PROFILE),stress)
 	kubectl -n $(KUBE_NAMESPACE) apply -f test/stress/massive-workflow.yaml
-endif
-ifeq ($(UI_SECURE)$(PROFILE),truesso)
-	KUBE_NAMESPACE=$(KUBE_NAMESPACE) ./hack/update-sso-redirect-url.sh
 endif
 
 .PHONY: argosay
@@ -646,7 +661,7 @@ endif
 	grep '127.0.0.1.*postgres' /etc/hosts
 	grep '127.0.0.1.*mysql' /etc/hosts
 ifeq ($(RUN_MODE),local)
-	env DEFAULT_REQUEUE_TIME=$(DEFAULT_REQUEUE_TIME) ARGO_SECURE=$(SECURE) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) ARGO_LOGLEVEL=$(LOG_LEVEL) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) ARGO_AUTH_MODE=$(AUTH_MODE) ARGO_NAMESPACED=$(NAMESPACED) ARGO_NAMESPACE=$(KUBE_NAMESPACE) ARGO_MANAGED_NAMESPACE=$(MANAGED_NAMESPACE) ARGO_EXECUTOR_PLUGINS=$(PLUGINS) ARGO_POD_STATUS_CAPTURE_FINALIZER=$(POD_STATUS_CAPTURE_FINALIZER) ARGO_UI_SECURE=$(UI_SECURE) PROFILE=$(PROFILE) kit $(TASKS)
+	env DEFAULT_REQUEUE_TIME=$(DEFAULT_REQUEUE_TIME) ARGO_SECURE=$(SECURE) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) ARGO_LOGLEVEL=$(LOG_LEVEL) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) ARGO_AUTH_MODE=$(AUTH_MODE) ARGO_NAMESPACED=$(NAMESPACED) ARGO_NAMESPACE=$(KUBE_NAMESPACE) ARGO_MANAGED_NAMESPACE=$(MANAGED_NAMESPACE) ARGO_EXECUTOR_PLUGINS=$(PLUGINS) ARGO_POD_STATUS_CAPTURE_FINALIZER=$(POD_STATUS_CAPTURE_FINALIZER) ARGO_UI_SECURE=$(UI_SECURE) ARGO_BASE_HREF=$(BASE_HREF) PROFILE=$(PROFILE) kit $(TASKS)
 endif
 
 .PHONY: wait

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -157,6 +157,19 @@ To test SSO integration, use `PROFILE=sso`:
 make start UI=true PROFILE=sso
 ```
 
+### Proxying
+
+When using `UI=true`, `make start` will start [webpack-dev-server](https://github.com/webpack/webpack-dev-server) to serve requests to <http://localhost:8080>, while proxying API requests to the Argo Server at <http://localhost:2746>.
+
+Use `BASE_HREF` to customize the [base HREF](argo-server.md#base-href), which will cause webpack-dev-server to strip out the provided path when proxying requests to the Argo Server.
+For example, to make the UI accessible at <http://localhost:8080/argo/>:
+
+```bash
+make start UI=true BASE_HREF=/argo/
+```
+
+Note that if you're using `PROFILE=sso`, you may need to run `kubectl rollout restart deploy dex` to restart Dex after changing the base HREF.
+
 ### TLS
 
 By default, `make start` will start Argo in [plain text mode](tls.md#plain-text).

--- a/hack/update-sso-redirect-url.sh
+++ b/hack/update-sso-redirect-url.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
-
-# Rewrite the SSO redirect URL to use HTTPS to support "make start PROFILE=sso UI_SECURE=true".
-# Can't use "kubectl patch" because the SSO config is a YAML string.
-kubectl -n "${KUBE_NAMESPACE}" get configmap workflow-controller-configmap -o yaml | \
-    sed 's@redirectUrl: http://localhost:8080/oauth2/callback@redirectUrl: https://localhost:8080/oauth2/callback@' | \
-    kubectl apply -n "${KUBE_NAMESPACE}" -f -

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -119,6 +119,7 @@ tasks:
     - "8080"
     watch:
     - package.json
+    - webpack.config.js
     workingDir: ui
   ui-deps:
     command:

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Argo</title>
-    <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex">
     <link rel="icon" type="image/png" href="assets/favicon/favicon-32x32.png" sizes="32x32">


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->



### Motivation
This updates the dev environment to allow testing the [base HREF option](https://argo-workflows.readthedocs.io/en/stable/argo-server/#base-href), since some users have reported issues with that (https://github.com/argoproj/argo-workflows/issues/14668#issuecomment-3207368612).


### Modifications

* Previously, we used `hack/update-sso-redirect-url.sh` to update the SSO redirect URL when `UI_SECURE` is set, but that didn't account for `BASE_HREF`. Updating it to do so would be possible, but it gets messy because we now need to update two different `ConfigMaps`, not just `workflow-controller-configmap`: 
  * https://github.com/argoproj/argo-workflows/blob/cb7ebd9393f3322abf455d906e39a3a976421b30/manifests/components/sso/overlays/workflow-controller-configmap.yaml#L15
  * https://github.com/argoproj/argo-workflows/blob/cb7ebd9393f3322abf455d906e39a3a976421b30/manifests/components/sso/dex/dex-cm.yaml#L20-L23

  Instead, this removes that script and moves the logic to  `Makefile`, where it does a global `sed` on the output of `kustomize` to replace all instances of the redirect URL. Obviously, this is rather hacky, but I couldn't think of a better way of doing this.
* Update `ui/webpack.config.js` to respect `ARGO_BASE_HREF` and use it for both populating the `<base href="...">` tag and proxying connections to the API server. This required removing the tag from `ui/src/index.html`, since Webpack will populate it now. 
* Update `tasks.yaml` to restart Webpack if `webpack.config.js` changes, to simplify development

### Verification
Tested by running the following commands to start up the environment, then verified I can access the workflows page and login:
1. `make start UI=true`
<img width="1339" height="885" alt="image" src="https://github.com/user-attachments/assets/32d68e3d-43d9-4e61-82ca-3c19c8b1028a" />

2. `make start UI=true PROFILE=sso BASE_HREF=/test`
<img width="1339" height="885" alt="image" src="https://github.com/user-attachments/assets/bb2b353f-f062-43cd-ba3d-d897365aace5" />

3. `make start UI_SECURE=true PROFILE=sso BASE_HREF=/test/argo-workflows`
<img width="1339" height="885" alt="image" src="https://github.com/user-attachments/assets/cfb2641e-cf1b-4aa4-a1ce-492ce6dfaea0" />

4. `make start UI_SECURE=true BASE_HREF=test`
<img width="1339" height="885" alt="image" src="https://github.com/user-attachments/assets/428c8276-28c8-40a9-971e-910a57fa3afd" />


### Documentation
I added a "Proxying" section to the "Running Locally" page to document this
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
