### PR TITLE
fix: use alpine 3.23 version in tests, examples, workflows

### DIFF
--- a/cmd/argo/commands/common/get_test.go
+++ b/cmd/argo/commands/common/get_test.go
@@ -203,7 +203,7 @@ spec:
       - sh
       - -c
       - sleep 10
-      image: alpine:latest
+      image: alpine:3.23
     name: sleep
 status:
   conditions:

--- a/docs/container-set-template.md
+++ b/docs/container-set-template.md
@@ -148,7 +148,7 @@ spec:
         containers:
           # this container completes successfully, so it won't be retried.
           - name: success
-            image: python:alpine
+            image: python:alpine3.23
             command:
               - python
               - -c
@@ -157,7 +157,7 @@ spec:
                 print("hi")
           # if fails, it will retry at most ten times.
           - name: fail-retry
-            image: python:alpine
+            image: python:alpine3.23
             command: ["python", -c]
             # fail with a 66% probability
             args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/docs/cron-workflows.md
+++ b/docs/cron-workflows.md
@@ -25,7 +25,7 @@ spec:
     templates:
     - name: date
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["date; sleep 90"]
 ```

--- a/docs/executor_plugins.md
+++ b/docs/executor_plugins.md
@@ -157,7 +157,7 @@ spec:
         - python
         - -u # disables output buffering
         - -c
-      image: python:alpine
+      image: python:alpine3.23
       name: hello-executor-plugin
       ports:
         - containerPort: 4355

--- a/docs/lifecyclehook.md
+++ b/docs/lifecyclehook.md
@@ -52,7 +52,7 @@ spec:
 
    - name: heads
      container:
-       image: alpine:latest
+       image: alpine:3.23
        command: [sh, -c]
        args: ["echo \"it was heads\""]
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -711,7 +711,7 @@ An example of a `Template`-level Counter metric that will increase a counter eve
             counter:
               value: "1"                            # This increments the counter by 1
       container:
-        image: python:alpine
+        image: python:alpine3.23
         command: ["python", -c]
         # fail with a 66% probability
         args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
@@ -738,7 +738,7 @@ A similar example of such a Counter metric that will increase for every step sta
             counter:
               value: "1"
       container:
-        image: python:alpine
+        image: python:alpine3.23
         command: ["python", -c]
         # fail with a 66% probability
         args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]
@@ -771,7 +771,7 @@ Finally, an example of a `Template`-level Histogram metric that tracks an intern
             valueFrom:
               path: /tmp/rand_int.txt
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["RAND_INT=$((1 + RANDOM % 10)); echo $RAND_INT; echo $RAND_INT > /tmp/rand_int.txt"]
 ...

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -61,7 +61,7 @@ spec:
             template: progress
     - name: progress
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [ "/bin/sh", "-c" ]
         args:
           - |

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -16,7 +16,7 @@ spec:
     retryStrategy:
       limit: "10"
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -52,7 +52,7 @@ spec:
       - name: message
         path: /tmp/message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/message"]
 ```
@@ -85,7 +85,7 @@ Optionally, for large artifacts, you can set `podSpecPatch` in the workflow spec
       - name: data
         path: /tmp/large-file
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/large-file"]
 # <... snipped ...>

--- a/docs/walk-through/conditionals.md
+++ b/docs/walk-through/conditionals.md
@@ -43,7 +43,7 @@ spec:
   # Return heads or tails based on a random number
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random
@@ -52,19 +52,19 @@ spec:
 
   - name: heads
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo \"it was heads\""]
 
   - name: tails
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo \"it was tails\""]
 
   - name: heads-tails-or-twice-tails
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo \"it was heads the first flip and tails the second. Or it was two times tails.\""]
 ```

--- a/docs/walk-through/dag.md
+++ b/docs/walk-through/dag.md
@@ -20,7 +20,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
   - name: diamond
     dag:

--- a/docs/walk-through/exit-handlers.md
+++ b/docs/walk-through/exit-handlers.md
@@ -21,7 +21,7 @@ spec:
   # primary workflow template
   - name: intentional-fail
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo intentional failure; exit 1"]
 
@@ -41,17 +41,17 @@ spec:
         when: "{{workflow.status}} != Succeeded"
   - name: send-email
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo send e-mail: {{workflow.name}} {{workflow.status}} {{workflow.duration}}"]
   - name: celebrate
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo hooray!"]
   - name: cry
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo boohoo!"]
 ```

--- a/docs/walk-through/loops.md
+++ b/docs/walk-through/loops.md
@@ -190,7 +190,7 @@ spec:
   # Generate a list of numbers in JSON format
   - name: gen-number-list
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import json
@@ -202,7 +202,7 @@ spec:
       parameters:
       - name: seconds
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]
 ```
@@ -245,7 +245,7 @@ spec:
       - name: index
     # The output must be a valid JSON
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         cat <<EOF
@@ -260,7 +260,7 @@ spec:
       - name: aggregate-results
         value: 'no-value'
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         echo 'inputs.parameters.aggregate-results: "{{inputs.parameters.aggregate-results}}"'

--- a/docs/walk-through/recursion.md
+++ b/docs/walk-through/recursion.md
@@ -25,7 +25,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random
@@ -34,7 +34,7 @@ spec:
 
   - name: heads
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo \"it was heads\""]
 ```

--- a/docs/walk-through/retrying-failed-or-errored-steps.md
+++ b/docs/walk-through/retrying-failed-or-errored-steps.md
@@ -22,7 +22,7 @@ spec:
       affinity:
         nodeAntiAffinity: {}
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/docs/walk-through/scripts-and-results.md
+++ b/docs/walk-through/scripts-and-results.md
@@ -30,7 +30,7 @@ spec:
 
   - name: gen-random-int-python
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random
@@ -50,7 +50,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]
 ```

--- a/docs/walk-through/secrets.md
+++ b/docs/walk-through/secrets.md
@@ -20,7 +20,7 @@ spec:
   templates:
   - name: print-secrets
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ['
         echo "secret from env: $MYSECRETPASSWORD";

--- a/docs/walk-through/timeouts.md
+++ b/docs/walk-through/timeouts.md
@@ -13,7 +13,7 @@ spec:
   templates:
   - name: sleep
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo sleeping for 1m; sleep 60; echo done"]
 ```
@@ -31,7 +31,7 @@ spec:
   - name: sleep
     activeDeadlineSeconds: 10 # terminate container template after 10 seconds
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo sleeping for 1m; sleep 60; echo done"]
 ```

--- a/docs/walk-through/volumes.md
+++ b/docs/walk-through/volumes.md
@@ -38,7 +38,7 @@ spec:
 
   - name: print-message-from-file
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"]
       # Mount workdir volume at /mnt/vol before invoking the container
@@ -97,7 +97,7 @@ spec:
 
   - name: print-message-from-file
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"]
       volumeMounts:
@@ -186,7 +186,7 @@ spec:
         persistentVolumeClaim:
           claimName: '{{inputs.parameters.pvc-name}}'
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"]
       volumeMounts:

--- a/docs/workflow-concepts.md
+++ b/docs/workflow-concepts.md
@@ -74,7 +74,7 @@ Example:
 ```yaml
   - name: gen-random-int
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random

--- a/docs/workflow-executors.md
+++ b/docs/workflow-executors.md
@@ -26,8 +26,8 @@ Historically there were multiple available executor types, but as of 3.4 the onl
 You can determine the default command for a container image using:
 
 ```bash
-docker pull alpine:latest
-docker image inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}' alpine:latest
+docker pull alpine:3.23
+docker image inspect -f '{{.Config.Entrypoint}} {{.Config.Cmd}}' alpine:3.23
 ```
 
 [Learn more about command and args](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes)

--- a/examples/ci-output-artifact.yaml
+++ b/examples/ci-output-artifact.yaml
@@ -78,7 +78,7 @@ spec:
 
   - name: release-artifact
     container:
-      image: alpine:latest
+      image: alpine:3.23
       volumeMounts:
       - name: workdir
         mountPath: /go

--- a/examples/cluster-workflow-template/clustertemplates.yaml
+++ b/examples/cluster-workflow-template/clustertemplates.yaml
@@ -23,7 +23,7 @@ spec:
     retryStrategy:
       limit: 10
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python, -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/coinflip-recursive.yaml
+++ b/examples/coinflip-recursive.yaml
@@ -23,7 +23,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random

--- a/examples/coinflip.yaml
+++ b/examples/coinflip.yaml
@@ -26,7 +26,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random

--- a/examples/colored-logs.yaml
+++ b/examples/colored-logs.yaml
@@ -10,7 +10,7 @@ spec:
   templates:
   - name: print-colors
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python"]
       source: |
         import time

--- a/examples/conditional-artifacts.yaml
+++ b/examples/conditional-artifacts.yaml
@@ -31,7 +31,7 @@ spec:
 
     - name: flip-coin
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           import random
@@ -39,7 +39,7 @@ spec:
 
     - name: heads
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           with open("result.txt", "w") as f:
@@ -51,7 +51,7 @@ spec:
 
     - name: tails
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           with open("result.txt", "w") as f:

--- a/examples/conditional-parameters.yaml
+++ b/examples/conditional-parameters.yaml
@@ -32,7 +32,7 @@ spec:
 
     - name: flip-coin
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           import random
@@ -40,14 +40,14 @@ spec:
 
     - name: heads
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           print("heads")
 
     - name: tails
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           print("tails")

--- a/examples/conditionals-complex.yaml
+++ b/examples/conditionals-complex.yaml
@@ -42,7 +42,7 @@ spec:
   # Return heads or tails based on a random number
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random

--- a/examples/container-set-template/outputs-result-workflow.yaml
+++ b/examples/container-set-template/outputs-result-workflow.yaml
@@ -28,7 +28,7 @@ spec:
       containerSet:
         containers:
           - name: main
