### PR TITLE
docs: Add Python side by side examples to walkthrough

### DIFF
--- a/docs/walk-through/custom-template-variable-reference.md
+++ b/docs/walk-through/custom-template-variable-reference.md
@@ -4,6 +4,8 @@ In this example, we can see how we can use the other template language variable 
 Argo will validate and resolve only the variable that starts with an Argo allowed prefix
 {***"item", "steps", "inputs", "outputs", "workflow", "tasks"***}
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -37,3 +39,40 @@ spec:
         command: [echo]
         args: ["{{user.username}}"]
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Parameter, Steps, Workflow
+
+with Workflow(
+    generate_name="custom-template-variable-",
+    entrypoint="hello-hello-hello",
+) as w:
+    print_message = Container(
+        name="print-message",
+        image="busybox",
+        command=["echo"],
+        args=["{{user.username}}"],
+        inputs=[Parameter(name="message")],
+    )
+
+    with Steps(name="hello-hello-hello") as steps:
+        print_message(
+            name="hello1",
+            arguments={"message": "hello1"},
+        )
+        with steps.parallel():
+            print_message(
+                name="hello2a",
+                arguments={"message": "hello2a"},
+            )
+            print_message(
+                name="hello2b",
+                arguments={"message": "hello2b"},
+            )
+```
+
+///

--- a/docs/walk-through/daemon-containers.md
+++ b/docs/walk-through/daemon-containers.md
@@ -2,6 +2,8 @@
 
 Argo workflows can start containers that run in the background (also known as `daemon containers`) while the workflow itself continues execution. Note that the daemons will be *automatically destroyed* when the workflow exits the template scope in which the daemon was invoked. Daemon containers are useful for starting up services to be tested or to be used in testing (e.g., fixtures). We also find it very useful when running large simulations to spin up a database as a daemon for collecting and organizing the results. The big advantage of daemons compared with sidecars is that their existence can persist across multiple steps or even the entire workflow.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -75,4 +77,72 @@ spec:
           cpu: 100m
 ```
 
