### PR TITLE
fix: server, label actor on retrywf

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -513,6 +513,8 @@ func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.Wor
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
 
+	creator.LabelActor(ctx, wf, creator.ActionRetry)
+
 	wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Update(ctx, wf, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -802,6 +802,7 @@ func TestRetryWorkflow(t *testing.T) {
 		retried, err := server.RetryWorkflow(ctx, &workflowpkg.WorkflowRetryRequest{Name: "failed", Namespace: "workflows"})
 		require.NoError(t, err)
 		assert.NotNil(t, retried)
+		assert.Equal(t, string(creator.ActionRetry), retried.Labels[common.LabelKeyAction])
 	})
 	t.Run("Unlabelled", func(t *testing.T) {
 		_, err := server.RetryWorkflow(ctx, &workflowpkg.WorkflowRetryRequest{Name: "unlabelled", Namespace: "workflows"})

--- a/workflow/creator/creator.go
+++ b/workflow/creator/creator.go
@@ -20,6 +20,7 @@ const (
 	ActionStop      ActionType = "Stop"
 	ActionTerminate ActionType = "Terminate"
 	ActionResume    ActionType = "Resume"
+	ActionRetry     ActionType = "Retry"
 	ActionNone      ActionType = ""
 )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15166

Label wf
`workflows.argoproj.io/action: Retry` when user uses Retry button from argo ui.

This was a missed scenario from https://github.com/argoproj/argo-workflows/pull/14104

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
