### PR TITLE
fix(ui): login/logout bug when base HREF set. Fixes #14897

### DIFF
--- a/ui/src/login/login.test.tsx
+++ b/ui/src/login/login.test.tsx
@@ -1,0 +1,80 @@
+import {fireEvent, render} from '@testing-library/react';
+import {createMemoryHistory, History} from 'history';
+import React from 'react';
+
+import {deleteCookie, setCookie} from '../shared/cookie';
+import {Login} from './login';
+
+jest.mock('../shared/cookie');
+
+describe('Login', () => {
+    const LoginWithHistory = (history: History) => <Login history={history} match={null} location={history.location} />;
+
+    beforeEach(() => {
+        const base = document.createElement('base');
+        base.setAttribute('href', '/');
+        document.head.appendChild(base);
+    });
+
+    afterEach(() => {
+        document.querySelector('base').remove();
+    });
+
+    describe('SSO login', () => {
+        it('button has right href', () => {
+            const {getAllByText} = render(LoginWithHistory(createMemoryHistory()));
+            const button = getAllByText('Login')[0];
+            expect(button.getAttribute('href')).toBe('/oauth2/redirect?redirect=%2Fworkflows');
+        });
+
+        it('button has right href with custom <base>', () => {
+            document.querySelector('base').setAttribute('href', '/test/');
+            const {getAllByText} = render(LoginWithHistory(createMemoryHistory()));
+
+            const button = getAllByText('Login')[0];
+            expect(button.getAttribute('href')).toBe('/test/oauth2/redirect?redirect=%2Ftest%2Fworkflows');
+        });
+
+        it('button has right href when ?redirect set', () => {
+            const history = createMemoryHistory();
+            history.push('/login?redirect=/workflow-templates');
+            const {getAllByText} = render(LoginWithHistory(history));
+
+            const button = getAllByText('Login')[0];
+            expect(button.getAttribute('href')).toBe('/oauth2/redirect?redirect=%2Fworkflow-templates');
+        });
+    });
+
+    describe('token login', () => {
+        it('responds to click', () => {
+            const {getAllByText, getByRole} = render(LoginWithHistory(createMemoryHistory()));
+
+            const button = getAllByText('Login')[1];
+            fireEvent.change(getByRole('textbox'), {target: {value: 'test-token'}});
+            fireEvent.click(button);
+
+            expect(button.getAttribute('href')).toBe('/');
+            expect(setCookie).toHaveBeenCalledWith('authorization', 'test-token');
+        });
+
+        it('responds to click with custom <base>', () => {
+            document.querySelector('base').setAttribute('href', '/test/argo');
+            const {getAllByText, getByRole} = render(LoginWithHistory(createMemoryHistory()));
+
+            const button = getAllByText('Login')[1];
+            fireEvent.change(getByRole('textbox'), {target: {value: 'test123'}});
+            fireEvent.click(button);
+
+            expect(button.getAttribute('href')).toBe('/test/argo');
+            expect(setCookie).toHaveBeenCalledWith('authorization', 'test123');
+        });
+    });
+
+    describe('logout', () => {
+        it('responds to button click', () => {
+            const {getByText} = render(LoginWithHistory(createMemoryHistory()));
+            fireEvent.click(getByText('Logout'));
+            expect(deleteCookie).toHaveBeenCalledWith('authorization');
+        });
+    });
+});

--- a/ui/src/login/login.tsx
+++ b/ui/src/login/login.tsx
@@ -1,25 +1,17 @@
 import * as React from 'react';
+import {useState} from 'react';
+import {RouteComponentProps} from 'react-router';
 
 import {uiUrl, uiUrlWithParams} from '../shared/base';
+import {deleteCookie, setCookie} from '../shared/cookie';
 import {useCollectEvent} from '../shared/use-collect-event';
 
 import './login.scss';
 
