### PR TITLE
fix(security): stored XSS in artifact directory listings (cherry-pick #15255 for 3.6)

### DIFF
--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -1,9 +1,11 @@
 package artifacts
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"mime"
 	"net/http"
@@ -202,31 +204,14 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 				return
 			}
 		}
-
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("<html><body><ul>\n"))
-
-		dirs := map[string]bool{} // to de-dupe sub-dirs
-
-		_, _ = fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>\n", "..", "..")
-
-		for _, object := range objects {
-
-			// object is prefixed the key, we must trim it
-			dir, file := path.Split(strings.TrimPrefix(object, key+"/"))
-
-			// if dir is empty string, we are in the root dir
-			if dir == "" {
-				_, _ = fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>\n", file, file)
-			} else if dirs[dir] {
-				continue
-			} else {
-				_, _ = fmt.Fprintf(w, "<li><a href=\"%s\">%s</a></li>\n", dir, dir)
-				dirs[dir] = true
-			}
+		a.setSecurityHeaders(w)
+		output, err := a.renderDirectoryListing(objects, key)
+		if err != nil {
+			a.serverInternalError(err, w)
+			return
 		}
-		_, _ = w.Write([]byte("</ul></body></html>"))
-
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(output)
 	} else { // stream the file itself
 		log.Debugf("not a directory, artifact: %+v", artifact)
 
@@ -237,6 +222,42 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+}
+
+func (a *ArtifactServer) renderDirectoryListing(objects []string, key string) ([]byte, error) {
+	output := bytes.NewBufferString("<html><body><ul>\n<li><a href=\"..\">..</a></li>\n")
+
+	dirs := map[string]bool{} // to de-dupe sub-dirs
+
+	// Use html/template to prevent XSS attacks.
+	// The "./" prefix is necessary so the template engine recognizes it as a relative URL.
+	// Without that, a file called "javascript:alert(1)" would be escaped to "#ZgotmplZ" by the urlFilter.
+	tmpl, err := template.New("list").Parse("<li><a href=\"./{{.}}\">{{.}}</a></li>\n")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, object := range objects {
+
+		// object is prefixed the key, we must trim it
+		dir, file := path.Split(strings.TrimPrefix(object, key+"/"))
+
+		// if dir is empty string, we are in the root dir
+		if dir == "" {
+			if err = tmpl.Execute(output, file); err != nil {
+				return nil, err
+			}
+		} else if dirs[dir] {
+			continue
+		} else {
+			if err = tmpl.Execute(output, dir); err != nil {
+				return nil, err
+			}
+			dirs[dir] = true
+		}
+	}
+	_, _ = output.WriteString("</ul></body></html>")
+	return output.Bytes(), nil
 }
 
 func (a *ArtifactServer) getArtifact(w http.ResponseWriter, r *http.Request, isInput bool) {
@@ -453,6 +474,13 @@ func (a *ArtifactServer) getArtifactAndDriver(ctx context.Context, nodeId, artif
 	return art, driver, nil
 }
 
+func (a *ArtifactServer) setSecurityHeaders(w http.ResponseWriter) {
+	// Set strict CSP headers for defense-in-depth against XSS: https://web.dev/articles/strict-csp
+	w.Header().Add("Content-Security-Policy", env.GetString("ARGO_ARTIFACT_CONTENT_SECURITY_POLICY", "sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'"))
+	// Mitigate clickjacking attacks
+	w.Header().Add("X-Frame-Options", env.GetString("ARGO_ARTIFACT_X_FRAME_OPTIONS", "SAMEORIGIN"))
+}
+
 func (a *ArtifactServer) returnArtifact(w http.ResponseWriter, art *wfv1.Artifact, driver common.ArtifactDriver) error {
 	stream, err := driver.OpenStream(art)
 	if err != nil {
@@ -468,8 +496,7 @@ func (a *ArtifactServer) returnArtifact(w http.ResponseWriter, art *wfv1.Artifac
 	key, _ := art.GetKey()
 	w.Header().Add("Content-Disposition", fmt.Sprintf(`filename="%s"`, path.Base(key)))
 	w.Header().Add("Content-Type", mime.TypeByExtension(path.Ext(key)))
-	w.Header().Add("Content-Security-Policy", env.GetString("ARGO_ARTIFACT_CONTENT_SECURITY_POLICY", "sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'"))
-	w.Header().Add("X-Frame-Options", env.GetString("ARGO_ARTIFACT_X_FRAME_OPTIONS", "SAMEORIGIN"))
+	a.setSecurityHeaders(w)
 
 	_, err = io.Copy(w, stream)
 	if err != nil {

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1202,7 +1202,13 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 			Status(200)
 
 		resp.Body().
-			Contains("<a href=\"subdirectory/\">subdirectory/</a>")
+			Contains("<a href=\"./subdirectory/\">subdirectory/</a>")
+
+		resp.Header("Content-Security-Policy").
+			IsEqual("sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
+
+		resp.Header("X-Frame-Options").
+			IsEqual("SAMEORIGIN")
 
 	})
 
@@ -1213,8 +1219,8 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 			Status(200)
 
 		resp.Body().
-			Contains("<a href=\"sub-file-1\">sub-file-1</a>").
-			Contains("<a href=\"sub-file-2\">sub-file-2</a>")
+			Contains("<a href=\"./sub-file-1\">sub-file-1</a>").
+			Contains("<a href=\"./sub-file-2\">sub-file-2</a>")
 
 	})
 


### PR DESCRIPTION

<!-- Does this PR fix an issue -->


### Motivation
Cherry-pick https://github.com/argoproj/argo-workflows/pull/15255 for `release-3.6`

### Modifications
Ran `git cherry-pick 7076bb938bead8f504c08ebdb3d77936569a26e3` to cherry-pick the commit from https://github.com/argoproj/argo-workflows/pull/15259 
<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification
Ran verification steps from the PR:
<img width="1102" height="286" alt="image" src="https://github.com/user-attachments/assets/a6da1306-0201-41a0-9135-adc1891fe711" />


### Documentation

N/A