### PR TITLE
chore: remove testify from cron e2e test suite #15138

### DIFF
--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -51,6 +50,7 @@ spec:
 			assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 		})
 }
+
 func TestBasicTimezone(t *testing.T) {
 	// This test works by scheduling a CronWorkflow for the next minute, but using the local time of another timezone
 	// then seeing if the Workflow was ran within the next minute. Since this test would be trivial if the selected
@@ -65,8 +65,7 @@ func TestBasicTimezone(t *testing.T) {
 		hour = (hour + 1) % 24
 	}
 	scheduleInTestTimezone := strconv.Itoa(minute) + " " + strconv.Itoa(hour) + " * * *"
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(fmt.Sprintf(`
 apiVersion: argoproj.io/v1alpha1
@@ -95,9 +94,9 @@ spec:
 			assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
 		})
 }
+
 func TestSuspend(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -131,8 +130,7 @@ spec:
 }
 
 func TestResume(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -166,8 +164,7 @@ spec:
 }
 
 func TestBasicForbid(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -203,8 +200,7 @@ spec:
 		})
 }
 func TestBasicAllow(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -241,8 +237,7 @@ spec:
 }
 
 func TestBasicReplace(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -281,8 +276,7 @@ spec:
 }
 
 func TestSuccessfulJobHistoryLimit(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -319,8 +313,7 @@ spec:
 }
 
 func TestFailedJobHistoryLimit(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -358,8 +351,7 @@ spec:
 }
 
 func TestStoppingConditionWithSucceeded(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -398,8 +390,7 @@ spec:
 		})
 }
 func TestStoppingConditionWithFailed(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -436,8 +427,7 @@ spec:
 }
 
 func TestMultipleWithTimezone(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().
 		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -474,7 +464,6 @@ spec:
 }
 
 func TestMalformedCronWorkflow(t *testing.T) {
-	runner := fixtures.NewRunner(t)
-	defer runner.DeleteResources(t)
+	runner := fixtures.NewRunner(t, fixtures.WithTestResourceCleanupEnabled(true))
 	runner.Given().KubectlApply("testdata/malformed/malformed-cronworkflow.yaml", fixtures.ErrorOutput(".spec.workflowSpec.arguments.parameters: expected list"))
 }

--- a/test/e2e/cron_test.go
+++ b/test/e2e/cron_test.go
@@ -10,33 +10,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
-type CronSuite struct {
-	fixtures.E2ESuite
-}
-
-func (s *CronSuite) TearDownSubTest() {
-	// Delete all CronWorkflows after every subtest (as opposed to after each
-	// test, which is the default) to avoid workflows from accumulating and
-	// causing intermittent failures due to the controller reaching the
-	// parallelism limit. When that happens, workflows can be postponed long
-	// enough to reach the test timeout, and you'll see the following in the logs:
-	//    time="2025-02-23T06:11:00.023Z" level=info msg="Workflow processing has been postponed due to max parallelism limit" key=argo/test-cron-wf-succeed-1-1740291060
-	//    time="2025-02-23T06:11:00.023Z" level=info msg="Updated phase  -> Pending" namespace=argo workflow=test-cron-wf-succeed-1-1740291060
-	//    time="2025-02-23T06:11:00.023Z" level=info msg="Updated message  -> Workflow processing has been postponed because too many workflows are already running" namespace=argo workflow=test-cron-wf-succeed-1-1740291060
-	s.DeleteResources()
-}
-
-func (s *CronSuite) TestBasic() {
-	s.Run("TestBasic", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+func TestBasic(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic
@@ -58,31 +42,33 @@ spec:
       - name: whalesay
         container:
           image: argoproj/argosay:v2`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeSucceeded).
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
-				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
-	s.Run("TestBasicTimezone", func() {
-		// This test works by scheduling a CronWorkflow for the next minute, but using the local time of another timezone
-		// then seeing if the Workflow was ran within the next minute. Since this test would be trivial if the selected
-		// timezone was the same as the local timezone, a little-used timezone is used.
-		testTimezone := "Pacific/Niue"
-		testLocation, err := time.LoadLocation(testTimezone)
-		s.CheckError(err)
-		hour, minute, _ := time.Now().In(testLocation).Clock()
-		minute++
-		if minute == 60 {
-			minute = 0
-			hour = (hour + 1) % 24
-		}
-		scheduleInTestTimezone := strconv.Itoa(minute) + " " + strconv.Itoa(hour) + " * * *"
-		s.Given().
-			CronWorkflow(fmt.Sprintf(`
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
+			assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
+		})
+}
+func TestBasicTimezone(t *testing.T) {
+	// This test works by scheduling a CronWorkflow for the next minute, but using the local time of another timezone
+	// then seeing if the Workflow was ran within the next minute. Since this test would be trivial if the selected
+	// timezone was the same as the local timezone, a little-used timezone is used.
+	testTimezone := "Pacific/Niue"
+	testLocation, err := time.LoadLocation(testTimezone)
+	fixtures.CheckError(t, err)
+	hour, minute, _ := time.Now().In(testLocation).Clock()
+	minute++
+	if minute == 60 {
+		minute = 0
+		hour = (hour + 1) % 24
+	}
+	scheduleInTestTimezone := strconv.Itoa(minute) + " " + strconv.Itoa(hour) + " * * *"
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(fmt.Sprintf(`
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
@@ -100,18 +86,20 @@ spec:
       - name: whalesay
         container:
           image: argoproj/argosay:v2`, scheduleInTestTimezone, testTimezone)).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeSucceeded).
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
-				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
-	s.Run("TestSuspend", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
+			assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
+		})
+}
+func TestSuspend(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic-suspend
@@ -133,17 +121,20 @@ spec:
       - name: whalesay
         container:
           image: argoproj/argosay:v2`).
-			When().
-			CreateCronWorkflow().
-			SuspendCronWorkflow().
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.True(t, cronWf.Spec.Suspend)
-			})
-	})
-	s.Run("TestResume", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		SuspendCronWorkflow().
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.True(t, cronWf.Spec.Suspend)
+		})
+}
+
+func TestResume(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic-resume
@@ -165,17 +156,20 @@ spec:
       - name: whalesay
         container:
           image: argoproj/argosay:v2`).
-			When().
-			CreateCronWorkflow().
-			ResumeCronWorkflow("test-cron-wf-basic-resume").
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.False(t, cronWf.Spec.Suspend)
-			})
-	})
-	s.Run("TestBasicForbid", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		ResumeCronWorkflow("test-cron-wf-basic-resume").
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.False(t, cronWf.Spec.Suspend)
+		})
+}
+
+func TestBasicForbid(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic-forbid
@@ -198,19 +192,21 @@ spec:
         container:
           image: argoproj/argosay:v2
           args: ["sleep", "300s"]`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeRunning).
