### PR TITLE
fix: ensure single trailing newline in feature generator output (MD047)

### DIFF
--- a/hack/featuregen/contents.go
+++ b/hack/featuregen/contents.go
@@ -209,5 +209,5 @@ func format(version string, features []feature) string {
 		}
 	}
 
-	return strings.TrimSuffix(output.String(), "\n\n")
+	return strings.TrimRight(output.String(), "\n") + "\n"
 }

--- a/hack/featuregen/contents.go
+++ b/hack/featuregen/contents.go
@@ -209,5 +209,5 @@ func format(version string, features []feature) string {
 		}
 	}
 
-	return output.String()
+	return strings.TrimRight(output.String(), "\n") + "\n"
 }

--- a/hack/featuregen/contents_test.go
+++ b/hack/featuregen/contents_test.go
@@ -260,7 +260,6 @@ This is a concise list of new features.
 
 - Test Description by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234))
   Test Details
-
 `,
 		},
 		{
@@ -285,7 +284,6 @@ This is a concise list of new features.
   Test Details
   - Point 1
   - Point 2
-
 `,
 		},
 		{
@@ -319,7 +317,6 @@ This is a concise list of new features.
 
 - Description 2 by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))
   Details 2
-
 `,
 		},
 		{
@@ -350,7 +347,6 @@ This is a concise list of new features.
 - First CLI feature by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234))
 
 - Second CLI feature by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))
-
 `,
 		},
 	}

--- a/hack/featuregen/contents_test.go
+++ b/hack/featuregen/contents_test.go
@@ -46,7 +46,8 @@ Some content here
 Component: Invalid second component
 Issues: 5678
 Description: Invalid second description
-Authors: [Another Author](https://github.com/another)`,
+Authors: [Another Author](https://github.com/another)
+`,
 			wantValid: false,
 			want: feature{
 				Component:   "UI",
@@ -116,9 +117,10 @@ Test Details`,
 			},
 		},
 		{
-			name:      "Empty content",
-			source:    "empty.md",
-			content:   ``,
+			name:   "Empty content",
+			source: "empty.md",
+			content: `
+		`,
 			wantValid: false,
 			want: feature{
 				Component:   "",
@@ -259,7 +261,8 @@ This is a concise list of new features.
 ## UI
 
 - Test Description by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234))
-  Test Details`,
+  Test Details
+`,
 		},
 		{
 			name:    "Released features",
@@ -282,7 +285,8 @@ This is a concise list of new features.
 - Test Description by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234), [#5678](https://github.com/argoproj/argo-workflows/issues/5678))
   Test Details
   - Point 1
-  - Point 2`,
+  - Point 2
+`,
 		},
 		{
 			name:    "Multiple features in different components",
@@ -314,7 +318,8 @@ This is a concise list of new features.
 ## UI
 
 - Description 2 by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))
-  Details 2`,
+  Details 2
+`,
 		},
 		{
 			name:    "Features in same component",
@@ -343,7 +348,8 @@ This is a concise list of new features.
 
 - First CLI feature by [Alan Clucas](https://github.com/Joibel) ([#1234](https://github.com/argoproj/argo-workflows/issues/1234))
 
-- Second CLI feature by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))`,
+- Second CLI feature by [Alan Clucas](https://github.com/Joibel) ([#5678](https://github.com/argoproj/argo-workflows/issues/5678))
+`,
 		},
 	}
 