-            image: python:alpine
+            image: python:alpine3.23
             command:
               - python
               - -c
@@ -41,7 +41,7 @@ spec:
         parameters:
           - name: x
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command:
           - python
         source: |

--- a/examples/custom-metrics.yaml
+++ b/examples/custom-metrics.yaml
@@ -84,7 +84,7 @@ spec:
             counter:
               value: "1"
       container:
-        image: python:alpine
+        image: python:alpine3.23
         command: ["python", -c]
         # fail with a 66% probability
         args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/dag-coinflip.yaml
+++ b/examples/dag-coinflip.yaml
@@ -38,7 +38,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random

--- a/examples/dag-conditional-artifacts.yaml
+++ b/examples/dag-conditional-artifacts.yaml
@@ -34,7 +34,7 @@ spec:
 
     - name: flip-coin
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           import random
@@ -42,7 +42,7 @@ spec:
 
     - name: heads
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           with open("result.txt", "w") as f:
@@ -54,7 +54,7 @@ spec:
 
     - name: tails
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           with open("result.txt", "w") as f:

--- a/examples/dag-conditional-parameters.yaml
+++ b/examples/dag-conditional-parameters.yaml
@@ -35,7 +35,7 @@ spec:
     
     - name: flip-coin
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [python]
         source: |
           import random
@@ -43,14 +43,14 @@ spec:
     
     - name: heads
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [python]
         source: |
           print("heads")
     
     - name: tails
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [python]
         source: |
           print("tails")

--- a/examples/exit-code-output-variable.yaml
+++ b/examples/exit-code-output-variable.yaml
@@ -20,7 +20,7 @@ spec:
 
     - name: failing-container
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["exit 123"]
 
@@ -29,6 +29,6 @@ spec:
         parameters:
         - name: exitCode
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo \"Exit code was: {{inputs.parameters.exitCode}}\""]

--- a/examples/exit-handler-slack.yaml
+++ b/examples/exit-handler-slack.yaml
@@ -14,7 +14,7 @@ spec:
   templates:
   - name: say-hello
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo hello"]
 

--- a/examples/exit-handler-with-artifacts.yaml
+++ b/examples/exit-handler-with-artifacts.yaml
@@ -23,7 +23,7 @@ spec:
     
     - name: output
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           with open("result.txt", "w") as f:
@@ -39,6 +39,6 @@ spec:
           - name: message
             path: /tmp/message
       container:
-        image: python:alpine
+        image: python:alpine3.23
         command: [sh, -c]
         args: ["cat /tmp/message"]

--- a/examples/exit-handler-with-param.yaml
+++ b/examples/exit-handler-with-param.yaml
@@ -23,7 +23,7 @@ spec:
     
     - name: output
       container:
-        image: python:alpine
+        image: python:alpine3.23
         command: [sh, -c]
         args: ["echo -n hello world > /tmp/hello_world.txt"]
       outputs:
@@ -38,7 +38,7 @@ spec:
         parameters:
           - name: message
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           print("{{inputs.parameters.message}}")

--- a/examples/exit-handlers.yaml
+++ b/examples/exit-handlers.yaml
@@ -19,7 +19,7 @@ spec:
   # primary workflow template
   - name: intentional-fail
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo intentional failure; exit 1"]
 
@@ -39,7 +39,7 @@ spec:
         when: "{{workflow.status}} != Succeeded"
   - name: send-email
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       # Tip: {{workflow.failures}} is a JSON list. If you're using bash to read it, we recommend using jq to manipulate
       # it. For example:
@@ -47,15 +47,15 @@ spec:
       # echo "{{workflow.failures}}" | jq -r '.[] | "Failed Step: \(.displayName)\tMessage: \(.message)"'
       #
       # Will print a list of all the failed steps and their messages. For more info look up the jq docs.
-      # Note: jq is not installed by default on the "alpine:latest" image, however it can be installed with "apk add jq"
+      # Note: jq is not installed by default on the "alpine:3.23" image, however it can be installed with "apk add jq"
       args: ["echo send e-mail: {{workflow.name}} {{workflow.status}} {{workflow.duration}}. Failed steps {{workflow.failures}}"]
   - name: celebrate
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo hooray!"]
   - name: cry
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo boohoo!"]

--- a/examples/fibonacci-seq-conditional-param.yaml
+++ b/examples/fibonacci-seq-conditional-param.yaml
@@ -99,7 +99,7 @@ spec:
               parameter: "{{steps.add.outputs.result}}"
     - name: return-1
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: print(1)
 
@@ -110,7 +110,7 @@ spec:
           - name: op
           - name: b
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [ python ]
         source: |
           print({{inputs.parameters.a}} {{inputs.parameters.op}} {{inputs.parameters.b}})

--- a/examples/fun-with-gifs.yaml
+++ b/examples/fun-with-gifs.yaml
@@ -45,7 +45,7 @@ spec:
 
   - name: create-output-dir
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["mkdir", "/mnt/data/output"]
       volumeMounts:
       - name: workdir
@@ -101,7 +101,7 @@ spec:
 
   - name: bundle-up
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["ls"]
       volumeMounts:
       - name: workdir

--- a/examples/global-outputs.yaml
+++ b/examples/global-outputs.yaml
@@ -17,7 +17,7 @@ spec:
   # Template which produces a global parameter and artifact
   - name: global-output
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 1; echo -n hello world > /tmp/hello_world.txt"]
     outputs:
@@ -55,7 +55,7 @@ spec:
         - name: param
           value: "{{workflow.outputs.parameters.my-global-param}}"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{inputs.parameters.param}}"]
 
@@ -65,6 +65,6 @@ spec:
       - name: art
         path: /art
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /art"]

--- a/examples/handle-large-output-results.yaml
+++ b/examples/handle-large-output-results.yaml
@@ -30,7 +30,7 @@ spec:
               count: "{{steps.get-items.outputs.parameters.count}}"
     - name: get-items
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: ["/bin/sh", "-c"]
         # This small array is just for an example. Make sure the count matches the actual size of
         # your JSON array.

--- a/examples/hdfs-artifact.yaml
+++ b/examples/hdfs-artifact.yaml
@@ -80,6 +80,6 @@ spec:
           #   key: krb5.conf
           # krbServicePrincipalName: hdfs/_HOST
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/message"]

--- a/examples/init-container.yaml
+++ b/examples/init-container.yaml
@@ -7,14 +7,14 @@ spec:
   templates:
   - name: init-container-example
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["echo", "bye"]
       volumeMounts:
       - name: foo
         mountPath: /foo
     initContainers:
     - name: hello
-      image: alpine:latest
+      image: alpine:3.23
       command: ["echo", "hello"]
       mirrorVolumeMounts: true
   volumes:

--- a/examples/input-artifact-http.yaml
+++ b/examples/input-artifact-http.yaml
@@ -17,6 +17,6 @@ spec:
         http:
           url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["kubectl version"]

--- a/examples/input-artifact-raw.yaml
+++ b/examples/input-artifact-raw.yaml
@@ -16,6 +16,6 @@ spec:
             the raw file
             contents
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/file"]

--- a/examples/k8s-jobs.yaml
+++ b/examples/k8s-jobs.yaml
@@ -46,7 +46,7 @@ spec:
             spec:
               containers:
               - name: rand
-                image: python:alpine
+                image: python:alpine3.23
                 command: ["python", "-c", "import random; import time; print(random.randint(1, 1000)); time.sleep(10)"]
               restartPolicy: Never
     # Resource templates can have output parameters extracted from fields of the

--- a/examples/k8s-orchestration.yaml
+++ b/examples/k8s-orchestration.yaml
@@ -57,7 +57,7 @@ spec:
             spec:
               containers:
               - name: rand
-                image: python:alpine
+                image: python:alpine3.23
                 command: ["python", "-c", "import random; import time; print(random.randint(1, 1000)); time.sleep(10)"]
               restartPolicy: Never
     outputs:

--- a/examples/k8s-wait-wf.yaml
+++ b/examples/k8s-wait-wf.yaml
@@ -32,7 +32,7 @@ spec:
           templates:
           - name: sleep
             container:
-              image: alpine:latest
+              image: alpine:3.23
               command: [sleep, "20"]
     outputs:
       parameters:

--- a/examples/life-cycle-hooks-tmpl-level.yaml
+++ b/examples/life-cycle-hooks-tmpl-level.yaml
@@ -29,7 +29,7 @@ spec:
 
     - name: echo
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo \"it was heads\""]
 

--- a/examples/life-cycle-hooks-wf-level.yaml
+++ b/examples/life-cycle-hooks-wf-level.yaml
@@ -18,7 +18,7 @@ spec:
     
     - name: heads
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo \"it was heads\""]
     

--- a/examples/loops-arbitrary-sequential-steps.yaml
+++ b/examples/loops-arbitrary-sequential-steps.yaml
@@ -46,6 +46,6 @@ spec:
           - name: exit_code
           - name: message
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [ '/bin/sh', '-c' ]
         args: [ "echo {{inputs.parameters.message}}; exit {{inputs.parameters.exit_code}}" ]

--- a/examples/loops-param-result.yaml
+++ b/examples/loops-param-result.yaml
@@ -23,7 +23,7 @@ spec:
 
   - name: gen-number-list
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import json
@@ -35,6 +35,6 @@ spec:
       parameters:
       - name: seconds
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]

--- a/examples/loops-sequence.yaml
+++ b/examples/loops-sequence.yaml
@@ -72,5 +72,5 @@ spec:
       parameters:
       - name: msg
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.msg}}"]

--- a/examples/map-reduce.yaml
+++ b/examples/map-reduce.yaml
@@ -49,7 +49,7 @@ spec:
         parameters:
           - name: numParts
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command:
           - python
         source: |