-			Wait(time.Minute). // wait for next scheduled time to ensure it's skipped by concurrencyPolicy
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Len(t, cronWf.Status.Active, 1)
-				assert.Less(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
-	s.Run("TestBasicAllow", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeRunning).
+		Wait(time.Minute). // wait for next scheduled time to ensure it's skipped by concurrencyPolicy
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Len(t, cronWf.Status.Active, 1)
+			assert.Less(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
+		})
+}
+func TestBasicAllow(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic-allow
@@ -235,17 +231,20 @@ spec:
         container:
           image: argoproj/argosay:v2
           args: ["sleep", "300s"]`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflowListCount(3*time.Minute, 2).
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Len(t, cronWf.Status.Active, 2)
-			})
-	})
-	s.Run("TestBasicReplace", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflowListCount(3*time.Minute, 2).
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Len(t, cronWf.Status.Active, 2)
+		})
+}
+
+func TestBasicReplace(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-basic-replace
@@ -268,21 +267,24 @@ spec:
         container:
           image: argoproj/argosay:v2
           args: ["sleep", "300s"]`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeRunning).
-			WaitForNewWorkflow(fixtures.ToBeRunning).
-			WaitForCronWorkflow().
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Len(t, cronWf.Status.Active, 1)
-				require.NotNil(t, cronWf.Status.LastScheduledTime)
-				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
-	s.Run("TestSuccessfulJobHistoryLimit", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeRunning).
+		WaitForNewWorkflow(fixtures.ToBeRunning).
+		WaitForCronWorkflow().
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Len(t, cronWf.Status.Active, 1)
+			require.NotNil(t, cronWf.Status.LastScheduledTime)
+			assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
+		})
+}
+
+func TestSuccessfulJobHistoryLimit(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-succeed-1
@@ -304,20 +306,23 @@ spec:
       - name: whalesay
         container:
           image: argoproj/argosay:v2`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeSucceeded).
-			WaitForNewWorkflow(fixtures.ToBeRunning).
-			WaitForWorkflowListCount(2*time.Minute, 1).
-			Then().
-			ExpectWorkflowListFromCronWorkflow(func(t *testing.T, wfList *wfv1.WorkflowList) {
-				assert.Len(t, wfList.Items, 1)
-				assert.Greater(t, wfList.Items[0].Status.FinishedAt.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
-	s.Run("TestFailedJobHistoryLimit", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		WaitForNewWorkflow(fixtures.ToBeRunning).
+		WaitForWorkflowListCount(2*time.Minute, 1).
+		Then().
+		ExpectWorkflowListFromCronWorkflow(func(t *testing.T, wfList *wfv1.WorkflowList) {
+			assert.Len(t, wfList.Items, 1)
+			assert.Greater(t, wfList.Items[0].Status.FinishedAt.Time, time.Now().Add(-1*time.Minute))
+		})
+}
+
+func TestFailedJobHistoryLimit(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-fail-1
@@ -340,20 +345,23 @@ spec:
         container:
           image: argoproj/argosay:v2
           args: ["exit", "1"]`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeFailed).
