### PR TITLE
fix: add timeout for database query in workflow estimation to prevent blocking.

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -58,7 +58,7 @@ This document outlines environment variables that can be used to customize behav
 | `SEMAPHORE_NOTIFY_DELAY`                 | `time.Duration`     | `1s`                                                                                        | Tuning Delay when notifying semaphore waiters about availability in the semaphore                                                                                                                                                                                        |
 | `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS` | `bool` | `true` | Whether to watch the Controller's ConfigMap and semaphore ConfigMaps for run-time changes. When disabled, the Controller will only read these ConfigMaps once and will have to be manually restarted to pick up new changes. |
 | `SKIP_WORKFLOW_DURATION_ESTIMATION` | `bool` | `false` | Whether to lookup resource usage from prior workflows to estimate usage for new workflows. |
-| `WORKFLOW_ESTIMATION_DB_QUERY_TIMEOUT` | `time.Duration` | `5s` | Timeout for database queries when estimating workflow duration. Prevents workflow execution from being blocked when database is slow or locked. |
+| `WORKFLOW_ESTIMATION_DB_QUERY_TIMEOUT_SECONDS` | `int` | `5` | Timeout in seconds for database queries when estimating workflow duration. Prevents workflow execution from being blocked when database is slow or locked. |
 
 CLI parameters of the Controller can be specified as environment variables with the `ARGO_` prefix.
 For example:


### PR DESCRIPTION
I found that when the database was locked, it blocked the execution of a large number of our workflows.

Add timeout control for GetWorkflowForEstimator database query to prevent workflow execution from being blocked when database is slow or locked.

- Add default 5 second timeout for database queries
- Configurable via WORKFLOW_ESTIMATION_DB_QUERY_TIMEOUT environment variable
- Return default estimator on timeout/error to ensure workflow continues
- Add warning logs for timeout and error cases
- Add documentation for new environment variable

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
