### PR TITLE
chore: update golangci-lint to version 2.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,7 @@ manifests-validate:
 	kubectl apply --server-side --validate=strict --dry-run=server -f 'manifests/*.yaml'
 
 $(TOOL_GOLANGCI_LINT): Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.5.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.7.2
 
 .PHONY: lint lint-go lint-ui
 lint: lint-go lint-ui features-validate ## Lint the project


### PR DESCRIPTION
Update to golangci-lint - it found no additional issues. I'd like to enable the `modernize` linter, which is in this version.

See these for some prior work on this:
- #14946
- #14943
- #14928