### PR TITLE
fix: add archive location if artifact is needed in data source. Fixes #14990

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -2054,8 +2054,6 @@ Outputs hold parameters, artifacts, and results from a step
 
 - [`dag-conditional-parameters.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/dag-conditional-parameters.yaml)
 
-- [`data-transformations.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/data-transformations.yaml)
-
 - [`exit-handler-with-artifacts.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/exit-handler-with-artifacts.yaml)
 
 - [`exit-handler-with-param.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/exit-handler-with-param.yaml)

--- a/examples/data-transformations.yaml
+++ b/examples/data-transformations.yaml
@@ -38,10 +38,6 @@ spec:
 
         transformation:
           - expression: "filter(data, {# endsWith \"main.log\"})"
-      outputs:
-        artifacts:
-          - name: file
-            path: /file
 
     - name: process-logs
       inputs:

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -1205,7 +1205,13 @@ func (woc *wfOperationCtx) addArchiveLocation(ctx context.Context, tmpl *wfv1.Te
 	}
 	archiveLogs := woc.IsArchiveLogs(tmpl)
 	needLocation := archiveLogs
-	for _, art := range append(tmpl.Inputs.Artifacts, tmpl.Outputs.Artifacts...) {
+	artifacts := append(tmpl.Inputs.Artifacts, tmpl.Outputs.Artifacts...)
+	if tmpl.Data != nil {
+		if art, exist := tmpl.Data.Source.GetArtifactIfNeeded(); exist {
+			artifacts = append(artifacts, *art)
+		}
+	}
+	for _, art := range artifacts {
 		if !art.HasLocation() {
 			needLocation = true
 		}


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14990

### Motivation

<!-- TODO: Say why you made your changes. -->
https://github.com/argoproj/argo-workflows/discussions/14940#discussioncomment-14726200

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Add archive location if artifact is needed in data source.
- Remove unused `outputs.artifacts` in example `data-transformations`.

### Verification

<!-- TODO: Say how you tested your changes. -->

Disable `archiveLogs` and use the workflow below for testing and validation.

```yaml
# See doc docs/data-sourcing-and-transformation.md
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: data-transformations-
  annotations:
    workflows.argoproj.io/description: |
      This workflow demonstrates using a data template to list in an S3 bucket
      and then process those log files.
    workflows.argoproj.io/version: ">= 3.1.0"
spec:
  entrypoint: data-transformations
  templates:
    - name: data-transformations
      steps:
        - - name: list-log-files
            template: list-log-files
        - - name: process-logs
            template: process-logs
            withParam: "{{steps.list-log-files.outputs.result}}"
            arguments:
              artifacts:
                - name: file
                  s3:
                    key: "{{item}}"

              parameters:
                - name: file-name
                  value: "{{item}}"

    - name: list-log-files
      data:
        source:
          artifactPaths:
            name: test-bucket
            s3:
              bucket: my-bucket

        transformation:
          - expression: "filter(data, {# endsWith \"main.log\"})"

    - name: process-logs
      inputs:
        parameters:
          - name: file-name
        artifacts:
          - name: file
            path: /file
      container:
        image:  argoproj/argosay:v2
        command: [ sh, -c ]
        args:
          - |
            echo {{inputs.parameters.file-name}}
            head /file
```

```shell
# argo get data-transformations-2lxxp
Name:                data-transformations-2lxxp
Namespace:           argo
ServiceAccount:      unset (will run with the default ServiceAccount)
Status:              Succeeded
Conditions:          
 PodRunning          False
 Completed           True
Created:             Mon Nov 03 19:39:04 +0800 (31 minutes ago)
Started:             Mon Nov 03 19:39:04 +0800 (31 minutes ago)
Finished:            Mon Nov 03 19:39:26 +0800 (30 minutes ago)
Duration:            22 seconds
Progress:            3/3
ResourcesDuration:   0s*(1 cpu),4s*(100Mi memory)

STEP                                                                                              TEMPLATE              PODNAME                                DURATION  MESSAGE
 ✔ data-transformations-2lxxp                                                                     data-transformations                                                     
 ├───✔ list-log-files                                                                             list-log-files        data-transformations-2lxxp-1577854924  6s          
 └─┬─✔ process-logs(0:data-transformations-s787k/data-transformations-s787k-1684829053/main.log)  process-logs          data-transformations-2lxxp-1296497094  8s          
   └─✔ process-logs(1:fantastic-dragon/fantastic-dragon/main.log)                                 process-logs          data-transformations-2lxxp-3200542704  6s
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
