### PR TITLE
chore(ci): parallelize CLI builds in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,24 @@ jobs:
   build-linux:
     name: Build & push linux
     if: github.repository == 'argoproj/argo-workflows'
+    # Available runners are listable here if you have access https://github.com/organizations/argoproj/settings/actions/runners
+    # Current oracle runners are:
+    # # amd64
+    # oracle-vm-2cpu-8gb-x86-64
+    # oracle-vm-4cpu-16gb-x86-64
+    # oracle-vm-8cpu-32gb-x86-64
+    # oracle-vm-16cpu-64gb-x86-64
+    # oracle-vm-24cpu-96gb-x86-64
+    # oracle-vm-32cpu-128gb-x86-64
+
+    # # arm64
+    # oracle-vm-2cpu-8gb-arm64
+    # oracle-vm-4cpu-16gb-arm64
+    # oracle-vm-8cpu-32gb-arm64
+    # oracle-vm-16cpu-64gb-arm64
+    # oracle-vm-24cpu-96gb-arm64
+    # oracle-vm-32cpu-128gb-arm64
+    # Unfortunately there are no more minimal labels on the runners to select by label
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'oracle-vm-16cpu-64gb-arm64' || 'oracle-vm-16cpu-64gb-x86-64' }}
     strategy:
       matrix:


### PR DESCRIPTION
### Motivation

The release process takes around 2 hours. A human must wait from the creation until it releases to announce this, which is annoying.

### Modifications

Optimise the release workflow by parallelising the 'make clis' step which builds CLI binaries for 8 different platform/architecture combinations.

Changes:
- Add build-ui job to build the UI once and share via artifacts
- Add build-clis job using matrix strategy to build all 8 CLI variants in parallel
- Update publish-release to download pre-built CLI artifacts
- Remove sequential 'make clis' step from publish-release
- Use oracle runners, including arm runners for the arm build as qemu was failing us

This should significantly reduce release build time by running CLI builds concurrently instead of sequentially.

### Verification

Ran a modified version of this [here](https://github.com/Joibel/argo-workflows/actions/runs/20029489945) to prove the first couple of things work as expected. Running the release process is hard outside of argoproj.

### Documentation

None required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build and release infrastructure for more efficient artifact management and version handling across the release pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->