### PR TITLE
fix: check ClusterWorkflowTemplate RBAC cluster wide instead of namespaced. Fixes #15071 (cherry-pick #15162 for 3.7)

### DIFF
--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -157,7 +157,7 @@ func (a *argoKubeClient) startStores(ctx context.Context, restConfig *restclient
 		a.wfTmplStore = workflowtemplateserver.NewWorkflowTemplateClientStore()
 	}
 
-	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, a.kubeClient, a.namespace) {
+	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, a.kubeClient) {
 		if a.opts.CacheClusterWorkflowTemplates {
 			cwftmplInformer, err := clusterworkflowtmplserver.NewInformer(restConfig)
 			if err != nil {

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -239,7 +239,7 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	}
 	kubeclientset := kubernetes.NewForConfigOrDie(as.restConfig)
 	var cwftmplInformer clusterworkflowtemplate.ClusterWorkflowTemplateInformer
-	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, resourceCacheNamespace) {
+	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, kubeclientset) {
 		cwftmplInformer, err = clusterworkflowtemplate.NewInformer(as.restConfig)
 		if err != nil {
 			log.Fatal(err)

--- a/util/rbac/rbac.go
+++ b/util/rbac/rbac.go
@@ -9,12 +9,12 @@ import (
 	errorsutil "github.com/argoproj/argo-workflows/v3/util/errors"
 )
 
-func HasAccessToClusterWorkflowTemplates(ctx context.Context, kubeclientset kubernetes.Interface, namespace string) bool {
-	cwftGetAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "get", "clusterworkflowtemplates", namespace, "")
+func HasAccessToClusterWorkflowTemplates(ctx context.Context, kubeclientset kubernetes.Interface) bool {
+	cwftGetAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "get", "clusterworkflowtemplates", "", "")
 	errorsutil.CheckError(err)
-	cwftListAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "list", "clusterworkflowtemplates", namespace, "")
+	cwftListAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "list", "clusterworkflowtemplates", "", "")
 	errorsutil.CheckError(err)
-	cwftWatchAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "watch", "clusterworkflowtemplates", namespace, "")
+	cwftWatchAllowed, err := authutil.CanIArgo(ctx, kubeclientset, "watch", "clusterworkflowtemplates", "", "")
 	errorsutil.CheckError(err)
 
 	if !cwftGetAllowed || !cwftListAllowed || !cwftWatchAllowed {

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -20,7 +20,7 @@ func TestRBAC_AccessClusterWorkflowTemplates(t *testing.T) {
 		allowedVerbs := []string{"get", "list", "watch"}
 		kubeclientset.AddReactor("create", "selfsubjectaccessreviews", reactionFuncWithAllowedVerbs(allowedVerbs))
 		ctx := context.Background()
-		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, "")
+		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset)
 		assert.True(t, allowed)
 	})
 
@@ -29,7 +29,7 @@ func TestRBAC_AccessClusterWorkflowTemplates(t *testing.T) {
 		allowedVerbs := []string{"get", "list"}
 		kubeclientset.AddReactor("create", "selfsubjectaccessreviews", reactionFuncWithAllowedVerbs(allowedVerbs))
 		ctx := context.Background()
-		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, "")
+		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset)
 		assert.False(t, allowed)
 	})
 
@@ -38,7 +38,7 @@ func TestRBAC_AccessClusterWorkflowTemplates(t *testing.T) {
 		allowedVerbs := []string{"get"}
 		kubeclientset.AddReactor("create", "selfsubjectaccessreviews", reactionFuncWithAllowedVerbs(allowedVerbs))
 		ctx := context.Background()
-		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset, "")
+		allowed := HasAccessToClusterWorkflowTemplates(ctx, kubeclientset)
 		assert.False(t, allowed)
 	})
 }

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -523,7 +523,7 @@ func (wfc *WorkflowController) notifySemaphoreConfigUpdate(cm *apiv1.ConfigMap) 
 
 // Check if the controller has RBAC access to ClusterWorkflowTemplates
 func (wfc *WorkflowController) createClusterWorkflowTemplateInformer(ctx context.Context) {
-	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, wfc.kubeclientset, wfc.namespace) {
+	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, wfc.kubeclientset) {
 		wfc.cwftmplInformer = informer.NewTolerantClusterWorkflowTemplateInformer(wfc.dynamicInterface, clusterWorkflowTemplateResyncPeriod)
 		go wfc.cwftmplInformer.Informer().Run(ctx.Done())
 


### PR DESCRIPTION
Cherry-picked fix: check ClusterWorkflowTemplate RBAC cluster wide instead of namespaced. Fixes #15071 (#15162)