### PR TITLE
chore: mark http-success-condition as flaky test

### DIFF
--- a/examples/http-success-condition.yaml
+++ b/examples/http-success-condition.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: http-template-condition-
+  labels:
+    workflows.argoproj.io/no-test: "flaky"
   annotations:
     workflows.argoproj.io/description: |
       Exemplifies usage of successCondition in HTTP template (available since v3.3)


### PR DESCRIPTION
Add workflows.argoproj.io/no-test: "flaky" label to skip this test in the flaky test detection.

https://github.com/argoproj/argo-workflows/actions/runs/20091278698/job/57650785435?pr=15115
