### PR TITLE
chore(deps): bump golang to 1.25 (#15235) `cherry-pick` for `release-3.7`

### DIFF
--- a/.devcontainer/builder/devcontainer.json
+++ b/.devcontainer/builder/devcontainer.json
@@ -14,7 +14,7 @@
 
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.10"
+      "version": "1.25.5"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
       - name: Upload coverage report
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       # windows run does not use makefile target because it does a lot more than just testing and is not cross-platform compatible
       - run: if (!(Test-Path "ui/dist/app/index.html")) { New-Item -ItemType Directory -Force -Path "ui/dist/app" | Out-Null; New-Item -ItemType File -Path "ui/dist/app/placeholder" | Out-Null }; go test -p 20 -covermode=atomic -coverprofile='coverage.out' $(go list ./... | select-string -Pattern 'github.com/argoproj/argo-workflows/v3/workflow/controller' , 'github.com/argoproj/argo-workflows/v3/server' -NotMatch)
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - name: Build
         run: make ${{matrix.target}}
@@ -291,7 +291,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - name: Install Java for the SDK
         if: ${{matrix.test == 'test-java-sdk'}}
@@ -443,7 +443,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - name: Install protoc
         run: |
@@ -480,7 +480,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
       - run: make lint STATIC_FILES=false
       # if lint makes changes that are not in the PR, fail the build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "19"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,3 +19,5 @@ jobs:
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Download UI artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
@@ -393,7 +393,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Install cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.24.10-alpine3.22 as builder
+FROM golang:1.25.5-alpine3.23 as builder
 
 # libc-dev to build openapi-gen
 RUN apk update && apk add --no-cache \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -11,7 +11,7 @@ ARG GIT_TREE_STATE=unknown
 
 # had issues with official golange image for windows so I'm using plain servercore
 FROM mcr.microsoft.com/windows/servercore:${IMAGE_OS_VERSION} as builder
-ENV GOLANG_VERSION=1.24
+ENV GOLANG_VERSION=1.25
 SHELL ["powershell", "-Command"]
 
 # install chocolatey package manager

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ argoexec-nonroot-image:
 codegen: types swagger manifests $(TOOL_MOCKERY) $(GENERATED_DOCS)
 	go generate ./...
  	# The generated markdown contains links to nowhere for interfaces, so remove them
-	sed -i.bak 's/\[interface{}\](#interface)/`interface{}`/g' docs/executor_swagger.md && rm -f docs/executor_swagger.md.bak
+	sed -i.bak 's/\[any\](#any)/`any`/g' docs/executor_swagger.md && rm -f docs/executor_swagger.md.bak
 	make --directory sdks/java USE_NIX=$(USE_NIX) generate
 	make --directory sdks/python USE_NIX=$(USE_NIX) generate
 
@@ -410,7 +410,7 @@ endif
 $(TOOL_SWAGGER): Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0
+	go install github.com/go-swagger/go-swagger/cmd/swagger@v0.33.1
 endif
 $(TOOL_GOIMPORTS): Makefile
 # update this in Nix when upgrading it here

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -113,7 +113,7 @@ ownership management and SELinux relabeling.
 
 
 
-`interface{}`
+`any`
 
 ### <span id="any-string"></span> AnyString
 
@@ -1116,7 +1116,7 @@ can be used as map keys in json.
 
 
 
-`interface{}`
+`any`
 
 ### <span id="empty-dir-volume-source"></span> EmptyDirVolumeSource
 
@@ -1309,7 +1309,7 @@ The exact format is defined in sigs.k8s.io/structured-merge-diff
 
 
 
-`interface{}`
+`any`
 
 ### <span id="flex-volume-source"></span> FlexVolumeSource
 
@@ -1861,7 +1861,7 @@ ISCSI volumes support ownership management and SELinux relabeling.
 
 
 
-`interface{}`
+`any`
 
 ### <span id="key-to-path"></span> KeyToPath
 
@@ -2347,7 +2347,7 @@ save/load the directory appropriately.
 
 
 
-`interface{}`
+`any`
 
 ### <span id="o-auth2-auth"></span> OAuth2Auth
 
@@ -2523,7 +2523,7 @@ be cluster-scoped, so there is no namespace field.
 
   
 
-`interface{}`
+`any`
 
 ### <span id="parameter"></span> Parameter
 
@@ -2683,7 +2683,7 @@ type of volume that is owned by someone else (the system).
 
 
 
-`interface{}`
+`any`
 
 ### <span id="pod-affinity"></span> PodAffinity
 
@@ -3037,7 +3037,7 @@ cause implementors to also use a fixed point implementation.
 
 
 
-`interface{}`
+`any`
 
 ### <span id="quobyte-volume-source"></span> QuobyteVolumeSource
 
@@ -3247,7 +3247,7 @@ cause implementors to also use a fixed point implementation.
 
 
 
-`interface{}`
+`any`
 
 ### <span id="retry-policy"></span> RetryPolicy
 
@@ -3718,7 +3718,7 @@ of the first container processes are calculated.
 
   
 
-`interface{}`
+`any`
 
 ### <span id="suspend-template"></span> SuspendTemplate
 
@@ -4349,4 +4349,4 @@ intent and helps make sure that UIDs and names do not get conflated.
 
 
 
-`interface{}`
+`any`


### PR DESCRIPTION
This updates the go version to 1.25