### PR TITLE
feat: update featuregen to use plural "Authors:" field

### DIFF
--- a/.features/TEMPLATE.md
+++ b/.features/TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Required: All of these fields are required, including at least one issue -->
 Description: <!-- A brief one line description of the feature -->
-Author: <!-- Author name and GitHub link in markdown format e.g. [Alan Clucas](https://github.com/Joibel) -->
+Authors: <!-- Author name and GitHub link in markdown format e.g. [Alan Clucas](https://github.com/Joibel) -->
 Component: <!-- component name here, see hack/featuregen/components.go for the list -->
 Issues: <!-- Space separated list of issues 1234 5678 -->
 

--- a/.features/pending/plural-authors-field.md
+++ b/.features/pending/plural-authors-field.md
@@ -1,0 +1,8 @@
+Component: Build and Development
+Issues: 14155
+Description: Support plural "Authors:" field in feature notes
+Authors: [Claude](https://github.com/anthropics)
+
+The featuregen tool now uses the plural "Authors:" field instead of "Author:" for new feature notes.
+This better reflects that features can have multiple authors.
+The change maintains full backwards compatibility with existing feature files that use the singular "Author:" field.

--- a/hack/featuregen/contents.go
+++ b/hack/featuregen/contents.go
@@ -20,7 +20,7 @@ type feature struct {
 
 // Metadata field definitions
 var (
-	metadataFields = []string{"Component", "Issues", "Description", "Author"}
+	metadataFields = []string{"Component", "Issues", "Description", "Authors", "Author"}
 )
 
 func getMetadataPattern(field string) *regexp.Regexp {
@@ -80,9 +80,19 @@ func parseContent(source string, content string) (bool, feature, error) {
 	// Check required sections
 	isValid := true
 	for _, field := range metadataFields {
-		if !strings.Contains(content, field+":") {
-			fmt.Printf("Error: Missing required section '%s:' in %s\n", field, source)
-			isValid = false
+		switch field {
+		case "Authors":
+			if !strings.Contains(content, "Authors:") && !strings.Contains(content, "Author:") {
+				fmt.Printf("Error: Missing required section 'Authors:' (or 'Author:') in %s\n", source)
+				isValid = false
+			}
+		case "Author":
+			// Skip - handled by "Authors" check above
+		default:
+			if !strings.Contains(content, field+":") {
+				fmt.Printf("Error: Missing required section '%s:' in %s\n", field, source)
+				isValid = false
+			}
 		}
 	}
 
@@ -126,7 +136,9 @@ func parseContent(source string, content string) (bool, feature, error) {
 	}
 
 	author := ""
-	if matches := getMetadataPattern("Author").FindStringSubmatch(content); len(matches) > 1 {
+	if matches := getMetadataPattern("Authors").FindStringSubmatch(content); len(matches) > 1 {
+		author = strings.TrimSpace(matches[1])
+	} else if matches := getMetadataPattern("Author").FindStringSubmatch(content); len(matches) > 1 {
 		author = strings.TrimSpace(matches[1])
 	}
 

--- a/hack/featuregen/contents_test.go
+++ b/hack/featuregen/contents_test.go
@@ -19,7 +19,7 @@ func TestParseContent(t *testing.T) {
 			content: `Component: UI
 Issues: 1234 5678
 Description: Test Description
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Test Details
 - Point 1
@@ -39,21 +39,21 @@ Test Details
 			content: `Component: UI
 Issues: 1234
 Description: Test Description
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Some content here
 
 Component: Invalid second component
 Issues: 5678
 Description: Invalid second description
-Author: [Another Author](https://github.com/another)`,
+Authors: [Another Author](https://github.com/another)`,
 			wantValid: false,
 			want: feature{
 				Component:   "UI",
 				Description: "Test Description",
 				Author:      "[Alan Clucas](https://github.com/Joibel)",
 				Issues:      []string{"1234"},
-				Details:     "Some content here\n\nComponent: Invalid second component\nIssues: 5678\nDescription: Invalid second description\nAuthor: [Another Author](https://github.com/another)",
+				Details:     "Some content here\n\nComponent: Invalid second component\nIssues: 5678\nDescription: Invalid second description\nAuthors: [Another Author](https://github.com/another)",
 			},
 		},
 		{
@@ -62,7 +62,7 @@ Author: [Another Author](https://github.com/another)`,
 			content: `Component: UI
 Issues: 1234
 Description: Test Description
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Test Details
 
@@ -84,7 +84,7 @@ Test Details
 			content: `Component: CronWorkflows
 Issues: 1234
 Description: Test Description with issue 4567
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Test Details
 - Point 1
@@ -103,7 +103,7 @@ Test Details
 			source: "invalid.md",
 			content: `Component: UI
 Description: Test Description
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Test Details`,
 			wantValid: false,
@@ -134,7 +134,7 @@ Test Details`,
 			content: `Component: InvalidComponent
 Issues: 1234
 Description: Test Description
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Test Details`,
 			wantValid: false,
@@ -152,7 +152,7 @@ Test Details`,
 			content: `Component: UI
 Issues:
 Description: Test Description
-Author: [Alan Clucas](https://github.com/Joibel)
+Authors: [Alan Clucas](https://github.com/Joibel)
 
 Test Details`,
 			wantValid: false,
@@ -161,6 +161,24 @@ Test Details`,
 				Description: "Test Description",
 				Author:      "[Alan Clucas](https://github.com/Joibel)",
 				Issues:      []string{},
+				Details:     "Test Details",
+			},
+		},
+		{
+			name:   "Backwards compatibility with Author field",
+			source: "test.md",
+			content: `Component: UI
+Issues: 1234
+Description: Test Description
+Author: [Alan Clucas](https://github.com/Joibel)
+
+Test Details`,
+			wantValid: true,
+			want: feature{
+				Component:   "UI",
+				Description: "Test Description",
+				Author:      "[Alan Clucas](https://github.com/Joibel)",
+				Issues:      []string{"1234"},
 				Details:     "Test Details",
 			},
 		},


### PR DESCRIPTION
Vibe coded by claude web UI as an experiment

### Motivation

https://github.com/argoproj/argo-workflows/pull/14915#discussion_r2440256419

### Modifications

- Changed TEMPLATE.md to use "Authors:" instead of "Author:"
- Updated metadataFields to include both "Authors" and "Author" for backwards compatibility
- Updated validation to accept either "Authors:" or "Author:" field
- Updated all tests to use "Authors:" field
- Added test case for backwards compatibility with old "Author:" field

### Verification

Built in tests

### Documentation

Self documenting