@@ -80,7 +80,7 @@ spec:
           - name: part
             path: /mnt/in/part.json
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command:
           - python
         source: |
@@ -109,7 +109,7 @@ spec:
             s3:
               key: "{{workflow.name}}/results"
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command:
           - python
         source: |

--- a/examples/nested-workflow.yaml
+++ b/examples/nested-workflow.yaml
@@ -88,7 +88,7 @@ spec:
       - name: in-artifact
         path: /tmp/art
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["
         echo 'input parameter value: {{inputs.parameters.in-parameter}}' &&

--- a/examples/node-selector.yaml
+++ b/examples/node-selector.yaml
@@ -25,6 +25,6 @@ spec:
     nodeSelector:
       beta.kubernetes.io/arch: "{{inputs.parameters.arch}}"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["uname -a"]

--- a/examples/parallelism-nested-dag.yaml
+++ b/examples/parallelism-nested-dag.yaml
@@ -84,6 +84,6 @@ spec:
       parameters:
       - name: msg
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ['/bin/sh', '-c']
       args: ["echo {{inputs.parameters.msg}}; sleep 10"]

--- a/examples/parallelism-nested-workflow.yaml
+++ b/examples/parallelism-nested-workflow.yaml
@@ -49,6 +49,6 @@ spec:
       parameters:
       - name: seq-id
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ['/bin/sh', '-c']
       args: ["echo {{inputs.parameters.seq-id}}; sleep 30"]

--- a/examples/parallelism-nested.yaml
+++ b/examples/parallelism-nested.yaml
@@ -60,6 +60,6 @@ spec:
       - name: seq-id
       - name: parallel-id
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ['/bin/sh', '-c']
       args: ["echo {{inputs.parameters.parallel-id}} {{inputs.parameters.seq-id}}; sleep 10"]

--- a/examples/parallelism-template-limit.yaml
+++ b/examples/parallelism-template-limit.yaml
@@ -26,5 +26,5 @@ spec:
 
   - name: sleep
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c, sleep 10]

--- a/examples/parameter-aggregation-dag.yaml
+++ b/examples/parameter-aggregation-dag.yaml
@@ -59,7 +59,7 @@ spec:
       parameters:
       - name: num
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args:
       - |
@@ -85,7 +85,7 @@ spec:
       parameters:
       - name: num
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args:
         - echo $(({{inputs.parameters.num}}/2))

--- a/examples/parameter-aggregation-script.yaml
+++ b/examples/parameter-aggregation-script.yaml
@@ -30,7 +30,7 @@ spec:
       parameters:
       - name: num
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import json
@@ -47,7 +47,7 @@ spec:
       parameters:
       - name: num
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -x]
       source: |
         echo $(({{inputs.parameters.num}}/2))

--- a/examples/parameter-aggregation.yaml
+++ b/examples/parameter-aggregation.yaml
@@ -54,7 +54,7 @@ spec:
       parameters:
       - name: num
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -xc]
       args:
       - |
@@ -80,7 +80,7 @@ spec:
       parameters:
       - name: num
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -x]
       source: |
         #!/bin/sh

--- a/examples/pod-gc-strategy-with-label-selector.yaml
+++ b/examples/pod-gc-strategy-with-label-selector.yaml
@@ -42,7 +42,7 @@ spec:
         labels:
           should-be-deleted: "true"
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["exit 1"]
 
@@ -52,7 +52,7 @@ spec:
         labels:
           should-be-deleted: "true"
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["exit 0"]
 
@@ -62,6 +62,6 @@ spec:
         labels:
           should-be-deleted: "false"
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [ sh, -c ]
         args: [ "exit 0" ]

--- a/examples/pod-gc-strategy.yaml
+++ b/examples/pod-gc-strategy.yaml
@@ -30,12 +30,12 @@ spec:
 
   - name: fail
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 1"]
 
   - name: succeed
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 0"]

--- a/examples/pod-spec-from-previous-step.yaml
+++ b/examples/pod-spec-from-previous-step.yaml
@@ -25,7 +25,7 @@ spec:
           valueFrom:
             path: /tmp/resources.json
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         echo '{"memory": "10Gi", "cpu": "2000m"}' > /tmp/resources.json && cat /tmp/resources.json
@@ -36,7 +36,7 @@ spec:
       - name: resources
     podSpecPatch: '{"containers":[{"name":"main", "resources":{"limits": {{inputs.parameters.resources}}, "requests": {{inputs.parameters.resources}} }}]}'
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         echo {{inputs.parameters.resources}}

--- a/examples/recursive-for-loop.yaml
+++ b/examples/recursive-for-loop.yaml
@@ -45,7 +45,7 @@ spec:
         parameters:
           - name: counter
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [python]
         source: |
           print({{inputs.parameters.counter}} + 1)

--- a/examples/resubmit.yaml
+++ b/examples/resubmit.yaml
@@ -43,6 +43,6 @@ spec:
   # fail with a 33% probability
   - name: random-fail
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", -c]
       args: ["import random; import sys; exit_code = random.choice([0, 0, 1]); print('exiting with code {}'.format(exit_code)); sys.exit(exit_code)"]

--- a/examples/retry-backoff.yaml
+++ b/examples/retry-backoff.yaml
@@ -17,7 +17,7 @@ spec:
         maxDuration: "1m" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h"
         cap: "5" # Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h"
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/retry-conditional.yaml
+++ b/examples/retry-conditional.yaml
@@ -23,7 +23,7 @@ spec:
 
     - name: safe-to-retry
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: ["python"]
         source: |
           print("true")
@@ -44,7 +44,7 @@ spec:
           asInt(lastRetry.duration) < 120 &&
           ({{inputs.parameters.safe-to-retry}} == true || lastRetry.message matches 'imminent node shutdown|pod deleted')
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: ["python"]
         # Exit 1 with 50% probability and 2 with 50%
         source: |

--- a/examples/retry-container-to-completion.yaml
+++ b/examples/retry-container-to-completion.yaml
@@ -9,7 +9,7 @@ spec:
   - name: retry-to-completion
     retryStrategy: {}
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", "-c"]
       # fail with a 80% probability
       args: ["import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)"]

--- a/examples/retry-container.yaml
+++ b/examples/retry-container.yaml
@@ -10,7 +10,7 @@ spec:
     retryStrategy:
       limit: "10"
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/retry-on-error.yaml
+++ b/examples/retry-on-error.yaml
@@ -13,7 +13,7 @@ spec:
       limit: "2"
       retryPolicy: "Always"   # Retry on errors AND failures. Also available: "OnFailure" (default), "OnError", and "OnTransientError" (retry only on transient errors such as i/o or TLS handshake timeout. Available after v3.0.0-rc2)
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", "-c"]
       # fail with a 80% probability
       args: ["import random; import sys; exit_code = random.choice(range(0, 5)); sys.exit(exit_code)"]

--- a/examples/retry-script.yaml
+++ b/examples/retry-script.yaml
@@ -10,7 +10,7 @@ spec:
     retryStrategy:
       limit: "10"
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python"]
       # fail with a 66% probability
       source: |

--- a/examples/retry-with-steps.yaml
+++ b/examples/retry-with-steps.yaml
@@ -20,7 +20,7 @@ spec:
     retryStrategy:
       limit: "10"
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python, -c]
       # fail with a 66% probability
       args: ["import random; import sys; print('retries: {{retries}}'); exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/scripts-bash.yaml
+++ b/examples/scripts-bash.yaml
@@ -25,7 +25,7 @@ spec:
 
   - name: gen-random-int
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       source: |
         cat /dev/urandom | od -N2 -An -i | awk -v f=1 -v r=100 '{printf "%i\n", f + r * $1 / 65536}'
@@ -35,6 +35,6 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]

--- a/examples/scripts-javascript.yaml
+++ b/examples/scripts-javascript.yaml
@@ -36,6 +36,6 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]

--- a/examples/scripts-python.yaml
+++ b/examples/scripts-python.yaml
@@ -25,7 +25,7 @@ spec:
 
   - name: gen-random-int
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random
@@ -37,6 +37,6 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]

--- a/examples/secrets.yaml
+++ b/examples/secrets.yaml
@@ -27,7 +27,7 @@ spec:
   templates:
   - name: print-secret
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ['
         echo "secret from env: $MYSECRETPASSWORD";

--- a/examples/sidecar.yaml
+++ b/examples/sidecar.yaml
@@ -7,7 +7,7 @@ spec:
   templates:
   - name: sidecar-example
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["
         apk update &&

--- a/examples/status-reference.yaml
+++ b/examples/status-reference.yaml
@@ -24,18 +24,18 @@ spec:
 
     - name: flakey-container
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["exit 1"]
 
     - name: failed
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo \"the flakey container failed\""]
 
     - name: succeeded
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo \"the flakey container passed\""]

--- a/examples/step-level-timeout.yaml
+++ b/examples/step-level-timeout.yaml
@@ -29,6 +29,6 @@ spec:
       parameters:
       - name: timeout
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 30s"]

--- a/examples/synchronization-db-mutex-tmpl-level.yaml
+++ b/examples/synchronization-db-mutex-tmpl-level.yaml
@@ -33,7 +33,7 @@ spec:
         - name: welcome
           database: true # v3.7 and after
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 20; echo acquired lock"]
 
@@ -43,6 +43,6 @@ spec:
         - name: test
           database: true # v3.7 and after
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 50; echo acquired lock"]

--- a/examples/synchronization-db-tmpl-level.yaml
+++ b/examples/synchronization-db-tmpl-level.yaml
@@ -27,6 +27,6 @@ spec:
         - database: # v3.7 and after
             key: template
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 10; echo acquired lock"]

