### PR TITLE
docs: added Juno sdk to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Just some of the projects that use or rely on Argo Workflows (complete list [her
 
 ## Client Libraries
 
-Check out our [Java, Golang, and Python (Hera) clients](docs/client-libraries.md).
+Check out our [Java, Golang, Python (Hera), and Typescript (Juno) clients](docs/client-libraries.md).
 
 ## Quickstart
 
@@ -117,7 +117,7 @@ An incomplete list of features Argo Workflows provides:
 * Multiple executors
 * Multiple pod and workflow garbage collection strategies
 * Automatically calculated resource usage per step
-* Java, Golang, and Python (Hera) SDKs
+* Java, Golang, Python (Hera), and Typescript (Juno) SDKs
 * Pod Disruption Budget support
 * Single-sign on (OAuth2/OIDC)
 * Webhook triggering

--- a/USERS.md
+++ b/USERS.md
@@ -229,3 +229,4 @@ In addition, the following projects are **officially** using Argo Workflows:
 1. [SQLFlow](https://github.com/sql-machine-learning/sqlflow)
 1. [BisQue](https://github.com/UCSB-VRL/bisqueUCSB)
 1. [Tator](https://www.tator.io)
+1. [Juno](https://github.com/lumindigital/juno)

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ Just some of the projects that use or rely on Argo Workflows (complete list [her
 
 ## Client Libraries
 
-Check out our [Java, Golang, and Python (Hera) clients](client-libraries.md).
+Check out our [Java, Golang, Python (Hera), and Typescript (Juno) clients](client-libraries.md).
 
 ## Quickstart
 
@@ -117,7 +117,7 @@ An incomplete list of features Argo Workflows provides:
 * Multiple executors
 * Multiple pod and workflow garbage collection strategies
 * Automatically calculated resource usage per step
-* Java, Golang, and Python (Hera) SDKs
+* Java, Golang, Python (Hera), and Typescript (Juno) SDKs
 * Pod Disruption Budget support
 * Single-sign on (OAuth2/OIDC)
 * Webhook triggering

--- a/docs/use-cases/machine-learning.md
+++ b/docs/use-cases/machine-learning.md
@@ -4,7 +4,7 @@
 
 * Try out [Hera](https://hera.readthedocs.io/en/stable/) for writing Workflows in Python.
     * Also read: [How To Get the Most out of Hera for Data Science](https://pipekit.io/blog/how-to-get-the-most-out-of-hera-for-data-science)
-* Try out the [Go and Java SDKs](../client-libraries.md).
+* Try out the [Go, Java, and Typescript SDKs](../client-libraries.md).
 
 ## Videos
 

--- a/docs/walk-through/index.md
+++ b/docs/walk-through/index.md
@@ -19,3 +19,7 @@ Start with [Argo CLI](argo-cli.md).
 
 If you would prefer to write Workflows using Python instead of YAML, check out the walk through for
 [Hera, the Python SDK for Argo Workflows](https://hera.readthedocs.io/en/stable/walk-through/quick-start/).
+
+## Juno SDK for Typescript Users
+
+You can also write Workflows in typescript, check out the documentation on [Juno](https://github.com/lumindigital/juno/blob/main/docs/index.md)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

A new Typescript SDK for argo-workflows (Juno) has been released and I wanted to add it to the documentation so others could find it and use it if they have an interest in it.

### Modifications

Updated the documentation to include references to the Juno project

### Verification

Previewed the Markdown, and also reviewed in on my fork

### Documentation

N/A
