### PR TITLE
feat: archive sidecar container logs. Fixes #14802

### DIFF
--- a/.features/pending/10542-archive-sidecar-container-logs.md
+++ b/.features/pending/10542-archive-sidecar-container-logs.md
@@ -1,0 +1,7 @@
+Description: Archive sidecar container logs when archiving workflow logs
+Author: [Shiwei Tang](https://github.com/siwet)
+Component: General
+Issues: 14802
+
+When `archiveLogs` is enabled, sidecar container logs are now included in the archived logs alongside main container logs.
+This ensures complete log visibility for workflows with sidecar containers after pod garbage collection.

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -670,6 +670,7 @@ func (we *WorkflowExecutor) SaveLogs(ctx context.Context) []wfv1.Artifact {
 		}
 
 		containerNames := we.Template.GetMainContainerNames()
+		containerNames = append(containerNames, we.Template.GetSidecarNames()...)
 		logArtifacts = make([]wfv1.Artifact, 0)
 
 		for _, containerName := range containerNames {


### PR DESCRIPTION
Fixes #14802

### Motivation

- Archive sidecar container logs when `archiveLogs: true` so that users can still inspect sidecar behavior after pods are deleted, improving debuggability for workflows that rely on sidecar services (e.g. proxies, log shippers). See [issue #14802](https://github.com/argoproj/argo-workflows/issues/14802).

### Modifications

- Updated the wait container executor to include all sidecar container names in the list of containers whose logs are archived when `SaveLogsAsArtifact()` is enabled.
- Keeps existing behavior unchanged when `archiveLogs` is disabled or when no sidecars are defined on the template.

### Verification

- Ran a workflow with a sidecar container and `archiveLogs: true` and verified that:
  - Log artifacts are created for both the main container and the sidecar container.
  - Workflows without sidecars continue to archive only the main container logs.

### Documentation

- No documentation changes proposed: this change extends the existing `archiveLogs` behavior to sidecars without introducing new configuration fields.