### PR TITLE
chore: clean up kubebuilder annotations in executor_swagger.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,9 +366,7 @@ argoexec-nonroot-image:
 .PHONY: codegen
 codegen: types swagger manifests $(TOOL_MOCKERY) $(TOOL_BUF) $(GENERATED_DOCS) ## Generate code via `go generate`, as well as SDKs
 	go generate ./...
-	GOFLAGS="$(GOFLAGS) -mod=mod" $(TOOL_MOCKERY) --config .mockery.yaml
- 	# The generated markdown contains links to nowhere for interfaces, so remove them
-	sed -i.bak 's/\[any\](#any)/`any`/g' docs/executor_swagger.md && rm -f docs/executor_swagger.md.bak
+	$(TOOL_MOCKERY) --config .mockery.yaml
 	make --directory sdks/java USE_NIX=$(USE_NIX) generate
 
 .PHONY: check-pwd

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -81,9 +81,9 @@ ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is the filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore</br>TODO: how do we prevent errors in the filesystem from compromising the machine</br>+optional |  |
-| partition | int32 (formatted integer)| `int32` |  | | partition is the partition in the volume that you want to mount.</br>If omitted, the default is to mount by volume name.</br>Examples: For volume /dev/sda1, you specify the partition as "1".</br>Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly value true will force the readOnly setting in VolumeMounts.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore</br>+optional |  |
+| fsType | string| `string` |  | | fsType is the filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore</br>TODO: how do we prevent errors in the filesystem from compromising the machine </br>*Optional.*|  |
+| partition | int32 (formatted integer)| `int32` |  | | partition is the partition in the volume that you want to mount.</br>If omitted, the default is to mount by volume name.</br>Examples: For volume /dev/sda1, you specify the partition as "1".</br>Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly value true will force the readOnly setting in VolumeMounts.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore </br>*Optional.*|  |
 | volumeID | string| `string` |  | | volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore |  |
 
 
@@ -108,7 +108,6 @@ ownership management and SELinux relabeling.
 ### <span id="amount"></span> Amount
 
 
-> +kubebuilder:validation:Type=number
   
 
 
@@ -133,7 +132,6 @@ It will marshall back to string - marshalling is not symmetric.
 ### <span id="app-armor-profile"></span> AppArmorProfile
 
 
-> +union
   
 
 
