### PR TITLE
fix: treat sidecar OOMKilled as workflow failure

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1841,6 +1841,13 @@ func (woc *wfOperationCtx) inferFailedReason(ctx context.Context, pod *apiv1.Pod
 			// the legacy init/wait paths do separately.
 			return wfv1.NodeError, msg
 		default:
+			// A sidecar that was OOMKilled terminates with exit code 137, which would
+			// otherwise be treated as an argoexec-initiated SIGKILL and ignored below.
+			// OOMKilled is a genuine failure the wait container may not observe, so
+			// surface it as a node failure.
+			if t.Reason == "OOMKilled" {
+				return wfv1.NodeFailed, msg
+			}
 			if t.ExitCode != 137 && t.ExitCode != 143 {
 				return wfv1.NodeFailed, msg
 			}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7846,6 +7846,54 @@ status:
   startTime: "2021-01-22T10:28:12Z"
 `
 
+var podWithSidecarOOM = `
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: main
+    env:
+    - name: ARGO_CONTAINER_NAME
+      value: main
+status:
+  containerStatuses:
+  - name: main
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      terminated:
+        exitCode: 0
+        finishedAt: "2021-01-22T09:50:17Z"
+        reason: Completed
+        startedAt: "2021-01-22T09:50:16Z"
+  - name: wait
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      terminated:
+        exitCode: 0
+        finishedAt: "2021-01-22T09:50:18Z"
+        reason: Completed
+        startedAt: "2021-01-22T09:50:16Z"
+  - name: istio-proxy
+    ready: false
+    restartCount: 0
+    started: false
+    state:
+      terminated:
+        exitCode: 137
+        finishedAt: "2021-01-22T09:50:17Z"
+        reason: OOMKilled
+        startedAt: "2021-01-22T09:50:16Z"
+  hostIP: 172.19.0.2
+  phase: Failed
+  podIP: 10.42.0.74
+  qosClass: Burstable
+  startTime: "2021-01-22T09:50:15Z"
+`
+
 func TestPodFailureWithContainerOOM(t *testing.T) {
 	tests := []struct {
 		podDetail string
@@ -7855,6 +7903,10 @@ func TestPodFailureWithContainerOOM(t *testing.T) {
 		phase:     wfv1.NodeError,
 	}, {
 		podDetail: podWithMainContainerOOM,
+		phase:     wfv1.NodeFailed,
+	}, {
+		// A sidecar OOMKilled (exit 137) must fail the node, not be ignored as a SIGKILL.
+		podDetail: podWithSidecarOOM,
 		phase:     wfv1.NodeFailed,
 	}}
 	var pod apiv1.Pod


### PR DESCRIPTION
Previously, sidecar containers with exit code 137 were always ignored, assuming they were killed by argoexec. However, if a sidecar is OOMKilled (exit code 137 with reason OOMKilled), it should be treated as a failure because the wait container may not be able to observe the sidecar OOM.

This change adds a check for OOMKilled reason before ignoring exit code 137, ensuring that sidecar OOM failures are properly reported.

Fixes sidecar OOM detection issue where workflows would succeed even when sidecars were killed due to memory exhaustion.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
UT and e2e with the sample.
```
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: sidecar-oom-example-
spec:
  entrypoint: main-step
  templates:
    - name: main-step
      container:
        image: alpine:3.7
        command: ["sh", "-c"]
        args:
          - |
            echo "Main container started. I will sleep for 30 seconds and then exit successfully."
            sleep 30
            echo "Main container finished with exit code 0."
        resources:
          requests:
            cpu: 2
            memory: "3Gi"

      # sidecar
      sidecars:
        - name: memory-eater 
          image: alpine:3.7
          command: ["sh", "-c"]
          args:
            - |
              echo "Sidecar started. I will now consume as much memory as possible..."
              dd if=/dev/urandom of=/dev/shm/largefile bs=1M count=100
              tail -f /dev/shm/largefile
          resources:
            requests:
              memory: "16Mi"
            limits:
              memory: "32Mi"
```
<img width="2406" height="360" alt="image" src="https://github.com/user-attachments/assets/e3c676db-de4d-4ea4-bfbc-f5c21bd29d4c" />


### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidecar containers terminated due to out-of-memory conditions are now correctly reported as node failures.
  * Prevents these failures from being misclassified as non-failing termination events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->