### PR TITLE
feat: Allow user name for persistence to be passed as plain text. Fixes #10521

### DIFF
--- a/.features/pending/pass-database-username-as-plaintext.md
+++ b/.features/pending/pass-database-username-as-plaintext.md
@@ -1,0 +1,23 @@
+Component: General
+Issues: 10521
+Description: Allow user name for persistenence configuration to be passed in plain text
+Author: [Shivaram Vasudevan](https://github.com/Shivaram-Vasudevan)
+
+Allow the user name for the persistence configuration to be passed in plain text (via a new configuration key `userName`). Currently in the persistence configuration, the user name can only be passed as Kubernetes secrets (via `userNameSecret`). An error is thrown if both `userNameSecret` and `userName` are set or if none of them are set.
+
+Sample usage:
+```yaml
+persistence: |
+    # Skipping some configuration for brevity
+    postgresql:
+      host: localhost
+      port: 5432
+      database: postgres
+      tableName: argo_workflows
+      userName: your-database-username
+      passwordSecret:
+        name: argo-postgres-config
+        key: password
+      ssl: true
+      sslMode: require
+```

--- a/config/config.go
+++ b/config/config.go
@@ -282,6 +282,8 @@ type DatabaseConfig struct {
 	Database string `json:"database"`
 	// TableName is the name of the table to use, must be set
 	TableName string `json:"tableName,omitempty"`
+	// Username passed in plaintext (Both Username and UsernameSecret are supported but pass user name in only one field)
+	Username string `json:"userName,omitempty"`
 	// UsernameSecret references a secret containing the database username
 	UsernameSecret apiv1.SecretKeySelector `json:"userNameSecret,omitempty"`
 	// PasswordSecret references a secret containing the database password

--- a/docs/workflow-controller-configmap.md
+++ b/docs/workflow-controller-configmap.md
@@ -194,16 +194,17 @@ PostgreSQLConfig contains PostgreSQL-specific database configuration
 
 ### Fields
 
-|    Field Name    |                                                         Field Type                                                          |                                Description                                |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| `Host`           | `string`                                                                                                                    | Host is the database server hostname                                      |
-| `Port`           | `int`                                                                                                                       | Port is the database server port                                          |
-| `Database`       | `string`                                                                                                                    | Database is the name of the database to connect to                        |
-| `TableName`      | `string`                                                                                                                    | TableName is the name of the table to use, must be set                    |
-| `UsernameSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | UsernameSecret references a secret containing the database username       |
-| `PasswordSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | PasswordSecret references a secret containing the database password       |
-| `SSL`            | `bool`                                                                                                                      | SSL enables SSL connection to the database                                |
-| `SSLMode`        | `string`                                                                                                                    | SSLMode specifies the SSL mode (disable, require, verify-ca, verify-full) |
+|    Field Name    |                                                         Field Type                                                          |                                                    Description                                                     |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `Host`           | `string`                                                                                                                    | Host is the database server hostname                                                                               |
+| `Port`           | `int`                                                                                                                       | Port is the database server port                                                                                   |
+| `Database`       | `string`                                                                                                                    | Database is the name of the database to connect to                                                                 |
+| `TableName`      | `string`                                                                                                                    | TableName is the name of the table to use, must be set                                                             |
+| `Username`       | `string`                                                                                                                    | Username passed in plaintext (Both Username and UsernameSecret are supported but pass user name in only one field) |
+| `UsernameSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | UsernameSecret references a secret containing the database username                                                |
+| `PasswordSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | PasswordSecret references a secret containing the database password                                                |
+| `SSL`            | `bool`                                                                                                                      | SSL enables SSL connection to the database                                                                         |
+| `SSLMode`        | `string`                                                                                                                    | SSLMode specifies the SSL mode (disable, require, verify-ca, verify-full)                                          |
 
 ## MySQLConfig
 
@@ -211,15 +212,16 @@ MySQLConfig contains MySQL-specific database configuration
 
 ### Fields
 
-|    Field Name    |                                                         Field Type                                                          |                             Description                             |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-| `Host`           | `string`                                                                                                                    | Host is the database server hostname                                |
-| `Port`           | `int`                                                                                                                       | Port is the database server port                                    |
-| `Database`       | `string`                                                                                                                    | Database is the name of the database to connect to                  |
-| `TableName`      | `string`                                                                                                                    | TableName is the name of the table to use, must be set              |
-| `UsernameSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | UsernameSecret references a secret containing the database username |
-| `PasswordSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | PasswordSecret references a secret containing the database password |
-| `Options`        | `Map<string,string>`                                                                                                        | Options contains additional MySQL connection options                |
+|    Field Name    |                                                         Field Type                                                          |                                                    Description                                                     |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `Host`           | `string`                                                                                                                    | Host is the database server hostname                                                                               |
+| `Port`           | `int`                                                                                                                       | Port is the database server port                                                                                   |
+| `Database`       | `string`                                                                                                                    | Database is the name of the database to connect to                                                                 |
+| `TableName`      | `string`                                                                                                                    | TableName is the name of the table to use, must be set                                                             |
+| `Username`       | `string`                                                                                                                    | Username passed in plaintext (Both Username and UsernameSecret are supported but pass user name in only one field) |
+| `UsernameSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | UsernameSecret references a secret containing the database username                                                |
+| `PasswordSecret` | [`apiv1.SecretKeySelector`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretkeyselector-v1-core) | PasswordSecret references a secret containing the database password                                                |
+| `Options`        | `Map<string,string>`                                                                                                        | Options contains additional MySQL connection options                                                               |
 
 ## ConnectionPool
 

--- a/docs/workflow-controller-configmap.yaml
+++ b/docs/workflow-controller-configmap.yaml
@@ -286,6 +286,8 @@ data:
       port: 5432
       database: postgres
       tableName: argo_workflows
+      # The user name can either be passed in plaintext with userName configuration or as a secret with the userNameSecret configuration
+      # userName: your-database-username
       # the database secrets must be in the same namespace of the controller
       userNameSecret:
         name: argo-postgres-config


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #10521

### Motivation

Allow the user name to connect to persistent datastore (Postgres or MySQL) to be passed as plain text instead of having to pass it via a Kubernetes secret

### Modifications

1. Update the `DatabaseConfig` structure to also include a field: `Username` which will get the user name in plain text format
2. As part of creating the database session:
   a. Validate if the user name was passed in plain text as well as a Kubernetes secret and throw an error in case this is true
   b. Validate if the user name was not passed in plain text as well as a Kubernetes secret and throw an error in case this is true
   c. Try getting the user name in plain text (`userName` configuration key). If it is not set, then proceed to get the user name from the Kubernetes secret (`userNameSecret` configuration key)

### Verification

Testing involved the following steps:
1. Changed the persistence configuration in manifests/components/postgres/overlays/workflow-controller-configmap.yaml
2. Start the controller with
```bash
make start PROFILE=postgres
```
3.  Verified if the controller is up along with validating that the hello world workflows can be submitted

**Test 1: Not specifying user name in any format**
```bash
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl get configmap workflow-controller-configmap -o yaml
Tue Oct 21 07:34:17 PM UTC 2025
apiVersion: v1
data:
  artifactRepository: |
    s3:
      bucket: my-bucket
      endpoint: minio:9000
      insecure: true
      accessKeySecret:
        name: my-minio-cred
        key: accesskey
      secretKeySecret:
        name: my-minio-cred
        key: secretkey
  columns: |
    - name: Workflow Completed
      type: label
      key: workflows.argoproj.io/completed
  executor: |
    imagePullPolicy: IfNotPresent
    resources:
      requests:
        cpu: 0.1
        memory: 64Mi
      limits:
        cpu: 0.5
        memory: 256Mi
  images: |
    docker/whalesay:latest:
       cmd: [cowsay]
  links: |
    - name: Workflow Link
      scope: workflow
      url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Link
      scope: pod
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Logs Link
      scope: pod-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Event Source Logs Link
      scope: event-source-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Sensor Logs Link
      scope: sensor-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Completed Workflows
      scope: workflow-list
      url: http://workflows?label=workflows.argoproj.io/completed=true
  metricsConfig: |
    enabled: true
    path: /metrics
    port: 9090
  namespaceParallelism: "10"
  persistence: |
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    nodeStatusOffLoad: true
    archive: true
    archiveTTL: 7d
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      tableName: argo_workflows
      passwordSecret:
        name: argo-postgres-config
        key: password
  retentionPolicy: |
    completed: 10
    failed: 3
    errored: 3
  synchronization: |
    enableAPI: true
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    controllerName: test
    limitTableName: sync_limit
    stateTableName: sync_state
    controllerTableName: sync_controller
    inactiveControllerSeconds: 300
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      userNameSecret:
        name: argo-postgres-config
        key: username
      passwordSecret:
        name: argo-postgres-config
        key: password
  workflowDefaults: |
    spec:
      activeDeadlineSeconds: 300
      podSpecPatch: |
        terminationGracePeriodSeconds: 3
      workflowMetadata:
        labels:
          default-label: thisLabelIsFromWorkflowDefaults
kind: ConfigMap
metadata:
  creationTimestamp: "2025-10-06T21:20:18Z"
  labels:
    applyset.kubernetes.io/part-of: applyset-0PwcthXyEwapYHTyGfGxNVzbVwsuJ0TAQMnX0hq5yVk-v1
  name: workflow-controller-configmap
  namespace: argo
  resourceVersion: "11700"
  uid: 182ab571-217c-4432-acb9-db8c4a286ec7
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ 
```

Logs for controller telling that the startup failed due to no username
```bash
time=2025-10-21T19:33:55.870Z level=INFO msg="index config" indexWorkflowSemaphoreKeys=true
time=2025-10-21T19:33:55.870Z level=INFO msg="cron config" cronSyncPeriod=10s
time=2025-10-21T19:33:55.870Z level=INFO msg="Memoization caches will be garbage-collected if they have not been hit after" gcAfterNotHitDuration=30s
time=2025-10-21T19:33:55.871Z level=INFO msg="not enabling pprof debug endpoints"
time=2025-10-21T19:33:55.883Z level=DEBUG msg="K8S request" verb=Get kind=configmaps status=200
time=2025-10-21T19:33:55.906Z level=INFO msg="Configuration updated"
time=2025-10-21T19:33:55.906Z level=INFO msg="Persistence configuration enabled"
time=2025-10-21T19:33:55.906Z level=ERROR msg="Failed to update config" error="user name has not been configured both as plaintext or as secret"
```

**Test 2: Specifying both username and username secret**
```bash
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl get configmap workflow-controller-configmap -o yaml
Tue Oct 21 07:38:21 PM UTC 2025
apiVersion: v1
data:
  artifactRepository: |
    s3:
      bucket: my-bucket
      endpoint: minio:9000
      insecure: true
      accessKeySecret:
        name: my-minio-cred
        key: accesskey
      secretKeySecret:
        name: my-minio-cred
        key: secretkey
  columns: |
    - name: Workflow Completed
      type: label
      key: workflows.argoproj.io/completed
  executor: |
    imagePullPolicy: IfNotPresent
    resources:
      requests:
        cpu: 0.1
        memory: 64Mi
      limits:
        cpu: 0.5
        memory: 256Mi
  images: |
    docker/whalesay:latest:
       cmd: [cowsay]
  links: |
    - name: Workflow Link
      scope: workflow
      url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Link
      scope: pod
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Logs Link
      scope: pod-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Event Source Logs Link
      scope: event-source-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Sensor Logs Link
      scope: sensor-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Completed Workflows
      scope: workflow-list
      url: http://workflows?label=workflows.argoproj.io/completed=true
  metricsConfig: |
    enabled: true
    path: /metrics
    port: 9090
  namespaceParallelism: "10"
  persistence: |
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    nodeStatusOffLoad: true
    archive: true
    archiveTTL: 7d
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      tableName: argo_workflows
      userName: postgres
      userNameSecret:
        name: argo-postgres-config
        key: username
      passwordSecret:
        name: argo-postgres-config
        key: password
  retentionPolicy: |
    completed: 10
    failed: 3
    errored: 3
  synchronization: |
    enableAPI: true
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    controllerName: test
    limitTableName: sync_limit
    stateTableName: sync_state
    controllerTableName: sync_controller
    inactiveControllerSeconds: 300
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      userNameSecret:
        name: argo-postgres-config
        key: username
      passwordSecret:
        name: argo-postgres-config
        key: password
  workflowDefaults: |
    spec:
      activeDeadlineSeconds: 300
      podSpecPatch: |
        terminationGracePeriodSeconds: 3
      workflowMetadata:
        labels:
          default-label: thisLabelIsFromWorkflowDefaults
kind: ConfigMap
metadata:
  creationTimestamp: "2025-10-06T21:20:18Z"
  labels:
    applyset.kubernetes.io/part-of: applyset-0PwcthXyEwapYHTyGfGxNVzbVwsuJ0TAQMnX0hq5yVk-v1
  name: workflow-controller-configmap
  namespace: argo
  resourceVersion: "11787"
  uid: 182ab571-217c-4432-acb9-db8c4a286ec7
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ 
```

Logs from controller mentions that the controller couldn't start 
```bash
time=2025-10-21T19:38:39.843Z level=INFO msg="index config" indexWorkflowSemaphoreKeys=true
time=2025-10-21T19:38:39.843Z level=INFO msg="cron config" cronSyncPeriod=10s
time=2025-10-21T19:38:39.843Z level=INFO msg="Memoization caches will be garbage-collected if they have not been hit after" gcAfterNotHitDuration=30s
time=2025-10-21T19:38:39.845Z level=INFO msg="not enabling pprof debug endpoints"
time=2025-10-21T19:38:39.881Z level=DEBUG msg="K8S request" status=200 verb=Get kind=configmaps
time=2025-10-21T19:38:39.904Z level=INFO msg="Configuration updated"
time=2025-10-21T19:38:39.904Z level=INFO msg="Persistence configuration enabled"
time=2025-10-21T19:38:39.904Z level=ERROR msg="Failed to update config" error="configure user name either as plaintext or as secret but not as both"
```

Test 3: Passing username only as secret
```bash
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl get configmap workflow-controller-configmap -o yaml
Tue Oct 21 07:41:51 PM UTC 2025
apiVersion: v1
data:
  artifactRepository: |
    s3:
      bucket: my-bucket
      endpoint: minio:9000
      insecure: true
      accessKeySecret:
        name: my-minio-cred
        key: accesskey
      secretKeySecret:
        name: my-minio-cred
        key: secretkey
  columns: |
    - name: Workflow Completed
      type: label
      key: workflows.argoproj.io/completed
  executor: |
    imagePullPolicy: IfNotPresent
    resources:
      requests:
        cpu: 0.1
        memory: 64Mi
      limits:
        cpu: 0.5
        memory: 256Mi
  images: |
    docker/whalesay:latest:
       cmd: [cowsay]
  links: |
    - name: Workflow Link
      scope: workflow
      url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Link
      scope: pod
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Logs Link
      scope: pod-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Event Source Logs Link
      scope: event-source-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Sensor Logs Link
      scope: sensor-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Completed Workflows
      scope: workflow-list
      url: http://workflows?label=workflows.argoproj.io/completed=true
  metricsConfig: |
    enabled: true
    path: /metrics
    port: 9090
  namespaceParallelism: "10"
  persistence: |
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    nodeStatusOffLoad: true
    archive: true
    archiveTTL: 7d
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      tableName: argo_workflows
      userNameSecret:
        name: argo-postgres-config
        key: username
      passwordSecret:
        name: argo-postgres-config
        key: password
  retentionPolicy: |
    completed: 10
    failed: 3
    errored: 3
  synchronization: |
    enableAPI: true
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    controllerName: test
    limitTableName: sync_limit
    stateTableName: sync_state
    controllerTableName: sync_controller
    inactiveControllerSeconds: 300
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      userNameSecret:
        name: argo-postgres-config
        key: username
      passwordSecret:
        name: argo-postgres-config
        key: password
  workflowDefaults: |
    spec:
      activeDeadlineSeconds: 300
      podSpecPatch: |
        terminationGracePeriodSeconds: 3
      workflowMetadata:
        labels:
          default-label: thisLabelIsFromWorkflowDefaults
kind: ConfigMap
metadata:
  creationTimestamp: "2025-10-06T21:20:18Z"
  labels:
    applyset.kubernetes.io/part-of: applyset-0PwcthXyEwapYHTyGfGxNVzbVwsuJ0TAQMnX0hq5yVk-v1
  name: workflow-controller-configmap
  namespace: argo
  resourceVersion: "11839"
  uid: 182ab571-217c-4432-acb9-db8c4a286ec7
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ 
```
The controller was up and running and I was able to submit the sample workflow
```bash
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl create -f examples/hello-world.yaml
Tue Oct 21 07:42:16 PM UTC 2025
workflow.argoproj.io/hello-world-ttvsp created
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl get workflows --watch
Tue Oct 21 07:42:23 PM UTC 2025
NAME                STATUS      AGE   MESSAGE
hello-world-ttvsp   Running     6s    
hello-world-ttvsp   Running     11s   
hello-world-ttvsp   Running     12s   
hello-world-ttvsp   Succeeded   13s   
hello-world-ttvsp   Succeeded   13s   
^C
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ 
```

Test 4: Passing username only as plain text
```bash
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ kubectl delete workflows hel
lo-world-78n8v hello-world-ttvsp
workflow.argoproj.io "hello-world-78n8v" deleted
workflow.argoproj.io "hello-world-ttvsp" deleted
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl get configma
p workflow-controller-configmap -o yaml
Tue Oct 21 07:46:19 PM UTC 2025
apiVersion: v1
data:
  artifactRepository: |
    s3:
      bucket: my-bucket
      endpoint: minio:9000
      insecure: true
      accessKeySecret:
        name: my-minio-cred
        key: accesskey
      secretKeySecret:
        name: my-minio-cred
        key: secretkey
  columns: |
    - name: Workflow Completed
      type: label
      key: workflows.argoproj.io/completed
  executor: |
    imagePullPolicy: IfNotPresent
    resources:
      requests:
        cpu: 0.1
        memory: 64Mi
      limits:
        cpu: 0.5
        memory: 256Mi
  images: |
    docker/whalesay:latest:
       cmd: [cowsay]
  links: |
    - name: Workflow Link
      scope: workflow
      url: http://logging-facility?namespace=${metadata.namespace}&workflowName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Link
      scope: pod
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Pod Logs Link
      scope: pod-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Event Source Logs Link
      scope: event-source-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Sensor Logs Link
      scope: sensor-logs
      url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
    - name: Completed Workflows
      scope: workflow-list
      url: http://workflows?label=workflows.argoproj.io/completed=true
  metricsConfig: |
    enabled: true
    path: /metrics
    port: 9090
  namespaceParallelism: "10"
  persistence: |
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    nodeStatusOffLoad: true
    archive: true
    archiveTTL: 7d
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      tableName: argo_workflows
      userName: postgres
      passwordSecret:
        name: argo-postgres-config
        key: password
  retentionPolicy: |
    completed: 10
    failed: 3
    errored: 3
  synchronization: |
    enableAPI: true
    connectionPool:
      maxIdleConns: 100
      maxOpenConns: 0
      connMaxLifetime: 0s
    controllerName: test
    limitTableName: sync_limit
    stateTableName: sync_state
    controllerTableName: sync_controller
    inactiveControllerSeconds: 300
    postgresql:
      host: postgres
      port: 5432
      database: postgres
      userNameSecret:
        name: argo-postgres-config
        key: username
      passwordSecret:
        name: argo-postgres-config
        key: password
  workflowDefaults: |
    spec:
      activeDeadlineSeconds: 300
      podSpecPatch: |
        terminationGracePeriodSeconds: 3
      workflowMetadata:
        labels:
          default-label: thisLabelIsFromWorkflowDefaults
kind: ConfigMap
metadata:
  creationTimestamp: "2025-10-06T21:20:18Z"
  labels:
    applyset.kubernetes.io/part-of: applyset-0PwcthXyEwapYHTyGfGxNVzbVwsuJ0TAQMnX0hq5yVk-v1
  name: workflow-controller-configmap
  namespace: argo
  resourceVersion: "12015"
  uid: 182ab571-217c-4432-acb9-db8c4a286ec7
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ 
```

I was able to see that the controller was running and I was able to submit the sample workflow:
```bash
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl create -f examples/hello-world.yaml
Tue Oct 21 07:46:41 PM UTC 2025
workflow.argoproj.io/hello-world-nsn8r created
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ date && kubectl get workflows --watch
Tue Oct 21 07:47:00 PM UTC 2025
NAME                STATUS      AGE   MESSAGE
hello-world-nsn8r   Succeeded   18s   
^C
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (feature/allow-database-username-as-plaintext) $ 
```


### Documentation

The workflow-controller-configmap markdown file has been updated to make users aware of this feature (the configuration key to be used is in a comment)

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