--- a/examples/synchronization-mutex-tmpl-level.yaml
+++ b/examples/synchronization-mutex-tmpl-level.yaml
@@ -34,7 +34,7 @@ spec:
       # mutex: # deprecated: v3.5 and before
       #   name: welcome
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 20; echo acquired lock"]
 
@@ -45,6 +45,6 @@ spec:
       # mutex: # deprecated: v3.5 and before
       #   name: test
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 50; echo acquired lock"]

--- a/examples/synchronization-tmpl-level.yaml
+++ b/examples/synchronization-tmpl-level.yaml
@@ -38,6 +38,6 @@ spec:
       #     name: my-config
       #     key: template
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 10; echo acquired lock"]

--- a/examples/template-defaults.yaml
+++ b/examples/template-defaults.yaml
@@ -34,7 +34,7 @@ spec:
 
     - name: retry-backoff
       container:
-        image: python:alpine
+        image: python:alpine3.23
         command: ["python", -c]
         # fail with a 66% probability
         args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/examples/timeouts-workflow.yaml
+++ b/examples/timeouts-workflow.yaml
@@ -36,4 +36,4 @@ spec:
     nodeSelector:
       beta.kubernetes.io/arch: no-such-arch
     container:
-      image: alpine:latest
+      image: alpine:3.23

--- a/examples/volumes-emptydir.yaml
+++ b/examples/volumes-emptydir.yaml
@@ -14,7 +14,7 @@ spec:
   templates:
   - name: volumes-emptydir-example
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["/bin/sh", "-c"]
       args: ["
         vol_found=`mount | grep /mnt/vol` && \

--- a/examples/volumes-existing.yaml
+++ b/examples/volumes-existing.yaml
@@ -28,7 +28,7 @@ spec:
 
   - name: append-to-accesslog
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo accessed at: $(date) | tee -a /mnt/vol/accesslog"]
       volumeMounts:
@@ -37,7 +37,7 @@ spec:
 
   - name: print-accesslog
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'Volume access log:'; cat /mnt/vol/accesslog"]
       volumeMounts:

--- a/examples/volumes-pvc.yaml
+++ b/examples/volumes-pvc.yaml
@@ -36,7 +36,7 @@ spec:
 
   - name: print-message-from-file
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo getting message from volume; find /mnt/vol; cat /mnt/vol/hello_world.txt"]
       volumeMounts:

--- a/examples/withsequence-nested-result.yaml
+++ b/examples/withsequence-nested-result.yaml
@@ -35,7 +35,7 @@ spec:
 
     - name: hello
       script:
-        image: python:alpine
+        image: python:alpine3.23
         command: [python]
         source: |
           import random

--- a/examples/workflow-template/templates.yaml
+++ b/examples/workflow-template/templates.yaml
@@ -24,7 +24,7 @@ spec:
     retryStrategy:
       limit: 10
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python, -c]
       # fail with a 66% probability
       args: ["import random; import sys; exit_code = random.choice([0, 1, 1]); sys.exit(exit_code)"]

