### PR TITLE
fix: rename variables #15061 and add failure error

### DIFF
--- a/util/telemetry/metrics.go
+++ b/util/telemetry/metrics.go
@@ -89,17 +89,19 @@ func NewMetrics(ctx context.Context, serviceName, prometheusName string, config 
 		}
 
 		if otlpProtocol == "" || otlpProtocol == "grpc" {
-			httpExporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithTemporalitySelector(config.Temporality))
-			if err != nil {
-				return nil, err
-			}
-			options = append(options, metricsdk.WithReader(metricsdk.NewPeriodicReader(httpExporter)))
-		} else if strings.HasPrefix(otlpProtocol, "http/") {
-			grpcExporter, err := otlpmetrichttp.New(ctx, otlpmetrichttp.WithTemporalitySelector(config.Temporality))
+			grpcExporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithTemporalitySelector(config.Temporality))
 			if err != nil {
 				return nil, err
 			}
 			options = append(options, metricsdk.WithReader(metricsdk.NewPeriodicReader(grpcExporter)))
+		} else if strings.HasPrefix(otlpProtocol, "http/") {
+			httpExporter, err := otlpmetrichttp.New(ctx, otlpmetrichttp.WithTemporalitySelector(config.Temporality))
+			if err != nil {
+				return nil, err
+			}
+			options = append(options, metricsdk.WithReader(metricsdk.NewPeriodicReader(httpExporter)))
+		} else {
+			logger.WithFatal().WithField("protocol", otlpProtocol).Error(ctx, "OTEL metric protocol invalid")
 		}
 	}
 


### PR DESCRIPTION
Fixups for #15061 which I probably reviewed too quickly.

Variable names used are the wrong way round.

Added a fatal log if you attempt to use a protocol we don't understand to try to prevent confusion where this doesn't start any exporter.