@@ -144,7 +142,7 @@ It will marshall back to string - marshalling is not symmetric.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| localhostProfile | string| `string` |  | | localhostProfile indicates a profile loaded on the node that should be used.</br>The profile must be preconfigured on the node to work.</br>Must match the loaded name of the profile.</br>Must be set if and only if type is "Localhost".</br>+optional |  |
+| localhostProfile | string| `string` |  | | localhostProfile indicates a profile loaded on the node that should be used.</br>The profile must be preconfigured on the node to work.</br>Must match the loaded name of the profile.</br>Must be set if and only if type is "Localhost". </br>*Optional.*|  |
 | type | [AppArmorProfileType](#app-armor-profile-type)| `AppArmorProfileType` |  | |  |  |
 
 
@@ -152,14 +150,13 @@ It will marshall back to string - marshalling is not symmetric.
 ### <span id="app-armor-profile-type"></span> AppArmorProfileType
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| AppArmorProfileType | string| string | | +enum |  |
+| AppArmorProfileType | string| string | |  |  |
 
 
 
@@ -198,7 +195,7 @@ It will marshall back to string - marshalling is not symmetric.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | artifacts | [Artifacts](#artifacts)| `Artifacts` |  | |  |  |
-| parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters is the list of parameters to pass to the template or workflow</br>+patchStrategy=merge</br>+patchMergeKey=name |  |
+| parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters is the list of parameters to pass to the template or workflow |  |
 
 
 
@@ -229,8 +226,8 @@ It will marshall back to string - marshalling is not symmetric.
 | globalName | string| `string` |  | | GlobalName exports an output artifact to the global scope, making it available as</br>'{{workflow.outputs.artifacts.XXXX}} and in workflow.status.outputs.artifacts |  |
 | hdfs | [HDFSArtifact](#h-d-f-s-artifact)| `HDFSArtifact` |  | |  |  |
 | http | [HTTPArtifact](#http-artifact)| `HTTPArtifact` |  | |  |  |
-| mode | int32 (formatted integer)| `int32` |  | | mode bits to use on this file, must be a value between 0 and 0777.</br>Set when loading input artifacts. It is recommended to set the mode value</br>to ensure the artifact has the expected permissions in your container.</br>+kubebuilder:validation:Minimum=0</br>+kubebuilder:validation:Maximum=511 |  |
-| name | string| `string` |  | | name of the artifact. must be unique within a template's inputs/outputs.</br>+kubebuilder:validation:Pattern=`^[-a-zA-Z0-9_{}.]+$` |  |
+| mode | int32 (formatted integer)| `int32` |  | | mode bits to use on this file, must be a value between 0 and 0777.</br>Set when loading input artifacts. It is recommended to set the mode value</br>to ensure the artifact has the expected permissions in your container. </br>*Minimum value: 0; Maximum value: 511.*|  |
+| name | string| `string` |  | | name of the artifact. must be unique within a template's inputs/outputs. </br>*Validation regex: `^[-a-zA-Z0-9_{}.]+$`.*|  |
 | optional | boolean| `bool` |  | | Make Artifacts optional, if Artifacts doesn't generate or exist |  |
 | oss | [OSSArtifact](#o-s-s-artifact)| `OSSArtifact` |  | |  |  |
 | path | string| `string` |  | | Path is the container path to the artifact |  |
@@ -279,7 +276,6 @@ It will marshall back to string - marshalling is not symmetric.
 > It is used as single artifact in the context of inputs/outputs (e.g. outputs.artifacts.artname).
 It is also used to describe the location of multiple artifacts such as the archive location
 of a single workflow step, which the executor will use as a default location to store its files.
-+kubebuilder:validation:XValidation:rule="(has(self.s3) ? 1 : 0) + (has(self.git) ? 1 : 0) + (has(self.http) ? 1 : 0) + (has(self.artifactory) ? 1 : 0) + (has(self.hdfs) ? 1 : 0) + (has(self.raw) ? 1 : 0) + (has(self.oss) ? 1 : 0) + (has(self.gcs) ? 1 : 0) + (has(self.azure) ? 1 : 0) + (has(self.plugin) ? 1 : 0) <= 1",message="at most one artifact location can be specified"
   
 
 
@@ -331,8 +327,8 @@ of a single workflow step, which the executor will use as a default location to 
 | globalName | string| `string` |  | | GlobalName exports an output artifact to the global scope, making it available as</br>'{{workflow.outputs.artifacts.XXXX}} and in workflow.status.outputs.artifacts |  |
 | hdfs | [HDFSArtifact](#h-d-f-s-artifact)| `HDFSArtifact` |  | |  |  |
 | http | [HTTPArtifact](#http-artifact)| `HTTPArtifact` |  | |  |  |
-| mode | int32 (formatted integer)| `int32` |  | | mode bits to use on this file, must be a value between 0 and 0777.</br>Set when loading input artifacts. It is recommended to set the mode value</br>to ensure the artifact has the expected permissions in your container.</br>+kubebuilder:validation:Minimum=0</br>+kubebuilder:validation:Maximum=511 |  |
-| name | string| `string` |  | | name of the artifact. must be unique within a template's inputs/outputs.</br>+kubebuilder:validation:Pattern=`^[-a-zA-Z0-9_{}.]+$` |  |
+| mode | int32 (formatted integer)| `int32` |  | | mode bits to use on this file, must be a value between 0 and 0777.</br>Set when loading input artifacts. It is recommended to set the mode value</br>to ensure the artifact has the expected permissions in your container. </br>*Minimum value: 0; Maximum value: 511.*|  |
+| name | string| `string` |  | | name of the artifact. must be unique within a template's inputs/outputs. </br>*Validation regex: `^[-a-zA-Z0-9_{}.]+$`.*|  |
 | optional | boolean| `bool` |  | | Make Artifacts optional, if Artifacts doesn't generate or exist |  |
 | oss | [OSSArtifact](#o-s-s-artifact)| `OSSArtifact` |  | |  |  |
 | path | string| `string` |  | | Path is the container path to the artifact |  |
@@ -410,28 +406,26 @@ of a single workflow step, which the executor will use as a default location to 
 ### <span id="azure-data-disk-caching-mode"></span> AzureDataDiskCachingMode
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| AzureDataDiskCachingMode | string| string | | +enum |  |
+| AzureDataDiskCachingMode | string| string | |  |  |
 
 
 
 ### <span id="azure-data-disk-kind"></span> AzureDataDiskKind
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| AzureDataDiskKind | string| string | | +enum |  |
+| AzureDataDiskKind | string| string | |  |  |
 
 
 
@@ -449,9 +443,9 @@ of a single workflow step, which the executor will use as a default location to 
 | cachingMode | [AzureDataDiskCachingMode](#azure-data-disk-caching-mode)| `AzureDataDiskCachingMode` |  | |  |  |
 | diskName | string| `string` |  | | diskName is the Name of the data disk in the blob storage |  |
 | diskURI | string| `string` |  | | diskURI is the URI of data disk in the blob storage |  |
-| fsType | string| `string` |  | | fsType is Filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>+optional</br>+default="ext4" |  |
+| fsType | string| `string` |  | | fsType is Filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. </br>*Optional; Default value: "ext4".*|  |
 | kind | [AzureDataDiskKind](#azure-data-disk-kind)| `AzureDataDiskKind` |  | |  |  |
-| readOnly | boolean| `bool` |  | | readOnly Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional</br>+default=false |  |
+| readOnly | boolean| `bool` |  | | readOnly Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional; Default value: false.*|  |
 
 
 
@@ -466,7 +460,7 @@ of a single workflow step, which the executor will use as a default location to 
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional.*|  |
 | secretName | string| `string` |  | | secretName is the  name of secret that contains Azure Storage Account Name and Key |  |
 | shareName | string| `string` |  | | shareName is the azure share Name |  |
 
@@ -527,10 +521,10 @@ of a single workflow step, which the executor will use as a default location to 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | driver | string| `string` |  | | driver is the name of the CSI driver that handles this volume.</br>Consult with your admin for the correct name as registered in the cluster. |  |
-| fsType | string| `string` |  | | fsType to mount. Ex. "ext4", "xfs", "ntfs".</br>If not provided, the empty value is passed to the associated CSI driver</br>which will determine the default filesystem to apply.</br>+optional |  |
+| fsType | string| `string` |  | | fsType to mount. Ex. "ext4", "xfs", "ntfs".</br>If not provided, the empty value is passed to the associated CSI driver</br>which will determine the default filesystem to apply. </br>*Optional.*|  |
 | nodePublishSecretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
-| readOnly | boolean| `bool` |  | | readOnly specifies a read-only configuration for the volume.</br>Defaults to false (read/write).</br>+optional |  |
-| volumeAttributes | map of string| `map[string]string` |  | | volumeAttributes stores driver-specific properties that are passed to the CSI</br>driver. Consult your driver's documentation for supported values.</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly specifies a read-only configuration for the volume.</br>Defaults to false (read/write). </br>*Optional.*|  |
+| volumeAttributes | map of string| `map[string]string` |  | | volumeAttributes stores driver-specific properties that are passed to the CSI</br>driver. Consult your driver's documentation for supported values. </br>*Optional.*|  |
 
 
 
@@ -563,8 +557,8 @@ of a single workflow step, which the executor will use as a default location to 
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| add | [][Capability](#capability)| `[]Capability` |  | | Added capabilities</br>+optional</br>+listType=atomic |  |
-| drop | [][Capability](#capability)| `[]Capability` |  | | Removed capabilities</br>+optional</br>+listType=atomic |  |
+| add | [][Capability](#capability)| `[]Capability` |  | | Added capabilities </br>*Optional.*|  |
+| drop | [][Capability](#capability)| `[]Capability` |  | | Removed capabilities </br>*Optional.*|  |
 
 
 
@@ -597,12 +591,12 @@ Cephfs volumes do not support ownership management or SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| monitors | []string| `[]string` |  | | monitors is Required: Monitors is a collection of Ceph monitors</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it</br>+listType=atomic |  |
-| path | string| `string` |  | | path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly is Optional: Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it</br>+optional |  |
-| secretFile | string| `string` |  | | secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it</br>+optional |  |
+| monitors | []string| `[]string` |  | | monitors is Required: Monitors is a collection of Ceph monitors</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it |  |
+| path | string| `string` |  | | path is Optional: Used as the mounted root, rather than the full Ceph tree, default is / </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly is Optional: Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it </br>*Optional.*|  |
+| secretFile | string| `string` |  | | secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
-| user | string| `string` |  | | user is optional: User is the rados user name, default is admin</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it</br>+optional |  |
+| user | string| `string` |  | | user is optional: User is the rados user name, default is admin</br>More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it </br>*Optional.*|  |
 
 
 
@@ -622,8 +616,8 @@ Cinder volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://examples.k8s.io/mysql-cinder-pd/README.md</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>More info: https://examples.k8s.io/mysql-cinder-pd/README.md</br>+optional |  |
+| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://examples.k8s.io/mysql-cinder-pd/README.md </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>More info: https://examples.k8s.io/mysql-cinder-pd/README.md </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
 | volumeID | string| `string` |  | | volumeID used to identify the volume in cinder.</br>More info: https://examples.k8s.io/mysql-cinder-pd/README.md |  |
 
@@ -665,10 +659,10 @@ filesystem.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | labelSelector | [LabelSelector](#label-selector)| `LabelSelector` |  | |  |  |
-| name | string| `string` |  | | Select a single ClusterTrustBundle by object name.  Mutually-exclusive</br>with signerName and labelSelector.</br>+optional |  |
-| optional | boolean| `bool` |  | | If true, don't block pod startup if the referenced ClusterTrustBundle(s)</br>aren't available.  If using name, then the named ClusterTrustBundle is</br>allowed not to exist.  If using signerName, then the combination of</br>signerName and labelSelector is allowed to match zero</br>ClusterTrustBundles.</br>+optional |  |
+| name | string| `string` |  | | Select a single ClusterTrustBundle by object name.  Mutually-exclusive</br>with signerName and labelSelector. </br>*Optional.*|  |
+| optional | boolean| `bool` |  | | If true, don't block pod startup if the referenced ClusterTrustBundle(s)</br>aren't available.  If using name, then the named ClusterTrustBundle is</br>allowed not to exist.  If using signerName, then the combination of</br>signerName and labelSelector is allowed to match zero</br>ClusterTrustBundles. </br>*Optional.*|  |
 | path | string| `string` |  | | Relative path from the volume root to write the bundle. |  |
-| signerName | string| `string` |  | | Select all ClusterTrustBundles that match this signer name.</br>Mutually-exclusive with name.  The contents of all selected</br>ClusterTrustBundles will be unified and deduplicated.</br>+optional |  |
+| signerName | string| `string` |  | | Select all ClusterTrustBundles that match this signer name.</br>Mutually-exclusive with name.  The contents of all selected</br>ClusterTrustBundles will be unified and deduplicated. </br>*Optional.*|  |
 
 
 
@@ -687,15 +681,14 @@ key-value pairs as environment variables.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | Specify whether the ConfigMap must be defined</br>+optional |  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | Specify whether the ConfigMap must be defined </br>*Optional.*|  |
 
 
 
 ### <span id="config-map-key-selector"></span> ConfigMapKeySelector
 
 
-> +structType=atomic
   
 
 
@@ -707,8 +700,8 @@ key-value pairs as environment variables.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | key | string| `string` |  | | The key to select. |  |
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | Specify whether the ConfigMap or its key must be defined</br>+optional |  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | Specify whether the ConfigMap or its key must be defined </br>*Optional.*|  |
 
 
 
@@ -730,9 +723,9 @@ mode.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items if unspecified, each key-value pair in the Data field of the referenced</br>ConfigMap will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the ConfigMap,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'.</br>+optional</br>+listType=atomic |  |
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | optional specify whether the ConfigMap or its keys must be defined</br>+optional |  |
+| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items if unspecified, each key-value pair in the Data field of the referenced</br>ConfigMap will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the ConfigMap,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'. </br>*Optional.*|  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | optional specify whether the ConfigMap or its keys must be defined </br>*Optional.*|  |
 
 
 
@@ -753,10 +746,10 @@ ConfigMap volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| defaultMode | int32 (formatted integer)| `int32` |  | | defaultMode is optional: mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>Defaults to 0644.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set.</br>+optional |  |
-| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items if unspecified, each key-value pair in the Data field of the referenced</br>ConfigMap will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the ConfigMap,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'.</br>+optional</br>+listType=atomic |  |
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | optional specify whether the ConfigMap or its keys must be defined</br>+optional |  |
+| defaultMode | int32 (formatted integer)| `int32` |  | | defaultMode is optional: mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>Defaults to 0644.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set. </br>*Optional.*|  |
+| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items if unspecified, each key-value pair in the Data field of the referenced</br>ConfigMap will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the ConfigMap,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'. </br>*Optional.*|  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | optional specify whether the ConfigMap or its keys must be defined </br>*Optional.*|  |
 
 
 
@@ -771,31 +764,31 @@ ConfigMap volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=name</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=name |  |
-| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated.</br>+optional</br>+listType=atomic |  |
-| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets.</br>+optional |  |
+| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated. </br>*Optional.*|  |
+| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated. </br>*Optional.*|  |
+| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets. </br>*Optional.*|  |
 | imagePullPolicy | [PullPolicy](#pull-policy)| `PullPolicy` |  | |  |  |
 | lifecycle | [Lifecycle](#lifecycle)| `Lifecycle` |  | |  |  |
 | livenessProbe | [Probe](#probe)| `Probe` |  | |  |  |
 | name | string| `string` |  | | Name of the container specified as a DNS_LABEL.</br>Each container in a pod must have a unique name (DNS_LABEL).</br>Cannot be updated. |  |
-| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=containerPort</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=containerPort</br>+listMapKey=protocol |  |
+| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated. </br>*Optional.*|  |
 | readinessProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers.</br>+featureGate=InPlacePodVerticalScaling</br>+optional</br>+listType=atomic |  |
+| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers. </br>*Optional.*|  |
 | resources | [ResourceRequirements](#resource-requirements)| `ResourceRequirements` |  | |  |  |
 | restartPolicy | [ContainerRestartPolicy](#container-restart-policy)| `ContainerRestartPolicy` |  | |  |  |
-| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy.</br>+featureGate=ContainerRestartRules</br>+optional</br>+listType=atomic |  |
+| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy. </br>*Optional.*|  |
 | securityContext | [SecurityContext](#security-context)| `SecurityContext` |  | |  |  |
 | startupProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false.</br>+optional |  |
-| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false</br>+optional |  |
-| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated.</br>+optional |  |
+| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false. </br>*Optional.*|  |
+| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false </br>*Optional.*|  |
+| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated. </br>*Optional.*|  |
 | terminationMessagePolicy | [TerminationMessagePolicy](#termination-message-policy)| `TerminationMessagePolicy` |  | |  |  |
-| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false.</br>+optional |  |
-| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container.</br>+patchMergeKey=devicePath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=devicePath</br>+optional |  |
-| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=mountPath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=mountPath |  |
-| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated.</br>+optional |  |
+| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false. </br>*Optional.*|  |
+| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container. </br>*Optional.*|  |
+| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated. </br>*Optional.*|  |
+| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated. </br>*Optional.*|  |
 
 
 
@@ -810,32 +803,32 @@ ConfigMap volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
+| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
 | dependencies | []string| `[]string` |  | |  |  |
-| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=name</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=name |  |
-| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated.</br>+optional</br>+listType=atomic |  |
-| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets.</br>+optional |  |
+| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated. </br>*Optional.*|  |
+| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated. </br>*Optional.*|  |
+| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets. </br>*Optional.*|  |
 | imagePullPolicy | [PullPolicy](#pull-policy)| `PullPolicy` |  | |  |  |
 | lifecycle | [Lifecycle](#lifecycle)| `Lifecycle` |  | |  |  |
 | livenessProbe | [Probe](#probe)| `Probe` |  | |  |  |
 | name | string| `string` |  | | Name of the container specified as a DNS_LABEL.</br>Each container in a pod must have a unique name (DNS_LABEL).</br>Cannot be updated. |  |
-| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=containerPort</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=containerPort</br>+listMapKey=protocol |  |
+| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated. </br>*Optional.*|  |
 | readinessProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers.</br>+featureGate=InPlacePodVerticalScaling</br>+optional</br>+listType=atomic |  |
+| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers. </br>*Optional.*|  |
 | resources | [ResourceRequirements](#resource-requirements)| `ResourceRequirements` |  | |  |  |
 | restartPolicy | [ContainerRestartPolicy](#container-restart-policy)| `ContainerRestartPolicy` |  | |  |  |
-| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy.</br>+featureGate=ContainerRestartRules</br>+optional</br>+listType=atomic |  |
+| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy. </br>*Optional.*|  |
 | securityContext | [SecurityContext](#security-context)| `SecurityContext` |  | |  |  |
 | startupProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false.</br>+optional |  |
-| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false</br>+optional |  |
-| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated.</br>+optional |  |
+| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false. </br>*Optional.*|  |
+| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false </br>*Optional.*|  |
+| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated. </br>*Optional.*|  |
 | terminationMessagePolicy | [TerminationMessagePolicy](#termination-message-policy)| `TerminationMessagePolicy` |  | |  |  |
-| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false.</br>+optional |  |
-| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container.</br>+patchMergeKey=devicePath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=devicePath</br>+optional |  |
-| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=mountPath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=mountPath |  |
-| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated.</br>+optional |  |
+| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false. </br>*Optional.*|  |
+| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container. </br>*Optional.*|  |
+| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated. </br>*Optional.*|  |
+| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated. </br>*Optional.*|  |
 
 
 
@@ -851,9 +844,9 @@ ConfigMap volumes support ownership management and SELinux relabeling.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | containerPort | int32 (formatted integer)| `int32` |  | | Number of port to expose on the pod's IP address.</br>This must be a valid port number, 0 < x < 65536. |  |
-| hostIP | string| `string` |  | | What host IP to bind the external port to.</br>+optional |  |
-| hostPort | int32 (formatted integer)| `int32` |  | | Number of port to expose on the host.</br>If specified, this must be a valid port number, 0 < x < 65536.</br>If HostNetwork is specified, this must match ContainerPort.</br>Most containers do not need this.</br>+optional |  |
-| name | string| `string` |  | | If specified, this must be an IANA_SVC_NAME and unique within the pod. Each</br>named port in a pod must have a unique name. Name for the port that can be</br>referred to by services.</br>+optional |  |
+| hostIP | string| `string` |  | | What host IP to bind the external port to. </br>*Optional.*|  |
+| hostPort | int32 (formatted integer)| `int32` |  | | Number of port to expose on the host.</br>If specified, this must be a valid port number, 0 < x < 65536.</br>If HostNetwork is specified, this must match ContainerPort.</br>Most containers do not need this. </br>*Optional.*|  |
+| name | string| `string` |  | | If specified, this must be an IANA_SVC_NAME and unique within the pod. Each</br>named port in a pod must have a unique name. Name for the port that can be</br>referred to by services. </br>*Optional.*|  |
 | protocol | [Protocol](#protocol)| `Protocol` |  | |  |  |
 
 
@@ -935,7 +928,7 @@ for handling an exited container based on its exit codes.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | operator | [ContainerRestartRuleOnExitCodesOperator](#container-restart-rule-on-exit-codes-operator)| `ContainerRestartRuleOnExitCodesOperator` |  | |  |  |
-| values | []int32 (formatted integer)| `[]int32` |  | | Specifies the set of values to check for container exit codes.</br>At most 255 elements are allowed.</br>+optional</br>+listType=set |  |
+| values | []int32 (formatted integer)| `[]int32` |  | | Specifies the set of values to check for container exit codes.</br>At most 255 elements are allowed. </br>*Optional.*|  |
 
 
 
@@ -1004,8 +997,8 @@ to take for the exit codes.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| error | boolean| `bool` |  | | +optional |  |
-| failed | boolean| `bool` |  | | +optional |  |
+| error | boolean| `bool` |  | |  </br>*Optional.*|  |
+| failed | boolean| `bool` |  | |  </br>*Optional.*|  |
 
 
 
@@ -1023,7 +1016,7 @@ to take for the exit codes.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| value | string| `string` |  | | Value is the value of the metric</br>+kubebuilder:validation:MinLength=1 |  |
+| value | string| `string` |  | | Value is the value of the metric </br>*Minimum length: 1.*|  |
 
 
 
@@ -1050,9 +1043,6 @@ to take for the exit codes.
 
 > DAGTask represents a node in the graph during DAG execution
 Note: CEL validation cannot check withItems (Schemaless) or inline (PreserveUnknownFields) fields.
-+kubebuilder:validation:XValidation:rule="!has(self.depends) || !has(self.dependencies)",message="cannot use both 'depends' and 'dependencies'"
-+kubebuilder:validation:XValidation:rule="!has(self.depends) || !has(self.continueOn)",message="cannot use 'continueOn' when using 'depends'"
-+kubebuilder:validation:XValidation:rule="!(has(self.depends) || has(self.dependencies)) || !self.name.matches('^[0-9]')",message="task name cannot begin with a digit when using 'depends' or 'dependencies'"
   
 
 
@@ -1069,12 +1059,12 @@ Note: CEL validation cannot check withItems (Schemaless) or inline (PreserveUnkn
 | depends | string| `string` |  | | Depends are name of other targets which this depends on |  |
 | hooks | [LifecycleHooks](#lifecycle-hooks)| `LifecycleHooks` |  | |  |  |
 | inline | [Template](#template)| `Template` |  | |  |  |
-| name | string| `string` |  | | Name is the name of the target</br>+kubebuilder:validation:MaxLength=128</br>+kubebuilder:validation:Pattern=`^[a-zA-Z0-9][-a-zA-Z0-9]*$` |  |
-| onExit | string| `string` |  | | OnExit is a template reference which is invoked at the end of the</br>template, irrespective of the success, failure, or error of the</br>primary template.</br></br>Deprecated: Use Hooks[exit].Template instead. |  |
+| name | string| `string` |  | | Name is the name of the target </br>*Maximum length: 128; Validation regex: `^[a-zA-Z0-9][-a-zA-Z0-9]*$`.*|  |
+| onExit | string| `string` |  | | OnExit is a template reference which is invoked at the end of the</br>template, irrespective of the success, failure, or error of the</br>primary template.</br>Deprecated: Use Hooks[exit].Template instead. |  |
 | template | string| `string` |  | | Name of template to execute |  |
 | templateRef | [TemplateRef](#template-ref)| `TemplateRef` |  | |  |  |
 | when | string| `string` |  | | When is an expression in which the task should conditionally execute |  |
-| withItems | [][Item](#item)| `[]Item` |  | | WithItems expands a task into multiple parallel tasks from the items in the list</br>Note: The structure of WithItems is free-form, so we need</br>"x-kubernetes-preserve-unknown-fields: true" in the validation schema.</br>+kubebuilder:validation:Schemaless</br>+kubebuilder:pruning:PreserveUnknownFields |  |
+| withItems | [][Item](#item)| `[]Item` |  | | WithItems expands a task into multiple parallel tasks from the items in the list</br>Note: The structure of WithItems is free-form, so we need</br>"x-kubernetes-preserve-unknown-fields: true" in the validation schema. |  |
 | withParam | string| `string` |  | | WithParam expands a task into multiple parallel tasks from the value in the parameter,</br>which is expected to be a JSON list. |  |
 | withSequence | [Sequence](#sequence)| `Sequence` |  | |  |  |
 
@@ -1096,7 +1086,7 @@ Note: CEL validation cannot check withItems (Schemaless) or inline (PreserveUnkn
 |------|------|---------|:--------:| ------- |-------------|---------|
 | failFast | boolean| `bool` |  | | This flag is for DAG logic. The DAG logic has a built-in "fail fast" feature to stop scheduling new steps,</br>as soon as it detects that one of the DAG nodes is failed. Then it waits until all DAG nodes are completed</br>before failing the DAG itself.</br>The FailFast flag default is true,  if set to false, it will allow a DAG to run all branches of the DAG to</br>completion (either success or failure), regardless of the failed outcomes of branches in the DAG.</br>More info and example about this feature at https://github.com/argoproj/argo-workflows/issues/1442 |  |
 | target | string| `string` |  | | Target are one or more names of targets to execute in a DAG |  |
-| tasks | [][DAGTask](#d-a-g-task)| `[]*DAGTask` |  | | Tasks are a list of DAG tasks</br>MaxItems is an artificial limit to limit CEL validation costs - see note at top of file</br>+patchStrategy=merge</br>+patchMergeKey=name</br>+kubebuilder:validation:MinItems=1</br>+kubebuilder:validation:MaxItems=200 |  |
+| tasks | [][DAGTask](#d-a-g-task)| `[]*DAGTask` |  | | Tasks are a list of DAG tasks</br>MaxItems is an artificial limit to limit CEL validation costs - see note at top of file </br>*Minimum items: 1; Maximum items: 200.*|  |
 
 
 
@@ -1152,7 +1142,7 @@ mode.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| items | [][DownwardAPIVolumeFile](#downward-api-volume-file)| `[]*DownwardAPIVolumeFile` |  | | Items is a list of DownwardAPIVolume file</br>+optional</br>+listType=atomic |  |
+| items | [][DownwardAPIVolumeFile](#downward-api-volume-file)| `[]*DownwardAPIVolumeFile` |  | | Items is a list of DownwardAPIVolume file </br>*Optional.*|  |
 
 
 
@@ -1171,7 +1161,7 @@ mode.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | fieldRef | [ObjectFieldSelector](#object-field-selector)| `ObjectFieldSelector` |  | |  |  |
-| mode | int32 (formatted integer)| `int32` |  | | Optional: mode bits used to set permissions on this file, must be an octal value</br>between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>If not specified, the volume defaultMode will be used.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set.</br>+optional |  |
+| mode | int32 (formatted integer)| `int32` |  | | Optional: mode bits used to set permissions on this file, must be an octal value</br>between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>If not specified, the volume defaultMode will be used.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set. </br>*Optional.*|  |
 | path | string| `string` |  | | Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..' |  |
 | resourceFieldRef | [ResourceFieldSelector](#resource-field-selector)| `ResourceFieldSelector` |  | |  |  |
 
@@ -1191,8 +1181,8 @@ mode.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| defaultMode | int32 (formatted integer)| `int32` |  | | Optional: mode bits to use on created files by default. Must be a</br>Optional: mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>Defaults to 0644.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set.</br>+optional |  |
-| items | [][DownwardAPIVolumeFile](#downward-api-volume-file)| `[]*DownwardAPIVolumeFile` |  | | Items is a list of downward API volume file</br>+optional</br>+listType=atomic |  |
+| defaultMode | int32 (formatted integer)| `int32` |  | | Optional: mode bits to use on created files by default. Must be a</br>Optional: mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>Defaults to 0644.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set. </br>*Optional.*|  |
+| items | [][DownwardAPIVolumeFile](#downward-api-volume-file)| `[]*DownwardAPIVolumeFile` |  | | Items is a list of downward API volume file </br>*Optional.*|  |
 
 
 
@@ -1242,7 +1232,7 @@ can be used as map keys in json.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | configMapRef | [ConfigMapEnvSource](#config-map-env-source)| `ConfigMapEnvSource` |  | |  |  |
-| prefix | string| `string` |  | | Optional text to prepend to the name of each environment variable.</br>May consist of any printable ASCII characters except '='.</br>+optional |  |
+| prefix | string| `string` |  | | Optional text to prepend to the name of each environment variable.</br>May consist of any printable ASCII characters except '='. </br>*Optional.*|  |
 | secretRef | [SecretEnvSource](#secret-env-source)| `SecretEnvSource` |  | |  |  |
 
 
@@ -1259,7 +1249,7 @@ can be used as map keys in json.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | name | string| `string` |  | | Name of the environment variable.</br>May consist of any printable ASCII characters except '='. |  |
-| value | string| `string` |  | | Variable references $(VAR_NAME) are expanded</br>using the previously defined environment variables in the container and</br>any service environment variables. If a variable cannot be resolved,</br>the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.</br>"$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".</br>Escaped references will never be expanded, regardless of whether the variable</br>exists or not.</br>Defaults to "".</br>+optional |  |
+| value | string| `string` |  | | Variable references $(VAR_NAME) are expanded</br>using the previously defined environment variables in the container and</br>any service environment variables. If a variable cannot be resolved,</br>the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.</br>"$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".</br>Escaped references will never be expanded, regardless of whether the variable</br>exists or not.</br>Defaults to "". </br>*Optional.*|  |
 | valueFrom | [EnvVarSource](#env-var-source)| `EnvVarSource` |  | |  |  |
 
 
@@ -1309,7 +1299,7 @@ can be used as map keys in json.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| command | []string| `[]string` |  | | Command is the command line to execute inside the container, the working directory for the</br>command  is root ('/') in the container's filesystem. The command is simply exec'd, it is</br>not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use</br>a shell, you need to explicitly call out to that shell.</br>Exit status of 0 is treated as live/healthy and non-zero is unhealthy.</br>+optional</br>+listType=atomic |  |
+| command | []string| `[]string` |  | | Command is the command line to execute inside the container, the working directory for the</br>command  is root ('/') in the container's filesystem. The command is simply exec'd, it is</br>not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use</br>a shell, you need to explicitly call out to that shell.</br>Exit status of 0 is treated as live/healthy and non-zero is unhealthy. </br>*Optional.*|  |
 
 
 
@@ -1375,11 +1365,11 @@ Fibre Channel volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>TODO: how do we prevent errors in the filesystem from compromising the machine</br>+optional |  |
-| lun | int32 (formatted integer)| `int32` |  | | lun is Optional: FC target lun number</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly is Optional: Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional |  |
-| targetWWNs | []string| `[]string` |  | | targetWWNs is Optional: FC target worldwide names (WWNs)</br>+optional</br>+listType=atomic |  |
-| wwids | []string| `[]string` |  | | wwids Optional: FC volume world wide identifiers (wwids)</br>Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.</br>+optional</br>+listType=atomic |  |
+| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>TODO: how do we prevent errors in the filesystem from compromising the machine </br>*Optional.*|  |
+| lun | int32 (formatted integer)| `int32` |  | | lun is Optional: FC target lun number </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly is Optional: Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional.*|  |
+| targetWWNs | []string| `[]string` |  | | targetWWNs is Optional: FC target worldwide names (WWNs) </br>*Optional.*|  |
+| wwids | []string| `[]string` |  | | wwids Optional: FC volume world wide identifiers (wwids)</br>Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously. </br>*Optional.*|  |
 
 
 
@@ -1395,7 +1385,6 @@ or a string representing a sub-field or item. The string will follow one of thes
 If a key maps to an empty Fields value, the field that key represents is part of the set.
 
 The exact format is defined in sigs.k8s.io/structured-merge-diff
-+protobuf.options.(gogoproto.goproto_stringer)=false
   
 
 
@@ -1405,7 +1394,6 @@ The exact format is defined in sigs.k8s.io/structured-merge-diff
 ### <span id="file-key-selector"></span> FileKeySelector
 
 
-> +structType=atomic
   
 
 
@@ -1416,10 +1404,10 @@ The exact format is defined in sigs.k8s.io/structured-merge-diff
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| key | string| `string` |  | | The key within the env file. An invalid key will prevent the pod from starting.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.</br>+required |  |
-| optional | boolean| `bool` |  | | Specify whether the file or its key must be defined. If the file or key</br>does not exist, then the env var is not published.</br>If optional is set to true and the specified key does not exist,</br>the environment variable will not be set in the Pod's containers.</br></br>If optional is set to false and the specified key does not exist,</br>an error will be returned during Pod creation.</br>+optional</br>+default=false |  |
-| path | string| `string` |  | | The path within the volume from which to select the file.</br>Must be relative and may not contain the '..' path or start with '..'.</br>+required |  |
-| volumeName | string| `string` |  | | The name of the volume mount containing the env file.</br>+required |  |
+| key | string| `string` |  | | The key within the env file. An invalid key will prevent the pod from starting.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters. |  |
+| optional | boolean| `bool` |  | | Specify whether the file or its key must be defined. If the file or key</br>does not exist, then the env var is not published.</br>If optional is set to true and the specified key does not exist,</br>the environment variable will not be set in the Pod's containers.</br>If optional is set to false and the specified key does not exist,</br>an error will be returned during Pod creation. </br>*Optional; Default value: false.*|  |
+| path | string| `string` |  | | The path within the volume from which to select the file.</br>Must be relative and may not contain the '..' path or start with '..'. |  |
+| volumeName | string| `string` |  | | The name of the volume mount containing the env file. |  |
 
 
 
@@ -1439,9 +1427,9 @@ provisioned/attached using an exec based plugin.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | driver | string| `string` |  | | driver is the name of the driver to use for this volume. |  |
-| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.</br>+optional |  |
-| options | map of string| `map[string]string` |  | | options is Optional: this field holds extra command options if any.</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly is Optional: defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional |  |
+| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script. </br>*Optional.*|  |
+| options | map of string| `map[string]string` |  | | options is Optional: this field holds extra command options if any. </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly is Optional: defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
 
 
@@ -1461,8 +1449,8 @@ Flocker volumes do not support ownership management or SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| datasetName | string| `string` |  | | datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker</br>should be considered as deprecated</br>+optional |  |
-| datasetUUID | string| `string` |  | | datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset</br>+optional |  |
+| datasetName | string| `string` |  | | datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker</br>should be considered as deprecated </br>*Optional.*|  |
+| datasetUUID | string| `string` |  | | datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset </br>*Optional.*|  |
 
 
 
@@ -1483,10 +1471,10 @@ PDs support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk</br>TODO: how do we prevent errors in the filesystem from compromising the machine</br>+optional |  |
-| partition | int32 (formatted integer)| `int32` |  | | partition is the partition in the volume that you want to mount.</br>If omitted, the default is to mount by volume name.</br>Examples: For volume /dev/sda1, you specify the partition as "1".</br>Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk</br>+optional |  |
+| fsType | string| `string` |  | | fsType is filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk</br>TODO: how do we prevent errors in the filesystem from compromising the machine </br>*Optional.*|  |
+| partition | int32 (formatted integer)| `int32` |  | | partition is the partition in the volume that you want to mount.</br>If omitted, the default is to mount by volume name.</br>Examples: For volume /dev/sda1, you specify the partition as "1".</br>Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk </br>*Optional.*|  |
 | pdName | string| `string` |  | | pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk |  |
-| readOnly | boolean| `bool` |  | | readOnly here will force the ReadOnly setting in VolumeMounts.</br>Defaults to false.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly here will force the ReadOnly setting in VolumeMounts.</br>Defaults to false.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk </br>*Optional.*|  |
 
 
 
@@ -1522,7 +1510,7 @@ PDs support ownership management and SELinux relabeling.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | port | int32 (formatted integer)| `int32` |  | | Port number of the gRPC service. Number must be in the range 1 to 65535. |  |
-| service | string| `string` |  | | Service is the name of the service to place in the gRPC HealthCheckRequest</br>(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).</br></br>If this is not specified, the default behavior is defined by gRPC.</br>+optional</br>+default="" |  |
+| service | string| `string` |  | | Service is the name of the service to place in the gRPC HealthCheckRequest</br>(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).</br>If this is not specified, the default behavior is defined by gRPC. </br>*Optional; Default value: "".*|  |
 
 
 
@@ -1530,7 +1518,6 @@ PDs support ownership management and SELinux relabeling.
 
 
 > Gauge is a Gauge prometheus metric
-+kubebuilder:validation:XValidation:rule="!has(self.realtime) || !self.realtime || !self.value.contains('resourcesDuration.')",message="'resourcesDuration.*' metrics cannot be used in real-time gauges"
   
 
 
@@ -1543,21 +1530,20 @@ PDs support ownership management and SELinux relabeling.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | operation | [GaugeOperation](#gauge-operation)| `GaugeOperation` |  | |  |  |
 | realtime | boolean| `bool` |  | | Realtime emits this metric in real time if applicable |  |
-| value | string| `string` |  | | Value is the value to be used in the operation with the metric's current value. If no operation is set,</br>value is the value of the metric</br>MaxLength is an artificial limit to limit CEL validation costs - see note at top of file</br>+kubebuilder:validation:MinLength=1</br>+kubebuilder:validation:MaxLength=256 |  |
+| value | string| `string` |  | | Value is the value to be used in the operation with the metric's current value. If no operation is set,</br>value is the value of the metric</br>MaxLength is an artificial limit to limit CEL validation costs - see note at top of file </br>*Minimum length: 1; Maximum length: 256.*|  |
 
 
 
 ### <span id="gauge-operation"></span> GaugeOperation
 
 
-> +kubebuilder:validation:Enum=Set;Add;Sub
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| GaugeOperation | string| string | | +kubebuilder:validation:Enum=Set;Add;Sub |  |
+| GaugeOperation | string| string | |  </br>*Allowed values: Set, Add, Sub.*|  |
 
 
 
@@ -1606,9 +1592,9 @@ into the Pod's container.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| directory | string| `string` |  | | directory is the target directory name.</br>Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the</br>git repository.  Otherwise, if specified, the volume will contain the git repository in</br>the subdirectory with the given name.</br>+optional |  |
+| directory | string| `string` |  | | directory is the target directory name.</br>Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the</br>git repository.  Otherwise, if specified, the volume will contain the git repository in</br>the subdirectory with the given name. </br>*Optional.*|  |
 | repository | string| `string` |  | | repository is the URL |  |
-| revision | string| `string` |  | | revision is the commit hash for the specified revision.</br>+optional |  |
+| revision | string| `string` |  | | revision is the commit hash for the specified revision. </br>*Optional.*|  |
 
 
 
@@ -1628,7 +1614,7 @@ into the Pod's container.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | endpoints | string| `string` |  | | endpoints is the endpoint name that details Glusterfs topology. |  |
 | path | string| `string` |  | | path is the Glusterfs volume path.</br>More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod |  |
-| readOnly | boolean| `bool` |  | | readOnly here will force the Glusterfs volume to be mounted with read-only permissions.</br>Defaults to false.</br>More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly here will force the Glusterfs volume to be mounted with read-only permissions.</br>Defaults to false.</br>More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod </br>*Optional.*|  |
 
 
 
@@ -1745,9 +1731,9 @@ into the Pod's container.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| host | string| `string` |  | | Host name to connect to, defaults to the pod IP. You probably want to set</br>"Host" in httpHeaders instead.</br>+optional |  |
-| httpHeaders | [][HTTPHeader](#http-header)| `[]*HTTPHeader` |  | | Custom headers to set in the request. HTTP allows repeated headers.</br>+optional</br>+listType=atomic |  |
-| path | string| `string` |  | | Path to access on the HTTP server.</br>+optional |  |
+| host | string| `string` |  | | Host name to connect to, defaults to the pod IP. You probably want to set</br>"Host" in httpHeaders instead. </br>*Optional.*|  |
+| httpHeaders | [][HTTPHeader](#http-header)| `[]*HTTPHeader` |  | | Custom headers to set in the request. HTTP allows repeated headers. </br>*Optional.*|  |
+| path | string| `string` |  | | Path to access on the HTTP server. </br>*Optional.*|  |
 | port | [IntOrString](#int-or-string)| `IntOrString` |  | |  |  |
 | scheme | [URIScheme](#uri-scheme)| `URIScheme` |  | |  |  |
 
@@ -1826,7 +1812,7 @@ into the Pod's container.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | buckets | [][Amount](#amount)| `[]Amount` |  | | Buckets is a list of bucket divisors for the histogram |  |
-| value | string| `string` |  | | Value is the value of the metric</br>+kubebuilder:validation:MinLength=1 |  |
+| value | string| `string` |  | | Value is the value of the metric </br>*Minimum length: 1.*|  |
 
 
 
@@ -1845,22 +1831,21 @@ pod's hosts file.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| hostnames | []string| `[]string` |  | | Hostnames for the above IP address.</br>+listType=atomic |  |
-| ip | string| `string` |  | | IP address of the host file entry.</br>+required |  |
+| hostnames | []string| `[]string` |  | | Hostnames for the above IP address. |  |
+| ip | string| `string` |  | | IP address of the host file entry. |  |
 
 
 
 ### <span id="host-path-type"></span> HostPathType
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| HostPathType | string| string | | +enum |  |
+| HostPathType | string| string | |  |  |
 
 
 
@@ -1898,15 +1883,15 @@ ISCSI volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| chapAuthDiscovery | boolean| `bool` |  | | chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication</br>+optional |  |
-| chapAuthSession | boolean| `bool` |  | | chapAuthSession defines whether support iSCSI Session CHAP authentication</br>+optional |  |
-| fsType | string| `string` |  | | fsType is the filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi</br>TODO: how do we prevent errors in the filesystem from compromising the machine</br>+optional |  |
-| initiatorName | string| `string` |  | | initiatorName is the custom iSCSI Initiator Name.</br>If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface</br><target portal>:<volume name> will be created for the connection.</br>+optional |  |
+| chapAuthDiscovery | boolean| `bool` |  | | chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication </br>*Optional.*|  |
+| chapAuthSession | boolean| `bool` |  | | chapAuthSession defines whether support iSCSI Session CHAP authentication </br>*Optional.*|  |
+| fsType | string| `string` |  | | fsType is the filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi</br>TODO: how do we prevent errors in the filesystem from compromising the machine </br>*Optional.*|  |
+| initiatorName | string| `string` |  | | initiatorName is the custom iSCSI Initiator Name.</br>If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface</br><target portal>:<volume name> will be created for the connection. </br>*Optional.*|  |
 | iqn | string| `string` |  | | iqn is the target iSCSI Qualified Name. |  |
-| iscsiInterface | string| `string` |  | | iscsiInterface is the interface Name that uses an iSCSI transport.</br>Defaults to 'default' (tcp).</br>+optional</br>+default="default" |  |
+| iscsiInterface | string| `string` |  | | iscsiInterface is the interface Name that uses an iSCSI transport.</br>Defaults to 'default' (tcp). </br>*Optional; Default value: "default".*|  |
 | lun | int32 (formatted integer)| `int32` |  | | lun represents iSCSI Target Lun number. |  |
-| portals | []string| `[]string` |  | | portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port</br>is other than default (typically TCP ports 860 and 3260).</br>+optional</br>+listType=atomic |  |
-| readOnly | boolean| `bool` |  | | readOnly here will force the ReadOnly setting in VolumeMounts.</br>Defaults to false.</br>+optional |  |
+| portals | []string| `[]string` |  | | portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port</br>is other than default (typically TCP ports 860 and 3260). </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly here will force the ReadOnly setting in VolumeMounts.</br>Defaults to false. </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
 | targetPortal | string| `string` |  | | targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port</br>is other than default (typically TCP ports 860 and 3260). |  |
 
@@ -1924,7 +1909,7 @@ ISCSI volumes support ownership management and SELinux relabeling.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | pullPolicy | [PullPolicy](#pull-policy)| `PullPolicy` |  | |  |  |
-| reference | string| `string` |  | | Required: Image or artifact reference to be used.</br>Behaves in the same way as pod.spec.containers[*].image.</br>Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets.</br>+optional |  |
+| reference | string| `string` |  | | Required: Image or artifact reference to be used.</br>Behaves in the same way as pod.spec.containers[*].image.</br>Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets. </br>*Optional.*|  |
 
 
 
@@ -1943,17 +1928,15 @@ ISCSI volumes support ownership management and SELinux relabeling.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | artifacts | [Artifacts](#artifacts)| `Artifacts` |  | |  |  |
-| parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters are a list of parameters passed as inputs</br>MaxItems is an artificial limit to limit CEL validation costs - see note at top of file</br>+patchStrategy=merge</br>+patchMergeKey=name</br>+kubebuilder:validation:MaxItems=500 |  |
+| parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters are a list of parameters passed as inputs</br>MaxItems is an artificial limit to limit CEL validation costs - see note at top of file </br>*Maximum items: 500.*|  |
 
 
 
 ### <span id="int-or-string"></span> IntOrString
 
 
-> +protobuf=true
-+protobuf.options.(gogoproto.goproto_stringer)=false
-+k8s:openapi-gen=true
-+k8s:openapi-model-package=io.k8s.apimachinery.pkg.util.intstr
+
+
   
 
 
@@ -1973,7 +1956,6 @@ ISCSI volumes support ownership management and SELinux relabeling.
 ### <span id="item"></span> Item
 
 
-> +protobuf.options.(gogoproto.goproto_stringer)=false
   
 
 
@@ -1992,7 +1974,7 @@ ISCSI volumes support ownership management and SELinux relabeling.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | key | string| `string` |  | | key is the key to project. |  |
-| mode | int32 (formatted integer)| `int32` |  | | mode is Optional: mode bits used to set permissions on this file.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>If not specified, the volume defaultMode will be used.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set.</br>+optional |  |
+| mode | int32 (formatted integer)| `int32` |  | | mode is Optional: mode bits used to set permissions on this file.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>If not specified, the volume defaultMode will be used.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set. </br>*Optional.*|  |
 | path | string| `string` |  | | path is the relative path of the file to map the key to.</br>May not be an absolute path.</br>May not contain the path element '..'.</br>May not start with the string '..'. |  |
 
 
@@ -2003,7 +1985,6 @@ ISCSI volumes support ownership management and SELinux relabeling.
 > A label selector is a label query over a set of resources. The result of matchLabels and
 matchExpressions are ANDed. An empty label selector matches all objects. A null
 label selector matches no objects.
-+structType=atomic
   
 
 
@@ -2014,8 +1995,8 @@ label selector matches no objects.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| matchExpressions | [][LabelSelectorRequirement](#label-selector-requirement)| `[]*LabelSelectorRequirement` |  | | matchExpressions is a list of label selector requirements. The requirements are ANDed.</br>+optional</br>+listType=atomic |  |
-| matchLabels | map of string| `map[string]string` |  | | matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels</br>map is equivalent to an element of matchExpressions, whose key field is "key", the</br>operator is "In", and the values array contains only "value". The requirements are ANDed.</br>+optional |  |
+| matchExpressions | [][LabelSelectorRequirement](#label-selector-requirement)| `[]*LabelSelectorRequirement` |  | | matchExpressions is a list of label selector requirements. The requirements are ANDed. </br>*Optional.*|  |
+| matchLabels | map of string| `map[string]string` |  | | matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels</br>map is equivalent to an element of matchExpressions, whose key field is "key", the</br>operator is "In", and the values array contains only "value". The requirements are ANDed. </br>*Optional.*|  |
 
 
 
@@ -2047,7 +2028,7 @@ relates the key and values.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | key | string| `string` |  | | key is the label key that the selector applies to. |  |
 | operator | [LabelSelectorOperator](#label-selector-operator)| `LabelSelectorOperator` |  | |  |  |
-| values | []string| `[]string` |  | | values is an array of string values. If the operator is In or NotIn,</br>the values array must be non-empty. If the operator is Exists or DoesNotExist,</br>the values array must be empty. This array is replaced during a strategic</br>merge patch.</br>+optional</br>+listType=atomic |  |
+| values | []string| `[]string` |  | | values is an array of string values. If the operator is In or NotIn,</br>the values array must be non-empty. If the operator is Exists or DoesNotExist,</br>the values array must be empty. This array is replaced during a strategic</br>merge patch. </br>*Optional.*|  |
 
 
 
@@ -2133,7 +2114,6 @@ will affect numerous schemas.  Don't make new APIs embed an underspecified API t
 
 Instead of using this type, create a locally provided and used type that is well-focused on your reference.
 For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
-+structType=atomic
   
 
 
@@ -2144,7 +2124,7 @@ For example, ServiceReferences for admission registration: https://github.com/ku
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
 
 
 
@@ -2169,7 +2149,7 @@ that the fieldset applies to.
 | manager | string| `string` |  | | Manager is an identifier of the workflow managing these fields. |  |
 | operation | [ManagedFieldsOperationType](#managed-fields-operation-type)| `ManagedFieldsOperationType` |  | |  |  |
 | subresource | string| `string` |  | | Subresource is the name of the subresource used to update that object, or</br>empty string if the object was updated through the main resource. The</br>value of this field is used to distinguish between managers, even if they</br>share the same name. For example, a status update will be distinct from a</br>regular update using the same manager name.</br>Note that the APIVersion field is not related to the Subresource field and</br>it always corresponds to the version of the main resource. |  |
-| time | string| `string` |  | | Time is the timestamp of when the ManagedFields entry was added. The</br>timestamp will also be updated if a field is added, the manager</br>changes any of the owned fields value or removes a field. The</br>timestamp does not update when a field is removed from the entry</br>because another manager took it over.</br>+optional |  |
+| time | string| `string` |  | | Time is the timestamp of when the ManagedFields entry was added. The</br>timestamp will also be updated if a field is added, the manager</br>changes any of the owned fields value or removes a field. The</br>timestamp does not update when a field is removed from the entry</br>because another manager took it over. </br>*Optional.*|  |
 
 
 
@@ -2246,7 +2226,7 @@ that the fieldset applies to.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| key | string| `string` |  | | +kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$` |  |
+| key | string| `string` |  | |  </br>*Validation regex: `^[a-zA-Z_][a-zA-Z0-9_]*$`.*|  |
 | value | string| `string` |  | |  |  |
 
 
@@ -2265,21 +2245,20 @@ that the fieldset applies to.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| prometheus | [][Prometheus](#prometheus)| `[]*Prometheus` |  | | Prometheus is a list of prometheus metrics to be emitted</br>MaxItems is an artificial limit to limit CEL validation costs - see note at top of file</br>+kubebuilder:validation:MaxItems=100 |  |
+| prometheus | [][Prometheus](#prometheus)| `[]*Prometheus` |  | | Prometheus is a list of prometheus metrics to be emitted</br>MaxItems is an artificial limit to limit CEL validation costs - see note at top of file </br>*Maximum items: 100.*|  |
 
 
 
 ### <span id="mount-propagation-mode"></span> MountPropagationMode
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| MountPropagationMode | string| string | | +enum |  |
+| MountPropagationMode | string| string | |  |  |
 
 
 
@@ -2318,7 +2297,7 @@ that the fieldset applies to.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | path | string| `string` |  | | path that is exported by the NFS server.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  |
-| readOnly | boolean| `bool` |  | | readOnly here will force the NFS export to be mounted with read-only permissions.</br>Defaults to false.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly here will force the NFS export to be mounted with read-only permissions.</br>Defaults to false.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs </br>*Optional.*|  |
 | server | string| `string` |  | | server is the hostname or IP address of the NFS server.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs |  |
 
 
@@ -2334,7 +2313,7 @@ that the fieldset applies to.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| preferredDuringSchedulingIgnoredDuringExecution | [][PreferredSchedulingTerm](#preferred-scheduling-term)| `[]*PreferredSchedulingTerm` |  | | The scheduler will prefer to schedule pods to nodes that satisfy</br>the affinity expressions specified by this field, but it may choose</br>a node that violates one or more of the expressions. The node that is</br>most preferred is the one with the greatest sum of weights, i.e.</br>for each node that meets all of the scheduling requirements (resource</br>request, requiredDuringScheduling affinity expressions, etc.),</br>compute a sum by iterating through the elements of this field and adding</br>"weight" to the sum if the node matches the corresponding matchExpressions; the</br>node(s) with the highest sum are the most preferred.</br>+optional</br>+listType=atomic |  |
+| preferredDuringSchedulingIgnoredDuringExecution | [][PreferredSchedulingTerm](#preferred-scheduling-term)| `[]*PreferredSchedulingTerm` |  | | The scheduler will prefer to schedule pods to nodes that satisfy</br>the affinity expressions specified by this field, but it may choose</br>a node that violates one or more of the expressions. The node that is</br>most preferred is the one with the greatest sum of weights, i.e.</br>for each node that meets all of the scheduling requirements (resource</br>request, requiredDuringScheduling affinity expressions, etc.),</br>compute a sum by iterating through the elements of this field and adding</br>"weight" to the sum if the node matches the corresponding matchExpressions; the</br>node(s) with the highest sum are the most preferred. </br>*Optional.*|  |
 | requiredDuringSchedulingIgnoredDuringExecution | [NodeSelector](#node-selector)| `NodeSelector` |  | |  |  |
 
 
@@ -2374,7 +2353,6 @@ that the fieldset applies to.
 > A node selector represents the union of the results of one or more label queries
 over a set of nodes; that is, it represents the OR of the selectors represented
 by the node selector terms.
-+structType=atomic
   
 
 
@@ -2385,7 +2363,7 @@ by the node selector terms.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| nodeSelectorTerms | [][NodeSelectorTerm](#node-selector-term)| `[]*NodeSelectorTerm` |  | | Required. A list of node selector terms. The terms are ORed.</br>+listType=atomic |  |
+| nodeSelectorTerms | [][NodeSelectorTerm](#node-selector-term)| `[]*NodeSelectorTerm` |  | | Required. A list of node selector terms. The terms are ORed. |  |
 
 
 
@@ -2394,14 +2372,13 @@ by the node selector terms.
 
 > A node selector operator is the set of operators that can be used in
 a node selector requirement.
-+enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| NodeSelectorOperator | string| string | | A node selector operator is the set of operators that can be used in</br>a node selector requirement.</br>+enum |  |
+| NodeSelectorOperator | string| string | | A node selector operator is the set of operators that can be used in</br>a node selector requirement.|  |
 
 
 
@@ -2422,7 +2399,7 @@ that relates the key and values.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | key | string| `string` |  | | The label key that the selector applies to. |  |
 | operator | [NodeSelectorOperator](#node-selector-operator)| `NodeSelectorOperator` |  | |  |  |
-| values | []string| `[]string` |  | | An array of string values. If the operator is In or NotIn,</br>the values array must be non-empty. If the operator is Exists or DoesNotExist,</br>the values array must be empty. If the operator is Gt or Lt, the values</br>array must have a single element, which will be interpreted as an integer.</br>This array is replaced during a strategic merge patch.</br>+optional</br>+listType=atomic |  |
+| values | []string| `[]string` |  | | An array of string values. If the operator is In or NotIn,</br>the values array must be non-empty. If the operator is Exists or DoesNotExist,</br>the values array must be empty. If the operator is Gt or Lt, the values</br>array must have a single element, which will be interpreted as an integer.</br>This array is replaced during a strategic merge patch. </br>*Optional.*|  |
 
 
 
@@ -2432,7 +2409,6 @@ that relates the key and values.
 > A null or empty node selector term matches no objects. The requirements of
 them are ANDed.
 The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-+structType=atomic
   
 
 
@@ -2443,8 +2419,8 @@ The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| matchExpressions | [][NodeSelectorRequirement](#node-selector-requirement)| `[]*NodeSelectorRequirement` |  | | A list of node selector requirements by node's labels.</br>+optional</br>+listType=atomic |  |
-| matchFields | [][NodeSelectorRequirement](#node-selector-requirement)| `[]*NodeSelectorRequirement` |  | | A list of node selector requirements by node's fields.</br>+optional</br>+listType=atomic |  |
+| matchExpressions | [][NodeSelectorRequirement](#node-selector-requirement)| `[]*NodeSelectorRequirement` |  | | A list of node selector requirements by node's labels. </br>*Optional.*|  |
+| matchFields | [][NodeSelectorRequirement](#node-selector-requirement)| `[]*NodeSelectorRequirement` |  | | A list of node selector requirements by node's fields. </br>*Optional.*|  |
 
 
 
@@ -2546,7 +2522,6 @@ save/load the directory appropriately.
 ### <span id="object-field-selector"></span> ObjectFieldSelector
 
 
-> +structType=atomic
   
 
 
@@ -2557,7 +2532,7 @@ save/load the directory appropriately.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| apiVersion | string| `string` |  | | Version of the schema the FieldPath is written in terms of, defaults to "v1".</br>+optional |  |
+| apiVersion | string| `string` |  | | Version of the schema the FieldPath is written in terms of, defaults to "v1". </br>*Optional.*|  |
 | fieldPath | string| `string` |  | | Path of the field to select in the specified API version. |  |
 
 
@@ -2595,7 +2570,7 @@ save/load the directory appropriately.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | artifacts | [Artifacts](#artifacts)| `Artifacts` |  | |  |  |
 | exitCode | string| `string` |  | | ExitCode holds the exit code of a script template |  |
-| parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters holds the list of output parameters produced by a step</br>+patchStrategy=merge</br>+patchMergeKey=name |  |
+| parameters | [][Parameter](#parameter)| `[]*Parameter` |  | | Parameters holds the list of output parameters produced by a step |  |
 | result | string| `string` |  | | Result holds the result (stdout) of a script or container template, or the response body of an HTTP template |  |
 
 
@@ -2606,7 +2581,6 @@ save/load the directory appropriately.
 > OwnerReference contains enough information to let you identify an owning
 object. An owning object must be in the same namespace as the dependent, or
 be cluster-scoped, so there is no namespace field.
-+structType=atomic
   
 
 
@@ -2618,8 +2592,8 @@ be cluster-scoped, so there is no namespace field.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | apiVersion | string| `string` |  | | API version of the referent. |  |
-| blockOwnerDeletion | boolean| `bool` |  | | If true, AND if the owner has the "foregroundDeletion" finalizer, then</br>the owner cannot be deleted from the key-value store until this</br>reference is removed.</br>See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion</br>for how the garbage collector interacts with this field and enforces the foreground deletion.</br>Defaults to false.</br>To set this field, a user needs "delete" permission of the owner,</br>otherwise 422 (Unprocessable Entity) will be returned.</br>+optional |  |
-| controller | boolean| `bool` |  | | If true, this reference points to the managing controller.</br>+optional |  |
+| blockOwnerDeletion | boolean| `bool` |  | | If true, AND if the owner has the "foregroundDeletion" finalizer, then</br>the owner cannot be deleted from the key-value store until this</br>reference is removed.</br>See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion</br>for how the garbage collector interacts with this field and enforces the foreground deletion.</br>Defaults to false.</br>To set this field, a user needs "delete" permission of the owner,</br>otherwise 422 (Unprocessable Entity) will be returned. </br>*Optional.*|  |
+| controller | boolean| `bool` |  | | If true, this reference points to the managing controller. </br>*Optional.*|  |
 | kind | string| `string` |  | | Kind of the referent.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |
 | name | string| `string` |  | | Name of the referent.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names |  |
 | uid | [UID](#uid)| `UID` |  | |  |  |
@@ -2649,9 +2623,9 @@ be cluster-scoped, so there is no namespace field.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | default | [AnyString](#any-string)| `AnyString` |  | |  |  |
 | description | [AnyString](#any-string)| `AnyString` |  | |  |  |
-| enum | [][AnyString](#any-string)| `[]AnyString` |  | | Enum holds a list of string values to choose from, for the actual value of the parameter</br>+kubebuilder:validation:MinItems=1 |  |
+| enum | [][AnyString](#any-string)| `[]AnyString` |  | | Enum holds a list of string values to choose from, for the actual value of the parameter </br>*Minimum items: 1.*|  |
 | globalName | string| `string` |  | | GlobalName exports an output parameter to the global scope, making it available as</br>'{{workflow.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters |  |
-| name | string| `string` |  | | Name is the parameter name</br>+kubebuilder:validation:Pattern=`^[-a-zA-Z0-9_]+$` |  |
+| name | string| `string` |  | | Name is the parameter name </br>*Validation regex: `^[-a-zA-Z0-9_]+$`.*|  |
 | value | [AnyString](#any-string)| `AnyString` |  | |  |  |
 | valueFrom | [ValueFrom](#value-from)| `ValueFrom` |  | |  |  |
 
@@ -2660,14 +2634,13 @@ be cluster-scoped, so there is no namespace field.
 ### <span id="persistent-volume-access-mode"></span> PersistentVolumeAccessMode
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| PersistentVolumeAccessMode | string| string | | +enum |  |
+| PersistentVolumeAccessMode | string| string | |  |  |
 
 
 
@@ -2686,15 +2659,15 @@ and allows a Source for provider-specific attributes
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| accessModes | [][PersistentVolumeAccessMode](#persistent-volume-access-mode)| `[]PersistentVolumeAccessMode` |  | | accessModes contains the desired access modes the volume should have.</br>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1</br>+optional</br>+listType=atomic |  |
+| accessModes | [][PersistentVolumeAccessMode](#persistent-volume-access-mode)| `[]PersistentVolumeAccessMode` |  | | accessModes contains the desired access modes the volume should have.</br>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1 </br>*Optional.*|  |
 | dataSource | [TypedLocalObjectReference](#typed-local-object-reference)| `TypedLocalObjectReference` |  | |  |  |
 | dataSourceRef | [TypedObjectReference](#typed-object-reference)| `TypedObjectReference` |  | |  |  |
 | resources | [VolumeResourceRequirements](#volume-resource-requirements)| `VolumeResourceRequirements` |  | |  |  |
 | selector | [LabelSelector](#label-selector)| `LabelSelector` |  | |  |  |
-| storageClassName | string| `string` |  | | storageClassName is the name of the StorageClass required by the claim.</br>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1</br>+optional |  |
-| volumeAttributesClassName | string| `string` |  | | volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.</br>If specified, the CSI driver will create or update the volume with the attributes defined</br>in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,</br>it can be changed after the claim is created. An empty string or nil value indicates that no</br>VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,</br>this field can be reset to its previous value (including nil) to cancel the modification.</br>If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be</br>set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource</br>exists.</br>More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/</br>+featureGate=VolumeAttributesClass</br>+optional |  |
+| storageClassName | string| `string` |  | | storageClassName is the name of the StorageClass required by the claim.</br>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1 </br>*Optional.*|  |
+| volumeAttributesClassName | string| `string` |  | | volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.</br>If specified, the CSI driver will create or update the volume with the attributes defined</br>in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,</br>it can be changed after the claim is created. An empty string or nil value indicates that no</br>VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,</br>this field can be reset to its previous value (including nil) to cancel the modification.</br>If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be</br>set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource</br>exists.</br>More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ </br>*Optional.*|  |
 | volumeMode | [PersistentVolumeMode](#persistent-volume-mode)| `PersistentVolumeMode` |  | |  |  |
-| volumeName | string| `string` |  | | volumeName is the binding reference to the PersistentVolume backing this claim.</br>+optional |  |
+| volumeName | string| `string` |  | | volumeName is the binding reference to the PersistentVolume backing this claim. </br>*Optional.*|  |
 
 
 
@@ -2713,20 +2686,20 @@ PersistentVolumeClaim objects as part of an EphemeralVolumeSource.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| annotations | map of string| `map[string]string` |  | | Annotations is an unstructured key value map stored with a resource that may be</br>set by external tools to store and retrieve arbitrary metadata. They are not</br>queryable and should be preserved when modifying objects.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations</br>+optional |  |
-| creationTimestamp | string| `string` |  | | CreationTimestamp is a timestamp representing the server time when this object was</br>created. It is not guaranteed to be set in happens-before order across separate operations.</br>Clients may not set this value. It is represented in RFC3339 form and is in UTC.</br></br>Populated by the system.</br>Read-only.</br>Null for lists.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata</br>+optional |  |
-| deletionGracePeriodSeconds | int64 (formatted integer)| `int64` |  | | Number of seconds allowed for this object to gracefully terminate before</br>it will be removed from the system. Only set when deletionTimestamp is also set.</br>May only be shortened.</br>Read-only.</br>+optional |  |
-| deletionTimestamp | string| `string` |  | | DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This</br>field is set by the server when a graceful deletion is requested by the user, and is not</br>directly settable by a client. The resource is expected to be deleted (no longer visible</br>from resource lists, and not reachable by name) after the time in this field, once the</br>finalizers list is empty. As long as the finalizers list contains items, deletion is blocked.</br>Once the deletionTimestamp is set, this value may not be unset or be set further into the</br>future, although it may be shortened or the resource may be deleted prior to this time.</br>For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react</br>by sending a graceful termination signal to the containers in the pod. After that 30 seconds,</br>the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,</br>remove the pod from the API. In the presence of network partitions, this object may still</br>exist after this timestamp, until an administrator or automated process can determine the</br>resource is fully terminated.</br>If not set, graceful deletion of the object has not been requested.</br></br>Populated by the system when a graceful deletion is requested.</br>Read-only.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata</br>+optional |  |
-| finalizers | []string| `[]string` |  | | Must be empty before the object is deleted from the registry. Each entry</br>is an identifier for the responsible component that will remove the entry</br>from the list. If the deletionTimestamp of the object is non-nil, entries</br>in this list can only be removed.</br>Finalizers may be processed and removed in any order.  Order is NOT enforced</br>because it introduces significant risk of stuck finalizers.</br>finalizers is a shared field, any actor with permission can reorder it.</br>If the finalizer list is processed in order, then this can lead to a situation</br>in which the component responsible for the first finalizer in the list is</br>waiting for a signal (field value, external system, or other) produced by a</br>component responsible for a finalizer later in the list, resulting in a deadlock.</br>Without enforced ordering finalizers are free to order amongst themselves and</br>are not vulnerable to ordering changes in the list.</br>+optional</br>+patchStrategy=merge</br>+listType=set |  |
-| generateName | string| `string` |  | | GenerateName is an optional prefix, used by the server, to generate a unique</br>name ONLY IF the Name field has not been provided.</br>If this field is used, the name returned to the client will be different</br>than the name passed. This value will also be combined with a unique suffix.</br>The provided value has the same validation rules as the Name field,</br>and may be truncated by the length of the suffix required to make the value</br>unique on the server.</br></br>If this field is specified and the generated name exists, the server will return a 409.</br></br>Applied only if Name is not specified.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency</br>+optional |  |
-| generation | int64 (formatted integer)| `int64` |  | | A sequence number representing a specific generation of the desired state.</br>Populated by the system. Read-only.</br>+optional |  |
-| labels | map of string| `map[string]string` |  | | Map of string keys and values that can be used to organize and categorize</br>(scope and select) objects. May match selectors of replication controllers</br>and services.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels</br>+optional |  |
-| managedFields | [][ManagedFieldsEntry](#managed-fields-entry)| `[]*ManagedFieldsEntry` |  | | ManagedFields maps workflow-id and version to the set of fields</br>that are managed by that workflow. This is mostly for internal</br>housekeeping, and users typically shouldn't need to set or</br>understand this field. A workflow can be the user's name, a</br>controller's name, or the name of a specific apply path like</br>"ci-cd". The set of fields is always in the version that the</br>workflow used when modifying the object.</br></br>+optional</br>+listType=atomic |  |
-| name | string| `string` |  | | Name must be unique within a namespace. Is required when creating resources, although</br>some resources may allow a client to request the generation of an appropriate name</br>automatically. Name is primarily intended for creation idempotence and configuration</br>definition.</br>Cannot be updated.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names</br>+optional |  |
-| namespace | string| `string` |  | | Namespace defines the space within which each name must be unique. An empty namespace is</br>equivalent to the "default" namespace, but "default" is the canonical representation.</br>Not all objects are required to be scoped to a namespace - the value of this field for</br>those objects will be empty.</br></br>Must be a DNS_LABEL.</br>Cannot be updated.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces</br>+optional |  |
-| ownerReferences | [][OwnerReference](#owner-reference)| `[]*OwnerReference` |  | | List of objects depended by this object. If ALL objects in the list have</br>been deleted, this object will be garbage collected. If this object is managed by a controller,</br>then an entry in this list will point to this controller, with the controller field set to true.</br>There cannot be more than one managing controller.</br>+optional</br>+patchMergeKey=uid</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=uid |  |
-| resourceVersion | string| `string` |  | | An opaque value that represents the internal version of this object that can</br>be used by clients to determine when objects have changed. May be used for optimistic</br>concurrency, change detection, and the watch operation on a resource or set of resources.</br>Clients must treat these values as opaque and passed unmodified back to the server.</br>They may only be valid for a particular resource or set of resources.</br></br>Populated by the system.</br>Read-only.</br>Value must be treated as opaque by clients and .</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency</br>+optional |  |
-| selfLink | string| `string` |  | | Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.</br>+optional |  |
+| annotations | map of string| `map[string]string` |  | | Annotations is an unstructured key value map stored with a resource that may be</br>set by external tools to store and retrieve arbitrary metadata. They are not</br>queryable and should be preserved when modifying objects.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations </br>*Optional.*|  |
+| creationTimestamp | string| `string` |  | | CreationTimestamp is a timestamp representing the server time when this object was</br>created. It is not guaranteed to be set in happens-before order across separate operations.</br>Clients may not set this value. It is represented in RFC3339 form and is in UTC.</br>Populated by the system.</br>Read-only.</br>Null for lists.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata </br>*Optional.*|  |
+| deletionGracePeriodSeconds | int64 (formatted integer)| `int64` |  | | Number of seconds allowed for this object to gracefully terminate before</br>it will be removed from the system. Only set when deletionTimestamp is also set.</br>May only be shortened.</br>Read-only. </br>*Optional.*|  |
+| deletionTimestamp | string| `string` |  | | DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This</br>field is set by the server when a graceful deletion is requested by the user, and is not</br>directly settable by a client. The resource is expected to be deleted (no longer visible</br>from resource lists, and not reachable by name) after the time in this field, once the</br>finalizers list is empty. As long as the finalizers list contains items, deletion is blocked.</br>Once the deletionTimestamp is set, this value may not be unset or be set further into the</br>future, although it may be shortened or the resource may be deleted prior to this time.</br>For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react</br>by sending a graceful termination signal to the containers in the pod. After that 30 seconds,</br>the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup,</br>remove the pod from the API. In the presence of network partitions, this object may still</br>exist after this timestamp, until an administrator or automated process can determine the</br>resource is fully terminated.</br>If not set, graceful deletion of the object has not been requested.</br>Populated by the system when a graceful deletion is requested.</br>Read-only.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata </br>*Optional.*|  |
+| finalizers | []string| `[]string` |  | | Must be empty before the object is deleted from the registry. Each entry</br>is an identifier for the responsible component that will remove the entry</br>from the list. If the deletionTimestamp of the object is non-nil, entries</br>in this list can only be removed.</br>Finalizers may be processed and removed in any order.  Order is NOT enforced</br>because it introduces significant risk of stuck finalizers.</br>finalizers is a shared field, any actor with permission can reorder it.</br>If the finalizer list is processed in order, then this can lead to a situation</br>in which the component responsible for the first finalizer in the list is</br>waiting for a signal (field value, external system, or other) produced by a</br>component responsible for a finalizer later in the list, resulting in a deadlock.</br>Without enforced ordering finalizers are free to order amongst themselves and</br>are not vulnerable to ordering changes in the list. </br>*Optional.*|  |
+| generateName | string| `string` |  | | GenerateName is an optional prefix, used by the server, to generate a unique</br>name ONLY IF the Name field has not been provided.</br>If this field is used, the name returned to the client will be different</br>than the name passed. This value will also be combined with a unique suffix.</br>The provided value has the same validation rules as the Name field,</br>and may be truncated by the length of the suffix required to make the value</br>unique on the server.</br>If this field is specified and the generated name exists, the server will return a 409.</br>Applied only if Name is not specified.</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency </br>*Optional.*|  |
+| generation | int64 (formatted integer)| `int64` |  | | A sequence number representing a specific generation of the desired state.</br>Populated by the system. Read-only. </br>*Optional.*|  |
+| labels | map of string| `map[string]string` |  | | Map of string keys and values that can be used to organize and categorize</br>(scope and select) objects. May match selectors of replication controllers</br>and services.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels </br>*Optional.*|  |
+| managedFields | [][ManagedFieldsEntry](#managed-fields-entry)| `[]*ManagedFieldsEntry` |  | | ManagedFields maps workflow-id and version to the set of fields</br>that are managed by that workflow. This is mostly for internal</br>housekeeping, and users typically shouldn't need to set or</br>understand this field. A workflow can be the user's name, a</br>controller's name, or the name of a specific apply path like</br>"ci-cd". The set of fields is always in the version that the</br>workflow used when modifying the object.</br>*Optional.*|  |
+| name | string| `string` |  | | Name must be unique within a namespace. Is required when creating resources, although</br>some resources may allow a client to request the generation of an appropriate name</br>automatically. Name is primarily intended for creation idempotence and configuration</br>definition.</br>Cannot be updated.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names </br>*Optional.*|  |
+| namespace | string| `string` |  | | Namespace defines the space within which each name must be unique. An empty namespace is</br>equivalent to the "default" namespace, but "default" is the canonical representation.</br>Not all objects are required to be scoped to a namespace - the value of this field for</br>those objects will be empty.</br>Must be a DNS_LABEL.</br>Cannot be updated.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces </br>*Optional.*|  |
+| ownerReferences | [][OwnerReference](#owner-reference)| `[]*OwnerReference` |  | | List of objects depended by this object. If ALL objects in the list have</br>been deleted, this object will be garbage collected. If this object is managed by a controller,</br>then an entry in this list will point to this controller, with the controller field set to true.</br>There cannot be more than one managing controller. </br>*Optional.*|  |
+| resourceVersion | string| `string` |  | | An opaque value that represents the internal version of this object that can</br>be used by clients to determine when objects have changed. May be used for optimistic</br>concurrency, change detection, and the watch operation on a resource or set of resources.</br>Clients must treat these values as opaque and passed unmodified back to the server.</br>They may only be valid for a particular resource or set of resources.</br>Populated by the system.</br>Read-only.</br>Value must be treated as opaque by clients and .</br>More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency </br>*Optional.*|  |
+| selfLink | string| `string` |  | | Deprecated: selfLink is a legacy read-only field that is no longer populated by the system. </br>*Optional.*|  |
 | spec | [PersistentVolumeClaimSpec](#persistent-volume-claim-spec)| `PersistentVolumeClaimSpec` |  | |  |  |
 | uid | [UID](#uid)| `UID` |  | |  |  |
 
@@ -2749,21 +2722,20 @@ type of volume that is owned by someone else (the system).
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | claimName | string| `string` |  | | claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.</br>More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims |  |
-| readOnly | boolean| `bool` |  | | readOnly Will force the ReadOnly setting in VolumeMounts.</br>Default false.</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly Will force the ReadOnly setting in VolumeMounts.</br>Default false. </br>*Optional.*|  |
 
 
 
 ### <span id="persistent-volume-mode"></span> PersistentVolumeMode
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| PersistentVolumeMode | string| string | | +enum |  |
+| PersistentVolumeMode | string| string | |  |  |
 
 
 
@@ -2825,8 +2797,8 @@ type of volume that is owned by someone else (the system).
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| preferredDuringSchedulingIgnoredDuringExecution | [][WeightedPodAffinityTerm](#weighted-pod-affinity-term)| `[]*WeightedPodAffinityTerm` |  | | The scheduler will prefer to schedule pods to nodes that satisfy</br>the affinity expressions specified by this field, but it may choose</br>a node that violates one or more of the expressions. The node that is</br>most preferred is the one with the greatest sum of weights, i.e.</br>for each node that meets all of the scheduling requirements (resource</br>request, requiredDuringScheduling affinity expressions, etc.),</br>compute a sum by iterating through the elements of this field and adding</br>"weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the</br>node(s) with the highest sum are the most preferred.</br>+optional</br>+listType=atomic |  |
-| requiredDuringSchedulingIgnoredDuringExecution | [][PodAffinityTerm](#pod-affinity-term)| `[]*PodAffinityTerm` |  | | If the affinity requirements specified by this field are not met at</br>scheduling time, the pod will not be scheduled onto the node.</br>If the affinity requirements specified by this field cease to be met</br>at some point during pod execution (e.g. due to a pod label update), the</br>system may or may not try to eventually evict the pod from its node.</br>When there are multiple elements, the lists of nodes corresponding to each</br>podAffinityTerm are intersected, i.e. all terms must be satisfied.</br>+optional</br>+listType=atomic |  |
+| preferredDuringSchedulingIgnoredDuringExecution | [][WeightedPodAffinityTerm](#weighted-pod-affinity-term)| `[]*WeightedPodAffinityTerm` |  | | The scheduler will prefer to schedule pods to nodes that satisfy</br>the affinity expressions specified by this field, but it may choose</br>a node that violates one or more of the expressions. The node that is</br>most preferred is the one with the greatest sum of weights, i.e.</br>for each node that meets all of the scheduling requirements (resource</br>request, requiredDuringScheduling affinity expressions, etc.),</br>compute a sum by iterating through the elements of this field and adding</br>"weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the</br>node(s) with the highest sum are the most preferred. </br>*Optional.*|  |
+| requiredDuringSchedulingIgnoredDuringExecution | [][PodAffinityTerm](#pod-affinity-term)| `[]*PodAffinityTerm` |  | | If the affinity requirements specified by this field are not met at</br>scheduling time, the pod will not be scheduled onto the node.</br>If the affinity requirements specified by this field cease to be met</br>at some point during pod execution (e.g. due to a pod label update), the</br>system may or may not try to eventually evict the pod from its node.</br>When there are multiple elements, the lists of nodes corresponding to each</br>podAffinityTerm are intersected, i.e. all terms must be satisfied. </br>*Optional.*|  |
 
 
 
@@ -2850,10 +2822,10 @@ a pod of the set of pods is running
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | labelSelector | [LabelSelector](#label-selector)| `LabelSelector` |  | |  |  |
-| matchLabelKeys | []string| `[]string` |  | | MatchLabelKeys is a set of pod label keys to select which pods will</br>be taken into consideration. The keys are used to lookup values from the</br>incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`</br>to select the group of existing pods which pods will be taken into consideration</br>for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming</br>pod labels will be ignored. The default value is empty.</br>The same key is forbidden to exist in both matchLabelKeys and labelSelector.</br>Also, matchLabelKeys cannot be set when labelSelector isn't set.</br></br>+listType=atomic</br>+optional |  |
-| mismatchLabelKeys | []string| `[]string` |  | | MismatchLabelKeys is a set of pod label keys to select which pods will</br>be taken into consideration. The keys are used to lookup values from the</br>incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`</br>to select the group of existing pods which pods will be taken into consideration</br>for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming</br>pod labels will be ignored. The default value is empty.</br>The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.</br>Also, mismatchLabelKeys cannot be set when labelSelector isn't set.</br></br>+listType=atomic</br>+optional |  |
+| matchLabelKeys | []string| `[]string` |  | | MatchLabelKeys is a set of pod label keys to select which pods will</br>be taken into consideration. The keys are used to lookup values from the</br>incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`</br>to select the group of existing pods which pods will be taken into consideration</br>for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming</br>pod labels will be ignored. The default value is empty.</br>The same key is forbidden to exist in both matchLabelKeys and labelSelector.</br>Also, matchLabelKeys cannot be set when labelSelector isn't set.</br>*Optional.*|  |
+| mismatchLabelKeys | []string| `[]string` |  | | MismatchLabelKeys is a set of pod label keys to select which pods will</br>be taken into consideration. The keys are used to lookup values from the</br>incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`</br>to select the group of existing pods which pods will be taken into consideration</br>for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming</br>pod labels will be ignored. The default value is empty.</br>The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.</br>Also, mismatchLabelKeys cannot be set when labelSelector isn't set.</br>*Optional.*|  |
 | namespaceSelector | [LabelSelector](#label-selector)| `LabelSelector` |  | |  |  |
-| namespaces | []string| `[]string` |  | | namespaces specifies a static list of namespace names that the term applies to.</br>The term is applied to the union of the namespaces listed in this field</br>and the ones selected by namespaceSelector.</br>null or empty namespaces list and null namespaceSelector means "this pod's namespace".</br>+optional</br>+listType=atomic |  |
+| namespaces | []string| `[]string` |  | | namespaces specifies a static list of namespace names that the term applies to.</br>The term is applied to the union of the namespaces listed in this field</br>and the ones selected by namespaceSelector.</br>null or empty namespaces list and null namespaceSelector means "this pod's namespace". </br>*Optional.*|  |
 | topologyKey | string| `string` |  | | This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching</br>the labelSelector in the specified namespaces, where co-located is defined as running on a node</br>whose value of the label with key topologyKey matches that of any node on which any of the</br>selected pods is running.</br>Empty topologyKey is not allowed. |  |
 
 
@@ -2869,8 +2841,8 @@ a pod of the set of pods is running
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| preferredDuringSchedulingIgnoredDuringExecution | [][WeightedPodAffinityTerm](#weighted-pod-affinity-term)| `[]*WeightedPodAffinityTerm` |  | | The scheduler will prefer to schedule pods to nodes that satisfy</br>the anti-affinity expressions specified by this field, but it may choose</br>a node that violates one or more of the expressions. The node that is</br>most preferred is the one with the greatest sum of weights, i.e.</br>for each node that meets all of the scheduling requirements (resource</br>request, requiredDuringScheduling anti-affinity expressions, etc.),</br>compute a sum by iterating through the elements of this field and subtracting</br>"weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the</br>node(s) with the highest sum are the most preferred.</br>+optional</br>+listType=atomic |  |
-| requiredDuringSchedulingIgnoredDuringExecution | [][PodAffinityTerm](#pod-affinity-term)| `[]*PodAffinityTerm` |  | | If the anti-affinity requirements specified by this field are not met at</br>scheduling time, the pod will not be scheduled onto the node.</br>If the anti-affinity requirements specified by this field cease to be met</br>at some point during pod execution (e.g. due to a pod label update), the</br>system may or may not try to eventually evict the pod from its node.</br>When there are multiple elements, the lists of nodes corresponding to each</br>podAffinityTerm are intersected, i.e. all terms must be satisfied.</br>+optional</br>+listType=atomic |  |
+| preferredDuringSchedulingIgnoredDuringExecution | [][WeightedPodAffinityTerm](#weighted-pod-affinity-term)| `[]*WeightedPodAffinityTerm` |  | | The scheduler will prefer to schedule pods to nodes that satisfy</br>the anti-affinity expressions specified by this field, but it may choose</br>a node that violates one or more of the expressions. The node that is</br>most preferred is the one with the greatest sum of weights, i.e.</br>for each node that meets all of the scheduling requirements (resource</br>request, requiredDuringScheduling anti-affinity expressions, etc.),</br>compute a sum by iterating through the elements of this field and subtracting</br>"weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the</br>node(s) with the highest sum are the most preferred. </br>*Optional.*|  |
+| requiredDuringSchedulingIgnoredDuringExecution | [][PodAffinityTerm](#pod-affinity-term)| `[]*PodAffinityTerm` |  | | If the anti-affinity requirements specified by this field are not met at</br>scheduling time, the pod will not be scheduled onto the node.</br>If the anti-affinity requirements specified by this field cease to be met</br>at some point during pod execution (e.g. due to a pod label update), the</br>system may or may not try to eventually evict the pod from its node.</br>When there are multiple elements, the lists of nodes corresponding to each</br>podAffinityTerm are intersected, i.e. all terms must be satisfied. </br>*Optional.*|  |
 
 
 
@@ -2889,13 +2861,13 @@ pod filesystem.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| certificateChainPath | string| `string` |  | | Write the certificate chain at this path in the projected volume.</br></br>Most applications should use credentialBundlePath.  When using keyPath</br>and certificateChainPath, your application needs to check that the key</br>and leaf certificate are consistent, because it is possible to read the</br>files mid-rotation.</br></br>+optional |  |
-| credentialBundlePath | string| `string` |  | | Write the credential bundle at this path in the projected volume.</br></br>The credential bundle is a single file that contains multiple PEM blocks.</br>The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private</br>key.</br></br>The remaining blocks are CERTIFICATE blocks, containing the issued</br>certificate chain from the signer (leaf and any intermediates).</br></br>Using credentialBundlePath lets your Pod's application code make a single</br>atomic read that retrieves a consistent key and certificate chain.  If you</br>project them to separate files, your application code will need to</br>additionally check that the leaf certificate was issued to the key.</br></br>+optional |  |
-| keyPath | string| `string` |  | | Write the key at this path in the projected volume.</br></br>Most applications should use credentialBundlePath.  When using keyPath</br>and certificateChainPath, your application needs to check that the key</br>and leaf certificate are consistent, because it is possible to read the</br>files mid-rotation.</br></br>+optional |  |
-| keyType | string| `string` |  | | The type of keypair Kubelet will generate for the pod.</br></br>Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",</br>"ECDSAP521", and "ED25519".</br></br>+required |  |
-| maxExpirationSeconds | int32 (formatted integer)| `int32` |  | | maxExpirationSeconds is the maximum lifetime permitted for the</br>certificate.</br></br>Kubelet copies this value verbatim into the PodCertificateRequests it</br>generates for this projection.</br></br>If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver</br>will reject values shorter than 3600 (1 hour).  The maximum allowable</br>value is 7862400 (91 days).</br></br>The signer implementation is then free to issue a certificate with any</br>lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600</br>seconds (1 hour).  This constraint is enforced by kube-apiserver.</br>`kubernetes.io` signers will never issue certificates with a lifetime</br>longer than 24 hours.</br></br>+optional |  |
-| signerName | string| `string` |  | | Kubelet's generated CSRs will be addressed to this signer.</br></br>+required |  |
-| userAnnotations | map of string| `map[string]string` |  | | userAnnotations allow pod authors to pass additional information to</br>the signer implementation.  Kubernetes does not restrict or validate this</br>metadata in any way.</br></br>These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of</br>the PodCertificateRequest objects that Kubelet creates.</br></br>Entries are subject to the same validation as object metadata annotations,</br>with the addition that all keys must be domain-prefixed. No restrictions</br>are placed on values, except an overall size limitation on the entire field.</br></br>Signers should document the keys and values they support. Signers should</br>deny requests that contain keys they do not recognize. |  |
+| certificateChainPath | string| `string` |  | | Write the certificate chain at this path in the projected volume.</br>Most applications should use credentialBundlePath.  When using keyPath</br>and certificateChainPath, your application needs to check that the key</br>and leaf certificate are consistent, because it is possible to read the</br>files mid-rotation.</br>*Optional.*|  |
+| credentialBundlePath | string| `string` |  | | Write the credential bundle at this path in the projected volume.</br>The credential bundle is a single file that contains multiple PEM blocks.</br>The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private</br>key.</br>The remaining blocks are CERTIFICATE blocks, containing the issued</br>certificate chain from the signer (leaf and any intermediates).</br>Using credentialBundlePath lets your Pod's application code make a single</br>atomic read that retrieves a consistent key and certificate chain.  If you</br>project them to separate files, your application code will need to</br>additionally check that the leaf certificate was issued to the key.</br>*Optional.*|  |
+| keyPath | string| `string` |  | | Write the key at this path in the projected volume.</br>Most applications should use credentialBundlePath.  When using keyPath</br>and certificateChainPath, your application needs to check that the key</br>and leaf certificate are consistent, because it is possible to read the</br>files mid-rotation.</br>*Optional.*|  |
+| keyType | string| `string` |  | | The type of keypair Kubelet will generate for the pod.</br>Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",</br>"ECDSAP521", and "ED25519".|  |
+| maxExpirationSeconds | int32 (formatted integer)| `int32` |  | | maxExpirationSeconds is the maximum lifetime permitted for the</br>certificate.</br>Kubelet copies this value verbatim into the PodCertificateRequests it</br>generates for this projection.</br>If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver</br>will reject values shorter than 3600 (1 hour).  The maximum allowable</br>value is 7862400 (91 days).</br>The signer implementation is then free to issue a certificate with any</br>lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600</br>seconds (1 hour).  This constraint is enforced by kube-apiserver.</br>`kubernetes.io` signers will never issue certificates with a lifetime</br>longer than 24 hours.</br>*Optional.*|  |
+| signerName | string| `string` |  | | Kubelet's generated CSRs will be addressed to this signer.|  |
+| userAnnotations | map of string| `map[string]string` |  | | userAnnotations allow pod authors to pass additional information to</br>the signer implementation.  Kubernetes does not restrict or validate this</br>metadata in any way.</br>These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of</br>the PodCertificateRequest objects that Kubelet creates.</br>Entries are subject to the same validation as object metadata annotations,</br>with the addition that all keys must be domain-prefixed. No restrictions</br>are placed on values, except an overall size limitation on the entire field.</br>Signers should document the keys and values they support. Signers should</br>deny requests that contain keys they do not recognize. |  |
 
 
 
@@ -2904,14 +2876,13 @@ pod filesystem.
 
 > PodFSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume
 when volume is mounted.
-+enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| PodFSGroupChangePolicy | string| string | | PodFSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume</br>when volume is mounted.</br>+enum |  |
+| PodFSGroupChangePolicy | string| string | | PodFSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume</br>when volume is mounted.|  |
 
 
 
@@ -2942,17 +2913,17 @@ container.securityContext take precedence over field values of PodSecurityContex
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | appArmorProfile | [AppArmorProfile](#app-armor-profile)| `AppArmorProfile` |  | |  |  |
-| fsGroup | int64 (formatted integer)| `int64` |  | | A special supplemental group that applies to all containers in a pod.</br>Some volume types allow the Kubelet to change the ownership of that volume</br>to be owned by the pod:</br></br>1. The owning GID will be the FSGroup</br>2. The setgid bit is set (new files created in the volume will be owned by FSGroup)</br>3. The permission bits are OR'd with rw-rw----</br></br>If unset, the Kubelet will not modify the ownership and permissions of any volume.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
+| fsGroup | int64 (formatted integer)| `int64` |  | | A special supplemental group that applies to all containers in a pod.</br>Some volume types allow the Kubelet to change the ownership of that volume</br>to be owned by the pod:</br>1. The owning GID will be the FSGroup</br>2. The setgid bit is set (new files created in the volume will be owned by FSGroup)</br>3. The permission bits are OR'd with rw-rw----</br>If unset, the Kubelet will not modify the ownership and permissions of any volume.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | fsGroupChangePolicy | [PodFSGroupChangePolicy](#pod-f-s-group-change-policy)| `PodFSGroupChangePolicy` |  | |  |  |
-| runAsGroup | int64 (formatted integer)| `int64` |  | | The GID to run the entrypoint of the container process.</br>Uses runtime default if unset.</br>May also be set in SecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence</br>for that container.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
-| runAsNonRoot | boolean| `bool` |  | | Indicates that the container must run as a non-root user.</br>If true, the Kubelet will validate the image at runtime to ensure that it</br>does not run as UID 0 (root) and fail to start the container if it does.</br>If unset or false, no such validation will be performed.</br>May also be set in SecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>+optional |  |
-| runAsUser | int64 (formatted integer)| `int64` |  | | The UID to run the entrypoint of the container process.</br>Defaults to user specified in image metadata if unspecified.</br>May also be set in SecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence</br>for that container.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
+| runAsGroup | int64 (formatted integer)| `int64` |  | | The GID to run the entrypoint of the container process.</br>Uses runtime default if unset.</br>May also be set in SecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence</br>for that container.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
+| runAsNonRoot | boolean| `bool` |  | | Indicates that the container must run as a non-root user.</br>If true, the Kubelet will validate the image at runtime to ensure that it</br>does not run as UID 0 (root) and fail to start the container if it does.</br>If unset or false, no such validation will be performed.</br>May also be set in SecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence. </br>*Optional.*|  |
+| runAsUser | int64 (formatted integer)| `int64` |  | | The UID to run the entrypoint of the container process.</br>Defaults to user specified in image metadata if unspecified.</br>May also be set in SecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence</br>for that container.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | seLinuxChangePolicy | [PodSELinuxChangePolicy](#pod-s-e-linux-change-policy)| `PodSELinuxChangePolicy` |  | |  |  |
 | seLinuxOptions | [SELinuxOptions](#s-e-linux-options)| `SELinuxOptions` |  | |  |  |
 | seccompProfile | [SeccompProfile](#seccomp-profile)| `SeccompProfile` |  | |  |  |
-| supplementalGroups | []int64 (formatted integer)| `[]int64` |  | | A list of groups applied to the first process run in each container, in</br>addition to the container's primary GID and fsGroup (if specified).  If</br>the SupplementalGroupsPolicy feature is enabled, the</br>supplementalGroupsPolicy field determines whether these are in addition</br>to or instead of any group memberships defined in the container image.</br>If unspecified, no additional groups are added, though group memberships</br>defined in the container image may still be used, depending on the</br>supplementalGroupsPolicy field.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional</br>+listType=atomic |  |
+| supplementalGroups | []int64 (formatted integer)| `[]int64` |  | | A list of groups applied to the first process run in each container, in</br>addition to the container's primary GID and fsGroup (if specified).  If</br>the SupplementalGroupsPolicy feature is enabled, the</br>supplementalGroupsPolicy field determines whether these are in addition</br>to or instead of any group memberships defined in the container image.</br>If unspecified, no additional groups are added, though group memberships</br>defined in the container image may still be used, depending on the</br>supplementalGroupsPolicy field.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | supplementalGroupsPolicy | [SupplementalGroupsPolicy](#supplemental-groups-policy)| `SupplementalGroupsPolicy` |  | |  |  |
-| sysctls | [][Sysctl](#sysctl)| `[]*Sysctl` |  | | Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported</br>sysctls (by the container runtime) might fail to launch.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional</br>+listType=atomic |  |
+| sysctls | [][Sysctl](#sysctl)| `[]*Sysctl` |  | | Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported</br>sysctls (by the container runtime) might fail to launch.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | windowsOptions | [WindowsSecurityContextOptions](#windows-security-context-options)| `WindowsSecurityContextOptions` |  | |  |  |
 
 
@@ -2969,7 +2940,7 @@ container.securityContext take precedence over field values of PodSecurityContex
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | fsType | string| `string` |  | | fSType represents the filesystem type to mount</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified. |  |
-| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional |  |
+| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional.*|  |
 | volumeID | string| `string` |  | | volumeID uniquely identifies a Portworx volume |  |
 
 
@@ -3010,29 +2981,28 @@ alive or ready to receive traffic.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | exec | [ExecAction](#exec-action)| `ExecAction` |  | |  |  |
-| failureThreshold | int32 (formatted integer)| `int32` |  | | Minimum consecutive failures for the probe to be considered failed after having succeeded.</br>Defaults to 3. Minimum value is 1.</br>+optional |  |
+| failureThreshold | int32 (formatted integer)| `int32` |  | | Minimum consecutive failures for the probe to be considered failed after having succeeded.</br>Defaults to 3. Minimum value is 1. </br>*Optional.*|  |
 | grpc | [GRPCAction](#g-rpc-action)| `GRPCAction` |  | |  |  |
 | httpGet | [HTTPGetAction](#http-get-action)| `HTTPGetAction` |  | |  |  |
-| initialDelaySeconds | int32 (formatted integer)| `int32` |  | | Number of seconds after the container has started before liveness probes are initiated.</br>More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</br>+optional |  |
-| periodSeconds | int32 (formatted integer)| `int32` |  | | How often (in seconds) to perform the probe.</br>Default to 10 seconds. Minimum value is 1.</br>+optional |  |
-| successThreshold | int32 (formatted integer)| `int32` |  | | Minimum consecutive successes for the probe to be considered successful after having failed.</br>Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.</br>+optional |  |
+| initialDelaySeconds | int32 (formatted integer)| `int32` |  | | Number of seconds after the container has started before liveness probes are initiated.</br>More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes </br>*Optional.*|  |
+| periodSeconds | int32 (formatted integer)| `int32` |  | | How often (in seconds) to perform the probe.</br>Default to 10 seconds. Minimum value is 1. </br>*Optional.*|  |
+| successThreshold | int32 (formatted integer)| `int32` |  | | Minimum consecutive successes for the probe to be considered successful after having failed.</br>Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1. </br>*Optional.*|  |
 | tcpSocket | [TCPSocketAction](#tcp-socket-action)| `TCPSocketAction` |  | |  |  |
-| terminationGracePeriodSeconds | int64 (formatted integer)| `int64` |  | | Optional duration in seconds the pod needs to terminate gracefully upon probe failure.</br>The grace period is the duration in seconds after the processes running in the pod are sent</br>a termination signal and the time when the processes are forcibly halted with a kill signal.</br>Set this value longer than the expected cleanup time for your process.</br>If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this</br>value overrides the value provided by the pod spec.</br>Value must be non-negative integer. The value zero indicates stop immediately via</br>the kill signal (no opportunity to shut down).</br>This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.</br>Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.</br>+optional |  |
-| timeoutSeconds | int32 (formatted integer)| `int32` |  | | Number of seconds after which the probe times out.</br>Defaults to 1 second. Minimum value is 1.</br>More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes</br>+optional |  |
+| terminationGracePeriodSeconds | int64 (formatted integer)| `int64` |  | | Optional duration in seconds the pod needs to terminate gracefully upon probe failure.</br>The grace period is the duration in seconds after the processes running in the pod are sent</br>a termination signal and the time when the processes are forcibly halted with a kill signal.</br>Set this value longer than the expected cleanup time for your process.</br>If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this</br>value overrides the value provided by the pod spec.</br>Value must be non-negative integer. The value zero indicates stop immediately via</br>the kill signal (no opportunity to shut down).</br>This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.</br>Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset. </br>*Optional.*|  |
+| timeoutSeconds | int32 (formatted integer)| `int32` |  | | Number of seconds after which the probe times out.</br>Defaults to 1 second. Minimum value is 1.</br>More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes </br>*Optional.*|  |
 
 
 
 ### <span id="proc-mount-type"></span> ProcMountType
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| ProcMountType | string| string | | +enum |  |
+| ProcMountType | string| string | |  |  |
 
 
 
@@ -3061,8 +3031,8 @@ alive or ready to receive traffic.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| defaultMode | int32 (formatted integer)| `int32` |  | | defaultMode are the mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set.</br>+optional |  |
-| sources | [][VolumeProjection](#volume-projection)| `[]*VolumeProjection` |  | | sources is the list of volume projections. Each entry in this list</br>handles one source.</br>+optional</br>+listType=atomic |  |
+| defaultMode | int32 (formatted integer)| `int32` |  | | defaultMode are the mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set. </br>*Optional.*|  |
+| sources | [][VolumeProjection](#volume-projection)| `[]*VolumeProjection` |  | | sources is the list of volume projections. Each entry in this list</br>handles one source. </br>*Optional.*|  |
 
 
 
@@ -3082,10 +3052,10 @@ alive or ready to receive traffic.
 |------|------|---------|:--------:| ------- |-------------|---------|
 | counter | [Counter](#counter)| `Counter` |  | |  |  |
 | gauge | [Gauge](#gauge)| `Gauge` |  | |  |  |
-| help | string| `string` |  | | Help is a string that describes the metric</br>+kubebuilder:validation:MinLength=1 |  |
+| help | string| `string` |  | | Help is a string that describes the metric </br>*Minimum length: 1.*|  |
 | histogram | [Histogram](#histogram)| `Histogram` |  | |  |  |
 | labels | [][MetricLabel](#metric-label)| `[]*MetricLabel` |  | | Labels is a list of metric labels |  |
-| name | string| `string` |  | | Name is the name of the metric</br>+kubebuilder:validation:Pattern=`^[a-zA-Z_][a-zA-Z0-9_]*$` |  |
+| name | string| `string` |  | | Name is the name of the metric </br>*Validation regex: `^[a-zA-Z_][a-zA-Z0-9_]*$`.*|  |
 | when | string| `string` |  | | When is a conditional statement that decides when to emit the metric |  |
 
 
@@ -3093,14 +3063,13 @@ alive or ready to receive traffic.
 ### <span id="protocol"></span> Protocol
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| Protocol | string| string | | +enum |  |
+| Protocol | string| string | |  |  |
 
 
 
@@ -3108,14 +3077,13 @@ alive or ready to receive traffic.
 
 
 > PullPolicy describes a policy for if/when to pull a container image
-+enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| PullPolicy | string| string | | PullPolicy describes a policy for if/when to pull a container image</br>+enum |  |
+| PullPolicy | string| string | | PullPolicy describes a policy for if/when to pull a container image|  |
 
 
 
@@ -3181,13 +3149,9 @@ This format is intended to make it difficult to use these numbers without
 writing some sort of special handling code in the hopes that that will
 cause implementors to also use a fixed point implementation.
 
-+protobuf=true
-+protobuf.embed=string
-+protobuf.options.marshal=false
-+protobuf.options.(gogoproto.goproto_stringer)=false
-+k8s:deepcopy-gen=true
-+k8s:openapi-gen=true
-+k8s:openapi-model-package=io.k8s.apimachinery.pkg.api.resource
+
+
+
   
 
 
@@ -3208,11 +3172,11 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| group | string| `string` |  | | group to map volume access to</br>Default is no group</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly here will force the Quobyte volume to be mounted with read-only permissions.</br>Defaults to false.</br>+optional |  |
+| group | string| `string` |  | | group to map volume access to</br>Default is no group </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly here will force the Quobyte volume to be mounted with read-only permissions.</br>Defaults to false. </br>*Optional.*|  |
 | registry | string| `string` |  | | registry represents a single or multiple Quobyte Registry services</br>specified as a string as host:port pair (multiple entries are separated with commas)</br>which acts as the central registry for volumes |  |
-| tenant | string| `string` |  | | tenant owning the given Quobyte volume in the Backend</br>Used with dynamically provisioned Quobyte volumes, value is set by the plugin</br>+optional |  |
-| user | string| `string` |  | | user to map volume access to</br>Defaults to serivceaccount user</br>+optional |  |
+| tenant | string| `string` |  | | tenant owning the given Quobyte volume in the Backend</br>Used with dynamically provisioned Quobyte volumes, value is set by the plugin </br>*Optional.*|  |
+| user | string| `string` |  | | user to map volume access to</br>Defaults to serivceaccount user </br>*Optional.*|  |
 | volume | string| `string` |  | | volume is a string that references an already created Quobyte volume by name. |  |
 
 
@@ -3231,14 +3195,14 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is the filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd</br>TODO: how do we prevent errors in the filesystem from compromising the machine</br>+optional |  |
+| fsType | string| `string` |  | | fsType is the filesystem type of the volume that you want to mount.</br>Tip: Ensure that the filesystem type is supported by the host operating system.</br>Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd</br>TODO: how do we prevent errors in the filesystem from compromising the machine </br>*Optional.*|  |
 | image | string| `string` |  | | image is the rados image name.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it |  |
-| keyring | string| `string` |  | | keyring is the path to key ring for RBDUser.</br>Default is /etc/ceph/keyring.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it</br>+optional</br>+default="/etc/ceph/keyring" |  |
-| monitors | []string| `[]string` |  | | monitors is a collection of Ceph monitors.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it</br>+listType=atomic |  |
-| pool | string| `string` |  | | pool is the rados pool name.</br>Default is rbd.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it</br>+optional</br>+default="rbd" |  |
-| readOnly | boolean| `bool` |  | | readOnly here will force the ReadOnly setting in VolumeMounts.</br>Defaults to false.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it</br>+optional |  |
+| keyring | string| `string` |  | | keyring is the path to key ring for RBDUser.</br>Default is /etc/ceph/keyring.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it </br>*Optional; Default value: "/etc/ceph/keyring".*|  |
+| monitors | []string| `[]string` |  | | monitors is a collection of Ceph monitors.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it |  |
+| pool | string| `string` |  | | pool is the rados pool name.</br>Default is rbd.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it </br>*Optional; Default value: "rbd".*|  |
+| readOnly | boolean| `bool` |  | | readOnly here will force the ReadOnly setting in VolumeMounts.</br>Defaults to false.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
-| user | string| `string` |  | | user is the rados user name.</br>Default is admin.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it</br>+optional</br>+default="admin" |  |
+| user | string| `string` |  | | user is the rados user name.</br>Default is admin.</br>More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it </br>*Optional; Default value: "admin".*|  |
 
 
 
@@ -3283,7 +3247,7 @@ cause implementors to also use a fixed point implementation.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | name | string| `string` |  | | Name must match the name of one entry in pod.spec.resourceClaims of</br>the Pod where this field is used. It makes that resource available</br>inside a container. |  |
-| request | string| `string` |  | | Request is the name chosen for a request in the referenced claim.</br>If empty, everything from the claim is made available, otherwise</br>only the result of this request.</br></br>+optional |  |
+| request | string| `string` |  | | Request is the name chosen for a request in the referenced claim.</br>If empty, everything from the claim is made available, otherwise</br>only the result of this request.</br>*Optional.*|  |
 
 
 
@@ -3291,7 +3255,6 @@ cause implementors to also use a fixed point implementation.
 
 
 > ResourceFieldSelector represents container resources (cpu, memory) and their output format
-+structType=atomic
   
 
 
@@ -3302,7 +3265,7 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| containerName | string| `string` |  | | Container name: required for volumes, optional for env vars</br>+optional |  |
+| containerName | string| `string` |  | | Container name: required for volumes, optional for env vars </br>*Optional.*|  |
 | divisor | [Quantity](#quantity)| `Quantity` |  | |  |  |
 | resource | string| `string` |  | | Required: resource to select |  |
 
@@ -3337,7 +3300,7 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| claims | [][ResourceClaim](#resource-claim)| `[]*ResourceClaim` |  | | Claims lists the names of resources, defined in spec.resourceClaims,</br>that are used by this container.</br></br>This field depends on the</br>DynamicResourceAllocation feature gate.</br></br>This field is immutable. It can only be set for containers.</br></br>+listType=map</br>+listMapKey=name</br>+featureGate=DynamicResourceAllocation</br>+optional |  |
+| claims | [][ResourceClaim](#resource-claim)| `[]*ResourceClaim` |  | | Claims lists the names of resources, defined in spec.resourceClaims,</br>that are used by this container.</br>This field depends on the</br>DynamicResourceAllocation feature gate.</br>This field is immutable. It can only be set for containers.</br>*Optional.*|  |
 | limits | [ResourceList](#resource-list)| `ResourceList` |  | |  |  |
 | requests | [ResourceList](#resource-list)| `ResourceList` |  | |  |  |
 
@@ -3358,7 +3321,6 @@ cause implementors to also use a fixed point implementation.
 
 
 > ResourceTemplate is a template subtype to manipulate kubernetes resources
-+kubebuilder:validation:XValidation:rule="(has(self.manifest) && !has(self.manifestFrom)) || (!has(self.manifest) && has(self.manifestFrom)) || (!has(self.manifest) && !has(self.manifestFrom))",message="only one of manifest or manifestFrom can be specified"
   
 
 
@@ -3369,12 +3331,12 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| action | string| `string` |  | | Action is the action to perform to the resource.</br>Must be one of: get, create, apply, delete, replace, patch</br>+kubebuilder:validation:Enum=get;create;apply;delete;replace;patch |  |
+| action | string| `string` |  | | Action is the action to perform to the resource.</br>Must be one of: get, create, apply, delete, replace, patch </br>*Allowed values: get, create, apply, delete, replace, patch.*|  |
 | failureCondition | string| `string` |  | | FailureCondition is a label selector expression which describes the conditions</br>of the k8s resource in which the step was considered failed |  |
 | flags | []string| `[]string` |  | | Flags is a set of additional options passed to kubectl before submitting a resource</br>I.e. to disable resource validation:</br>flags: [</br>"--validate=false"  # disable resource validation</br>] |  |
 | manifest | string| `string` |  | | Manifest contains the kubernetes manifest |  |
 | manifestFrom | [ManifestFrom](#manifest-from)| `ManifestFrom` |  | |  |  |
-| mergeStrategy | string| `string` |  | | MergeStrategy is the strategy used to merge a patch. It defaults to "strategic"</br>Must be one of: strategic, merge, json</br>+kubebuilder:validation:Enum=strategic;merge;json |  |
+| mergeStrategy | string| `string` |  | | MergeStrategy is the strategy used to merge a patch. It defaults to "strategic"</br>Must be one of: strategic, merge, json </br>*Allowed values: strategic, merge, json.*|  |
 | setOwnerReference | boolean| `bool` |  | | SetOwnerReference sets the reference to the workflow on the OwnerReference of generated resource. |  |
 | successCondition | string| `string` |  | | SuccessCondition is a label selector expression which describes the conditions</br>of the k8s resource in which it is acceptable to proceed to the following step |  |
 
@@ -3408,14 +3370,13 @@ cause implementors to also use a fixed point implementation.
 ### <span id="retry-policy"></span> RetryPolicy
 
 
-> +kubebuilder:validation:Enum=Always;OnFailure;OnError;OnTransientError
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| RetryPolicy | string| string | | +kubebuilder:validation:Enum=Always;OnFailure;OnError;OnTransientError |  |
+| RetryPolicy | string| string | |  </br>*Allowed values: Always, OnFailure, OnError, OnTransientError.*|  |
 
 
 
@@ -3506,10 +3467,10 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| level | string| `string` |  | | Level is SELinux level label that applies to the container.</br>+optional |  |
-| role | string| `string` |  | | Role is a SELinux role label that applies to the container.</br>+optional |  |
-| type | string| `string` |  | | Type is a SELinux type label that applies to the container.</br>+optional |  |
-| user | string| `string` |  | | User is a SELinux user label that applies to the container.</br>+optional |  |
+| level | string| `string` |  | | Level is SELinux level label that applies to the container. </br>*Optional.*|  |
+| role | string| `string` |  | | Role is a SELinux role label that applies to the container. </br>*Optional.*|  |
+| type | string| `string` |  | | Type is a SELinux type label that applies to the container. </br>*Optional.*|  |
+| user | string| `string` |  | | User is a SELinux user label that applies to the container. </br>*Optional.*|  |
 
 
 
@@ -3527,14 +3488,14 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs".</br>Default is "xfs".</br>+optional</br>+default="xfs" |  |
+| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs".</br>Default is "xfs". </br>*Optional; Default value: "xfs".*|  |
 | gateway | string| `string` |  | | gateway is the host address of the ScaleIO API Gateway. |  |
-| protectionDomain | string| `string` |  | | protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional |  |
+| protectionDomain | string| `string` |  | | protectionDomain is the name of the ScaleIO Protection Domain for the configured storage. </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly Defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
-| sslEnabled | boolean| `bool` |  | | sslEnabled Flag enable/disable SSL communication with Gateway, default false</br>+optional |  |
-| storageMode | string| `string` |  | | storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.</br>Default is ThinProvisioned.</br>+optional</br>+default="ThinProvisioned" |  |
-| storagePool | string| `string` |  | | storagePool is the ScaleIO Storage Pool associated with the protection domain.</br>+optional |  |
+| sslEnabled | boolean| `bool` |  | | sslEnabled Flag enable/disable SSL communication with Gateway, default false </br>*Optional.*|  |
+| storageMode | string| `string` |  | | storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.</br>Default is ThinProvisioned. </br>*Optional; Default value: "ThinProvisioned".*|  |
+| storagePool | string| `string` |  | | storagePool is the ScaleIO Storage Pool associated with the protection domain. </br>*Optional.*|  |
 | system | string| `string` |  | | system is the name of the storage system as configured in ScaleIO. |  |
 | volumeName | string| `string` |  | | volumeName is the name of a volume already created in the ScaleIO system</br>that is associated with this volume source. |  |
 
@@ -3554,32 +3515,32 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=name</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=name |  |
-| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated.</br>+optional</br>+listType=atomic |  |
-| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets.</br>+optional |  |
+| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated. </br>*Optional.*|  |
+| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated. </br>*Optional.*|  |
+| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets. </br>*Optional.*|  |
 | imagePullPolicy | [PullPolicy](#pull-policy)| `PullPolicy` |  | |  |  |
 | lifecycle | [Lifecycle](#lifecycle)| `Lifecycle` |  | |  |  |
 | livenessProbe | [Probe](#probe)| `Probe` |  | |  |  |
 | name | string| `string` |  | | Name of the container specified as a DNS_LABEL.</br>Each container in a pod must have a unique name (DNS_LABEL).</br>Cannot be updated. |  |
-| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=containerPort</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=containerPort</br>+listMapKey=protocol |  |
+| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated. </br>*Optional.*|  |
 | readinessProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers.</br>+featureGate=InPlacePodVerticalScaling</br>+optional</br>+listType=atomic |  |
+| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers. </br>*Optional.*|  |
 | resources | [ResourceRequirements](#resource-requirements)| `ResourceRequirements` |  | |  |  |
 | restartPolicy | [ContainerRestartPolicy](#container-restart-policy)| `ContainerRestartPolicy` |  | |  |  |
-| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy.</br>+featureGate=ContainerRestartRules</br>+optional</br>+listType=atomic |  |
+| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy. </br>*Optional.*|  |
 | securityContext | [SecurityContext](#security-context)| `SecurityContext` |  | |  |  |
-| source | string| `string` |  | | Source contains the source code of the script to execute</br>+optional |  |
+| source | string| `string` |  | | Source contains the source code of the script to execute </br>*Optional.*|  |
 | startupProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false.</br>+optional |  |
-| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false</br>+optional |  |
-| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated.</br>+optional |  |
+| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false. </br>*Optional.*|  |
+| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false </br>*Optional.*|  |
+| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated. </br>*Optional.*|  |
 | terminationMessagePolicy | [TerminationMessagePolicy](#termination-message-policy)| `TerminationMessagePolicy` |  | |  |  |
-| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false.</br>+optional |  |
-| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container.</br>+patchMergeKey=devicePath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=devicePath</br>+optional |  |
-| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=mountPath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=mountPath |  |
-| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated.</br>+optional |  |
+| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false. </br>*Optional.*|  |
+| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container. </br>*Optional.*|  |
+| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated. </br>*Optional.*|  |
+| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated. </br>*Optional.*|  |
 
 
 
@@ -3587,7 +3548,6 @@ cause implementors to also use a fixed point implementation.
 
 
 > Only one profile source may be set.
-+union
   
 
 
@@ -3598,7 +3558,7 @@ cause implementors to also use a fixed point implementation.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| localhostProfile | string| `string` |  | | localhostProfile indicates a profile defined in a file on the node should be used.</br>The profile must be preconfigured on the node to work.</br>Must be a descending path, relative to the kubelet's configured seccomp profile location.</br>Must be set if type is "Localhost". Must NOT be set for any other type.</br>+optional |  |
+| localhostProfile | string| `string` |  | | localhostProfile indicates a profile defined in a file on the node should be used.</br>The profile must be preconfigured on the node to work.</br>Must be a descending path, relative to the kubelet's configured seccomp profile location.</br>Must be set if type is "Localhost". Must NOT be set for any other type. </br>*Optional.*|  |
 | type | [SeccompProfileType](#seccomp-profile-type)| `SeccompProfileType` |  | |  |  |
 
 
@@ -3606,14 +3566,13 @@ cause implementors to also use a fixed point implementation.
 ### <span id="seccomp-profile-type"></span> SeccompProfileType
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| SeccompProfileType | string| string | | +enum |  |
+| SeccompProfileType | string| string | |  |  |
 
 
 
@@ -3632,15 +3591,14 @@ key-value pairs as environment variables.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | Specify whether the Secret must be defined</br>+optional |  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | Specify whether the Secret must be defined </br>*Optional.*|  |
 
 
 
 ### <span id="secret-key-selector"></span> SecretKeySelector
 
 
-> +structType=atomic
   
 
 
@@ -3652,8 +3610,8 @@ key-value pairs as environment variables.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | key | string| `string` |  | | The key of the secret to select from.  Must be a valid secret key. |  |
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | Specify whether the Secret or its key must be defined</br>+optional |  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | Specify whether the Secret or its key must be defined </br>*Optional.*|  |
 
 
 
@@ -3674,9 +3632,9 @@ mode.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items if unspecified, each key-value pair in the Data field of the referenced</br>Secret will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the Secret,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'.</br>+optional</br>+listType=atomic |  |
-| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>+optional</br>+default=""</br>+kubebuilder:default=""</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. |  |
-| optional | boolean| `bool` |  | | optional field specify whether the Secret or its key must be defined</br>+optional |  |
+| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items if unspecified, each key-value pair in the Data field of the referenced</br>Secret will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the Secret,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'. </br>*Optional.*|  |
+| name | string| `string` |  | | Name of the referent.</br>This field is effectively required, but due to backwards compatibility is</br>allowed to be empty. Instances of this type with an empty value here are</br>almost certainly wrong.</br>More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names</br>TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896. </br>*Optional; Default value: "".*|  |
+| optional | boolean| `bool` |  | | optional field specify whether the Secret or its key must be defined </br>*Optional.*|  |
 
 
 
@@ -3696,10 +3654,10 @@ Secret volumes support ownership management and SELinux relabeling.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| defaultMode | int32 (formatted integer)| `int32` |  | | defaultMode is Optional: mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values</br>for mode bits. Defaults to 0644.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set.</br>+optional |  |
-| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items If unspecified, each key-value pair in the Data field of the referenced</br>Secret will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the Secret,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'.</br>+optional</br>+listType=atomic |  |
-| optional | boolean| `bool` |  | | optional field specify whether the Secret or its keys must be defined</br>+optional |  |
-| secretName | string| `string` |  | | secretName is the name of the secret in the pod's namespace to use.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#secret</br>+optional |  |
+| defaultMode | int32 (formatted integer)| `int32` |  | | defaultMode is Optional: mode bits used to set permissions on created files by default.</br>Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.</br>YAML accepts both octal and decimal values, JSON requires decimal values</br>for mode bits. Defaults to 0644.</br>Directories within the path are not affected by this setting.</br>This might be in conflict with other options that affect the file</br>mode, like fsGroup, and the result can be other mode bits set. </br>*Optional.*|  |
+| items | [][KeyToPath](#key-to-path)| `[]*KeyToPath` |  | | items If unspecified, each key-value pair in the Data field of the referenced</br>Secret will be projected into the volume as a file whose name is the</br>key and content is the value. If specified, the listed keys will be</br>projected into the specified paths, and unlisted keys will not be</br>present. If a key is specified which is not present in the Secret,</br>the volume setup will error unless it is marked optional. Paths must be</br>relative and may not contain the '..' path or start with '..'. </br>*Optional.*|  |
+| optional | boolean| `bool` |  | | optional field specify whether the Secret or its keys must be defined </br>*Optional.*|  |
+| secretName | string| `string` |  | | secretName is the name of the secret in the pod's namespace to use.</br>More info: https://kubernetes.io/docs/concepts/storage/volumes#secret </br>*Optional.*|  |
 
 
 
@@ -3718,15 +3676,15 @@ are set, the values in SecurityContext take precedence.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| allowPrivilegeEscalation | boolean| `bool` |  | | AllowPrivilegeEscalation controls whether a process can gain more</br>privileges than its parent process. This bool directly controls if</br>the no_new_privs flag will be set on the container process.</br>AllowPrivilegeEscalation is true always when the container is:</br>1) run as Privileged</br>2) has CAP_SYS_ADMIN</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
+| allowPrivilegeEscalation | boolean| `bool` |  | | AllowPrivilegeEscalation controls whether a process can gain more</br>privileges than its parent process. This bool directly controls if</br>the no_new_privs flag will be set on the container process.</br>AllowPrivilegeEscalation is true always when the container is:</br>1) run as Privileged</br>2) has CAP_SYS_ADMIN</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | appArmorProfile | [AppArmorProfile](#app-armor-profile)| `AppArmorProfile` |  | |  |  |
 | capabilities | [Capabilities](#capabilities)| `Capabilities` |  | |  |  |
-| privileged | boolean| `bool` |  | | Run container in privileged mode.</br>Processes in privileged containers are essentially equivalent to root on the host.</br>Defaults to false.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
+| privileged | boolean| `bool` |  | | Run container in privileged mode.</br>Processes in privileged containers are essentially equivalent to root on the host.</br>Defaults to false.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | procMount | [ProcMountType](#proc-mount-type)| `ProcMountType` |  | |  |  |
-| readOnlyRootFilesystem | boolean| `bool` |  | | Whether this container has a read-only root filesystem.</br>Default is false.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
-| runAsGroup | int64 (formatted integer)| `int64` |  | | The GID to run the entrypoint of the container process.</br>Uses runtime default if unset.</br>May also be set in PodSecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
-| runAsNonRoot | boolean| `bool` |  | | Indicates that the container must run as a non-root user.</br>If true, the Kubelet will validate the image at runtime to ensure that it</br>does not run as UID 0 (root) and fail to start the container if it does.</br>If unset or false, no such validation will be performed.</br>May also be set in PodSecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>+optional |  |
-| runAsUser | int64 (formatted integer)| `int64` |  | | The UID to run the entrypoint of the container process.</br>Defaults to user specified in image metadata if unspecified.</br>May also be set in PodSecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>Note that this field cannot be set when spec.os.name is windows.</br>+optional |  |
+| readOnlyRootFilesystem | boolean| `bool` |  | | Whether this container has a read-only root filesystem.</br>Default is false.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
+| runAsGroup | int64 (formatted integer)| `int64` |  | | The GID to run the entrypoint of the container process.</br>Uses runtime default if unset.</br>May also be set in PodSecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
+| runAsNonRoot | boolean| `bool` |  | | Indicates that the container must run as a non-root user.</br>If true, the Kubelet will validate the image at runtime to ensure that it</br>does not run as UID 0 (root) and fail to start the container if it does.</br>If unset or false, no such validation will be performed.</br>May also be set in PodSecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence. </br>*Optional.*|  |
+| runAsUser | int64 (formatted integer)| `int64` |  | | The UID to run the entrypoint of the container process.</br>Defaults to user specified in image metadata if unspecified.</br>May also be set in PodSecurityContext.  If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>Note that this field cannot be set when spec.os.name is windows. </br>*Optional.*|  |
 | seLinuxOptions | [SELinuxOptions](#s-e-linux-options)| `SELinuxOptions` |  | |  |  |
 | seccompProfile | [SeccompProfile](#seccomp-profile)| `SeccompProfile` |  | |  |  |
 | windowsOptions | [WindowsSecurityContextOptions](#windows-security-context-options)| `WindowsSecurityContextOptions` |  | |  |  |
@@ -3757,7 +3715,6 @@ are set, the values in SecurityContext take precedence.
 
 
 > Sequence expands a workflow step into numeric range
-+kubebuilder:validation:XValidation:rule="!(has(self.count) && has(self.end))",message="only one of count or end can be defined"
   
 
 
@@ -3792,8 +3749,8 @@ otherwise).
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| audience | string| `string` |  | | audience is the intended audience of the token. A recipient of a token</br>must identify itself with an identifier specified in the audience of the</br>token, and otherwise should reject the token. The audience defaults to the</br>identifier of the apiserver.</br>+optional |  |
-| expirationSeconds | int64 (formatted integer)| `int64` |  | | expirationSeconds is the requested duration of validity of the service</br>account token. As the token approaches expiration, the kubelet volume</br>plugin will proactively rotate the service account token. The kubelet will</br>start trying to rotate the token if the token is older than 80 percent of</br>its time to live or if the token is older than 24 hours.Defaults to 1 hour</br>and must be at least 10 minutes.</br>+optional |  |
+| audience | string| `string` |  | | audience is the intended audience of the token. A recipient of a token</br>must identify itself with an identifier specified in the audience of the</br>token, and otherwise should reject the token. The audience defaults to the</br>identifier of the apiserver. </br>*Optional.*|  |
+| expirationSeconds | int64 (formatted integer)| `int64` |  | | expirationSeconds is the requested duration of validity of the service</br>account token. As the token approaches expiration, the kubelet volume</br>plugin will proactively rotate the service account token. The kubelet will</br>start trying to rotate the token if the token is older than 80 percent of</br>its time to live or if the token is older than 24 hours.Defaults to 1 hour</br>and must be at least 10 minutes. </br>*Optional.*|  |
 | path | string| `string` |  | | path is the path relative to the mount point of the file to project the</br>token into. |  |
 
 
@@ -3802,14 +3759,13 @@ otherwise).
 
 
 > Signal defines the stop signal of containers
-+enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| Signal | string| string | | Signal defines the stop signal of containers</br>+enum |  |
+| Signal | string| string | | Signal defines the stop signal of containers|  |
 
 
 
@@ -3850,11 +3806,11 @@ otherwise).
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>+optional |  |
-| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts.</br>+optional |  |
+| fsType | string| `string` |  | | fsType is the filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. </br>*Optional.*|  |
+| readOnly | boolean| `bool` |  | | readOnly defaults to false (read/write). ReadOnly here will force</br>the ReadOnly setting in VolumeMounts. </br>*Optional.*|  |
 | secretRef | [LocalObjectReference](#local-object-reference)| `LocalObjectReference` |  | |  |  |
 | volumeName | string| `string` |  | | volumeName is the human-readable name of the StorageOS volume.  Volume</br>names are only unique within a namespace. |  |
-| volumeNamespace | string| `string` |  | | volumeNamespace specifies the scope of the volume within StorageOS.  If no</br>namespace is specified then the Pod's namespace will be used.  This allows the</br>Kubernetes name scoping to be mirrored within StorageOS for tighter integration.</br>Set VolumeName to any name to override the default behaviour.</br>Set to "default" if you are not using namespaces within StorageOS.</br>Namespaces that do not pre-exist within StorageOS will be created.</br>+optional |  |
+| volumeNamespace | string| `string` |  | | volumeNamespace specifies the scope of the volume within StorageOS.  If no</br>namespace is specified then the Pod's namespace will be used.  This allows the</br>Kubernetes name scoping to be mirrored within StorageOS for tighter integration.</br>Set VolumeName to any name to override the default behaviour.</br>Set to "default" if you are not using namespaces within StorageOS.</br>Namespaces that do not pre-exist within StorageOS will be created. </br>*Optional.*|  |
 
 
 
@@ -3863,14 +3819,13 @@ otherwise).
 
 > SupplementalGroupsPolicy defines how supplemental groups
 of the first container processes are calculated.
-+enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| SupplementalGroupsPolicy | string| string | | SupplementalGroupsPolicy defines how supplemental groups</br>of the first container processes are calculated.</br>+enum |  |
+| SupplementalGroupsPolicy | string| string | | SupplementalGroupsPolicy defines how supplemental groups</br>of the first container processes are calculated.|  |
 
 
 
@@ -3966,7 +3921,7 @@ of the first container processes are calculated.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| host | string| `string` |  | | Optional: Host name to connect to, defaults to the pod IP.</br>+optional |  |
+| host | string| `string` |  | | Optional: Host name to connect to, defaults to the pod IP. </br>*Optional.*|  |
 | port | [IntOrString](#int-or-string)| `IntOrString` |  | |  |  |
 
 
@@ -3974,14 +3929,13 @@ of the first container processes are calculated.
 ### <span id="taint-effect"></span> TaintEffect
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| TaintEffect | string| string | | +enum |  |
+| TaintEffect | string| string | |  |  |
 
 
 
@@ -4029,33 +3983,33 @@ of the first container processes are calculated.
 | data | [Data](#data)| `Data` |  | |  |  |
 | executor | [ExecutorConfig](#executor-config)| `ExecutorConfig` |  | |  |  |
 | failFast | boolean| `bool` |  | | FailFast, if specified, will fail this template if any of its child pods has failed. This is useful for when this</br>template is expanded with `withItems`, etc. |  |
-| hostAliases | [][HostAlias](#host-alias)| `[]*HostAlias` |  | | HostAliases is an optional list of hosts and IPs that will be injected into the pod spec</br>+patchStrategy=merge</br>+patchMergeKey=ip |  |
+| hostAliases | [][HostAlias](#host-alias)| `[]*HostAlias` |  | | HostAliases is an optional list of hosts and IPs that will be injected into the pod spec |  |
 | http | [HTTP](#http)| `HTTP` |  | |  |  |
-| initContainers | [][UserContainer](#user-container)| `[]*UserContainer` |  | | InitContainers is a list of containers which run before the main container.</br>+patchStrategy=merge</br>+patchMergeKey=name |  |
+| initContainers | [][UserContainer](#user-container)| `[]*UserContainer` |  | | InitContainers is a list of containers which run before the main container. |  |
 | inputs | [Inputs](#inputs)| `Inputs` |  | |  |  |
 | memoize | [Memoize](#memoize)| `Memoize` |  | |  |  |
 | metadata | [Metadata](#metadata)| `Metadata` |  | |  |  |
 | metrics | [Metrics](#metrics)| `Metrics` |  | |  |  |
-| name | string| `string` |  | | Name is the name of the template</br>+kubebuilder:validation:MaxLength=128</br>+kubebuilder:validation:Pattern=`^[a-zA-Z0-9][-a-zA-Z0-9]*$` |  |
+| name | string| `string` |  | | Name is the name of the template </br>*Maximum length: 128; Validation regex: `^[a-zA-Z0-9][-a-zA-Z0-9]*$`.*|  |
 | nodeSelector | map of string| `map[string]string` |  | | NodeSelector is a selector to schedule this step of the workflow to be</br>run on the selected node(s). Overrides the selector set at the workflow level. |  |
 | outputs | [Outputs](#outputs)| `Outputs` |  | |  |  |
-| parallelism | int64 (formatted integer)| `int64` |  | | Parallelism limits the max total parallel pods that can execute at the same time within the</br>boundaries of this template invocation. If additional steps/dag templates are invoked, the</br>pods created by those templates will not be counted towards this total.</br>+kubebuilder:validation:Minimum=1 |  |
+| parallelism | int64 (formatted integer)| `int64` |  | | Parallelism limits the max total parallel pods that can execute at the same time within the</br>boundaries of this template invocation. If additional steps/dag templates are invoked, the</br>pods created by those templates will not be counted towards this total. </br>*Minimum value: 1.*|  |
 | plugin | [Plugin](#plugin)| `Plugin` |  | |  |  |
 | podSpecPatch | string| `string` |  | | PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of</br>container fields which are not strings (e.g. resource limits). |  |
 | priorityClassName | string| `string` |  | | PriorityClassName to apply to workflow pods. |  |
 | resource | [ResourceTemplate](#resource-template)| `ResourceTemplate` |  | |  |  |
 | retryStrategy | [RetryStrategy](#retry-strategy)| `RetryStrategy` |  | |  |  |
-| schedulerName | string| `string` |  | | If specified, the pod will be dispatched by specified scheduler.</br>Or it will be dispatched by workflow scope scheduler if specified.</br>If neither specified, the pod will be dispatched by default scheduler.</br>+optional |  |
+| schedulerName | string| `string` |  | | If specified, the pod will be dispatched by specified scheduler.</br>Or it will be dispatched by workflow scope scheduler if specified.</br>If neither specified, the pod will be dispatched by default scheduler. </br>*Optional.*|  |
 | script | [ScriptTemplate](#script-template)| `ScriptTemplate` |  | |  |  |
 | securityContext | [PodSecurityContext](#pod-security-context)| `PodSecurityContext` |  | |  |  |
 | serviceAccountName | string| `string` |  | | ServiceAccountName to apply to workflow pods |  |
-| sidecars | [][UserContainer](#user-container)| `[]*UserContainer` |  | | Sidecars is a list of containers which run alongside the main container</br>Sidecars are automatically killed when the main container completes</br>+patchStrategy=merge</br>+patchMergeKey=name |  |
-| steps | [][ParallelSteps](#parallel-steps)| `[]ParallelSteps` |  | | Steps define a series of sequential/parallel workflow steps</br>+kubebuilder:validation:MinItems=1 |  |
+| sidecars | [][UserContainer](#user-container)| `[]*UserContainer` |  | | Sidecars is a list of containers which run alongside the main container</br>Sidecars are automatically killed when the main container completes |  |
+| steps | [][ParallelSteps](#parallel-steps)| `[]ParallelSteps` |  | | Steps define a series of sequential/parallel workflow steps </br>*Minimum items: 1.*|  |
 | suspend | [SuspendTemplate](#suspend-template)| `SuspendTemplate` |  | |  |  |
 | synchronization | [Synchronization](#synchronization)| `Synchronization` |  | |  |  |
 | timeout | string| `string` |  | | Timeout allows to set the total node execution timeout duration counting from the node's start time.</br>This duration also includes time in which the node spends in Pending state. This duration may not be applied to Step or DAG templates. |  |
-| tolerations | [][Toleration](#toleration)| `[]*Toleration` |  | | Tolerations to apply to workflow pods.</br>+patchStrategy=merge</br>+patchMergeKey=key |  |
-| volumes | [][Volume](#volume)| `[]*Volume` |  | | Volumes is a list of volumes that can be mounted by containers in a template.</br>+patchStrategy=merge</br>+patchMergeKey=name |  |
+| tolerations | [][Toleration](#toleration)| `[]*Toleration` |  | | Tolerations to apply to workflow pods. |  |
+| volumes | [][Volume](#volume)| `[]*Volume` |  | | Volumes is a list of volumes that can be mounted by containers in a template. |  |
 
 
 
@@ -4079,14 +4033,13 @@ of the first container processes are calculated.
 ### <span id="termination-message-policy"></span> TerminationMessagePolicy
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| TerminationMessagePolicy | string| string | | +enum |  |
+| TerminationMessagePolicy | string| string | |  |  |
 
 
 
@@ -4106,24 +4059,23 @@ the triple <key,value,effect> using the matching operator <operator>.
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | effect | [TaintEffect](#taint-effect)| `TaintEffect` |  | |  |  |
-| key | string| `string` |  | | Key is the taint key that the toleration applies to. Empty means match all taint keys.</br>If the key is empty, operator must be Exists; this combination means to match all values and all keys.</br>+optional |  |
+| key | string| `string` |  | | Key is the taint key that the toleration applies to. Empty means match all taint keys.</br>If the key is empty, operator must be Exists; this combination means to match all values and all keys. </br>*Optional.*|  |
 | operator | [TolerationOperator](#toleration-operator)| `TolerationOperator` |  | |  |  |
-| tolerationSeconds | int64 (formatted integer)| `int64` |  | | TolerationSeconds represents the period of time the toleration (which must be</br>of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,</br>it is not set, which means tolerate the taint forever (do not evict). Zero and</br>negative values will be treated as 0 (evict immediately) by the system.</br>+optional |  |
-| value | string| `string` |  | | Value is the taint value the toleration matches to.</br>If the operator is Exists, the value should be empty, otherwise just a regular string.</br>+optional |  |
+| tolerationSeconds | int64 (formatted integer)| `int64` |  | | TolerationSeconds represents the period of time the toleration (which must be</br>of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,</br>it is not set, which means tolerate the taint forever (do not evict). Zero and</br>negative values will be treated as 0 (evict immediately) by the system. </br>*Optional.*|  |
+| value | string| `string` |  | | Value is the taint value the toleration matches to.</br>If the operator is Exists, the value should be empty, otherwise just a regular string. </br>*Optional.*|  |
 
 
 
 ### <span id="toleration-operator"></span> TolerationOperator
 
 
-> +enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| TolerationOperator | string| string | | +enum |  |
+| TolerationOperator | string| string | |  |  |
 
 
 
@@ -4176,7 +4128,6 @@ will affect numerous schemas.  Don't make new APIs embed an underspecified API t
 
 Instead of using this type, create a locally provided and used type that is well-focused on your reference.
 For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
-+structType=atomic
   
 
 
@@ -4187,7 +4138,7 @@ For example, ServiceReferences for admission registration: https://github.com/ku
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| apiGroup | string| `string` |  | | APIGroup is the group for the resource being referenced.</br>If APIGroup is not specified, the specified Kind must be in the core API group.</br>For any other third-party types, APIGroup is required.</br>+optional |  |
+| apiGroup | string| `string` |  | | APIGroup is the group for the resource being referenced.</br>If APIGroup is not specified, the specified Kind must be in the core API group.</br>For any other third-party types, APIGroup is required. </br>*Optional.*|  |
 | kind | string| `string` |  | | Kind is the type of resource being referenced |  |
 | name | string| `string` |  | | Name is the name of resource being referenced |  |
 
@@ -4207,10 +4158,10 @@ For example, ServiceReferences for admission registration: https://github.com/ku
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| apiGroup | string| `string` |  | | APIGroup is the group for the resource being referenced.</br>If APIGroup is not specified, the specified Kind must be in the core API group.</br>For any other third-party types, APIGroup is required.</br>+optional |  |
+| apiGroup | string| `string` |  | | APIGroup is the group for the resource being referenced.</br>If APIGroup is not specified, the specified Kind must be in the core API group.</br>For any other third-party types, APIGroup is required. </br>*Optional.*|  |
 | kind | string| `string` |  | | Kind is the type of resource being referenced |  |
 | name | string| `string` |  | | Name is the name of resource being referenced |  |
-| namespace | string| `string` |  | | Namespace is the namespace of resource being referenced</br>Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.</br>(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.</br>+featureGate=CrossNamespaceVolumeDataSource</br>+optional |  |
+| namespace | string| `string` |  | | Namespace is the namespace of resource being referenced</br>Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.</br>(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled. </br>*Optional.*|  |
 
 
 
@@ -4234,14 +4185,13 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 
 > URIScheme identifies the scheme used for connection to a host for Get actions
-+enum
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| URIScheme | string| string | | URIScheme identifies the scheme used for connection to a host for Get actions</br>+enum |  |
+| URIScheme | string| string | | URIScheme identifies the scheme used for connection to a host for Get actions|  |
 
 
 
@@ -4256,32 +4206,32 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell</br>+optional</br>+listType=atomic |  |
-| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=name</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=name |  |
-| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated.</br>+optional</br>+listType=atomic |  |
-| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets.</br>+optional |  |
+| args | []string| `[]string` |  | | Arguments to the entrypoint.</br>The container image's CMD is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| command | []string| `[]string` |  | | Entrypoint array. Not executed within a shell.</br>The container image's ENTRYPOINT is used if this is not provided.</br>Variable references $(VAR_NAME) are expanded using the container's environment. If a variable</br>cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced</br>to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will</br>produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless</br>of whether the variable exists or not. Cannot be updated.</br>More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell </br>*Optional.*|  |
+| env | [][EnvVar](#env-var)| `[]*EnvVar` |  | | List of environment variables to set in the container.</br>Cannot be updated. </br>*Optional.*|  |
+| envFrom | [][EnvFromSource](#env-from-source)| `[]*EnvFromSource` |  | | List of sources to populate environment variables in the container.</br>The keys defined within a source may consist of any printable ASCII characters except '='.</br>When a key exists in multiple</br>sources, the value associated with the last source will take precedence.</br>Values defined by an Env with a duplicate key will take precedence.</br>Cannot be updated. </br>*Optional.*|  |
+| image | string| `string` |  | | Container image name.</br>More info: https://kubernetes.io/docs/concepts/containers/images</br>This field is optional to allow higher level config management to default or override</br>container images in workload controllers like Deployments and StatefulSets. </br>*Optional.*|  |
 | imagePullPolicy | [PullPolicy](#pull-policy)| `PullPolicy` |  | |  |  |
 | lifecycle | [Lifecycle](#lifecycle)| `Lifecycle` |  | |  |  |
 | livenessProbe | [Probe](#probe)| `Probe` |  | |  |  |
 | mirrorVolumeMounts | boolean| `bool` |  | | MirrorVolumeMounts will mount the same volumes specified in the main container</br>to the container (including artifacts), at the same mountPaths. This enables</br>dind daemon to partially see the same filesystem as the main container in</br>order to use features such as docker volume binding |  |
 | name | string| `string` |  | | Name of the container specified as a DNS_LABEL.</br>Each container in a pod must have a unique name (DNS_LABEL).</br>Cannot be updated. |  |
-| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=containerPort</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=containerPort</br>+listMapKey=protocol |  |
+| ports | [][ContainerPort](#container-port)| `[]*ContainerPort` |  | | List of ports to expose from the container. Not specifying a port here</br>DOES NOT prevent that port from being exposed. Any port which is</br>listening on the default "0.0.0.0" address inside a container will be</br>accessible from the network.</br>Modifying this array with strategic merge patch may corrupt the data.</br>For more information See https://github.com/kubernetes/kubernetes/issues/108255.</br>Cannot be updated. </br>*Optional.*|  |
 | readinessProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers.</br>+featureGate=InPlacePodVerticalScaling</br>+optional</br>+listType=atomic |  |
+| resizePolicy | [][ContainerResizePolicy](#container-resize-policy)| `[]*ContainerResizePolicy` |  | | Resources resize policy for the container.</br>This field cannot be set on ephemeral containers. </br>*Optional.*|  |
 | resources | [ResourceRequirements](#resource-requirements)| `ResourceRequirements` |  | |  |  |
 | restartPolicy | [ContainerRestartPolicy](#container-restart-policy)| `ContainerRestartPolicy` |  | |  |  |
-| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy.</br>+featureGate=ContainerRestartRules</br>+optional</br>+listType=atomic |  |
+| restartPolicyRules | [][ContainerRestartRule](#container-restart-rule)| `[]*ContainerRestartRule` |  | | Represents a list of rules to be checked to determine if the</br>container should be restarted on exit. The rules are evaluated in</br>order. Once a rule matches a container exit condition, the remaining</br>rules are ignored. If no rule matches the container exit condition,</br>the Container-level restart policy determines the whether the container</br>is restarted or not. Constraints on the rules:</br>At most 20 rules are allowed.</br>Rules can have the same action.</br>Identical rules are not forbidden in validations.</br>When rules are specified, container MUST set RestartPolicy explicitly</br>even it if matches the Pod's RestartPolicy. </br>*Optional.*|  |
 | securityContext | [SecurityContext](#security-context)| `SecurityContext` |  | |  |  |
 | startupProbe | [Probe](#probe)| `Probe` |  | |  |  |
-| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false.</br>+optional |  |
-| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false</br>+optional |  |
-| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated.</br>+optional |  |
+| stdin | boolean| `bool` |  | | Whether this container should allocate a buffer for stdin in the container runtime. If this</br>is not set, reads from stdin in the container will always result in EOF.</br>Default is false. </br>*Optional.*|  |
+| stdinOnce | boolean| `bool` |  | | Whether the container runtime should close the stdin channel after it has been opened by</br>a single attach. When stdin is true the stdin stream will remain open across multiple attach</br>sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the</br>first client attaches to stdin, and then remains open and accepts data until the client disconnects,</br>at which time stdin is closed and remains closed until the container is restarted. If this</br>flag is false, a container processes that reads from stdin will never receive an EOF.</br>Default is false </br>*Optional.*|  |
+| terminationMessagePath | string| `string` |  | | Optional: Path at which the file to which the container's termination message</br>will be written is mounted into the container's filesystem.</br>Message written is intended to be brief final status, such as an assertion failure message.</br>Will be truncated by the node if greater than 4096 bytes. The total message length across</br>all containers will be limited to 12kb.</br>Defaults to /dev/termination-log.</br>Cannot be updated. </br>*Optional.*|  |
 | terminationMessagePolicy | [TerminationMessagePolicy](#termination-message-policy)| `TerminationMessagePolicy` |  | |  |  |
-| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false.</br>+optional |  |
-| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container.</br>+patchMergeKey=devicePath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=devicePath</br>+optional |  |
-| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated.</br>+optional</br>+patchMergeKey=mountPath</br>+patchStrategy=merge</br>+listType=map</br>+listMapKey=mountPath |  |
-| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated.</br>+optional |  |
+| tty | boolean| `bool` |  | | Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.</br>Default is false. </br>*Optional.*|  |
+| volumeDevices | [][VolumeDevice](#volume-device)| `[]*VolumeDevice` |  | | volumeDevices is the list of block devices to be used by the container. </br>*Optional.*|  |
+| volumeMounts | [][VolumeMount](#volume-mount)| `[]*VolumeMount` |  | | Pod volumes to mount into the container's filesystem.</br>Cannot be updated. </br>*Optional.*|  |
+| workingDir | string| `string` |  | | Container's working directory.</br>If not specified, the container runtime's default will be used, which</br>might be configured in the container image.</br>Cannot be updated. </br>*Optional.*|  |
 
 
 
@@ -4386,10 +4336,10 @@ intent and helps make sure that UIDs and names do not get conflated.
 | mountPath | string| `string` |  | | Path within the container at which the volume should be mounted.  Must</br>not contain ':'. |  |
 | mountPropagation | [MountPropagationMode](#mount-propagation-mode)| `MountPropagationMode` |  | |  |  |
 | name | string| `string` |  | | This must match the Name of a Volume. |  |
-| readOnly | boolean| `bool` |  | | Mounted read-only if true, read-write otherwise (false or unspecified).</br>Defaults to false.</br>+optional |  |
+| readOnly | boolean| `bool` |  | | Mounted read-only if true, read-write otherwise (false or unspecified).</br>Defaults to false. </br>*Optional.*|  |
 | recursiveReadOnly | [RecursiveReadOnlyMode](#recursive-read-only-mode)| `RecursiveReadOnlyMode` |  | |  |  |
-| subPath | string| `string` |  | | Path within the volume from which the container's volume should be mounted.</br>Defaults to "" (volume's root).</br>+optional |  |
-| subPathExpr | string| `string` |  | | Expanded path within the volume from which the container's volume should be mounted.</br>Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.</br>Defaults to "" (volume's root).</br>SubPathExpr and SubPath are mutually exclusive.</br>+optional |  |
+| subPath | string| `string` |  | | Path within the volume from which the container's volume should be mounted.</br>Defaults to "" (volume's root). </br>*Optional.*|  |
+| subPathExpr | string| `string` |  | | Expanded path within the volume from which the container's volume should be mounted.</br>Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.</br>Defaults to "" (volume's root).</br>SubPathExpr and SubPath are mutually exclusive. </br>*Optional.*|  |
 
 
 
@@ -4443,9 +4393,9 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| fsType | string| `string` |  | | fsType is filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.</br>+optional |  |
-| storagePolicyID | string| `string` |  | | storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.</br>+optional |  |
-| storagePolicyName | string| `string` |  | | storagePolicyName is the storage Policy Based Management (SPBM) profile name.</br>+optional |  |
+| fsType | string| `string` |  | | fsType is filesystem type to mount.</br>Must be a filesystem type supported by the host operating system.</br>Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. </br>*Optional.*|  |
+| storagePolicyID | string| `string` |  | | storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName. </br>*Optional.*|  |
+| storagePolicyName | string| `string` |  | | storagePolicyName is the storage Policy Based Management (SPBM) profile name. </br>*Optional.*|  |
 | volumePath | string| `string` |  | | volumePath is the path that identifies vSphere volume vmdk |  |
 
 
@@ -4480,10 +4430,10 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| gmsaCredentialSpec | string| `string` |  | | GMSACredentialSpec is where the GMSA admission webhook</br>(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the</br>GMSA credential spec named by the GMSACredentialSpecName field.</br>+optional |  |
-| gmsaCredentialSpecName | string| `string` |  | | GMSACredentialSpecName is the name of the GMSA credential spec to use.</br>+optional |  |
-| hostProcess | boolean| `bool` |  | | HostProcess determines if a container should be run as a 'Host Process' container.</br>All of a Pod's containers must have the same effective HostProcess value</br>(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).</br>In addition, if HostProcess is true then HostNetwork must also be set to true.</br>+optional |  |
-| runAsUserName | string| `string` |  | | The UserName in Windows to run the entrypoint of the container process.</br>Defaults to the user specified in image metadata if unspecified.</br>May also be set in PodSecurityContext. If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence.</br>+optional |  |
+| gmsaCredentialSpec | string| `string` |  | | GMSACredentialSpec is where the GMSA admission webhook</br>(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the</br>GMSA credential spec named by the GMSACredentialSpecName field. </br>*Optional.*|  |
+| gmsaCredentialSpecName | string| `string` |  | | GMSACredentialSpecName is the name of the GMSA credential spec to use. </br>*Optional.*|  |
+| hostProcess | boolean| `bool` |  | | HostProcess determines if a container should be run as a 'Host Process' container.</br>All of a Pod's containers must have the same effective HostProcess value</br>(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).</br>In addition, if HostProcess is true then HostNetwork must also be set to true. </br>*Optional.*|  |
+| runAsUserName | string| `string` |  | | The UserName in Windows to run the entrypoint of the container process.</br>Defaults to the user specified in image metadata if unspecified.</br>May also be set in PodSecurityContext. If set in both SecurityContext and</br>PodSecurityContext, the value specified in SecurityContext takes precedence. </br>*Optional.*|  |
 
 
 

--- a/hack/docs/clean_swagger_md.py
+++ b/hack/docs/clean_swagger_md.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Clean up kubebuilder and other annotations in generated swagger markdown.
+
+Converts annotations to human-readable text in a "Validation" section.
+"""
+
+import re
+import sys
+
+
+def extract_and_remove(text, search_pattern, remove_pattern):
+    """Extract a value using search_pattern, then remove all matches of remove_pattern."""
+    match = re.search(search_pattern, text)
+    value = match.group(1) if match else None
+    text = re.sub(r'</br>' + remove_pattern, '', text)
+    text = re.sub(remove_pattern, '', text)
+    return text, value
+
+
+def parse_annotations(text):
+    """Extract annotations from text and return (clean_text, annotations_dict)."""
+    annotations = {}
+
+    # Boolean flags
+    for name in ('optional', 'required'):
+        annotations[name] = bool(re.search(rf'\+{name}\b', text))
+        text = re.sub(rf'</br>\+{name}\b', '', text)
+        text = re.sub(rf'\+{name}\b', '', text)
+
+    # +default="value" or +default=value or +kubebuilder:default="value"
+    match = re.search(r'\+(?:kubebuilder:)?default="([^"]*)"', text)
+    if match:
+        annotations['default'] = f'"{match.group(1)}"'
+    else:
+        match = re.search(r'\+(?:kubebuilder:)?default=(\S+?)(?:</br>|\s|\||$)', text)
+        annotations['default'] = match.group(1) if match else None
+    for prefix in (r'\+kubebuilder:default', r'\+default'):
+        text = re.sub(rf'</br>{prefix}="[^"]*"', '', text)
+        text = re.sub(rf'</br>{prefix}=\S+?(?=</br>|\s|\||$)', '', text)
+        text = re.sub(rf'{prefix}="[^"]*"', '', text)
+        text = re.sub(rf'{prefix}=\S+?(?=</br>|\s|\||$)', '', text)
+
+    # +kubebuilder:validation:Enum=A;B;C (special: semicolons become commas)
+    text, enum_val = extract_and_remove(
+        text,
+        r'\+kubebuilder:validation:Enum=([^|<\s]+)',
+        r'\+kubebuilder:validation:Enum=[^|<\s]+')
+    annotations['enum_values'] = enum_val.replace(';', ', ') if enum_val else None
+
+    # Numeric kubebuilder validations
+    validation_fields = [
+        ('minimum', 'Minimum'),
+        ('maximum', 'Maximum'),
+        ('min_length', 'MinLength'),
+        ('max_length', 'MaxLength'),
+        ('min_items', 'MinItems'),
+        ('max_items', 'MaxItems'),
+    ]
+    for key, validator in validation_fields:
+        text, annotations[key] = extract_and_remove(
+            text,
+            rf'\+kubebuilder:validation:{validator}=([+-]?\d+)',
+            rf'\+kubebuilder:validation:{validator}=[+-]?\d+')
+
+    # +kubebuilder:validation:Pattern=`X`
+    text, annotations['pattern'] = extract_and_remove(
+        text,
+        r'\+kubebuilder:validation:Pattern=`([^`]+)`',
+        r'\+kubebuilder:validation:Pattern=`[^`]+`')
+
+    # Handle +enum - just remove it (it's a type marker, not useful in docs)
+    text = re.sub(r'\+enum\b', '', text)
+
+    # Remove annotations we don't convert (internal implementation details)
+    patterns_to_remove = [
+        r'\+kubebuilder:validation:XValidation:[^|<]*',
+        r'\+kubebuilder:validation:Type=[^|<\s]+',
+        r'\+kubebuilder:validation:Schemaless',
+        r'\+kubebuilder:pruning:PreserveUnknownFields',
+        r'\+kubebuilder:[^|<]*',
+        r'\+patchStrategy=[^|<\s]+',
+        r'\+patchMergeKey=[^|<\s]+',
+        r'\+listType=[^|<\s]+',
+        r'\+listMapKey=[^|<\s]+',
+        r'\+featureGate=[^|<\s]+',
+        r'\+structType=[^|<\s]+',
+        r'\+protobuf[^|<]*',
+        r'\+union\b',
+        r'\+k8s:[^|<\s]+',
+    ]
+
+    for pattern in patterns_to_remove:
+        text = re.sub(r'</br>' + pattern, '', text)
+        text = re.sub(pattern, '', text)
+
+    return text, annotations
+
+
+def build_validation_section(annotations):
+    """Build a human-readable validation section from annotations."""
+    parts = []
+
+    if annotations.get('optional'):
+        parts.append('Optional')
+
+    # Fields with labels
+    labeled_fields = [
+        ('default', 'Default value'),
+        ('enum_values', 'Allowed values'),
+        ('minimum', 'Minimum value'),
+        ('maximum', 'Maximum value'),
+        ('min_length', 'Minimum length'),
+        ('max_length', 'Maximum length'),
+        ('min_items', 'Minimum items'),
+        ('max_items', 'Maximum items'),
+    ]
+    for key, label in labeled_fields:
+        if annotations.get(key) is not None:
+            parts.append(f"{label}: {annotations[key]}")
+
+    if annotations.get('pattern'):
+        parts.append(f"Validation regex: `{annotations['pattern']}`")
+
+    if not parts:
+        return ''
+
+    return '</br>*' + '; '.join(parts) + '.*'
+
+
+def process_table_cell(cell):
+    """Process a table cell that might contain annotations."""
+    clean_text, annotations = parse_annotations(cell)
+    validation_section = build_validation_section(annotations)
+
+    # Clean up any trailing </br> before adding validation (but preserve cell spacing)
+    clean_text = re.sub(r'(</br>)+\s*$', '', clean_text)
+
+    if validation_section:
+        clean_text = clean_text + validation_section
+
+    return clean_text
+
+
+def process_line(line):
+    """Process a single line, handling table rows specially."""
+    # Check if this is a table row
+    if line.startswith('|') and '|' in line[1:]:
+        # Split into cells
+        cells = line.split('|')
+        # Process each cell (skip first and last which are empty due to leading/trailing |)
+        processed_cells = []
+        for i, cell in enumerate(cells):
+            if i == 0 or i == len(cells) - 1:
+                processed_cells.append(cell)
+            else:
+                processed_cells.append(process_table_cell(cell))
+        return '|'.join(processed_cells)
+
+    # Check for standalone annotation lines like "> +kubebuilder:..." or "+kubebuilder:..."
+    if re.match(r'^>?\s*\+kubebuilder:', line):
+        return None  # Remove this line
+    if re.match(r'^>?\s*\+enum\s*$', line):
+        return None  # Remove standalone +enum lines
+    if re.match(r'^>?\s*\+union\s*$', line):
+        return None  # Remove standalone +union lines
+    if re.match(r'^>?\s*\+structType=', line):
+        return None
+    if re.match(r'^>?\s*\+protobuf', line):
+        return None
+
+    # For description lines, also clean up annotations
+    if '|' not in line:
+        clean_text, annotations = parse_annotations(line)
+        validation_section = build_validation_section(annotations)
+        if validation_section:
+            clean_text = clean_text.rstrip() + ' ' + validation_section.replace('</br>', ' ')
+        # Clean up +enum from inline text
+        clean_text = re.sub(r'\s*\+enum\s*', '', clean_text)
+        return clean_text
+
+    return line
+
+
+def process_markdown(content):
+    """Process the entire markdown content."""
+    lines = content.split('\n')
+    processed_lines = []
+
+    for line in lines:
+        processed = process_line(line)
+        if processed is not None:
+            processed_lines.append(processed)
+
+    result = '\n'.join(processed_lines)
+
+    # Also fix the interface{} links issue
+    result = re.sub(r'\[any\]\(#any\)', '`any`', result)
+
+    # Clean up any multiple </br> (but don't touch other whitespace)
+    result = re.sub(r'(</br>){2,}', '</br>', result)
+
+    return result
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <markdown_file>", file=sys.stderr)
+        sys.exit(1)
+
+    filepath = sys.argv[1]
+
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    processed = process_markdown(content)
+
+    with open(filepath, 'w', encoding='utf-8') as f:
+        f.write(processed)
+
+    print(f"Processed {filepath}")
+
+
+if __name__ == '__main__':
+    main()

--- a/pkg/plugins/executor/swagger.go
+++ b/pkg/plugins/executor/swagger.go
@@ -16,3 +16,4 @@ package executor
 
 //go:generate env SWAGGER_GENERATE_EXTENSION=false swagger generate spec -o swagger.yml
 //go:generate env SWAGGER_GENERATE_EXTENSION=false swagger generate markdown -f swagger.yml --output ../../../docs/executor_swagger.md
+//go:generate python3 ../../../hack/docs/clean_swagger_md.py ../../../docs/executor_swagger.md


### PR DESCRIPTION
### Motivation

We've got a lot of messy comments coming through into executor_swagger.md these days. The few we used to allow through have been supplemented by a lot of kubebuilder text.

### Modifications

Add a Python script to make the generated executor swagger documentation more readable by converting annotations to a human-readable "Validation" section:

- +optional → **Validation:** Optional.
- +default=X → **Validation:** Default: X.
- +kubebuilder:validation:Minimum=X → **Validation:** Minimum: X.
- +kubebuilder:validation:Maximum=X → **Validation:** Maximum: X.
- +kubebuilder:validation:MinLength=X → **Validation:** Minimum length: X.
- +kubebuilder:validation:MaxLength=X → **Validation:** Maximum length: X.
- +kubebuilder:validation:MinItems=X → **Validation:** Minimum items: X.
- +kubebuilder:validation:MaxItems=X → **Validation:** Maximum items: X.
- +kubebuilder:validation:Pattern=X → **Validation:** Pattern: X.
- +kubebuilder:validation:Enum=A;B → **Validation:** Valid values: A, B.

Internal annotations are removed: +patchStrategy, +patchMergeKey, +listType, +listMapKey, +featureGate, +structType, +protobuf, +union, +enum, +kubebuilder:validation:XValidation (complex CEL rules).

### Verification

NA

### Documentation

Yup, this is all about documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Swagger-generated documentation formatting by converting internal annotations into human-readable validation sections, improving clarity and readability of API documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->