### PR TITLE
fix!: status->phase in the gauge metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -297,9 +297,9 @@ A gauge of the number of workflows currently in the cluster in each phase.
 The `Running` count does not mean that a workflows pods are running, just that the controller has scheduled them.
 A workflow can be stuck in `Running` with pending pods for a long time.
 
-| attribute |        explanation         |
-|-----------|----------------------------|
-| `status`  | Boolean: `true` or `false` |
+| attribute |               explanation               |
+|-----------|-----------------------------------------|
+| `phase`   | The phase that the Workflow has entered |
 
 #### `is_leader`
 

--- a/util/telemetry/builder/values.yaml
+++ b/util/telemetry/builder/values.yaml
@@ -140,7 +140,7 @@ metrics:
       The `Running` count does not mean that a workflows pods are running, just that the controller has scheduled them.
       A workflow can be stuck in `Running` with pending pods for a long time.
     attributes:
-      - name: WorkflowStatus
+      - name: WorkflowPhase
     unit: "{workflow}"
     type: Int64ObservableGauge
   - name: IsLeader

--- a/util/telemetry/metrics_list.go
+++ b/util/telemetry/metrics_list.go
@@ -69,7 +69,7 @@ var InstrumentGauge = BuiltinInstrument{
 	instType:    Int64ObservableGauge,
 	attributes: []BuiltinAttribute{
 		{
-			name: AttribWorkflowStatus,
+			name: AttribWorkflowPhase,
 		},
 	},
 }

--- a/workflow/metrics/gauge_workflow_phase.go
+++ b/workflow/metrics/gauge_workflow_phase.go
@@ -37,7 +37,7 @@ func addWorkflowPhaseGauge(_ context.Context, m *Metrics) error {
 func (p *workflowPhaseGauge) update(ctx context.Context, o metric.Observer) error {
 	phases := p.callback(ctx)
 	for phase, val := range phases {
-		p.gauge.ObserveInt(ctx, o, val, telemetry.InstAttribs{{Name: telemetry.AttribWorkflowStatus, Value: phase}})
+		p.gauge.ObserveInt(ctx, o, val, telemetry.InstAttribs{{Name: telemetry.AttribWorkflowPhase, Value: phase}})
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes attribute for the gauge metric

This is a breaking change for anyone using the old attribute.

### Motivation

This only has one attribute of Phase, but we've been labelling it as status and this is wrong.

### Modifications

Changed the word Status to Phase

### Verification

Code inspection and CI

### Documentation

Autogenerated.