-Step templates use the `steps` prefix to refer to another step: for example `{{steps.influx.ip}}`. In DAG templates, the `tasks` prefix is used instead: for example `{{tasks.influx.ip}}`.
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Step, Steps, Workflow
+from hera.workflows.models import (
+    HTTPGetAction,
+    Parameter,
+    Probe,
+    ResourceRequirements,
+    RetryStrategy,
+)
+
+with Workflow(
+    generate_name="daemon-step-",
+    entrypoint="daemon-example",
+) as w:
+    influxdb = Container(
+        name="influxdb",
+        image="influxdb:1.2",
+        command=["influxd"],
+        retry_strategy=RetryStrategy(limit=10),
+        readiness_probe=Probe(http_get=HTTPGetAction(path="/ping", port=8086)),
+        daemon=True,
+    )
+    influxdb_client = Container(
+        name="influxdb-client",
+        image="appropriate/curl:latest",
+        command=["/bin/sh", "-c"],
+        args=["{{inputs.parameters.cmd}}"],
+        inputs=[Parameter(name="cmd")],
+        resources=ResourceRequirements(
+            requests={
+                "memory": "32Mi",
+                "cpu": "100m",
+            }
+        ),
+    )
+
+    with Steps(name="daemon-example") as steps:
+        influxdb(name="influx")
+        influxdb_client(
+            name="init-database",
+            arguments={"cmd": "curl -XPOST 'http://{{steps.influx.ip}}:8086/query' --data-urlencode \"q=CREATE DATABASE mydb\""},
+        )
+        with steps.parallel():
+            influxdb_client(
+                name="producer-1",
+                arguments={"cmd": "for i in $(seq 1 20); do curl -XPOST 'http://{{steps.influx.ip}}:8086/write?db=mydb' -d \"cpu,host=server01,region=uswest load=$i\" ; sleep .5 ; done"},
+            )
+            influxdb_client(
+                name="producer-2",
+                arguments={"cmd": "for i in $(seq 1 20); do curl -XPOST 'http://{{steps.influx.ip}}:8086/write?db=mydb' -d \"cpu,host=server02,region=uswest load=$((RANDOM % 100))\" ; sleep .5 ; done"},
+            )
+            influxdb_client(
+                name="producer-3",
+                arguments={"cmd": "curl -XPOST 'http://{{steps.influx.ip}}:8086/write?db=mydb' -d 'cpu,host=server03,region=useast load=15.4'"},
+            )
+        influxdb_client(
+            name="consumer",
+            arguments={"cmd":'curl --silent -G http://{{steps.influx.ip}}:8086/query?pretty=true --data-urlencode "db=mydb" --data-urlencode "q=SELECT * FROM cpu"'},
+        )
+```
+
+///
+
+Step templates use the `steps` prefix to refer to [certain attributes](../variables.md#steps-templates) of another step: for example `{{steps.influx.ip}}`.
+In DAG templates, the `tasks` prefix is used instead: for example `{{tasks.influx.ip}}`.

--- a/docs/walk-through/dag.md
+++ b/docs/walk-through/dag.md
@@ -7,6 +7,8 @@ In the following workflow, step `A` runs first, as it has no dependencies.
 Once `A` has finished, steps `B` and `C` run in parallel.
 Finally, once `B` and `C` have completed, step `D` runs.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -45,6 +47,33 @@ spec:
         arguments:
           parameters: [{name: message, value: D}]
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import DAG, Container, Parameter, Workflow # (1)!
+
+with Workflow(generate_name="dag-diamond-", entrypoint="diamond") as w:
+    echo = Container(
+        name="echo",
+        image="alpine:3.7",
+        command=["echo", "{{inputs.parameters.message}}"],
+        inputs=[Parameter(name="message")],
+    )
+    with DAG(name="diamond"):
+        A = echo(name="A", arguments={"message": "A"})
+        B = echo(name="B", arguments={"message": "B"})
+        C = echo(name="C", arguments={"message": "C"})
+        D = echo(name="D", arguments={"message": "D"})
+        A >> [B, C] >> D # (2)!
+```
+
+1. Install the `hera` package to define your Workflows in Python. Learn more at [the Hera docs](https://hera.readthedocs.io/en/stable/).
+2. Hera uses [enhanced depends logic](../enhanced-depends-logic.md) when using `>>` to define dependencies.
+
+///
 
 The dependency graph may have [multiple roots](https://github.com/argoproj/argo-workflows/tree/main/examples/dag-multiroot.yaml).
 The templates called from a DAG or steps template can themselves be DAG or steps templates, allowing complex workflows to be split into manageable pieces.

--- a/docs/walk-through/hello-world.md
+++ b/docs/walk-through/hello-world.md
@@ -10,6 +10,8 @@ hello world
 Below, run the same container on a Kubernetes cluster with a Workflow.
 The comments provide useful explanations.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow                  # new type of k8s spec
@@ -28,6 +30,30 @@ spec:
             memory: 32Mi
             cpu: 100m
 ```
+
+///
+
+/// tab | Python
+
+```py
+from hera.workflows import Container, Resources, Workflow # (1)!
+
+with Workflow(
+    generate_name="hello-world-",
+    entrypoint="hello-world",
+) as w:
+    Container(
+        name="hello-world",
+        image="busybox",
+        command=["echo"],
+        args=["hello world"],
+        resources=Resources(memory_limit="32Mi", cpu_limit="100m"),
+    )
+```
+
+1. Install the `hera` package to define your Workflows in Python. Learn more at [the Hera docs](https://hera.readthedocs.io/en/stable/).
+
+///
 
 Argo adds a new `kind` of Kubernetes resource called a `Workflow`.
 

--- a/docs/walk-through/loops.md
+++ b/docs/walk-through/loops.md
@@ -14,6 +14,8 @@ There are three basic ways of running a template multiple times.
 
 This runs a template multiple times using `withSequence`.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -37,9 +39,35 @@ spec:
       args: ["hello world!"]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Workflow
+from hera.workflows.models import Sequence
+
+with Workflow(
+    generate_name="loop-sequence-",
+    entrypoint="loop-sequence-example",
+) as w:
+    hello_world = Container(
+        name="hello-world", image="busybox", command=["echo"], args=["hello world!"]
+    )
+    with Steps(name="loop-sequence-example") as steps:
+        hello_world(
+            name="hello-world-x5",
+            with_sequence=Sequence(count=5),
+        )
+```
+
+///
+
 ## `withItems` basic example
 
 This iterates over a list of items with `withItems`, substituting a string for each instantiated template.
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -71,9 +99,40 @@ spec:
       args: ["{{inputs.parameters.message}}"]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Workflow
+from hera.workflows.models import Inputs, Parameter
+
+with Workflow(
+    generate_name="loops-",
+    entrypoint="loop-example",
+) as w:
+    print_message = Container(
+        name="print-message",
+        image="busybox",
+        command=["echo"],
+        args=["{{inputs.parameters.message}}"],
+        inputs=[Parameter(name="message")],
+    )
+    with Steps(name="loop-example") as steps:
+        print_message(
+            name="print-message-loop",
+            arguments={"message": "{{item}}"},
+            with_items=["hello world", "goodbye world"],
+        )
+```
+
+///
+
 ## `withItems` more complex example
 
 If we'd like to pass more than one piece of information in each workflow, you can instead use a JSON object for each entry in `withItems` and then address the elements by key, as shown in this example.
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -94,10 +153,10 @@ spec:
           - name: tag
             value: "{{item.tag}}"
         withItems:
-        - { image: 'debian', tag: '9.1' }       #item set 1
-        - { image: 'debian', tag: '8.9' }       #item set 2
-        - { image: 'alpine', tag: '3.6' }       #item set 3
-        - { image: 'ubuntu', tag: '17.10' }     #item set 4
+        - { image: 'debian', tag: '9.1' }       # item set 1
+        - { image: 'debian', tag: '8.9' }       # item set 2
+        - { image: 'alpine', tag: '3.6' }       # item set 3
+        - { image: 'ubuntu', tag: '17.10' }     # item set 4
 
   - name: cat-os-release
     inputs:
@@ -110,9 +169,48 @@ spec:
       args: [/etc/os-release]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Parameter, Steps, Workflow
+
+with Workflow(
+    generate_name="loops-maps-",
+    entrypoint="loop-map-example",
+) as w:
+    cat_os_release = Container(
+        name="cat-os-release",
+        inputs=[Parameter(name="image"), Parameter(name="tag")],
+        image="{{inputs.parameters.image}}:{{inputs.parameters.tag}}",
+        command=["cat"],
+        args=["/etc/os-release"],
+    )
+
+    with Steps(name="loop-map-example") as loop_map_example:
+        cat_os_release(
+            name="test-linux",
+            arguments=[
+                Parameter(name="image", value="{{item.image}}"),
+                Parameter(name="tag", value="{{item.tag}}"),
+            ],
+            with_items=[
+                {"image": "debian", "tag": "9.1"},
+                {"image": "debian", "tag": "8.9"},
+                {"image": "alpine", "tag": "3.6"},
+                {"image": "ubuntu", "tag": "17.10"},
+            ],
+        )
+```
+
+///
+
 ## `withParam` example
 
 This example does exactly the same job as the previous example, but using `withParam` to pass the information as a JSON array argument, instead of hard-coding it into the template.
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -162,9 +260,64 @@ spec:
       args: [/etc/os-release]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Workflow
+from hera.workflows.models import Parameter
+
+with Workflow(
+    generate_name="loops-param-arg-",
+    entrypoint="loop-param-arg-example",
+    arguments={
+        "os-list": """[
+  { "image": "debian", "tag": "9.1" },
+  { "image": "debian", "tag": "8.9" },
+  { "image": "alpine", "tag": "3.6" },
+  { "image": "ubuntu", "tag": "17.10" }
+]
+""",
+    },
+) as w:
+    cat_os_release = Container(
+        name="cat-os-release",
+        annotations={"workflows.argoproj.io/display-name": "os-{{inputs.parameters.image}}-{{inputs.parameters.tag}}"},
+        inputs=[
+            Parameter(
+                name="image",
+            ),
+            Parameter(
+                name="tag",
+            ),
+        ],
+        command=["cat"],
+        args=["/etc/os-release"],
+        image="{{inputs.parameters.image}}:{{inputs.parameters.tag}}",
+    )
+
+    with Steps(
+        name="loop-param-arg-example",
+        inputs=[Parameter(name="os-list")],
+    ) as invocator:
+        cat_os_release(
+            name="test-linux",
+            with_param="{{inputs.parameters.os-list}}",
+            arguments={
+                "image": "{{item.image}}",
+                "tag": "{{item.tag}}",
+            },
+        )
+```
+
+///
+
 ## `withParam` example from another step in the workflow
 
 Finally, the most powerful form of this is to generate that JSON array of objects dynamically in one step, and then pass it to the next step so that the number and values used in the second step are only calculated at runtime.
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -207,12 +360,53 @@ spec:
       args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Workflow, script
+from hera.workflows.models import Parameter
+
+
+@script()
+def gen_number_list():
+    import json
+    import sys
+    json.dump([i for i in range(20, 31)], sys.stdout)
+
+with Workflow(
+    generate_name="loops-param-result-",
+    entrypoint="loop-param-result-example",
+) as w:
+    sleep_n_sec = Container(
+        name="sleep-n-sec",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"
+        ],
+        inputs=[Parameter(name="seconds")],
+    )
+    with Steps(name="loop-param-result-example") as steps:
+        gen_number_list(name="generate")
+        sleep_n_sec(
+            name="sleep",
+            arguments={"seconds": "{{item}}"},
+            with_param="{{steps.generate.outputs.result}}",
+        )
+```
+
+///
+
 ## Accessing the aggregate results of a loop
 
 The output of all iterations can be accessed as a JSON array, once the loop is done.
 The example below shows how you can read it.
 
 Please note: the output of each iteration _must_ be a **valid JSON**.
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -266,7 +460,52 @@ spec:
         echo 'inputs.parameters.aggregate-results: "{{inputs.parameters.aggregate-results}}"'
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Script, Step, Steps, WorkflowTemplate
+from hera.workflows.models import Inputs, Parameter
+
+with WorkflowTemplate(
+    name="loop-test",
+    entrypoint="main",
+) as w:
+    print_json_entry = Script(
+        name="print-json-entry",
+        image="alpine:latest",
+        command=["sh"],
+        source='cat <<EOF\n{\n"input": "{{inputs.parameters.index}}",\n"transformed-input": "{{inputs.parameters.index}}.jpeg"\n}\nEOF\n',
+        inputs=Inputs(parameters=[Parameter(name="index")]),
+    )
+    access_aggregate_output = Script(
+        name="access-aggregate-output",
+        image="alpine:latest",
+        command=["sh"],
+        source="echo 'inputs.parameters.aggregate-results: \"{{inputs.parameters.aggregate-results}}\"'\n",
+        inputs=[Parameter(name="aggregate-results", value="no-value")],
+    )
+
+    with Steps(name="main") as steps:
+        execute = Step(
+            name="execute-parallel-steps",
+            with_param="[1, 2, 3]",
+            arguments={"index": "{{item}}"},
+            template="print-json-entry"
+        )
+        access_aggregate_output(
+            name="call-access-aggregate-output",
+            arguments={"aggregate-results": execute.result},
+        )
+```
+
+///
+
 ![image](../assets/aggregate-result-of-all-iterations-of-a-loop.png)
 
 The last step of the workflow above should have this output:
-`inputs.parameters.aggregate-results: "[{"input":"1","transformed-input":"1.jpeg"},{"input":"2","transformed-input":"2.jpeg"},{"input":"3","transformed-input":"3.jpeg"}]"`
+
+```console
+inputs.parameters.aggregate-results: "[{"input":"1","transformed-input":"1.jpeg"},{"input":"2","transformed-input":"2.jpeg"},{"input":"3","transformed-input":"3.jpeg"}]"
+```

--- a/docs/walk-through/parameters.md
+++ b/docs/walk-through/parameters.md
@@ -2,14 +2,15 @@
 
 Let's look at a slightly more complex workflow spec with parameters.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: hello-world-parameters-
 spec:
-  # invoke the print-message template with "hello world" as the argument to the message parameter
-  entrypoint: print-message
+  entrypoint: print-message # (1)!
   arguments:
     parameters:
     - name: message
@@ -19,13 +20,41 @@ spec:
   - name: print-message
     inputs:
       parameters:
-      - name: message       # parameter declaration
-    container:
-      # run echo with that message input parameter as args
+      - name: message # (2)!
+    container: # (3)!
       image: busybox
       command: [echo]
       args: ["{{inputs.parameters.message}}"]
 ```
+
+1. Invoke the print-message template with "hello world" as the argument to the message parameter.
+2. This declares `message` as an input parameter.
+3. This container runs `echo` with the `message` input parameter as `args`.
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Parameter, Workflow # (1)!
+
+with Workflow(
+    generate_name="hello-world-parameters-",
+    entrypoint="print-message",
+    arguments=Parameter(name="message", value="hello world"),
+) as w:
+    Container(
+        name="print-message",
+        image="busybox",
+        command=["echo"],
+        args=["{{inputs.parameters.message}}"],
+        inputs=Parameter(name="message"),
+    )
+```
+
+1. Install the `hera` package to define your Workflows in Python. Learn more at [the Hera docs](https://hera.readthedocs.io/en/stable/).
+
+///
 
 This time, the `print-message` template takes an input parameter named `message` that is passed as the `args` to the `echo` command. In order to reference parameters (e.g., ``"{{inputs.parameters.message}}"``), the parameters must be enclosed in double quotes to escape the curly braces in YAML.
 
@@ -57,6 +86,8 @@ By using a combination of the `--entrypoint` and `-p` parameters, you can call a
 
 The values set in the `spec.arguments.parameters` are globally scoped and can be accessed via `{{workflow.parameters.parameter_name}}`. This can be useful to pass information to multiple steps in a workflow. For example, if you wanted to run your workflows with different logging levels that are set in the environment of each container, you could have a YAML file similar to this one:
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -85,5 +116,34 @@ spec:
         value: "{{workflow.parameters.log-level}}"
       command: [runB]
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows.models import Arguments, EnvVar, Parameter
+from hera.workflows import Container, Workflow
+
+with Workflow(
+    generate_name="global-parameters-",
+    entrypoint="A",
+    arguments=[Parameter(name="log-level", value="INFO")],
+) as w:
+    Container(
+        name="A",
+        image="containerA",
+        command=["runA"],
+        env=[EnvVar(name="LOG_LEVEL", value="{{workflow.parameters.log-level}}")],
+    )
+    Container(
+        name="B",
+        image="containerB",
+        command=["runB"],
+        env=[EnvVar(name="LOG_LEVEL", value="{{workflow.parameters.log-level}}")],
+    )
+```
+
+///
 
 In this workflow, both steps `A` and `B` would have the same log-level set to `INFO` and can easily be changed between workflow submissions using the `-p` flag.

--- a/docs/walk-through/retrying-failed-or-errored-steps.md
+++ b/docs/walk-through/retrying-failed-or-errored-steps.md
@@ -2,6 +2,8 @@
 
 You can specify a `retryStrategy` that will dictate how failed or errored steps are retried:
 
+/// tab | YAML
+
 ```yaml
 # This example demonstrates the use of retry back offs
 apiVersion: argoproj.io/v1alpha1
@@ -27,6 +29,43 @@ spec:
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Workflow
+from hera.workflows.models import (
+    Backoff,
+    RetryAffinity,
+    RetryNodeAntiAffinity,
+    RetryStrategy,
+)
+
+with Workflow(
+    generate_name="retry-backoff-",
+    entrypoint="retry-backoff",
+) as w:
+    Container(
+        name="retry-backoff",
+        retry_strategy=RetryStrategy(
+            affinity=RetryAffinity(node_anti_affinity=RetryNodeAntiAffinity()),
+            backoff=Backoff(
+                duration="1", factor=2, max_duration="1m"
+            ),
+            limit=10,
+            retry_policy="Always",
+        ),
+        image="python:alpine3.6",
+        command=["python", "-c"],
+        args=[
+            "import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"
+        ],
+    )
+```
+
+///
 
 * `limit` is the maximum number of times the container will be retried.
 * `retryPolicy` specifies if a container will be retried on failure, error, both, or only transient errors (e.g. i/o or TLS handshake timeout). "Always" retries on both errors and failures. Also available: `OnFailure` (default), "`OnError`", and "`OnTransientError`" (available after v3.0.0-rc2).

--- a/docs/walk-through/scripts-and-results.md
+++ b/docs/walk-through/scripts-and-results.md
@@ -1,6 +1,12 @@
 # Scripts And Results
 
-Often, we just want a template that executes a script specified as a here-script (also known as a `here document`) in the workflow spec. This example shows how to do that:
+## Running Scripts Using `source`
+
+Often, we just want a template that executes a script specified as a [here-script](https://en.wikipedia.org/wiki/Here_document) (also known as a `here document`) in the workflow spec.
+You can pass source code to the `source` parameter of a `script` template to run it through the given `image` and `command`.
+This example shows how to do that:
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -55,9 +61,160 @@ spec:
       args: ["echo result was: {{inputs.parameters.message}}"]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Parameter, Script, Steps, Workflow
+
+with Workflow(
+    generate_name="scripts-bash-",
+    entrypoint="bash-script-example",
+) as w:
+    bash_script = Script(
+        name="gen-random-int-bash",
+        image="debian:9.4",
+        command=["bash"],
+        source="cat /dev/urandom | od -N2 -An -i | awk -v f=1 -v r=100 '{printf \"%i\\n\", f + r * $1 / 65536}'\n",
+    )
+    python_script = Script(
+        name="gen-random-int-python",
+        image="python:alpine3.6",
+        command=["python"],
+        source="import random\ni = random.randint(1, 100)\nprint(i)\n",
+    )
+    javascript_script = Script(
+        name="gen-random-int-javascript",
+        image="node:9.1-alpine",
+        command=["node"],
+        source="var rand = Math.floor(Math.random() * 100);\nconsole.log(rand);\n",
+    )
+
+    print_message = Container(
+        name="print-message",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=["echo result was: {{inputs.parameters.message}}"],
+        inputs=[Parameter(name="message")],
+    )
+
+    with Steps(name="bash-script-example") as steps:
+        bash_script(name="generate")
+        print_message(
+            name="print",
+            arguments={"message": "{{steps.generate.outputs.result}}"},
+        )
+```
+
+///
+
 The `script` keyword allows the specification of the script body using the `source` tag.
 This creates a temporary file containing the script body and then passes the name of the temporary file as the final parameter to `command`, which should be an interpreter that executes the script body.
 
 In the same way as `container` templates do, the use of the `script` feature also assigns the standard output of running the script to a special output parameter named `result`.
 This allows you to use the result of running the script itself in the rest of the workflow spec.
 In this example, the result is simply echoed by the print-message template.
+
+## Python Scripts Using Hera
+
+If you are mainly using Python Scripts, the Python SDK (Hera) offers a `script` decorator to turn any regular Python function into a Script Template.
+Hera will convert input parameters of the function into input parameters for the Script Template, add boilerplate for `json` loading the values, and will then run the rest of your script verbatim.
+As mentioned above, the contents of the `source` tag are copied into a temporary file, so your whole script, including imports and variables, must be defined within that function:
+
+/// tab | Python
+
+```py
+from hera.workflows import Steps, Workflow, script
+
+
+@script()
+def roll_die(message: str):
+    import random
+
+    print(message)
+    print("I'm rolling a die:", random.randint(1, 6))
+
+@script()
+def echo_result(message: str):
+    print(message)
+
+with Workflow(
+    generate_name="python-script-",
+    entrypoint="steps",
+) as w:
+    with Steps(name="steps"):
+        roll_step = roll_die(arguments={"message": "Hello world!"})
+        echo_result(arguments={"message": roll_step.result})
+
+```
+
+///
+
+/// tab | YAML
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: python-script-
+spec:
+  entrypoint: steps
+  templates:
+  - name: steps
+    steps:
+    - - name: roll-die
+        template: roll-die
+        arguments:
+          parameters:
+          - name: message
+            value: Hello world!
+    - - name: echo-result
+        template: echo-result
+        arguments:
+          parameters:
+          - name: message
+            value: '{{steps.roll-die.outputs.result}}'
+  - name: roll-die
+    inputs:
+      parameters:
+      - name: message
+    script:
+      image: python:3.10
+      command:
+      - python
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        import json
+        try: message = json.loads(r'''{{inputs.parameters.message}}''')
+        except: message = r'''{{inputs.parameters.message}}'''
+
+        import random
+        print(message)
+        print("I'm rolling a die:", random.randint(1, 6))
+  - name: echo-result
+    inputs:
+      parameters:
+      - name: message
+    script:
+      image: python:3.10
+      command:
+      - python
+      source: |-
+        import os
+        import sys
+        sys.path.append(os.getcwd())
+        import json
+        try: message = json.loads(r'''{{inputs.parameters.message}}''')
+        except: message = r'''{{inputs.parameters.message}}'''
+
+        print(message)
+```
+
+///
+
+Hera offers native Python integrations for Script Templates to avoid the pitfalls of the `source` tag and to improve input and output handling.
+You will also be able to test functions as normal Python functions.
+Read more in [the Hera Scripts guide](https://hera.readthedocs.io/en/stable/user-guides/script-basics/).

--- a/docs/walk-through/sidecars.md
+++ b/docs/walk-through/sidecars.md
@@ -2,6 +2,8 @@
 
 A sidecar is another container that executes concurrently in the same pod as the main container and is useful in creating multi-container pods.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -22,5 +24,33 @@ spec:
       image: nginx:1.13
       command: [nginx, -g, daemon off;]
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, UserContainer, Workflow
+
+with Workflow(
+    generate_name="sidecar-nginx-",
+    entrypoint="sidecar-nginx-example",
+) as w:
+    Container(
+        name="sidecar-nginx-example",
+        image="appropriate/curl",
+        command=["sh", "-c"],
+        args=["until `curl -G 'http://127.0.0.1/' >& /tmp/out`; do echo sleep && sleep 1; done && cat /tmp/out"],
+        sidecars=[
+            UserContainer(
+                name="nginx",
+                image="nginx:1.13",
+                command=["nginx", "-g", "daemon off;"],
+            )
+        ],
+    )
+```
+
+///
 
 In the above example, we create a sidecar container that runs Nginx as a simple web server. The order in which containers come up is random, so in this example the main container polls the Nginx container until it is ready to service requests. This is a good design pattern when designing multi-container systems: always wait for any services you need to come up before running your main code.

--- a/docs/walk-through/steps.md
+++ b/docs/walk-through/steps.md
@@ -3,6 +3,8 @@
 You can create multi-step workflows and nested workflows, as well as define more than one template in a workflow.
 See the comments in the example below:
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -46,6 +48,49 @@ spec:
       command: [echo]
       args: ["{{inputs.parameters.message}}"]
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Parameter, Step, Steps, Workflow # (1)!
+
+with Workflow(
+    generate_name="steps-",
+    entrypoint="hello-hello-hello",
+) as w:
+    print_message = Container(
+        name="print-message",
+        inputs=[Parameter(name="message")],
+        image="busybox",
+        command=["echo"],
+        args=["{{inputs.parameters.message}}"],
+    )
+
+    with Steps(name="hello-hello-hello") as s:
+        Step(
+            name="hello1",
+            template=print_message,
+            arguments=[Parameter(name="message", value="hello1")],
+        )
+
+        with s.parallel():
+            Step(
+                name="hello2a",
+                template=print_message,
+                arguments=[Parameter(name="message", value="hello2a")],
+            )
+            Step(
+                name="hello2b",
+                template=print_message,
+                arguments=[Parameter(name="message", value="hello2b")],
+            )
+```
+
+1. Install the `hera` package to define your Workflows in Python. Learn more at [the Hera docs](https://hera.readthedocs.io/en/stable/).
+
+///
 
 The above workflow prints three variants of "hello".
 The `hello-hello-hello` template has three `steps`.

--- a/docs/walk-through/suspending.md
+++ b/docs/walk-through/suspending.md
@@ -8,6 +8,8 @@ argo suspend WORKFLOW
 
 Or by specifying a `suspend` step on the workflow:
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -41,6 +43,33 @@ spec:
       args: ["hello world"]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Suspend, Workflow
+
+with Workflow(
+    generate_name="suspend-template-",
+    entrypoint="suspend",
+) as w:
+    approve = Suspend(name="approve")
+    delay = Suspend(name="delay", duration="20")
+    hello_world = Container(
+        name="hello-world",
+        image="busybox",
+        command=["echo"],
+        args=["hello world"],
+    )
+    with Steps(name="suspend") as steps:
+        hello_world(name="build")
+        approve()
+        delay()
+        hello_world(name="release")
+```
+
+///
 Once suspended, a Workflow will not schedule any new steps until it is resumed. It can be resumed manually by
 
 ```bash

--- a/docs/walk-through/timeouts.md
+++ b/docs/walk-through/timeouts.md
@@ -2,6 +2,8 @@
 
 You can use the field `activeDeadlineSeconds` to limit the elapsed time for a workflow:
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -18,7 +20,31 @@ spec:
       args: ["echo sleeping for 1m; sleep 60; echo done"]
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Workflow
+
+with Workflow(
+    generate_name="timeouts-",
+    active_deadline_seconds=10,
+    entrypoint="sleep",
+) as w:
+    Container(
+        name="sleep",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=["echo sleeping for 1m; sleep 60; echo done"],
+    )
+```
+
+///
+
 You can limit the elapsed time for a specific template as well:
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -35,3 +61,24 @@ spec:
       command: [sh, -c]
       args: ["echo sleeping for 1m; sleep 60; echo done"]
 ```
+
+///
+/// tab | Python
+
+```python
+from hera.workflows import Container, Workflow
+
+with Workflow(
+    generate_name="timeouts-",
+    entrypoint="sleep",
+) as w:
+    Container(
+        name="sleep",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=["echo sleeping for 1m; sleep 60; echo done"],
+        active_deadline_seconds=10,
+    )
+```
+
+///

--- a/docs/walk-through/volumes.md
+++ b/docs/walk-through/volumes.md
@@ -2,6 +2,8 @@
 
 The following example dynamically creates a volume and then uses the volume in a two step workflow.
 
+/// tab | YAML
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
@@ -48,6 +50,60 @@ spec:
 
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Workflow
+from hera.workflows.models import (
+    ObjectMeta,
+    PersistentVolumeClaim,
+    PersistentVolumeClaimSpec,
+    VolumeMount,
+    VolumeResourceRequirements,
+)
+
+with Workflow(
+    generate_name="volumes-pvc-",
+    entrypoint="volumes-pvc-example",
+    volume_claim_templates=[
+        PersistentVolumeClaim(
+            metadata=ObjectMeta(name="workdir"),
+            spec=PersistentVolumeClaimSpec(
+                access_modes=["ReadWriteOnce"],
+                resources=VolumeResourceRequirements(
+                    requests={"storage": "1Gi"}
+                ),
+            ),
+        )
+    ],
+) as w:
+    hello_to_file = Container(
+        name="hello-world-to-file",
+        image="busybox",
+        command=["sh", "-c"],
+        args=[
+            "echo generating message in volume; echo hello world | tee /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[VolumeMount(mount_path="/mnt/vol", name="workdir")],
+    )
+    print_from_file = Container(
+        name="print-message-from-file",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[VolumeMount(mount_path="/mnt/vol", name="workdir")],
+    )
+    with Steps(name="volumes-pvc-example") as steps:
+        hello_to_file(name="generate")
+        print_from_file(name="print")
+```
+
+///
+
 Volumes are a very useful way to move large amounts of data from one step in a workflow to another. Depending on the system, some volumes may be accessible concurrently from multiple steps.
 
 In some cases, you want to access an already existing volume rather than creating/destroying one dynamically.
@@ -63,8 +119,11 @@ spec:
   resources:
     requests:
       storage: 1Gi
+```
 
----
+/// tab | YAML
+
+```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
@@ -105,8 +164,56 @@ spec:
         mountPath: /mnt/vol
 ```
 
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Steps, Workflow
+from hera.workflows.models import PersistentVolumeClaimVolumeSource, Volume, VolumeMount
+
+with Workflow(
+    generate_name="volumes-existing-",
+    entrypoint="volumes-existing-example",
+    volumes=[
+        Volume(
+            name="workdir",
+            persistent_volume_claim=PersistentVolumeClaimVolumeSource(
+                claim_name="my-existing-volume"
+            ),
+        )
+    ],
+) as w:
+    hello_to_file = Container(
+        name="hello-world-to-file",
+        image="busybox",
+        command=["sh", "-c"],
+        args=[
+            "echo generating message in volume; echo hello world | tee /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[VolumeMount(mount_path="/mnt/vol", name="workdir")],
+    )
+    print_from_file = Container(
+        name="print-message-from-file",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=[
+            "echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"
+        ],
+        volume_mounts=[VolumeMount(mount_path="/mnt/vol", name="workdir")],
+    )
+    with Steps(name="volumes-existing-example") as steps:
+        hello_to_file(name="generate")
+        print_from_file(name="print")
+
+```
+
+///
+
 It's also possible to declare existing volumes at the template level, instead of the workflow level.
 Workflows can generate volumes using a [`resource`](kubernetes-resources.md) step.
+
+/// tab | YAML
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -194,3 +301,77 @@ spec:
         mountPath: /mnt/vol
 
 ```
+
+///
+
+/// tab | Python
+
+```python
+from hera.workflows import Container, Resource, Steps, Workflow
+from hera.workflows.models import (
+    Arguments,
+    Inputs,
+    Outputs,
+    Parameter,
+    PersistentVolumeClaimVolumeSource,
+    ValueFrom,
+    Volume,
+    VolumeMount,
+)
+
+with Workflow(
+    generate_name="template-level-volume-",
+    entrypoint="generate-and-use-volume",
+) as w:
+    generate_volume = Resource(
+        name="generate-volume",
+        inputs=[Parameter(name="pvc-size")],
+        outputs=[Parameter(name="pvc-name", value_from=ValueFrom(json_path="{.metadata.name}"))],
+        action="create",
+        manifest="apiVersion: v1\nkind: PersistentVolumeClaim\nmetadata:\n  generateName: pvc-example-\nspec:\n  accessModes: ['ReadWriteOnce', 'ReadOnlyMany']\n  resources:\n    requests:\n      storage: '{{inputs.parameters.pvc-size}}'\n",
+        set_owner_reference=True,
+    )
+    hello_to_file = Container(
+        name="hello-world-to-file",
+        image="busybox",
+        command=["sh", "-c"],
+        args=["echo generating message in volume; echo hello world | tee /mnt/vol/hello_world.txt"],
+        inputs=[Parameter(name="pvc-name")],
+        volumes=[
+            Volume(
+                name="workdir",
+                persistent_volume_claim=PersistentVolumeClaimVolumeSource(claim_name="{{inputs.parameters.pvc-name}}"),
+            )
+        ],
+        volume_mounts=[VolumeMount(mount_path="/mnt/vol", name="workdir")],
+    )
+    print_from_file = Container(
+        name="print-message-from-file",
+        image="alpine:latest",
+        command=["sh", "-c"],
+        args=["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"],
+        inputs=[Parameter(name="pvc-name")],
+        volumes=[
+            Volume(
+                name="workdir",
+                persistent_volume_claim=PersistentVolumeClaimVolumeSource(claim_name="{{inputs.parameters.pvc-name}}"),
+            )
+        ],
+        volume_mounts=[VolumeMount(mount_path="/mnt/vol", name="workdir")],
+    )
+    with Steps(name="generate-and-use-volume") as steps:
+        generate_volume_step = generate_volume(
+            name="generate-volume",
+            arguments={"pvc-size": "1Gi"},
+        )
+        hello_to_file(
+            name="generate",
+            arguments=generate_volume_step.get_parameter("pvc-name"),
+        )
+        print_from_file(
+            name="print",
+            arguments=generate_volume_step.get_parameter("pvc-name"),
+        )
+```
+
+///

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,23 +24,29 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
 extra:
   analytics:
     provider: google
     property: G-5Z1VTPDL73
 markdown_extensions:
-  - codehilite
   - admonition
   - md_in_html
+  - pymdownx.highlight
   - pymdownx.details
   - pymdownx.snippets
   - pymdownx.tilde
+  - pymdownx.superfences
   - pymdownx.superfences:
       custom_fences:
         # support mermaid diagrams per https://squidfunk.github.io/mkdocs-material/reference/diagrams/#configuration
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.blocks.tab:
+      alternate_style: true
   - toc:
       permalink: true
 plugins:


### PR DESCRIPTION
### Motivation

Argo Workflows focuses on using YAML to write Workflows. It is not immediately obvious from the Walkthrough that Python is usable through Hera. Using the tabbed approach for the code examples means users can view the entire walkthrough in their preferred language, which should be even more useful if/when Argo Workflows supports SDKs in other languages (notably Go could be used). The tab is "linked" throughout the docs, so once a reader clicks "Python", all tabbed examples will switch to Python.

### Modifications

* Updated the `mkdocs.yml` configuration to allow features like the tabbed examples
* Added Python examples to the walkthrough, in particular improving the `Scripts and Results` page wording and introducing Hera for Python.
* I mostly converted the YAML from the walkthrough using the Hera CLI to convert it to Python code, then tidied up the boilerplate to be a bit more idiomatic (though most of the examples use `container` which isn't the main strength of Hera).
* The first few examples also use the "annotate" feature of the material mkdocs theme, to tell the user to install the `hera` package and link to the Hera walkthrough for a Python-centric walkthrough.

The finished result looks like:
YAML:
<img width="1086" height="736" alt="image" src="https://github.com/user-attachments/assets/f98c9af2-2ac2-4be1-8021-5f02a1f063b2" />

Python:
<img width="1082" height="676" alt="image" src="https://github.com/user-attachments/assets/e644cd12-1bef-483a-a74e-8730f21a0893" />

Annotation:
<img width="1039" height="206" alt="image" src="https://github.com/user-attachments/assets/3a8e5edc-4996-4cb0-a350-18a91df829bd" />