--- a/hack/featuregen/main.go
+++ b/hack/featuregen/main.go
@@ -228,7 +228,7 @@ func updateFeatures(dryRun bool, version string, final bool) error {
 
 	fmt.Printf("Preview of changes with %d features:\n", len(features))
 	fmt.Println("===================")
-	fmt.Println(outputContent)
+	fmt.Print(outputContent)
 
 	if !dryRun {
 		if err := os.MkdirAll(filepath.Dir(docsOutput), 0755); err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Ref: https://github.com/argoproj/argo-workflows/issues/15149

### Motivation

<!-- TODO: Say why you made your changes. -->
New feature documentation (`./docs/new-features.md`) generated by the `hack/featuregen` tool was failing CI due to a missing trailing newline, violating the `MD047` (single-trailing-newline) markdownlint rule.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Updated `hack/featuregen/contents.go` to ensure the generated string always ends with exactly one newline character by trimming existing trailing newlines and adding a single `\n`.
- Updated expected outputs in `hack/featuregen/contents_test.go` to align with the new formatting logic.

### Verification

<!-- TODO: Say how you tested your changes. -->

- Ran `go test ./hack/featuregen/...` to confirm that the generator now produces output with the correct trailing newline.
- Verified that the generated markdown no longer triggers the `MD047` lint error.

<details>
<summary>asis</summary>

```console
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (fix-MD047-single-trailing-newline) $ make features-update
go test ./hack/featuregen
ok      github.com/argoproj/argo-workflows/v3/hack/featuregen   0.008s
go build -o hack/featuregen/featuregen ./hack/featuregen
npm list -g markdownlint-cli@0.33.0 > /dev/null || npm i -g markdownlint-cli@0.33.0
# Update the features documentation, but keep the feature files in the pending directory
# Updates docs/new-features.md for release-candidates
hack/featuregen/featuregen update --version latest
All 21 feature documents are valid
Preview of changes with 21 features:
===================
# New features in latest (2026-01-14)

This is a concise list of new features.

## General

- Name filter parameter for prefix/contains/exact search in `/archived-workflows` by [Armin Friedl](https://github.com/arminfriedl) ([#14069](https://github.com/argoproj/argo-workflows/issues/14069))
  A new `nameFilter` parameter was added to the `GET
  /archived-workflows` endpoint. The filter works analogous to the one
  in `GET /workflows`. It allows to specify how a search for
  `?listOptions.fieldSelector=metadata.name=<search-string>` in these
  endpoints should be interpreted. Possible values are `Prefix`,
  `Contains` and `Exact`. The `metadata.name` field is matched
  accordingly against the value for `<search-string>`.

- Artifact Drivers as plugins by [Alan Clucas](https://github.com/Joibel), [JP Zivalich](https://github.com/JPZ13), [Elliot Gunton](https://github.com/elliotgunton) ([#5862](https://github.com/argoproj/argo-workflows/issues/5862))
  Artifact Drivers can now be added via a plugin mechanism.
  You can write a GRPC server which acts as an artifact driver to upload and download artifacts to a repository, and supply that as a container image.
  Argo workflows can then use that as a driver.

- Support update total parallelism without restart controller. by [Shuangkun Tian](https://github.com/shuangkun) ([#14689](https://github.com/argoproj/argo-workflows/issues/14689))
  When modify the global parallelism in workflow-controller-configmap, the change takes effect directly without restarting the controller.

- Added CRD validation rules by [Alan Clucas](https://github.com/Joibel ([#13503](https://github.com/argoproj/argo-workflows/issues/13503))
  Added some validation rules to the full CRDs which allow some simpler validation to happen as the object is added to the kubernetes cluster.
  This is useful if you're using a mechanism which bypasses the validator such as kubectl apply.
  It will inform you of
  **Note:** Some validations cannot be implemented as CEL rules due to Kubernetes limitations.
  Fields marked with `+kubebuilder:validation:Schemaless` (like `withItems`) or `+kubebuilder:pruning:PreserveUnknownFields` (like `inline`) are not visible to CEL validation expressions.
  **CEL Budget Management:** Kubernetes limits the total cost of CEL validation rules per CRD. To stay within these limits:
      - All `status` blocks have CEL validations automatically stripped during CRD generation
      - Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
      - Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
  **Array and String Size Limits:** To manage CEL validation costs, the following maximum sizes are enforced:
      - Templates per workflow: 200
      - DAG tasks per DAG template: 200
      - Parameters: 500
      - Prometheus metrics per template: 100
      - Gauge metric value string: 256 characters
  **Mutual Exclusivity Rules:**
      - only one template type per template
      - only one of sequence count/end
      - only one of manifest/manifestFrom
      - cannot use both depends and dependencies in DAG tasks.
  **DAG Task Constraints:**
      - task names cannot start with digit when using depends/dependencies
      - cannot use continueOn with depends.
  **Timeout on Non-Leaf Templates:**
      - Timeout cannot be set on steps or dag templates (only on leaf templates).
  **Cron Schedule Format:**
      - CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
  **Metric Validation:**
      - metric and label names validation
      - help and value fields required
      - real-time gauges cannot use resourcesDuration metrics
  **Artifact:**
      - At most one artifact location may be specified
      - Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
  **Enum Validations:**
      - PodGC strategy
      - ConcurrencyPolicy
      - RetryPolicy
      - GaugeOperation
      - Resource action
      - MergeStrategy
        all have restricted allowed values.
  **Name Pattern Constraints:**
      - Template/Step/Task names: max 128 chars, pattern `^[a-zA-Z0-9][-a-zA-Z0-9]*$;`
      - Parameter/Artifact names: pattern `^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.`
  **Minimum Array Sizes:**
      - Template.Steps requires at least one step group
      - Parameter.Enum requires at least one value
      - CronWorkflow.Schedules requires at least one schedule
      - DAG.Tasks requires at least one task.
  **Numeric Constraints:**
      - Parallelism minimum 1
      - StartingDeadlineSeconds minimum 0.

- Allow custom CA certificate configuration for SSO OIDC provider connections by [bradfordwagner](https://github.com/bradfordwagner) ([#7198](https://github.com/argoproj/argo-workflows/issues/7198))
  This feature adds support for custom TLS configuration when connecting to OIDC providers for SSO authentication.
  This is particularly useful when your OIDC provider uses self-signed certificates or custom Certificate Authorities (CAs).
      - Use this feature when your OIDC provider uses custom self-signed CA certificates
      - Configure custom CA certificates either inline or by file path
  **Configuration Examples**
  **Inline PEM content**
      sso:
        # Custom PEM encoded CA certificate file contents
        rootCA: |-
          -----BEGIN CERTIFICATE-----
          MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
          ...
          -----END CERTIFICATE-----
  The system will automatically use certificates configured with SSL_CERT_DIR, and SSL_CERT_FILE for non macOS environments.
  For production environments, always use proper CA certificates instead of skipping TLS verification.

- Deprecate singular in favour of plural items by [Alan Clucas](https://github.com/Joibel) ([#14977](https://github.com/argoproj/argo-workflows/issues/14977))
  Deprecation: remove singluar `mutex`, `semaphore` and `schedule` from the specs, all were replaced by the plural version in 3.6

- Disable write back informer by default by [Eduardo Rodrigues](https://github.com/eduardodbr) ([#12352](https://github.com/argoproj/argo-workflows/issues/12352))
  Update the controller’s default behavior to disable the write-back informer. We’ve seen several cases of unexpected behavior that appear to be caused by the write-back mechanism, and Kubernetes docs recommend avoiding writes to the informer store. Although turning it off may increase the frequency of 409 Conflict errors, it should help reduce unpredictable controller behavior.

- This migrates most of the logging off logrus and onto a custom logger. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120))
  Currently it is quite hard to identify log lines with it's corresponding
  workflow. This change propagates a context object down the call hierarchy
  containing an annotated logging object. This allows context aware logging from
  deep within the codebase.

- Support metadata.name= and metadata.name!= in field selectors by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
  Field selectors for `metadata.name` now support the `==` and `!=` operators, giving you more flexible control over resource filtering.
  Use the `==` operator to match resources with an exact name, or use `!=` to exclude resources by name.
  This brings field selector behavior in line with native Kubernetes functionality and enables more precise resource queries.

- Restart pods that fail before starting by [Alan Clucas](https://github.com/Joibel) ([#12572](https://github.com/argoproj/argo-workflows/issues/12572))
  Automatically restart pods that fail before starting for reasons like node eviction.
  This is safe to do even for non-idempotent workloads.
  You need to configure this in your workflow controller configmap for it to take effect.

- Removal of logrus and more structured logging by [Alan Clucas](https://github.com/Joibel) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120), [#2308](https://github.com/argoproj/argo-workflows/issues/2308))
  Complete context passing so all logs should have correct context and enable remaining logs to be fully structured logs.

## UI

- Add an informational message to the CronWorkflow delete confirmation modal indicating that Workflows created by the CronSchedule will also be deleted. by [minsun yun](https://github.com/miinsun) ([#14679](https://github.com/argoproj/argo-workflows/issues/14679))
  UI/UX only; **no functional logic** is changed
  Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly

- Add label query parameter sync with URL in WorkflowTemplates UI to match Workflows list behavior for consistent filtering. by [puretension](https://github.com/puretension) ([#14807](https://github.com/argoproj/argo-workflows/issues/14807))
  WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
  Combined URL updates and localStorage persistence in single useEffect
  Enables custom UI links for filtered template views
  Verified that URL updates when changing filters and filters persist on page refresh

- Name Not Equals filter now available in the UI for filtering workflows by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
  You can now use the "Name Not Equals" filter in the workflow list to exclude workflows by name.
  This complements the existing "Name Exact" filter and provides more flexible filtering options.
  Use this filter when you want to view all workflows except those matching a specific name pattern.

- Support open custom links in new tab automatically. by [Shuangkun Tian](https://github.com/shuangkun) ([#13114](https://github.com/argoproj/argo-workflows/issues/13114))
  Support configuring a custom link to open in a new tab by default.
  If `target == _blank`, open in new tab, if target is null or `_self`, open in this tab. For example:
      - name: Pod Link
        scope: pod
        target: _blank
        url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}

- Optimize pagination performance when counting workflows in archive. by [Shuangkun Tian](https://github.com/shuangkun) ([#13948](https://github.com/argoproj/argo-workflows/issues/13948))
  When querying archived workflows with pagination, the system now uses more efficient methods to check if there are more items available. Instead of performing expensive full table scans, the new implementation uses LIMIT queries to check if there are items beyond the current offset+limit, significantly improving performance for large datasets.

## CLI

- Add support for creating a configmap semaphore config using CLI by [Darko Janjic](https://github.com/djanjic) ([#14671](https://github.com/argoproj/argo-workflows/issues/14671))
  Allow user to create a configmap semaphore configuration using CLI

- `convert` CLI command to convert to new workflow format by [Alan Clucas](https://github.com/Joibel) ([#14977](https://github.com/argoproj/argo-workflows/issues/14977))
  A new CLI command `convert` which will convert Workflows, CronWorkflows, and (Cluster)WorkflowTemplates to the new format.
  It will remove `schedule` from CronWorkflows, moving that into `schedules`
  It will remove `mutex` and `semaphore` from `synchronization` blocks and move them to the plural version.
  Otherwise this command works much the same as linting.

- Add support for creating a database semaphore config using CLI by [Darko Janjic](https://github.com/djanjic) ([#14783](https://github.com/argoproj/argo-workflows/issues/14783))
  Allow user to create a database semaphore configuration using CLI

## Build and Development

- Document features as they are created by [Alan Clucas](https://github.com/Joibel) ([#14155](https://github.com/argoproj/argo-workflows/issues/14155))
  To assist with creating release documentation and blog postings, all features now require a document in .features/pending explaining what they do for users.

- Support plural "Authors:" field in feature notes by " field in feature notes ([#14155](https://github.com/argoproj/argo-workflows/issues/14155))
  The featuregen tool now uses the plural "Authors:" field instead of "Author:" for new feature notes.
  This better reflects that features can have multiple authors.
  The change maintains full backwards compatibility with existing feature files that use the singular "Author:" field.
Updated features documentation with version latest
Features remain in pending directory (--final not specified)
/usr/local/share/nvm/versions/node/v20.19.5/bin/markdownlint ./docs/new-features.md
./docs/new-features.md:171:118 MD047/single-trailing-newline Files should end with a single newline character
make: *** [Makefile:943: features-update] Error 1
```
</details>

<details>
<summary>tobe</summary>

```console
vscode ➜ ~/go/src/github.com/argoproj/argo-workflows (fix-MD047-single-trailing-newline) $ make features-update
npm list -g markdownlint-cli@0.33.0 > /dev/null || npm i -g markdownlint-cli@0.33.0
# Update the features documentation, but keep the feature files in the pending directory
# Updates docs/new-features.md for release-candidates
hack/featuregen/featuregen update --version latest
All 21 feature documents are valid
Preview of changes with 21 features:
===================
# New features in latest (2026-01-14)

This is a concise list of new features.

## General

- Name filter parameter for prefix/contains/exact search in `/archived-workflows` by [Armin Friedl](https://github.com/arminfriedl) ([#14069](https://github.com/argoproj/argo-workflows/issues/14069))
  A new `nameFilter` parameter was added to the `GET
  /archived-workflows` endpoint. The filter works analogous to the one
  in `GET /workflows`. It allows to specify how a search for
  `?listOptions.fieldSelector=metadata.name=<search-string>` in these
  endpoints should be interpreted. Possible values are `Prefix`,
  `Contains` and `Exact`. The `metadata.name` field is matched
  accordingly against the value for `<search-string>`.

- Artifact Drivers as plugins by [Alan Clucas](https://github.com/Joibel), [JP Zivalich](https://github.com/JPZ13), [Elliot Gunton](https://github.com/elliotgunton) ([#5862](https://github.com/argoproj/argo-workflows/issues/5862))
  Artifact Drivers can now be added via a plugin mechanism.
  You can write a GRPC server which acts as an artifact driver to upload and download artifacts to a repository, and supply that as a container image.
  Argo workflows can then use that as a driver.

- Support update total parallelism without restart controller. by [Shuangkun Tian](https://github.com/shuangkun) ([#14689](https://github.com/argoproj/argo-workflows/issues/14689))
  When modify the global parallelism in workflow-controller-configmap, the change takes effect directly without restarting the controller.

- Added CRD validation rules by [Alan Clucas](https://github.com/Joibel ([#13503](https://github.com/argoproj/argo-workflows/issues/13503))
  Added some validation rules to the full CRDs which allow some simpler validation to happen as the object is added to the kubernetes cluster.
  This is useful if you're using a mechanism which bypasses the validator such as kubectl apply.
  It will inform you of
  **Note:** Some validations cannot be implemented as CEL rules due to Kubernetes limitations.
  Fields marked with `+kubebuilder:validation:Schemaless` (like `withItems`) or `+kubebuilder:pruning:PreserveUnknownFields` (like `inline`) are not visible to CEL validation expressions.
  **CEL Budget Management:** Kubernetes limits the total cost of CEL validation rules per CRD. To stay within these limits:
      - All `status` blocks have CEL validations automatically stripped during CRD generation
      - Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
      - Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
  **Array and String Size Limits:** To manage CEL validation costs, the following maximum sizes are enforced:
      - Templates per workflow: 200
      - DAG tasks per DAG template: 200
      - Parameters: 500
      - Prometheus metrics per template: 100
      - Gauge metric value string: 256 characters
  **Mutual Exclusivity Rules:**
      - only one template type per template
      - only one of sequence count/end
      - only one of manifest/manifestFrom
      - cannot use both depends and dependencies in DAG tasks.
  **DAG Task Constraints:**
      - task names cannot start with digit when using depends/dependencies
      - cannot use continueOn with depends.
  **Timeout on Non-Leaf Templates:**
      - Timeout cannot be set on steps or dag templates (only on leaf templates).
  **Cron Schedule Format:**
      - CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
  **Metric Validation:**
      - metric and label names validation
      - help and value fields required
      - real-time gauges cannot use resourcesDuration metrics
  **Artifact:**
      - At most one artifact location may be specified
      - Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
  **Enum Validations:**
      - PodGC strategy
      - ConcurrencyPolicy
      - RetryPolicy
      - GaugeOperation
      - Resource action
      - MergeStrategy
        all have restricted allowed values.
  **Name Pattern Constraints:**
      - Template/Step/Task names: max 128 chars, pattern `^[a-zA-Z0-9][-a-zA-Z0-9]*$;`
      - Parameter/Artifact names: pattern `^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.`
  **Minimum Array Sizes:**
      - Template.Steps requires at least one step group
      - Parameter.Enum requires at least one value
      - CronWorkflow.Schedules requires at least one schedule
      - DAG.Tasks requires at least one task.
  **Numeric Constraints:**
      - Parallelism minimum 1
      - StartingDeadlineSeconds minimum 0.

- Allow custom CA certificate configuration for SSO OIDC provider connections by [bradfordwagner](https://github.com/bradfordwagner) ([#7198](https://github.com/argoproj/argo-workflows/issues/7198))
  This feature adds support for custom TLS configuration when connecting to OIDC providers for SSO authentication.
  This is particularly useful when your OIDC provider uses self-signed certificates or custom Certificate Authorities (CAs).
      - Use this feature when your OIDC provider uses custom self-signed CA certificates
      - Configure custom CA certificates either inline or by file path
  **Configuration Examples**
  **Inline PEM content**
      sso:
        # Custom PEM encoded CA certificate file contents
        rootCA: |-
          -----BEGIN CERTIFICATE-----
          MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
          ...
          -----END CERTIFICATE-----
  The system will automatically use certificates configured with SSL_CERT_DIR, and SSL_CERT_FILE for non macOS environments.
  For production environments, always use proper CA certificates instead of skipping TLS verification.

- Deprecate singular in favour of plural items by [Alan Clucas](https://github.com/Joibel) ([#14977](https://github.com/argoproj/argo-workflows/issues/14977))
  Deprecation: remove singluar `mutex`, `semaphore` and `schedule` from the specs, all were replaced by the plural version in 3.6

- Disable write back informer by default by [Eduardo Rodrigues](https://github.com/eduardodbr) ([#12352](https://github.com/argoproj/argo-workflows/issues/12352))
  Update the controller’s default behavior to disable the write-back informer. We’ve seen several cases of unexpected behavior that appear to be caused by the write-back mechanism, and Kubernetes docs recommend avoiding writes to the informer store. Although turning it off may increase the frequency of 409 Conflict errors, it should help reduce unpredictable controller behavior.

- This migrates most of the logging off logrus and onto a custom logger. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120))
  Currently it is quite hard to identify log lines with it's corresponding
  workflow. This change propagates a context object down the call hierarchy
  containing an annotated logging object. This allows context aware logging from
  deep within the codebase.

- Support metadata.name= and metadata.name!= in field selectors by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
  Field selectors for `metadata.name` now support the `==` and `!=` operators, giving you more flexible control over resource filtering.
  Use the `==` operator to match resources with an exact name, or use `!=` to exclude resources by name.
  This brings field selector behavior in line with native Kubernetes functionality and enables more precise resource queries.

- Restart pods that fail before starting by [Alan Clucas](https://github.com/Joibel) ([#12572](https://github.com/argoproj/argo-workflows/issues/12572))
  Automatically restart pods that fail before starting for reasons like node eviction.
  This is safe to do even for non-idempotent workloads.
  You need to configure this in your workflow controller configmap for it to take effect.

- Removal of logrus and more structured logging by [Alan Clucas](https://github.com/Joibel) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120), [#2308](https://github.com/argoproj/argo-workflows/issues/2308))
  Complete context passing so all logs should have correct context and enable remaining logs to be fully structured logs.

## UI

- Add an informational message to the CronWorkflow delete confirmation modal indicating that Workflows created by the CronSchedule will also be deleted. by [minsun yun](https://github.com/miinsun) ([#14679](https://github.com/argoproj/argo-workflows/issues/14679))
  UI/UX only; **no functional logic** is changed
  Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly

- Add label query parameter sync with URL in WorkflowTemplates UI to match Workflows list behavior for consistent filtering. by [puretension](https://github.com/puretension) ([#14807](https://github.com/argoproj/argo-workflows/issues/14807))
  WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
  Combined URL updates and localStorage persistence in single useEffect
  Enables custom UI links for filtered template views
  Verified that URL updates when changing filters and filters persist on page refresh

- Name Not Equals filter now available in the UI for filtering workflows by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
  You can now use the "Name Not Equals" filter in the workflow list to exclude workflows by name.
  This complements the existing "Name Exact" filter and provides more flexible filtering options.
  Use this filter when you want to view all workflows except those matching a specific name pattern.

- Support open custom links in new tab automatically. by [Shuangkun Tian](https://github.com/shuangkun) ([#13114](https://github.com/argoproj/argo-workflows/issues/13114))
  Support configuring a custom link to open in a new tab by default.
  If `target == _blank`, open in new tab, if target is null or `_self`, open in this tab. For example:
      - name: Pod Link
        scope: pod
        target: _blank
        url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}

- Optimize pagination performance when counting workflows in archive. by [Shuangkun Tian](https://github.com/shuangkun) ([#13948](https://github.com/argoproj/argo-workflows/issues/13948))
  When querying archived workflows with pagination, the system now uses more efficient methods to check if there are more items available. Instead of performing expensive full table scans, the new implementation uses LIMIT queries to check if there are items beyond the current offset+limit, significantly improving performance for large datasets.

## CLI

- Add support for creating a configmap semaphore config using CLI by [Darko Janjic](https://github.com/djanjic) ([#14671](https://github.com/argoproj/argo-workflows/issues/14671))
  Allow user to create a configmap semaphore configuration using CLI

- `convert` CLI command to convert to new workflow format by [Alan Clucas](https://github.com/Joibel) ([#14977](https://github.com/argoproj/argo-workflows/issues/14977))
  A new CLI command `convert` which will convert Workflows, CronWorkflows, and (Cluster)WorkflowTemplates to the new format.
  It will remove `schedule` from CronWorkflows, moving that into `schedules`
  It will remove `mutex` and `semaphore` from `synchronization` blocks and move them to the plural version.
  Otherwise this command works much the same as linting.

- Add support for creating a database semaphore config using CLI by [Darko Janjic](https://github.com/djanjic) ([#14783](https://github.com/argoproj/argo-workflows/issues/14783))
  Allow user to create a database semaphore configuration using CLI

## Build and Development

- Document features as they are created by [Alan Clucas](https://github.com/Joibel) ([#14155](https://github.com/argoproj/argo-workflows/issues/14155))
  To assist with creating release documentation and blog postings, all features now require a document in .features/pending explaining what they do for users.

- Support plural "Authors:" field in feature notes by " field in feature notes ([#14155](https://github.com/argoproj/argo-workflows/issues/14155))
  The featuregen tool now uses the plural "Authors:" field instead of "Author:" for new feature notes.
  This better reflects that features can have multiple authors.
  The change maintains full backwards compatibility with existing feature files that use the singular "Author:" field.

Updated features documentation with version latest
Features remain in pending directory (--final not specified)
/usr/local/share/nvm/versions/node/v20.19.5/bin/markdownlint ./docs/new-features.md
```
</details>

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No documentation updates are required as this is a fix for the documentation generation tool itself.
