### PR TITLE
fix: sync example is wrong for mutexes

### DIFF
--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -83,8 +83,8 @@ metadata:
 spec:
   synchronization:
     mutexes:
-      - database:
-          key: bar
+      - database: true
+        name: bar
 ```
 
 And a Workflow that uses a Workflow-level database semaphore would look like this:


### PR DESCRIPTION
### Documentation

This example is wrong, the syntax is from semaphores.