### PR TITLE
docs: update workflow inputs example to match the doc wording

### DIFF
--- a/docs/workflow-inputs.md
+++ b/docs/workflow-inputs.md
@@ -55,6 +55,9 @@ spec:
     - name: workflow-param-1
   templates:
   - name: main
+    inputs:
+      parameters:
+      - name: workflow-param-1
     dag:
       tasks:
       - name: step-A 
@@ -62,7 +65,7 @@ spec:
         arguments:
           parameters:
           - name: template-param-1
-            value: "{{workflow.parameters.workflow-param-1}}"
+            value: "{{inputs.parameters.workflow-param-1}}"
  
   - name: step-template-a
     inputs:


### PR DESCRIPTION
The document talks about the various ways to funnel the input parameter in and then the combined example does not match the wording. While functional it does not show the full way of passing the parameters all the way in.