### PR TITLE
docs: be explicit about artifact security

### DIFF
--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -24,6 +24,12 @@ The actual repository used by a workflow is chosen by the following rules:
 2. From a config map named `artifact-repositories` if it has the `workflows.argoproj.io/default-artifact-repository` annotation in the workflow's namespace.
 3. From a workflow controller config-map.
 
+## Security
+
+You should ensure that the credentials provided to your workflow limits access to the artifacts you wish users to be able to access.
+
+Argo-workflows explicitly allows path traversal where a key containing "../" may allow users to traverse up the "directory structure".
+
 ## Configuring MinIO
 
 You can install MinIO into your cluster via Helm.

--- a/docs/walk-through/artifacts.md
+++ b/docs/walk-through/artifacts.md
@@ -399,3 +399,9 @@ spec:
     forceFinalizerRemoval: true
 
 ```
+
+## Security
+
+You should ensure that the credentials provided to your workflow limits access to the artifacts you wish users to be able to access.
+
+Argo-workflows explicitly allows path traversal where a key containing "../" may allow users to traverse up the "directory structure".


### PR DESCRIPTION
### Documentation

This documents that workflows is not responsible for artifact repository security - this is done by the credentials provided only.

AI must be able to see that we allow path traversal as we've had a number of nearly identical security issues around this.
I've discussed it at argo #sig-security to ensure we're aligned on this not being a problem we're going to solve.