### PR TITLE
refactor: use wg.Go() instead of manual Add+Defer

### DIFF
--- a/cmd/argo/commands/common/wait.go
+++ b/cmd/argo/commands/common/wait.go
@@ -24,14 +24,11 @@ func WaitWorkflows(ctx context.Context, serviceClient workflowpkg.WorkflowServic
 	wfSuccessStatus := true
 
 	for _, name := range workflowNames {
-		wg.Add(1)
-		go func(name string) {
+		wg.Go(func() {
 			if ok, _ := waitOnOne(ctx, serviceClient, name, namespace, ignoreNotFound, quiet); !ok {
 				wfSuccessStatus = false
 			}
-			wg.Done()
-		}(name)
-
+		})
 	}
 	wg.Wait()
 

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -73,12 +73,10 @@ func TestEmissary(t *testing.T) {
 			err := os.WriteFile(varRunArgo+"/ctr/main/signal", []byte(strconv.Itoa(int(signal))), 0o600)
 			require.NoError(t, err)
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				err := run("sleep 3")
 				assert.EqualError(t, err, fmt.Sprintf("exit status %d", 128+signal))
-			}()
+			})
 			wg.Wait()
 		}
 	})

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -142,11 +142,9 @@ func NewRootCommand() *cobra.Command {
 				dummyCtx, dummyCancel := context.WithCancel(ctx)
 				defer dummyCancel()
 
-				wg.Add(1)
-				go func() {
+				wg.Go(func() {
 					wfController.RunPrometheusServer(dummyCtx, true)
-					wg.Done()
-				}()
+				})
 
 				go leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 					Lock: &resourcelock.LeaseLock{
@@ -162,11 +160,9 @@ func NewRootCommand() *cobra.Command {
 							dummyCancel()
 							wg.Wait()
 							go wfController.Run(ctx, workflowWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, workflowArchiveWorkers)
-							wg.Add(1)
-							go func() {
+							wg.Go(func() {
 								wfController.RunPrometheusServer(ctx, false)
-								wg.Done()
-							}()
+							})
 						},
 						OnStoppedLeading: func() {
 							log.WithField("id", nodeID).Info(ctx, "stopped leading")

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -487,10 +487,7 @@ func (as *argoServer) validateArtifactDriverConnections(ctx context.Context, cfg
 
 	// Validate each driver connection in parallel
 	for _, driver := range cfg.ArtifactDrivers {
-		wg.Add(1)
-		go func(driver config.ArtifactDriver) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			// Create a new driver connection
 			pluginDriver, err := plugin.NewDriver(ctx, driver.Name, driver.Name.SocketPath(), driver.ConnectionTimeout())
 			if err != nil {
@@ -506,7 +503,7 @@ func (as *argoServer) validateArtifactDriverConnections(ctx context.Context, cfg
 			}()
 
 			log.WithField("driver", driver.Name).Info(ctx, "Successfully validated connection to artifact driver")
-		}(driver)
+		})
 	}
 
 	// Wait for all validations to complete

--- a/server/event/event_server.go
+++ b/server/event/event_server.go
@@ -51,14 +51,12 @@ func (s *Controller) Run(ctx context.Context, stopCh <-chan struct{}) {
 	logger := logging.RequireLoggerFromContext(ctx)
 
 	for w := 0; w < s.workerCount; w++ {
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for operation := range s.operationQueue {
 				ctx := operation.Context()
 				_ = operation.Dispatch(ctx)
 			}
-		}()
-		wg.Add(1)
+		})
 	}
 
 	<-stopCh

--- a/util/telemetry/exporter_prometheus_test.go
+++ b/util/telemetry/exporter_prometheus_test.go
@@ -51,11 +51,9 @@ func TestPrometheusServer(t *testing.T) {
 	defer cancel()
 	m, err := NewMetrics(ctx, testScopeName, testScopeName, &config)
 	require.NoError(t, err)
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		m.RunPrometheusServer(ctx, false)
-		wg.Done()
-	}()
+	})
 	time.Sleep(1 * time.Second)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d%s", DefaultPrometheusServerPort, DefaultPrometheusServerPath), nil)
 	resp, err := http.DefaultClient.Do(req)
