### PR TITLE
docs: Upgrading 4.0 docs

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -42,8 +42,13 @@ Many go-lang functions have changed signature to require a [context](https://pkg
 In almost all cases you will need to provide a logger in your context.
 The details are in [logging.go](https://github.com/argoproj/argo-workflows/blob/main/util/logging/logging.go)
 
+The kubernetes client does not require a context.
+The API client from [apiclient](https://github.com/argoproj/argo-workflows/blob/main/pkg/apiclient/apiclient.go) is an exception and will create a logger for you if you don't provide one.
+
 In particular:
 
 * Your logger must conform to the logging interface `Logger` from that file.
 * Your logger should be retrievable from the context key `logger` (util/logging/logging.go `LoggerKey`)
 * You may wish to use the logger from [slog.go](https://github.com/argoproj/argo-workflows/blob/main/util/logging/slog.go)
+
+Apiclient no longer provides `NewClient` or `NewClientFromOpts`, you must use `NewClientFromOptsWithContext`.

--- a/pkg/apiclient/apiclient.go
+++ b/pkg/apiclient/apiclient.go
@@ -48,27 +48,6 @@ func (o Opts) String() string {
 	return fmt.Sprintf("(argoServerOpts=%v,instanceID=%v)", o.ArgoServerOpts, o.InstanceID)
 }
 
-// DEPRECATED: use NewClientFromOptsWithContext
-func NewClient(argoServer string, authSupplier func() string, clientConfig clientcmd.ClientConfig) (context.Context, Client, error) {
-	return NewClientFromOptsWithContext(context.Background(), Opts{
-		ArgoServerOpts: ArgoServerOpts{URL: argoServer},
-		AuthSupplier:   authSupplier,
-		ClientConfigSupplier: func() clientcmd.ClientConfig {
-			return clientConfig
-		},
-	})
-}
-
-// DEPRECATED: use NewClientFromOptsWithContext
-func NewClientFromOpts(opts Opts) (context.Context, Client, error) {
-	ctx := opts.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	return NewClientFromOptsWithContext(ctx, opts)
-}
-
 func NewClientFromOptsWithContext(ctx context.Context, opts Opts) (context.Context, Client, error) {
 	log := logging.GetLoggerFromContextOrNil(ctx)
 	if log == nil {


### PR DESCRIPTION
## Documentation

Our upgrading guide only guides you for one one version at a time.
Note this in the upgrading guide and explain how to find the other versions.

Note the deprecated features are now removed
Add a note on upgrading if you're writing in golang and importing the workflows codebase