### PR TITLE
fix: don't lint on protobuf generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,8 +459,8 @@ else
 endif
 endif
 
-# go-to-protobuf fails with mysterious errors on code that doesn't compile, hence lint-go as a dependency here
-pkg/apis/workflow/v1alpha1/generated.proto: $(TOOL_GO_TO_PROTOBUF) $(PROTO_BINARIES) $(TYPES) $(GOPATH)/src/github.com/gogo/protobuf lint-go
+# go-to-protobuf fails with mysterious errors on code that doesn't compile
+pkg/apis/workflow/v1alpha1/generated.proto: $(TOOL_GO_TO_PROTOBUF) $(PROTO_BINARIES) $(TYPES) $(GOPATH)/src/github.com/gogo/protobuf
 	# These files are generated on a v3/ folder by the tool. Link them to the root folder
 	[ -e ./v3 ] || ln -s . v3
 	# Format proto files. Formatting changes generated code, so we do it here, rather that at lint time.


### PR DESCRIPTION
Removed lint-go dependency from protobuf generation rule.

This is often helpful which was the original intention of adding it in #14619, but often breaks things if what you're doing is modifying the CRD structs in a golang incompatible way: https://github.com/argoproj/argo-workflows/pull/15060#issuecomment-3564668893