@@ -86,11 +84,9 @@ func TestDummyPrometheusServer(t *testing.T) {
 	defer cancel()
 	m, err := NewMetrics(ctx, testScopeName, testScopeName, &config)
 	require.NoError(t, err)
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		m.RunPrometheusServer(ctx, true)
-		wg.Done()
-	}()
+	})
 	time.Sleep(1 * time.Second)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d%s", DefaultPrometheusServerPort, DefaultPrometheusServerPath), nil)
 	resp, err := http.DefaultClient.Do(req)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1232,13 +1232,11 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) (error, bool) 
 
 	for _, pod := range podList {
 		parallelPodNum <- pod.Name
-		wg.Add(1)
-		go func(pod *apiv1.Pod) {
-			defer wg.Done()
+		wg.Go(func() {
 			performAssessment(pod)
 			woc.applyExecutionControl(ctx, pod, wfNodesLock)
 			<-parallelPodNum
-		}(pod)
+		})
 	}
 
 	wg.Wait()

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -499,15 +499,13 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 	var wg sync.WaitGroup
 	for i, step := range stepGroup {
 		parallelStepNum <- step.Name
-		wg.Add(1)
-		go func(i int, step wfv1.WorkflowStep) {
-			defer wg.Done()
+		wg.Go(func() {
 			if err := resolveStepReferences(i, step, newStepGroup); err != nil {
 				woc.log.WithFields(logging.Fields{"stepName": step.Name}).WithError(err).Error(ctx, "Failed to resolve references")
 				errCh <- err
 			}
 			<-parallelStepNum
-		}(i, step)
+		})
 	}
 	wg.Wait()
 

--- a/workflow/executor/osspecific/signal_windows_test.go
+++ b/workflow/executor/osspecific/signal_windows_test.go
@@ -22,14 +22,11 @@ func TestKill(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		err = cmd.Wait()
 		// we'll get an exit code
 		assert.Error(t, err)
-	}()
+	})
 
 	err = Kill(cmd.Process.Pid, syscall.SIGTERM)
 	require.NoError(t, err)

--- a/workflow/sync/sync_manager_multiple_test.go
+++ b/workflow/sync/sync_manager_multiple_test.go
@@ -187,7 +187,6 @@ func testSyncManagersContendingForSemaphore(t *testing.T, dbType sqldb.DBType) {
 
 	// Function to run workflows for a sync manager
 	runWorkflows := func(sm *Manager, name string, count int) {
-		defer wg.Done()
 		for testCounter := range count {
 			wfCopy := wfbase.DeepCopy()
 			wfName := fmt.Sprintf("%s-%d", name, testCounter)
@@ -228,9 +227,8 @@ func testSyncManagersContendingForSemaphore(t *testing.T, dbType sqldb.DBType) {
 
 	const iterationCount = 5
 	// Start two goroutines
-	wg.Add(2)
-	go runWorkflows(syncMgr1, "wf1", iterationCount)
-	go runWorkflows(syncMgr2, "wf2", iterationCount)
+	wg.Go(func() { runWorkflows(syncMgr1, "wf1", iterationCount) })
+	wg.Go(func() { runWorkflows(syncMgr2, "wf2", iterationCount) })
 	wg.Wait()
 
 	// Verify that at no point were multiple locks held


### PR DESCRIPTION
### Motivation

Simplify goroutine management by using `wg.Go()` method instead of manually calling `wg.Add(1)`, and `wg.Done()`, and passing closure parameters. This reduces boilerplate code and makes the codebase more idiomatic.

### Modifications

Replaced manual `sync.WaitGroup` patterns with `wg.Go()` across multiple files.

### Verification

These are refactoring changes that maintain the same functionality while improving code clarity. The behavior of all goroutine management remains identical - only the implementation pattern has changed to use the more idiomatic `wg.Go()` method.

### Documentation

No documentation changes needed - this is an internal refactoring with no user-facing changes.

### AI

This was mostly written by Claude.