### PR TITLE
fix: Add instanceID label to WorkflowTaskSet. Fixes #15219 (cherry-pick #15220 for 3.6)

### DIFF
--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -173,6 +173,10 @@ func (woc *wfOperationCtx) createTaskSet(ctx context.Context) error {
 	}
 
 	woc.log.Info("Creating TaskSet")
+	labels := map[string]string{}
+	if woc.controller.Config.InstanceID != "" {
+		labels[common.LabelKeyControllerInstanceID] = woc.controller.Config.InstanceID
+	}
 	taskSet := wfv1.WorkflowTaskSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       workflow.WorkflowTaskSetKind,
@@ -181,6 +185,7 @@ func (woc *wfOperationCtx) createTaskSet(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: woc.wf.Namespace,
 			Name:      woc.wf.Name,
+			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: woc.wf.APIVersion,

--- a/workflow/controller/taskset_test.go
+++ b/workflow/controller/taskset_test.go
@@ -102,6 +102,7 @@ spec:
 			assert.Equal(t, ts.Name, wf.Name)
 			assert.Equal(t, ts.Namespace, wf.Namespace)
 			assert.Len(t, ts.Spec.Tasks, 1)
+			assert.Equal(t, "testID", ts.Labels[common.LabelKeyControllerInstanceID], "WorkflowTaskSet should have instanceID label")
 		}
 		pods, err := woc.controller.kubeclientset.CoreV1().Pods("default").List(ctx, v1.ListOptions{})
 		require.NoError(t, err)


### PR DESCRIPTION
Cherry-picked fix: Add instanceID label to WorkflowTaskSet. Fixes #15219 (#15220)