### PR TITLE
fix: Avoid resetting resourceVersion for watch. Fixes #15106

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -851,7 +851,10 @@ func (wfc *WorkflowController) tweakListRequestListOptions(options *metav1.ListO
 	options.LabelSelector = labelSelector.String()
 	// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
 	// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
-	options.ResourceVersion = ""
+	// Check if ResourceVersion is "0" and reset it to empty string to ensure proper pagination behavior
+	if options.ResourceVersion == "0" {
+		options.ResourceVersion = ""
+	}
 }
 
 func (wfc *WorkflowController) tweakWatchRequestListOptions(options *metav1.ListOptions) {

--- a/workflow/controller/informer/tolerant_cluster_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_cluster_workflow_template_informer.go
@@ -24,7 +24,10 @@ func NewTolerantClusterWorkflowTemplateInformer(dynamicInterface dynamic.Interfa
 	return &tolerantClusterWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, "", func(options *metav1.ListOptions) {
 		// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
 		// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
-		options.ResourceVersion = ""
+		// Check if ResourceVersion is "0" and reset it to empty string to ensure proper pagination behavior
+		if options.ResourceVersion == "0" {
+			options.ResourceVersion = ""
+		}
 	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.ClusterWorkflowTemplatePlural})}
 }
 

--- a/workflow/controller/informer/tolerant_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_workflow_template_informer.go
@@ -24,7 +24,10 @@ func NewTolerantWorkflowTemplateInformer(dynamicInterface dynamic.Interface, def
 	return &tolerantWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, namespace, func(options *metav1.ListOptions) {
 		// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
 		// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
-		options.ResourceVersion = ""
+		// Check if ResourceVersion is "0" and reset it to empty string to ensure proper pagination behavior
+		if options.ResourceVersion == "0" {
+			options.ResourceVersion = ""
+		}
 	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural})}
 }
 

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -45,7 +45,10 @@ func (wfc *WorkflowController) newWorkflowTaskResultInformer(ctx context.Context
 			options.LabelSelector = labelSelector
 			// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
 			// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
-			options.ResourceVersion = ""
+			// Check if ResourceVersion is "0" and reset it to empty string to avoid missing watch event.
+			if options.ResourceVersion == "0" {
+				options.ResourceVersion = ""
+			}
 		},
 	)
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes Avoid resetting resourceVersion for watch. Fixes #15106

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Check resourceVersion before resetting to avoid setting to "" for watch connection

### Verification

<!-- TODO: Say how you tested your changes. -->
No repeated error in #15106 after fix.

