### PR TITLE
chore: make renovate do much more useful work

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,77 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "baseBranchPatterns": [
+    "main",
+    "release-3.6",
+    "release-3.7"
+  ],
   "nix": {
     "enabled": true
   },
-  "includePaths": [
-    "**/dev/nix/flake.nix"
-  ]
+  "packageRules": [
+    {
+      "description": "Disable argo updates (maintained separately)",
+      "matchPackageNames": [
+        "argo-ui",
+        "argoproj/argosay",
+        "github.com/argoproj/pkg"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Only allow patch updates on release branches",
+      "matchBaseBranches": [
+        "release-3.6",
+        "release-3.7"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Use conservative lock file updates on release branches",
+      "matchBaseBranches": [
+        "release-3.6",
+        "release-3.7"
+      ],
+      "rangeStrategy": "in-range-only"
+    },
+    {
+      "description": "Automerge patch updates on main",
+      "matchBaseBranches": [
+        "main"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Disable lock file maintenance on release branches",
+      "matchBaseBranches": [
+        "release-3.6",
+        "release-3.7"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "enabled": false
+    }
+  ],
+  "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "postUpdateOptions": [
+    "yarnDedupeFewer",
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
### Motivation

Dependabot has been turned down to minimum, and I think we could benefit from making renovate help us more.

### Modifications

Updated `renovate.json` with this configuration.

#### Branches
Renovate manages dependencies on **main**, **release-3.6**, and **release-3.7**.

#### Disabled Packages
Skipping argoproj packages:
- `argo-ui`
- `argoproj/argosay`
- `github.com/argoproj/pkg`

#### Release Branch Restrictions
On **release-3.6** and **release-3.7**:
- Only **patch** updates allowed (major and minor disabled)
- Conservative lock file updates (`rangeStrategy: in-range-only`)
- Lock file maintenance disabled

#### Main Branch Features
On **main**:
- All update types enabled (major, minor, patch)
- Patch updates **auto-merge** after CI passes (via GitHub native auto-merge)
- Weekly **lock file maintenance** to refresh transitive dependencies

#### Post-Update Options
After dependency updates, Renovate automatically runs:
- `yarnDedupeFewer` - Minimizes duplicate packages in yarn.lock
- `gomodTidy` - Runs `go mod tidy` for Go dependencies
- `gomodUpdateImportPaths` - Updates Go import paths for major version bumps

#### Security
- **OSV vulnerability alerts** - Queries the Open Source Vulnerabilities database
- **GitHub vulnerability alerts** - Integrates with GitHub security advisories

#### Other
- **Dependency Dashboard** - Creates a tracking issue for all pending updates
- **Nix** support remains enabled

### Verification

See my detached fork at https://github.com/Joibel/argo-workflows-renovate, with the PRs and issue generated by renovate.

### Documentation

None for argo, this is just renovate.