### PR TITLE
Update test for .Failed handling of ancestors

### DIFF
--- a/workflow/common/ancestry_test.go
+++ b/workflow/common/ancestry_test.go
@@ -65,6 +65,11 @@ func TestGetTaskDependenciesFromDepends(t *testing.T) {
 	assert.Equal(t, map[string]DependencyType{"task-1": DependencyTypeItems}, deps)
 	assert.Equal(t, "task-1.Succeeded && task-1.AnySucceeded", logic)
 
+	task := &wfv1.DAGTask{Depends: "task-1.Failed"}
+	deps, logic := GetTaskDependencies(ctx, task, dctx)
+	assert.Equal(t, map[string]DependencyType{"task-1": DependencyTypeItems}, deps)
+	assert.Equal(t, "task-1.Failed", logic)
+
 	dctx.testTasks[0].ContinueOn = &wfv1.ContinueOn{Failed: true}
 	task = &wfv1.DAGTask{Depends: "task-1"}
 	deps, logic = GetTaskDependencies(ctx, task, dctx)


### PR DESCRIPTION
Refactor test for DependencyTypeItems ancestor handling. Add case to detect a potential regression

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

We faced a regression after upgrading to argo 3.7.2 with the Task depends logic. It seems that for some reason the evaluation of `task1.Failed` stopped working for a task that has a dependency on a fan out step.

### Modifications

Add a testcase to verify the `.Failed` flag is working when used in the task.`depends`

### Verification

I'm testing them through this PR

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
