### PR TITLE
docs: remove beta designation from SSO RBAC Namespace Delegation

### DIFF
--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -119,7 +119,6 @@ See [Service Account Secrets](service-account-secrets.md) for detailed instructi
 You can optionally configure RBAC SSO per namespace.
 Typically, an organization has a Kubernetes cluster and a central team (the owner of the cluster) manages the cluster. Along with this, there are multiple namespaces which are owned by individual teams. This feature would help namespace owners to define RBAC for their own namespace.
 
-The feature is currently in beta.
 To enable the feature, set env variable `SSO_DELEGATE_RBAC_TO_NAMESPACE=true` in your argo-server deployment.
 
 ### Recommended usage


### PR DESCRIPTION
### Motivation

The caveat here has been around since 3.3 and there aren't significant issues raised against it. It's of a similar quality to the rest of the features.

### Documentation

The SSO RBAC Namespace Delegation feature is now stable and no longer considered beta.