--- a/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
@@ -269,13 +269,13 @@ func TestWorkflowTemplateServer_UpdateClusterWorkflowTemplate(t *testing.T) {
 		req := &clusterwftmplpkg.ClusterWorkflowTemplateUpdateRequest{
 			Template: cwftObj2.DeepCopy(),
 		}
-		req.Template.Spec.Templates[0].Container.Image = "alpine:latest"
+		req.Template.Spec.Templates[0].Container.Image = "alpine:3.23"
 		cwftRsp, err := server.UpdateClusterWorkflowTemplate(ctx, req)
 		require.NoError(t, err)
 		assert.Contains(t, cwftRsp.Labels, common.LabelKeyActor)
 		assert.Equal(t, string(creator.ActionUpdate), cwftRsp.Labels[common.LabelKeyAction])
 		assert.Equal(t, userEmailLabel, cwftRsp.Labels[common.LabelKeyActorEmail])
-		assert.Equal(t, "alpine:latest", cwftRsp.Spec.Templates[0].Container.Image)
+		assert.Equal(t, "alpine:3.23", cwftRsp.Spec.Templates[0].Container.Image)
 	})
 	t.Run("Unlabelled", func(t *testing.T) {
 		_, err := server.UpdateClusterWorkflowTemplate(ctx, &clusterwftmplpkg.ClusterWorkflowTemplateUpdateRequest{

--- a/server/cronworkflow/cron_workflow_server_test.go
+++ b/server/cronworkflow/cron_workflow_server_test.go
@@ -44,7 +44,7 @@ spec:
     templates:
       - name: whalesay
         container:
-          image: python:alpine
+          image: python:alpine3.23
           imagePullPolicy: IfNotPresent
           command: ["sh", -c]
           args: ["echo hello"]`, &cronWf)

--- a/server/workflowtemplate/workflow_template_server_test.go
+++ b/server/workflowtemplate/workflow_template_server_test.go
@@ -267,7 +267,7 @@ func TestWorkflowTemplateServer_UpdateWorkflowTemplate(t *testing.T) {
 	t.Run("Labelled", func(t *testing.T) {
 		var wftObj1 v1alpha1.WorkflowTemplate
 		v1alpha1.MustUnmarshal(wftStr2, &wftObj1)
-		wftObj1.Spec.Templates[0].Container.Image = "alpine:latest"
+		wftObj1.Spec.Templates[0].Container.Image = "alpine:3.23"
 		wftRsp, err := server.UpdateWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateUpdateRequest{
 			Namespace: "default",
 			Template:  &wftObj1,
@@ -276,7 +276,7 @@ func TestWorkflowTemplateServer_UpdateWorkflowTemplate(t *testing.T) {
 		assert.Contains(t, wftRsp.Labels, common.LabelKeyActor)
 		assert.Equal(t, string(creator.ActionUpdate), wftRsp.Labels[common.LabelKeyAction])
 		assert.Equal(t, userEmailLabel, wftRsp.Labels[common.LabelKeyActorEmail])
-		assert.Equal(t, "alpine:latest", wftRsp.Spec.Templates[0].Container.Image)
+		assert.Equal(t, "alpine:3.23", wftRsp.Spec.Templates[0].Container.Image)
 	})
 	t.Run("Unlabelled", func(t *testing.T) {
 		_, err := server.UpdateWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateUpdateRequest{

--- a/test/e2e/expectedfailures/dag-disable-failFast.yaml
+++ b/test/e2e/expectedfailures/dag-disable-failFast.yaml
@@ -14,14 +14,14 @@ spec:
     retryStrategy:
       limit: 2
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 30; echo haha"]
   - name: c
     retryStrategy:
       limit: 3
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo intentional failure; exit 2"]
   - name: d

--- a/test/e2e/expectedfailures/dag-fail.yaml
+++ b/test/e2e/expectedfailures/dag-fail.yaml
@@ -17,7 +17,7 @@ spec:
       parameters:
       - name: cmd
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["{{inputs.parameters.cmd}}"]
   - name: diamond

--- a/test/e2e/expectedfailures/dag-noroot-branch-failed.yaml
+++ b/test/e2e/expectedfailures/dag-noroot-branch-failed.yaml
@@ -14,14 +14,14 @@ spec:
     retryStrategy:
       limit: 2
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 30; echo haha"]
   - name: c
     retryStrategy:
       limit: 3
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo intentional failure; exit 2"]
   - name: d

--- a/test/e2e/expectedfailures/exit-handler-failed.yaml
+++ b/test/e2e/expectedfailures/exit-handler-failed.yaml
@@ -10,12 +10,12 @@ spec:
   # primary workflow template
   - name: pass
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 0"]
 
   - name: fail
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 1"]

--- a/test/e2e/expectedfailures/failed-artifact-load.yaml
+++ b/test/e2e/expectedfailures/failed-artifact-load.yaml
@@ -16,6 +16,6 @@ spec:
         http:
           url: https://non-existent-http-location.com/doesnt-exist.txt
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'we shouldn't get here'"]

--- a/test/e2e/expectedfailures/failed-artifact-save.yaml
+++ b/test/e2e/expectedfailures/failed-artifact-save.yaml
@@ -24,6 +24,6 @@ spec:
             name: non-existent-secret
             key: secretkey
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'hello world'"]

--- a/test/e2e/expectedfailures/failed-retries.yaml
+++ b/test/e2e/expectedfailures/failed-retries.yaml
@@ -17,7 +17,7 @@ spec:
     retryStrategy:
       limit: 1
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 1"]
 
@@ -25,6 +25,6 @@ spec:
     retryStrategy:
       limit: 1
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 1; exit 1"]

--- a/test/e2e/expectedfailures/failed-step.yaml
+++ b/test/e2e/expectedfailures/failed-step.yaml
@@ -24,6 +24,6 @@ spec:
         parameters:
           - name: code
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo 'exiting with exit code {{inputs.parameters.code}}'; exit {{inputs.parameters.code}}"]

--- a/test/e2e/expectedfailures/pod-termination-failure.yaml
+++ b/test/e2e/expectedfailures/pod-termination-failure.yaml
@@ -32,7 +32,7 @@ spec:
         parameters:
           - name: seconds
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]
     - name: check-status

--- a/test/e2e/expectedfailures/unschedulable.yaml
+++ b/test/e2e/expectedfailures/unschedulable.yaml
@@ -20,4 +20,4 @@ spec:
     nodeSelector:
       beta.kubernetes.io/arch: no-such-arch
     container:
-      image: alpine:latest
+      image: alpine:3.23

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -167,7 +167,7 @@ func (g *Given) checkImages(wf interface{}, isExample bool) {
 			image == "argoproj/argosay:v2" ||
 			image == "quay.io/argoproj/argocli:latest" ||
 			(isExample && (image == "busybox" ||
-				image == "python:alpine" ||
+				image == "python:alpine3.23" ||
 				image == "golang:1.18" ||
 				image == "nginx:1.13" ||
 				image == "curlimages/curl:latest" ||
@@ -175,7 +175,7 @@ func (g *Given) checkImages(wf interface{}, isExample bool) {
 				image == "docker:19.03.13" ||
 				image == "docker:19.03.13-dind" ||
 				image == "alpine/git:v2.26.2" ||
-				image == "alpine:latest" ||
+				image == "alpine:3.23" ||
 				image == "stedolan/jq:latest" ||
 				image == "influxdb:1.2"))
 	}

--- a/test/e2e/functional/artifact-input-output-samedir.yaml
+++ b/test/e2e/functional/artifact-input-output-samedir.yaml
@@ -91,7 +91,7 @@ spec:
       - name: coincidental-prefix
         path: /coincidental-prefix.txt
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -xe]
       source: |
         cat /outer/outer.txt

--- a/test/e2e/functional/dag-argument-passing.yaml
+++ b/test/e2e/functional/dag-argument-passing.yaml
@@ -14,7 +14,7 @@ spec:
       - name: passthrough
         path: /tmp/passthrough
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c, -x]
       args: ['sleep 1; echo "{{inputs.parameters.message}}"; cat /tmp/passthrough']
     outputs:

--- a/test/e2e/functional/dag-targets-input-param.yaml
+++ b/test/e2e/functional/dag-targets-input-param.yaml
@@ -48,5 +48,5 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]

--- a/test/e2e/functional/dag-with-retries.yaml
+++ b/test/e2e/functional/dag-with-retries.yaml
@@ -18,6 +18,6 @@ spec:
     retryStrategy:
       limit: 20
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit $(( ${RANDOM} % 5 ))"]

--- a/test/e2e/functional/global-outputs-dag.yaml
+++ b/test/e2e/functional/global-outputs-dag.yaml
@@ -19,7 +19,7 @@ spec:
   # Template which produces a global parameter and artifact
   - name: global-output
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 1; echo -n hello world > /tmp/hello_world.txt"]
     outputs:
@@ -54,7 +54,7 @@ spec:
 
   - name: consume-global-param
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{workflow.outputs.parameters.my-global-param}}"]
 
@@ -64,6 +64,6 @@ spec:
       - name: art
         path: /art
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /art"]

--- a/test/e2e/functional/global-outputs-variable.yaml
+++ b/test/e2e/functional/global-outputs-variable.yaml
@@ -21,7 +21,7 @@ spec:
       parameters:
       - name: globalname
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 1; echo -n hello world > /tmp/hello_world.txt"]
     outputs:

--- a/test/e2e/functional/global-param-sub-with-artifacts.yaml
+++ b/test/e2e/functional/global-param-sub-with-artifacts.yaml
@@ -21,6 +21,6 @@ spec:
         path: /tmp/foo.txt
         mode: 0644
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["cat"]
       args: ["/tmp/foo.txt"]

--- a/test/e2e/functional/loop-sequence-empty.yaml
+++ b/test/e2e/functional/loop-sequence-empty.yaml
@@ -31,5 +31,5 @@ spec:
       parameters:
       - name: num
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.num}}"]

--- a/test/e2e/functional/loops-sequence-dag.yaml
+++ b/test/e2e/functional/loops-sequence-dag.yaml
@@ -36,5 +36,5 @@ spec:
       parameters:
       - name: msg
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.msg}}"]

--- a/test/e2e/functional/nested-dag-outputs.yaml
+++ b/test/e2e/functional/nested-dag-outputs.yaml
@@ -90,7 +90,7 @@ spec:
       - name: in-artifact
         path: /tmp/art
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["
         echo 'input parameter value: {{inputs.parameters.in-parameter}}' &&

--- a/test/e2e/functional/output-input-artifact-optional.yaml
+++ b/test/e2e/functional/output-input-artifact-optional.yaml
@@ -35,6 +35,6 @@ spec:
             path: /tmp/message
             optional: true
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo /tmp/message"]

--- a/test/e2e/functional/param-sub-with-artifacts.yaml
+++ b/test/e2e/functional/param-sub-with-artifacts.yaml
@@ -22,6 +22,6 @@ spec:
           url: "{{inputs.parameters.artifact-url}}"
 
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["cat"]
       args: ["/tmp/foo.txt"]

--- a/test/e2e/functional/retry-with-artifacts.yaml
+++ b/test/e2e/functional/retry-with-artifacts.yaml
@@ -35,6 +35,6 @@ spec:
       - name: message
         path: /tmp/message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/message"]

--- a/test/e2e/functional/script-with-input-art.yaml
+++ b/test/e2e/functional/script-with-input-art.yaml
@@ -13,7 +13,7 @@ spec:
         http:
           url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         ls /bin/kubectl

--- a/test/e2e/functional/script-with-volume.yaml
+++ b/test/e2e/functional/script-with-volume.yaml
@@ -11,7 +11,7 @@ spec:
   templates:
   - name: script-with-vol
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         ls /mnt/vol

--- a/test/e2e/functional/sidecar-force-kill.yaml
+++ b/test/e2e/functional/sidecar-force-kill.yaml
@@ -7,9 +7,9 @@ spec:
   templates:
   - name: sidecar-force-kill
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sleep, 5s]
     sidecars:
     - name: sleep
-      image: alpine:latest
+      image: alpine:3.23
       command: [sleep, 1d]

--- a/test/e2e/functional/suspend-dag-template.yaml
+++ b/test/e2e/functional/suspend-dag-template.yaml
@@ -22,7 +22,7 @@ spec:
 
   - name: pass
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c, exit 0]
 
   - name: approve

--- a/test/e2e/functional/template_level_host_aliases.yaml
+++ b/test/e2e/functional/template_level_host_aliases.yaml
@@ -12,6 +12,6 @@ spec:
         hostnames:
           - "argo.io"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: [" nslookup argo.io"]

--- a/test/e2e/functional/tty.yaml
+++ b/test/e2e/functional/tty.yaml
@@ -16,7 +16,7 @@ spec:
       script:
         tty: true
         stdin: true
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh]
         source: |
           if [[ ! -t 0 ]]; then
@@ -26,7 +26,7 @@ spec:
 
     - name: tty-false
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh]
         source: |
           if [[ -t 0 ]]; then

--- a/test/e2e/functional/workflow_level_host_aliases.yaml
+++ b/test/e2e/functional/workflow_level_host_aliases.yaml
@@ -11,6 +11,6 @@ spec:
   templates:
   - name: nslookup
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["nslookup argo.io"]

--- a/test/e2e/functional/workflow_template_level_host_aliases.yaml
+++ b/test/e2e/functional/workflow_template_level_host_aliases.yaml
@@ -16,6 +16,6 @@ spec:
         hostnames:
           - "argo1.io"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["nslookup argo.io argo1.io "]

--- a/test/e2e/manifests/plugins/hello-executor-plugin-configmap.yaml
+++ b/test/e2e/manifests/plugins/hello-executor-plugin-configmap.yaml
@@ -50,7 +50,7 @@ data:
     command:
     - python
     - -c
-    image: python:alpine
+    image: python:alpine3.23
     name: hello-executor-plugin
     ports:
     - containerPort: 4355

--- a/test/e2e/smoke/with-items-with-hooks.yaml
+++ b/test/e2e/smoke/with-items-with-hooks.yaml
@@ -16,7 +16,7 @@ spec:
           - name: 'foo'
       script:
         image: >-
-          alpine:latest
+          alpine:3.23
         command:
           - sh
         source: >-
@@ -27,7 +27,7 @@ spec:
           - name: fanoutValue
       script:
         image: >-
-          alpine:latest
+          alpine:3.23
         command:
           - sh
         source: >-

--- a/test/e2e/testdata/convert/convert-legacy-sync.yaml
+++ b/test/e2e/testdata/convert/convert-legacy-sync.yaml
@@ -14,7 +14,7 @@ spec:
   templates:
   - name: main
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo]
       args: ["hello"]
     synchronization:

--- a/ui/test/ui/ui-memoize.yaml
+++ b/ui/test/ui/ui-memoize.yaml
@@ -41,7 +41,7 @@ spec:
           - name: flag
       container:
         name: ''
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - '-c'

--- a/ui/test/ui/ui-wacky-workflow.yaml
+++ b/ui/test/ui/ui-wacky-workflow.yaml
@@ -66,7 +66,7 @@ spec:
   # Generate a list of numbers in JSON format
   - name: gen-number-list1
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import json
@@ -75,7 +75,7 @@ spec:
   
   - name: gen-number-list2
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import json
@@ -84,7 +84,7 @@ spec:
   
   - name: gen-number-list3
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import json
@@ -114,7 +114,7 @@ spec:
       parameters:
       - name: seconds
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo sleeping for {{inputs.parameters.seconds}} seconds; sleep {{inputs.parameters.seconds}}; echo done"]
   
@@ -123,6 +123,6 @@ spec:
       parameters:
       - name: seconds
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo input was {{inputs.parameters.seconds}} seconds; echo done"]

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -228,7 +228,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         print("{{inputs.parameters.message}}")`
 
@@ -841,7 +841,7 @@ spec:
   templates:
   - name: test-container
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["echo", "bye"]
 `
 
@@ -859,7 +859,7 @@ spec:
   templates:
   - name: test-container
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: ["echo", "bye"]
 `
 

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -72,17 +72,17 @@ spec:
 
  - name: Succeeded
    container:
-     image: alpine:latest
+     image: alpine:3.23
      command: [sh, -c, "exit 0"]
 
  - name: Failed
    container:
-     image: alpine:latest
+     image: alpine:3.23
      command: [sh, -c, "exit 1"]
 
  - name: Skipped
    container:
-     image: alpine:latest
+     image: alpine:3.23
      command: [sh, -c, "echo Hello"]
 `
 
@@ -184,7 +184,7 @@ spec:
       - name: message
         path: /tmp/message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/message"]
 
@@ -610,7 +610,7 @@ spec:
       command:
       - sh
       - -xc
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:
@@ -638,7 +638,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
       resources: {}
       source: |
@@ -881,7 +881,7 @@ spec:
       command:
       - sh
       - -xc
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:
@@ -1148,7 +1148,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -1374,7 +1374,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -1736,7 +1736,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -1750,7 +1750,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -1902,7 +1902,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -1916,7 +1916,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -2025,7 +2025,7 @@ spec:
     container:
       args: ['mkdir -p /tmp/outputs/A && echo "exist" > /tmp/outputs/A/data']
       command: [sh, -c]
-      image: alpine:latest
+      image: alpine:3.23
     outputs:
       artifacts:
       - {name: A-out, path: /tmp/outputs/A/data}
@@ -2033,7 +2033,7 @@ spec:
     container:
       args: ['[ -f /tmp/outputs/condition/data ] && cat /tmp/outputs/condition/data || echo not exist']
       command: [sh, -c]
-      image: alpine:latest
+      image: alpine:3.23
     inputs:
       artifacts:
       - {name: B-in, optional: true,  path: /tmp/outputs/condition/data}
@@ -2303,7 +2303,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -3284,7 +3284,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:

--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -525,7 +525,7 @@ spec:
       - set -xe && ls -ltr /
       command:
       - sh
-      image: alpine:latest
+      image: alpine:3.23
     inputs:
       parameters:
       - name: IMAGE
@@ -536,7 +536,7 @@ spec:
       - set -xe && ls -ltr /
       command:
       - sh
-      image: alpine:latest
+      image: alpine:3.23
     name: LinuxJobBase
     retryStrategy:
       limit: "3"
@@ -548,7 +548,7 @@ spec:
             arguments:
               parameters:
               - name: IMAGE
-                value: alpine:latest
+                value: alpine:3.23
             template: LinuxExitHandler
         name: Python2Compile
         template: LinuxJobBase
@@ -558,7 +558,7 @@ spec:
             arguments:
               parameters:
               - name: IMAGE
-                value: alpine:latest
+                value: alpine:3.23
             template: LinuxExitHandler
         name: DependencyTesting
         template: LinuxJobBase
@@ -650,7 +650,7 @@ status:
       inputs:
         parameters:
         - name: IMAGE
-          value: alpine:latest
+          value: alpine:3.23
       name: test-workflow-with-retry-strategy8h899[0].Execute.Python2Compile.onExit
       phase: Succeeded
       startedAt: "2021-07-29T16:16:27Z"
@@ -679,7 +679,7 @@ status:
       inputs:
         parameters:
         - name: IMAGE
-          value: alpine:latest
+          value: alpine:3.23
       name: test-workflow-with-retry-strategy8h899[0].Execute.DependencyTesting.onExit
       phase: Succeeded
       startedAt: "2021-07-29T16:16:27Z"
@@ -886,7 +886,7 @@ spec:
       command:
       - sh
       - -c
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
     name: output
     outputs:
@@ -902,7 +902,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
       source: |
         print("{{inputs.parameters.message}}")
@@ -1022,7 +1022,7 @@ spec:
                       value: "{{steps.main.status}}"
     - name: echo
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo hi"]
     - name: hook
@@ -1030,7 +1030,7 @@ spec:
         parameters:
           - name: status
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo {{inputs.parameters.status}}"]
 `)

--- a/workflow/controller/hooks_test.go
+++ b/workflow/controller/hooks_test.go
@@ -44,7 +44,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
     name: heads
   - http:
@@ -179,7 +179,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
     name: echo
   - http:
       url: https://raw.githubusercontent.com/argoproj/argo-workflows/4e450e250168e6b4d51a126b784e90b11a0162bc/pkg/apis/workflow/v1alpha1/generated.swagger.json
@@ -308,7 +308,7 @@ spec:
 
     - name: echo
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo \"it was heads\""]
 
@@ -459,7 +459,7 @@ status:
         command:
         - sh
         - -c
-        image: alpine:latest
+        image: alpine:3.23
         name: ""
         resources: {}
       inputs: {}
@@ -531,7 +531,7 @@ status:
         command:
         - sh
         - -c
-        image: alpine:latest
+        image: alpine:3.23
         name: ""
       name: echo
     - http:
@@ -724,7 +724,7 @@ status:
         command:
         - sh
         - -c
-        image: alpine:latest
+        image: alpine:3.23
         name: ""
         resources: {}
       inputs: {}
@@ -870,7 +870,7 @@ status:
         command:
         - sh
         - -c
-        image: alpine:latest
+        image: alpine:3.23
         name: ""
         resources: {}
       inputs: {}
@@ -915,7 +915,7 @@ status:
         command:
         - sh
         - -c
-        image: alpine:latest
+        image: alpine:3.23
         name: ""
         resources: {}
       inputs: {}
@@ -965,7 +965,7 @@ spec:
   templates:
     - name: intentional-fail
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo intentional failure; exit 1"]
     - name: message
@@ -973,7 +973,7 @@ spec:
         parameters:
           - name: message
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh]
         source: |
           echo {{ inputs.parameters.message }}
@@ -1021,7 +1021,7 @@ spec:
   templates:
     - name: message
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh]
         source: |
           echo Hi
