### PR TITLE
fix: preserve existing parameter value for suspend enum inputs

### DIFF
--- a/ui/src/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/workflows/components/workflow-details/workflow-details.tsx
@@ -139,7 +139,7 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
         return (
             selectedWorkflowNode?.inputs?.parameters?.map(param => {
                 const paramClone = {...param};
-                if (paramClone.enum) {
+                if (paramClone.enum && !paramClone.value) {
                     paramClone.value = paramClone.default;
                 }
                 return paramClone;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12896

### Motivation

When clicking "Resume" on a suspend node with enum parameters, the UI was not correctly displaying the parameter values. If a value was passed via workflow arguments, it would be incorrectly overwritten with the default value (or undefined if no default was specified).

This PR complements the changes in #15240

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
