### PR TITLE
fix(ui): fix BASE_HREF in production index.html. Fixes #15046

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -24,7 +24,6 @@ const config = {
     output: {
         filename: '[name].[contenthash].js',
         path: __dirname + '/dist/app',
-        publicPath: base,
     },
 
     devtool: isProd ? 'source-map' : 'eval',
@@ -118,6 +117,9 @@ const config = {
             disableDotRule: true,
             // Needed to fix 404s: https://github.com/webpack/webpack-dev-server/issues/1457#issuecomment-415527819
             index: base
+        },
+        devMiddleware: {
+            publicPath: base,
         },
         headers: {
             'X-Frame-Options': 'SAMEORIGIN'


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15046

### Motivation
https://github.com/argoproj/argo-workflows/pull/14894 introduced a bug where the `ui/dist/app/index.html` file generated during production builds has a script tag of the form `<script defer="defer" src="/main.<HASH>.js">`, whereas it was previously `<script defer="defer" src="main.<HASH>.js">`.

This is because the production build process that generates `ui/dist/app/index.html` never has `ARGO_BASE_HREF` set, so `output.publicPath` was set to `/`. The default for that setting is `auto` ([docs](https://webpack.js.org/configuration/output/#outputpublicpath)).

### Modifications

 We only need to set `publicPath` for the development build, so I moved the setting to  `devServer.devMiddleware.publicPath` ([docs](https://webpack.js.org/configuration/dev-server/#devserverdevmiddleware)).

### Verification


Tested locally using `make start UI=true BASE_HREF=/argo/` and `make start UI=true` and verifying the workflows page loads in both.
<img width="1265" height="948" alt="image" src="https://github.com/user-attachments/assets/c16d57b6-ff7f-4c98-8298-3f21f9990be2" />

### Documentation

N/A

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