@@ -1060,7 +1060,7 @@ spec:
                 template: message
     - name: message
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh]
         source: |
           echo Hi
@@ -1101,12 +1101,12 @@ spec:
   templates:
     - name: main
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo", "This template finish fastest"]
     - name: sleep
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh]
         source: |
           sleep 10
@@ -1190,13 +1190,13 @@ spec:
                 template: hook
     - name: hook
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [/bin/sh]
         source: |
           sleep 5
     - name: exit0
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [/bin/sh]
         source: |
           exit 0

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -73,7 +73,7 @@ spec:
             key: template
             name: my-config
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python"]
       # fail with a 66% probability
       source: |
@@ -100,7 +100,7 @@ spec:
             key: template
             name: my-config
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python"]
       # fail with a 66% probability
       source: |
@@ -455,7 +455,7 @@ spec:
      mutexes:
        - name: welcome
    container:
-     image: alpine:latest
+     image: alpine:3.23
      command: [sh, -c, "exit 0"]
 `
 
@@ -527,7 +527,7 @@ spec:
      parameters:
      - name: message
    container:
-     image: alpine:latest
+     image: alpine:3.23
      command: [sh, -c, "echo {{inputs.parameters.message}}"]
 `
 
@@ -877,7 +877,7 @@ spec:
               name: my-config
               key: template
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["sleep 300"]`
 
@@ -1081,7 +1081,7 @@ spec:
         parameters:
           - name: sleep_duration
       script:
-        image: alpine:latest
+        image: alpine:3.23
         command: [/bin/sh]
         source: |
           echo "Sleeping for {{ inputs.parameters.sleep_duration }}"

--- a/workflow/controller/operator_data_test.go
+++ b/workflow/controller/operator_data_test.go
@@ -91,7 +91,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
     inputs:
       artifacts:
@@ -111,7 +111,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
     inputs:
       parameters:
       - name: file

--- a/workflow/controller/operator_metrics_test.go
+++ b/workflow/controller/operator_metrics_test.go
@@ -39,7 +39,7 @@ spec:
             valueFrom:
               path: /tmp/rand_int.txt
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["RAND_INT=$((1 + RANDOM % 10)); echo $RAND_INT; echo $RAND_INT > /tmp/rand_int.txt"]
 `
@@ -386,7 +386,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -424,7 +424,7 @@ spec:
       command:
       - python
       - -c
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
       resources: {}
     inputs: {}
@@ -856,7 +856,7 @@ spec:
 
   - name: echo
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "hello"]
 `
 

--- a/workflow/controller/operator_template_scope_test.go
+++ b/workflow/controller/operator_template_scope_test.go
@@ -46,7 +46,7 @@ spec:
           template: steps
   - name: hello
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         print("hello world")
@@ -66,7 +66,7 @@ spec:
         template: hello
   - name: hello
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         print("hello world")
@@ -156,7 +156,7 @@ spec:
         parameters:
          - name: letter
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo {{inputs.parameters.letter}}"]
 `
@@ -245,7 +245,7 @@ spec:
         parameters:
          - name: letter
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo {{inputs.parameters.letter}}"]
 `
@@ -347,7 +347,7 @@ spec:
         parameters:
          - name: letter
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["echo {{inputs.parameters.letter}}"]
 `
@@ -442,7 +442,7 @@ spec:
           template: steps
   - name: hello
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         print("hello world")

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -337,7 +337,7 @@ spec:
   templates:
   - name: sidecar-with-volumes
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         print("hello world")
@@ -442,7 +442,7 @@ spec:
   templates:
   - name: workflow-with-volumes
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       volumeMounts:
       - name: claim-vol
@@ -1204,7 +1204,7 @@ spec:
       command:
       - python
       - -c
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
       resources: {}
     inputs: {}
@@ -1536,7 +1536,7 @@ spec:
             limits:
               memory: "{{= (sprig.int(lastRetry.exitCode)==1 ? (sprig.int(retries)+1) : 1)* 100}}Mi"
     container:
-      image: python:alpine
+      image: python:alpine3.23
       command: ["python", -c]
       args: ["import sys; sys.exit(1)"]
 `
@@ -2144,7 +2144,7 @@ spec:
 
   - name: sleep
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c, sleep 10]
 `
 
