### PR TITLE
fix: release process bugs from #15124

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -320,6 +320,7 @@ jobs:
         with:
           name: ui-dist
           path: ui/dist/
+          if-no-files-found: error
 
   build-clis:
     name: Build CLI ${{ matrix.goos }}-${{ matrix.goarch }}
@@ -375,7 +376,8 @@ jobs:
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: argo-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/argo-${{ matrix.goos }}-${{ matrix.goarch }}.gz
+          path: dist/argo-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' }}.gz
+          if-no-files-found: error
 
   publish-release:
     permissions:
@@ -389,17 +391,9 @@ jobs:
       COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
-        with:
-          node-version: "20" # change in all GH Workflows
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.24"
-      - name: Restore node packages cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ui/node_modules
-          key: ${{ runner.os }}-node-dep-v1-${{ hashFiles('**/yarn.lock') }}
       - name: Install cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
@@ -418,7 +412,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: argo-*
-          path: .
+          path: dist/
           merge-multiple: true
       - run: generator -o dist -p .
       - run: yarn --cwd ui install


### PR DESCRIPTION
Added failure if-no-files-found because we didn't actually find the windows CLI but it wasn't flagged as an error
Fix the windows CLI I hope
Remove the node packages from `publish-release` as we don't build it there any more.
Revert co-pilot's erroneous suggestion about paths https://github.com/argoproj/argo-workflows/pull/15124#discussion_r2598738491