### PR TITLE
feat: add !=, == support for namespace field selector

### DIFF
--- a/.features/pending/namespace-field-selectors-operators.md
+++ b/.features/pending/namespace-field-selectors-operators.md
@@ -1,0 +1,8 @@
+Description: Add `!=` and `==` operators for namespace field selector
+Authors: [Miltiadis Alexis](https://github.com/miltalex)
+Component: General
+Issues: 13468
+
+You can now use the `!=` and `==` operators when filtering workflows by namespace field.
+This provides more flexible query capabilities, allowing you to easily exclude specific namespaces or match exact namespace values in your workflow queries.
+For example, you can filter with `namespace!=kube-system` to exclude system namespaces or `namespace==production` to target only production environments.

--- a/persist/sqldb/selector.go
+++ b/persist/sqldb/selector.go
@@ -10,8 +10,13 @@ import (
 )
 
 func BuildArchivedWorkflowSelector(selector db.Selector, tableName, labelTableName string, t sqldb.DBType, options utils.ListOptions, count bool) (db.Selector, error) {
+	if options.NamespaceFilter == "NotEquals" {
+		selector = selector.And(namespaceNotEqual(options.Namespace))
+	} else {
+		selector = selector.And(namespaceEqual(options.Namespace))
+	}
+
 	selector = selector.
-		And(namespaceEqual(options.Namespace)).
 		And(namePrefixClause(options.NamePrefix)).
 		And(startedAtFromClause(options.MinStartedAt)).
 		And(startedAtToClause(options.MaxStartedAt)).
@@ -59,7 +64,11 @@ func BuildArchivedWorkflowSelector(selector db.Selector, tableName, labelTableNa
 func BuildWorkflowSelector(in string, inArgs []any, tableName, labelTableName string, t sqldb.DBType, options utils.ListOptions, count bool) (out string, outArgs []any, err error) {
 	var clauses []*db.RawExpr
 	if options.Namespace != "" {
-		clauses = append(clauses, db.Raw("namespace = ?", options.Namespace))
+		if options.NamespaceFilter == "NotEquals" {
+			clauses = append(clauses, db.Raw("namespace != ?", options.Namespace))
+		} else {
+			clauses = append(clauses, db.Raw("namespace = ?", options.Namespace))
+		}
 	}
 	if options.Name != "" {
 		nameFilter := options.NameFilter

--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -293,8 +293,15 @@ func (r *workflowArchive) CountWorkflows(ctx context.Context, options sutils.Lis
 		selector := r.session.SQL().
 			Select(db.Raw("count(*) as total")).
 			From(archiveTableName).
-			Where(r.clusterManagedNamespaceAndInstanceID()).
-			And(namespaceEqual(options.Namespace)).
+			Where(r.clusterManagedNamespaceAndInstanceID())
+
+		if options.NamespaceFilter == "NotEquals" {
+			selector = selector.And(namespaceNotEqual(options.Namespace))
+		} else {
+			selector = selector.And(namespaceEqual(options.Namespace))
+		}
+
+		selector = selector.
 			And(namePrefixClause(options.NamePrefix)).
 			And(startedAtFromClause(options.MinStartedAt)).
 			And(startedAtToClause(options.MaxStartedAt)).
@@ -348,8 +355,15 @@ func (r *workflowArchive) countWorkflowsOptimized(options sutils.ListOptions) (i
 	sampleSelector := r.session.SQL().
 		Select(db.Raw("count(*) as total")).
 		From(archiveTableName).
-		Where(r.clusterManagedNamespaceAndInstanceID()).
-		And(namespaceEqual(options.Namespace)).
+		Where(r.clusterManagedNamespaceAndInstanceID())
+
+	if options.NamespaceFilter == "NotEquals" {
+		sampleSelector = sampleSelector.And(namespaceNotEqual(options.Namespace))
+	} else {
+		sampleSelector = sampleSelector.And(namespaceEqual(options.Namespace))
+	}
+
+	sampleSelector = sampleSelector.
 		And(namePrefixClause(options.NamePrefix)).
 		And(startedAtFromClause(options.MinStartedAt)).
 		And(startedAtToClause(options.MaxStartedAt)).
@@ -405,8 +419,15 @@ func (r *workflowArchive) HasMoreWorkflows(ctx context.Context, options sutils.L
 	selector := r.session.SQL().
 		Select("uid").
 		From(archiveTableName).
-		Where(r.clusterManagedNamespaceAndInstanceID()).
-		And(namespaceEqual(options.Namespace)).
+		Where(r.clusterManagedNamespaceAndInstanceID())
+
+	if options.NamespaceFilter == "NotEquals" {
+		selector = selector.And(namespaceNotEqual(options.Namespace))
+	} else {
+		selector = selector.And(namespaceEqual(options.Namespace))
+	}
+
+	selector = selector.
 		And(namePrefixClause(options.NamePrefix)).
 		And(startedAtFromClause(options.MinStartedAt)).
 		And(startedAtToClause(options.MaxStartedAt)).
@@ -490,6 +511,13 @@ func startedAtToClause(to time.Time) db.Cond {
 func namespaceEqual(namespace string) db.Cond {
 	if namespace != "" {
 		return db.Cond{"namespace": namespace}
+	}
+	return db.Cond{}
+}
+
+func namespaceNotEqual(namespace string) db.Cond {
+	if namespace != "" {
+		return db.Cond{"namespace !=": namespace}
 	}
 	return db.Cond{}
 }

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -194,12 +194,17 @@ func (s *workflowServer) ListWorkflows(ctx context.Context, req *workflowpkg.Wor
 	}
 
 	// verify if we have permission to list Workflows
-	allowed, err := auth.CanI(ctx, "list", workflow.WorkflowPlural, options.Namespace, "")
+	targetNamespace := options.Namespace
+	if options.NamespaceFilter == "NotEquals" {
+		targetNamespace = ""
+	}
+	allowed, err := auth.CanI(ctx, "list", workflow.WorkflowPlural, targetNamespace, "")
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
+
 	if !allowed {
-		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf("Permission denied, you are not allowed to list workflows in namespace \"%s\". Maybe you want to specify a namespace with query parameter `.namespace=%s`?", options.Namespace, options.Namespace))
+		return nil, status.Error(codes.PermissionDenied, fmt.Sprintf("Permission denied, you are not allowed to list workflows in namespace \"%s\". Maybe you want to specify a namespace with query parameter `.namespace=%s`?", targetNamespace, targetNamespace))
 	}
 
 	var wfs wfv1.Workflows


### PR DESCRIPTION
Fixes #13468

### Motivation

Currently, argo-workflows only supports the '=' operator for the field selector `metadata.namespace` when listing workflows. This limitation restricts the flexibility of our queries, particularly when users wish to exclude specific namespaces from their results. The goal of this PR is to expand support to include the '==' and '!=' operators for `metadata.namespace`, aligning our capabilities with native Kubernetes functionality. This enhancement allows users to perform exclusion queries (e.g., "list all workflows except those in the 'test' namespace"), improving overall system usability.

### Modifications

*   **ListOptions Expansion:**
    *   Extended the `ListOptions` struct in `server/utils` to include a new `NamespaceFilter` field to store the operator type.

*   **BuildListOptions Enhancement:**
    *   Modified the `BuildListOptions` function to parse `metadata.namespace==` and `metadata.namespace!=`.
    *   Logic added to ensure `!=` sets the correct filter type and `==` behaves consistent with `=`.

*   **Database Selector Update:**
    *   Updated `BuildArchivedWorkflowSelector` and `BuildWorkflowSelector` in `persist/sqldb` to handle the `NamespaceFilter`.
    *   Implemented SQL generation for namespace exclusion (`namespace != ?`) to support the `NotEquals` filter in the archive.

*   **Workflow Server Authorization:**
    *   Updated `ListWorkflows` in `server/workflow/workflow_server.go` to handle authorization for namespace exclusion.
    *   Implemented strict security logic: If `metadata.namespace!=` is used, the user must have cluster-wide list permissions. If they do not, the request is denied immediately. This mirrors `kubectl` behavior and prevents potential security issues where excluding a namespace might imply access to all others.

### Verification

*   **Unit Testing:**
    *   Added comprehensive unit tests in `server/utils/list_options_test.go` to cover parsing of the new operators and conflict detection.
    *   Updated `server/workflowarchive/archived_workflow_server_test.go` to verify that the new options are correctly passed to the repository layer.

*   **E2E Testing:**
    *   Added end-to-e2e tests in `test/e2e/argo_server_test.go`.
    *   Validated that `argo list --field-selector metadata.namespace!=<ns>` returns the correct workflows for authorized users.
    *   Validated that unauthorized users (lacking cluster-wide permissions) receive a 403 Forbidden error when attempting to use the exclusion operator.
 
Example audit log from local testing:
```json
{
    "kind": "Event",
    "apiVersion": "audit.k8s.io/v1",
    "level": "Metadata",
    "auditID": "f8a139b4-9201-4dee-b57b-15e095887f79",
    "stage": "ResponseComplete",
    "requestURI": "/apis/argoproj.io/v1alpha1/workflows?fieldSelector=metadata.namespace%21%3Dargo-test-2\u0026labelSelector=%21workflows.argoproj.io%2Fcontroller-instanceid",
    "verb": "list",
    "user": {
        "username": "system:admin",
        "groups": [
            "system:masters",
            "system:authenticated"
        ]
    },
    "sourceIPs": [
        "192.168.107.3"
    ],
    "userAgent": "argo/v0.0.0 (darwin/amd64) kubernetes/$Format/argo-workflows/latest+6fb2b9f.dirty argo-api-client",
    "objectRef": {
        "resource": "workflows",
        "apiGroup": "argoproj.io",
        "apiVersion": "v1alpha1"
    },
    "responseStatus": {
        "metadata": {},
        "code": 200
    },
    "requestReceivedTimestamp": "2025-12-03T10:34:35.475997Z",
    "stageTimestamp": "2025-12-03T10:34:35.483591Z",
    "annotations": {
        "authorization.k8s.io/decision": "allow",
        "authorization.k8s.io/reason": ""
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added namespace field selector operators: `!=` for excluding namespaces and `==` for exact namespace matching. Users can now filter workflows using expressions like `namespace!=kube-system` or `namespace==production`.

* **Tests**
  * Expanded test coverage for namespace field selector filtering and cluster-scoped RBAC authorization scenarios.

* **Documentation**
  * Added documentation describing the new namespace field selector operators and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->