### PR TITLE
fix: add a special case for `item` variable during global expression replacement (cherry-pick #15033 for 3.7)

### DIFF
--- a/test/e2e/expr_lang_test.go
+++ b/test/e2e/expr_lang_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ type ExprSuite struct {
 	fixtures.E2ESuite
 }
 
-func (s *ExprSuite) TestRegression12037() {
+func (s *ExprSuite) TestShadowedExprFunctionsAsTaskNames() {
 	s.Given().
 		Workflow(`apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -39,12 +40,11 @@ spec:
 
     - name: foo
       container:
-        image: alpine
+        image: argoproj/argosay:v2
         command:
-          - sh
-          - -c
-          - |
-            echo "foo"
+        - echo
+        args:
+        - foo
 `).When().
 		SubmitWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded).
@@ -64,6 +64,49 @@ spec:
 		})
 }
 
-func TestExprLangSSuite(t *testing.T) {
+func (s *ExprSuite) TestItemInSprigExpr() {
+	s.Given().
+		Workflow(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: item-used-in-sprig-
+spec:
+  entrypoint: loop-example
+  templates:
+  - name: print-message
+    container:
+      image: argoproj/argosay:v2
+      args:
+      - '{{inputs.parameters.message}}'
+      command:
+      - echo
+    inputs:
+      parameters:
+      - name: message
+  - name: loop-example
+    steps:
+    - - name: print-message-loop
+        template: print-message
+        withItems:
+        - example
+        arguments:
+          parameters:
+          - name: message
+            value: '{{=sprig.upper(item)}}'
+`).When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectWorkflow(func(t *testing.T, metadata *v1.ObjectMeta, status *v1alpha1.WorkflowStatus) {
+			assert.Equal(t, v1alpha1.WorkflowSucceeded, status.Phase)
+
+			stepNode := status.Nodes.FindByDisplayName("print-message-loop(0:example)")
+			require.NotNil(t, stepNode)
+			require.NotNil(t, stepNode.Inputs.Parameters[0].Value)
+			assert.Equal(t, "EXAMPLE", string(*stepNode.Inputs.Parameters[0].Value))
+		})
+}
+
+func TestExprLangSuite(t *testing.T) {
 	suite.Run(t, new(ExprSuite))
 }

--- a/util/template/expression_template_test.go
+++ b/util/template/expression_template_test.go
@@ -8,30 +8,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_hasRetries(t *testing.T) {
-	t.Run("hasRetiresInExpression", func(t *testing.T) {
-		assert.True(t, hasRetries("retries"))
-		assert.True(t, hasRetries("retries + 1"))
-		assert.True(t, hasRetries("sprig(retries)"))
-		assert.True(t, hasRetries("sprig(retries + 1) * 64"))
-		assert.False(t, hasRetries("foo"))
-		assert.False(t, hasRetries("retriesCustom + 1"))
-	})
+func Test_hasVariableInExpression(t *testing.T) {
+	assert.True(t, hasVariableInExpression("retries", "retries"))
+	assert.True(t, hasVariableInExpression("retries + 1", "retries"))
+	assert.True(t, hasVariableInExpression("sprig(retries)", "retries"))
+	assert.True(t, hasVariableInExpression("sprig(retries + 1) * 64", "retries"))
+	assert.False(t, hasVariableInExpression("foo", "retries"))
+	assert.False(t, hasVariableInExpression("retriesCustom + 1", "retries"))
+	assert.True(t, hasVariableInExpression("item", "item"))
+	assert.False(t, hasVariableInExpression("foo", "item"))
+	assert.True(t, hasVariableInExpression("sprig.upper(item)", "item"))
 }
 
 func Test_hasWorkflowParameters(t *testing.T) {
-	t.Run("hasVariableInExpression", func(t *testing.T) {
-		expression := `workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"`
-		exprToks, _ := lexer.Lex(file.NewSource(expression))
-		variableToks, _ := lexer.Lex(file.NewSource("workflow.status"))
-		variableToks = filterEOF(variableToks)
-		assert.True(t, searchTokens(exprToks, variableToks))
-		assert.True(t, hasVariableInExpression(expression, "workflow.status"))
+	expression := `workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"`
+	exprToks, _ := lexer.Lex(file.NewSource(expression))
+	variableToks, _ := lexer.Lex(file.NewSource("workflow.status"))
+	variableToks = filterEOF(variableToks)
+	assert.True(t, searchTokens(exprToks, variableToks))
+	assert.True(t, hasVariableInExpression(expression, "workflow.status"))
 
-		assert.False(t, hasVariableInExpression(expression, "workflow status"))
-		assert.False(t, hasVariableInExpression(expression, "workflow .status"))
+	assert.False(t, hasVariableInExpression(expression, "workflow status"))
+	assert.False(t, hasVariableInExpression(expression, "workflow .status"))
 
-		expression = `"workflow.status" == "Succeeded" ? "SUCCESSFUL" : "FAILED"`
-		assert.False(t, hasVariableInExpression(expression, "workflow .status"))
-	})
+	expression = `"workflow.status" == "Succeeded" ? "SUCCESSFUL" : "FAILED"`
+	assert.False(t, hasVariableInExpression(expression, "workflow .status"))
 }


### PR DESCRIPTION
Cherry-picked fix: add a special case for `item` variable during global expression replacement (#15033)