### PR TITLE
docs: update CI example link in documentation

### DIFF
--- a/docs/walk-through/continuous-integration-examples.md
+++ b/docs/walk-through/continuous-integration-examples.md
@@ -11,5 +11,5 @@ And a CI `WorkflowTemplate` example:
 
 - <https://github.com/argoproj/argo-workflows/blob/main/examples/ci-workflowtemplate.yaml>
 
-A more detailed example is <https://github.com/sendible-labs/argo-workflows-ci-example>, which allows you to
+A more detailed example is <https://github.com/pipekit/argo-workflows-ci-example>, which allows you to
 create a local CI workflow for the purposes of learning.


### PR DESCRIPTION
@tico24 moved this repo a long time ago, so the old URL links to the new URL. I'm just updating the link to the current location here.