### PR TITLE
fix: prevent nil pointer dereference in GetTemplateFromRef with podMetadata. Fixes #14968

### DIFF
--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -148,12 +148,13 @@ func (tplCtx *TemplateContext) GetTemplateFromRef(ctx context.Context, tmplRef *
 
 	template = wftmpl.GetTemplateByName(tmplRef.Template)
 
-	podMetadata := wftmpl.GetPodMetadata()
-	tplCtx.addPodMetadata(podMetadata, template)
-
 	if template == nil {
 		return nil, errors.Errorf(errors.CodeNotFound, "template %s not found in workflow template %s", tmplRef.Template, tmplRef.Name)
 	}
+
+	podMetadata := wftmpl.GetPodMetadata()
+	tplCtx.addPodMetadata(podMetadata, template)
+
 	return template.DeepCopy(), nil
 }
 

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -362,3 +362,56 @@ func TestOnWorkflowTemplate(t *testing.T) {
 	tmpl := newCtx.tmplBase.GetTemplateByName("whalesay")
 	assert.NotNil(t, tmpl)
 }
+
+// TestGetTemplateFromRefWithPodMetadataAndMissingTemplate tests the bug where
+// GetTemplateFromRef causes a nil pointer dereference when:
+// 1. A WorkflowTemplate has podMetadata defined
+// 2. A templateRef references a template name that doesn't exist in that WorkflowTemplate
+func TestGetTemplateFromRefWithPodMetadataAndMissingTemplate(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wfClientset := fakewfclientset.NewSimpleClientset()
+
+	// Create a WorkflowTemplate with podMetadata but without the template "nonexistent"
+	workflowTemplateWithPodMetadata := `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: template-with-podmetadata
+spec:
+  podMetadata:
+    labels:
+      example-label: example-value
+    annotations:
+      example-annotation: example-value
+  templates:
+  - name: existing-template
+    container:
+      image: alpine:latest
+      command: [echo, hello]
+`
+
+	err := createWorkflowTemplate(ctx, wfClientset, workflowTemplateWithPodMetadata)
+	require.NoError(t, err)
+
+	// Create a base workflow template to use as context
+	baseWftmpl := unmarshalWftmpl(baseWorkflowTemplateYaml)
+	log := logging.RequireLoggerFromContext(ctx)
+	tplCtx := NewContextFromClientSet(
+		wfClientset.ArgoprojV1alpha1().WorkflowTemplates(metav1.NamespaceDefault),
+		wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates(),
+		baseWftmpl,
+		nil,
+		log,
+	)
+
+	// Try to get a template that doesn't exist from a WorkflowTemplate that HAS podMetadata
+	tmplRef := wfv1.TemplateRef{
+		Name:     "template-with-podmetadata",
+		Template: "nonexistent-template",
+	}
+
+	_, err = tplCtx.GetTemplateFromRef(ctx, &tmplRef)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "template nonexistent-template not found in workflow template template-with-podmetadata")
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14968

### Motivation

I ran into this nil pointer due to malformed CronWorkflows and wanted to see if I could fix it.

### Modifications

I made sure a nil check happened before that object was subsequently accessed in `addPodMetadata()`

### Verification

I wrote a unit test to replicate the issue

### Documentation

No update to documentation should be necessary as this simply fixes a bug.

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