-function logout() {
-    document.cookie = 'authorization=;Max-Age=0';
-    document.location.reload();
-}
-function user(token: string) {
-    const path = uiUrl('');
-    document.cookie = 'authorization=' + token + ';SameSite=Strict;path=' + path;
-    document.location.href = path;
-}
-function getRedirect(): URLSearchParams {
-    const urlParams = new URLSearchParams(document.location.search);
-    return new URLSearchParams({redirect: urlParams.get('redirect') ?? '/workflows'});
-}
-
-export function Login() {
+export function Login({location, history}: RouteComponentProps<any>) {
+    const urlParams = new URLSearchParams(location.search);
+    const redirect = new URLSearchParams({redirect: urlParams.get('redirect') ?? uiUrl('workflows')});
+    const [token, setToken] = useState('');
     useCollectEvent('openedLogin');
     return (
         <div className='login'>
@@ -47,13 +39,9 @@ export function Login() {
                             If your organisation has configured <b>single sign-on</b>:
                         </p>
                         <div>
-                            <button
-                                className='argo-button argo-button--base-o'
-                                onClick={() => {
-                                    document.location.href = uiUrlWithParams('oauth2/redirect', getRedirect());
-                                }}>
+                            <a className='argo-button argo-button--base-o' href={uiUrlWithParams('oauth2/redirect', redirect)}>
                                 <i className='fa fa-sign-in-alt' /> Login
-                            </button>
+                            </a>
                         </div>
                     </div>
                     <div className='white-box login__token-section'>
@@ -65,19 +53,24 @@ export function Login() {
                             paste in this box:
                         </p>
                         <div>
-                            <textarea id='token' className='token-input' rows={4} />
+                            <textarea id='token' className='token-input' rows={4} value={token} onChange={e => setToken(e.target.value)} />
                         </div>
                         <div>
-                            <button className='argo-button argo-button--base-o' onClick={() => user((document.getElementById('token') as HTMLInputElement).value)}>
+                            <a className='argo-button argo-button--base-o' href={uiUrl('')} onClick={() => setCookie('authorization', token)}>
                                 <i className='fa fa-sign-in-alt' /> Login
-                            </button>
+                            </a>
                         </div>
                     </div>
                     <div className='white-box login__logout-section'>
                         <p>Something wrong? Try logging out and logging back in:</p>
-                        <button className='argo-button argo-button--base-o' onClick={logout}>
+                        <a
+                            className='argo-button argo-button--base-o'
+                            onClick={() => {
+                                deleteCookie('authorization');
+                                history.go(0);
+                            }}>
                             <i className='fa fa-sign-out-alt' /> Logout
-                        </button>
+                        </a>
                     </div>
                 </div>
                 <div className='login__footer'>

--- a/ui/src/shared/cookie.ts
+++ b/ui/src/shared/cookie.ts
@@ -11,3 +11,13 @@ export const getCookie = (name: string) =>
 export function setCookie(name: string, value: string) {
     document.cookie = name + '=' + value + ';SameSite=Strict;path=' + uiUrl('');
 }
+
+export function deleteCookie(name: string) {
+    // "If the user agent receives a new cookie with the same cookie-name,
+    // domain-value, and path-value as a cookie that it has already stored, the
+    // existing cookie is evicted and replaced with the new cookie. Notice that
+    // servers can delete cookies by sending the user agent a new cookie with an
+    // Expires attribute with a value in the past."
+    // Spec: https://httpwg.org/specs/rfc6265.html#sane-set-cookie-semantics
+    document.cookie = name + '=;Max-Age=0;path=' + uiUrl('');
+}


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14897

### Motivation
This fixes two bugs when the [base HREF option](https://argo-workflows.readthedocs.io/en/stable/argo-server/#base-href) is set:
1. The "Logout" button doesn't delete the `Authorization` cookie properly.
2. If you visit the login page directly and click the SSO button, you'll be redirected to the `/workflows` page without the base HREF, which will likely result in a 404. I think this was a regression from https://github.com/argoproj/argo-workflows/pull/13747



### Modifications
The first issue is because logging out calls `document.cookie = 'authorization=;Max-Age=0';` without the `path` attribute, whereas the cookie is set using `document.cookie = 'authorization=TOKEN;SameSite=Strict;path=' = uiUrl('')`, which does have the `path` attribute. Per [RFC 6265](https://httpwg.org/specs/rfc6265.html#sane-set-cookie-semantics), the `path` attribute must match when deleting or overriding a cookie. If you don't have base HREF set, that's not a problem, since the default value of `path` will be `/`.

The second issue is because the default value of the `redirect` query parameter was hardcoded to `'/workflows'`, when it should be `uiUrl('/workflows')`. The `uiUrl()` function handles prepending the base HREF.

I had to do some refactoring to make this easily testable using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).


### Verification
Tested by following these steps:
1. Merge these changes with https://github.com/argoproj/argo-workflows/pull/14894
2. Run `make start UI_SECURE=true PROFILE=sso BASE_HREF=/test/argo-workflows`
3. Visit https://localhost:8080/test/argo-workflows/login
4. Click the first "Login" button
5. Click "Log in with Example" at Dex
6. Click "Grant Access"
7. Verify I'm redirected to https://localhost:8080/test/argo-workflows/workflows
8. Go back to https://localhost:8080/test/argo-workflows/login and click "Logout"
9. Verify the `Authorization` cookie is deleted


https://github.com/user-attachments/assets/a60ddc46-8f66-492a-b2f7-fb30739477e8



### Documentation

N/A
<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