-			WaitForNewWorkflow(fixtures.ToBeRunning).
-			WaitForWorkflowListCount(2*time.Minute, 1).
-			Then().
-			ExpectWorkflowListFromCronWorkflow(func(t *testing.T, wfList *wfv1.WorkflowList) {
-				assert.Len(t, wfList.Items, 1)
-				assert.Greater(t, wfList.Items[0].Status.FinishedAt.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
-	s.Run("TestStoppingConditionWithSucceeded", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeFailed).
+		WaitForNewWorkflow(fixtures.ToBeRunning).
+		WaitForWorkflowListCount(2*time.Minute, 1).
+		Then().
+		ExpectWorkflowListFromCronWorkflow(func(t *testing.T, wfList *wfv1.WorkflowList) {
+			assert.Len(t, wfList.Items, 1)
+			assert.Greater(t, wfList.Items[0].Status.FinishedAt.Time, time.Now().Add(-1*time.Minute))
+		})
+}
+
+func TestStoppingConditionWithSucceeded(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-stop-condition-succeeded
@@ -378,20 +386,22 @@ spec:
         container:
             image: argoproj/argosay:v2
             command: [/argosay]`).
-			When().
-			CreateCronWorkflow().
-			WaitForCronWorkflowCompleted(3 * time.Minute).
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, int64(0), cronWf.Status.Failed)
-				assert.Equal(t, int64(1), cronWf.Status.Succeeded)
-				assert.Equal(t, wfv1.StoppedPhase, cronWf.Status.Phase)
-				assert.Equal(t, "true", cronWf.Labels[common.LabelKeyCronWorkflowCompleted])
-			})
-	})
-	s.Run("TestStoppingConditionWithFailed", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForCronWorkflowCompleted(3 * time.Minute).
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Equal(t, int64(0), cronWf.Status.Failed)
+			assert.Equal(t, int64(1), cronWf.Status.Succeeded)
+			assert.Equal(t, wfv1.StoppedPhase, cronWf.Status.Phase)
+			assert.Equal(t, "true", cronWf.Labels[common.LabelKeyCronWorkflowCompleted])
+		})
+}
+func TestStoppingConditionWithFailed(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-cron-wf-stop-condition-failed
@@ -413,20 +423,23 @@ spec:
         container:
           image: argoproj/argosay:v2
           args: ["exit", "1"]`).
-			When().
-			CreateCronWorkflow().
-			WaitForCronWorkflowCompleted(3 * time.Minute).
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, int64(0), cronWf.Status.Succeeded)
-				assert.Equal(t, int64(1), cronWf.Status.Failed)
-				assert.Equal(t, wfv1.StoppedPhase, cronWf.Status.Phase)
-				assert.Equal(t, "true", cronWf.Labels[common.LabelKeyCronWorkflowCompleted])
-			})
-	})
-	s.Run("TestMultipleWithTimezone", func() {
-		s.Given().
-			CronWorkflow(`apiVersion: argoproj.io/v1alpha1
+		When().
+		CreateCronWorkflow().
+		WaitForCronWorkflowCompleted(3 * time.Minute).
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Equal(t, int64(0), cronWf.Status.Succeeded)
+			assert.Equal(t, int64(1), cronWf.Status.Failed)
+			assert.Equal(t, wfv1.StoppedPhase, cronWf.Status.Phase)
+			assert.Equal(t, "true", cronWf.Labels[common.LabelKeyCronWorkflowCompleted])
+		})
+}
+
+func TestMultipleWithTimezone(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().
+		CronWorkflow(`apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: test-multiple-with-timezone
@@ -450,21 +463,18 @@ spec:
       - name: whalesay
         container:
           image: argoproj/argosay:v2`).
-			When().
-			CreateCronWorkflow().
-			WaitForWorkflow(fixtures.ToBeSucceeded).
-			Then().
-			ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
-				assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
-				assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
-			})
-	})
+		When().
+		CreateCronWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectCron(func(t *testing.T, cronWf *wfv1.CronWorkflow) {
+			assert.Equal(t, cronWf.Spec.GetScheduleWithTimezoneString(), cronWf.GetLatestSchedule())
+			assert.Greater(t, cronWf.Status.LastScheduledTime.Time, time.Now().Add(-1*time.Minute))
+		})
 }
 
-func (s *CronSuite) TestMalformedCronWorkflow() {
-	s.Given().KubectlApply("testdata/malformed/malformed-cronworkflow.yaml", fixtures.ErrorOutput(".spec.workflowSpec.arguments.parameters: expected list"))
-}
-
-func TestCronSuite(t *testing.T) {
-	suite.Run(t, new(CronSuite))
+func TestMalformedCronWorkflow(t *testing.T) {
+	runner := fixtures.NewRunner(t)
+	defer runner.DeleteResources(t)
+	runner.Given().KubectlApply("testdata/malformed/malformed-cronworkflow.yaml", fixtures.ErrorOutput(".spec.workflowSpec.arguments.parameters: expected list"))
 }

--- a/test/e2e/examples_test.go
+++ b/test/e2e/examples_test.go
@@ -10,17 +10,11 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"k8s.io/client-go/kubernetes"
-
-	"github.com/argoproj/argo-workflows/v3/config"
-	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	"github.com/argoproj/argo-workflows/v3/test/e2e/fixtures"
 	fileutil "github.com/argoproj/argo-workflows/v3/util/file"
 	"github.com/argoproj/argo-workflows/v3/util/kubeconfig"
 	"github.com/argoproj/argo-workflows/v3/util/logging"
-	"github.com/argoproj/argo-workflows/v3/util/secrets"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
-	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
@@ -28,32 +22,33 @@ import (
 )
 
 func TestExampleWorkflows(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
 	restConfig, err := kubeconfig.DefaultRestConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
-	kubeClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	//kubeClient, err := kubernetes.NewForConfig(restConfig)
+	//if err != nil {
+	//t.Fatal(err)
+	//}
 	dyn := dynamic.NewForConfigOrDie(restConfig)
 
-	configController := config.NewController(fixtures.Namespace, common.ConfigMapName, kubeClient)
-	ctx := logging.TestContext(t.Context())
-	config, err := configController.Get(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	persistence := fixtures.NewPersistence(ctx, kubeClient, config)
+	//configController := config.NewController(fixtures.Namespace, common.ConfigMapName, kubeClient)
+	//ctx := logging.TestContext(t.Context())
+	//config, err := configController.Get(ctx)
+	//if err != nil {
+	//t.Fatal(err)
+	//}
+	//persistence := fixtures.NewPersistence(ctx, kubeClient, config)
 
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sec, err := clientset.CoreV1().Secrets(fixtures.Namespace).Get(ctx, secrets.TokenName("argo-server"), metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	//clientset, err := kubernetes.NewForConfig(restConfig)
+	//if err != nil {
+	//t.Fatal(err)
+	//}
+	//sec, err := clientset.CoreV1().Secrets(fixtures.Namespace).Get(ctx, secrets.TokenName("argo-server"), metav1.GetOptions{})
+	//if err != nil {
+	//t.Fatal(err)
+	//}
 
 	kindToApply := map[string]bool{
 		"ConfigMap":               true,
@@ -128,24 +123,12 @@ func TestExampleWorkflows(t *testing.T) {
 		for _, wf := range wfs {
 			t.Run(path, func(t *testing.T) {
 				t.Parallel()
+				runner := fixtures.NewRunner(t)
 				noTestKeyword, noTextLabelExists := wf.GetLabels()["workflows.argoproj.io/no-test"]
 				if noTextLabelExists {
 					t.Skip(fmt.Sprintf("Impossible to run this example: %s", noTestKeyword))
 				}
-				fixtures.NewGiven(
-					t,
-					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().Workflows(fixtures.Namespace),
-					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().WorkflowEventBindings(fixtures.Namespace),
-					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().WorkflowTemplates(fixtures.Namespace),
-					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().WorkflowTaskSets(fixtures.Namespace),
-					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().ClusterWorkflowTemplates(),
-					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().CronWorkflows(fixtures.Namespace),
-					hydrator.New(persistence.OffloadNodeStatusRepo),
-					kubeClient,
-					string(sec.Data["token"]),
-					restConfig,
-					config).
-					ExampleWorkflow(&wf).
+				runner.Given().ExampleWorkflow(&wf).
 					When().
 					SubmitWorkflow().
 					WaitForWorkflow(fixtures.ToBeSucceeded)

--- a/test/e2e/examples_test.go
+++ b/test/e2e/examples_test.go
@@ -27,29 +27,7 @@ func TestExampleWorkflows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//kubeClient, err := kubernetes.NewForConfig(restConfig)
-	//if err != nil {
-	//t.Fatal(err)
-	//}
 	dyn := dynamic.NewForConfigOrDie(restConfig)
-
-	//configController := config.NewController(fixtures.Namespace, common.ConfigMapName, kubeClient)
-	//ctx := logging.TestContext(t.Context())
-	//config, err := configController.Get(ctx)
-	//if err != nil {
-	//t.Fatal(err)
-	//}
-	//persistence := fixtures.NewPersistence(ctx, kubeClient, config)
-
-	//clientset, err := kubernetes.NewForConfig(restConfig)
-	//if err != nil {
-	//t.Fatal(err)
-	//}
-	//sec, err := clientset.CoreV1().Secrets(fixtures.Namespace).Get(ctx, secrets.TokenName("argo-server"), metav1.GetOptions{})
-	//if err != nil {
-	//t.Fatal(err)
-	//}
-
 	kindToApply := map[string]bool{
 		"ConfigMap":               true,
 		"PersistentVolumeClaim":   true,

--- a/test/e2e/fixtures/runner.go
+++ b/test/e2e/fixtures/runner.go
@@ -1,0 +1,160 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	apierr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+
+	"github.com/argoproj/argo-workflows/v3/config"
+	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
+	"github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
+	"github.com/argoproj/argo-workflows/v3/server/utils"
+	"github.com/argoproj/argo-workflows/v3/util/kubeconfig"
+	"github.com/argoproj/argo-workflows/v3/util/logging"
+	"github.com/argoproj/argo-workflows/v3/util/secrets"
+	"github.com/argoproj/argo-workflows/v3/workflow/common"
+	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
+)
+
+type Runner struct {
+	given       *Given
+	persistence *Persistence
+	restConfig  *rest.Config
+}
+
+func NewRunner(t *testing.T) *Runner {
+	restConfig, err := kubeconfig.DefaultRestConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configController := config.NewController(Namespace, common.ConfigMapName, kubeClient)
+	ctx := logging.TestContext(t.Context())
+	config, err := configController.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persistence := NewPersistence(ctx, kubeClient, config)
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sec, err := clientset.CoreV1().Secrets(Namespace).Get(ctx, secrets.TokenName("argo-server"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &Runner{
+		persistence: persistence,
+		restConfig:  restConfig,
+	}
+	runner.given = NewGiven(
+		t,
+		versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().Workflows(Namespace),
+		versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().WorkflowEventBindings(Namespace),
+		versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().WorkflowTemplates(Namespace),
+		versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().WorkflowTaskSets(Namespace),
+		versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().ClusterWorkflowTemplates(),
+		versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().CronWorkflows(Namespace),
+		hydrator.New(persistence.OffloadNodeStatusRepo),
+		kubeClient,
+		string(sec.Data["token"]),
+		restConfig,
+		config)
+	return runner
+}
+
+func (r *Runner) Given() *Given {
+	return r.given
+}
+
+func (r *Runner) DeleteResources(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	l := func(r schema.GroupVersionResource) string {
+		if r.Resource == "pods" {
+			return common.LabelKeyWorkflow
+		}
+		return Label
+	}
+
+	pods := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	resources := []schema.GroupVersionResource{
+		{Group: workflow.Group, Version: workflow.Version, Resource: workflow.CronWorkflowPlural},
+		{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowPlural},
+		{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural},
+		{Group: workflow.Group, Version: workflow.Version, Resource: workflow.ClusterWorkflowTemplatePlural},
+		{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowEventBindingPlural},
+		{Group: workflow.Group, Version: workflow.Version, Resource: "sensors"},
+		{Group: workflow.Group, Version: workflow.Version, Resource: "eventsources"},
+		pods,
+		{Version: "v1", Resource: "resourcequotas"},
+		{Version: "v1", Resource: "configmaps"},
+	}
+	for _, resource := range resources {
+		for {
+			// remove finalizer from all the resources of the given GroupVersionResource
+			resourceInf := DynamicFor(r.restConfig, pods)
+			resourceList, err := resourceInf.List(ctx, metav1.ListOptions{LabelSelector: common.LabelKeyCompleted + "=false"})
+			CheckError(t, err)
+			for _, item := range resourceList.Items {
+				patch, err := json.Marshal(map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"finalizers": []string{},
+					},
+				})
+				CheckError(t, err)
+				_, err = resourceInf.Patch(ctx, item.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+				if err != nil && !apierr.IsNotFound(err) {
+					CheckError(t, err)
+				}
+			}
+			CheckError(t, DynamicFor(r.restConfig, resource).DeleteCollection(ctx, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(2))}, metav1.ListOptions{LabelSelector: l(resource)}))
+			ls, err := DynamicFor(r.restConfig, resource).List(ctx, metav1.ListOptions{LabelSelector: l(resource)})
+			CheckError(t, err)
+			if len(ls.Items) == 0 {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// delete archived workflows from the archive
+	if r.persistence.IsEnabled() {
+		archive := r.persistence.WorkflowArchive
+		parse, err := labels.ParseToRequirements(Label)
+		CheckError(t, err)
+		workflows, err := archive.ListWorkflows(ctx, utils.ListOptions{
+			Namespace:         Namespace,
+			LabelRequirements: parse,
+		})
+		CheckError(t, err)
+		for _, w := range workflows {
+			err := archive.DeleteWorkflow(ctx, string(w.UID))
+			CheckError(t, err)
+		}
+		parse, err = labels.ParseToRequirements(Backfill)
+		CheckError(t, err)
+		backfillWorkflows, err := archive.ListWorkflows(ctx, utils.ListOptions{
+			Namespace:         Namespace,
+			LabelRequirements: parse,
+		})
+		CheckError(t, err)
+		for _, w := range backfillWorkflows {
+			err := archive.DeleteWorkflow(ctx, string(w.UID))
+			CheckError(t, err)
+		}
+	}
+}

--- a/test/e2e/fixtures/util.go
+++ b/test/e2e/fixtures/util.go
@@ -8,10 +8,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow"
 )
 
 func errorln(args ...interface{}) {
@@ -81,4 +87,19 @@ func LoadObject(text string) (runtime.Object, error) {
 		return nil, err
 	}
 	return obj, nil
+}
+
+func CheckError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func DynamicFor(restConfig *rest.Config, r schema.GroupVersionResource) dynamic.ResourceInterface {
+	resourceInterface := dynamic.NewForConfigOrDie(restConfig).Resource(r)
+	if r.Resource == workflow.ClusterWorkflowTemplatePlural {
+		return resourceInterface
+	}
+	return resourceInterface.Namespace(Namespace)
 }


### PR DESCRIPTION
Fixes #15138

### Motivation

This commit explores how to drop testify from another (first was example
suite) e2e suite. In this case the cronjob one with particular focus on
how to abstract the code used for both migrations in a reusable fashion


### Modifications

I created a new structure to pre-configure and dispatch the Given fixture.
I refactored both Example and Cron suite to use it

### Verification

CI/CD is green

### Documentation

N/A
