### PR TITLE
fix: expose not equals to UI

### DIFF
--- a/.features/pending/not-equals-filter.md
+++ b/.features/pending/not-equals-filter.md
@@ -1,0 +1,8 @@
+Description: Name Not Equals filter now available in the UI for filtering workflows
+Authors: [Miltiadis Alexis](https://github.com/miltalex)
+Component: UI
+Issues: #13468
+
+You can now use the "Name Not Equals" filter in the workflow list to exclude workflows by name.
+This complements the existing "Name Exact" filter and provides more flexible filtering options.
+Use this filter when you want to view all workflows except those matching a specific name pattern.

--- a/ui/src/workflows/components/workflow-filters/workflow-filters.tsx
+++ b/ui/src/workflows/components/workflow-filters/workflow-filters.tsx
@@ -29,6 +29,10 @@ const NAME_FILTERS = [
     {
         title: 'Name Exact',
         id: 'Exact' as const
+    },
+    {
+        title: 'Name Not Equals',
+        id: 'NotEquals' as const
     }
 ];
 


### PR DESCRIPTION
Partial fix for https://github.com/argoproj/argo-workflows/issues/13468

### Motivation

The "Not Equals" filter option was implemented in the backend but not exposed to the UI, limiting user's ability to filter workflows by name exclusion.

### Modifications

- Added "Name Not Equals" filter option to the workflow filters UI component
- Updated `ui/src/workflows/components/workflow-filters/workflow-filters.tsx` to include the new filter in the NAME_FILTERS array

### Verification

Tested the filter in the UI to ensure it appears alongside the existing name filters and functions correctly.

<img width="1440" height="649" alt="image" src="https://github.com/user-attachments/assets/9e78e688-5360-4fbf-a2ab-49fe64ba2344" />
<img width="1440" height="649" alt="image" src="https://github.com/user-attachments/assets/effa9542-2f88-4c10-b842-a3fcdb51285a" />


### Documentation

You can now use the "Name Not Equals" filter in the workflow list to exclude workflows by name.                                                                                 
This complements the existing "Name Exact" filter and provides more flexible filtering options.                                                                                 Use this filter when you want to view all workflows except those matching a specific name.