### PR TITLE
fix: typo paramaters to parameters in cli help text (cherry-pick #14939 for 3.7)

### DIFF
--- a/cmd/argo/commands/archive/retry.go
+++ b/cmd/argo/commands/archive/retry.go
@@ -97,7 +97,7 @@ func NewRetryCommand() *cobra.Command {
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is retried")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")
 	command.Flags().BoolVar(&retryOpts.restartSuccessful, "restart-successful", false, "indicates to restart successful nodes matching the --node-field-selector")
-	command.Flags().StringVar(&retryOpts.nodeFieldSelector, "node-field-selector", "", "selector of nodes to reset, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVar(&retryOpts.nodeFieldSelector, "node-field-selector", "", "selector of nodes to reset, eg: --node-field-selector inputs.parameters.myparam.value=abc")
 	command.Flags().StringVarP(&retryOpts.labelSelector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&retryOpts.fieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	return command

--- a/cmd/argo/commands/node.go
+++ b/cmd/argo/commands/node.go
@@ -88,7 +88,7 @@ func NewNodeCommand() *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&setArgs.nodeFieldSelector, "node-field-selector", "", "Selector of node to set, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVar(&setArgs.nodeFieldSelector, "node-field-selector", "", "Selector of node to set, eg: --node-field-selector inputs.parameters.myparam.value=abc")
 	command.Flags().StringVar(&setArgs.phase, "phase", "", "Phase to set the node to, eg: --phase Succeeded")
 	command.Flags().StringArrayVarP(&setArgs.outputParameters, "output-parameter", "p", []string{}, "Set a \"supplied\" output parameter of node, eg: --output-parameter parameter-name=\"Hello, world!\"")
 	command.Flags().StringVarP(&setArgs.message, "message", "m", "", "Set the message of a node, eg: --message \"Hello, world!\"")

--- a/cmd/argo/commands/resume.go
+++ b/cmd/argo/commands/resume.go
@@ -35,7 +35,7 @@ func NewResumeCommand() *cobra.Command {
 		
 # Resume multiple workflows by node field selector:
 		
-  argo resume --node-field-selector inputs.paramaters.myparam.value=abc		
+  argo resume --node-field-selector inputs.parameters.myparam.value=abc		
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 && resumeArgs.nodeFieldSelector == "" {
@@ -70,6 +70,6 @@ func NewResumeCommand() *cobra.Command {
 			return nil
 		},
 	}
-	command.Flags().StringVar(&resumeArgs.nodeFieldSelector, "node-field-selector", "", "selector of node to resume, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVar(&resumeArgs.nodeFieldSelector, "node-field-selector", "", "selector of node to resume, eg: --node-field-selector inputs.parameters.myparam.value=abc")
 	return command
 }

--- a/cmd/argo/commands/retry.go
+++ b/cmd/argo/commands/retry.go
@@ -98,7 +98,7 @@ func NewRetryCommand() *cobra.Command {
 	command.Flags().BoolVar(&cliSubmitOpts.Watch, "watch", false, "watch the workflow until it completes, only works when a single workflow is retried")
 	command.Flags().BoolVar(&cliSubmitOpts.Log, "log", false, "log the workflow until it completes")
 	command.Flags().BoolVar(&retryOpts.restartSuccessful, "restart-successful", false, "indicates to restart successful nodes matching the --node-field-selector")
-	command.Flags().StringVar(&retryOpts.nodeFieldSelector, "node-field-selector", "", "selector of nodes to reset, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVar(&retryOpts.nodeFieldSelector, "node-field-selector", "", "selector of nodes to reset, eg: --node-field-selector inputs.parameters.myparam.value=abc")
 	command.Flags().StringVarP(&retryOpts.labelSelector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&retryOpts.fieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	return command

--- a/cmd/argo/commands/stop.go
+++ b/cmd/argo/commands/stop.go
@@ -72,7 +72,7 @@ func NewStopCommand() *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&stopArgs.message, "message", "", "Message to add to previously running nodes")
-	command.Flags().StringVar(&stopArgs.nodeFieldSelector, "node-field-selector", "", "selector of node to stop, eg: --node-field-selector inputs.paramaters.myparam.value=abc")
+	command.Flags().StringVar(&stopArgs.nodeFieldSelector, "node-field-selector", "", "selector of node to stop, eg: --node-field-selector inputs.parameters.myparam.value=abc")
 	command.Flags().StringVarP(&stopArgs.labelSelector, "selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	command.Flags().StringVar(&stopArgs.fieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	command.Flags().BoolVar(&stopArgs.dryRun, "dry-run", false, "If true, only print the workflows that would be stopped, without stopping them.")

--- a/docs/cli/argo_archive_retry.md
+++ b/docs/cli/argo_archive_retry.md
@@ -45,7 +45,7 @@ argo archive retry [WORKFLOW...] [flags]
       --field-selector string        Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                         help for retry
       --log                          log the workflow until it completes
-      --node-field-selector string   selector of nodes to reset, eg: --node-field-selector inputs.paramaters.myparam.value=abc
+      --node-field-selector string   selector of nodes to reset, eg: --node-field-selector inputs.parameters.myparam.value=abc
   -o, --output string                Output format. One of: name|json|yaml|wide
   -p, --parameter stringArray        input parameter to override on the original workflow spec
       --restart-successful           indicates to restart successful nodes matching the --node-field-selector

--- a/docs/cli/argo_node.md
+++ b/docs/cli/argo_node.md
@@ -24,7 +24,7 @@ argo node ACTION WORKFLOW FLAGS [flags]
 ```
   -h, --help                           help for node
   -m, --message string                 Set the message of a node, eg: --message "Hello, world!"
-      --node-field-selector string     Selector of node to set, eg: --node-field-selector inputs.paramaters.myparam.value=abc
+      --node-field-selector string     Selector of node to set, eg: --node-field-selector inputs.parameters.myparam.value=abc
   -p, --output-parameter stringArray   Set a "supplied" output parameter of node, eg: --output-parameter parameter-name="Hello, world!"
       --phase string                   Phase to set the node to, eg: --phase Succeeded
 ```

--- a/docs/cli/argo_resume.md
+++ b/docs/cli/argo_resume.md
@@ -23,7 +23,7 @@ argo resume WORKFLOW1 WORKFLOW2... [flags]
 		
 # Resume multiple workflows by node field selector:
 		
-  argo resume --node-field-selector inputs.paramaters.myparam.value=abc		
+  argo resume --node-field-selector inputs.parameters.myparam.value=abc		
 
 ```
 
@@ -31,7 +31,7 @@ argo resume WORKFLOW1 WORKFLOW2... [flags]
 
 ```
   -h, --help                         help for resume
-      --node-field-selector string   selector of node to resume, eg: --node-field-selector inputs.paramaters.myparam.value=abc
+      --node-field-selector string   selector of node to resume, eg: --node-field-selector inputs.parameters.myparam.value=abc
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/argo_retry.md
+++ b/docs/cli/argo_retry.md
@@ -56,7 +56,7 @@ argo retry [WORKFLOW...] [flags]
       --field-selector string        Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                         help for retry
       --log                          log the workflow until it completes
-      --node-field-selector string   selector of nodes to reset, eg: --node-field-selector inputs.paramaters.myparam.value=abc
+      --node-field-selector string   selector of nodes to reset, eg: --node-field-selector inputs.parameters.myparam.value=abc
   -o, --output string                Output format. One of: name|json|yaml|wide
   -p, --parameter stringArray        input parameter to override on the original workflow spec
       --restart-successful           indicates to restart successful nodes matching the --node-field-selector

--- a/docs/cli/argo_stop.md
+++ b/docs/cli/argo_stop.md
@@ -38,7 +38,7 @@ argo stop WORKFLOW WORKFLOW2... [flags]
       --field-selector string        Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                         help for stop
       --message string               Message to add to previously running nodes
-      --node-field-selector string   selector of node to stop, eg: --node-field-selector inputs.paramaters.myparam.value=abc
+      --node-field-selector string   selector of node to stop, eg: --node-field-selector inputs.parameters.myparam.value=abc
   -l, --selector string              Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
 ```
 


### PR DESCRIPTION
Cherry-picked fix: typo paramaters to parameters in cli help text (#14939)