### PR TITLE
chore: mark artifact-disable-archive as flaky test

### DIFF
--- a/examples/artifact-disable-archive.yaml
+++ b/examples/artifact-disable-archive.yaml
@@ -7,6 +7,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: artifact-disable-archive-
+  labels:
+    workflows.argoproj.io/no-test: "flaky"
 spec:
   entrypoint: artifact-disable-archive
   templates:


### PR DESCRIPTION
Add workflows.argoproj.io/no-test: "flaky" label to skip this test in the examples suite.

See https://github.com/argoproj/argo-workflows/actions/runs/20091278698/job/57648991546