### PR TITLE
fix: remove pod finalizer in abnormal scenarios

### DIFF
--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -242,7 +242,8 @@ func (c *Controller) addPodEvent(ctx context.Context, pod *apiv1.Pod) {
 	if err != nil {
 		c.log.WithField("pod", pod.Name).Warn(ctx, "callback for pod add failed")
 	}
-	c.commonPodEvent(ctx, pod, false)
+	deleting := pod.DeletionTimestamp != nil
+	c.commonPodEvent(ctx, pod, deleting)
 }
 
 func (c *Controller) updatePodEvent(ctx context.Context, old *apiv1.Pod, newPod *apiv1.Pod) {
@@ -252,7 +253,8 @@ func (c *Controller) updatePodEvent(ctx context.Context, old *apiv1.Pod, newPod 
 	if err != nil {
 		c.log.WithField("pod", newPod.Name).Warn(ctx, "callback for pod update failed")
 	}
-	c.commonPodEvent(ctx, newPod, false)
+	deleting := newPod.DeletionTimestamp != nil
+	c.commonPodEvent(ctx, newPod, deleting)
 }
 
 func (c *Controller) deletePodEvent(ctx context.Context, obj interface{}) {


### PR DESCRIPTION
### Motivation
We enabled the finalizer feature in our production environment (20,000 workflows), but encountered two online issues: 1. When a pending pod is deleted by another service, it gets stuck in the `Terminating `state, waiting for the finalizer to be cleaned up., however, the Pod `DeleteFunc `doesn't receive the deletion event; in fact, the `UpdateFunc `receives the update event, causing the Pod Finalizer to fail to clean up.  2. When the workflow controller restarts, the Pod `AddFunc `receives historical creation events and cannot clean up the finalizer.


### Modifications
Regardless of the event detected in the Pod, the system will determine whether the Pod has been deleted based on the Pod `DeletionTimestamp `field and delete the Finalizer accordingly.
`
deleting := pod.DeletionTimestamp != nil
c.commonPodEvent(ctx, pod, deleting)
`

### Doucument
Like [this](https://medium.com/@ismailkovvuru/inside-kubernetes-what-really-happens-when-you-delete-a-pod-74f304474928), when pod is cleaned up by other services,  `DeletionTimestamp` is set, this is the Update event.

