### PR TITLE
fix: add timeout for database query in workflow estimation to prevent blocking. (cherry-pick #15116 for 3.7)

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -58,6 +58,7 @@ This document outlines environment variables that can be used to customize behav
 | `SEMAPHORE_NOTIFY_DELAY`                 | `time.Duration`     | `1s`                                                                                        | Tuning Delay when notifying semaphore waiters about availability in the semaphore                                                                                                                                                                                        |
 | `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS` | `bool` | `true` | Whether to watch the Controller's ConfigMap and semaphore ConfigMaps for run-time changes. When disabled, the Controller will only read these ConfigMaps once and will have to be manually restarted to pick up new changes. |
 | `SKIP_WORKFLOW_DURATION_ESTIMATION` | `bool` | `false` | Whether to lookup resource usage from prior workflows to estimate usage for new workflows. |
+| `WORKFLOW_ESTIMATION_DB_QUERY_TIMEOUT_SECONDS` | `int` | `5` | Timeout in seconds for database queries when estimating workflow duration. Prevents workflow execution from being blocked when database is slow or locked. |
 
 CLI parameters of the Controller can be specified as environment variables with the `ARGO_` prefix.
 For example:


### PR DESCRIPTION
Cherry-picked fix: add timeout for database query in workflow estimation to prevent blocking. (#15116)