@@ -2198,7 +2198,7 @@ spec:
 
   - name: sleep
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c, sleep 10]
 `
 
@@ -2258,7 +2258,7 @@ spec:
         template: sleep
   - name: sleep
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c, sleep 10]
 `
 
@@ -2552,7 +2552,7 @@ spec:
       parameters:
       - name: msg
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.msg}}"]
 `
 
@@ -3021,7 +3021,7 @@ spec:
   templates:
   - name: append-to-accesslog
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo accessed at: $(date) | tee -a /mnt/vol/accesslog"]
       volumeMounts:
@@ -3661,7 +3661,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]
 `
@@ -3853,7 +3853,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]
 `
@@ -3971,7 +3971,7 @@ spec:
       parameters:
       - name: message
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]
 `
@@ -4054,12 +4054,12 @@ spec:
   templates:
   - name: intentional-fail
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo intentional failure; exit 1"]
   - name: exit-handler
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo send e-mail: {{workflow.name}} {{workflow.status}} {{workflow.duration}}. Failed steps {{workflow.failures}}"]
 `
@@ -4098,7 +4098,7 @@ spec:
     suspend: {}
   - name: exit-handler
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo send e-mail: {{workflow.name}} {{workflow.status}}."]
 `
@@ -4791,7 +4791,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo]
       args: ["{{pod.name}}: {{inputs.parameters.message}}"]
 `
@@ -4846,7 +4846,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -5108,7 +5108,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -5186,7 +5186,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -5852,7 +5852,7 @@ spec:
 
   - name: hello
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo Hello"]
 `
@@ -5891,7 +5891,7 @@ spec:
 
   - name: hello
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo Hello"]
 `
@@ -6857,7 +6857,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       resources:
         requests:
           memory: 1Gi
@@ -7144,7 +7144,7 @@ status:
     type: PodScheduled
   containerStatuses:
   - containerID: docker://502dda61a8f05e08d10cffc972d2fb9226e82af7daaacff98e84727bb96f11e6
-    image: python:alpine
+    image: python:alpine3.23
     imageID: docker-pullable://python@sha256:766a961bf699491995cc29e20958ef11fd63741ff41dcc70ec34355b39d52971
     lastState:
       waiting: {}
@@ -7516,7 +7516,7 @@ spec:
       parameters:
       - name: num
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -x]
       source: |
         #!/bin/sh
@@ -7613,7 +7613,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:
@@ -7927,7 +7927,7 @@ spec:
       affinity:
         nodeAntiAffinity: {}
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         exit(1)
@@ -8252,7 +8252,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo result was: {{inputs.parameters.message}}"]
 `
@@ -8828,7 +8828,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
     name: global-output
     outputs:
       artifacts:
@@ -8856,7 +8856,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
     inputs:
       parameters:
       - name: param
@@ -8868,7 +8868,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
     inputs:
       artifacts:
       - name: art
@@ -8937,7 +8937,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
     inputs:
       parameters:
       - name: job_name
@@ -8950,7 +8950,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         import json
   - name: materializations
@@ -8961,7 +8961,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
       resources: {}
       source: |
@@ -9036,7 +9036,7 @@ spec:
         - -c
         - |
           print("hi")
-        image: python:alpine
+        image: python:alpine3.23
         name: main
     name: group
   - inputs:
@@ -9044,7 +9044,7 @@ spec:
       - name: x
     name: verify
     script:
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         assert "{{inputs.parameters.x}}" == "hi"
 status:
@@ -9092,7 +9092,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         print("true")
   - inputs:
@@ -9106,7 +9106,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         import random;
         import sys;
@@ -9285,7 +9285,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         print("true")
   - inputs:
@@ -9298,7 +9298,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         import random;
         import sys;
@@ -9460,7 +9460,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         print("true")
   - inputs:
@@ -9472,7 +9472,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       source: |
         import random;
         import sys;
@@ -9644,7 +9644,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -9674,7 +9674,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
       source: ""
@@ -9930,7 +9930,7 @@ spec:
       metadata: {}
       script:
         name: ''
-        image: 'alpine:latest'
+        image: 'alpine:3.23'
         command:
           - /bin/sh
         resources: {}
@@ -9948,7 +9948,7 @@ spec:
       metadata: {}
       script:
         name: ''
-        image: 'alpine:latest'
+        image: 'alpine:3.23'
         command:
           - /bin/sh
         resources: {}
@@ -9971,7 +9971,7 @@ spec:
       metadata: {}
       script:
         name: ''
-        image: 'alpine:latest'
+        image: 'alpine:3.23'
         command:
           - /bin/sh
         resources: {}
@@ -10760,7 +10760,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 
 `
@@ -11086,7 +11086,7 @@ spec:
       - name: workflow_artifact_key
         value: '{{workflow.name}}'
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       env:
       - name: message
@@ -11205,7 +11205,7 @@ spec:
       command:
       - sleep
       - "10"
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -11421,14 +11421,14 @@ spec:
       containerSet:
         containers:
           - name: main
-            image: alpine:latest
+            image: alpine:3.23
             command:
               - /bin/sh
             args:
               - '-c'
               - sleep 9000
           - name: main2
-            image: alpine:latest
+            image: alpine:3.23
             command:
               - /bin/sh
             args:
@@ -11501,14 +11501,14 @@ spec:
       containerSet:
         containers:
           - name: main
-            image: alpine:latest
+            image: alpine:3.23
             command:
               - /bin/sh
             args:
               - '-c'
               - sleep 9000
           - name: main2
-            image: alpine:latest
+            image: alpine:3.23
             command:
               - /bin/sh
             args:
@@ -11752,7 +11752,7 @@ spec:
             optional: true
             path: /tmp/message
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["test -e /tmp/message && ls /tmp/message || echo 0"]`
 
@@ -11813,7 +11813,7 @@ spec:
             optional: true
             path: /tmp/message
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sh, -c]
         args: ["test -e /tmp/message && ls /tmp/message || echo 0"]`
 
@@ -12308,7 +12308,7 @@ spec:
         parameters:
           - name: arg
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [echo]
         args: ["{{inputs.parameters.arg}}"]
   ttlStrategy:

--- a/workflow/controller/operator_tmpl_default_test.go
+++ b/workflow/controller/operator_tmpl_default_test.go
@@ -81,7 +81,7 @@ spec:
 
   - name: flip-coin
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random
@@ -90,7 +90,7 @@ spec:
 
   - name: heads
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo \"it was heads\""]
 `

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -59,7 +59,7 @@ spec:
       - name: message
         path: /tmp/message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /tmp/message"]
 
@@ -221,7 +221,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -238,7 +238,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:

--- a/workflow/controller/testdata/dag-disable-fail-fast.yaml
+++ b/workflow/controller/testdata/dag-disable-fail-fast.yaml
@@ -34,7 +34,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -49,7 +49,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}

--- a/workflow/controller/testdata/dag_retry_succeeded.yaml
+++ b/workflow/controller/testdata/dag_retry_succeeded.yaml
@@ -30,7 +30,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}

--- a/workflow/controller/testdata/dag_wftmpl_hook_with_retry.yaml
+++ b/workflow/controller/testdata/dag_wftmpl_hook_with_retry.yaml
@@ -22,7 +22,7 @@ spec:
     - name: task
       container:
         name: ''
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - '-c'
@@ -31,7 +31,7 @@ spec:
     - name: exit-handler
       container:
         name: ''
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - '-c'
@@ -43,7 +43,7 @@ spec:
     - name: finish
       container:
         name: ''
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - '-c'

--- a/workflow/controller/testdata/dag_xfail.yaml
+++ b/workflow/controller/testdata/dag_xfail.yaml
@@ -21,7 +21,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:

--- a/workflow/controller/testdata/steps-failed-retries.yaml
+++ b/workflow/controller/testdata/steps-failed-retries.yaml
@@ -30,7 +30,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -45,7 +45,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -63,7 +63,7 @@ spec:
         http:
           url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
     script:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh]
       source: |
         ls /bin/kubectl
@@ -78,7 +78,7 @@ inputs:
     http:
       url: https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl
 script:
-  image: alpine:latest
+  image: alpine:3.23
   command: [sh]
   source: |
     ls /bin/kubectl
@@ -103,7 +103,7 @@ inputs:
     http:
         url: https://raw.githubusercontent.com/argoproj/argo-workflows/stable/manifests/install.yaml
 script:
-  image: alpine:latest
+  image: alpine:3.23
   command: [sh]
   source: |
     ls -al
@@ -122,7 +122,7 @@ script:
   volumeMounts:
   - mountPath: /manifest
     name: my-mount
-  image: alpine:latest
+  image: alpine:3.23
   command: [sh]
   source: |
     ls -al

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -449,7 +449,7 @@ spec:
         command:
         - sh
         - -c
-        image: alpine:latest
+        image: alpine:3.23
         name: ""
         resources: {}
       inputs: {}

--- a/workflow/sync/mutex_test.go
+++ b/workflow/sync/mutex_test.go
@@ -317,7 +317,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
     name: acquire-lock
     synchronization:

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -146,7 +146,7 @@ spec:
     script:
       command:
       - python
-      image: python:alpine
+      image: python:alpine3.23
       name: ""
       resources: {}
       source: |
@@ -159,7 +159,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:
@@ -1100,7 +1100,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources:
         requests:
@@ -1116,7 +1116,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources:
         requests:
@@ -1323,7 +1323,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}

