### PR TITLE
fix(controller): Arifact GC not executing when a workflow has tasks with inline templates

### DIFF
--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -90,6 +90,18 @@ func (woc *wfOperationCtx) HasArtifactGC() bool {
 				return true
 			}
 		}
+		for _, steps := range template.Steps {
+			for _, step := range steps.Steps {
+				if step.Inline != nil {
+					for _, artifact := range step.Inline.Outputs.Artifacts {
+						strategy := woc.execWf.GetArtifactGCStrategy(&artifact)
+						if strategy != wfv1.ArtifactGCStrategyUndefined && strategy != wfv1.ArtifactGCNever {
+							return true
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// need to go to woc.wf.Status.StoredTemplates in the case of a Step referencing a WorkflowTemplate

--- a/workflow/controller/artifact_gc_test.go
+++ b/workflow/controller/artifact_gc_test.go
@@ -723,3 +723,108 @@ func TestWorkflowHasArtifactGC(t *testing.T) {
 	}
 
 }
+
+func TestInlineWorkflowHasArtifactGC(t *testing.T) {
+	tests := []struct {
+		name                      string
+		workflowArtGCStrategySpec string
+		artifactGCStrategySpec    string
+		expectedResult            bool
+	}{
+		{
+			name: "WorkflowSpecGC_Completion",
+			workflowArtGCStrategySpec: `
+  artifactGC:
+    strategy: OnWorkflowCompletion`,
+			artifactGCStrategySpec: "",
+			expectedResult:         true,
+		},
+		{
+			name:                      "ArtifactSpecGC_Completion",
+			workflowArtGCStrategySpec: "",
+			artifactGCStrategySpec: `
+                artifactGC:
+                  strategy: OnWorkflowCompletion`,
+			expectedResult: true,
+		},
+		{
+			name: "WorkflowSpecGC_Deletion",
+			workflowArtGCStrategySpec: `
+  artifactGC:
+    strategy: OnWorkflowDeletion`,
+			artifactGCStrategySpec: "",
+			expectedResult:         true,
+		},
+		{
+			name:                      "ArtifactSpecGC_Deletion",
+			workflowArtGCStrategySpec: "",
+			artifactGCStrategySpec: `
+                artifactGC:
+                  strategy: OnWorkflowDeletion`,
+			expectedResult: true,
+		},
+		{
+			name:                      "NoGC",
+			workflowArtGCStrategySpec: "",
+			artifactGCStrategySpec:    "",
+			expectedResult:            false,
+		},
+		{
+			name: "WorkflowSpecGC_None",
+			workflowArtGCStrategySpec: `
+  artifactGC:
+    strategy: ""`,
+			artifactGCStrategySpec: "",
+			expectedResult:         false,
+		},
+		{
+			name: "ArtifactSpecGC_None",
+			workflowArtGCStrategySpec: `
+  artifactGC:
+    strategy: OnWorkflowDeletion`,
+			artifactGCStrategySpec: `
+                artifactGC:
+                  strategy: Never`,
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			workflowSpec := fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: artifact-passing-
+spec:
+  entrypoint: whalesay
+  %s
+  templates:
+  - name: whalesay
+    steps:
+    - - name: generate-artifact
+        inline:
+          container:
+            image: docker/whalesay:latest
+            command: [sh, -c]
+            args: ["sleep 1; cowsay hello world | tee /tmp/hello_world.txt"]
+          outputs:
+            artifacts:
+              - name: out
+                path: /out
+                s3:
+                  key: out
+                  %s`, tt.workflowArtGCStrategySpec, tt.artifactGCStrategySpec)
+
+			wf := wfv1.MustUnmarshalWorkflow(workflowSpec)
+			ctx := logging.TestContext(t.Context())
+			cancel, controller := newController(ctx, wf)
+			defer cancel()
+			woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+			hasArtifact := woc.HasArtifactGC()
+
+			assert.Equal(t, tt.expectedResult, hasArtifact)
+		})
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14922 

### Motivation
let inline templates execute artifact-gc

### Modifications

1. fix inline artifact outputs missing finalizers
2. fix inline step missing template name

### Verification
unit-test

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
