### PR TITLE
chore: import argo-cd cherry-pick bot

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -1,0 +1,114 @@
+name: Cherry Pick Single
+
+on:
+  workflow_call:
+    inputs:
+      merge_commit_sha:
+        required: true
+        type: string
+        description: "The merge commit SHA to cherry-pick"
+      version_number:
+        required: true
+        type: string
+        description: "The version number (from cherry-pick/ label)"
+      pr_number:
+        required: true
+        type: string
+        description: "The original PR number"
+      pr_title:
+        required: true
+        type: string
+        description: "The original PR title"
+    secrets:
+      CHERRYPICK_APP_ID:
+        required: true
+      CHERRYPICK_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick to ${{ inputs.version_number }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.CHERRYPICK_APP_ID }}
+          private-key: ${{ secrets.CHERRYPICK_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Cherry pick commit
+        id: cherry-pick
+        run: |
+          set -e
+
+          MERGE_COMMIT="${{ inputs.merge_commit_sha }}"
+          TARGET_BRANCH="release-${{ inputs.version_number }}"
+
+          echo "🍒 Cherry-picking commit $MERGE_COMMIT to branch $TARGET_BRANCH"
+
+          # Check if target branch exists
+          if ! git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
+            echo "❌ Target branch '$TARGET_BRANCH' does not exist"
+            exit 1
+          fi
+
+          # Create new branch for cherry-pick
+          CHERRY_PICK_BRANCH="cherry-pick-${{ inputs.pr_number }}-to-${TARGET_BRANCH}"
+          git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
+
+          # Perform cherry-pick
+          if git cherry-pick -m 1 "$MERGE_COMMIT"; then
+            echo "✅ Cherry-pick successful"
+
+            # Extract Signed-off-by from the cherry-pick commit
+            SIGNOFF=$(git log -1 --pretty=format:"%B" | grep -E '^Signed-off-by:' || echo "")
+
+            # Push the new branch
+            git push origin "$CHERRY_PICK_BRANCH"
+
+            # Save data for PR creation
+            echo "branch_name=$CHERRY_PICK_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "signoff=$SIGNOFF" >> "$GITHUB_OUTPUT"
+            echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ Cherry-pick failed due to conflicts"
+            git cherry-pick --abort
+            exit 1
+          fi
+
+      - name: Create Pull Request
+        run: |
+          # Create cherry-pick PR
+          gh pr create \
+            --title "${{ inputs.pr_title }} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})" \
+            --body "Cherry-picked ${{ inputs.pr_title }} (#${{ inputs.pr_number }})
+
+          ${{ steps.cherry-pick.outputs.signoff }}" \
+            --base "${{ steps.cherry-pick.outputs.target_branch }}" \
+            --head "${{ steps.cherry-pick.outputs.branch_name }}"
+
+          # Comment on original PR
+          gh pr comment ${{ inputs.pr_number }} \
+            --body "🍒 Cherry-pick PR created for ${{ inputs.version_number }}: #$(gh pr list --head ${{ steps.cherry-pick.outputs.branch_name }} --json number --jq '.[0].number')"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Comment on failure
+        if: failure()
+        run: |
+          gh pr comment ${{ inputs.pr_number }} \
+            --body "❌ Cherry-pick failed for ${{ inputs.version_number }}. Please check the [workflow logs](https://github.com/argoproj/argo-workflows/actions/runs/${{ github.run_id }}) for details."
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,53 @@
+name: Cherry Pick
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: ["labeled", "closed"]
+
+jobs:
+  find-labels:
+    name: Find Cherry Pick Labels
+    if: |
+      github.event.pull_request.merged == true && (
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'cherry-pick/')) ||
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick/'))
+      )
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.extract-labels.outputs.labels }}
+    steps:
+      - name: Extract cherry-pick labels
+        id: extract-labels
+        run: |
+          if [[ "${{ github.event.action }}" == "labeled" ]]; then
+            # Label was just added - use it directly
+            LABEL_NAME="${{ github.event.label.name }}"
+            VERSION="${LABEL_NAME#cherry-pick/}"
+            CHERRY_PICK_DATA='[{"label":"'$LABEL_NAME'","version":"'$VERSION'"}]'
+          else
+            # PR was closed - find all cherry-pick labels
+            CHERRY_PICK_DATA=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -c '[.[] | select(.name | startswith("cherry-pick/")) | {label: .name, version: (.name | sub("cherry-pick/"; ""))}]')
+          fi
+
+          echo "labels=$CHERRY_PICK_DATA" >> "$GITHUB_OUTPUT"
+          echo "Found cherry-pick data: $CHERRY_PICK_DATA"
+
+  cherry-pick:
+    name: Cherry Pick
+    needs: find-labels
+    if: needs.find-labels.outputs.labels != '[]'
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.find-labels.outputs.labels) }}
+      fail-fast: false
+    uses: ./.github/workflows/cherry-pick-single.yml
+    with:
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      version_number: ${{ matrix.version }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+    secrets:
+      CHERRYPICK_APP_ID: ${{ vars.CHERRYPICK_APP_ID }}
+      CHERRYPICK_APP_PRIVATE_KEY: ${{ secrets.CHERRYPICK_APP_PRIVATE_KEY }}

--- a/.spelling
+++ b/.spelling
@@ -147,6 +147,7 @@ async
 auth
 backend
 backoff
+backport
 backported
 boolean
 booleans

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -150,8 +150,13 @@ See the [Stale Action configuration](https://github.com/argoproj/argo-workflows/
 As a member (see [roles](https://github.com/argoproj/argoproj/blob/main/community/membership.md)) of the argo-project you can use the following comments on PRs to trigger actions:
 
 * `/retest` - re-run any failing test cases
-* `/cherry-pick <branchname>` - will [attempt to cherry-pick](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot) this commit after it has been merged to the target branch.
-This can be used prior to merging and the PR will be created after the merge, or commented after merging for an immediate attempt.
+
+If your PR contains a bug fix, and you want to have that fix backported to a previous release branch, please label your PR with `cherry-pick/x.y` (example: `cherry-pick/3.1`).
+If you do not have access to add labels, ask a maintainer to add them for you.
+
+If you add labels before the PR is merged, the cherry-pick bot will open the backport PRs when your PR is merged.
+
+Adding a label after the PR is merged will also cause the bot to open the backport PR.
 
 ## Sustainability Effort
 


### PR DESCRIPTION
This is a copy of the cherry-pick workflow from argo-cd, 

* https://github.com/argoproj/argo-cd/pull/24322
* https://github.com/argoproj/argo-cd/pull/24543
* https://github.com/argoproj/argo-cd/pull/24575

Modified the "failed action workflow link" to be argoproj/argo-workflows rather than argoproj/argo-cd, but otherwise just a file copy of the two workflows.
Launches on branch `main` rather than `master`

Seen in action here: https://github.com/argoproj/argo-cd/pull/24541

I've also:
* added labels for cherry-pick/3.6 and cherry-pick/3.7
* Added this repo to the github app
* Copied the `CHERRYPICK_APP_ID` as a repository variable (could probably make this Org level really), identical app to argo-cd
* Created a new secret in the cherry-pick app and put that into the repository secret `CHERRYPICK_APP_PRIVATE_KEY`