### PR TITLE
fix(ui): fix column alignment in workflow list

### DIFF
--- a/ui/src/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/workflows/components/workflows-row/workflows-row.tsx
@@ -65,10 +65,10 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                         </div>
                     </Link>
                     <div className='columns small-1'>{wf.metadata.namespace}</div>
-                    <div className={`columns small-1' ${props.displayISOFormatStart ? 'workflows-list__timestamp' : ''}`}>
+                    <div className={`columns small-1 ${props.displayISOFormatStart ? 'workflows-list__timestamp' : ''}`}>
                         <Timestamp date={wf.status.startedAt} displayISOFormat={props.displayISOFormatStart} />
                     </div>
-                    <div className={`columns small-1' ${props.displayISOFormatFinished ? 'workflows-list__timestamp' : ''}`}>
+                    <div className={`columns small-1 ${props.displayISOFormatFinished ? 'workflows-list__timestamp' : ''}`}>
                         <Timestamp date={wf.status.finishedAt} displayISOFormat={props.displayISOFormatFinished} />
                     </div>
                     <div className='columns small-1'>


### PR DESCRIPTION
### Motivation

The current workflow list has a bug where the started and finished columns are not sized properly. This causes the title row to become misaligned with the actual list, which confused me to no end.

### Modifications

Fixed a stray apostrophe in the CSS classes of the workflow row component.

<img width="1837" height="194" alt="image" src="https://github.com/user-attachments/assets/a5fdad3d-21ed-41b3-9034-4fc7715f1bb5" />

