### PR TITLE
fix: optimize index to prevent 'out of sort memory' error Fixes #14240

### DIFF
--- a/persist/sqldb/migrate.go
+++ b/persist/sqldb/migrate.go
@@ -188,12 +188,6 @@ func Migrate(ctx context.Context, session db.Session, clusterName, tableName str
 		}),
 		// add argo_archived_workflows index
 		sqldb.AnsiSQLChange(`create index argo_archived_workflows_i1 on argo_archived_workflows (clustername,instanceid,namespace)`),
-		// change argo_archived_workflows_i1 index to add startedat DESC to resolve MySQL out of sort memory issues. #14240
-		sqldb.ByType(dbType, sqldb.TypedChanges{
-			sqldb.MySQL:    sqldb.AnsiSQLChange(`drop index argo_archived_workflows_i1 on argo_archived_workflows`),
-			sqldb.Postgres: sqldb.AnsiSQLChange(`drop index argo_archived_workflows_i1`),
-		}),
-		sqldb.AnsiSQLChange(`create index argo_archived_workflows_i1 on argo_archived_workflows (clustername, instanceid, namespace, startedat DESC)`),
 		// drop tableName indexes
 		// xxx_i1 is not needed because xxx_i2 already covers it, drop both and recreat an index named xxx_i1
 		sqldb.ByType(dbType, sqldb.TypedChanges{
@@ -232,5 +226,11 @@ func Migrate(ctx context.Context, session db.Session, clusterName, tableName str
 		}),
 		// add index on creationtimestamp column
 		sqldb.AnsiSQLChange(`create index argo_archived_workflows_i5 on argo_archived_workflows (creationtimestamp)`),
+		// change argo_archived_workflows_i1 index to add startedat DESC to resolve MySQL out of sort memory issues. #14240
+		sqldb.ByType(dbType, sqldb.TypedChanges{
+			sqldb.MySQL:    sqldb.AnsiSQLChange(`drop index argo_archived_workflows_i1 on argo_archived_workflows`),
+			sqldb.Postgres: sqldb.AnsiSQLChange(`drop index argo_archived_workflows_i1`),
+		}),
+		sqldb.AnsiSQLChange(`create index argo_archived_workflows_i1 on argo_archived_workflows (clustername, instanceid, namespace, startedat DESC)`),
 	})
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14240 

### Motivation

The existing index(`argo_archived_workflows_i1`) lacked a sort order, causing the database to extract all data first and then perform sorting on startedat within the sort buffer. This resulted in 'Out of sort memory' errors and system failure.
  
This issue specifically occurs under the following conditions:
- The optimizer selects `argo_archived_workflows_i1` instead of `argo_archived_workflows_i4` during namespace filtering.
- The workflow JSON data is large enough to exceed the MySQL `sort_buffer_size`.

### Modifications

Since this modification includes all existing index columns, it resolves the failure without causing any side effects to existing queries.
- Added `startedat DESC` to the `argo_archived_workflows_i1(clustername, instanceid, namespace)` index.

### Verification

Detailed reproduction steps and query execution plans can be found in this https://github.com/argoproj/argo-workflows/issues/14240#issuecomment-3753236025

**Actual UI failure state**:
<img width="837" height="450" alt="스크린샷 2026-01-18 133344" src="https://github.com/user-attachments/assets/767d72c9-10a8-4a9f-9467-db98386f23e1" />

**Resolved state under the same conditions**:
<img width="837" height="450" alt="스크린샷 2026-01-18 133302" src="https://github.com/user-attachments/assets/0541dec8-737a-42ad-8f08-e969489fc862" />
