### PR TITLE
chore: enable modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - iotamixing
     - mirror
     - misspell
+    - modernize
     - nakedret
     - nilerr
     - noctx

--- a/api/openapi-spec/swagger_test.go
+++ b/api/openapi-spec/swagger_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type obj = map[string]interface{}
+type obj = map[string]any
 
 func TestSwagger(t *testing.T) {
 	swagger := obj{}

--- a/cmd/argo/commands/common/get.go
+++ b/cmd/argo/commands/common/get.go
@@ -498,13 +498,13 @@ func printNode(w *tabwriter.Writer, node wfv1.NodeStatus, wfName, nodePrefix str
 	} else if node.TemplateName != "" {
 		fmtTemplateName = node.TemplateName
 	}
-	var args []interface{}
+	var args []any
 	duration := humanize.RelativeDurationShort(node.StartedAt.Time, node.FinishedAt.Time)
 	if node.Type == wfv1.NodeTypePod {
 		podName := util.GeneratePodName(wfName, nodeName, templateName, node.ID, podNameVersion)
-		args = []interface{}{nodePrefix, fmtNodeName, fmtTemplateName, podName, duration, node.Message, ""}
+		args = []any{nodePrefix, fmtNodeName, fmtTemplateName, podName, duration, node.Message, ""}
 	} else {
-		args = []interface{}{nodePrefix, fmtNodeName, fmtTemplateName, "", "", node.Message, ""}
+		args = []any{nodePrefix, fmtNodeName, fmtTemplateName, "", "", node.Message, ""}
 	}
 	switch getArgs.Output.String() {
 	case "wide":

--- a/cmd/argo/commands/convert.go
+++ b/cmd/argo/commands/convert.go
@@ -93,7 +93,7 @@ func convertDocument(data []byte, outputFormat string, isJSON bool) error {
 		return fmt.Errorf("failed to parse TypeMeta: %w", err)
 	}
 
-	var converted interface{}
+	var converted any
 
 	// Parse into legacy type and convert to current type
 	switch typeMeta.Kind {
@@ -128,7 +128,7 @@ func convertDocument(data []byte, outputFormat string, isJSON bool) error {
 	default:
 		// Unknown type - pass through unchanged
 		// Re-parse as generic map to preserve structure
-		var generic map[string]interface{}
+		var generic map[string]any
 		if err := yaml.Unmarshal(data, &generic); err != nil {
 			return fmt.Errorf("failed to parse unknown kind %s: %w", typeMeta.Kind, err)
 		}
@@ -138,7 +138,7 @@ func convertDocument(data []byte, outputFormat string, isJSON bool) error {
 	return outputObject(converted, outputFormat, isJSON)
 }
 
-func outputObject(obj interface{}, format string, preferJSON bool) error {
+func outputObject(obj any, format string, preferJSON bool) error {
 	var outBytes []byte
 	var err error
 

--- a/cmd/argo/commands/cron/backfill.go
+++ b/cmd/argo/commands/cron/backfill.go
@@ -213,7 +213,7 @@ func CreateMonitorWf(ctx context.Context, wf, namespace, cronWFName string, sche
 	startIdx := 0
 	var endIdx int
 	var wfNames []string
-	for i := 0; i < iterCount; i++ {
+	for i := range iterCount {
 		tmpl := monitorWfObj.GetTemplateByName("create-workflow")
 		if (TotalScheCount - i*cliOps.maxWorkflowCount) < cliOps.maxWorkflowCount {
 			endIdx = TotalScheCount

--- a/cmd/argo/commands/cron/util.go
+++ b/cmd/argo/commands/cron/util.go
@@ -95,28 +95,28 @@ func printCronWorkflow(ctx context.Context, wf *v1alpha1.CronWorkflow, outFmt st
 func getCronWorkflowGet(ctx context.Context, cwf *v1alpha1.CronWorkflow) string {
 	const fmtStr = "%-30s %v\n"
 
-	out := ""
-	out += fmt.Sprintf(fmtStr, "Name:", cwf.Name)
-	out += fmt.Sprintf(fmtStr, "Namespace:", cwf.Namespace)
-	out += fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(cwf.CreationTimestamp.Time))
-	out += fmt.Sprintf(fmtStr, "Schedules:", cwf.Spec.GetScheduleString())
-	out += fmt.Sprintf(fmtStr, "Suspended:", cwf.Spec.Suspend)
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(fmtStr, "Name:", cwf.Name))
+	out.WriteString(fmt.Sprintf(fmtStr, "Namespace:", cwf.Namespace))
+	out.WriteString(fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(cwf.CreationTimestamp.Time)))
+	out.WriteString(fmt.Sprintf(fmtStr, "Schedules:", cwf.Spec.GetScheduleString()))
+	out.WriteString(fmt.Sprintf(fmtStr, "Suspended:", cwf.Spec.Suspend))
 	if cwf.Spec.Timezone != "" {
-		out += fmt.Sprintf(fmtStr, "Timezone:", cwf.Spec.Timezone)
+		out.WriteString(fmt.Sprintf(fmtStr, "Timezone:", cwf.Spec.Timezone))
 	}
 	if cwf.Spec.StartingDeadlineSeconds != nil {
-		out += fmt.Sprintf(fmtStr, "StartingDeadlineSeconds:", *cwf.Spec.StartingDeadlineSeconds)
+		out.WriteString(fmt.Sprintf(fmtStr, "StartingDeadlineSeconds:", *cwf.Spec.StartingDeadlineSeconds))
 	}
 	if cwf.Spec.ConcurrencyPolicy != "" {
-		out += fmt.Sprintf(fmtStr, "ConcurrencyPolicy:", cwf.Spec.ConcurrencyPolicy)
+		out.WriteString(fmt.Sprintf(fmtStr, "ConcurrencyPolicy:", cwf.Spec.ConcurrencyPolicy))
 	}
 	if cwf.Status.LastScheduledTime != nil {
-		out += fmt.Sprintf(fmtStr, "LastScheduledTime:", humanize.Timestamp(cwf.Status.LastScheduledTime.Time))
+		out.WriteString(fmt.Sprintf(fmtStr, "LastScheduledTime:", humanize.Timestamp(cwf.Status.LastScheduledTime.Time)))
 	}
 
 	next, err := GetNextRuntime(ctx, cwf)
 	if err == nil {
-		out += fmt.Sprintf(fmtStr, "NextScheduledTime:", humanize.Timestamp(next)+" (assumes workflow-controller is in UTC)")
+		out.WriteString(fmt.Sprintf(fmtStr, "NextScheduledTime:", humanize.Timestamp(next)+" (assumes workflow-controller is in UTC)"))
 	}
 
 	if len(cwf.Status.Active) > 0 {
@@ -124,19 +124,19 @@ func getCronWorkflowGet(ctx context.Context, cwf *v1alpha1.CronWorkflow) string 
 		for _, activeWf := range cwf.Status.Active {
 			activeWfNames = append(activeWfNames, activeWf.Name)
 		}
-		out += fmt.Sprintf(fmtStr, "Active Workflows:", strings.Join(activeWfNames, ", "))
+		out.WriteString(fmt.Sprintf(fmtStr, "Active Workflows:", strings.Join(activeWfNames, ", ")))
 	}
 	if len(cwf.Status.Conditions) > 0 {
-		out += cwf.Status.Conditions.DisplayString(fmtStr, map[v1alpha1.ConditionType]string{v1alpha1.ConditionTypeSubmissionError: "✖"})
+		out.WriteString(cwf.Status.Conditions.DisplayString(fmtStr, map[v1alpha1.ConditionType]string{v1alpha1.ConditionTypeSubmissionError: "✖"}))
 	}
 	if len(cwf.Spec.WorkflowSpec.Arguments.Parameters) > 0 {
-		out += fmt.Sprintf(fmtStr, "Workflow Parameters:", "")
+		out.WriteString(fmt.Sprintf(fmtStr, "Workflow Parameters:", ""))
 		for _, param := range cwf.Spec.WorkflowSpec.Arguments.Parameters {
 			if !param.HasValue() {
 				continue
 			}
-			out += fmt.Sprintf(fmtStr, "  "+param.Name+":", param.GetValue())
+			out.WriteString(fmt.Sprintf(fmtStr, "  "+param.Name+":", param.GetValue()))
 		}
 	}
-	return out
+	return out.String()
 }

--- a/cmd/argoexec/commands/artifact/delete.go
+++ b/cmd/argoexec/commands/artifact/delete.go
@@ -114,7 +114,7 @@ func deleteArtifacts(labelSelector string, ctx context.Context, artifactGCTaskIn
 
 			task.Status.ArtifactResultsByNode[nodeName] = artResultNodeStatus
 		}
-		patch, err := json.Marshal(map[string]interface{}{"status": v1alpha1.ArtifactGCStatus{ArtifactResultsByNode: task.Status.ArtifactResultsByNode}})
+		patch, err := json.Marshal(map[string]any{"status": v1alpha1.ArtifactGCStatus{ArtifactResultsByNode: task.Status.ArtifactResultsByNode}})
 		if err != nil {
 			return err
 		}

--- a/config/ttl.go
+++ b/config/ttl.go
@@ -17,7 +17,7 @@ func (l TTL) MarshalJSON() ([]byte, error) {
 }
 
 func (l *TTL) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
@@ -27,23 +27,23 @@ func (l *TTL) UnmarshalJSON(b []byte) error {
 			*l = 0
 			return nil
 		}
-		if strings.HasSuffix(value, "d") {
-			days, err := strconv.Atoi(strings.TrimSuffix(value, "d"))
+		if before, ok := strings.CutSuffix(value, "d"); ok {
+			days, err := strconv.Atoi(before)
 			*l = TTL(time.Duration(days) * 24 * time.Hour)
 			return err
 		}
-		if strings.HasSuffix(value, "h") {
-			hours, err := strconv.Atoi(strings.TrimSuffix(value, "h"))
+		if before, ok := strings.CutSuffix(value, "h"); ok {
+			hours, err := strconv.Atoi(before)
 			*l = TTL(time.Duration(hours) * time.Hour)
 			return err
 		}
-		if strings.HasSuffix(value, "m") {
-			minutes, err := strconv.Atoi(strings.TrimSuffix(value, "m"))
+		if before, ok := strings.CutSuffix(value, "m"); ok {
+			minutes, err := strconv.Atoi(before)
 			*l = TTL(time.Duration(minutes) * time.Minute)
 			return err
 		}
-		if strings.HasSuffix(value, "s") {
-			seconds, err := strconv.Atoi(strings.TrimSuffix(value, "s"))
+		if before, ok := strings.CutSuffix(value, "s"); ok {
+			seconds, err := strconv.Atoi(before)
 			*l = TTL(time.Duration(seconds) * time.Second)
 			return err
 		}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -42,7 +42,7 @@ func New(code string, message string) error {
 }
 
 // Errorf returns an error and formats according to a format specifier
-func Errorf(code string, format string, args ...interface{}) error {
+func Errorf(code string, format string, args ...any) error {
 	return New(code, fmt.Sprintf(format, args...))
 }
 
@@ -52,7 +52,7 @@ func InternalError(message string) error {
 }
 
 // InternalErrorf is a convenience function to format an Internal error
-func InternalErrorf(format string, args ...interface{}) error {
+func InternalErrorf(format string, args ...any) error {
 	return Errorf(CodeInternal, format, args...)
 }
 
@@ -65,7 +65,7 @@ func InternalWrapError(err error, message ...string) error {
 }
 
 // InternalWrapErrorf annotates the error with the ERR_INTERNAL code and a stack trace, optional message
-func InternalWrapErrorf(err error, format string, args ...interface{}) error {
+func InternalWrapErrorf(err error, format string, args ...any) error {
 	return Wrap(err, CodeInternal, fmt.Sprintf(format, args...))
 }
 

--- a/hack/api/jsonschema/main.go
+++ b/hack/api/jsonschema/main.go
@@ -42,7 +42,7 @@ func main() {
 			"$id":     "https://raw.githubusercontent.com/argoproj/argo-workflows/HEAD/api/jsonschema/schema.json",
 			"$schema": "https://json-schema.org/draft/2020-12/schema",
 			"type":    "object",
-			"oneOf": []interface{}{
+			"oneOf": []any{
 				obj{"$ref": "#/definitions/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate"},
 				obj{"$ref": "#/definitions/io.argoproj.workflow.v1alpha1.CronWorkflow"},
 				obj{"$ref": "#/definitions/io.argoproj.workflow.v1alpha1.Workflow"},

--- a/hack/api/jsonschema/types.go
+++ b/hack/api/jsonschema/types.go
@@ -1,3 +1,3 @@
 package main
 
-type obj = map[string]interface{}
+type obj = map[string]any

--- a/hack/api/swagger/secondaryswaggergen.go
+++ b/hack/api/swagger/secondaryswaggergen.go
@@ -21,7 +21,7 @@ We do some hackerey here too:
 * Change "argo-workflows" into "argo_workflows".
 */
 func secondarySwaggerGen() {
-	definitions := make(map[string]interface{})
+	definitions := make(map[string]any)
 	for n, d := range wfv1.GetOpenAPIDefinitions(func(path string) spec.Ref {
 		return spec.Ref{
 			Ref: jsonreference.MustCreateRef("#/definitions/" + strings.ReplaceAll(path, "/", ".")),
@@ -31,7 +31,7 @@ func secondarySwaggerGen() {
 		println(n)
 		definitions[n] = d.Schema
 	}
-	swagger := map[string]interface{}{
+	swagger := map[string]any{
 		"definitions": definitions,
 	}
 	f, err := os.Create("pkg/apiclient/_.secondary.swagger.json")

--- a/hack/api/swagger/types.go
+++ b/hack/api/swagger/types.go
@@ -1,6 +1,6 @@
 package main
 
 type (
-	obj   = map[string]interface{}
-	array = []interface{}
+	obj   = map[string]any
+	array = []any
 )

--- a/hack/docs/configdoc.go
+++ b/hack/docs/configdoc.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	md "github.com/nao1215/markdown"
@@ -238,10 +239,8 @@ func processFieldWithNames(field *ast.Field, typeStr string, names []string, row
 
 // addToRecursionList adds a type to the recursion list only if it's not already present
 func addToRecursionList(typesToRecurse *[]string, baseType string) {
-	for _, existing := range *typesToRecurse {
-		if existing == baseType {
-			return // Already in the list, skip
-		}
+	if slices.Contains(*typesToRecurse, baseType) {
+		return // Already in the list, skip
 	}
 	*typesToRecurse = append(*typesToRecurse, baseType)
 }

--- a/hack/featuregen/contents.go
+++ b/hack/featuregen/contents.go
@@ -48,7 +48,7 @@ func validateMetadataOrder(content string) (bool, string) {
 
 	// Find the first line that's not a metadata field
 	metadataEnd := 0
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		line := lines[i]
 		isMetadata := false
 		for _, field := range metadataFields {

--- a/hack/manifests/helpers_test.go
+++ b/hack/manifests/helpers_test.go
@@ -10,40 +10,40 @@ import (
 
 func TestSetNestedField(t *testing.T) {
 	o := &obj{
-		"a": map[string]interface{}{
-			"b": map[string]interface{}{},
+		"a": map[string]any{
+			"b": map[string]any{},
 		},
 	}
 	o.SetNestedField("newValue", "a", "b", "c")
-	val := (*o)["a"].(map[string]interface{})["b"].(map[string]interface{})["c"]
+	val := (*o)["a"].(map[string]any)["b"].(map[string]any)["c"]
 	assert.Equal(t, "newValue", val)
 }
 
 func TestCopyNestedField(t *testing.T) {
 	nested_o := &obj{
-		"items": map[string]interface{}{
-			"properties": map[string]interface{}{
+		"items": map[string]any{
+			"properties": map[string]any{
 				"name": "foo",
 			},
 		},
 	}
 	o := &obj{
-		"steps": map[string]interface{}{
-			"items": map[string]interface{}{
-				"properties": map[string]interface{}{
+		"steps": map[string]any{
+			"items": map[string]any{
+				"properties": map[string]any{
 					"steps": nested_o,
 				},
 			},
 		},
 	}
 	o.CopyNestedField([]string{"steps", "items", "properties", "steps"}, []string{"steps", "items"})
-	assert.Equal(t, &obj{"steps": map[string]interface{}{"items": nested_o}}, o)
+	assert.Equal(t, &obj{"steps": map[string]any{"items": nested_o}}, o)
 }
 
 func TestName(t *testing.T) {
 	expectedName := "test-name"
 	o := &obj{
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name": expectedName,
 		},
 	}
@@ -51,13 +51,13 @@ func TestName(t *testing.T) {
 }
 
 func TestOpenAPIV3Schema(t *testing.T) {
-	expectedSchema := map[string]interface{}{"foo": "bar"}
+	expectedSchema := map[string]any{"foo": "bar"}
 	o := &obj{
-		"spec": map[string]interface{}{
-			"versions": []interface{}{
-				map[string]interface{}{
-					"schema": map[string]interface{}{
-						"openAPIV3Schema": map[string]interface{}{
+		"spec": map[string]any{
+			"versions": []any{
+				map[string]any{
+					"schema": map[string]any{
+						"openAPIV3Schema": map[string]any{
 							"properties": expectedSchema,
 						},
 					},
@@ -86,16 +86,16 @@ func TestParseYaml(t *testing.T) {
 
 func TestRecursiveRemoveDescriptions(t *testing.T) {
 	o := &obj{
-		"spec": map[string]interface{}{
-			"schema": map[string]interface{}{
+		"spec": map[string]any{
+			"schema": map[string]any{
 				"description": "desc",
-				"properties": map[string]interface{}{
+				"properties": map[string]any{
 					"description": "Test",
-					"a": map[string]interface{}{
+					"a": map[string]any{
 						"description": "descA",
 					},
-					"b": map[string]interface{}{
-						"description": map[string]interface{}{
+					"b": map[string]any{
+						"description": map[string]any{
 							"type": "string",
 						},
 					},
@@ -105,13 +105,13 @@ func TestRecursiveRemoveDescriptions(t *testing.T) {
 	}
 	o.RecursiveRemoveDescriptions("spec", "schema")
 	assert.Equal(t, &obj{
-		"spec": map[string]interface{}{
-			"schema": map[string]interface{}{
+		"spec": map[string]any{
+			"schema": map[string]any{
 				"description": "desc.\nAll nested field descriptions have been dropped due to Kubernetes size limitations.",
-				"properties": map[string]interface{}{
-					"a": map[string]interface{}{},
-					"b": map[string]interface{}{
-						"description": map[string]interface{}{
+				"properties": map[string]any{
+					"a": map[string]any{},
+					"b": map[string]any{
+						"description": map[string]any{
 							"type": "string",
 						},
 					},

--- a/pkg/apiclient/http1/facade.go
+++ b/pkg/apiclient/http1/facade.go
@@ -33,23 +33,23 @@ func NewFacade(baseURL, authorization string, insecureSkipVerify bool, headers [
 	return Facade{baseURL, authorization, insecureSkipVerify, headers, httpClient}
 }
 
-func (h Facade) Get(ctx context.Context, in, out interface{}, path string) error {
+func (h Facade) Get(ctx context.Context, in, out any, path string) error {
 	return h.do(ctx, in, out, "GET", path)
 }
 
-func (h Facade) Put(ctx context.Context, in, out interface{}, path string) error {
+func (h Facade) Put(ctx context.Context, in, out any, path string) error {
 	return h.do(ctx, in, out, "PUT", path)
 }
 
-func (h Facade) Post(ctx context.Context, in, out interface{}, path string) error {
+func (h Facade) Post(ctx context.Context, in, out any, path string) error {
 	return h.do(ctx, in, out, "POST", path)
 }
 
-func (h Facade) Delete(ctx context.Context, in, out interface{}, path string) error {
+func (h Facade) Delete(ctx context.Context, in, out any, path string) error {
 	return h.do(ctx, in, out, "DELETE", path)
 }
 
-func (h Facade) EventStreamReader(ctx context.Context, in interface{}, path string) (*bufio.Reader, error) {
+func (h Facade) EventStreamReader(ctx context.Context, in any, path string) (*bufio.Reader, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	method := "GET"
 	u, err := h.url(method, path, in)
@@ -90,7 +90,7 @@ func (h Facade) EventStreamReader(ctx context.Context, in interface{}, path stri
 	return bufio.NewReader(resp.Body), nil
 }
 
-func (h Facade) do(ctx context.Context, in interface{}, out interface{}, method string, path string) error {
+func (h Facade) do(ctx context.Context, in any, out any, method string, path string) error {
 	log := logging.RequireLoggerFromContext(ctx)
 	var data []byte
 	if method != "GET" && method != "DELETE" {
@@ -142,7 +142,7 @@ func (h Facade) do(ctx context.Context, in interface{}, out interface{}, method 
 	}
 }
 
-func (h Facade) url(method, path string, in interface{}) (*url.URL, error) {
+func (h Facade) url(method, path string, in any) (*url.URL, error) {
 	query := url.Values{}
 	for s, v := range flatten.Flatten(in) {
 		x := "{" + s + "}"

--- a/pkg/apiclient/http1/server-sent-events-client.go
+++ b/pkg/apiclient/http1/server-sent-events-client.go
@@ -35,17 +35,17 @@ func (c serverSentEventsClient) Context() context.Context {
 	return c.ctx
 }
 
-func (c serverSentEventsClient) SendMsg(interface{}) error {
+func (c serverSentEventsClient) SendMsg(any) error {
 	panic("implement me")
 }
 
-func (c serverSentEventsClient) RecvMsg(interface{}) error {
+func (c serverSentEventsClient) RecvMsg(any) error {
 	panic("implement me")
 }
 
 const prefixLength = len("data: ")
 
-func (c serverSentEventsClient) RecvEvent(v interface{}) error {
+func (c serverSentEventsClient) RecvEvent(v any) error {
 	log := logging.RequireLoggerFromContext(c.ctx)
 	for {
 		line, err := c.reader.ReadBytes('\n')
@@ -60,7 +60,7 @@ func (c serverSentEventsClient) RecvEvent(v interface{}) error {
 		}
 		// the actual data itself always has a `{"result": v}` field
 		x := struct {
-			Result interface{} `json:"result"`
+			Result any `json:"result"`
 		}{
 			Result: v,
 		}

--- a/pkg/apiclient/panic-intermediary.go
+++ b/pkg/apiclient/panic-intermediary.go
@@ -16,11 +16,11 @@ func (w abstractIntermediary) CloseSend() error {
 	panic("implement me")
 }
 
-func (w abstractIntermediary) SendMsg(interface{}) error {
+func (w abstractIntermediary) SendMsg(any) error {
 	panic("implement me")
 }
 
-func (w abstractIntermediary) RecvMsg(interface{}) error {
+func (w abstractIntermediary) RecvMsg(any) error {
 	panic("implement me")
 }
 

--- a/pkg/apis/workflow/v1alpha1/anystring.go
+++ b/pkg/apis/workflow/v1alpha1/anystring.go
@@ -11,17 +11,17 @@ import (
 // * It will marshall back to string - marshalling is not symmetric.
 type AnyString string
 
-func ParseAnyString(val interface{}) AnyString {
+func ParseAnyString(val any) AnyString {
 	return AnyString(fmt.Sprintf("%v", val))
 }
 
-func AnyStringPtr(val interface{}) *AnyString {
+func AnyStringPtr(val any) *AnyString {
 	i := ParseAnyString(val)
 	return &i
 }
 
 func (i *AnyString) UnmarshalJSON(value []byte) error {
-	var v interface{}
+	var v any
 	err := json.Unmarshal(value, &v)
 	if err != nil {
 		return err

--- a/pkg/apis/workflow/v1alpha1/data_types.go
+++ b/pkg/apis/workflow/v1alpha1/data_types.go
@@ -38,5 +38,5 @@ type ArtifactPaths struct {
 }
 
 type DataSourceProcessor interface {
-	ProcessArtifactPaths(context.Context, *ArtifactPaths) (interface{}, error)
+	ProcessArtifactPaths(context.Context, *ArtifactPaths) (any, error)
 }

--- a/pkg/apis/workflow/v1alpha1/item.go
+++ b/pkg/apis/workflow/v1alpha1/item.go
@@ -43,11 +43,11 @@ func (i *Item) GetType() Type {
 	if _, err := strconv.ParseBool(strValue); err == nil {
 		return Bool
 	}
-	var list []interface{}
+	var list []any
 	if err := json.Unmarshal(i.Value, &list); err == nil {
 		return List
 	}
-	var object map[string]interface{}
+	var object map[string]any
 	if err := json.Unmarshal(i.Value, &object); err == nil {
 		return Map
 	}

--- a/pkg/apis/workflow/v1alpha1/item_test.go
+++ b/pkg/apis/workflow/v1alpha1/item_test.go
@@ -67,7 +67,7 @@ func TestItem_GetStrVal(t *testing.T) {
 
 var testItemStringTable = []struct {
 	name   string
-	origin interface{}
+	origin any
 	str    string
 }{
 	{"json-string", []string{`{"foo": "bar"}`}, `["{\"foo\": \"bar\"}"]`},

--- a/pkg/apis/workflow/v1alpha1/marshall.go
+++ b/pkg/apis/workflow/v1alpha1/marshall.go
@@ -12,7 +12,7 @@ import (
 // MustUnmarshal is a utility function to unmarshall either a file, byte array, or string of JSON or YAMl into a object.
 // text - a byte array or string, if starts with "@" it assumed to be a file and read from disk, is starts with "{" assumed to be JSON, otherwise assumed to be YAML
 // v - a pointer to an object
-func MustUnmarshal(text, v interface{}) {
+func MustUnmarshal(text, v any) {
 	switch x := text.(type) {
 	case string:
 		MustUnmarshal([]byte(x), v)
@@ -42,7 +42,7 @@ func MustUnmarshal(text, v interface{}) {
 	}
 }
 
-func MustMarshallJSON(v interface{}) string {
+func MustMarshallJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		panic(err)
@@ -50,37 +50,37 @@ func MustMarshallJSON(v interface{}) string {
 	return string(data)
 }
 
-func MustUnmarshalClusterWorkflowTemplate(text interface{}) *ClusterWorkflowTemplate {
+func MustUnmarshalClusterWorkflowTemplate(text any) *ClusterWorkflowTemplate {
 	x := &ClusterWorkflowTemplate{}
 	MustUnmarshal(text, &x)
 	return x
 }
 
-func MustUnmarshalCronWorkflow(text interface{}) *CronWorkflow {
+func MustUnmarshalCronWorkflow(text any) *CronWorkflow {
 	x := &CronWorkflow{}
 	MustUnmarshal(text, &x)
 	return x
 }
 
-func MustUnmarshalTemplate(text interface{}) *Template {
+func MustUnmarshalTemplate(text any) *Template {
 	x := &Template{}
 	MustUnmarshal(text, &x)
 	return x
 }
 
-func MustUnmarshalWorkflow(text interface{}) *Workflow {
+func MustUnmarshalWorkflow(text any) *Workflow {
 	x := &Workflow{}
 	MustUnmarshal(text, &x)
 	return x
 }
 
-func MustUnmarshalWorkflowTemplate(text interface{}) *WorkflowTemplate {
+func MustUnmarshalWorkflowTemplate(text any) *WorkflowTemplate {
 	x := &WorkflowTemplate{}
 	MustUnmarshal(text, &x)
 	return x
 }
 
-func MustUnmarshalWorkflowArtifactGCTask(text interface{}) *WorkflowArtifactGCTask {
+func MustUnmarshalWorkflowArtifactGCTask(text any) *WorkflowArtifactGCTask {
 	x := &WorkflowArtifactGCTask{}
 	MustUnmarshal(text, &x)
 	return x

--- a/pkg/apis/workflow/v1alpha1/plugin_types.go
+++ b/pkg/apis/workflow/v1alpha1/plugin_types.go
@@ -18,7 +18,7 @@ func (p *Plugin) UnmarshalJSON(value []byte) error {
 	}
 	// by validating the structure in UnmarshallJSON, we prevent bad data entering the system at the point of
 	// parsing, which means we do not need validate
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	if err := json.Unmarshal(p.Value, &m); err != nil {
 		return err
 	}

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -790,10 +790,10 @@ func TestNodes_Map(t *testing.T) {
 		"node_2": NodeStatus{ID: "node_2", HostNodeName: "host_2"},
 	}
 	t.Run("Empty", func(t *testing.T) {
-		assert.Empty(t, Nodes{}.Map(func(x NodeStatus) interface{} { return x.HostNodeName }))
+		assert.Empty(t, Nodes{}.Map(func(x NodeStatus) any { return x.HostNodeName }))
 	})
 	t.Run("Exist", func(t *testing.T) {
-		n := nodes.Map(func(x NodeStatus) interface{} { return x.HostNodeName })
+		n := nodes.Map(func(x NodeStatus) any { return x.HostNodeName })
 		assert.Equal(t, "host_1", n["node_1"])
 		assert.Equal(t, "host_2", n["node_2"])
 	})
@@ -905,7 +905,7 @@ func TestPrometheus_GetDescIsStable(t *testing.T) {
 		},
 	}
 	stableDesc := metric.GetKey()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		require.Equal(t, stableDesc, metric.GetKey())
 	}
 }

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -96,13 +97,7 @@ func (a *fakeArtifactDriver) OpenStream(_ context.Context, artifact *wfv1.Artifa
 		if !found {
 			return nil, fmt.Errorf("artifact bucket not found: %+v", artifact)
 		}
-		foundKey := false
-		for _, recognizableKey := range keysInBucket {
-			if key == recognizableKey {
-				foundKey = true
-				break
-			}
-		}
+		foundKey := slices.Contains(keysInBucket, key)
 		if !foundKey {
 			return nil, fmt.Errorf("artifact key '%s' not found in bucket '%s'", key, artifact.S3.Bucket)
 		}

--- a/server/auth/authorizing_server_stream.go
+++ b/server/auth/authorizing_server_stream.go
@@ -26,12 +26,12 @@ func (l *authorizingServerStream) Context() context.Context {
 	return l.ctx
 }
 
-func (l *authorizingServerStream) SendMsg(m interface{}) error {
+func (l *authorizingServerStream) SendMsg(m any) error {
 	return l.ServerStream.SendMsg(m)
 }
 
 // RecvMsg is overridden so that we can understand the request and use it for RBAC
-func (l *authorizingServerStream) RecvMsg(m interface{}) error {
+func (l *authorizingServerStream) RecvMsg(m any) error {
 	err := l.ServerStream.RecvMsg(m)
 	if err != nil {
 		return err

--- a/server/auth/mocks/Gatekeeper.go
+++ b/server/auth/mocks/Gatekeeper.go
@@ -101,7 +101,7 @@ func (_c *Gatekeeper_Context_Call) RunAndReturn(run func(ctx context.Context) (c
 }
 
 // ContextWithRequest provides a mock function for the type Gatekeeper
-func (_mock *Gatekeeper) ContextWithRequest(ctx context.Context, req interface{}) (context.Context, error) {
+func (_mock *Gatekeeper) ContextWithRequest(ctx context.Context, req any) (context.Context, error) {
 	ret := _mock.Called(ctx, req)
 
 	if len(ret) == 0 {
@@ -110,17 +110,17 @@ func (_mock *Gatekeeper) ContextWithRequest(ctx context.Context, req interface{}
 
 	var r0 context.Context
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, interface{}) (context.Context, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, any) (context.Context, error)); ok {
 		return returnFunc(ctx, req)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, interface{}) context.Context); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, any) context.Context); ok {
 		r0 = returnFunc(ctx, req)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(context.Context)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, interface{}) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, any) error); ok {
 		r1 = returnFunc(ctx, req)
 	} else {
 		r1 = ret.Error(1)
@@ -135,20 +135,20 @@ type Gatekeeper_ContextWithRequest_Call struct {
 
 // ContextWithRequest is a helper method to define mock.On call
 //   - ctx context.Context
-//   - req interface{}
+//   - req any
 func (_e *Gatekeeper_Expecter) ContextWithRequest(ctx interface{}, req interface{}) *Gatekeeper_ContextWithRequest_Call {
 	return &Gatekeeper_ContextWithRequest_Call{Call: _e.mock.On("ContextWithRequest", ctx, req)}
 }
 
-func (_c *Gatekeeper_ContextWithRequest_Call) Run(run func(ctx context.Context, req interface{})) *Gatekeeper_ContextWithRequest_Call {
+func (_c *Gatekeeper_ContextWithRequest_Call) Run(run func(ctx context.Context, req any)) *Gatekeeper_ContextWithRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 interface{}
+		var arg1 any
 		if args[1] != nil {
-			arg1 = args[1].(interface{})
+			arg1 = args[1].(any)
 		}
 		run(
 			arg0,
@@ -163,7 +163,7 @@ func (_c *Gatekeeper_ContextWithRequest_Call) Return(context1 context.Context, e
 	return _c
 }
 
-func (_c *Gatekeeper_ContextWithRequest_Call) RunAndReturn(run func(ctx context.Context, req interface{}) (context.Context, error)) *Gatekeeper_ContextWithRequest_Call {
+func (_c *Gatekeeper_ContextWithRequest_Call) RunAndReturn(run func(ctx context.Context, req any) (context.Context, error)) *Gatekeeper_ContextWithRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/auth/types/claims.go
+++ b/server/auth/types/claims.go
@@ -11,14 +11,14 @@ import (
 
 type Claims struct {
 	jwt.Claims
-	Groups                  []string               `json:"groups,omitempty"`
-	Email                   string                 `json:"email,omitempty"`
-	EmailVerified           bool                   `json:"-"`
-	Name                    string                 `json:"name,omitempty"`
-	ServiceAccountName      string                 `json:"service_account_name,omitempty"`
-	ServiceAccountNamespace string                 `json:"service_account_namespace,omitempty"`
-	PreferredUsername       string                 `json:"preferred_username,omitempty"`
-	RawClaim                map[string]interface{} `json:"-"`
+	Groups                  []string       `json:"groups,omitempty"`
+	Email                   string         `json:"email,omitempty"`
+	EmailVerified           bool           `json:"-"`
+	Name                    string         `json:"name,omitempty"`
+	ServiceAccountName      string         `json:"service_account_name,omitempty"`
+	ServiceAccountNamespace string         `json:"service_account_namespace,omitempty"`
+	PreferredUsername       string         `json:"preferred_username,omitempty"`
+	RawClaim                map[string]any `json:"-"`
 }
 
 type UserInfo struct {
@@ -69,7 +69,7 @@ func (c *Claims) GetCustomGroup(customKeyName string) ([]string, error) {
 		return nil, fmt.Errorf("no claim found for key: %v", customKeyName)
 	}
 
-	sliceInterface, ok := groups.([]interface{})
+	sliceInterface, ok := groups.([]any)
 	if !ok {
 		return nil, fmt.Errorf("expected an array, got %v", groups)
 	}

--- a/server/auth/types/claims_test.go
+++ b/server/auth/types/claims_test.go
@@ -41,12 +41,12 @@ func TestUnmarshalJSON(t *testing.T) {
 					IssuedAt:  &testissuedAt,
 				},
 				ServiceAccountName: "",
-				RawClaim: map[string]interface{}{
-					"ad_groups":         []interface{}{"argo_admin", "argo_readonly"},
-					"amr":               []interface{}{"USERNAME_PASSWORD"},
-					"aud":               []interface{}{"example-aud"},
-					"clientAppRoles":    []interface{}{"Authenticated Client", "Cross Tenant"},
-					"userAppRoles":      []interface{}{"Authenticated", "Global Viewer", "Identity Domain Administrator"},
+				RawClaim: map[string]any{
+					"ad_groups":         []any{"argo_admin", "argo_readonly"},
+					"amr":               []any{"USERNAME_PASSWORD"},
+					"aud":               []any{"example-aud"},
+					"clientAppRoles":    []any{"Authenticated Client", "Cross Tenant"},
+					"userAppRoles":      []any{"Authenticated", "Global Viewer", "Identity Domain Administrator"},
 					"ca_guid":           "test-ca_guid",
 					"client_guid":       "adsf34534645654653454",
 					"client_id":         "tokenGenerator",
@@ -97,12 +97,12 @@ func TestUnmarshalJSON(t *testing.T) {
 				},
 				Groups:             []string{"argo_admin", "argo_readonly"},
 				ServiceAccountName: "",
-				RawClaim: map[string]interface{}{
-					"groups":            []interface{}{"argo_admin", "argo_readonly"},
-					"amr":               []interface{}{"USERNAME_PASSWORD"},
-					"aud":               []interface{}{"example-aud"},
-					"clientAppRoles":    []interface{}{"Authenticated Client", "Cross Tenant"},
-					"userAppRoles":      []interface{}{"Authenticated", "Global Viewer", "Identity Domain Administrator"},
+				RawClaim: map[string]any{
+					"groups":            []any{"argo_admin", "argo_readonly"},
+					"amr":               []any{"USERNAME_PASSWORD"},
+					"aud":               []any{"example-aud"},
+					"clientAppRoles":    []any{"Authenticated Client", "Cross Tenant"},
+					"userAppRoles":      []any{"Authenticated", "Global Viewer", "Identity Domain Administrator"},
 					"ca_guid":           "test-ca_guid",
 					"client_guid":       "adsf34534645654653454",
 					"client_id":         "tokenGenerator",
@@ -142,7 +142,7 @@ func TestUnmarshalJSON(t *testing.T) {
 			data:        `{"email_verified":"true"}`,
 			expectedErr: nil,
 			expectedClaims: &Claims{
-				RawClaim: map[string]interface{}{
+				RawClaim: map[string]any{
 					"email_verified": "true",
 				},
 				EmailVerified: true,
@@ -153,7 +153,7 @@ func TestUnmarshalJSON(t *testing.T) {
 			data:        `{"email_verified":true}`,
 			expectedErr: nil,
 			expectedClaims: &Claims{
-				RawClaim: map[string]interface{}{
+				RawClaim: map[string]any{
 					"email_verified": true,
 				},
 				EmailVerified: true,
@@ -164,7 +164,7 @@ func TestUnmarshalJSON(t *testing.T) {
 			data:        `{}`,
 			expectedErr: nil,
 			expectedClaims: &Claims{
-				RawClaim: map[string]interface{}{},
+				RawClaim: map[string]any{},
 			},
 		},
 	}
@@ -187,11 +187,11 @@ func TestGetCustomGroup(t *testing.T) {
 	})
 	t.Run("CustomGroupSet", func(t *testing.T) {
 		tGroup := []string{"my-group"}
-		tGroupsIf := make([]interface{}, len(tGroup))
+		tGroupsIf := make([]any, len(tGroup))
 		for i := range tGroup {
 			tGroupsIf[i] = tGroup[i]
 		}
-		claims := &Claims{RawClaim: map[string]interface{}{
+		claims := &Claims{RawClaim: map[string]any{
 			"ad_groups": tGroupsIf,
 		}}
 		groups, err := claims.GetCustomGroup(("ad_groups"))
@@ -200,11 +200,11 @@ func TestGetCustomGroup(t *testing.T) {
 	})
 	t.Run("CustomGroupNotString", func(t *testing.T) {
 		tGroup := []int{0}
-		tGroupsIf := make([]interface{}, len(tGroup))
+		tGroupsIf := make([]any, len(tGroup))
 		for i := range tGroup {
 			tGroupsIf[i] = tGroup[i]
 		}
-		claims := &Claims{RawClaim: map[string]interface{}{
+		claims := &Claims{RawClaim: map[string]any{
 			"ad_groups": tGroupsIf,
 		}}
 		_, err := claims.GetCustomGroup(("ad_groups"))
@@ -212,7 +212,7 @@ func TestGetCustomGroup(t *testing.T) {
 	})
 	t.Run("CustomGroupNotSlice", func(t *testing.T) {
 		tGroup := "None"
-		claims := &Claims{RawClaim: map[string]interface{}{
+		claims := &Claims{RawClaim: map[string]any{
 			"ad_groups": tGroup,
 		}}
 		_, err := claims.GetCustomGroup(("ad_groups"))

--- a/server/cronworkflow/cron_workflow_server.go
+++ b/server/cronworkflow/cron_workflow_server.go
@@ -138,7 +138,7 @@ func (c *cronWorkflowServiceServer) SuspendCronWorkflow(ctx context.Context, req
 }
 
 func setCronWorkflowSuspend(ctx context.Context, setTo bool, namespace, name string) (*v1alpha1.CronWorkflow, error) {
-	data, err := json.Marshal(map[string]interface{}{"spec": map[string]interface{}{"suspend": setTo}})
+	data, err := json.Marshal(map[string]any{"spec": map[string]any{"suspend": setTo}})
 	if err != nil {
 		return nil, sutils.ToStatusError(fmt.Errorf("failed to marshall cron workflow patch data: %w", err), codes.Internal)
 	}

--- a/server/event/dispatch/operation.go
+++ b/server/event/dispatch/operation.go
@@ -34,7 +34,7 @@ type Operation struct {
 	eventRecorder     record.EventRecorder
 	instanceIDService instanceid.Service
 	events            []wfv1.WorkflowEventBinding
-	env               map[string]interface{}
+	env               map[string]any
 }
 
 // Context returns the context associated with this operation
@@ -216,8 +216,8 @@ func (o *Operation) evaluateStringExpression(statement string, errorInfo string)
 	return v, nil
 }
 
-func expressionEnvironment(ctx context.Context, namespace, discriminator string, payload *wfv1.Item) (map[string]interface{}, error) {
-	src := map[string]interface{}{
+func expressionEnvironment(ctx context.Context, namespace, discriminator string, payload *wfv1.Item) (map[string]any, error) {
+	src := map[string]any{
 		"namespace":     namespace,
 		"discriminator": discriminator,
 		"metadata":      metaData(ctx),
@@ -226,8 +226,8 @@ func expressionEnvironment(ctx context.Context, namespace, discriminator string,
 	return jsonutil.Jsonify(src)
 }
 
-func metaData(ctx context.Context) map[string]interface{} {
-	meta := make(map[string]interface{})
+func metaData(ctx context.Context) map[string]any {
+	meta := make(map[string]any)
 	md, _ := metadata.FromIncomingContext(ctx)
 	for k, v := range md {
 		// only allow headers `X-`  headers, e.g. `X-Github-Action`

--- a/server/event/dispatch/operation_test.go
+++ b/server/event/dispatch/operation_test.go
@@ -414,5 +414,5 @@ func Test_expressionEnvironment(t *testing.T) {
 	assert.Equal(t, "my-ns", env["namespace"])
 	assert.Equal(t, "my-d", env["discriminator"])
 	assert.Contains(t, env, "metadata")
-	assert.Equal(t, map[string]interface{}{"foo": "bar"}, env["payload"], "make sure we parse an object as a map")
+	assert.Equal(t, map[string]any{"foo": "bar"}, env["payload"], "make sure we parse an object as a map")
 }

--- a/server/workflow/store/sqlite_store.go
+++ b/server/workflow/store/sqlite_store.go
@@ -163,7 +163,7 @@ where instanceid = ?
 	return total, nil
 }
 
-func (s *SQLiteStore) Add(obj interface{}) error {
+func (s *SQLiteStore) Add(obj any) error {
 	wf, ok := obj.(*wfv1.Workflow)
 	if !ok {
 		return fmt.Errorf("unable to convert object to Workflow. object: %v", obj)
@@ -176,7 +176,7 @@ func (s *SQLiteStore) Add(obj interface{}) error {
 	return err
 }
 
-func (s *SQLiteStore) Update(obj interface{}) error {
+func (s *SQLiteStore) Update(obj any) error {
 	wf, ok := obj.(*wfv1.Workflow)
 	if !ok {
 		return fmt.Errorf("unable to convert object to Workflow. object: %v", obj)
@@ -189,7 +189,7 @@ func (s *SQLiteStore) Update(obj interface{}) error {
 	return err
 }
 
-func (s *SQLiteStore) Delete(obj interface{}) error {
+func (s *SQLiteStore) Delete(obj any) error {
 	wf, ok := obj.(*wfv1.Workflow)
 	if !ok {
 		return fmt.Errorf("unable to convert object to Workflow. object: %v", obj)
@@ -199,7 +199,7 @@ func (s *SQLiteStore) Delete(obj interface{}) error {
 	return sqlitex.Execute(s.conn, deleteWorkflowQuery, &sqlitex.ExecOptions{Args: []any{string(wf.UID)}})
 }
 
-func (s *SQLiteStore) Replace(list []interface{}, resourceVersion string) error {
+func (s *SQLiteStore) Replace(list []any, resourceVersion string) error {
 	wfs := make([]*wfv1.Workflow, 0, len(list))
 	for _, obj := range list {
 		wf, ok := obj.(*wfv1.Workflow)
@@ -220,7 +220,7 @@ func (s *SQLiteStore) Resync() error {
 	return nil
 }
 
-func (s *SQLiteStore) List() []interface{} {
+func (s *SQLiteStore) List() []any {
 	panic("not implemented")
 }
 
@@ -228,11 +228,11 @@ func (s *SQLiteStore) ListKeys() []string {
 	panic("not implemented")
 }
 
-func (s *SQLiteStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+func (s *SQLiteStore) Get(obj any) (item any, exists bool, err error) {
 	panic("not implemented")
 }
 
-func (s *SQLiteStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+func (s *SQLiteStore) GetByKey(key string) (item any, exists bool, err error) {
 	panic("not implemented")
 }
 

--- a/server/workflow/store/sqlite_store_test.go
+++ b/server/workflow/store/sqlite_store_test.go
@@ -78,7 +78,7 @@ func TestStoreOperation(t *testing.T) {
 		instanceService: instanceIDSvc,
 	}
 	t.Run("TestAddWorkflow", func(t *testing.T) {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			require.NoError(t, store.Add(generateWorkflow(i)))
 		}
 		ctx := logging.TestContext(t.Context())

--- a/server/workflow/test_server_stream_test.go
+++ b/server/workflow/test_server_stream_test.go
@@ -30,10 +30,10 @@ func (t testServerStream) Context() context.Context {
 	return t.ctx
 }
 
-func (t testServerStream) SendMsg(interface{}) error {
+func (t testServerStream) SendMsg(any) error {
 	panic("implement me")
 }
 
-func (t testServerStream) RecvMsg(interface{}) error {
+func (t testServerStream) RecvMsg(any) error {
 	panic("implement me")
 }

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1042,7 +1042,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path(`$.items[*].metadata.labels["workflows.argoproj.io/workflow-archiving-status"]`).
 			Array().
-			IsEqual([]interface{}{"Persisted", "Persisted"})
+			IsEqual([]any{"Persisted", "Persisted"})
 	})
 
 	s.Run("ListNameContainsAlice", func() {
@@ -1054,7 +1054,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf})
+			IsEqualUnordered([]any{uidAliceWf})
 	})
 
 	s.Run("ListNameContainsNoMatch", func() {
@@ -1077,7 +1077,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ListNamePrefixBobNoMatch", func() {
@@ -1101,7 +1101,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf})
+			IsEqualUnordered([]any{uidAliceWf})
 	})
 
 	s.Run("ListNameExactAliceNoMatch", func() {
@@ -1124,7 +1124,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ListNameDoubleEqualsBob", func() {
@@ -1135,7 +1135,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ListNameContainsTest", func() {
@@ -1147,7 +1147,7 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf, uidBobWf})
+			IsEqualUnordered([]any{uidAliceWf, uidBobWf})
 	})
 }
 
@@ -1228,7 +1228,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path(`$.items[*].metadata.labels["workflows.argoproj.io/workflow-archiving-status"]`).
 			Array().
-			IsEqual([]interface{}{"Persisted", "Persisted"})
+			IsEqual([]any{"Persisted", "Persisted"})
 	})
 
 	s.Run("ArchiveNameContainsAlice", func() {
@@ -1240,7 +1240,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf})
+			IsEqualUnordered([]any{uidAliceWf})
 	})
 
 	s.Run("ArchiveNameContainsNoMatch", func() {
@@ -1263,7 +1263,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ArchiveNamePrefixBobNoMatch", func() {
@@ -1287,7 +1287,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf})
+			IsEqualUnordered([]any{uidAliceWf})
 	})
 
 	s.Run("ArchiveNameExactAliceNoMatch", func() {
@@ -1310,7 +1310,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ArchiveNameDoubleEqualsBob", func() {
@@ -1321,7 +1321,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ArchiveNameContainsTest", func() {
@@ -1333,7 +1333,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf, uidBobWf})
+			IsEqualUnordered([]any{uidAliceWf, uidBobWf})
 	})
 
 	s.Run("ArchiveNamePrefixNameFilterContainsBobTest", func() {
@@ -1346,7 +1346,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ArchiveNamePrefixNameFilterEmptyTest", func() {
@@ -1391,7 +1391,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf, uidAliceWf})
+			IsEqualUnordered([]any{uidBobWf, uidAliceWf})
 	})
 
 	s.Run("ListNameNotEqualsAlice", func() {
@@ -1403,7 +1403,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ListNameNotEqualsNoMatch", func() {
@@ -1415,7 +1415,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidAliceWf, uidBobWf})
+			IsEqualUnordered([]any{uidAliceWf, uidBobWf})
 	})
 
 	s.Run("ListNameNotEqualsPrecedence", func() {
@@ -1427,7 +1427,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ArchiveNameNotEqualsAlice", func() {
@@ -1439,7 +1439,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 
 	s.Run("ArchiveNameNotEqualsNoMatch", func() {
@@ -1451,7 +1451,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf, uidAliceWf})
+			IsEqualUnordered([]any{uidBobWf, uidAliceWf})
 	})
 
 	s.Run("ArchiveNameNotEqualsPrecedence", func() {
@@ -1463,7 +1463,7 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 			JSON().
 			Path("$.items[*].metadata.uid").
 			Array().
-			IsEqualUnordered([]interface{}{uidBobWf})
+			IsEqualUnordered([]any{uidBobWf})
 	})
 }
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -352,7 +352,7 @@ func (s *CLISuite) TestLogs() {
 
 func toLines(x string) []string {
 	var y []string
-	for _, s := range strings.Split(x, "\n") {
+	for s := range strings.SplitSeq(x, "\n") {
 		println("s=", s)
 		if s != "" && !strings.Contains(s, "argo=true") {
 			y = append(y, s)

--- a/test/e2e/fixtures/e2e_suite.go
+++ b/test/e2e/fixtures/e2e_suite.go
@@ -154,8 +154,8 @@ func (s *E2ESuite) DeleteResources() {
 			resourceList, err := resourceInf.List(ctx, metav1.ListOptions{LabelSelector: common.LabelKeyCompleted + "=false"})
 			s.CheckError(err)
 			for _, item := range resourceList.Items {
-				patch, err := json.Marshal(map[string]interface{}{
-					"metadata": map[string]interface{}{
+				patch, err := json.Marshal(map[string]any{
+					"metadata": map[string]any{
 						"finalizers": []string{},
 					},
 				})

--- a/test/e2e/fixtures/given.go
+++ b/test/e2e/fixtures/given.go
@@ -137,7 +137,7 @@ func (g *Given) readResource(text string, v metav1.Object) {
 // Using an arbitrary image will result in slow and flakey tests as we can't really predict when they'll be
 // downloaded or evicted. To keep tests fast and reliable you must use allowed images.
 // Workflows from the examples/ folder are given special treatment and allowed to use a wider range of images.
-func (g *Given) checkImages(wf interface{}, isExample bool) {
+func (g *Given) checkImages(wf any, isExample bool) {
 	g.t.Helper()
 	var defaultImage string
 	var templates []wfv1.Template

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -187,7 +187,7 @@ func (t *Then) ExpectAuditEvents(filter func(event apiv1.Event) bool, num int, b
 		case event := <-eventList.ResultChan():
 			e, ok := event.Object.(*apiv1.Event)
 			if !ok {
-				t.t.Errorf("event is not an event: %v", reflect.TypeOf(e).String())
+				t.t.Errorf("event is not an event: %v", reflect.TypeFor[*apiv1.Event]().String())
 				return t
 			}
 			if filter(*e) {

--- a/test/e2e/fixtures/util.go
+++ b/test/e2e/fixtures/util.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func errorln(args ...interface{}) {
+func errorln(args ...any) {
 	_, _ = fmt.Fprint(os.Stderr, args...)
 }
 

--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -305,7 +305,7 @@ func describeListOptions(opts metav1.ListOptions) string {
 //   - just because the Workflow completed
 //
 // * `Condition` - a condition - `ToFinish` by default
-func (w *When) WaitForWorkflow(options ...interface{}) *When {
+func (w *When) WaitForWorkflow(options ...any) *When {
 	w.t.Helper()
 	timeout := defaultTimeout
 	condition := ToBeDone
@@ -516,9 +516,9 @@ func (w *When) RemoveFinalizers(shouldErr bool) *When {
 func (w *When) AddNamespaceLimit(limit string) *When {
 	w.t.Helper()
 	ctx := logging.TestContext(w.t.Context())
-	patchMap := make(map[string]interface{})
-	metadata := make(map[string]interface{})
-	labels := make(map[string]interface{})
+	patchMap := make(map[string]any)
+	metadata := make(map[string]any)
+	labels := make(map[string]any)
 	labels["workflows.argoproj.io/parallelism-limit"] = limit
 	metadata["labels"] = labels
 	patchMap["metadata"] = metadata
@@ -875,8 +875,8 @@ func (w *When) SuspendCronWorkflow() *When {
 func (w *When) setCronWorkflowSuspend(suspend bool) *When {
 	ctx := logging.TestContext(w.t.Context())
 	w.t.Helper()
-	spec := map[string]interface{}{"suspend": suspend}
-	data, err := json.Marshal(map[string]interface{}{"spec": spec})
+	spec := map[string]any{"suspend": suspend}
+	data, err := json.Marshal(map[string]any{"spec": spec})
 	if err != nil {
 		w.t.Fatal(err)
 	}
@@ -890,7 +890,7 @@ func (w *When) setCronWorkflowSuspend(suspend bool) *When {
 func (w *When) ShutdownWorkflow(strategy wfv1.ShutdownStrategy) *When {
 	w.t.Helper()
 	ctx := logging.TestContext(w.t.Context())
-	data, err := json.Marshal(map[string]interface{}{"spec": map[string]interface{}{"shutdown": strategy}})
+	data, err := json.Marshal(map[string]any{"spec": map[string]any{"shutdown": strategy}})
 	if err != nil {
 		w.t.Fatal(err)
 	}

--- a/test/e2e/pod_restart_test.go
+++ b/test/e2e/pod_restart_test.go
@@ -50,17 +50,17 @@ func (s *PodRestartSuite) TestEvictedPodRestarts() {
 			// - Reason is set to "Evicted"
 			// - Message describes the eviction cause
 			// - Main container never entered Running state (still in Waiting)
-			patch := map[string]interface{}{
-				"status": map[string]interface{}{
+			patch := map[string]any{
+				"status": map[string]any{
 					"phase":   "Failed",
 					"reason":  "Evicted",
 					"message": "The node had condition: [DiskPressure]",
-					"initContainerStatuses": []map[string]interface{}{
+					"initContainerStatuses": []map[string]any{
 						{
 							"name":  "init",
 							"image": "alpine:latest",
-							"state": map[string]interface{}{
-								"terminated": map[string]interface{}{
+							"state": map[string]any{
+								"terminated": map[string]any{
 									"exitCode": 0,
 									"reason":   "Completed",
 								},
@@ -71,8 +71,8 @@ func (s *PodRestartSuite) TestEvictedPodRestarts() {
 						{
 							"name":  "delay",
 							"image": "alpine:latest",
-							"state": map[string]interface{}{
-								"terminated": map[string]interface{}{
+							"state": map[string]any{
+								"terminated": map[string]any{
 									"exitCode": 137,
 									"reason":   "Error",
 								},
@@ -81,12 +81,12 @@ func (s *PodRestartSuite) TestEvictedPodRestarts() {
 							"restartCount": 0,
 						},
 					},
-					"containerStatuses": []map[string]interface{}{
+					"containerStatuses": []map[string]any{
 						{
 							"name":  "main",
 							"image": "alpine:latest",
-							"state": map[string]interface{}{
-								"waiting": map[string]interface{}{
+							"state": map[string]any{
+								"waiting": map[string]any{
 									"reason": "PodInitializing",
 								},
 							},

--- a/test/e2e/suspend_test.go
+++ b/test/e2e/suspend_test.go
@@ -1,5 +1,4 @@
 //go:build functional
-// +build functional
 
 package e2e
 

--- a/test/util/indexer.go
+++ b/test/util/indexer.go
@@ -5,37 +5,37 @@ import (
 )
 
 type Indexer struct {
-	byIndex map[string][]interface{}
-	byKey   map[string]interface{}
+	byIndex map[string][]any
+	byKey   map[string]any
 }
 
 var _ cache.Indexer = &Indexer{}
 
 func NewIndexer() *Indexer {
-	return &Indexer{make(map[string][]interface{}), make(map[string]interface{})}
+	return &Indexer{make(map[string][]any), make(map[string]any)}
 }
 
-func (i Indexer) Add(interface{}) error                                      { panic("implement me") }
-func (i Indexer) Update(interface{}) error                                   { panic("implement me") }
-func (i Indexer) Delete(interface{}) error                                   { panic("implement me") }
-func (i Indexer) List() []interface{}                                        { panic("implement me") }
-func (i Indexer) ListKeys() []string                                         { panic("implement me") }
-func (i Indexer) Get(interface{}) (item interface{}, exists bool, err error) { panic("implement me") }
-func (i Indexer) GetByKey(key string) (item interface{}, exists bool, err error) {
+func (i Indexer) Add(any) error                              { panic("implement me") }
+func (i Indexer) Update(any) error                           { panic("implement me") }
+func (i Indexer) Delete(any) error                           { panic("implement me") }
+func (i Indexer) List() []any                                { panic("implement me") }
+func (i Indexer) ListKeys() []string                         { panic("implement me") }
+func (i Indexer) Get(any) (item any, exists bool, err error) { panic("implement me") }
+func (i Indexer) GetByKey(key string) (item any, exists bool, err error) {
 	obj, ok := i.byKey[key]
 	return obj, ok, nil
 }
-func (i Indexer) SetByKey(key string, item interface{})            { i.byKey[key] = item }
-func (i Indexer) Replace([]interface{}, string) error              { panic("implement me") }
-func (i Indexer) Resync() error                                    { panic("implement me") }
-func (i Indexer) Index(string, interface{}) ([]interface{}, error) { panic("implement me") }
-func (i Indexer) IndexKeys(string, string) ([]string, error)       { panic("implement me") }
-func (i Indexer) ListIndexFuncValues(string) []string              { panic("implement me") }
-func (i Indexer) SetByIndex(indexName, indexedValue string, objs ...interface{}) {
+func (i Indexer) SetByKey(key string, item any)              { i.byKey[key] = item }
+func (i Indexer) Replace([]any, string) error                { panic("implement me") }
+func (i Indexer) Resync() error                              { panic("implement me") }
+func (i Indexer) Index(string, any) ([]any, error)           { panic("implement me") }
+func (i Indexer) IndexKeys(string, string) ([]string, error) { panic("implement me") }
+func (i Indexer) ListIndexFuncValues(string) []string        { panic("implement me") }
+func (i Indexer) SetByIndex(indexName, indexedValue string, objs ...any) {
 	i.byIndex[indexName+"="+indexedValue] = objs
 }
 
-func (i Indexer) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+func (i Indexer) ByIndex(indexName, indexedValue string) ([]any, error) {
 	return i.byIndex[indexName+"="+indexedValue], nil
 }
 func (i Indexer) GetIndexers() cache.Indexers      { panic("implement me") }

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -80,7 +80,7 @@ func IsURL(u string) bool {
 }
 
 // ParseLabels turns a string representation of a label set into a map[string]string
-func ParseLabels(labelSpec interface{}) (map[string]string, error) {
+func ParseLabels(labelSpec any) (map[string]string, error) {
 	labelString, isString := labelSpec.(string)
 	if !isString {
 		return nil, fmt.Errorf("expected string, found %v", labelSpec)

--- a/util/cmd/cmd_test.go
+++ b/util/cmd/cmd_test.go
@@ -45,7 +45,7 @@ func TestMakeParseLabels(t *testing.T) {
 
 	errorCases := []struct {
 		name   string
-		labels interface{}
+		labels any
 	}{
 		{
 			name:   "non-string",

--- a/util/diff/diff.go
+++ b/util/diff/diff.go
@@ -9,7 +9,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/logging"
 )
 
-func LogChanges(ctx context.Context, old, newObj interface{}) {
+func LogChanges(ctx context.Context, old, newObj any) {
 	logger := logging.RequireLoggerFromContext(ctx)
 	// Note: We don't have a direct equivalent to log.IsLevelEnabled(log.DebugLevel)
 	// The logger will handle level filtering internally

--- a/util/expand/expand.go
+++ b/util/expand/expand.go
@@ -7,7 +7,7 @@ import (
 	"github.com/doublerebel/bellows"
 )
 
-func Expand(m map[string]interface{}) map[string]interface{} {
+func Expand(m map[string]any) map[string]any {
 	return bellows.Expand(removeConflicts(m))
 }
 
@@ -15,9 +15,9 @@ func Expand(m map[string]interface{}) map[string]interface{} {
 // {"a.b": 1, "a": 2}
 // What should the result be? We remove the less-specific key.
 // {"a.b": 1, "a": 2} -> {"a.b": 1, "a": 2}
-func removeConflicts(m map[string]interface{}) map[string]interface{} {
+func removeConflicts(m map[string]any) map[string]any {
 	var keys []string
-	n := map[string]interface{}{}
+	n := map[string]any{}
 	for k, v := range m {
 		keys = append(keys, k)
 		n[k] = v

--- a/util/expand/expand_test.go
+++ b/util/expand/expand_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestExpand(t *testing.T) {
-	for i := 0; i < 1; i++ { // loop 100 times, because map ordering is not determisitic
+	for i := range 1 { // loop 100 times, because map ordering is not determisitic
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			before := map[string]interface{}{
+			before := map[string]any{
 				"a.b":   1,
 				"a.c.d": 2,
 				"a":     3, // should be deleted
@@ -19,10 +19,10 @@ func TestExpand(t *testing.T) {
 			}
 			after := Expand(before)
 			assert.Len(t, before, 5, "original map unchanged")
-			assert.Equal(t, map[string]interface{}{
-				"a": map[string]interface{}{
+			assert.Equal(t, map[string]any{
+				"a": map[string]any{
 					"b": 1,
-					"c": map[string]interface{}{
+					"c": map[string]any{
 						"d": 2,
 					},
 				},

--- a/util/expr/argoexpr/eval.go
+++ b/util/expr/argoexpr/eval.go
@@ -6,7 +6,7 @@ import (
 	"github.com/expr-lang/expr"
 )
 
-func EvalBool(input string, env interface{}) (bool, error) {
+func EvalBool(input string, env any) (bool, error) {
 	program, err := expr.Compile(input, expr.Env(env))
 	if err != nil {
 		return false, err

--- a/util/expr/argoexpr/eval_test.go
+++ b/util/expr/argoexpr/eval_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestEvalBool(t *testing.T) {
 	type args struct {
 		input string
-		env   interface{}
+		env   any
 	}
 	tests := []struct {
 		name    string
@@ -17,7 +17,7 @@ func TestEvalBool(t *testing.T) {
 			name: "test parse expression error",
 			args: args{
 				input: "invalid expression",
-				env:   map[string]interface{}{},
+				env:   map[string]any{},
 			},
 			want:    false,
 			wantErr: true,
@@ -26,7 +26,7 @@ func TestEvalBool(t *testing.T) {
 			name: "test eval expression false",
 			args: args{
 				input: " FOO == 1 ",
-				env:   map[string]interface{}{"FOO": 2},
+				env:   map[string]any{"FOO": 2},
 			},
 			want:    false,
 			wantErr: false,
@@ -35,7 +35,7 @@ func TestEvalBool(t *testing.T) {
 			name: "test eval expression true",
 			args: args{
 				input: " FOO == 1 ",
-				env:   map[string]interface{}{"FOO": 1},
+				env:   map[string]any{"FOO": 1},
 			},
 			want:    true,
 			wantErr: false,
@@ -44,7 +44,7 @@ func TestEvalBool(t *testing.T) {
 			name: "test override builtins",
 			args: args{
 				input: "split == 1",
-				env:   map[string]interface{}{"split": 1},
+				env:   map[string]any{"split": 1},
 			},
 			want:    true,
 			wantErr: false,
@@ -53,7 +53,7 @@ func TestEvalBool(t *testing.T) {
 			name: "test override builtins",
 			args: args{
 				input: "join == 1",
-				env:   map[string]interface{}{"join": 1},
+				env:   map[string]any{"join": 1},
 			},
 			want:    true,
 			wantErr: false,
@@ -62,8 +62,8 @@ func TestEvalBool(t *testing.T) {
 			name: "test null expression",
 			args: args{
 				input: "steps[\"prepare\"].outputs != null",
-				env: map[string]interface{}{"steps": map[string]interface{}{
-					"prepare": map[string]interface{}{"outputs": "msg"},
+				env: map[string]any{"steps": map[string]any{
+					"prepare": map[string]any{"outputs": "msg"},
 				}},
 			},
 			want:    false,

--- a/util/expr/env/env.go
+++ b/util/expr/env/env.go
@@ -17,7 +17,7 @@ func init() {
 	delete(sprigFuncMap, "expandenv")
 }
 
-func GetFuncMap(m map[string]interface{}) map[string]interface{} {
+func GetFuncMap(m map[string]any) map[string]any {
 	env := expand.Expand(m)
 	// Alias for the built-in `int` function, for backwards compatibility.
 	env["asInt"] = builtin.Int
@@ -29,7 +29,7 @@ func GetFuncMap(m map[string]interface{}) map[string]interface{} {
 	return env
 }
 
-func toJSON(v interface{}) string {
+func toJSON(v any) string {
 	output, err := json.Marshal(v)
 	if err != nil {
 		panic(err)
@@ -37,8 +37,8 @@ func toJSON(v interface{}) string {
 	return string(output)
 }
 
-func jsonPath(jsonStr string, path string) interface{} {
-	var jsonMap interface{}
+func jsonPath(jsonStr string, path string) any {
+	var jsonMap any
 	err := json.Unmarshal([]byte(jsonStr), &jsonMap)
 	if err != nil {
 		panic(err)

--- a/util/fields/fields.go
+++ b/util/fields/fields.go
@@ -24,7 +24,7 @@ type Cleaner struct {
 	fields  map[string]bool
 }
 
-func (f Cleaner) Clean(x, y interface{}) (bool, error) {
+func (f Cleaner) Clean(x, y any) (bool, error) {
 	if len(f.fields) == 0 {
 		return false, nil
 	}
@@ -32,7 +32,7 @@ func (f Cleaner) Clean(x, y interface{}) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 	if err := json.Unmarshal(v, &data); err != nil {
 		return false, err
 	}
@@ -67,8 +67,8 @@ func (f Cleaner) matches(x string) bool {
 	return false
 }
 
-func (f Cleaner) cleanItem(path []string, item interface{}) {
-	if mapItem, ok := item.(map[string]interface{}); ok {
+func (f Cleaner) cleanItem(path []string, item any) {
+	if mapItem, ok := item.(map[string]any); ok {
 		for k, v := range mapItem {
 			fieldPath := strings.Join(append(path, k), ".")
 			_, pathIn := f.fields[fieldPath]
@@ -89,7 +89,7 @@ func (f Cleaner) cleanItem(path []string, item interface{}) {
 				delete(mapItem, k)
 			}
 		}
-	} else if arrayItem, ok := item.([]interface{}); ok {
+	} else if arrayItem, ok := item.([]any); ok {
 		for i := range arrayItem {
 			f.cleanItem(path, arrayItem[i])
 		}

--- a/util/flatten/flatten.go
+++ b/util/flatten/flatten.go
@@ -7,12 +7,12 @@ import (
 	jsonutil "github.com/argoproj/argo-workflows/v3/util/json"
 )
 
-func toMap(in interface{}) map[string]interface{} {
+func toMap(in any) map[string]any {
 	v, _ := jsonutil.Jsonify(in)
 	return v
 }
 
-func flattenWithPrefix(in map[string]interface{}, out map[string]string, prefix string) {
+func flattenWithPrefix(in map[string]any, out map[string]string, prefix string) {
 	for k, v := range in {
 		if v == nil {
 			continue
@@ -28,7 +28,7 @@ func flattenWithPrefix(in map[string]interface{}, out map[string]string, prefix 
 
 // Flatten converts a struct into a map[string]string using dot-notation.
 // E.g. listOptions.continue="10"
-func Flatten(in interface{}) map[string]string {
+func Flatten(in any) map[string]string {
 	out := make(map[string]string)
 	flattenWithPrefix(toMap(in), out, "")
 	return out

--- a/util/flatten/flatten_test.go
+++ b/util/flatten/flatten_test.go
@@ -13,7 +13,7 @@ import (
 func Test_flatten(t *testing.T) {
 	tests := []struct {
 		name string
-		in   interface{}
+		in   any
 		want map[string]string
 	}{
 		{"Empty", workflowarchive.ListArchivedWorkflowsRequest{}, map[string]string{}},

--- a/util/grpc/interceptor_test.go
+++ b/util/grpc/interceptor_test.go
@@ -37,7 +37,7 @@ func TestSetVersionHeaderUnaryServerInterceptor(t *testing.T) {
 	mockReturn := "successful return"
 
 	t.Run("success", func(t *testing.T) {
-		handler := func(ctx context.Context, req interface{}) (interface{}, error) { return mockReturn, nil }
+		handler := func(ctx context.Context, req any) (any, error) { return mockReturn, nil }
 		msts := &mockServerTransportStream{}
 		baseCtx := logging.TestContext(t.Context())
 		ctx := grpc.NewContextWithServerTransportStream(baseCtx, msts)
@@ -51,7 +51,7 @@ func TestSetVersionHeaderUnaryServerInterceptor(t *testing.T) {
 	})
 
 	t.Run("upstream error handling", func(t *testing.T) {
-		handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, errors.New("error") }
+		handler := func(ctx context.Context, req any) (any, error) { return nil, errors.New("error") }
 		msts := &mockServerTransportStream{}
 		baseCtx := logging.TestContext(t.Context())
 		ctx := grpc.NewContextWithServerTransportStream(baseCtx, msts)
@@ -64,7 +64,7 @@ func TestSetVersionHeaderUnaryServerInterceptor(t *testing.T) {
 	})
 
 	t.Run("SetHeader error handling", func(t *testing.T) {
-		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		handler := func(ctx context.Context, req any) (any, error) {
 			return mockReturn, nil
 		}
 		msts := &mockServerTransportStream{isError: true}

--- a/util/json/json.go
+++ b/util/json/json.go
@@ -17,7 +17,7 @@ func (j *JSONMarshaler) ContentType() string {
 }
 
 // Marshal implements gwruntime.Marshaler.
-func (j *JSONMarshaler) Marshal(v interface{}) ([]byte, error) {
+func (j *JSONMarshaler) Marshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
@@ -32,7 +32,7 @@ func (j *JSONMarshaler) NewEncoder(w io.Writer) gwruntime.Encoder {
 }
 
 // Unmarshal implements gwruntime.Marshaler.
-func (j *JSONMarshaler) Unmarshal(data []byte, v interface{}) error {
+func (j *JSONMarshaler) Unmarshal(data []byte, v any) error {
 	return json.Unmarshal(data, v)
 }
 
@@ -47,7 +47,7 @@ func DisallowUnknownFields(d *json.Decoder) *json.Decoder {
 type JSONOpt func(*json.Decoder) *json.Decoder
 
 // Unmarshal is a convenience wrapper around json.Unmarshal to support json decode options
-func Unmarshal(j []byte, o interface{}, opts ...JSONOpt) error {
+func Unmarshal(j []byte, o any, opts ...JSONOpt) error {
 	d := json.NewDecoder(bytes.NewReader(j))
 	for _, opt := range opts {
 		d = opt(d)
@@ -56,7 +56,7 @@ func Unmarshal(j []byte, o interface{}, opts ...JSONOpt) error {
 }
 
 // UnmarshalStrict is a convenience wrapper around json.Unmarshal with strict unmarshal options
-func UnmarshalStrict(j []byte, o interface{}) error {
+func UnmarshalStrict(j []byte, o any) error {
 	return Unmarshal(j, o, DisallowUnknownFields)
 }
 

--- a/util/json/jsonify.go
+++ b/util/json/jsonify.go
@@ -2,11 +2,11 @@ package json
 
 import "encoding/json"
 
-func Jsonify(v interface{}) (map[string]interface{}, error) {
+func Jsonify(v any) (map[string]any, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
-	x := make(map[string]interface{})
+	x := make(map[string]any)
 	return x, json.Unmarshal(data, &x)
 }

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -260,11 +260,11 @@ func decodeBasicAuthToken(auth string) (username, password string, ok bool) {
 		return
 	}
 	cs := string(c)
-	s := strings.IndexByte(cs, ':')
-	if s < 0 {
+	before, after, ok0 := strings.Cut(cs, ":")
+	if !ok0 {
 		return
 	}
-	return cs[:s], cs[s+1:], true
+	return before, after, true
 }
 
 func ReloadKubeConfig(explicitPath string) clientcmd.ClientConfig {

--- a/util/logging/init_test.go
+++ b/util/logging/init_test.go
@@ -39,7 +39,7 @@ func TestInitLogger(t *testing.T) {
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		require.Len(t, lines, 4)
 
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 
 		err := json.Unmarshal([]byte(lines[0]), &logEntry)
 		require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestInitLogger(t *testing.T) {
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		require.Len(t, lines, 2)
 
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 
 		err := json.Unmarshal([]byte(lines[0]), &logEntry)
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestInitLogger(t *testing.T) {
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		require.Len(t, lines, 1)
 
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 		err := json.Unmarshal([]byte(lines[0]), &logEntry)
 		require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestInitLogger(t *testing.T) {
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		require.Len(t, lines, 2)
 
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 
 		err := json.Unmarshal([]byte(lines[0]), &logEntry)
 		require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestInitLogger(t *testing.T) {
 		lines := strings.Split(strings.TrimSpace(output), "\n")
 		require.Len(t, lines, 3)
 
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 
 		err := json.Unmarshal([]byte(lines[0]), &logEntry)
 		require.NoError(t, err)
@@ -262,7 +262,7 @@ func TestInitLogger(t *testing.T) {
 
 		// Start multiple goroutines logging simultaneously
 		done := make(chan bool, 10)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			go func(id int) {
 				defer func() { done <- true }()
 				initLogger.WithField("goroutine", id).Info(ctx, "concurrent message")
@@ -281,7 +281,7 @@ func TestInitLogger(t *testing.T) {
 		require.Len(t, lines, 10)
 
 		for _, line := range lines {
-			var logEntry map[string]interface{}
+			var logEntry map[string]any
 			err := json.Unmarshal([]byte(line), &logEntry)
 			require.NoError(t, err)
 			assert.Equal(t, "concurrent message", logEntry["msg"])

--- a/util/printer/workflow-printer_test.go
+++ b/util/printer/workflow-printer_test.go
@@ -113,7 +113,7 @@ my-wf   Running   0s    3s         2          test-message   1/2/3   my-param=my
 
 func TestPrintWorkflowCostOptimizationNudges(t *testing.T) {
 	completedWorkflows := wfv1.Workflows{}
-	for i := 0; i < 101; i++ {
+	for range 101 {
 		completedWorkflows = append(completedWorkflows,
 			wfv1.Workflow{
 				Status: wfv1.WorkflowStatus{
@@ -122,7 +122,7 @@ func TestPrintWorkflowCostOptimizationNudges(t *testing.T) {
 			})
 	}
 	incompleteWorkflows := wfv1.Workflows{}
-	for i := 0; i < 101; i++ {
+	for range 101 {
 		incompleteWorkflows = append(incompleteWorkflows,
 			wfv1.Workflow{
 				Status: wfv1.WorkflowStatus{

--- a/util/telemetry/instrument.go
+++ b/util/telemetry/instrument.go
@@ -12,8 +12,8 @@ import (
 type Instrument struct {
 	name        string
 	description string
-	otel        interface{}
-	userdata    interface{}
+	otel        any
+	userdata    any
 }
 
 func (m *Metrics) preCreateCheck(name string) error {
@@ -76,7 +76,7 @@ func (m *Metrics) CreateInstrument(instType instrumentType, name, desc, unit str
 	if opts.builtIn {
 		desc = addHelpLink(name, desc)
 	}
-	var instPtr interface{}
+	var instPtr any
 	switch instType {
 	case Float64ObservableGauge:
 		inst, insterr := (*m.otelMeter).Float64ObservableGauge(name,
@@ -154,14 +154,14 @@ func (i *Instrument) GetDescription() string {
 	return i.description
 }
 
-func (i *Instrument) GetOtel() interface{} {
+func (i *Instrument) GetOtel() any {
 	return i.otel
 }
 
-func (i *Instrument) SetUserdata(data interface{}) {
+func (i *Instrument) SetUserdata(data any) {
 	i.userdata = data
 }
 
-func (i *Instrument) GetUserdata() interface{} {
+func (i *Instrument) GetUserdata() any {
 	return i.userdata
 }

--- a/util/telemetry/operators.go
+++ b/util/telemetry/operators.go
@@ -91,7 +91,7 @@ func (i *Instrument) ObserveFloat(ctx context.Context, o metric.Observer, val fl
 type InstAttribs []InstAttrib
 type InstAttrib struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 func (i *Instrument) attributes(ctx context.Context, labels InstAttribs) metric.MeasurementOption {

--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -34,7 +34,7 @@ var variablesToCheck = []string{
 	"workflow.failures",
 }
 
-func anyVarNotInEnv(expression string, env map[string]interface{}) *string {
+func anyVarNotInEnv(expression string, env map[string]any) *string {
 	for _, variable := range variablesToCheck {
 		if hasVariableInExpression(expression, variable) && !hasVarInEnv(env, variable) {
 			return &variable
@@ -43,7 +43,7 @@ func anyVarNotInEnv(expression string, env map[string]interface{}) *string {
 	return nil
 }
 
-func expressionReplace(ctx context.Context, w io.Writer, expression string, env map[string]interface{}, allowUnresolved bool) (int, error) {
+func expressionReplace(ctx context.Context, w io.Writer, expression string, env map[string]any, allowUnresolved bool) (int, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	// The template is JSON-marshaled. This JSON-unmarshals the expression to undo any character escapes.
 	var unmarshalledExpression string
@@ -107,8 +107,8 @@ func expressionReplace(ctx context.Context, w io.Writer, expression string, env 
 	return w.Write(resultQuoted[1 : len(resultQuoted)-1])
 }
 
-func EnvMap(replaceMap map[string]string) map[string]interface{} {
-	envMap := make(map[string]interface{})
+func EnvMap(replaceMap map[string]string) map[string]any {
+	envMap := make(map[string]any)
 	for k, v := range replaceMap {
 		envMap[k] = v
 	}
@@ -124,7 +124,7 @@ func searchTokens(haystack []lexer.Token, needle []lexer.Token) bool {
 	}
 outer:
 	for i := 0; i <= len(haystack)-len(needle); i++ {
-		for j := 0; j < len(needle); j++ {
+		for j := range needle {
 			if haystack[i+j].String() != needle[j].String() {
 				continue outer
 			}
@@ -167,7 +167,7 @@ func hasVariableInExpression(expression, variable string) bool {
 }
 
 // hasVarInEnv checks if a parameter is in env or not
-func hasVarInEnv(env map[string]interface{}, parameter string) bool {
+func hasVarInEnv(env map[string]any, parameter string) bool {
 	flattenEnv := bellows.Flatten(env)
 	_, ok := flattenEnv[parameter]
 	return ok

--- a/util/template/replace.go
+++ b/util/template/replace.go
@@ -16,7 +16,7 @@ func Replace(ctx context.Context, s string, replaceMap map[string]string, allowU
 	if err != nil {
 		return "", err
 	}
-	interReplaceMap := make(map[string]interface{})
+	interReplaceMap := make(map[string]any)
 	for k, v := range replaceMap {
 		interReplaceMap[k] = v
 	}

--- a/util/template/replace_test.go
+++ b/util/template/replace_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/logging"
 )
 
-func toJSONString(v interface{}) string {
+func toJSONString(v any) string {
 	jsonString, _ := json.Marshal(v)
 	return string(jsonString)
 }

--- a/util/template/resolve_var.go
+++ b/util/template/resolve_var.go
@@ -8,7 +8,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/errors"
 )
 
-func ResolveVar(s string, m map[string]interface{}) (interface{}, error) {
+func ResolveVar(s string, m map[string]any) (any, error) {
 	tag := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(s, prefix), suffix))
 	kind, expression := parseTag(tag)
 	switch kind {

--- a/util/template/resolve_var_test.go
+++ b/util/template/resolve_var_test.go
@@ -10,12 +10,12 @@ import (
 func Test_ResolveVar(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
-			v, err := ResolveVar("{{foo}}", map[string]interface{}{"foo": "bar"})
+			v, err := ResolveVar("{{foo}}", map[string]any{"foo": "bar"})
 			require.NoError(t, err)
 			assert.Equal(t, "bar", v)
 		})
 		t.Run("Whitespace", func(t *testing.T) {
-			v, err := ResolveVar("{{ foo }}", map[string]interface{}{"foo": "bar"})
+			v, err := ResolveVar("{{ foo }}", map[string]any{"foo": "bar"})
 			require.NoError(t, err)
 			assert.Equal(t, "bar", v)
 		})
@@ -26,7 +26,7 @@ func Test_ResolveVar(t *testing.T) {
 	})
 	t.Run("Expression", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
-			v, err := ResolveVar("{{=foo}}", map[string]interface{}{"foo": "bar"})
+			v, err := ResolveVar("{{=foo}}", map[string]any{"foo": "bar"})
 			require.NoError(t, err)
 			assert.Equal(t, "bar", v)
 		})

--- a/util/template/simple_template.go
+++ b/util/template/simple_template.go
@@ -11,7 +11,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/logging"
 )
 
-func simpleReplace(ctx context.Context, w io.Writer, tag string, replaceMap map[string]interface{}, allowUnresolved bool) (int, error) {
+func simpleReplace(ctx context.Context, w io.Writer, tag string, replaceMap map[string]any, allowUnresolved bool) (int, error) {
 	replacement, ok := replaceMap[strings.TrimSpace(tag)]
 	if !ok {
 		// Attempt to resolve nested tags, if possible

--- a/util/template/template.go
+++ b/util/template/template.go
@@ -16,7 +16,7 @@ const (
 )
 
 type Template interface {
-	Replace(ctx context.Context, replaceMap map[string]interface{}, allowUnresolved bool) (string, error)
+	Replace(ctx context.Context, replaceMap map[string]any, allowUnresolved bool) (string, error)
 }
 
 func NewTemplate(s string) (Template, error) {
@@ -31,7 +31,7 @@ type impl struct {
 	*fasttemplate.Template
 }
 
-func (t *impl) Replace(ctx context.Context, replaceMap map[string]interface{}, allowUnresolved bool) (string, error) {
+func (t *impl) Replace(ctx context.Context, replaceMap map[string]any, allowUnresolved bool) (string, error) {
 	replacedTmpl := &bytes.Buffer{}
 	_, err := t.ExecuteFunc(replacedTmpl, func(w io.Writer, tag string) (int, error) {
 		kind, expression := parseTag(tag)

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -30,7 +30,7 @@ const (
 	tlsKeySecretKey = "tls.key"
 )
 
-func pemBlockForKey(priv interface{}) *pem.Block {
+func pemBlockForKey(priv any) *pem.Block {
 	switch k := priv.(type) {
 	case *ecdsa.PrivateKey:
 		b, err := x509.MarshalECPrivateKey(k)

--- a/util/unstructured/unstructured.go
+++ b/util/unstructured/unstructured.go
@@ -50,7 +50,7 @@ func NewFilteredUnstructuredInformer(ctx context.Context, resource schema.GroupV
 					continueTok = unList.GetContinue()
 				}
 				return &unstructured.UnstructuredList{
-					Object: map[string]interface{}{
+					Object: map[string]any{
 						"apiVersion": "v1",
 						"kind":       "List",
 					},

--- a/util/unstructured/workflow/conditions.go
+++ b/util/unstructured/workflow/conditions.go
@@ -15,7 +15,7 @@ func GetConditions(un *unstructured.Unstructured) wfv1.Conditions {
 	items, _, _ := unstructured.NestedSlice(un.Object, "status", "conditions")
 	var x wfv1.Conditions
 	for _, item := range items {
-		m, ok := item.(map[string]interface{})
+		m, ok := item.(map[string]any)
 		if !ok {
 			return nil
 		}

--- a/util/unstructured/workflow/conditions_test.go
+++ b/util/unstructured/workflow/conditions_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGetConditions(t *testing.T) {
 	t.Run("Nil", func(t *testing.T) {
-		un := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		un := &unstructured.Unstructured{Object: map[string]any{}}
 
 		assert.Nil(t, GetConditions(un))
 	})

--- a/util/util.go
+++ b/util/util.go
@@ -113,10 +113,10 @@ func GenerateFieldSelectorFromWorkflowName(wfName string) string {
 
 func RecoverWorkflowNameFromSelectorStringIfAny(selector string) string {
 	const tag = "metadata.name="
-	if starts := strings.Index(selector, tag); starts > -1 {
-		suffix := selector[starts+len(tag):]
-		if ends := strings.Index(suffix, ","); ends > -1 {
-			return strings.TrimSpace(suffix[:ends])
+	if _, after, ok := strings.Cut(selector, tag); ok {
+		suffix := after
+		if before, _, ok := strings.Cut(suffix, ","); ok {
+			return strings.TrimSpace(before)
 		}
 		return strings.TrimSpace(suffix)
 	}

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -290,7 +290,7 @@ var AnnotationKeyKillCmd = func(containerName string) string { return workflow.W
 // GlobalVarWorkflowRootTags is a list of root tags in workflow which could be used for variable reference
 var GlobalVarValidWorkflowVariablePrefix = []string{"item.", "steps.", "inputs.", "outputs.", "pod.", "workflow.", "tasks."}
 
-func UnstructuredHasCompletedLabel(obj interface{}) bool {
+func UnstructuredHasCompletedLabel(obj any) bool {
 	if wf, ok := obj.(*unstructured.Unstructured); ok {
 		return wf.GetLabels()[LabelKeyCompleted] == "true"
 	}

--- a/workflow/common/common_test.go
+++ b/workflow/common/common_test.go
@@ -11,18 +11,18 @@ func TestUnstructuredHasCompletedLabel(t *testing.T) {
 	noLabel := &unstructured.Unstructured{}
 	assert.False(t, UnstructuredHasCompletedLabel(noLabel))
 
-	label := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
+	label := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
 				LabelKeyCompleted: "true",
 			},
 		},
 	}}
 	assert.True(t, UnstructuredHasCompletedLabel(label))
 
-	falseLabel := &unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
+	falseLabel := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
 				LabelKeyCompleted: "false",
 			},
 		},

--- a/workflow/common/configmap.go
+++ b/workflow/common/configmap.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ConfigMapStore interface {
-	GetByKey(key string) (interface{}, bool, error)
+	GetByKey(key string) (any, bool, error)
 }
 
 // GetConfigMapValue retrieves a configmap value

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -117,7 +117,7 @@ func substituteAndGetConfigMapValue(ctx context.Context, inParam *wfv1.Parameter
 	log := logging.RequireLoggerFromContext(ctx)
 	if inParam.ValueFrom != nil && inParam.ValueFrom.ConfigMapKeyRef != nil {
 		if configMapStore != nil {
-			replaceMap := make(map[string]interface{})
+			replaceMap := make(map[string]any)
 			for k, v := range globalParams {
 				replaceMap[k] = v
 			}
@@ -209,7 +209,7 @@ func ProcessArgs(ctx context.Context, tmpl *wfv1.Template, args wfv1.ArgumentsPr
 }
 
 // substituteConfigMapKeyRefParam performs template substitution for ConfigMapKeyRef
-func substituteConfigMapKeyRefParam(ctx context.Context, in string, replaceMap map[string]interface{}) (string, error) {
+func substituteConfigMapKeyRefParam(ctx context.Context, in string, replaceMap map[string]any) (string, error) {
 	tmpl, err := template.NewTemplate(in)
 	if err != nil {
 		return "", err

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -131,16 +131,16 @@ func TestGetTemplateHolderString(t *testing.T) {
 
 func TestIsDone(t *testing.T) {
 	assert.False(t, IsDone(&unstructured.Unstructured{}))
-	assert.True(t, IsDone(&unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
+	assert.True(t, IsDone(&unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
 				LabelKeyCompleted: "true",
 			},
 		},
 	}}))
-	assert.False(t, IsDone(&unstructured.Unstructured{Object: map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
+	assert.False(t, IsDone(&unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
 				LabelKeyCompleted:               "true",
 				LabelKeyWorkflowArchivingStatus: "Pending",
 			},
@@ -149,7 +149,7 @@ func TestIsDone(t *testing.T) {
 }
 
 func TestSubstituteConfigMapKeyRefParam(t *testing.T) {
-	globalParams := map[string]interface{}{
+	globalParams := map[string]any{
 		"workflow.parameters.name": "simple-parameters",
 		"workflow.parameters.key":  "msg",
 	}
@@ -255,10 +255,10 @@ func TestOverridableDefaultInputArts(t *testing.T) {
 }
 
 type mockConfigMapStore struct {
-	getByKey func(key string) (interface{}, bool, error)
+	getByKey func(key string) (any, bool, error)
 }
 
-func (cs mockConfigMapStore) GetByKey(key string) (interface{}, bool, error) {
+func (cs mockConfigMapStore) GetByKey(key string) (any, bool, error) {
 	return cs.getByKey(key)
 }
 
@@ -274,7 +274,7 @@ func TestOverridableTemplateInputParamsValue(t *testing.T) {
 	overrideConfigMapValue := "override-config-map-value"
 
 	configMapStore := mockConfigMapStore{}
-	configMapStore.getByKey = func(key string) (interface{}, bool, error) {
+	configMapStore.getByKey = func(key string) (any, bool, error) {
 		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{LabelKeyConfigMapType: LabelValueTypeConfigMapParameter}},
 			Data: map[string]string{overrideConfigMapKey: overrideConfigMapValue},
@@ -321,7 +321,7 @@ func TestOverridableTemplateInputParamsValueFrom(t *testing.T) {
 	overrideConfigMapValue := "override-config-map-value"
 
 	configMapStore := mockConfigMapStore{}
-	configMapStore.getByKey = func(key string) (interface{}, bool, error) {
+	configMapStore.getByKey = func(key string) (any, bool, error) {
 		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{LabelKeyConfigMapType: LabelValueTypeConfigMapParameter}},
 			Data: map[string]string{configMapKey: configMapValue, overrideConfigMapKey: overrideConfigMapValue},

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -391,12 +391,12 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	go wait.UntilWithContext(ctx, wfc.syncManager.CheckWorkflowExistence, workflowExistenceCheckPeriod)
 
 	workerCtx, _ := logger.WithField("component", "workflow_worker").InContext(ctx)
-	for i := 0; i < wfWorkers; i++ {
+	for range wfWorkers {
 		go wait.UntilWithContext(workerCtx, wfc.runWorker, time.Second)
 	}
 
 	archiveCtx, _ := logger.WithField("component", "archive_worker").InContext(ctx)
-	for i := 0; i < wfArchiveWorkers; i++ {
+	for range wfArchiveWorkers {
 		go wait.UntilWithContext(archiveCtx, wfc.runArchiveWorker, time.Second)
 	}
 	if cacheGCPeriod != 0 {
@@ -824,7 +824,7 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 	return true
 }
 
-func (wfc *WorkflowController) getWorkflowByKey(ctx context.Context, key string) (interface{}, bool) {
+func (wfc *WorkflowController) getWorkflowByKey(ctx context.Context, key string) (any, bool) {
 	logger := logging.RequireLoggerFromContext(ctx)
 	obj, exists, err := wfc.wfInformer.GetIndexer().GetByKey(key)
 	if err != nil {
@@ -880,7 +880,7 @@ func (wfc *WorkflowController) tweakWatchRequestListOptions(options *metav1.List
 	options.LabelSelector = labelSelector.String()
 }
 
-func getWfPriority(obj interface{}) (int32, time.Time) {
+func getWfPriority(obj any) (int32, time.Time) {
 	un, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return 0, time.Now()
@@ -956,7 +956,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 			// informer cache and can be used to reject things from
 			// the cache. When they are rejected (this returns false)
 			// they will be deleted.
-			FilterFunc: func(obj interface{}) bool {
+			FilterFunc: func(obj any) bool {
 				un, ok := obj.(*unstructured.Unstructured)
 				if !ok {
 					logger.WithField("obj", obj).Warn(ctx, "Workflow FilterFunc: is not an unstructured")
@@ -973,7 +973,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 			Handler: cache.ResourceEventHandlerFuncs{
 				// This function is called when a new to the informer object
 				// is to be added to the informer
-				AddFunc: func(obj interface{}) {
+				AddFunc: func(obj any) {
 					key, err := cache.MetaNamespaceKeyFunc(obj)
 					if err == nil {
 						// for a new workflow, we do not want to rate limit its execution using AddRateLimited
@@ -984,7 +984,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 				},
 				// This function is called when an updated (we already know about this object)
 				// is to be updated in the informer
-				UpdateFunc: func(old, newObj interface{}) {
+				UpdateFunc: func(old, newObj any) {
 					oldWf, newWf := old.(*unstructured.Unstructured), newObj.(*unstructured.Unstructured)
 					// this check is very important to prevent doing many reconciliations we do not need to do
 					if oldWf.GetResourceVersion() == newWf.GetResourceVersion() {
@@ -999,7 +999,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 				},
 				// This function is called when an object is to be removed
 				// from the informer
-				DeleteFunc: func(obj interface{}) {
+				DeleteFunc: func(obj any) {
 					// IndexerInformer uses a delta queue, therefore for deletes we have to use this
 					// key function.
 
@@ -1033,19 +1033,19 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 		return err
 	}
 	_, err = wfc.wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: func(obj interface{}) bool {
+		FilterFunc: func(obj any) bool {
 			un, ok := obj.(*unstructured.Unstructured)
 			// no need to check the `common.LabelKeyCompleted` as we already know it must be complete
 			return ok && un.GetLabels()[common.LabelKeyWorkflowArchivingStatus] == "Pending"
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				key, err := cache.MetaNamespaceKeyFunc(obj)
 				if err == nil {
 					wfc.wfArchiveQueue.Add(key)
 				}
 			},
-			UpdateFunc: func(_, obj interface{}) {
+			UpdateFunc: func(_, obj any) {
 				key, err := cache.MetaNamespaceKeyFunc(obj)
 				if err == nil {
 					wfc.wfArchiveQueue.Add(key)
@@ -1057,7 +1057,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 		return err
 	}
 	_, err = wfc.wfInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			var wf *unstructured.Unstructured
 			switch x := obj.(type) {
 			case *unstructured.Unstructured:
@@ -1076,7 +1076,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 	return nil
 }
 
-func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj interface{}) {
+func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) {
 	logger := logging.RequireLoggerFromContext(ctx)
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
@@ -1096,7 +1096,7 @@ func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj interfac
 	}
 }
 
-func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj interface{}) error {
+func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) error {
 	un, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return nil
@@ -1115,7 +1115,7 @@ func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj inter
 	if err != nil {
 		return fmt.Errorf("failed to archive workflow: %w", err)
 	}
-	data, err := json.Marshal(map[string]interface{}{
+	data, err := json.Marshal(map[string]any{
 		"metadata": metav1.ObjectMeta{
 			Labels: map[string]string{
 				common.LabelKeyWorkflowArchivingStatus: "Archived",
@@ -1158,7 +1158,7 @@ func (wfc *WorkflowController) newConfigMapInformer(ctx context.Context) cache.S
 	if wfc.executorPlugins != nil {
 		//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 		indexInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
+			FilterFunc: func(obj any) bool {
 				cm, err := meta.Accessor(obj)
 				if err != nil {
 					return false
@@ -1166,7 +1166,7 @@ func (wfc *WorkflowController) newConfigMapInformer(ctx context.Context) cache.S
 				return cm.GetLabels()[common.LabelKeyConfigMapType] == common.LabelValueTypeConfigMapExecutorPlugin
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
+				AddFunc: func(obj any) {
 					cm := obj.(*apiv1.ConfigMap)
 					p, err := plugin.FromConfigMap(cm)
 					if err != nil {
@@ -1185,7 +1185,7 @@ func (wfc *WorkflowController) newConfigMapInformer(ctx context.Context) cache.S
 						"name":      cm.GetName(),
 					}).Info(ctx, "Executor plugin added")
 				},
-				UpdateFunc: func(_, obj interface{}) {
+				UpdateFunc: func(_, obj any) {
 					cm := obj.(*apiv1.ConfigMap)
 					p, err := plugin.FromConfigMap(cm)
 					if err != nil {
@@ -1202,7 +1202,7 @@ func (wfc *WorkflowController) newConfigMapInformer(ctx context.Context) cache.S
 						"name":      cm.GetName(),
 					}).Info(ctx, "Executor plugin updated")
 				},
-				DeleteFunc: func(obj interface{}) {
+				DeleteFunc: func(obj any) {
 					key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 					namespace, name, _ := cache.SplitMetaNamespaceKey(key)
 					delete(wfc.executorPlugins[namespace], name)
@@ -1270,7 +1270,7 @@ func (wfc *WorkflowController) getMetricsServerConfig() *telemetry.Config {
 	return &metricsConfig
 }
 
-func (wfc *WorkflowController) releaseAllWorkflowLocks(ctx context.Context, obj interface{}) {
+func (wfc *WorkflowController) releaseAllWorkflowLocks(ctx context.Context, obj any) {
 	un, ok := obj.(*unstructured.Unstructured)
 	logger := logging.RequireLoggerFromContext(ctx)
 	if !ok {
@@ -1338,7 +1338,7 @@ func (wfc *WorkflowController) newWorkflowTaskSetInformer() wfextvv1alpha1.Workf
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	informer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			UpdateFunc: func(old, newObj interface{}) {
+			UpdateFunc: func(old, newObj any) {
 				key, err := cache.MetaNamespaceKeyFunc(newObj)
 				if err == nil {
 					wfc.wfQueue.AddRateLimited(key)
@@ -1360,7 +1360,7 @@ func (wfc *WorkflowController) newArtGCTaskInformer() wfextvv1alpha1.WorkflowArt
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	informer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			UpdateFunc: func(old, newObj interface{}) {
+			UpdateFunc: func(old, newObj any) {
 				key, err := cache.MetaNamespaceKeyFunc(newObj)
 				if err == nil {
 					wfc.wfQueue.AddRateLimited(key)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -253,7 +253,7 @@ var defaultServiceAccount = &apiv1.ServiceAccount{
 // test exporter extract metric values from the metrics subsystem
 var testExporter *telemetry.TestMetricsExporter
 
-func newController(ctx context.Context, options ...interface{}) (context.CancelFunc, *WorkflowController) {
+func newController(ctx context.Context, options ...any) (context.CancelFunc, *WorkflowController) {
 	// get all the objects and add to the fake
 	var objects, coreObjects []runtime.Object
 	for _, opt := range options {
@@ -967,7 +967,7 @@ func TestNotifySemaphoreConfigUpdate(t *testing.T) {
 	assert.Equal(3, controller.wfQueue.Len())
 
 	// Remove all Wf from Worker queue
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		key, _ := controller.wfQueue.Get()
 		controller.wfQueue.Done(key)
 		controller.wfQueue.Forget(key)

--- a/workflow/controller/healthz.go
+++ b/workflow/controller/healthz.go
@@ -53,7 +53,7 @@ func (wfc *WorkflowController) Healthz(w http.ResponseWriter, r *http.Request) {
 
 		// establish a list of unreconciled workflows
 		unreconciledWorkflows := make(map[string]*wfv1.Workflow)
-		err = cache.ListAllByNamespace(wfc.wfInformer.GetIndexer(), wfc.managedNamespace, selector, func(m interface{}) {
+		err = cache.ListAllByNamespace(wfc.wfInformer.GetIndexer(), wfc.managedNamespace, selector, func(m any) {
 			// Informer holds Workflows as type *Unstructured
 			un := m.(*unstructured.Unstructured)
 			// verify it's of type *Workflow (if not, it's an incorrectly formatted Workflow spec)

--- a/workflow/controller/healthz_test.go
+++ b/workflow/controller/healthz_test.go
@@ -77,7 +77,7 @@ func TestHealthz(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		workflowsAsInterfaceSlice := []interface{}{}
+		workflowsAsInterfaceSlice := []any{}
 		for _, wf := range tt.workflows {
 			workflowsAsInterfaceSlice = append(workflowsAsInterfaceSlice, wf)
 		}

--- a/workflow/controller/indexes/conditions_index.go
+++ b/workflow/controller/indexes/conditions_index.go
@@ -9,7 +9,7 @@ import (
 	unwf "github.com/argoproj/argo-workflows/v3/util/unstructured/workflow"
 )
 
-func ConditionsIndexFunc(obj interface{}) ([]string, error) {
+func ConditionsIndexFunc(obj any) ([]string, error) {
 	var values []string
 	for _, x := range unwf.GetConditions(obj.(*unstructured.Unstructured)) {
 		values = append(values, ConditionValue(x))

--- a/workflow/controller/indexes/configmap_index.go
+++ b/workflow/controller/indexes/configmap_index.go
@@ -6,7 +6,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
-func ConfigMapIndexFunc(obj interface{}) ([]string, error) {
+func ConfigMapIndexFunc(obj any) ([]string, error) {
 	cm, ok := obj.(*corev1.ConfigMap)
 
 	if !ok {

--- a/workflow/controller/indexes/labels.go
+++ b/workflow/controller/indexes/labels.go
@@ -13,7 +13,7 @@ func MetaNamespaceLabelIndex(namespace, label string) string {
 }
 
 func MetaWorkflowPhaseIndexFunc() cache.IndexFunc {
-	return func(obj interface{}) ([]string, error) {
+	return func(obj any) ([]string, error) {
 		v, err := meta.Accessor(obj)
 		if err != nil {
 			return nil, err
@@ -28,7 +28,7 @@ func MetaWorkflowPhaseIndexFunc() cache.IndexFunc {
 }
 
 func MetaNamespaceLabelIndexFunc(label string) cache.IndexFunc {
-	return func(obj interface{}) ([]string, error) {
+	return func(obj any) ([]string, error) {
 		v, err := meta.Accessor(obj)
 		if err != nil {
 			return nil, err

--- a/workflow/controller/indexes/pod_index.go
+++ b/workflow/controller/indexes/pod_index.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func PodPhaseIndexFunc(obj interface{}) ([]string, error) {
+func PodPhaseIndexFunc(obj any) ([]string, error) {
 	pod, ok := obj.(*corev1.Pod)
 
 	if !ok {

--- a/workflow/controller/indexes/uid_index.go
+++ b/workflow/controller/indexes/uid_index.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-var MetaUIDFunc cache.IndexFunc = func(obj interface{}) ([]string, error) {
+var MetaUIDFunc cache.IndexFunc = func(obj any) ([]string, error) {
 	v, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, nil

--- a/workflow/controller/indexes/workflow_index.go
+++ b/workflow/controller/indexes/workflow_index.go
@@ -21,7 +21,7 @@ func init() {
 	logging.InitLogger().WithField("indexWorkflowSemaphoreKeys", indexWorkflowSemaphoreKeys).Info(context.Background(), "index config")
 }
 
-func MetaWorkflowIndexFunc(obj interface{}) ([]string, error) {
+func MetaWorkflowIndexFunc(obj any) ([]string, error) {
 	m, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func MetaWorkflowIndexFunc(obj interface{}) ([]string, error) {
 
 // MetaNodeIDIndexFunc takes a kubernetes object and returns either the
 // namespace and its node id or the namespace and its name
-func MetaNodeIDIndexFunc(obj interface{}) ([]string, error) {
+func MetaNodeIDIndexFunc(obj any) ([]string, error) {
 	m, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -54,11 +54,11 @@ func WorkflowIndexValue(namespace, name string) string {
 
 func WorkflowSemaphoreKeysIndexFunc() cache.IndexFunc {
 	if !indexWorkflowSemaphoreKeys {
-		return func(obj interface{}) ([]string, error) {
+		return func(obj any) ([]string, error) {
 			return nil, nil
 		}
 	}
-	return func(obj interface{}) ([]string, error) {
+	return func(obj any) ([]string, error) {
 		un, ok := obj.(*unstructured.Unstructured)
 		if !ok {
 			return nil, nil

--- a/workflow/controller/informer/cluster_workflow_template_convert.go
+++ b/workflow/controller/informer/cluster_workflow_template_convert.go
@@ -27,7 +27,7 @@ func objectsToClusterWorkflowTemplates(list []runtime.Object) []*wfv1.ClusterWor
 }
 
 // this function always tries to return a value, even if it is badly formed
-func interfaceToClusterWorkflowTemplate(object interface{}) (*wfv1.ClusterWorkflowTemplate, error) {
+func interfaceToClusterWorkflowTemplate(object any) (*wfv1.ClusterWorkflowTemplate, error) {
 	v := &wfv1.ClusterWorkflowTemplate{}
 	un, ok := object.(*unstructured.Unstructured)
 	if !ok {

--- a/workflow/controller/informer/cluster_workflow_template_convert_test.go
+++ b/workflow/controller/informer/cluster_workflow_template_convert_test.go
@@ -19,8 +19,8 @@ func Test_objectToClusterWorkflowTemplate(t *testing.T) {
 		assert.NotNil(t, v)
 	})
 	t.Run("MalformedClusterWorkflowTemplate", func(t *testing.T) {
-		v, err := objectToClusterWorkflowTemplate(&unstructured.Unstructured{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"name": "my-name"},
+		v, err := objectToClusterWorkflowTemplate(&unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "my-name"},
 			"spec":     "ops",
 		}})
 		require.EqualError(t, err, "malformed cluster workflow template \"my-name\": cannot restore struct from: string")

--- a/workflow/controller/informer/workflow_template_convert.go
+++ b/workflow/controller/informer/workflow_template_convert.go
@@ -26,7 +26,7 @@ func objectsToWorkflowTemplates(list []runtime.Object) []*wfv1.WorkflowTemplate 
 	return ret
 }
 
-func interfaceToWorkflowTemplate(object interface{}) (*wfv1.WorkflowTemplate, error) {
+func interfaceToWorkflowTemplate(object any) (*wfv1.WorkflowTemplate, error) {
 	v := &wfv1.WorkflowTemplate{}
 	un, ok := object.(*unstructured.Unstructured)
 	if !ok {

--- a/workflow/controller/informer/workflow_template_convert_test.go
+++ b/workflow/controller/informer/workflow_template_convert_test.go
@@ -19,8 +19,8 @@ func Test_objectToWorkflowTemplate(t *testing.T) {
 		assert.NotNil(t, v)
 	})
 	t.Run("MalformedWorkflowTemplate", func(t *testing.T) {
-		v, err := objectToWorkflowTemplate(&unstructured.Unstructured{Object: map[string]interface{}{
-			"metadata": map[string]interface{}{"namespace": "my-ns", "name": "my-name"},
+		v, err := objectToWorkflowTemplate(&unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"namespace": "my-ns", "name": "my-name"},
 			"spec":     "ops",
 		}})
 		require.EqualError(t, err, "malformed workflow template \"my-ns/my-name\": cannot restore struct from: string")

--- a/workflow/controller/ns_watcher.go
+++ b/workflow/controller/ns_watcher.go
@@ -59,7 +59,7 @@ func (wfc *WorkflowController) newNamespaceInformer(ctx context.Context, kubecli
 
 	_, err := informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				ns, err := nsFromObj(obj)
 				if err != nil {
 					return
@@ -67,7 +67,7 @@ func (wfc *WorkflowController) newNamespaceInformer(ctx context.Context, kubecli
 				updateNS(ctx, ns, wfc.throttler.UpdateNamespaceParallelism, wfc.throttler.ResetNamespaceParallelism)
 			},
 
-			UpdateFunc: func(old, newVal interface{}) {
+			UpdateFunc: func(old, newVal any) {
 				ns, err := nsFromObj(newVal)
 				if err != nil {
 					return
@@ -79,7 +79,7 @@ func (wfc *WorkflowController) newNamespaceInformer(ctx context.Context, kubecli
 				updateNS(ctx, ns, wfc.throttler.UpdateNamespaceParallelism, wfc.throttler.ResetNamespaceParallelism)
 			},
 
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				ns, err := nsFromObj(obj)
 				if err != nil {
 					return
@@ -114,7 +114,7 @@ func updateNS(ctx context.Context, ns *apiv1.Namespace, updateFn updateFunc, res
 	updateFn(ns.Name, limit)
 }
 
-func nsFromObj(obj interface{}) (*apiv1.Namespace, error) {
+func nsFromObj(obj any) (*apiv1.Namespace, error) {
 	ns, ok := obj.(*apiv1.Namespace)
 	if !ok {
 		return nil, errors.New("was unable to convert to namespace")

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2048,8 +2048,8 @@ func getRetryNodeChildrenIds(node *wfv1.NodeStatus, nodes wfv1.Nodes) []string {
 	return childrenIds
 }
 
-func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[string]interface{} {
-	localScope := make(map[string]interface{})
+func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[string]any {
+	localScope := make(map[string]any)
 
 	// `retries` variable
 	childNodeIds, lastChildNode := getChildNodeIdsAndLastRetriedNode(node, nodes)
@@ -3607,19 +3607,19 @@ func (woc *wfOperationCtx) processAggregateNodeOutputs(scope *wfScope, prefix st
 // JSON and NOT a plain JSON value.
 // If returns success only if all items can be unmarshalled and are either
 // maps or lists
-func tryJSONUnmarshal(valueList []string) ([]interface{}, bool) {
+func tryJSONUnmarshal(valueList []string) ([]any, bool) {
 	success := true
-	var list []interface{}
+	var list []any
 	for _, value := range valueList {
-		var unmarshalledValue interface{}
+		var unmarshalledValue any
 		err := json.Unmarshal([]byte(value), &unmarshalledValue)
 		if err != nil {
 			success = false
 			break // Unmarshal failed, fall back to strings
 		}
 		switch unmarshalledValue.(type) {
-		case []interface{}:
-		case map[string]interface{}:
+		case []any:
+		case map[string]any:
 			// Keep these types
 		default:
 			// Drop anything else
@@ -3875,8 +3875,8 @@ func addRawOutputFields(node *wfv1.NodeStatus, tmpl *wfv1.Template) *wfv1.NodeSt
 	return node
 }
 
-func processItem(ctx context.Context, tmpl template.Template, name string, index int, item wfv1.Item, obj interface{}, whenCondition string, globalScope map[string]string) (string, error) {
-	replaceMap := make(map[string]interface{})
+func processItem(ctx context.Context, tmpl template.Template, name string, index int, item wfv1.Item, obj any, whenCondition string, globalScope map[string]string) (string, error) {
+	replaceMap := make(map[string]any)
 	// Start with the global scope
 	for k, v := range globalScope {
 		replaceMap[k] = v
@@ -3943,7 +3943,7 @@ func processItem(ctx context.Context, tmpl template.Template, name string, index
 	return newName, nil
 }
 
-func generateNodeName(name string, index int, desc interface{}) string {
+func generateNodeName(name string, index int, desc any) string {
 	// Do not display parentheses in node name. Nodes are still guaranteed to be unique due to the index number
 	replacer := strings.NewReplacer("(", "", ")", "")
 	cleanName := replacer.Replace(fmt.Sprint(desc))

--- a/workflow/controller/operator_aggregation_test.go
+++ b/workflow/controller/operator_aggregation_test.go
@@ -12,7 +12,7 @@ func TestTryJSONUnmarshal(t *testing.T) {
 	for _, testcase := range []struct {
 		input    []string
 		success  bool
-		expected []interface{}
+		expected []any
 	}{
 		{[]string{"1"}, false, nil},
 		{[]string{"1", "2"}, false, nil},
@@ -20,11 +20,11 @@ func TestTryJSONUnmarshal(t *testing.T) {
 		{[]string{"foo", "bar"}, false, nil},
 		{[]string{`["1"]`, "2"}, false, nil},       // Fails on second element
 		{[]string{`{"foo":"1"}`, "2"}, false, nil}, // Fails on second element
-		{[]string{`["1"]`, `["2"]`}, true, []interface{}{[]interface{}{"1"}, []interface{}{"2"}}},
-		{[]string{`["1"]`, `["2"]`}, true, []interface{}{[]interface{}{"1"}, []interface{}{"2"}}},
-		{[]string{"\n[\"1\"]  \n", "\t[\"2\"]\t"}, true, []interface{}{[]interface{}{"1"}, []interface{}{"2"}}},
-		{[]string{`{"number":"1"}`, `{"number":"2"}`}, true, []interface{}{map[string]interface{}{"number": "1"}, map[string]interface{}{"number": "2"}}},
-		{[]string{`[{"foo":"apple", "bar":"pear"}]`, `{"foo":"banana"}`}, true, []interface{}{[]interface{}{map[string]interface{}{"bar": "pear", "foo": "apple"}}, map[string]interface{}{"foo": "banana"}}},
+		{[]string{`["1"]`, `["2"]`}, true, []any{[]any{"1"}, []any{"2"}}},
+		{[]string{`["1"]`, `["2"]`}, true, []any{[]any{"1"}, []any{"2"}}},
+		{[]string{"\n[\"1\"]  \n", "\t[\"2\"]\t"}, true, []any{[]any{"1"}, []any{"2"}}},
+		{[]string{`{"number":"1"}`, `{"number":"2"}`}, true, []any{map[string]any{"number": "1"}, map[string]any{"number": "2"}}},
+		{[]string{`[{"foo":"apple", "bar":"pear"}]`, `{"foo":"banana"}`}, true, []any{[]any{map[string]any{"bar": "pear", "foo": "apple"}}, map[string]any{"foo": "banana"}}},
 	} {
 		t.Run(fmt.Sprintf("Unmarshal %v", testcase.input),
 			func(t *testing.T) {

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -977,8 +977,8 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		assert.Equal(t, wfv1.WorkflowPending, wocTwo.wf.Status.Phase)
 
 		// Shutdown the second workflow that's pending.
-		patchObj := map[string]interface{}{
-			"spec": map[string]interface{}{
+		patchObj := map[string]any{
+			"spec": map[string]any{
 				"shutdown": wfv1.ShutdownStrategyTerminate,
 			},
 		}
@@ -1021,8 +1021,8 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		assert.Equal(t, wfv1.WorkflowPending, wocTwo.wf.Status.Phase)
 
 		// Shutdown the second workflow that's pending.
-		patchObj := map[string]interface{}{
-			"spec": map[string]interface{}{
+		patchObj := map[string]any{
+			"spec": map[string]any{
 				"shutdown": wfv1.ShutdownStrategyStop,
 			},
 		}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -544,7 +544,7 @@ func TestProcessNodeRetries(t *testing.T) {
 	assert.Nil(t, lastChild)
 
 	// Add child nodes.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childNode)
@@ -628,7 +628,7 @@ func TestProcessNodeRetriesOnErrors(t *testing.T) {
 	assert.Nil(t, lastChild)
 
 	// Add child nodes.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childNode)
@@ -701,7 +701,7 @@ func TestProcessNodeRetriesOnTransientErrors(t *testing.T) {
 	assert.Nil(t, lastChild)
 
 	// Add child nodes.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childNode)
@@ -918,7 +918,7 @@ func TestProcessNodeRetriesBackoffOverflow(t *testing.T) {
 	woc.wf.Status.Nodes[nodeID] = *node
 
 	// Add 32 child nodes to trigger overflow (2^31 * 5s would overflow int64)
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		childName := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childName, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeFailed, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childName)
@@ -964,7 +964,7 @@ func TestProcessNodeRetriesWithExpression(t *testing.T) {
 	assert.Nil(t, lastChild)
 
 	// Add child nodes.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childNode)
@@ -1047,7 +1047,7 @@ func TestProcessNodeRetriesMessageOrder(t *testing.T) {
 	assert.Nil(t, lastChild)
 
 	// Add child nodes.
-	for i := 0; i < 1; i++ {
+	for i := range 1 {
 		childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childNode)
@@ -1181,7 +1181,7 @@ func TestProcessNodesNoRetryWithError(t *testing.T) {
 	assert.Nil(t, lastChild)
 
 	// Add child nodes.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 		woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true)
 		woc.addChildNode(ctx, nodeName, childNode)
@@ -1436,7 +1436,7 @@ func TestRetriesVariable(t *testing.T) {
 	assert.Len(t, pods.Items, iterations)
 	expected := []string{}
 	actual := []string{}
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		actual = append(actual, pods.Items[i].Spec.Containers[1].Args[0])
 		expected = append(expected, fmt.Sprintf("cowsay %d", i))
 	}
@@ -1490,7 +1490,7 @@ func TestRetriesVariableInPodSpecPatch(t *testing.T) {
 	assert.Len(t, pods.Items, iterations)
 	expected := []string{}
 	actual := []string{}
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		actual = append(actual, pods.Items[i].Spec.Containers[1].Resources.Limits.Memory().String())
 		expected = append(expected, fmt.Sprintf("%dMi", (i+1)*64))
 	}
@@ -1547,7 +1547,7 @@ func TestRetriesVariableWithGlobalVariableInPodSpecPatch(t *testing.T) {
 	assert.Len(t, pods.Items, iterations)
 	expected := []string{}
 	actual := []string{}
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		actual = append(actual, pods.Items[i].Spec.Containers[1].Resources.Limits.Memory().String())
 		expected = append(expected, fmt.Sprintf("%dMi", (i+1)*100))
 	}
@@ -1600,7 +1600,7 @@ func TestLastRetryVariableInPodSpecPatch(t *testing.T) {
 	assert.Len(t, pods.Items, iterations)
 	expected := []string{}
 	actual := []string{}
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		actual = append(actual, pods.Items[i].Spec.Containers[1].Resources.Limits.Memory().String())
 		expected = append(expected, fmt.Sprintf("%dMi", (i+1)*100))
 	}
@@ -1661,7 +1661,7 @@ func TestStepsRetriesVariable(t *testing.T) {
 
 	expected := []string{}
 	actual := []string{}
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		actual = append(actual, pods.Items[i].Spec.Containers[1].Args[0])
 		expected = append(expected, fmt.Sprintf("cowsay %d", i))
 	}
@@ -4357,7 +4357,7 @@ spec:
 func getEventsWithoutAnnotations(controller *WorkflowController, num int) []string {
 	c := controller.eventRecorderManager.(*testEventRecorderManager).eventRecorder.Events
 	events := make([]string, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		event := <-c
 		events[i] = truncateAnnotationsFromEvent(event)
 	}
@@ -4365,9 +4365,9 @@ func getEventsWithoutAnnotations(controller *WorkflowController, num int) []stri
 }
 
 func truncateAnnotationsFromEvent(event string) string {
-	mapIndex := strings.Index(event, " map[")
-	if mapIndex != -1 {
-		return event[:mapIndex]
+	before, _, ok := strings.Cut(event, " map[")
+	if ok {
+		return before
 	}
 	return event
 }
@@ -4711,7 +4711,7 @@ func TestRetryNodeOutputs(t *testing.T) {
 	assert.NotNil(t, retryNode)
 	fmt.Println(retryNode)
 	scope := &wfScope{
-		scope: make(map[string]interface{}),
+		scope: make(map[string]any),
 	}
 	woc.buildLocalScope(scope, "steps.influx", retryNode)
 	assert.Contains(t, scope.scope, "steps.influx.ip")
@@ -10959,7 +10959,7 @@ func TestGetChildNodeIdsAndLastRetriedNode(t *testing.T) {
 		woc := setup()
 		childNodes := []*wfv1.NodeStatus{}
 		// Add child nodes.
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 			childNodes = append(childNodes, woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true))
 			woc.addChildNode(ctx, nodeName, childNode)
@@ -10976,7 +10976,7 @@ func TestGetChildNodeIdsAndLastRetriedNode(t *testing.T) {
 		woc := setup()
 		childNodes := []*wfv1.NodeStatus{}
 		// Add child nodes.
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 			childNodes = append(childNodes, woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true}, true))
 			woc.addChildNode(ctx, nodeName, childNode)
@@ -11000,7 +11000,7 @@ func TestGetChildNodeIdsAndLastRetriedNode(t *testing.T) {
 		woc := setup()
 		childNodes := []*wfv1.NodeStatus{}
 		// Add child hooked noes
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			childNode := fmt.Sprintf("%s(%d)", nodeName, i)
 			childNodes = append(childNodes, woc.initializeNode(ctx, childNode, wfv1.NodeTypePod, "", &wfv1.WorkflowStep{}, "", wfv1.NodeRunning, &wfv1.NodeFlag{Retried: true, Hooked: true}, true))
 			woc.addChildNode(ctx, nodeName, childNode)

--- a/workflow/controller/pod/accessors.go
+++ b/workflow/controller/pod/accessors.go
@@ -24,7 +24,7 @@ func (c *Controller) GetPod(namespace string, podName string) (*apiv1.Pod, error
 }
 
 // TODO - return []*apiv1.Pod instead, save on duplicating this
-func (c *Controller) GetPodsByIndex(index, key string) ([]interface{}, error) {
+func (c *Controller) GetPodsByIndex(index, key string) ([]any, error) {
 	return c.podInformer.GetIndexer().ByIndex(index, key)
 }
 

--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -72,7 +72,7 @@ func NewController(ctx context.Context, config *argoConfig.Config, restConfig *r
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	podController.podInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				pod, err := podFromObj(obj)
 				if err != nil {
 					log.WithError(err).Error(ctx, "object from informer wasn't a pod")
@@ -80,7 +80,7 @@ func NewController(ctx context.Context, config *argoConfig.Config, restConfig *r
 				}
 				podController.addPodEvent(ctx, pod)
 			},
-			UpdateFunc: func(old, newVal interface{}) {
+			UpdateFunc: func(old, newVal any) {
 				key, err := keyFunc(newVal)
 				if err != nil {
 					return
@@ -96,7 +96,7 @@ func NewController(ctx context.Context, config *argoConfig.Config, restConfig *r
 				}
 				podController.updatePodEvent(ctx, oldPod, newPod)
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				podController.deletePodEvent(ctx, obj)
 			},
 		},
@@ -257,7 +257,7 @@ func (c *Controller) updatePodEvent(ctx context.Context, old *apiv1.Pod, newPod 
 	c.commonPodEvent(ctx, newPod, deleting)
 }
 
-func (c *Controller) deletePodEvent(ctx context.Context, obj interface{}) {
+func (c *Controller) deletePodEvent(ctx context.Context, obj any) {
 	pod, err := podFromObj(obj)
 	if err != nil {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -327,7 +327,7 @@ func newInformer(ctx context.Context, clientSet kubernetes.Interface, instanceID
 	return informer
 }
 
-func podFromObj(obj interface{}) (*apiv1.Pod, error) {
+func podFromObj(obj any) (*apiv1.Pod, error) {
 	pod, ok := obj.(*apiv1.Pod)
 	if !ok {
 		return nil, fmt.Errorf("object is not a pod")

--- a/workflow/controller/scope.go
+++ b/workflow/controller/scope.go
@@ -18,13 +18,13 @@ import (
 // wfScope contains the current scope of variables available when executing a template
 type wfScope struct {
 	tmpl  *wfv1.Template
-	scope map[string]interface{}
+	scope map[string]any
 }
 
 func createScope(tmpl *wfv1.Template) *wfScope {
 	scope := &wfScope{
 		tmpl:  tmpl,
-		scope: make(map[string]interface{}),
+		scope: make(map[string]any),
 	}
 	if tmpl != nil {
 		for _, param := range scope.tmpl.Inputs.Parameters {
@@ -60,8 +60,8 @@ func (s *wfScope) addArtifactToScope(key string, artifact wfv1.Artifact) {
 }
 
 // resolveVar resolves a parameter or artifact
-func (s *wfScope) resolveVar(v string) (interface{}, error) {
-	m := make(map[string]interface{})
+func (s *wfScope) resolveVar(v string) (any, error) {
+	m := make(map[string]any)
 	maps.Copy(m, s.scope)
 	if s.tmpl != nil {
 		for _, a := range s.tmpl.Inputs.Artifacts {
@@ -71,7 +71,7 @@ func (s *wfScope) resolveVar(v string) (interface{}, error) {
 	return template.ResolveVar(v, m)
 }
 
-func (s *wfScope) resolveParameter(p *wfv1.ValueFrom) (interface{}, error) {
+func (s *wfScope) resolveParameter(p *wfv1.ValueFrom) (any, error) {
 	if p == nil || (p.Parameter == "" && p.Expression == "") {
 		return "", nil
 	}
@@ -93,7 +93,7 @@ func (s *wfScope) resolveArtifact(ctx context.Context, art *wfv1.Artifact) (*wfv
 	}
 
 	var err error
-	var val interface{}
+	var val any
 
 	if art.FromExpression != "" {
 		env := env.GetFuncMap(s.scope)

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -54,12 +54,12 @@ func (wfc *WorkflowController) newWorkflowTaskResultInformer(ctx context.Context
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(newObj interface{}) {
+			AddFunc: func(newObj any) {
 				result := newObj.(*wfv1.WorkflowTaskResult)
 				workflow := result.Labels[common.LabelKeyWorkflow]
 				wfc.wfQueue.AddRateLimited(result.Namespace + "/" + workflow)
 			},
-			UpdateFunc: func(old, newObj interface{}) {
+			UpdateFunc: func(old, newObj any) {
 				result := newObj.(*wfv1.WorkflowTaskResult)
 				workflow := result.Labels[common.LabelKeyWorkflow]
 				wfc.wfQueue.AddRateLimited(result.Namespace + "/" + workflow)

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -18,7 +18,7 @@ import (
 	controllercache "github.com/argoproj/argo-workflows/v3/workflow/controller/cache"
 )
 
-func (woc *wfOperationCtx) mergePatchTaskSet(ctx context.Context, patch interface{}, subresources ...string) error {
+func (woc *wfOperationCtx) mergePatchTaskSet(ctx context.Context, patch any, subresources ...string) error {
 	patchByte, err := json.Marshal(patch)
 	if err != nil {
 		return argoerrors.InternalWrapError(err)
@@ -30,8 +30,8 @@ func (woc *wfOperationCtx) mergePatchTaskSet(ctx context.Context, patch interfac
 	return nil
 }
 
-func (woc *wfOperationCtx) getDeleteTaskAndNodePatch() (tasksPatch map[string]interface{}, nodesPatch map[string]interface{}) {
-	deletedNode := make(map[string]interface{})
+func (woc *wfOperationCtx) getDeleteTaskAndNodePatch() (tasksPatch map[string]any, nodesPatch map[string]any) {
+	deletedNode := make(map[string]any)
 	for _, node := range woc.wf.Status.Nodes {
 		if node.IsTaskSetNode() && node.Fulfilled() {
 			deletedNode[node.ID] = nil
@@ -39,13 +39,13 @@ func (woc *wfOperationCtx) getDeleteTaskAndNodePatch() (tasksPatch map[string]in
 	}
 
 	// Delete the completed Tasks and nodes status
-	tasksPatch = map[string]interface{}{
-		"spec": map[string]interface{}{
+	tasksPatch = map[string]any{
+		"spec": map[string]any{
 			"tasks": deletedNode,
 		},
 	}
-	nodesPatch = map[string]interface{}{
-		"status": map[string]interface{}{
+	nodesPatch = map[string]any{
+		"status": map[string]any{
 			"nodes": deletedNode,
 		},
 	}
@@ -199,7 +199,7 @@ func (woc *wfOperationCtx) createTaskSet(ctx context.Context) error {
 
 	if apierr.IsConflict(err) || apierr.IsAlreadyExists(err) {
 		woc.log.Debug(ctx, "patching the exiting taskset")
-		spec := map[string]interface{}{
+		spec := map[string]any{
 			"metadata": metav1.ObjectMeta{
 				Labels: map[string]string{
 					common.LabelKeyCompleted: strconv.FormatBool(woc.wf.Status.Fulfilled()),

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -392,7 +392,7 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 				if err != nil {
 					return nil, err
 				}
-				for _, obj := range []interface{}{tmpl.ArchiveLocation} {
+				for _, obj := range []any{tmpl.ArchiveLocation} {
 					err = validate.VerifyResolvedVariables(obj)
 					if err != nil {
 						return nil, err

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -1958,7 +1958,7 @@ func TestPodFinalizerDoesNotExist(t *testing.T) {
 }
 
 func TestProgressEnvVars(t *testing.T) {
-	setup := func(t *testing.T, options ...interface{}) (context.CancelFunc, *apiv1.Pod) {
+	setup := func(t *testing.T, options ...any) (context.CancelFunc, *apiv1.Pod) {
 		ctx := logging.TestContext(t.Context())
 		cancel, controller := newController(ctx, options...)
 
@@ -2082,7 +2082,7 @@ spec:
 `
 
 func TestMergeEnvVars(t *testing.T) {
-	setup := func(t *testing.T, options ...interface{}) (context.CancelFunc, *apiv1.Pod) {
+	setup := func(t *testing.T, options ...any) (context.CancelFunc, *apiv1.Pod) {
 		ctx := logging.TestContext(t.Context())
 		cancel, controller := newController(ctx, options...)
 

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -216,7 +216,7 @@ func (cc *Controller) processNextCronItem(ctx context.Context) bool {
 func (cc *Controller) addCronWorkflowInformerHandler(ctx context.Context) error {
 	_, err := cc.cronWfInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
+			FilterFunc: func(obj any) bool {
 				un, ok := obj.(*unstructured.Unstructured)
 				if !ok {
 					cc.logger.WithField("obj", obj).Warn(ctx, "Cron Workflow FilterFunc: is not an unstructured")
@@ -225,19 +225,19 @@ func (cc *Controller) addCronWorkflowInformerHandler(ctx context.Context) error 
 				return !isCompleted(un)
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
+				AddFunc: func(obj any) {
 					key, err := cache.MetaNamespaceKeyFunc(obj)
 					if err == nil {
 						cc.cronWfQueue.Add(key)
 					}
 				},
-				UpdateFunc: func(old, newObj interface{}) {
+				UpdateFunc: func(old, newObj any) {
 					key, err := cache.MetaNamespaceKeyFunc(newObj)
 					if err == nil {
 						cc.cronWfQueue.Add(key)
 					}
 				},
-				DeleteFunc: func(obj interface{}) {
+				DeleteFunc: func(obj any) {
 					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 					if err == nil {
 						cc.cronWfQueue.Add(key)

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -168,14 +168,14 @@ func getWorkflowObjectReference(wf *v1alpha1.Workflow, runWf *v1alpha1.Workflow)
 }
 
 func (woc *cronWfOperationCtx) persistUpdate(ctx context.Context) {
-	woc.patch(ctx, map[string]interface{}{"status": woc.cronWf.Status, "metadata": map[string]interface{}{"annotations": woc.cronWf.Annotations, "labels": woc.cronWf.Labels}})
+	woc.patch(ctx, map[string]any{"status": woc.cronWf.Status, "metadata": map[string]any{"annotations": woc.cronWf.Annotations, "labels": woc.cronWf.Labels}})
 }
 
 func (woc *cronWfOperationCtx) persistCurrentWorkflowStatus(ctx context.Context) {
-	woc.patch(ctx, map[string]interface{}{"status": map[string]interface{}{"active": woc.cronWf.Status.Active, "succeeded": woc.cronWf.Status.Succeeded, "failed": woc.cronWf.Status.Failed, "phase": woc.cronWf.Status.Phase}})
+	woc.patch(ctx, map[string]any{"status": map[string]any{"active": woc.cronWf.Status.Active, "succeeded": woc.cronWf.Status.Succeeded, "failed": woc.cronWf.Status.Failed, "phase": woc.cronWf.Status.Phase}})
 }
 
-func (woc *cronWfOperationCtx) patch(ctx context.Context, patch map[string]interface{}) {
+func (woc *cronWfOperationCtx) patch(ctx context.Context, patch map[string]any) {
 	data, err := json.Marshal(patch)
 	if err != nil {
 		woc.log.WithError(err).Error(ctx, "failed to marshall cron workflow status.active data")
@@ -226,8 +226,8 @@ func evalWhen(ctx context.Context, cron *v1alpha1.CronWorkflow) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	env := make(map[string]interface{})
-	addSetField := func(name string, value interface{}) {
+	env := make(map[string]any)
+	addSetField := func(name string, value any) {
 		env[fmt.Sprintf("%s.%s", variablePrefix, name)] = value
 	}
 	err = expressionEnv(cron, addSetField)
@@ -494,7 +494,7 @@ func (woc *cronWfOperationCtx) updateWfPhaseCounter(phase v1alpha1.WorkflowPhase
 	}
 }
 
-func expressionEnv(cron *v1alpha1.CronWorkflow, addSetField func(name string, value interface{})) error {
+func expressionEnv(cron *v1alpha1.CronWorkflow, addSetField func(name string, value any)) error {
 	addSetField("name", cron.Name)
 	addSetField("namespace", cron.Namespace)
 	addSetField("labels", cron.Labels)
@@ -531,11 +531,11 @@ func (woc *cronWfOperationCtx) checkStopingCondition() (bool, error) {
 	if woc.cronWf.Spec.StopStrategy == nil {
 		return false, nil
 	}
-	prefixedEnv := make(map[string]interface{})
-	addSetField := func(name string, value interface{}) {
+	prefixedEnv := make(map[string]any)
+	addSetField := func(name string, value any) {
 		prefixedEnv[name] = value
 	}
-	env := make(map[string]interface{})
+	env := make(map[string]any)
 	env[variablePrefix] = prefixedEnv
 	err := expressionEnv(woc.cronWf, addSetField)
 	if err != nil {

--- a/workflow/data/data.go
+++ b/workflow/data/data.go
@@ -9,7 +9,7 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 )
 
-func ProcessData(ctx context.Context, data *wfv1.Data, processor wfv1.DataSourceProcessor) (interface{}, error) {
+func ProcessData(ctx context.Context, data *wfv1.Data, processor wfv1.DataSourceProcessor) (any, error) {
 	sourcedData, err := processSource(ctx, data.Source, processor)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process data source: %w", err)
@@ -21,8 +21,8 @@ func ProcessData(ctx context.Context, data *wfv1.Data, processor wfv1.DataSource
 	return transformedData, nil
 }
 
-func processSource(ctx context.Context, source wfv1.DataSource, processor wfv1.DataSourceProcessor) (interface{}, error) {
-	var data interface{}
+func processSource(ctx context.Context, source wfv1.DataSource, processor wfv1.DataSourceProcessor) (any, error) {
+	var data any
 	var err error
 	switch {
 	case source.ArtifactPaths != nil:
@@ -37,7 +37,7 @@ func processSource(ctx context.Context, source wfv1.DataSource, processor wfv1.D
 	return data, nil
 }
 
-func processTransformation(data interface{}, transformation *wfv1.Transformation) (interface{}, error) {
+func processTransformation(data any, transformation *wfv1.Transformation) (any, error) {
 	if transformation == nil {
 		return data, nil
 	}
@@ -55,8 +55,8 @@ func processTransformation(data interface{}, transformation *wfv1.Transformation
 	return data, nil
 }
 
-func processExpression(expression string, data interface{}) (interface{}, error) {
-	env := map[string]interface{}{"data": data}
+func processExpression(expression string, data any) (any, error) {
+	env := map[string]any{"data": data}
 	program, err := expr.Compile(expression, expr.Env(env))
 	if err != nil {
 		return nil, err

--- a/workflow/data/data_test.go
+++ b/workflow/data/data_test.go
@@ -16,15 +16,15 @@ type testDataSourceProcessor struct{}
 
 var _ v1alpha1.DataSourceProcessor = &testDataSourceProcessor{}
 
-func (t testDataSourceProcessor) ProcessArtifactPaths(context.Context, *v1alpha1.ArtifactPaths) (interface{}, error) {
-	return []interface{}{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}, nil
+func (t testDataSourceProcessor) ProcessArtifactPaths(context.Context, *v1alpha1.ArtifactPaths) (any, error) {
+	return []any{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}, nil
 }
 
 type nullTestDataSourceProcessor struct{}
 
 var _ v1alpha1.DataSourceProcessor = &nullTestDataSourceProcessor{}
 
-func (t nullTestDataSourceProcessor) ProcessArtifactPaths(context.Context, *v1alpha1.ArtifactPaths) (interface{}, error) {
+func (t nullTestDataSourceProcessor) ProcessArtifactPaths(context.Context, *v1alpha1.ArtifactPaths) (any, error) {
 	return nil, fmt.Errorf("cannot get artifacts")
 }
 
@@ -33,7 +33,7 @@ func TestProcessSource(t *testing.T) {
 	artifactPathsSource := v1alpha1.DataSource{ArtifactPaths: &v1alpha1.ArtifactPaths{}}
 	data, err := processSource(ctx, artifactPathsSource, &testDataSourceProcessor{})
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}, data)
+	assert.Equal(t, []any{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}, data)
 
 	_, err = processSource(ctx, artifactPathsSource, &nullTestDataSourceProcessor{})
 	require.Error(t, err)
@@ -43,42 +43,42 @@ func TestProcessSource(t *testing.T) {
 }
 
 func TestProcessTransformation(t *testing.T) {
-	files := []interface{}{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}
+	files := []any{"foo.py", "bar.pdf", "goo/foo.py", "moo/bar.pdf"}
 
 	filterFiles := &v1alpha1.Transformation{{Expression: `filter(data, {# endsWith '.py'})`}}
 	filtered, err := processTransformation(files, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"foo.py", "goo/foo.py"}, filtered)
+	assert.Equal(t, []any{"foo.py", "goo/foo.py"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {# contains '/'})`}}
 	filtered, err = processTransformation(files, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"goo/foo.py", "moo/bar.pdf"}, filtered)
+	assert.Equal(t, []any{"goo/foo.py", "moo/bar.pdf"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {# contains 'foo'})`}}
 	filtered, err = processTransformation(filtered, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"goo/foo.py"}, filtered)
+	assert.Equal(t, []any{"goo/foo.py"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {# contains '/'})`}, {Expression: `filter(data, {# contains 'foo'})`}}
 	filtered, err = processTransformation(files, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"goo/foo.py"}, filtered)
+	assert.Equal(t, []any{"goo/foo.py"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {not(# contains '/')})`}}
 	filtered, err = processTransformation(files, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"foo.py", "bar.pdf"}, filtered)
+	assert.Equal(t, []any{"foo.py", "bar.pdf"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `map(data, {# + '.processed'})`}}
 	filtered, err = processTransformation(files, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"foo.py.processed", "bar.pdf.processed", "goo/foo.py.processed", "moo/bar.pdf.processed"}, filtered)
+	assert.Equal(t, []any{"foo.py.processed", "bar.pdf.processed", "goo/foo.py.processed", "moo/bar.pdf.processed"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {not(# contains '/')})`}, {Expression: `map(data, {# + '.processed'})`}}
 	filtered, err = processTransformation(files, filterFiles)
 	require.NoError(t, err)
-	assert.Equal(t, []interface{}{"foo.py.processed", "bar.pdf.processed"}, filtered)
+	assert.Equal(t, []any{"foo.py.processed", "bar.pdf.processed"}, filtered)
 
 	filterFiles = &v1alpha1.Transformation{{Expression: `filter(data, {not(# contains '/')})`}, {Expression: `map(data, {# + '.processed'})`}, {}}
 	_, err = processTransformation(files, filterFiles)

--- a/workflow/events/event_recorder_logger.go
+++ b/workflow/events/event_recorder_logger.go
@@ -39,14 +39,14 @@ func (s *logrSink) Enabled(level int) bool {
 }
 
 // Info implements logr.LogSink
-func (s *logrSink) Info(level int, msg string, keysAndValues ...interface{}) {
+func (s *logrSink) Info(level int, msg string, keysAndValues ...any) {
 	fields := s.parseKeyValues(keysAndValues)
 	loggerWithFields := s.logger.WithFields(fields)
 	s.logAtLevel(loggerWithFields, level, msg)
 }
 
 // Error implements logr.LogSink
-func (s *logrSink) Error(err error, msg string, keysAndValues ...interface{}) {
+func (s *logrSink) Error(err error, msg string, keysAndValues ...any) {
 	fields := s.parseKeyValues(keysAndValues)
 	loggerWithFields := s.logger.WithFields(fields)
 	if err != nil {
@@ -63,7 +63,7 @@ func (s *logrSink) WithName(name string) logr.LogSink {
 }
 
 // WithValues implements logr.LogSink
-func (s *logrSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+func (s *logrSink) WithValues(keysAndValues ...any) logr.LogSink {
 	fields := s.parseKeyValues(keysAndValues)
 	return &logrSink{
 		logger: s.logger.WithFields(fields),
@@ -71,7 +71,7 @@ func (s *logrSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
 }
 
 // parseKeyValues converts logr key-value pairs to our Fields format
-func (s *logrSink) parseKeyValues(keysAndValues []interface{}) logging.Fields {
+func (s *logrSink) parseKeyValues(keysAndValues []any) logging.Fields {
 	fields := make(logging.Fields)
 	for i := 0; i < len(keysAndValues); i += 2 {
 		if i+1 < len(keysAndValues) {

--- a/workflow/executor/agent.go
+++ b/workflow/executor/agent.go
@@ -86,7 +86,7 @@ func (ae *AgentExecutor) Agent(ctx context.Context) error {
 	taskSetInterface := ae.WorkflowInterface.ArgoprojV1alpha1().WorkflowTaskSets(ae.Namespace)
 
 	go ae.patchWorker(ctx, taskSetInterface, responseQueue, requeueTime)
-	for i := 0; i < taskWorkers; i++ {
+	for range taskWorkers {
 		go ae.taskWorker(ctx, taskQueue, responseQueue)
 	}
 
@@ -180,7 +180,7 @@ func (ae *AgentExecutor) patchWorker(ctx context.Context, taskSetInterface v1alp
 				continue
 			}
 
-			patch, err := json.Marshal(map[string]interface{}{"status": wfv1.WorkflowTaskSetStatus{Nodes: nodeResults}})
+			patch, err := json.Marshal(map[string]any{"status": wfv1.WorkflowTaskSetStatus{Nodes: nodeResults}})
 			if err != nil {
 				logger.WithError(err).Error(ctx, "Generating Patch Failed")
 				continue
@@ -278,15 +278,15 @@ func (ae *AgentExecutor) executeHTTPTemplate(ctx context.Context, tmpl wfv1.Temp
 			message = fmt.Sprintf("received non-2xx response code: %d", response.StatusCode)
 		}
 	} else {
-		evalScope := map[string]interface{}{
-			"request": map[string]interface{}{
+		evalScope := map[string]any{
+			"request": map[string]any{
 				"method":    tmpl.HTTP.Method,
 				"url":       tmpl.HTTP.URL,
 				"body":      tmpl.HTTP.Body,
 				"bodyBytes": tmpl.HTTP.GetBodyBytes(),
 				"headers":   tmpl.HTTP.Headers.ToHeader(),
 			},
-			"response": map[string]interface{}{
+			"response": map[string]any{
 				"statusCode": response.StatusCode,
 				"body":       string(bodyBytes),
 				"headers":    response.Header,

--- a/workflow/executor/common/common.go
+++ b/workflow/executor/common/common.go
@@ -24,11 +24,11 @@ const (
 
 // GetContainerID returns container ID of a ContainerStatus resource
 func GetContainerID(container string) string {
-	i := strings.Index(container, containerShimPrefix)
-	if i == -1 {
+	_, after, ok := strings.Cut(container, containerShimPrefix)
+	if !ok {
 		return container
 	}
-	return container[i+len(containerShimPrefix):]
+	return after
 }
 
 // KubernetesClientInterface is the interface to implement getContainerStatus method

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -962,7 +962,7 @@ func (we *WorkflowExecutor) HasError() error {
 
 // AddAnnotation adds an annotation to the workflow pod
 func (we *WorkflowExecutor) AddAnnotation(ctx context.Context, key, value string) error {
-	data, err := json.Marshal(map[string]interface{}{"metadata": metav1.ObjectMeta{
+	data, err := json.Marshal(map[string]any{"metadata": metav1.ObjectMeta{
 		Annotations: map[string]string{
 			key: value,
 		},

--- a/workflow/executor/executor_data_source_processor.go
+++ b/workflow/executor/executor_data_source_processor.go
@@ -16,7 +16,7 @@ func newExecutorDataSourceProcessor(we *WorkflowExecutor) *executorDataSourcePro
 	}
 }
 
-func (ep *executorDataSourceProcessor) ProcessArtifactPaths(ctx context.Context, artifacts *wfv1.ArtifactPaths) (interface{}, error) {
+func (ep *executorDataSourceProcessor) ProcessArtifactPaths(ctx context.Context, artifacts *wfv1.ArtifactPaths) (any, error) {
 	driverArt, err := ep.we.newDriverArt(&artifacts.Artifact)
 	if err != nil {
 		return nil, err

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -150,7 +150,7 @@ func (we *WorkflowExecutor) getKubectlArguments(action string, manifestPath stri
 		if mergeStrategy == "json" {
 			appendFileFlag = false
 		} else {
-			var obj map[string]interface{}
+			var obj map[string]any
 			err = yaml.Unmarshal(buff, &obj)
 			if err != nil {
 				return []string{}, argoerrors.New(argoerrors.CodeBadRequest, err.Error())
@@ -352,7 +352,7 @@ func (we *WorkflowExecutor) SaveResourceParameters(ctx context.Context, resource
 }
 
 func jqFilter(ctx context.Context, input []byte, filter string) (string, error) {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(input, &v); err != nil {
 		return "", err
 	}

--- a/workflow/gccontroller/gc_controller.go
+++ b/workflow/gccontroller/gc_controller.go
@@ -61,15 +61,15 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 	}
 
 	_, err := wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: func(obj interface{}) bool {
+		FilterFunc: func(obj any) bool {
 			un, ok := obj.(*unstructured.Unstructured)
 			return ok && common.IsDone(un)
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				controller.enqueueWF(ctx, obj)
 			},
-			UpdateFunc: func(old, newObj interface{}) {
+			UpdateFunc: func(old, newObj any) {
 				controller.enqueueWF(ctx, newObj)
 			},
 		},
@@ -79,15 +79,15 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 	}
 
 	_, err = wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: func(obj interface{}) bool {
+		FilterFunc: func(obj any) bool {
 			un, ok := obj.(*unstructured.Unstructured)
 			return ok && common.IsDone(un)
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
-			UpdateFunc: func(old, newObj interface{}) {
+			UpdateFunc: func(old, newObj any) {
 				controller.retentionEnqueue(ctx, newObj)
 			},
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				controller.retentionEnqueue(ctx, obj)
 			},
 		},
@@ -98,7 +98,7 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 	return controller
 }
 
-func (c *Controller) retentionEnqueue(ctx context.Context, obj interface{}) {
+func (c *Controller) retentionEnqueue(ctx context.Context, obj any) {
 	// No need to queue the workflow if the retention policy is not set
 	if c.retentionPolicy == nil {
 		return
@@ -131,7 +131,7 @@ func (c *Controller) Run(ctx context.Context, workflowGCWorkers int) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	for i := 0; i < workflowGCWorkers; i++ {
+	for range workflowGCWorkers {
 		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
 	}
 	c.log.Info(ctx, "Started workflow garbage collection")
@@ -185,7 +185,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 // enqueueWF conditionally queues a workflow to the ttl queue if it is within the deletion period
-func (c *Controller) enqueueWF(ctx context.Context, obj interface{}) {
+func (c *Controller) enqueueWF(ctx context.Context, obj any) {
 	un, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		c.log.WithField("obj", obj).Warn(ctx, "is not an unstructured")

--- a/workflow/gccontroller/heap.go
+++ b/workflow/gccontroller/heap.go
@@ -22,7 +22,7 @@ func (h *gcHeap) Less(i, j int) bool {
 }
 func (h *gcHeap) Swap(i, j int) { h.heap[i], h.heap[j] = h.heap[j], h.heap[i] }
 
-func (h *gcHeap) Push(x interface{}) {
+func (h *gcHeap) Push(x any) {
 	if _, ok := h.dedup[x.(*unstructured.Unstructured).GetName()]; ok {
 		return
 	}
@@ -30,7 +30,7 @@ func (h *gcHeap) Push(x interface{}) {
 	h.heap = append(h.heap, x.(*unstructured.Unstructured))
 }
 
-func (h *gcHeap) Pop() interface{} {
+func (h *gcHeap) Pop() any {
 	old := h.heap
 	n := len(old)
 	x := old[n-1]

--- a/workflow/sync/cached_limit_test.go
+++ b/workflow/sync/cached_limit_test.go
@@ -71,7 +71,7 @@ func TestGetLimitMultipleCalls(t *testing.T) {
 	assert.Equal(t, 1, callCount, "Getter should be called once initially")
 
 	// Make several more calls while within TTL - should use cache
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		// Advance time slightly but stay within TTL
 		advanceTime(1 * time.Minute)
 
@@ -95,7 +95,7 @@ func TestGetLimitMultipleCalls(t *testing.T) {
 	assert.Equal(t, 2, callCount, "Getter should be called a second time after TTL expires")
 
 	// Make several more calls with the new cache
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		// Advance time slightly but stay within new TTL
 		advanceTime(2 * time.Minute)
 

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -192,7 +192,7 @@ func (s *databaseSemaphore) notifyWaiters(ctx context.Context) {
 		"triggerCount": triggerCount,
 		"pendingCount": len(pending),
 	}).Debug(ctx, "Notifying waiters for semaphore")
-	for idx := 0; idx < triggerCount; idx++ {
+	for idx := range triggerCount {
 		item := pending[idx]
 		if item.Controller != s.info.Config.ControllerName {
 			continue

--- a/workflow/sync/lock_name_test.go
+++ b/workflow/sync/lock_name_test.go
@@ -30,7 +30,7 @@ func TestDecodeLockName(t *testing.T) {
 				Key:          "",
 				Kind:         lockKindMutex,
 			},
-			func(t assert.TestingT, err error, i ...interface{}) bool {
+			func(t assert.TestingT, err error, i ...any) bool {
 				return true
 			},
 		},
@@ -43,7 +43,7 @@ func TestDecodeLockName(t *testing.T) {
 				Key:          "",
 				Kind:         lockKindMutex,
 			},
-			func(t assert.TestingT, err error, i ...interface{}) bool {
+			func(t assert.TestingT, err error, i ...any) bool {
 				return true
 			},
 		},
@@ -55,7 +55,7 @@ func TestDecodeLockName(t *testing.T) {
 				ResourceName: "foo",
 				Kind:         lockKindDatabase,
 			},
-			func(t assert.TestingT, err error, i ...interface{}) bool {
+			func(t assert.TestingT, err error, i ...any) bool {
 				return true
 			},
 		},
@@ -68,7 +68,7 @@ func TestDecodeLockName(t *testing.T) {
 				Key:          "bar",
 				Kind:         lockKindConfigMap,
 			},
-			func(t assert.TestingT, err error, i ...interface{}) bool {
+			func(t assert.TestingT, err error, i ...any) bool {
 				return true
 			},
 		},
@@ -76,7 +76,7 @@ func TestDecodeLockName(t *testing.T) {
 			"TestConfigMapKeysCannotContainSlashes",
 			args{"default/ConfigMap/foo/bar/baz/qux"},
 			nil,
-			func(t assert.TestingT, err error, i ...interface{}) bool {
+			func(t assert.TestingT, err error, i ...any) bool {
 				return err == nil // this should error
 			},
 		},

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -255,7 +255,7 @@ func (pq priorityQueue) Swap(i, j int) {
 	pq.items[j].index = j
 }
 
-func (pq *priorityQueue) Push(x interface{}) {
+func (pq *priorityQueue) Push(x any) {
 	n := len(pq.items)
 	item := x.(*item)
 	item.index = n
@@ -263,7 +263,7 @@ func (pq *priorityQueue) Push(x interface{}) {
 	pq.itemByKey[item.key] = item
 }
 
-func (pq *priorityQueue) Pop() interface{} {
+func (pq *priorityQueue) Pop() any {
 	old := pq.items
 	n := len(old)
 	item := old[n-1]

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -127,7 +127,7 @@ func (s *prioritySemaphore) release(ctx context.Context, key string) bool {
 // where N is the availability of the semaphore. If semaphore is out of capacity, this does nothing.
 func (s *prioritySemaphore) notifyWaiters(ctx context.Context) {
 	triggerCount := min(s.pending.Len(), s.getLimit(ctx)-len(s.lockHolder))
-	for idx := 0; idx < triggerCount; idx++ {
+	for idx := range triggerCount {
 		item := s.pending.items[idx]
 		wfKey := workflowKey(item.key)
 		s.logger(ctx).WithField("workflow", wfKey).Debug(ctx, "Enqueue the workflow")

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -910,7 +910,7 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 			triggerCount++
 		}, WorkflowExistenceFunc)
 		var wfs []wfv1.Workflow
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
 			wf.Name = fmt.Sprintf("%s-%d", "acquired", i)
 			status, wfUpdate, msg, failedLockName, err := syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
@@ -922,7 +922,7 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 			wfs = append(wfs, *wf)
 
 		}
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
 			wf.Name = fmt.Sprintf("%s-%d", "wait", i)
 			status, wfUpdate, msg, failedLockName, err := syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)

--- a/workflow/util/plugins/plugin.go
+++ b/workflow/util/plugins/plugin.go
@@ -38,7 +38,7 @@ func New(address, token string, timeout time.Duration, backoff wait.Backoff) Cli
 	}
 }
 
-func (p *Client) Call(ctx context.Context, method string, args interface{}, reply interface{}) error {
+func (p *Client) Call(ctx context.Context, method string, args any, reply any) error {
 	if p.invalid[method] {
 		return nil
 	}

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -141,7 +141,7 @@ func FromUnstructured(un *unstructured.Unstructured) (*wfv1.Workflow, error) {
 	return &wf, err
 }
 
-func FromUnstructuredObj(un *unstructured.Unstructured, v interface{}) error {
+func FromUnstructuredObj(un *unstructured.Unstructured, v any) error {
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, v)
 	if err != nil {
 		if err.Error() == "cannot convert int64 to v1alpha1.AnyString" {
@@ -1408,8 +1408,8 @@ func (e AlreadyShutdownError) Error() string {
 
 // patchShutdownStrategy patches the shutdown strategy to a workflow.
 func patchShutdownStrategy(ctx context.Context, wfClient v1alpha1.WorkflowInterface, name string, strategy wfv1.ShutdownStrategy) error {
-	patchObj := map[string]interface{}{
-		"spec": map[string]interface{}{
+	patchObj := map[string]any{
+		"spec": map[string]any{
 			"shutdown": strategy,
 		},
 	}
@@ -1424,7 +1424,7 @@ func patchShutdownStrategy(ctx context.Context, wfClient v1alpha1.WorkflowInterf
 	}
 	userActionLabel := creator.UserActionLabel(ctx, action)
 	if userActionLabel != nil {
-		patchObj["metadata"] = map[string]interface{}{
+		patchObj["metadata"] = map[string]any{
 			"labels": userActionLabel,
 		}
 	}


### PR DESCRIPTION
### Motivation

Run and enable [`modernize`](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) linter for better code quality and updating to modern style golang.

Also, `any` is much nicer than `interface{}`

### Modifications

Enable modernize linter and run the autofixer.

Most of the `omitempty` possible changes are not included, as they'll break the CRDs - https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_omitzero explains that kubebuilder interprets these so they need to stay. (They make non-`omitempty` fields `required` in the CRD).

### Verification

CI will verify

### Documentation

None needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated codebase to use Go 1.18+ type alias standards throughout
  * Modernized loop constructs and string parsing patterns
  
* **Chores**
  * Added modernize linter to code quality checks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->