### PR TITLE
fix: Optimize DAG sort for retry

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1110,10 +1110,12 @@ func dagSortedNodes(nodes []*dagNode, rootNodeName string) []*dagNode {
 	}
 
 	queue := make([]*dagNode, 0)
+	visited := make(map[string]bool)
 
 	for _, n := range nodes {
 		if n.n.Name == rootNodeName {
 			queue = append(queue, n)
+			visited[n.n.ID] = true
 			break
 		}
 	}
@@ -1126,7 +1128,13 @@ func dagSortedNodes(nodes []*dagNode, rootNodeName string) []*dagNode {
 		curr := queue[0]
 		sortedNodes = append(sortedNodes, curr)
 		queue = queue[1:]
-		queue = append(queue, curr.children...)
+		for _, child := range curr.children {
+			if visited[child.n.ID] {
+				continue
+			}
+			visited[child.n.ID] = true
+			queue = append(queue, child)
+		}
 	}
 
 	return sortedNodes


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation
The existing retry functionality has a combinatorial explosion during the DAG sort stage. Consider a workflow
composed of sequential stages, each stage having a set of items in parallel:
```
                START
                  │
          ┌───────┼───────┐
          ▼       ▼       ▼
        [1-1]   [1-2]   [1-3]
          └───────┼───────┘
                  │
          ┌───────┼───────┐
          ▼       ▼       ▼
        [2-1]   [2-2]   [2-3]
          └───────┼───────┘
                  │
          ┌───────┼───────┐
          ▼       ▼       ▼
        [3-1]   [3-2]   [3-3]
          └───────┼───────┘
                  │
                 END
```

The current DAG sort code can reach each next stage as a `child` of all steps from the current stage. Each of them is processed, adding their children, ... which explodes the number of times the child nodes are processed. This leads to either very slow retries (referring to the manual retry button, `argo retry` equivalent) for complex workflows, or OOMs of the Argo server.

### Modifications

This optimizes the topsort to avoid re-visiting the same nodes more than once. This ensures that
the DAG sort is bounded (O(N)) in time and memory.

### Verification

<!-- TODO: Say how you tested your changes. -->

Submit this workflow: https://gist.github.com/spruett345/a73c0c9dd49fcd030c95ad015b03f158
This has 10 sequential stages, each with 20 parallel steps, each with 3 sub steps (mimicking the structure of a real Workflow which I ran to hit this pathological case). Once it has failed, attempt to retry it with `argo retry` -- it OOMs on my machine (10+GB of RAM). 

With this patch, the retry completes in a reasonable time frame without noticeable memory usage.

### Documentation

N/A: no expected behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate node processing in workflow traversal operations, preventing nodes from being processed multiple times and improving system performance and correctness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->