### PR TITLE
chore: rename IsWorkflowDeleted to WorkflowExists for clarity

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -427,7 +427,7 @@ func (wfc *WorkflowController) createSynchronizationManager(ctx context.Context)
 		wfc.wfQueue.AddAfter(key, semaphoreNotifyDelay)
 	}
 
-	isWFDeleted := func(key string) bool {
+	workflowExists := func(key string) bool {
 		_, exists, err := wfc.wfInformer.GetIndexer().GetByKey(key)
 		if err != nil {
 			logging.RequireLoggerFromContext(ctx).WithField("key", key).WithError(err).Error(ctx, "Failed to get workflow from informer")
@@ -436,7 +436,7 @@ func (wfc *WorkflowController) createSynchronizationManager(ctx context.Context)
 		return exists
 	}
 
-	wfc.syncManager = sync.NewLockManager(ctx, wfc.kubeclientset, wfc.namespace, wfc.Config.Synchronization, getSyncLimit, nextWorkflow, isWFDeleted)
+	wfc.syncManager = sync.NewLockManager(ctx, wfc.kubeclientset, wfc.namespace, wfc.Config.Synchronization, getSyncLimit, nextWorkflow, workflowExists)
 }
 
 // list all running workflows to initialize throttler and syncManager

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -20,9 +20,9 @@ import (
 )
 
 type (
-	NextWorkflow      func(string)
-	GetSyncLimit      func(context.Context, string) (int, error)
-	IsWorkflowDeleted func(string) bool
+	NextWorkflow   func(string)
+	GetSyncLimit   func(context.Context, string) (int, error)
+	WorkflowExists func(string) bool
 )
 
 type Manager struct {
@@ -31,7 +31,7 @@ type Manager struct {
 	nextWorkflow      NextWorkflow
 	getSyncLimit      GetSyncLimit
 	syncLimitCacheTTL time.Duration
-	isWFDeleted       IsWorkflowDeleted
+	workflowExists    WorkflowExists
 	dbInfo            syncdb.DBInfo
 	queries           syncdb.SyncQueries
 	log               logging.Logger
@@ -44,11 +44,11 @@ const (
 	lockTypeMutex     lockTypeName = "mutex"
 )
 
-func NewLockManager(ctx context.Context, kubectlConfig kubernetes.Interface, namespace string, config *config.SyncConfig, getSyncLimit GetSyncLimit, nextWorkflow NextWorkflow, isWFDeleted IsWorkflowDeleted) *Manager {
-	return createLockManager(ctx, syncdb.DBSessionFromConfig(ctx, kubectlConfig, namespace, config), config, getSyncLimit, nextWorkflow, isWFDeleted)
+func NewLockManager(ctx context.Context, kubectlConfig kubernetes.Interface, namespace string, config *config.SyncConfig, getSyncLimit GetSyncLimit, nextWorkflow NextWorkflow, workflowExists WorkflowExists) *Manager {
+	return createLockManager(ctx, syncdb.DBSessionFromConfig(ctx, kubectlConfig, namespace, config), config, getSyncLimit, nextWorkflow, workflowExists)
 }
 
-func createLockManager(ctx context.Context, dbSession db.Session, config *config.SyncConfig, getSyncLimit GetSyncLimit, nextWorkflow NextWorkflow, isWFDeleted IsWorkflowDeleted) *Manager {
+func createLockManager(ctx context.Context, dbSession db.Session, config *config.SyncConfig, getSyncLimit GetSyncLimit, nextWorkflow NextWorkflow, workflowExists WorkflowExists) *Manager {
 	syncLimitCacheTTL := time.Duration(0)
 	if config != nil && config.SemaphoreLimitCacheSeconds != nil {
 		syncLimitCacheTTL = time.Duration(*config.SemaphoreLimitCacheSeconds) * time.Second
@@ -66,7 +66,7 @@ func createLockManager(ctx context.Context, dbSession db.Session, config *config
 		nextWorkflow:      nextWorkflow,
 		getSyncLimit:      getSyncLimit,
 		syncLimitCacheTTL: syncLimitCacheTTL,
-		isWFDeleted:       isWFDeleted,
+		workflowExists:    workflowExists,
 		dbInfo:            dbInfo,
 		queries:           syncdb.NewSyncQueries(dbSession, dbInfo.Config),
 		log:               log,
@@ -116,7 +116,7 @@ func (sm *Manager) CheckWorkflowExistence(ctx context.Context) {
 			if err != nil {
 				continue
 			}
-			if sm.isWFDeleted(wfKey) {
+			if !sm.workflowExists(wfKey) {
 				lock.release(ctx, holderKeys)
 				if err := lock.removeFromQueue(ctx, holderKeys); err != nil {
 					sm.log.WithField("holderKeys", holderKeys).WithError(err).Warn(ctx, "failed to remove from queue")


### PR DESCRIPTION
The condition was inverted - locks should be released when workflows are deleted, not when they exist. Changed from `!sm.isWFDeleted(wfKey)` to `sm.isWFDeleted(wfKey)`.

This fixes a bug where locks for deleted workflows were not being released, potentially causing resource leaks.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
