### PR TITLE
fix: 3.7 version modal and docs

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -65,6 +65,7 @@ These take the form of `3.6.0-rc1` and the final digit increases for each RC.
 ### Documentation
 
 Before or after the first release candidate you should ensure that [`new-features.md`](new-features.md) and [`upgrading.md`](upgrading.md) are updated.
+Also ensure `ui/src/modals/new-version-modal.tsx` is updated with a short summary of new features.
 A post should be made on a blog site (we usually use medium) announcing the release, and the new features.
 This post should celebrate the new features and thank the contributors, including statistics from the release.
 
@@ -77,6 +78,9 @@ Update these three items ([`new-features.md`](new-features.md), [`upgrading.md`]
 There should be no changes between the final release candidate and the actual release.
 For the final release you should create a tag at the same place as the final release candidate.
 You must also create a `release/<version>` branch from that same point.
+
+Ensure you've run `make docs` and that docs/tested-kubernetes-versions.md is updated with some versions.
+This must be done on the new branch (otherwise it won't generate a file) but can be pushed after the release is generated.
 
 Now you can add the branch to ["Read the Docs"](https://app.readthedocs.org/projects/argo-workflows/) and then the new branch should be built and published.
 Close the release candidate GitHub issue and unpin it, and create a new issue for patches to this branch.

--- a/ui/src/modals/new-version-modal.tsx
+++ b/ui/src/modals/new-version-modal.tsx
@@ -17,6 +17,18 @@ export function NewVersionModal({version, dismiss}: {version: string; dismiss: (
             <h4 className='new-version-modal-title'>
                 It looks like <b>{version}</b> has just been installed!
             </h4>
+            <h5>v3.7</h5>
+            <ul className='new-version-modal-bullets'>
+                <li>Enhanced retry strategies with daemon container support, backoff caps, and retry variables in expressions</li>
+                <li>Multi-controller locks (semaphores and mutexes) and dynamic namespace parallelism</li>
+                <li>UI improvements: visualize workflows before submitting, markdown support in templates, and pre-filled submit forms</li>
+                <li>Cron workflow backfill support and non-root argoexec image for improved security</li>
+            </ul>
+            <p>
+                <a href='https://argo-workflows.readthedocs.io/en/release-3.7/features-3.7/?utm_source=argo-ui' target='_blank' rel='noreferrer'>
+                    See the list of changes
+                </a>
+            </p>
             <h5>v3.6</h5>
             <ul className='new-version-modal-bullets'>
                 <li>


### PR DESCRIPTION
Fixes #14912 (adds documentation here, actual issue is fixed on `release-3.7`)
Fixes #14913 

### Motivation

New version modal is missing release-notes from 3.7

Release process misses this and the kubernetes versions, so added reminders there.

### Modifications

Updated new-version-modal from release notes.

### Verification

<img width="883" height="248" alt="image" src="https://github.com/user-attachments/assets/5b309faf-e693-4927-860f-8eab92b65cfa" /> and clicked the links to ensure they work

Docs checked here via read-the-docs

### Documentation

Updated release process docs.