### PR TITLE
fix: cherry-pick title with quotes

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -90,10 +90,12 @@ jobs:
 
       - name: Create Pull Request
         run: |
-          # Create cherry-pick PR
+          TITLE="${PR_TITLE} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})"
+          BODY="Cherry-picked ${PR_TITLE} (#${{ inputs.pr_number }})
+
           gh pr create \
-            --title "${{ inputs.pr_title }} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})" \
-            --body "Cherry-picked ${{ inputs.pr_title }} (#${{ inputs.pr_number }})
+            --title "$TITLE" \
+            --body "$BODY"
 
           ${{ steps.cherry-pick.outputs.signoff }}" \
             --base "${{ steps.cherry-pick.outputs.target_branch }}" \
@@ -103,6 +105,7 @@ jobs:
           gh pr comment ${{ inputs.pr_number }} \
             --body "🍒 Cherry-pick PR created for ${{ inputs.version_number }}: #$(gh pr list --head ${{ steps.cherry-pick.outputs.branch_name }} --json number --jq '.[0].number')"
         env:
+          PR_TITLE: ${{ inputs.pr_title }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Comment on failure


### PR DESCRIPTION
Fixes cherry-pick robot PR titles

### Motivation

See #14945 for a cherry picked PR

This PR had an incorrect title due to the backticks in the original title having been evaluated by bash.

I manually fixed this:
<img width="870" height="82" alt="image" src="https://github.com/user-attachments/assets/be104565-b9c0-458d-8c13-8de7d049d6d9" />

I believe double quotes would have also caused issues, which I'm not sure is addressed

### Modifications

Bring the title in via an ENV var so we know it's already correct.

### Verification

https://github.com/Joibel/argo-workflows/commit/7f266f2d8aee524f5ce4e9301c434e048501e3cc#diff-1db9ab58aad2ec41f365037f21f52171ddd1f1d6778eeea0f2c49cdb443959f0

Run here:
https://github.com/Joibel/argo-workflows/actions/runs/18652295422/job/53172906891

### Documentation

None required, bugfix