### PR TITLE
fix: always `convert` singular to plural

### DIFF
--- a/workflow/convert/legacy_types.go
+++ b/workflow/convert/legacy_types.go
@@ -31,6 +31,7 @@ func (ls *LegacySynchronization) ToCurrent() *wfv1.Synchronization {
 	sync := &wfv1.Synchronization{}
 
 	// Copy semaphores to avoid aliasing, then append singular if present
+	// Unlike schedules, we honor both singular and plurals here
 	sync.Semaphores = make([]*wfv1.SemaphoreRef, len(ls.Semaphores))
 	copy(sync.Semaphores, ls.Semaphores)
 	if ls.Semaphore != nil {
@@ -114,16 +115,9 @@ type LegacyCronWorkflowSpec struct {
 
 // ToCurrent converts a LegacyCronWorkflowSpec to the current CronWorkflowSpec type
 func (lcs *LegacyCronWorkflowSpec) ToCurrent() wfv1.CronWorkflowSpec {
-	// Copy schedules to avoid aliasing, then append singular if present
-	schedules := make([]string, len(lcs.Schedules))
-	copy(schedules, lcs.Schedules)
-	if lcs.Schedule != "" {
-		schedules = append(schedules, lcs.Schedule)
-	}
-
-	return wfv1.CronWorkflowSpec{
+	spec := wfv1.CronWorkflowSpec{
 		WorkflowSpec:               lcs.WorkflowSpec.ToCurrent(),
-		Schedules:                  schedules,
+		Schedules:                  lcs.Schedules,
 		ConcurrencyPolicy:          lcs.ConcurrencyPolicy,
 		Suspend:                    lcs.Suspend,
 		StartingDeadlineSeconds:    lcs.StartingDeadlineSeconds,
@@ -134,6 +128,14 @@ func (lcs *LegacyCronWorkflowSpec) ToCurrent() wfv1.CronWorkflowSpec {
 		StopStrategy:               lcs.StopStrategy,
 		When:                       lcs.When,
 	}
+
+	// Migrate singular schedule to plural if needed
+	// Unlike synchronization we didn't honor both singular and plural, singular has priority
+	if lcs.Schedule != "" {
+		spec.Schedules = []string{lcs.Schedule}
+	}
+
+	return spec
 }
 
 // LegacyCronWorkflow wraps CronWorkflow with legacy field support

--- a/workflow/convert/legacy_types_test.go
+++ b/workflow/convert/legacy_types_test.go
@@ -112,14 +112,14 @@ func TestLegacyCronWorkflowSpec_ToCurrent(t *testing.T) {
 		assert.Equal(t, []string{"0 * * * *", "30 * * * *"}, result.Schedules)
 	})
 
-	t.Run("appends singular to plural without aliasing", func(t *testing.T) {
+	t.Run("singular only when both", func(t *testing.T) {
 		lcs := &LegacyCronWorkflowSpec{
 			Schedule:  "0 0 * * *",
 			Schedules: []string{"0 * * * *", "30 * * * *"},
 		}
 		result := lcs.ToCurrent()
 
-		assert.Equal(t, []string{"0 * * * *", "30 * * * *", "0 0 * * *"}, result.Schedules)
+		assert.Equal(t, []string{"0 0 * * *"}, result.Schedules)
 
 		// Verify no aliasing
 		assert.Len(t, lcs.Schedules, 2)


### PR DESCRIPTION
In #14996 the singular version of each of `semaphore`, `mutex` would not get moved over to the plural in the presence of both fields.

This is not really correct as if you have both sets in 3.7 you will get the behaviour of the appended list+singular. So this PR makes convert append instead of only replace.

For `schedule`, if present it would mask `schedules`. I have kept this behaviour.

Added tests for this.