### PR TITLE
fix: support snipdoc installation on aarch64-linux via cargo fallback

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,11 @@
   // This image is built and pushed by .github/workflows/devcontainer.yaml using .devcontainer/builder/devcontainer.json
   "image": "quay.io/argoproj/argo-workflows-devcontainer",
 
+  "features": {
+    // Required for building snipdoc on aarch64-linux (no pre-built binary available)
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
+
   "forwardPorts": [9000, 9001, 9090, 2746, 8080, 5556, 5554, 6060, 9091, 3306, 5432, 10000, 8000],
   "hostRequirements": {
     "cpus": 4


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/15246

### Motivation

<!-- TODO: Say why you made your changes. -->

snipdoc pre-built binaries are not available for aarch64-linux platforms, causing installation failures in devcontainer environments on ARM-based systems (e.g., Apple Silicon Macs, ARM cloud instances). This prevents
developers from building documentation on these platforms.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Modified `hack/install-snipdoc.sh` to implement a fallback mechanism:
  - First attempts to download pre-built binary
  - Falls back to `cargo install` if download fails (e.g., on aarch64-linux)
  - Adds proper error handling and user feedback
  - Copies cargo-installed binary to the expected location
- Added Rust feature to `.devcontainer/devcontainer.json` to ensure Rust toolchain is available for building snipdoc from source when needed

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested on aarch64-linux devcontainer environment:
- Verified that pre-built binary download fails gracefully
- Confirmed cargo fallback successfully builds and installs snipdoc
- Verified the installed binary is placed in the correct location and is executable
- Confirmed documentation builds work correctly with cargo-installed snipdoc

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No documentation update needed.
