### PR TITLE
chore(deps): bump golang to 1.25 (#15235). `cherry-pick` for `release-3.6`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "appPort": 8080,
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24"
+      "version": "1.25.5"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
       - name: Upload coverage report
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       # windows run does not use makefile target because it does a lot more than just testing and is not cross-platform compatible
       - run: go test -p 20 -covermode=atomic -coverprofile='coverage.out' $(go list ./... | select-string -Pattern 'github.com/argoproj/argo-workflows/v3/workflow/controller' , 'github.com/argoproj/argo-workflows/v3/server' -NotMatch)
@@ -165,6 +165,7 @@ jobs:
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 
   argo-images:
     name: argo-images
@@ -267,7 +268,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - name: Install Java for the SDK
         if: ${{matrix.test == 'test-java-sdk'}}
@@ -406,7 +407,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - name: Install protoc
         run: |
@@ -443,7 +444,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - run: make lint STATIC_FILES=false
       # if lint makes changes that are not in the PR, fail the build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "19"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,3 +19,4 @@ jobs:
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -359,7 +359,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Download UI artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Install cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.24.4-alpine3.22 as builder
+FROM golang:1.25.5-alpine3.23 as builder
 
 # libc-dev to build openapi-gen
 RUN apk update && apk add --no-cache \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -11,7 +11,7 @@ ARG GIT_TREE_STATE=unknown
 
 # had issues with official golange image for windows so I'm using plain servercore
 FROM mcr.microsoft.com/windows/servercore:${IMAGE_OS_VERSION} as builder
-ENV GOLANG_VERSION=1.24
+ENV GOLANG_VERSION=1.25
 SHELL ["powershell", "-Command"]
 
 # install chocolatey package manager

--- a/Makefile
+++ b/Makefile
@@ -276,9 +276,11 @@ argoexec-nonroot-image:
 .PHONY: codegen
 codegen: types swagger manifests $(GOPATH)/bin/mockery docs/fields.md docs/cli/argo.md
 	go generate ./...
+	$(GOPATH)/bin/mockery --config .mockery.yaml
+	# The generated markdown contains links to nowhere for interfaces, so remove them
+	sed -i.bak 's/\[any\](#any)/`any`/g' docs/executor_swagger.md && rm -f docs/executor_swagger.md.bak
 	make --directory sdks/java USE_NIX=$(USE_NIX) generate
 	make --directory sdks/python USE_NIX=$(USE_NIX) generate
-
 .PHONY: check-pwd
 check-pwd:
 
@@ -356,7 +358,7 @@ endif
 $(GOPATH)/bin/swagger: Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0
+	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.33.1
 endif
 $(GOPATH)/bin/goimports: Makefile
 # update this in Nix when upgrading it here

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -113,7 +113,7 @@ ownership management and SELinux relabeling.
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="any-string"></span> AnyString
 
@@ -1115,7 +1115,7 @@ can be used as map keys in json.
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="empty-dir-volume-source"></span> EmptyDirVolumeSource
 
@@ -1308,7 +1308,7 @@ The exact format is defined in sigs.k8s.io/structured-merge-diff
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="flex-volume-source"></span> FlexVolumeSource
 
@@ -1861,7 +1861,7 @@ ISCSI volumes support ownership management and SELinux relabeling.
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="key-to-path"></span> KeyToPath
 
@@ -2345,7 +2345,7 @@ save/load the directory appropriately.
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="o-auth2-auth"></span> OAuth2Auth
 
@@ -2522,9 +2522,7 @@ be cluster-scoped, so there is no namespace field.
 > +kubebuilder:validation:Type=array
   
 
-
-
-[interface{}](#interface)
+`any`
 
 ### <span id="parameter"></span> Parameter
 
@@ -2684,7 +2682,26 @@ type of volume that is owned by someone else (the system).
 
 
 
-[interface{}](#interface)
+`any`
+
+### <span id="plugin-artifact"></span> PluginArtifact
+
+
+> PluginArtifact is the location of a plugin artifact
+  
+
+
+
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| configuration | string| `string` |  | | Configuration is the plugin defined configuration for the artifact driver plugin |  |
+| connectionTimeoutSeconds | int32 (formatted integer)| `int32` |  | | ConnectionTimeoutSeconds is the timeout for the artifact driver connection, overriding the driver's timeout |  |
+| key | string| `string` |  | | Key is the path in the artifact repository where the artifact resides |  |
+| name | [ArtifactPluginName](#artifact-plugin-name)| `ArtifactPluginName` |  | |  |  |
 
 ### <span id="pod-affinity"></span> PodAffinity
 
@@ -3038,7 +3055,7 @@ cause implementors to also use a fixed point implementation.
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="quobyte-volume-source"></span> QuobyteVolumeSource
 
@@ -3248,7 +3265,7 @@ cause implementors to also use a fixed point implementation.
 
 
 
-[interface{}](#interface)
+`any`
 
 ### <span id="retry-policy"></span> RetryPolicy
 
@@ -3703,7 +3720,7 @@ of the first container processes are calculated.
 
   
 
-[interface{}](#interface)
+`any`
 
 ### <span id="suspend-template"></span> SuspendTemplate
 
@@ -4319,4 +4336,4 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 
 
-[interface{}](#interface)
+`any`


### PR DESCRIPTION
This updates the go version to 1.25