### PR TITLE
fix: Docs reference a UI service that does not exist

### DIFF
--- a/docs/argo-server.md
+++ b/docs/argo-server.md
@@ -70,6 +70,9 @@ To access the UI, use one of the following:
 kubectl -n argo port-forward svc/argo-server 2746:2746
 ```
 
+!!! Note "Helm installations"
+    If you installed Argo Workflows using the [Helm chart](https://github.com/argoproj/argo-helm/tree/main/charts/argo-workflows), use `svc/argo-workflows-server` instead of `svc/argo-server`.
+
 Then visit: <https://localhost:2746>
 
 ### Expose a `LoadBalancer`

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -82,6 +82,9 @@ argo logs -n argo @latest
     kubectl -n argo port-forward service/argo-server 2746:2746
     ```
 
+    !!! Note "Helm installations"
+        If you installed Argo Workflows using the [Helm chart](https://github.com/argoproj/argo-helm/tree/main/charts/argo-workflows), use `service/argo-workflows-server` instead of `service/argo-server`.
+
 1. Navigate your browser to <https://localhost:2746>.
     * **Note**: The URL uses `https` and not `http`. Navigating to `http` will result in a server-side error.
     * Due to the self-signed certificate, you will receive a TLS error which you will need to manually approve.


### PR DESCRIPTION
Fixes #14327

## Changes
- Added note in `docs/quick-start.md` clarifying that Helm users should use `service/argo-workflows-server` instead of `service/argo-server`
- Added same note in `docs/argo-server.md` for consistency