### PR TITLE
fix: type-aware application of template defaults (#14899) (cherry-pick #15144 for 3.6)

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -47,6 +47,24 @@ const (
 	TemplateTypeUnknown      TemplateType = "Unknown"
 )
 
+// IsValid returns true if t exists in the set of possible template types.
+func (t TemplateType) IsValid() bool {
+	switch t {
+	case TemplateTypeContainer,
+		TemplateTypeContainerSet,
+		TemplateTypeSteps,
+		TemplateTypeScript,
+		TemplateTypeResource,
+		TemplateTypeDAG,
+		TemplateTypeSuspend,
+		TemplateTypeData,
+		TemplateTypeHTTP,
+		TemplateTypePlugin:
+		return true
+	}
+	return false
+}
+
 // NodePhase is a label for the condition of a node at the current time.
 type NodePhase string
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4161,30 +4161,49 @@ func (woc *wfOperationCtx) setStoredWfSpec(ctx context.Context) error {
 	return nil
 }
 
+// mergedTemplateDefaultsInto modifies originalTmpl, setting any applicable default values.
 func (woc *wfOperationCtx) mergedTemplateDefaultsInto(originalTmpl *wfv1.Template) error {
-	if woc.execWf.Spec.TemplateDefaults != nil {
-		originalTmplType := originalTmpl.GetType()
-
-		tmplDefaultsJson, err := json.Marshal(woc.execWf.Spec.TemplateDefaults)
-		if err != nil {
-			return err
-		}
-
-		targetTmplJson, err := json.Marshal(originalTmpl)
-		if err != nil {
-			return err
-		}
-
-		resultTmpl, err := strategicpatch.StrategicMergePatch(tmplDefaultsJson, targetTmplJson, wfv1.Template{})
-		if err != nil {
-			return err
-		}
-		err = json.Unmarshal(resultTmpl, originalTmpl)
-		if err != nil {
-			return err
-		}
-		originalTmpl.SetType(originalTmplType)
+	if woc.execWf.Spec.TemplateDefaults == nil {
+		return nil
 	}
+
+	originalTmplType := originalTmpl.GetType()
+	applicableDefaults := woc.execWf.Spec.TemplateDefaults.DeepCopy()
+
+	v := reflect.ValueOf(applicableDefaults).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Type().Field(i)
+		// Check if the field is a pointer to a struct.
+		if field.Type.Kind() != reflect.Ptr || field.Type.Elem().Kind() != reflect.Struct {
+			continue
+		}
+
+		// Unset any Template-type defaults not applicable to the target type.
+		if t := wfv1.TemplateType(field.Name); t.IsValid() && t != originalTmplType {
+			v.Field(i).Set(reflect.Zero(v.Field(i).Type()))
+		}
+	}
+
+	tmplDefaultsJson, err := json.Marshal(applicableDefaults)
+	if err != nil {
+		return err
+	}
+
+	targetTmplJson, err := json.Marshal(originalTmpl)
+	if err != nil {
+		return err
+	}
+
+	resultTmpl, err := strategicpatch.StrategicMergePatch(tmplDefaultsJson, targetTmplJson, wfv1.Template{})
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(resultTmpl, originalTmpl); err != nil {
+		return err
+	}
+
+	originalTmpl.SetType(originalTmplType)
 	return nil
 }
 

--- a/workflow/controller/operator_tmpl_default_test.go
+++ b/workflow/controller/operator_tmpl_default_test.go
@@ -112,6 +112,19 @@ spec:
       args: ["hello world"]
 `
 
+const httpWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: http-
+spec:
+  entrypoint: http-template
+  templates:
+  - name: http-template
+    http:
+      url: http://dummy.rest.api/endpoint
+`
+
 func TestSetTemplateDefault(t *testing.T) {
 	cancel, controller := newController()
 	defer cancel()
@@ -255,5 +268,22 @@ func TestSetTemplateDefault(t *testing.T) {
 		assert.Len(t, tmpl2.Container.Env, 1)
 		assert.Equal(t, "test", tmpl2.Container.Env[0].Name)
 		assert.Nil(t, tmpl2.Script)
+	})
+	t.Run("HTTPTmplDefaultWf", func(t *testing.T) {
+		wf := wfv1.MustUnmarshalWorkflow(httpWf)
+		wf.Spec.TemplateDefaults = &wfv1.Template{
+			Container: &apiv1.Container{
+				ImagePullPolicy: apiv1.PullIfNotPresent,
+			},
+		}
+		woc := newWorkflowOperationCtx(wf, controller)
+		err := woc.setExecWorkflow(context.Background())
+		require.NoError(t, err)
+		tmpl := woc.execWf.Spec.Templates[0]
+		err = woc.mergedTemplateDefaultsInto(&tmpl)
+		require.NoError(t, err)
+		assert.NotNil(t, tmpl)
+		assert.Equal(t, wfv1.TemplateTypeHTTP, tmpl.GetType())
+		assert.Nil(t, tmpl.Container)
 	})
 }


### PR DESCRIPTION
Cherry-picked fix: type-aware application of template defaults (#14899) (#15144)