### PR TITLE
chore: Remove link check step

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,14 +60,3 @@ jobs:
           echo "A feature description was added to the ./.features/ directory."
           make features-validate \
             || { echo "New ./.features/*.md file failed validation."; exit 1; }
-
-      # In order to validate any links in the yaml file, render the config to markdown
-      - name: Render .features/*.md feature descriptions
-        run: make features-update
-
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # f613c4a64e50d792e0b31ec34bbcbba12263c6a6
-        with:
-          args: "--verbose --no-progress ./docs/new-features.md"
-          failIfEmpty: false


### PR DESCRIPTION
### Motivation

The link checked for new features is a github action, and [it's failing](https://github.com/argoproj/argo-workflows/actions/runs/21175710603/job/60903876246?pr=15256).

This is blocking new feature merging, and as it's a github action I can't make it run locally so that contributors can verify prior to pushing that this won't annoy them.

### Modifications

Remove the link checker - the one it's complaining about is quite valid to have in there.

### Verification

None

### Documentation

None required.