### PR TITLE
fix: permission error for executor plugin example doc #13015

### DIFF
--- a/docs/executor_plugins.md
+++ b/docs/executor_plugins.md
@@ -163,7 +163,7 @@ spec:
         - containerPort: 4355
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534 # nobody
+        runAsUser: 1000
       resources:
         requests:
           memory: "64Mi"


### PR DESCRIPTION
Fixes #13015
Fixes #13019

### Motivation

The current example in the documentation does not run correclty

If fails with the following error:

```
PermissionError: [Errno 13] Permission denied: '/var/run/argo/token'
```

### Modifications

The fix was already discovered and applied by Dejan Golja (co-author here) and
it changed the user that runs the python script.

### Verification

Following the documentation I can successfully run the workflow.

### Documentation

This commit only contains documentation update.