--- a/workflow/templateresolution/context_test.go
+++ b/workflow/templateresolution/context_test.go
@@ -386,7 +386,7 @@ spec:
   templates:
   - name: existing-template
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
 `
 

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -918,7 +918,7 @@ spec:
       metadata: {}
       script:
         name: ''
-        image: python:alpine
+        image: python:alpine3.23
         command:
           - python
         resources: {}
@@ -934,7 +934,7 @@ spec:
       metadata: {}
       container:
         name: ''
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - '-c'
@@ -1511,7 +1511,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -2375,7 +2375,7 @@ spec:
       command:
       - echo
       - '{{inputs.parameters.message}}'
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:
@@ -3048,7 +3048,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -3061,7 +3061,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -3191,7 +3191,7 @@ spec:
       command:
       - echo
       - '{{inputs.parameters.message}}'
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs:
@@ -3951,7 +3951,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -3981,7 +3981,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -3994,7 +3994,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}
@@ -4007,7 +4007,7 @@ spec:
       command:
       - sh
       - -c
-      image: alpine:latest
+      image: alpine:3.23
       name: ""
       resources: {}
     inputs: {}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -19,7 +19,7 @@ spec:
   templates:
   - name: echo
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
   - name: cycle
     dag:
@@ -50,7 +50,7 @@ spec:
   templates:
   - name: echo
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
   - name: entry
     dag:
@@ -100,7 +100,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
     outputs:
       parameters:
@@ -142,7 +142,7 @@ spec:
       - name: id
       - name: hostnodename
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
     outputs:
       parameters:
@@ -211,7 +211,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
     outputs:
       parameters:
@@ -253,7 +253,7 @@ spec:
   templates:
   - name: first
     container:
-      image: alpine:latest
+      image: alpine:3.23
     outputs:
       parameters:
       - name: hosts
@@ -262,7 +262,7 @@ spec:
         globalName: global
   - name: second
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{workflow.outputs.parameters.global}}"]
   - name: unresolved
     dag:
@@ -284,7 +284,7 @@ spec:
   templates:
   - name: first
     container:
-      image: alpine:latest
+      image: alpine:3.23
     outputs:
       parameters:
       - name: hosts
@@ -293,7 +293,7 @@ spec:
         globalName: global
   - name: second
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{workflow.outputs.parameters.global}}"]
   - name: unresolved
     dag:
@@ -332,7 +332,7 @@ spec:
   templates:
   - name: generate
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, generate]
     outputs:
       artifacts:
@@ -347,7 +347,7 @@ spec:
       - name: passthrough
         path: /tmp/passthrough
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
     outputs:
       parameters:
@@ -393,7 +393,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 
   - name: dag-arg-passing
@@ -429,7 +429,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 
   - name: dag-arg-passing
@@ -465,7 +465,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 
   - name: dag-arg-passing
@@ -508,7 +508,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 
   - name: dag-arg-passing
@@ -565,7 +565,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 
   - name: dag-arg-passing
@@ -657,7 +657,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 `
 
@@ -697,7 +697,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 `
 
@@ -731,7 +731,7 @@ spec:
       parameters:
       - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
 `
 
@@ -762,7 +762,7 @@ spec:
 
   - name: echo
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "hello"]
 `
 
@@ -794,7 +794,7 @@ spec:
 
   - name: echo
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "hello"]
 `
 
@@ -836,14 +836,14 @@ spec:
             template: pass
     - name: pass
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - -c
           - exit 0
     - name: fail
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - -c
@@ -888,14 +888,14 @@ spec:
             template: pass
     - name: pass
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - -c
           - exit 0
     - name: fail
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - -c
@@ -924,7 +924,7 @@ spec:
             template: pass
     - name: pass
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command:
           - sh
           - -c

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -349,7 +349,7 @@ spec:
       - name: message
         value: "value"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{inputs.parameters.message}}"]
 `
@@ -388,7 +388,7 @@ spec:
       - name: message
         value: "value"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{inputs.parameters.message}}"]
 `
@@ -410,7 +410,7 @@ spec:
   templates:
   - name: generate
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, generate]
     outputs:
       artifacts:
@@ -425,7 +425,7 @@ spec:
       - name: passthrough
         path: /tmp/passthrough
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.message}}"]
     outputs:
       parameters:
@@ -609,7 +609,7 @@ spec:
 
   - name: output-global
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["sleep 1; echo -n art > /tmp/art.txt; echo -n param > /tmp/param.txt"]
     outputs:
@@ -624,7 +624,7 @@ spec:
       - name: art
         path: /art
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["cat /art"]
 `
@@ -999,7 +999,7 @@ spec:
       command: [sh, -c]
       args: ["cowsay hello world | tee /tmp/hello_world.txt"]
     script:
-      image: python:alpine
+      image: python:alpine3.23
       command: [python]
       source: |
         import random
@@ -1023,12 +1023,12 @@ spec:
   templates:
   - name: pass
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 0"]
   - name: fail
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{workflow.status}} {{workflow.uid}} {{workflow.duration}}"]
 `
@@ -1043,7 +1043,7 @@ spec:
   templates:
   - name: pass
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{workflow.failures}}"]
 `
@@ -1103,7 +1103,7 @@ spec:
         git:
           repo: https://github.com/argoproj/argo-workflows.git
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 0"]
       volumeMounts:
@@ -1139,7 +1139,7 @@ spec:
   - name: pass
     activeDeadlineSeconds: -1
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 0"]
 `
@@ -1434,7 +1434,7 @@ spec:
       parameters:
       - name: num
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{inputs.parameters.num}}"]
 `
 
@@ -1474,7 +1474,7 @@ spec:
   templates:
   - name: A
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
 `
 
@@ -1492,7 +1492,7 @@ spec:
   templates:
   - name: A
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, "{{workflow.parameters.something}}"]
 `
 
@@ -1554,7 +1554,7 @@ spec:
       parameters:
         - name: message
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{inputs.parameters.message}}"]
 `
@@ -1860,7 +1860,7 @@ spec:
       - name: global-parameter-name
       - name: global-parameter-value
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["exit 0"]
     outputs:
@@ -1874,7 +1874,7 @@ spec:
       parameters:
       - name: parameter
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo {{inputs.parameters.parameter}}"]
 `
@@ -2185,7 +2185,7 @@ spec:
   templates:
   - name: A
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
 `
 
@@ -2245,7 +2245,7 @@ spec:
   templates:
   - name: A
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
 `
 
@@ -2326,7 +2326,7 @@ spec:
   entrypoint: whalesay
   templateDefaults:
     script:
-      image: alpine:latest
+      image: alpine:3.23
   templates:
   - name: whalesay
     script:
@@ -2349,7 +2349,7 @@ spec:
   entrypoint: whalesay
   templateDefaults:
     container:
-      image: alpine:latest
+      image: alpine:3.23
   templates:
   - name: whalesay
     container:
@@ -2373,7 +2373,7 @@ spec:
   entrypoint: whalesay
   templateDefaults:
     script:
-      image: alpine:latest
+      image: alpine:3.23
   templates:
   - name: whalesay
     script:
@@ -2409,7 +2409,7 @@ spec:
   entrypoint: whalesay
   templateDefaults:
     container:
-      image: alpine:latest
+      image: alpine:3.23
   templates:
   - name: whalesay
     container:
@@ -2449,7 +2449,7 @@ spec:
   templates:
   - name: A
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
 `
 
@@ -2526,7 +2526,7 @@ spec:
         path: /usr/local/bin/binfile
         mode: 0755
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [echo, hello]
 `
 
@@ -3032,7 +3032,7 @@ spec:
 
     - name: wait
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [sleep, "5"]
 
     - name: printer
@@ -3042,7 +3042,7 @@ spec:
           - name: finishedat
           - name: id
       container:
-        image: alpine:latest
+        image: alpine:3.23
         command: [echo, "{{inputs.parameters.startedat}}"]`
 	err := validate(logging.TestContext(t.Context()), wf)
 	require.NoError(t, err)
@@ -3221,13 +3221,13 @@ spec:
     retryStrategy:
       retryPolicy: Always
     initContainers:
-    - image: alpine:latest
+    - image: alpine:3.23
       # name: sleep
       command:
       - sleep
       - "15"
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command:
       - echo
       - "i am running"
@@ -3356,7 +3356,7 @@ spec:
   templates:
   - name: helloworld
     container:
-      image: "alpine:latest"
+      image: "alpine:3.23"
       command: ["echo", "{{  workflow.thisdoesnotexist  }}"]
 `
 
@@ -3451,7 +3451,7 @@ spec:
   templates:
   - name: main
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'test data' > /tmp/result.txt"]
     outputs:
@@ -3463,7 +3463,7 @@ spec:
           none: {}
   - name: exit-handler
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'Access artifact: {{workflow.outputs.artifacts.output-result-car}}'"]
 `
@@ -3494,7 +3494,7 @@ spec:
   templates:
   - name: main
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'test data' > /tmp/result.txt"]
     outputs:
@@ -3506,7 +3506,7 @@ spec:
           none: {}
   - name: exit-handler
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'Access artifact: {{workflow.outputs.artifacts.output-result-test}}'"]
 `
@@ -3540,7 +3540,7 @@ spec:
   templates:
   - name: main
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'test data' > /tmp/result.txt"]
     outputs:
@@ -3552,7 +3552,7 @@ spec:
           none: {}
   - name: exit-handler
     container:
-      image: alpine:latest
+      image: alpine:3.23
       command: [sh, -c]
       args: ["echo 'Access artifact: {{workflow.outputs.artifacts.nonexistent}}'"]
 `


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Motivation

All alpine versions prior to 3.20 are outdated and no longer receive security updates.

See: https://endoflife.date/alpine-linux


### Modifications

Updated all Alpine versions throughout the project.

UPDATE: using alpine version `:3.23`. As of 2025-12-12, this is the [current](https://www.alpinelinux.org/) stable version.

~~Since the commands used inside the Alpine images are basic, I believe it’s safe to rely on `latest`.
Alpine also has a very short release cycle, which means keeping explicit versions updated in the repository would require continuous and unnecessary maintenance.~~
 

