### PR TITLE
chore(ci): fix up generated docs in CI

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -69,6 +69,8 @@ jobs:
               - docs/fields.md
               - docs/executor_swagger.md
               - docs/cli/**
+              - docs/workflow-controller-configmap.md
+              - docs/metrics.md
               - pkg/**
               - sdks/java/**
               - sdks/python/**

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ SWAGGER_FILES := pkg/apiclient/_.primary.swagger.json \
 	pkg/apiclient/workflowtemplate/workflow-template.swagger.json \
 	pkg/apiclient/sync/sync.swagger.json
 PROTO_BINARIES := $(TOOL_PROTOC_GEN_GOGO) $(TOOL_PROTOC_GEN_GOGOFAST) $(TOOL_GOIMPORTS) $(TOOL_PROTOC_GEN_GRPC_GATEWAY) $(TOOL_PROTOC_GEN_SWAGGER) $(TOOL_CLANG_FORMAT)
-GENERATED_DOCS := docs/fields.md docs/cli/argo.md docs/workflow-controller-configmap.md
+GENERATED_DOCS := docs/fields.md docs/cli/argo.md docs/workflow-controller-configmap.md docs/metrics.md
 
 # protoc,my.proto
 define protoc


### PR DESCRIPTION
PR #15010 made me realise we don't have all the necessary entries in place to do codegen - the PR should have failed as that section of workflow-controller-configmap.md is generated.

I've fixed the ones which seemed obvious to me.
