### PR TITLE
fix: prevent int64 overflow in retry backoff calculation

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1056,7 +1056,13 @@ func (woc *wfOperationCtx) processNodeRetries(ctx context.Context, node *wfv1.No
 		if retryStrategyBackoffFactor != nil && *retryStrategyBackoffFactor > 0 {
 			// Formula: timeToWait = duration * factor^retry_number
 			// Note that timeToWait should equal to duration for the first retry attempt.
-			timeToWait = baseDuration * time.Duration(math.Pow(float64(*retryStrategyBackoffFactor), float64(len(childNodeIds)-1)))
+			factor := math.Pow(float64(*retryStrategyBackoffFactor), float64(len(childNodeIds)-1))
+			// Prevent overflow: cap at max duration if multiplication would exceed MaxInt64
+			if factor > float64(math.MaxInt64)/float64(baseDuration) {
+				timeToWait = time.Duration(math.MaxInt64)
+			} else {
+				timeToWait = baseDuration * time.Duration(factor)
+			}
 		}
 		if retryStrategy.Backoff.Cap != "" {
 			capDuration, err := wfv1.ParseStringToDuration(retryStrategy.Backoff.Cap)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -896,6 +896,44 @@ func TestProcessNodeRetriesWithExponentialBackoff(t *testing.T) {
 	require.Equal(wfv1.NodeSucceeded, n.Phase)
 }
 
+func TestProcessNodeRetriesBackoffOverflow(t *testing.T) {
+	require := require.New(t)
+
+	cancel, controller := newController(logging.TestContext(t.Context()))
+	defer cancel()
+	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
+	ctx := logging.TestContext(t.Context())
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	nodeName := "test-node"
+	nodeID := woc.wf.NodeID(nodeName)
+	node := woc.initializeNode(ctx, nodeName, wfv1.NodeTypeRetry, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{}, true)
+	retries := wfv1.RetryStrategy{}
+	retries.Limit = intstrutil.ParsePtr("100")
+	retries.RetryPolicy = wfv1.RetryPolicyAlways
+	retries.Backoff = &wfv1.Backoff{
+		Duration: "5s",
+		Factor:   intstrutil.ParsePtr("2"),
+	}
+	woc.wf.Status.Nodes[nodeID] = *node
+
+	// Add 32 child nodes to trigger overflow (2^31 * 5s would overflow int64)
+	for i := 0; i < 32; i++ {
+		childName := fmt.Sprintf("%s(%d)", nodeName, i)
+		woc.initializeNode(ctx, childName, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeFailed, &wfv1.NodeFlag{Retried: true}, true)
+		woc.addChildNode(ctx, nodeName, childName)
+	}
+
+	n, err := woc.wf.GetNodeByName(nodeName)
+	require.NoError(err)
+
+	// Should not panic or overflow - should cap at max duration
+	n, _, err = woc.processNodeRetries(ctx, n, retries, &executeTemplateOpts{})
+	require.NoError(err)
+	require.Equal(wfv1.NodeRunning, n.Phase)
+	require.Contains(n.Message, "Backoff for")
+}
+
 // TestProcessNodeRetries tests retrying with Expression
 func TestProcessNodeRetriesWithExpression(t *testing.T) {
 	cancel, controller := newController(logging.TestContext(t.Context()))


### PR DESCRIPTION
Fixes #15276

### Motivation

When using exponential backoff with high retry counts, the calculation `baseDuration * factor^retryNumber` can overflow Go's `int64` (which backs `time.Duration`), causing:
- Negative backoff duration
- Cap check `if timeToWait > capDuration` fails (negative < positive)
- Immediate retries instead of respecting the cap

**Overflow occurs at these retry counts (with 1s base duration):**
| Factor | First Overflow Retry |
|--------|---------------------|
| 2      | 32                  |
| 100    | 6                   |

### Modifications

- Check if `factor > MaxInt64/baseDuration` before multiplication to detect potential overflow
- Cap `timeToWait` at `math.MaxInt64` when overflow would occur
- The subsequent cap check then correctly applies the user-configured cap

### Verification

**Unit test:** Added `TestProcessNodeRetriesBackoffOverflow` that simulates 32 retries with factor=2, duration=5s

**Manual E2E testing:** Deployed fixed controller to minikube and ran test workflow with `duration=1s`, `factor=100`, `cap=30s`:

Before fix - retry intervals at overflow point:
```
overflow-repro(5)   22:52:32Z   (+50s) ✓
overflow-repro(6)   22:52:42Z   (+10s) ← BUG! Should be +50s
overflow-repro(7)   22:53:32Z   (+50s) ✓
overflow-repro(8)   22:53:42Z   (+10s) ← BUG!
```

After fix - all intervals consistent:
```
overflow-repro(5)   23:23:29Z   (+50s)
overflow-repro(6)   23:24:19Z   (+50s) ← Fixed!
overflow-repro(7)   23:25:09Z   (+50s)
overflow-repro(8)   23:25:59Z   (+50s)
```

Controller logs confirm proper backoff message for all retries including overflow point:
```
time=23:24:29Z msg="node message changed" message="Backoff for 30 seconds" ← Retry 6
```

### Documentation

No documentation changes needed - this is a bug fix for an edge case.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential integer overflow in exponential backoff calculations during retry operations, ensuring system stability when processing retries with high retry counts and large backoff factor multiplications.

* **Tests**
  * Added test coverage for retry backoff overflow edge cases to verify robust handling under extreme conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->