### PR TITLE
chore(deps): bump golang version from 1.24.4 to 1.24.10

### DIFF
--- a/.devcontainer/builder/devcontainer.json
+++ b/.devcontainer/builder/devcontainer.json
@@ -14,7 +14,7 @@
 
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.4"
+      "version": "1.24.10"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.24.4-alpine3.22 as builder
+FROM golang:1.24.10-alpine3.22 as builder
 
 # libc-dev to build openapi-gen
 RUN apk update && apk add --no-cache \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.24.4
+go 1.24.10
 
 require (
 	cloud.google.com/go/storage v1.55.0


### PR DESCRIPTION
Golang version 1.24.4 has known CVEs that have been fixed by newer versions of Golang this updates to the lastest golang 1.24 version

### Motivation

Fix vulnerabilities that show up when scanning images

### Modifications

Bumped the version of golang from 1.24.4 to 1.24.10

### Verification

Compiled with new version of golang
