### PR TITLE
chore: Add 'fish' to supported shells in completion error

### DIFF
--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -141,7 +141,7 @@ For fish, output to a file in ~/.config/fish/completions
 			}
 			completion, ok := availableCompletions[shell]
 			if !ok {
-				return fmt.Errorf("invalid shell %q: supported shells are bash and zsh", shell)
+				return fmt.Errorf("invalid shell %q: supported shells are bash, zsh, and fish", shell)
 			}
 			return completion(os.Stdout, rootCommand)
 		},


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

Error says it only supports bash and zsh when it supports fish also

### Modifications
Updated message to mention fish also

### Verification

Checked fish was mentioned in error message output

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
