### PR TITLE
fix: move logger context population before access

### DIFF
--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -376,13 +376,15 @@ func (a *ArtifactServer) gateKeeping(r *http.Request, ns types.NamespacedRequest
 		}
 	}
 	ctx := metadata.NewIncomingContext(r.Context(), metadata.MD{"authorization": []string{token}})
-	ctx, err := a.gatekeeper.ContextWithRequest(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
+
 	// Ensure context has a logger for artifact operations
 	if logging.GetLoggerFromContextOrNil(ctx) == nil {
 		ctx = logging.WithLogger(ctx, a.logger)
+	}
+
+	ctx, err := a.gatekeeper.ContextWithRequest(ctx, ns)
+	if err != nil {
+		return nil, err
 	}
 	return ctx, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15191

### Motivation

We currently end up accessing the logger before it is created in this instance

### Modifications

Not much at all, I simply moved the logger population logic before the gatekeeper was accessed.

### Verification

None

### Documentation

Not needed.
