### PR TITLE
chore: Add 'fish' to supported shells in completion error (cherry-pick #15200 for 3.7)

### DIFF
--- a/cmd/argo/commands/completion.go
+++ b/cmd/argo/commands/completion.go
@@ -141,7 +141,7 @@ For fish, output to a file in ~/.config/fish/completions
 			}
 			completion, ok := availableCompletions[shell]
 			if !ok {
-				return fmt.Errorf("Invalid shell '%s'. The supported shells are bash and zsh.\n", shell)
+				return fmt.Errorf("Invalid shell '%s'. The supported shells are bash, zsh, and fish.\n", shell)
 			}
 			return completion(os.Stdout, rootCommand)
 		},


### PR DESCRIPTION
Cherry-picked chore: Add 'fish' to supported shells in completion error (#15200)