### PR TITLE
fix: linting pointer error when template name is invalid

### DIFF
--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -706,6 +706,12 @@ func (s *CLISuite) TestWorkflowLint() {
 			assert.Contains(t, output, "no linting errors found")
 		})
 	})
+	s.Run("LintFileEmptyTemplateSteps", func() {
+		s.Given().RunCli([]string{"lint", "smoke/empty-template-steps.yaml"}, func(t *testing.T, output string, err error) {
+			require.NoError(t, err)
+			assert.Contains(t, output, "no linting errors found")
+		})
+	})
 	s.Run("LintFileEmptyParamDAG", func() {
 		s.Given().RunCli([]string{"lint", "expectedfailures/empty-parameter-dag.yaml"}, func(t *testing.T, output string, err error) {
 			require.EqualError(t, err, "exit status 1")
@@ -716,6 +722,12 @@ func (s *CLISuite) TestWorkflowLint() {
 		s.Given().RunCli([]string{"lint", "expectedfailures/empty-parameter-steps.yaml"}, func(t *testing.T, output string, err error) {
 			require.EqualError(t, err, "exit status 1")
 			assert.Contains(t, output, "templates.abc.steps[0].a templates.whalesay inputs.parameters.message was not supplied")
+		})
+	})
+	s.Run("LintFileMisreferenceTemplate", func() {
+		s.Given().RunCli([]string{"lint", "expectedfailures/misreference-template-name.yaml"}, func(t *testing.T, output string, err error) {
+			require.EqualError(t, err, "exit status 1")
+			assert.Contains(t, output, "templates.steps-with-misreference.steps[1].hello2 template name 'hell0' undefined")
 		})
 	})
 	s.Run("LintFileWithTemplate", func() {

--- a/test/e2e/expectedfailures/misreference-template-name.yaml
+++ b/test/e2e/expectedfailures/misreference-template-name.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-with-misreference-
+spec:
+  podMetadata:
+    labels:
+      test: steps-with-misreference
+  podPriorityClassName: lowest
+  entrypoint: steps-with-misreference
+  templates:
+    - name: steps-with-misreference
+      steps:
+        - - name: hello1
+            template: hello
+            arguments:
+              parameters:
+                - name: message
+                  value: "hello1"
+        - - name: hello2
+            template: hell0
+            arguments:
+              parameters:
+                - name: message
+                  value: "hello2"
+    - name: hello
+      inputs:
+        parameters:
+          - name: message
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "{{inputs.parameters.message}}"]

--- a/test/e2e/smoke/empty-template-steps.yaml
+++ b/test/e2e/smoke/empty-template-steps.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: empty-array-in-steps
+spec:
+  podMetadata:
+    labels:
+      test: empty-array-in-steps
+  podPriorityClassName: lowest
+  entrypoint: steps-with-empty-array
+  templates:
+    - name: steps-with-empty-array
+      steps:
+        - - name: hello1
+            template: hello
+            arguments:
+              parameters:
+                - name: message
+                  value: "hello1"
+        - []
+        - - name: hello2
+            template: hello
+            arguments:
+              parameters:
+                - name: message
+                  value: "hello2"
+    - name: hello
+      inputs:
+        parameters:
+          - name: message
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "{{inputs.parameters.message}}"]

--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -110,13 +110,13 @@ func (tplCtx *TemplateContext) GetTemplateByName(ctx context.Context, name strin
 	tplCtx.log.WithField("name", name).Debug(ctx, "Getting the template by name")
 
 	tmpl := tplCtx.tmplBase.GetTemplateByName(name)
+	if tmpl == nil {
+		return nil, errors.Errorf(errors.CodeNotFound, "template %s not found", name)
+	}
 
 	podMetadata := tplCtx.tmplBase.GetPodMetadata()
 	tplCtx.addPodMetadata(podMetadata, tmpl)
 
-	if tmpl == nil {
-		return nil, errors.Errorf(errors.CodeNotFound, "template %s not found", name)
-	}
 	return tmpl.DeepCopy(), nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14861

### Motivation

We need to check if the template is nil before using it. If it is we return and give helpful message.

### Modifications

I moved the if check to check if the `tmpl` (template) is nil before usage.

I added a test to show that we don't currently consider empty steps to be a linting error, as mentioned in [the issue](https://github.com/argoproj/argo-workflows/issues/14861). If we change our minds later we have a test that will break if so. :smile:

### Verification

Added linting test to the e2e tests for linting.

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
