### PR TITLE
chore: lint markdown new-features.md #15149

### DIFF
--- a/.features/pending/14679-cronworkflow-delete-warning.md
+++ b/.features/pending/14679-cronworkflow-delete-warning.md
@@ -3,5 +3,5 @@ Issues: 14679
 Description: Add an informational message to the CronWorkflow delete confirmation modal indicating that Workflows created by the CronSchedule will also be deleted.
 Author: [minsun yun](https://github.com/miinsun)
 
-- UI/UX only; **no functional logic** is changed.
-- Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly.
+UI/UX only; **no functional logic** is changed
+Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly

--- a/.features/pending/14807-workflow-templates-label-filter-sync.md
+++ b/.features/pending/14807-workflow-templates-label-filter-sync.md
@@ -3,7 +3,7 @@ Issues: 14807
 Description: Add label query parameter sync with URL in WorkflowTemplates UI to match Workflows list behavior for consistent filtering.
 Author: [puretension](https://github.com/puretension)
 
-- WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
-- Combined URL updates and localStorage persistence in single useEffect
-- Enables custom UI links for filtered template views
-- Verified that URL updates when changing filters and filters persist on page refresh
+WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
+Combined URL updates and localStorage persistence in single useEffect
+Enables custom UI links for filtered template views
+Verified that URL updates when changing filters and filters persist on page refresh

--- a/.features/pending/cel-validation.md
+++ b/.features/pending/cel-validation.md
@@ -11,61 +11,61 @@ It will inform you of
 Fields marked with `+kubebuilder:validation:Schemaless` (like `withItems`) or `+kubebuilder:pruning:PreserveUnknownFields` (like `inline`) are not visible to CEL validation expressions.
 
 **CEL Budget Management:** Kubernetes limits the total cost of CEL validation rules per CRD. To stay within these limits:
-* All `status` blocks have CEL validations automatically stripped during CRD generation
-* Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
-* Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
+    - All `status` blocks have CEL validations automatically stripped during CRD generation
+    - Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
+    - Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
 
 **Array and String Size Limits:** To manage CEL validation costs, the following maximum sizes are enforced:
-* Templates per workflow: 200
-* DAG tasks per DAG template: 200
-* Parameters: 500
-* Prometheus metrics per template: 100
-* Gauge metric value string: 256 characters
+    - Templates per workflow: 200
+    - DAG tasks per DAG template: 200
+    - Parameters: 500
+    - Prometheus metrics per template: 100
+    - Gauge metric value string: 256 characters
 
-#### Mutual Exclusivity Rules:
-* only one template type per template
-* only one of sequence count/end
-* only one of manifest/manifestFrom
-* cannot use both depends and dependencies in DAG tasks.
+**Mutual Exclusivity Rules:**
+    - only one template type per template
+    - only one of sequence count/end
+    - only one of manifest/manifestFrom
+    - cannot use both depends and dependencies in DAG tasks.
 
-#### DAG Task Constraints:
-* task names cannot start with digit when using depends/dependencies
-* cannot use continueOn with depends.
+**DAG Task Constraints:**
+    - task names cannot start with digit when using depends/dependencies
+    - cannot use continueOn with depends.
 
-#### Timeout on Non-Leaf Templates:
-* Timeout cannot be set on steps or dag templates (only on leaf templates).
+**Timeout on Non-Leaf Templates:**
+    - Timeout cannot be set on steps or dag templates (only on leaf templates).
 
-#### Cron Schedule Format:
-* CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
+**Cron Schedule Format:**
+    - CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
 
-#### Metric Validation:
-* metric and label names validation
-* help and value fields required
-* real-time gauges cannot use resourcesDuration metrics
+**Metric Validation:**
+    - metric and label names validation
+    - help and value fields required
+    - real-time gauges cannot use resourcesDuration metrics
 
-#### Artifact:
-* At most one artifact location may be specified
-* Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
+**Artifact:**
+    - At most one artifact location may be specified
+    - Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
 
-#### Enum Validations:
-* PodGC strategy
-* ConcurrencyPolicy
-* RetryPolicy
-* GaugeOperation
-* Resource action
-* MergeStrategy
-  all have restricted allowed values.
+**Enum Validations:**
+    - PodGC strategy
+    - ConcurrencyPolicy
+    - RetryPolicy
+    - GaugeOperation
+    - Resource action
+    - MergeStrategy
+      all have restricted allowed values.
 
-#### Name Pattern Constraints:
-* Template/Step/Task names: max 128 chars, pattern ^[a-zA-Z0-9][-a-zA-Z0-9]*$;
-* Parameter/Artifact names: pattern ^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.
+**Name Pattern Constraints:**
+    - Template/Step/Task names: max 128 chars, pattern `^[a-zA-Z0-9][-a-zA-Z0-9]*$;`
+    - Parameter/Artifact names: pattern `^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.`
 
-#### Minimum Array Sizes:
-* Template.Steps requires at least one step group
-* Parameter.Enum requires at least one value
-* CronWorkflow.Schedules requires at least one schedule
-* DAG.Tasks requires at least one task.
+**Minimum Array Sizes:**
+    - Template.Steps requires at least one step group
+    - Parameter.Enum requires at least one value
+    - CronWorkflow.Schedules requires at least one schedule
+    - DAG.Tasks requires at least one task.
 
-#### Numeric Constraints:
-* Parallelism minimum 1
-* StartingDeadlineSeconds minimum 0.
+**Numeric Constraints:**
+    - Parallelism minimum 1
+    - StartingDeadlineSeconds minimum 0.

--- a/.features/pending/custom-sso-ca-configuration.md
+++ b/.features/pending/custom-sso-ca-configuration.md
@@ -6,21 +6,19 @@ Issues: 7198
 This feature adds support for custom TLS configuration when connecting to OIDC providers for SSO authentication.
 This is particularly useful when your OIDC provider uses self-signed certificates or custom Certificate Authorities (CAs).
 
-* Use this feature when your OIDC provider uses custom self-signed CA certificates
-* Configure custom CA certificates either inline or by file path
+    - Use this feature when your OIDC provider uses custom self-signed CA certificates
+    - Configure custom CA certificates either inline or by file path
 
-### Configuration Examples
+**Configuration Examples**
+**Inline PEM content**
 
-#### Inline PEM content
-```yaml
-sso:
-  # Custom PEM encoded CA certificate file contents
-  rootCA: |-
-    -----BEGIN CERTIFICATE-----
-    MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-    ...
-    -----END CERTIFICATE-----
-```
+    sso:
+      # Custom PEM encoded CA certificate file contents
+      rootCA: |-
+        -----BEGIN CERTIFICATE-----
+        MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+        ...
+        -----END CERTIFICATE-----
 
 The system will automatically use certificates configured with SSL_CERT_DIR, and SSL_CERT_FILE for non macOS environments.
 For production environments, always use proper CA certificates instead of skipping TLS verification.

--- a/.features/pending/feat-logging.md
+++ b/.features/pending/feat-logging.md
@@ -3,7 +3,7 @@ Issues: 11120
 Description: This migrates most of the logging off logrus and onto a custom logger.
 Author: [Isitha Subasinghe](https://github.com/isubasinghe)
 
-Currently it is quite hard to identify log lines with it's corresponding workflow.
-This change propagates a context object down the call hierarchy containing an 
-annotated logging object. This allows context aware logging from deep within the
-codebase.
+Currently it is quite hard to identify log lines with it's corresponding
+workflow. This change propagates a context object down the call hierarchy
+containing an annotated logging object. This allows context aware logging from
+deep within the codebase.

--- a/.features/pending/open-custom-link-in-new-tab.md
+++ b/.features/pending/open-custom-link-in-new-tab.md
@@ -4,11 +4,9 @@ Description: Support open custom links in new tab automatically.
 Author: [Shuangkun Tian](https://github.com/shuangkun)
 
 Support configuring a custom link to open in a new tab by default.
-If target == _blank, open in new tab, if target is null or _self, open in this tab. For example:
-```
+If `target == _blank`, open in new tab, if target is null or `_self`, open in this tab. For example:
+
     - name: Pod Link
       scope: pod
       target: _blank
       url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
-```
-

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,11 +63,11 @@ jobs:
 
       # In order to validate any links in the yaml file, render the config to markdown
       - name: Render .features/*.md feature descriptions
-        run: make features-preview > features_preview.md
+        run: make features-update
 
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # f613c4a64e50d792e0b31ec34bbcbba12263c6a6
         with:
-          args: "--verbose --no-progress ./features_preview.md"
+          args: "--verbose --no-progress ./docs/new-features.md"
           failIfEmpty: false

--- a/Makefile
+++ b/Makefile
@@ -863,7 +863,7 @@ endif
 .PHONY: docs-lint
 docs-lint: $(TOOL_MARKDOWNLINT) docs/metrics.md
 	# lint docs
-	$(TOOL_MARKDOWNLINT) docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md --ignore docs/tested-kubernetes-versions.md --ignore docs/new-features.md --ignore docs/go-sdk-guide.md
+	$(TOOL_MARKDOWNLINT) docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md --ignore docs/tested-kubernetes-versions.md --ignore docs/go-sdk-guide.md
 
 $(TOOL_MKDOCS): docs/requirements.txt
 # update this in Nix when upgrading it here
@@ -924,9 +924,10 @@ feature-new: hack/featuregen/featuregen
 	$< new --filename $(FEATURE_FILENAME)
 
 .PHONY: features-validate
-features-validate: hack/featuregen/featuregen
+features-validate: hack/featuregen/featuregen $(TOOL_MARKDOWNLINT)
 	# Validate all pending feature documentation files
 	$< validate
+	$< update --dry |  tail +4 | $(TOOL_MARKDOWNLINT) -s
 
 .PHONY: features-preview
 features-preview: hack/featuregen/featuregen
@@ -935,16 +936,18 @@ features-preview: hack/featuregen/featuregen
 	$< update --dry
 
 .PHONY: features-update
-features-update: hack/featuregen/featuregen
+features-update: hack/featuregen/featuregen $(TOOL_MARKDOWNLINT) 
 	# Update the features documentation, but keep the feature files in the pending directory
 	# Updates docs/new-features.md for release-candidates
 	$< update --version $(VERSION)
+	$(TOOL_MARKDOWNLINT) ./docs/new-features.md
 
 .PHONY: features-release
-features-release: hack/featuregen/featuregen
+features-release: hack/featuregen/featuregen $(TOOL_MARKDOWNLINT) 
 	# Update the features documentation AND move the feature files to the released directory
 	# Use this for the final update when releasing a version
 	$< update --version $(VERSION) --final
+	$(TOOL_MARKDOWNLINT) ./docs/new-features.md
 
 hack/featuregen/featuregen: hack/featuregen/main.go hack/featuregen/contents.go hack/featuregen/contents_test.go hack/featuregen/main_test.go
 	go test ./hack/featuregen

--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -1,4 +1,4 @@
-# New features in v4.0.0-rc2 (2025-12-22)
+# New features in v4.0.0-rc2 (2026-01-08)
 
 This is a concise list of new features.
 
@@ -28,70 +28,68 @@ This is a concise list of new features.
   **Note:** Some validations cannot be implemented as CEL rules due to Kubernetes limitations.
   Fields marked with `+kubebuilder:validation:Schemaless` (like `withItems`) or `+kubebuilder:pruning:PreserveUnknownFields` (like `inline`) are not visible to CEL validation expressions.
   **CEL Budget Management:** Kubernetes limits the total cost of CEL validation rules per CRD. To stay within these limits:
-  * All `status` blocks have CEL validations automatically stripped during CRD generation
-  * Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
-  * Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
+      - All `status` blocks have CEL validations automatically stripped during CRD generation
+      - Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
+      - Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
   **Array and String Size Limits:** To manage CEL validation costs, the following maximum sizes are enforced:
-  * Templates per workflow: 200
-  * DAG tasks per DAG template: 200
-  * Parameters: 500
-  * Prometheus metrics per template: 100
-  * Gauge metric value string: 256 characters
-  #### Mutual Exclusivity Rules:
-  * only one template type per template
-  * only one of sequence count/end
-  * only one of manifest/manifestFrom
-  * cannot use both depends and dependencies in DAG tasks.
-  #### DAG Task Constraints:
-  * task names cannot start with digit when using depends/dependencies
-  * cannot use continueOn with depends.
-  #### Timeout on Non-Leaf Templates:
-  * Timeout cannot be set on steps or dag templates (only on leaf templates).
-  #### Cron Schedule Format:
-  * CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
-  #### Metric Validation:
-  * metric and label names validation
-  * help and value fields required
-  * real-time gauges cannot use resourcesDuration metrics
-  #### Artifact:
-  * At most one artifact location may be specified
-  * Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
-  #### Enum Validations:
-  * PodGC strategy
-  * ConcurrencyPolicy
-  * RetryPolicy
-  * GaugeOperation
-  * Resource action
-  * MergeStrategy
-    all have restricted allowed values.
-  #### Name Pattern Constraints:
-  * Template/Step/Task names: max 128 chars, pattern ^[a-zA-Z0-9][-a-zA-Z0-9]*$;
-  * Parameter/Artifact names: pattern ^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.
-  #### Minimum Array Sizes:
-  * Template.Steps requires at least one step group
-  * Parameter.Enum requires at least one value
-  * CronWorkflow.Schedules requires at least one schedule
-  * DAG.Tasks requires at least one task.
-  #### Numeric Constraints:
-  * Parallelism minimum 1
-  * StartingDeadlineSeconds minimum 0.
+      - Templates per workflow: 200
+      - DAG tasks per DAG template: 200
+      - Parameters: 500
+      - Prometheus metrics per template: 100
+      - Gauge metric value string: 256 characters
+  **Mutual Exclusivity Rules:**
+      - only one template type per template
+      - only one of sequence count/end
+      - only one of manifest/manifestFrom
+      - cannot use both depends and dependencies in DAG tasks.
+  **DAG Task Constraints:**
+      - task names cannot start with digit when using depends/dependencies
+      - cannot use continueOn with depends.
+  **Timeout on Non-Leaf Templates:**
+      - Timeout cannot be set on steps or dag templates (only on leaf templates).
+  **Cron Schedule Format:**
+      - CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
+  **Metric Validation:**
+      - metric and label names validation
+      - help and value fields required
+      - real-time gauges cannot use resourcesDuration metrics
+  **Artifact:**
+      - At most one artifact location may be specified
+      - Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
+  **Enum Validations:**
+      - PodGC strategy
+      - ConcurrencyPolicy
+      - RetryPolicy
+      - GaugeOperation
+      - Resource action
+      - MergeStrategy
+        all have restricted allowed values.
+  **Name Pattern Constraints:**
+      - Template/Step/Task names: max 128 chars, pattern `^[a-zA-Z0-9][-a-zA-Z0-9]*$;`
+      - Parameter/Artifact names: pattern `^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.`
+  **Minimum Array Sizes:**
+      - Template.Steps requires at least one step group
+      - Parameter.Enum requires at least one value
+      - CronWorkflow.Schedules requires at least one schedule
+      - DAG.Tasks requires at least one task.
+  **Numeric Constraints:**
+      - Parallelism minimum 1
+      - StartingDeadlineSeconds minimum 0.
 
 - Allow custom CA certificate configuration for SSO OIDC provider connections by [bradfordwagner](https://github.com/bradfordwagner) ([#7198](https://github.com/argoproj/argo-workflows/issues/7198))
   This feature adds support for custom TLS configuration when connecting to OIDC providers for SSO authentication.
   This is particularly useful when your OIDC provider uses self-signed certificates or custom Certificate Authorities (CAs).
-  * Use this feature when your OIDC provider uses custom self-signed CA certificates
-  * Configure custom CA certificates either inline or by file path
-  ### Configuration Examples
-  #### Inline PEM content
-  ```yaml
-  sso:
-    # Custom PEM encoded CA certificate file contents
-    rootCA: |-
-      -----BEGIN CERTIFICATE-----
-      MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-      ...
-      -----END CERTIFICATE-----
-  ```
+      - Use this feature when your OIDC provider uses custom self-signed CA certificates
+      - Configure custom CA certificates either inline or by file path
+  **Configuration Examples**
+  **Inline PEM content**
+      sso:
+        # Custom PEM encoded CA certificate file contents
+        rootCA: |-
+          -----BEGIN CERTIFICATE-----
+          MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+          ...
+          -----END CERTIFICATE-----
   The system will automatically use certificates configured with SSL_CERT_DIR, and SSL_CERT_FILE for non macOS environments.
   For production environments, always use proper CA certificates instead of skipping TLS verification.
 
@@ -102,10 +100,10 @@ This is a concise list of new features.
   Update the controller’s default behavior to disable the write-back informer. We’ve seen several cases of unexpected behavior that appear to be caused by the write-back mechanism, and Kubernetes docs recommend avoiding writes to the informer store. Although turning it off may increase the frequency of 409 Conflict errors, it should help reduce unpredictable controller behavior.
 
 - This migrates most of the logging off logrus and onto a custom logger. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120))
-  Currently it is quite hard to identify log lines with it's corresponding workflow.
-  This change propagates a context object down the call hierarchy containing an 
-  annotated logging object. This allows context aware logging from deep within the
-  codebase.
+  Currently it is quite hard to identify log lines with it's corresponding
+  workflow. This change propagates a context object down the call hierarchy
+  containing an annotated logging object. This allows context aware logging from
+  deep within the codebase.
 
 - Support metadata.name= and metadata.name!= in field selectors by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
   Field selectors for `metadata.name` now support the `==` and `!=` operators, giving you more flexible control over resource filtering.
@@ -123,14 +121,14 @@ This is a concise list of new features.
 ## UI
 
 - Add an informational message to the CronWorkflow delete confirmation modal indicating that Workflows created by the CronSchedule will also be deleted. by [minsun yun](https://github.com/miinsun) ([#14679](https://github.com/argoproj/argo-workflows/issues/14679))
-  - UI/UX only; **no functional logic** is changed.
-  - Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly.
+  UI/UX only; **no functional logic** is changed
+  Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly
 
 - Add label query parameter sync with URL in WorkflowTemplates UI to match Workflows list behavior for consistent filtering. by [puretension](https://github.com/puretension) ([#14807](https://github.com/argoproj/argo-workflows/issues/14807))
-  - WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
-  - Combined URL updates and localStorage persistence in single useEffect
-  - Enables custom UI links for filtered template views
-  - Verified that URL updates when changing filters and filters persist on page refresh
+  WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
+  Combined URL updates and localStorage persistence in single useEffect
+  Enables custom UI links for filtered template views
+  Verified that URL updates when changing filters and filters persist on page refresh
 
 - Name Not Equals filter now available in the UI for filtering workflows by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
   You can now use the "Name Not Equals" filter in the workflow list to exclude workflows by name.
@@ -139,13 +137,11 @@ This is a concise list of new features.
 
 - Support open custom links in new tab automatically. by [Shuangkun Tian](https://github.com/shuangkun) ([#13114](https://github.com/argoproj/argo-workflows/issues/13114))
   Support configuring a custom link to open in a new tab by default.
-  If target == _blank, open in new tab, if target is null or _self, open in this tab. For example:
-  ```
+  If `target == _blank`, open in new tab, if target is null or `_self`, open in this tab. For example:
       - name: Pod Link
         scope: pod
         target: _blank
         url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
-  ```
 
 - Optimize pagination performance when counting workflows in archive. by [Shuangkun Tian](https://github.com/shuangkun) ([#13948](https://github.com/argoproj/argo-workflows/issues/13948))
   When querying archived workflows with pagination, the system now uses more efficient methods to check if there are more items available. Instead of performing expensive full table scans, the new implementation uses LIMIT queries to check if there are items beyond the current offset+limit, significantly improving performance for large datasets.
@@ -173,4 +169,3 @@ This is a concise list of new features.
   The featuregen tool now uses the plural "Authors:" field instead of "Author:" for new feature notes.
   This better reflects that features can have multiple authors.
   The change maintains full backwards compatibility with existing feature files that use the singular "Author:" field.
-

--- a/hack/featuregen/contents.go
+++ b/hack/featuregen/contents.go
@@ -209,5 +209,5 @@ func format(version string, features []feature) string {
 		}
 	}
 
-	return output.String()
+	return strings.TrimSuffix(output.String(), "\n\n")
 }

--- a/hack/featuregen/contents_test.go
+++ b/hack/featuregen/contents_test.go
@@ -259,9 +259,7 @@ This is a concise list of new features.
 ## UI
 
 - Test Description by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234))
-  Test Details
-
-`,
+  Test Details`,
 		},
 		{
 			name:    "Released features",
@@ -284,9 +282,7 @@ This is a concise list of new features.
 - Test Description by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234), [#5678](https://github.com/argoproj/argo-workflows/issues/5678))
   Test Details
   - Point 1
-  - Point 2
-
-`,
+  - Point 2`,
 		},
 		{
 			name:    "Multiple features in different components",
@@ -318,9 +314,7 @@ This is a concise list of new features.
 ## UI
 
 - Description 2 by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))
-  Details 2
-
-`,
+  Details 2`,
 		},
 		{
 			name:    "Features in same component",
@@ -349,9 +343,7 @@ This is a concise list of new features.
 
 - First CLI feature by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234))
 
-- Second CLI feature by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))
-
-`,
+- Second CLI feature by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))`,
 		},
 	}
 


### PR DESCRIPTION
Reference #15149

### Motivation

Currently we do not lint the new-features.md file because it fails
straight during a release.

### Modifications

This pR makes the new-features.md compliant with the markdownlint
tool and it adds linting check at the right time and not during a CI
release.

I had to fix a few `.features/pending` files that could not be combined into a
new-features.md without making the linter to go crazy.

And then I added markdownlint in a few more places in the Makefile.

### Verification

`make features-update` should work with no issue and lint the generated file.

### Documentation
