### PR TITLE
docs(walk-through): update custom template variable reference and loop section

### DIFF
--- a/docs/walk-through/custom-template-variable-reference.md
+++ b/docs/walk-through/custom-template-variable-reference.md
@@ -35,5 +35,5 @@ spec:
       container:
         image: busybox
         command: [echo]
-        args: ["{{user.username}}"]
+        args: ["{{message.value}} not working, got value: {{inputs.parameters.message}}"]
 ```

--- a/docs/walk-through/loops.md
+++ b/docs/walk-through/loops.md
@@ -216,7 +216,7 @@ Please note: the output of each iteration _must_ be a **valid JSON**.
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
-kind: WorkflowTemplate
+kind: Workflow
 metadata:
   name: loop-test
 spec:


### PR DESCRIPTION


### Motivation

I was reading and testing most workflow examples in [walk-through](https://argo-workflows.readthedocs.io/en/latest/walk-through/custom-template-variable-reference/) tutorial documentation and found the following errors in that documentation

### Modifications

Update the custom-template-variable-reference.md file to correct the template variable usage from "{{user.username}}" to "{{message.value}} not working, got value: {{inputs.parameters.message}}".

Modify the loops.md file to change the resource kind from "WorkflowTemplate" to "Workflow" in the example YAML configuration.

### Verification

Already tested on my local workflow server



