### PR TITLE
chore(lint): rename stuttering exported names flagged by revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,7 @@ linters:
         - name: error-return
         - name: error-strings
         - name: errorf
+        - name: exported
         - name: increment-decrement
         - name: indent-error-flow
         - name: package-comments
@@ -65,8 +66,6 @@ linters:
         - name: unreachable-code
         - name: var-declaration
         # disabled defaults due to large number of fixes required for now - PRs welcome
-        - name: exported
-          disabled: true
         - name: unused-parameter
           disabled: true
         - name: var-naming

--- a/cmd/argo/commands/clustertemplate/lint.go
+++ b/cmd/argo/commands/clustertemplate/lint.go
@@ -45,7 +45,7 @@ func NewLintCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			opts := lint.LintOptions{
+			opts := lint.Options{
 				Files:            args,
 				DefaultNamespace: client.Namespace(ctx),
 				Strict:           strict,

--- a/cmd/argo/commands/clustertemplate/util.go
+++ b/cmd/argo/commands/clustertemplate/util.go
@@ -40,7 +40,7 @@ func generateClusterWorkflowTemplates(ctx context.Context, filePaths []string, s
 // unmarshalClusterWorkflowTemplates unmarshals the input bytes as either json or yaml
 func unmarshalClusterWorkflowTemplates(ctx context.Context, wfBytes []byte, strict bool) ([]wfv1.ClusterWorkflowTemplate, error) {
 	var cwft wfv1.ClusterWorkflowTemplate
-	var jsonOpts []argoJson.JSONOpt
+	var jsonOpts []argoJson.Opt
 	if strict {
 		jsonOpts = append(jsonOpts, argoJson.DisallowUnknownFields)
 	}

--- a/cmd/argo/commands/cron/backfill.go
+++ b/cmd/argo/commands/cron/backfill.go
@@ -46,7 +46,7 @@ func NewBackfillCommand() *cobra.Command {
 				os.Exit(0)
 			}
 			if cliOps.name == "" {
-				name, err := rand.RandString(5)
+				name, err := rand.String(5)
 				if err != nil {
 					return err
 				}

--- a/cmd/argo/commands/cron/lint.go
+++ b/cmd/argo/commands/cron/lint.go
@@ -26,7 +26,7 @@ func NewLintCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			opts := lint.LintOptions{
+			opts := lint.Options{
 				Files:            args,
 				Strict:           strict,
 				DefaultNamespace: client.Namespace(ctx),

--- a/cmd/argo/commands/cron/util.go
+++ b/cmd/argo/commands/cron/util.go
@@ -59,7 +59,7 @@ func generateCronWorkflows(ctx context.Context, filePaths []string, strict bool)
 // unmarshalCronWorkflows unmarshals the input bytes as either json or yaml
 func unmarshalCronWorkflows(ctx context.Context, wfBytes []byte, strict bool) []v1alpha1.CronWorkflow {
 	var cronWf v1alpha1.CronWorkflow
-	var jsonOpts []argoJson.JSONOpt
+	var jsonOpts []argoJson.Opt
 	if strict {
 		jsonOpts = append(jsonOpts, argoJson.DisallowUnknownFields)
 	}

--- a/cmd/argo/commands/lint.go
+++ b/cmd/argo/commands/lint.go
@@ -64,7 +64,7 @@ func runLint(ctx context.Context, args []string, offline bool, lintKinds []strin
 	if len(lintKinds) == 0 || strings.Contains(strings.Join(lintKinds, ","), "all") {
 		lintKinds = allKinds
 	}
-	ops := lint.LintOptions{
+	ops := lint.Options{
 		Files:            args,
 		Strict:           strict,
 		DefaultNamespace: client.Namespace(ctx),

--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -138,7 +138,7 @@ If your server is behind an ingress with a path (running "argo server --base-hre
 			logLevel = "debug"
 			glogLevel = 6
 		}
-		ctx, log, err := cmdutil.CmdContextWithLogger(cmd, logLevel, logFormat)
+		ctx, log, err := cmdutil.ContextWithLogger(cmd, logLevel, logFormat)
 		if err != nil {
 			logging.InitLogger().WithError(err).WithFatal().Error(ctx, "Failed to create argo pre-run logger")
 			os.Exit(1)
@@ -161,7 +161,7 @@ If your server is behind an ingress with a path (running "argo server --base-hre
 	command.PersistentFlags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.PersistentFlags().StringVar(&logFormat, "log-format", "text", "The formatter to use for logs. One of: text|json")
 	command.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enabled verbose logging, i.e. --loglevel debug")
-	cctx, log, err := cmdutil.CmdContextWithLogger(command, logLevel, logFormat)
+	cctx, log, err := cmdutil.ContextWithLogger(command, logLevel, logFormat)
 	if err != nil {
 		logging.InitLogger().WithError(err).WithFatal().Error(cctx, "Failed to create argo logger")
 		os.Exit(1)

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -67,7 +67,7 @@ func NewServerCommand() *cobra.Command {
 		Example: fmt.Sprintf(`
 See %s`, help.ArgoServer()),
 		RunE: func(c *cobra.Command, args []string) error {
-			ctx, logger, err := cmdutil.CmdContextWithLogger(c, logLevel, logFormat)
+			ctx, logger, err := cmdutil.ContextWithLogger(c, logLevel, logFormat)
 			if err != nil {
 				return err
 			}
@@ -222,7 +222,7 @@ See %s`, help.ArgoServer()),
 	viper.SetEnvPrefix("ARGO")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
-	ctx, logger, err := cmdutil.CmdContextWithLogger(&command, logLevel, logFormat)
+	ctx, logger, err := cmdutil.ContextWithLogger(&command, logLevel, logFormat)
 	if err != nil {
 		logging.InitLogger().WithError(err).WithFatal().Error(ctx, "Failed to create server logger")
 	}

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -105,7 +105,7 @@ func NewSubmitCommand() *cobra.Command {
 	command.Flags().StringVar(&cliSubmitOpts.ScheduledTime, "scheduled-time", "", "Override the workflow's scheduledTime parameter (useful for backfilling). The time must be RFC3339")
 
 	// Only complete files with appropriate extension.
-	ctx, _, err := cmdutil.CmdContextWithLogger(command, string(logging.Info), string(logging.Text))
+	ctx, _, err := cmdutil.ContextWithLogger(command, string(logging.Info), string(logging.Text))
 	if err != nil {
 		logging.InitLogger().WithError(err).WithFatal().Error(ctx, "Failed to create submit logger")
 		os.Exit(1)
@@ -263,7 +263,7 @@ func submitWorkflows(ctx context.Context, serviceClient workflowpkg.WorkflowServ
 // unmarshalWorkflows unmarshals the input bytes as either json or yaml
 func unmarshalWorkflows(ctx context.Context, wfBytes []byte, strict bool) []wfv1.Workflow {
 	var wf wfv1.Workflow
-	var jsonOpts []argoJson.JSONOpt
+	var jsonOpts []argoJson.Opt
 	if strict {
 		jsonOpts = append(jsonOpts, argoJson.DisallowUnknownFields)
 	}

--- a/cmd/argo/commands/template/lint.go
+++ b/cmd/argo/commands/template/lint.go
@@ -30,7 +30,7 @@ func NewLintCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			opts := lint.LintOptions{
+			opts := lint.Options{
 				Files:            args,
 				Strict:           strict,
 				DefaultNamespace: client.Namespace(ctx),

--- a/cmd/argo/commands/template/util.go
+++ b/cmd/argo/commands/template/util.go
@@ -37,7 +37,7 @@ func generateWorkflowTemplates(ctx context.Context, filePaths []string, strict b
 // unmarshalWorkflowTemplates unmarshals the input bytes as either json or yaml
 func unmarshalWorkflowTemplates(ctx context.Context, wfBytes []byte, strict bool) []wfv1.WorkflowTemplate {
 	var wf wfv1.WorkflowTemplate
-	var jsonOpts []argoJson.JSONOpt
+	var jsonOpts []argoJson.Opt
 	if strict {
 		jsonOpts = append(jsonOpts, argoJson.DisallowUnknownFields)
 	}

--- a/cmd/argo/lint/formatter_pretty.go
+++ b/cmd/argo/lint/formatter_pretty.go
@@ -15,7 +15,7 @@ const (
 
 type formatterPretty struct{}
 
-func (f formatterPretty) Format(l *LintResult) string {
+func (f formatterPretty) Format(l *Result) string {
 	setColorize()
 	if !l.Linted {
 		return ""
@@ -36,7 +36,7 @@ func (f formatterPretty) Format(l *LintResult) string {
 	return sb.String()
 }
 
-func (f formatterPretty) Summarize(l *LintResults) string {
+func (f formatterPretty) Summarize(l *Results) string {
 	setColorize()
 	if l.Success {
 		return fmt.Sprintf("%s no linting errors found!\n", color.Ize(color.Green, "✔"))

--- a/cmd/argo/lint/formatter_pretty_test.go
+++ b/cmd/argo/lint/formatter_pretty_test.go
@@ -13,14 +13,14 @@ import (
 
 func TestPrettySummarize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		msg := formatterPretty{}.Summarize(&LintResults{
+		msg := formatterPretty{}.Summarize(&Results{
 			Success: true,
 		})
 		expected := fmt.Sprintf("%s no linting errors found!\n", color.Ize(color.Green, "✔"))
 		assert.Equal(t, expected, msg)
 	})
 	t.Run("Nothing linted", func(t *testing.T) {
-		msg := formatterPretty{}.Summarize(&LintResults{
+		msg := formatterPretty{}.Summarize(&Results{
 			anythingLinted: false,
 			Success:        false,
 		})
@@ -31,7 +31,7 @@ func TestPrettySummarize(t *testing.T) {
 
 func TestPrettyFormat(t *testing.T) {
 	t.Run("Multiple", func(t *testing.T) {
-		msg := formatterPretty{}.Format(&LintResult{
+		msg := formatterPretty{}.Format(&Result{
 			File: "test1",
 			Errs: []error{
 				fmt.Errorf("some error"),
@@ -47,7 +47,7 @@ func TestPrettyFormat(t *testing.T) {
 	})
 
 	t.Run("One", func(t *testing.T) {
-		msg := formatterPretty{}.Format(&LintResult{
+		msg := formatterPretty{}.Format(&Result{
 			File: "test2",
 			Errs: []error{
 				fmt.Errorf("some error"),
@@ -62,7 +62,7 @@ func TestPrettyFormat(t *testing.T) {
 	})
 
 	t.Run("NotLinted", func(t *testing.T) {
-		msg := formatterPretty{}.Format(&LintResult{
+		msg := formatterPretty{}.Format(&Result{
 			File:   "test3",
 			Linted: false,
 		})
@@ -78,14 +78,14 @@ func TestPrettySummarizeWithColorDisabled(t *testing.T) {
 	}()
 
 	t.Run("Success", func(t *testing.T) {
-		msg := formatterPretty{}.Summarize(&LintResults{
+		msg := formatterPretty{}.Summarize(&Results{
 			Success: true,
 		})
 		expected := "✔ no linting errors found!\n"
 		assert.Equal(t, expected, msg)
 	})
 	t.Run("Nothing linted", func(t *testing.T) {
-		msg := formatterPretty{}.Summarize(&LintResults{
+		msg := formatterPretty{}.Summarize(&Results{
 			anythingLinted: false,
 			Success:        false,
 		})
@@ -101,7 +101,7 @@ func TestPrettyFormatWithColorDisabled(t *testing.T) {
 	}()
 
 	t.Run("Multiple", func(t *testing.T) {
-		msg := formatterPretty{}.Format(&LintResult{
+		msg := formatterPretty{}.Format(&Result{
 			File: "test1",
 			Errs: []error{
 				fmt.Errorf("some error"),
@@ -114,7 +114,7 @@ func TestPrettyFormatWithColorDisabled(t *testing.T) {
 	})
 
 	t.Run("One", func(t *testing.T) {
-		msg := formatterPretty{}.Format(&LintResult{
+		msg := formatterPretty{}.Format(&Result{
 			File: "test2",
 			Errs: []error{
 				fmt.Errorf("some error"),
@@ -126,7 +126,7 @@ func TestPrettyFormatWithColorDisabled(t *testing.T) {
 	})
 
 	t.Run("NotLinted", func(t *testing.T) {
-		msg := formatterPretty{}.Format(&LintResult{
+		msg := formatterPretty{}.Format(&Result{
 			File:   "test3",
 			Linted: false,
 		})

--- a/cmd/argo/lint/formatter_simple.go
+++ b/cmd/argo/lint/formatter_simple.go
@@ -7,7 +7,7 @@ import (
 
 type formatterSimple struct{}
 
-func (f formatterSimple) Format(l *LintResult) string {
+func (f formatterSimple) Format(l *Result) string {
 	if !l.Linted {
 		return ""
 	}
@@ -24,7 +24,7 @@ func (f formatterSimple) Format(l *LintResult) string {
 	return sb.String()
 }
 
-func (f formatterSimple) Summarize(l *LintResults) string {
+func (f formatterSimple) Summarize(l *Results) string {
 	if l.Success {
 		return "no linting errors found!\n"
 	}

--- a/cmd/argo/lint/formatter_simple_test.go
+++ b/cmd/argo/lint/formatter_simple_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestSimpleSummarize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		msg := formatterSimple{}.Summarize(&LintResults{
+		msg := formatterSimple{}.Summarize(&Results{
 			Success: true,
 		})
 		expected := "no linting errors found!\n"
 		assert.Equal(t, expected, msg)
 	})
 	t.Run("Nothing linted", func(t *testing.T) {
-		msg := formatterSimple{}.Summarize(&LintResults{
+		msg := formatterSimple{}.Summarize(&Results{
 			anythingLinted: false,
 			Success:        false,
 		})
@@ -27,7 +27,7 @@ func TestSimpleSummarize(t *testing.T) {
 
 func TestSimpleFormat(t *testing.T) {
 	t.Run("Multiple", func(t *testing.T) {
-		msg := formatterSimple{}.Format(&LintResult{
+		msg := formatterSimple{}.Format(&Result{
 			File: "test1",
 			Errs: []error{
 				fmt.Errorf("some error"),
@@ -42,7 +42,7 @@ test1: some error2
 	})
 
 	t.Run("One", func(t *testing.T) {
-		msg := formatterSimple{}.Format(&LintResult{
+		msg := formatterSimple{}.Format(&Result{
 			File: "test2",
 			Errs: []error{
 				fmt.Errorf("some error"),
@@ -54,7 +54,7 @@ test1: some error2
 	})
 
 	t.Run("NotLinted", func(t *testing.T) {
-		msg := formatterSimple{}.Format(&LintResult{
+		msg := formatterSimple{}.Format(&Result{
 			File:   "test3",
 			Linted: false,
 		})

--- a/cmd/argo/lint/lint.go
+++ b/cmd/argo/lint/lint.go
@@ -28,7 +28,7 @@ type ServiceClients struct {
 	ClusterWorkflowTemplateClient clusterworkflowtemplatepkg.ClusterWorkflowTemplateServiceClient
 }
 
-type LintOptions struct {
+type Options struct {
 	Files            []string
 	Strict           bool
 	DefaultNamespace string
@@ -40,16 +40,16 @@ type LintOptions struct {
 	Printer io.Writer
 }
 
-// LintResult represents the result of linting objects from a single source
-type LintResult struct {
+// Result represents the result of linting objects from a single source
+type Result struct {
 	File   string
 	Errs   []error
 	Linted bool
 }
 
-// LintResults represents the result of linting objects from multiple sources
-type LintResults struct {
-	Results        []*LintResult
+// Results represents the result of linting objects from multiple sources
+type Results struct {
+	Results        []*Result
 	Success        bool
 	msg            string
 	fmtr           Formatter
@@ -57,8 +57,8 @@ type LintResults struct {
 }
 
 type Formatter interface {
-	Format(*LintResult) string
-	Summarize(*LintResults) string
+	Format(*Result) string
+	Summarize(*Results) string
 }
 
 var (
@@ -80,7 +80,7 @@ func GetFormatter(fmtr string) (Formatter, error) {
 
 // RunLint lints the specified kinds in the specified files and prints the results to os.Stdout.
 // If linting fails it will exit with status code 1.
-func RunLint(ctx context.Context, client apiclient.Client, kinds []string, output string, offline bool, opts LintOptions) error {
+func RunLint(ctx context.Context, client apiclient.Client, kinds []string, output string, offline bool, opts Options) error {
 	fmtr, err := GetFormatter(output)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func RunLint(ctx context.Context, client apiclient.Client, kinds []string, outpu
 
 // Lint reads all files, returns linting errors of all of the enitities of the specified kinds.
 // Entities of other kinds are ignored.
-func Lint(ctx context.Context, opts *LintOptions) (*LintResults, error) {
+func Lint(ctx context.Context, opts *Options) (*Results, error) {
 	var fmtr Formatter = defaultFormatter
 	var w = io.Discard
 	if opts.Formatter != nil {
@@ -118,8 +118,8 @@ func Lint(ctx context.Context, opts *LintOptions) (*LintResults, error) {
 		w = opts.Printer
 	}
 
-	results := &LintResults{
-		Results: []*LintResult{},
+	results := &Results{
+		Results: []*Result{},
 		fmtr:    fmtr,
 	}
 
@@ -141,8 +141,8 @@ func Lint(ctx context.Context, opts *LintOptions) (*LintResults, error) {
 	return results, err
 }
 
-func lintData(ctx context.Context, src string, data []byte, opts *LintOptions) *LintResult {
-	res := &LintResult{
+func lintData(ctx context.Context, src string, data []byte, opts *Options) *Result {
+	res := &Result{
 		File: src,
 		Errs: []error{},
 	}
@@ -226,12 +226,12 @@ func lintData(ctx context.Context, src string, data []byte, opts *LintOptions) *
 	return res
 }
 
-func (l *LintResults) Msg() string {
+func (l *Results) Msg() string {
 	return l.msg
 }
 
 // evaluate must be called before checking the value of l.Success and l.String()
-func (l *LintResults) evaluate() *LintResults {
+func (l *Results) evaluate() *Results {
 	success := true
 	l.anythingLinted = false
 
@@ -257,7 +257,7 @@ func (l *LintResults) evaluate() *LintResults {
 	return l
 }
 
-func (l *LintResults) buildMsg() string {
+func (l *Results) buildMsg() string {
 	sb := &strings.Builder{}
 	for _, r := range l.Results {
 		sb.WriteString(l.fmtr.Format(r))

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -81,7 +81,7 @@ func TestLintFile(t *testing.T) {
 	wfServiceClientMock.On("LintWorkflow", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("lint error"))
 
 	ctx := logging.TestContext(t.Context())
-	res, err := Lint(ctx, &LintOptions{
+	res, err := Lint(ctx, &Options{
 		Files: []string{file.Name()},
 		ServiceClients: ServiceClients{
 			WorkflowsClient: wfServiceClientMock,
@@ -112,7 +112,7 @@ func TestLintMultipleKinds(t *testing.T) {
 	wftServiceSclientMock.On("LintWorkflowTemplate", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("lint error"))
 
 	ctx := logging.TestContext(t.Context())
-	res, err := Lint(ctx, &LintOptions{
+	res, err := Lint(ctx, &Options{
 		Files: []string{file.Name()},
 		ServiceClients: ServiceClients{
 			WorkflowsClient:         wfServiceClientMock,
@@ -157,7 +157,7 @@ func TestLintWithOutput(t *testing.T) {
 	mw.On("Write", mock.Anything).Return(0, nil)
 
 	ctx := logging.TestContext(t.Context())
-	res, err := Lint(ctx, &LintOptions{
+	res, err := Lint(ctx, &Options{
 		Files: []string{file.Name(), "-"},
 		ServiceClients: ServiceClients{
 			WorkflowsClient:         wfServiceClientMock,
@@ -201,7 +201,7 @@ func TestLintStdin(t *testing.T) {
 	wftServiceSclientMock.On("LintWorkflowTemplate", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("lint error"))
 
 	ctx := logging.TestContext(t.Context())
-	res, err := Lint(ctx, &LintOptions{
+	res, err := Lint(ctx, &Options{
 		Files: []string{"-"},
 		ServiceClients: ServiceClients{
 			WorkflowsClient:         wfServiceClientMock,
@@ -240,7 +240,7 @@ func TestLintDeviceFile(t *testing.T) {
 	deviceFileName := fmt.Sprintf("/dev/fd/%d", fd)
 
 	ctx := logging.TestContext(t.Context())
-	res, err := Lint(ctx, &LintOptions{
+	res, err := Lint(ctx, &Options{
 		Files: []string{deviceFileName},
 		ServiceClients: ServiceClients{
 			WorkflowsClient: wfServiceClientMock,
@@ -264,17 +264,17 @@ func TestGetFormatter(t *testing.T) {
 		"default": {
 			formatterName:  "",
 			expectedErr:    nil,
-			expectedOutput: (&LintResults{fmtr: formatterPretty{}}).buildMsg(),
+			expectedOutput: (&Results{fmtr: formatterPretty{}}).buildMsg(),
 		},
 		"pretty": {
 			formatterName:  "pretty",
 			expectedErr:    nil,
-			expectedOutput: (&LintResults{fmtr: formatterPretty{}}).buildMsg(),
+			expectedOutput: (&Results{fmtr: formatterPretty{}}).buildMsg(),
 		},
 		"simple": {
 			formatterName:  "simple",
 			expectedErr:    nil,
-			expectedOutput: (&LintResults{fmtr: formatterSimple{}}).buildMsg(),
+			expectedOutput: (&Results{fmtr: formatterSimple{}}).buildMsg(),
 		},
 		"unknown name": {
 			formatterName:  "foo",
@@ -300,7 +300,7 @@ func TestGetFormatter(t *testing.T) {
 			}
 
 			ctx := logging.TestContext(t.Context())
-			r, err := Lint(ctx, &LintOptions{Formatter: fmtr})
+			r, err := Lint(ctx, &Options{Formatter: fmtr})
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedOutput, r.Msg())
 		})

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -197,7 +197,7 @@ func TestEmissary(t *testing.T) {
 
 func run(script string) error {
 	cmd := NewEmissaryCommand()
-	_, _, err := cmdutil.CmdContextWithLogger(cmd, string(logging.Info), string(logging.Text))
+	_, _, err := cmdutil.ContextWithLogger(cmd, string(logging.Info), string(logging.Text))
 	if err != nil {
 		return err
 	}

--- a/cmd/argoexec/commands/emissary_windows_test.go
+++ b/cmd/argoexec/commands/emissary_windows_test.go
@@ -46,7 +46,7 @@ func TestEmissary(t *testing.T) {
 
 func run(script string) error {
 	cmd := NewEmissaryCommand()
-	_, _, err := cmdutil.CmdContextWithLogger(cmd, "info", "text")
+	_, _, err := cmdutil.ContextWithLogger(cmd, "info", "text")
 	if err != nil {
 		return err
 	}

--- a/cmd/argoexec/commands/root.go
+++ b/cmd/argoexec/commands/root.go
@@ -37,7 +37,7 @@ func NewRootCommand() *cobra.Command {
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			initConfig()
-			ctx, logger, err := cmdutil.CmdContextWithLogger(cmd, logLevel, logFormat)
+			ctx, logger, err := cmdutil.ContextWithLogger(cmd, logLevel, logFormat)
 			if err != nil {
 				logging.InitLogger().WithError(err).WithFatal().Error(cmd.Context(), "Failed to create argoexec pre-run logger")
 				os.Exit(1)
@@ -73,7 +73,7 @@ func NewRootCommand() *cobra.Command {
 	command.PersistentFlags().IntVar(&glogLevel, "gloglevel", 0, "Set the glog logging level")
 	command.PersistentFlags().StringVar(&logFormat, "log-format", "text", "The formatter to use for logs. One of: text|json")
 
-	ctx, logger, err := cmdutil.CmdContextWithLogger(&command, logLevel, logFormat)
+	ctx, logger, err := cmdutil.ContextWithLogger(&command, logLevel, logFormat)
 	if err != nil {
 		logging.InitLogger().WithError(err).WithFatal().Error(command.Context(), "Failed to create argoexec logger")
 		os.Exit(1)

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -70,7 +70,7 @@ func NewRootCommand() *cobra.Command {
 		Short: "workflow-controller is the controller to operate on workflows",
 		RunE: func(c *cobra.Command, args []string) error {
 			defer runtimeutil.HandleCrashWithContext(c.Context(), runtimeutil.PanicHandlers...)
-			ctx, log, err := cmdutil.CmdContextWithLogger(c, logLevel, logFormat)
+			ctx, log, err := cmdutil.ContextWithLogger(c, logLevel, logFormat)
 			if err != nil {
 				logging.InitLogger().WithError(err).WithFatal().Error(c.Context(), "Failed to create workflow-controller cmd logger")
 				return err
@@ -205,7 +205,7 @@ func NewRootCommand() *cobra.Command {
 	command.Flags().BoolVar(&namespaced, "namespaced", false, "run workflow-controller as namespaced mode")
 	command.Flags().StringVar(&managedNamespace, "managed-namespace", "", "namespace that workflow-controller watches, default to the installation namespace")
 	command.Flags().BoolVar(&executorPlugins, "executor-plugins", false, "enable executor plugins")
-	ctx, log, err := cmdutil.CmdContextWithLogger(&command, logLevel, logFormat)
+	ctx, log, err := cmdutil.ContextWithLogger(&command, logLevel, logFormat)
 	if err != nil {
 		logging.InitLogger().WithError(err).WithFatal().Error(command.Context(), "Failed to create workflow-controller logger")
 		os.Exit(1)

--- a/pkg/apiclient/argo-kube-client.go
+++ b/pkg/apiclient/argo-kube-client.go
@@ -156,7 +156,7 @@ func (a *argoKubeClient) startStores(ctx context.Context, restConfig *restclient
 		wftmplInformer.Run(ctx, a.opts.CachingCloseCh)
 		a.wfTmplStore = wftmplInformer
 	} else {
-		a.wfTmplStore = workflowtemplateserver.NewWorkflowTemplateClientStore()
+		a.wfTmplStore = workflowtemplateserver.NewClientStore()
 	}
 
 	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, a.kubeClient) {
@@ -168,7 +168,7 @@ func (a *argoKubeClient) startStores(ctx context.Context, restConfig *restclient
 			cwftmplInformer.Run(ctx, a.opts.CachingCloseCh)
 			a.cwfTmplStore = cwftmplInformer
 		} else {
-			a.cwfTmplStore = clusterworkflowtmplserver.NewClusterWorkflowTemplateClientStore()
+			a.cwfTmplStore = clusterworkflowtmplserver.NewClientStore()
 		}
 	} else {
 		a.cwfTmplStore = clusterworkflowtmplserver.NewNullClusterWorkflowTemplate()
@@ -179,7 +179,7 @@ func (a *argoKubeClient) startStores(ctx context.Context, restConfig *restclient
 
 func (a *argoKubeClient) NewWorkflowServiceClient(ctx context.Context) workflowpkg.WorkflowServiceClient {
 	wfArchive := sqldb.NullWorkflowArchive
-	wfServer := workflowserver.NewWorkflowServer(ctx, a.instanceIDService, argoKubeOffloadNodeStatusRepo, wfArchive, a.wfClient, a.wfLister, a.wfStore, a.wfTmplStore, a.cwfTmplStore, nil, &a.namespace)
+	wfServer := workflowserver.NewServer(ctx, a.instanceIDService, argoKubeOffloadNodeStatusRepo, wfArchive, a.wfClient, a.wfLister, a.wfStore, a.wfTmplStore, a.cwfTmplStore, nil, &a.namespace)
 	go wfServer.Run(a.opts.CachingCloseCh)
 	return &errorTranslatingWorkflowServiceClient{&argoKubeWorkflowServiceClient{wfServer}}
 }
@@ -189,7 +189,7 @@ func (a *argoKubeClient) NewCronWorkflowServiceClient() (cronworkflow.CronWorkfl
 }
 
 func (a *argoKubeClient) NewWorkflowTemplateServiceClient() (workflowtemplate.WorkflowTemplateServiceClient, error) {
-	return &errorTranslatingWorkflowTemplateServiceClient{&argoKubeWorkflowTemplateServiceClient{workflowtemplateserver.NewWorkflowTemplateServer(a.instanceIDService, a.wfTmplStore, a.cwfTmplStore)}}, nil
+	return &errorTranslatingWorkflowTemplateServiceClient{&argoKubeWorkflowTemplateServiceClient{workflowtemplateserver.NewServer(a.instanceIDService, a.wfTmplStore, a.cwfTmplStore)}}, nil
 }
 
 func (a *argoKubeClient) NewArchivedWorkflowServiceClient() (workflowarchivepkg.ArchivedWorkflowServiceClient, error) {

--- a/pkg/apiclient/offline-cluster-workflow-template-service-client.go
+++ b/pkg/apiclient/offline-cluster-workflow-template-service-client.go
@@ -39,7 +39,7 @@ func (o OfflineClusterWorkflowTemplateServiceClient) DeleteClusterWorkflowTempla
 }
 
 func (o OfflineClusterWorkflowTemplateServiceClient) LintClusterWorkflowTemplate(ctx context.Context, req *clusterworkflowtmplpkg.ClusterWorkflowTemplateLintRequest, opts ...grpc.CallOption) (*v1alpha1.ClusterWorkflowTemplate, error) {
-	err := validate.ValidateClusterWorkflowTemplate(ctx, nil, o.clusterWorkflowTemplateGetter, req.Template, nil, validate.ValidateOpts{Lint: true})
+	err := validate.ClusterWorkflowTemplate(ctx, nil, o.clusterWorkflowTemplateGetter, req.Template, nil, validate.Opts{Lint: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiclient/offline-cron-workflow-service-client.go
+++ b/pkg/apiclient/offline-cron-workflow-service-client.go
@@ -19,7 +19,7 @@ type OfflineCronWorkflowServiceClient struct {
 var _ cronworkflow.CronWorkflowServiceClient = &OfflineCronWorkflowServiceClient{}
 
 func (o OfflineCronWorkflowServiceClient) LintCronWorkflow(ctx context.Context, req *cronworkflow.LintCronWorkflowRequest, _ ...grpc.CallOption) (*v1alpha1.CronWorkflow, error) {
-	err := validate.ValidateCronWorkflow(ctx, o.namespacedWorkflowTemplateGetterMap.GetNamespaceGetter(req.Namespace), o.clusterWorkflowTemplateGetter, req.CronWorkflow, nil)
+	err := validate.CronWorkflow(ctx, o.namespacedWorkflowTemplateGetterMap.GetNamespaceGetter(req.Namespace), o.clusterWorkflowTemplateGetter, req.CronWorkflow, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiclient/offline-workflow-service-client.go
+++ b/pkg/apiclient/offline-workflow-service-client.go
@@ -71,7 +71,7 @@ func (o OfflineWorkflowServiceClient) SetWorkflow(context.Context, *workflowpkg.
 }
 
 func (o OfflineWorkflowServiceClient) LintWorkflow(ctx context.Context, req *workflowpkg.WorkflowLintRequest, _ ...grpc.CallOption) (*wfv1.Workflow, error) {
-	err := validate.ValidateWorkflow(ctx, o.namespacedWorkflowTemplateGetterMap.GetNamespaceGetter(req.Namespace), o.clusterWorkflowTemplateGetter, req.Workflow, nil, validate.ValidateOpts{Lint: true})
+	err := validate.Workflow(ctx, o.namespacedWorkflowTemplateGetterMap.GetNamespaceGetter(req.Namespace), o.clusterWorkflowTemplateGetter, req.Workflow, nil, validate.Opts{Lint: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiclient/offline-workflow-template-service-client.go
+++ b/pkg/apiclient/offline-workflow-template-service-client.go
@@ -39,7 +39,7 @@ func (o OfflineWorkflowTemplateServiceClient) DeleteWorkflowTemplate(_ context.C
 }
 
 func (o OfflineWorkflowTemplateServiceClient) LintWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateLintRequest, _ ...grpc.CallOption) (*v1alpha1.WorkflowTemplate, error) {
-	err := validate.ValidateWorkflowTemplate(ctx, o.namespacedWorkflowTemplateGetterMap.GetNamespaceGetter(req.Namespace), o.clusterWorkflowTemplateGetter, req.Template, nil, validate.ValidateOpts{Lint: true})
+	err := validate.WorkflowTemplate(ctx, o.namespacedWorkflowTemplateGetterMap.GetNamespaceGetter(req.Namespace), o.clusterWorkflowTemplateGetter, req.Template, nil, validate.Opts{Lint: true})
 	if err != nil {
 		return nil, err
 	}

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -236,7 +236,7 @@ func (s *sso) HandleRedirect(w http.ResponseWriter, r *http.Request) {
 	if !isValidFinalRedirectURL(finalRedirectURL) {
 		finalRedirectURL = s.baseHRef
 	}
-	state, err := pkgrand.RandString(10)
+	state, err := pkgrand.String(10)
 	if err != nil {
 		s.logger.WithError(err).Error(r.Context(), "failed to create state")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/server/auth/webhook/interceptor.go
+++ b/server/auth/webhook/interceptor.go
@@ -34,16 +34,16 @@ var webhookParsers = map[string]matcher{
 
 const pathPrefix = "/api/v1/events/"
 
-type WebhookInterceptor struct {
+type Interceptor struct {
 	logger logging.Logger
 }
 
-func NewWebhookInterceptor(logger logging.Logger) *WebhookInterceptor {
-	return &WebhookInterceptor{logger: logger}
+func NewInterceptor(logger logging.Logger) *Interceptor {
+	return &Interceptor{logger: logger}
 }
 
 // Interceptor creates an annotator that verifies webhook signatures and adds the appropriate access token to the request.
-func (i *WebhookInterceptor) Interceptor(client kubernetes.Interface) func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+func (i *Interceptor) Interceptor(client kubernetes.Interface) func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	return func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		err := i.addWebhookAuthorization(r, client)
 		if err != nil {
@@ -57,7 +57,7 @@ func (i *WebhookInterceptor) Interceptor(client kubernetes.Interface) func(w htt
 	}
 }
 
-func (i *WebhookInterceptor) addWebhookAuthorization(r *http.Request, kube kubernetes.Interface) error {
+func (i *Interceptor) addWebhookAuthorization(r *http.Request, kube kubernetes.Interface) error {
 	// try and exit quickly before we do anything API calls
 	if r.Method != http.MethodPost || len(r.Header["Authorization"]) > 0 || !strings.HasPrefix(r.URL.Path, pathPrefix) {
 		return nil

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -125,7 +125,7 @@ func intercept(ctx context.Context, method string, target string, headers map[st
 			Data:       map[string][]byte{"token": []byte("my-gitlab-token")},
 		},
 	)
-	i := NewWebhookInterceptor(logging.RequireLoggerFromContext(ctx)).Interceptor(k)
+	i := NewInterceptor(logging.RequireLoggerFromContext(ctx)).Interceptor(k)
 	w := httptest.NewRecorder()
 	b := &bytes.Buffer{}
 	b.WriteString("{}")

--- a/server/clusterworkflowtemplate/cluster_workflow_template_server.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server.go
@@ -19,7 +19,7 @@ import (
 	serverutils "github.com/argoproj/argo-workflows/v3/server/utils"
 )
 
-type ClusterWorkflowTemplateServer struct {
+type Server struct {
 	instanceIDService instanceid.Service
 	cwftmplStore      servertypes.ClusterWorkflowTemplateStore
 	wfDefaults        *v1alpha1.Workflow
@@ -27,12 +27,12 @@ type ClusterWorkflowTemplateServer struct {
 
 func NewClusterWorkflowTemplateServer(instanceID instanceid.Service, cwftmplStore servertypes.ClusterWorkflowTemplateStore, wfDefaults *v1alpha1.Workflow) clusterwftmplpkg.ClusterWorkflowTemplateServiceServer {
 	if cwftmplStore == nil {
-		cwftmplStore = NewClusterWorkflowTemplateClientStore()
+		cwftmplStore = NewClientStore()
 	}
-	return &ClusterWorkflowTemplateServer{instanceID, cwftmplStore, wfDefaults}
+	return &Server{instanceID, cwftmplStore, wfDefaults}
 }
 
-func (cwts *ClusterWorkflowTemplateServer) CreateClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateCreateRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
+func (cwts *Server) CreateClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateCreateRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
 	wfClient := auth.GetWfClient(ctx)
 	if req.Template == nil {
 		return nil, serverutils.ToStatusError(fmt.Errorf("cluster workflow template was not found in the request body"), codes.InvalidArgument)
@@ -40,7 +40,7 @@ func (cwts *ClusterWorkflowTemplateServer) CreateClusterWorkflowTemplate(ctx con
 	cwts.instanceIDService.Label(req.Template)
 	creator.LabelCreator(ctx, req.Template)
 	cwftmplGetter := cwts.cwftmplStore.Getter(ctx)
-	err := validate.ValidateClusterWorkflowTemplate(ctx, nil, cwftmplGetter, req.Template, cwts.wfDefaults, validate.ValidateOpts{})
+	err := validate.ClusterWorkflowTemplate(ctx, nil, cwftmplGetter, req.Template, cwts.wfDefaults, validate.Opts{})
 	if err != nil {
 		return nil, serverutils.ToStatusError(err, codes.InvalidArgument)
 	}
@@ -51,7 +51,7 @@ func (cwts *ClusterWorkflowTemplateServer) CreateClusterWorkflowTemplate(ctx con
 	return res, nil
 }
 
-func (cwts *ClusterWorkflowTemplateServer) GetClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateGetRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
+func (cwts *Server) GetClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateGetRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
 	wfTmpl, err := cwts.getTemplateAndValidate(ctx, req.Name)
 	if err != nil {
 		return nil, serverutils.ToStatusError(err, codes.Internal)
@@ -59,7 +59,7 @@ func (cwts *ClusterWorkflowTemplateServer) GetClusterWorkflowTemplate(ctx contex
 	return wfTmpl, nil
 }
 
-func (cwts *ClusterWorkflowTemplateServer) getTemplateAndValidate(ctx context.Context, name string) (*v1alpha1.ClusterWorkflowTemplate, error) {
+func (cwts *Server) getTemplateAndValidate(ctx context.Context, name string) (*v1alpha1.ClusterWorkflowTemplate, error) {
 	wfTmpl, err := cwts.cwftmplStore.Getter(ctx).Get(ctx, name)
 	if err != nil {
 		return nil, serverutils.ToStatusError(err, codes.Internal)
@@ -71,7 +71,7 @@ func (cwts *ClusterWorkflowTemplateServer) getTemplateAndValidate(ctx context.Co
 	return wfTmpl, nil
 }
 
-func (cwts *ClusterWorkflowTemplateServer) ListClusterWorkflowTemplates(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateListRequest) (*v1alpha1.ClusterWorkflowTemplateList, error) {
+func (cwts *Server) ListClusterWorkflowTemplates(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateListRequest) (*v1alpha1.ClusterWorkflowTemplateList, error) {
 	wfClient := auth.GetWfClient(ctx)
 	options := &v1.ListOptions{}
 	if req.ListOptions != nil {
@@ -88,7 +88,7 @@ func (cwts *ClusterWorkflowTemplateServer) ListClusterWorkflowTemplates(ctx cont
 	return cwfList, nil
 }
 
-func (cwts *ClusterWorkflowTemplateServer) DeleteClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateDeleteRequest) (*clusterwftmplpkg.ClusterWorkflowTemplateDeleteResponse, error) {
+func (cwts *Server) DeleteClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateDeleteRequest) (*clusterwftmplpkg.ClusterWorkflowTemplateDeleteResponse, error) {
 	wfClient := auth.GetWfClient(ctx)
 	_, err := cwts.getTemplateAndValidate(ctx, req.Name)
 	if err != nil {
@@ -102,12 +102,12 @@ func (cwts *ClusterWorkflowTemplateServer) DeleteClusterWorkflowTemplate(ctx con
 	return &clusterwftmplpkg.ClusterWorkflowTemplateDeleteResponse{}, nil
 }
 
-func (cwts *ClusterWorkflowTemplateServer) LintClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateLintRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
+func (cwts *Server) LintClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateLintRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
 	cwts.instanceIDService.Label(req.Template)
 	creator.LabelCreator(ctx, req.Template)
 	cwftmplGetter := cwts.cwftmplStore.Getter(ctx)
 
-	err := validate.ValidateClusterWorkflowTemplate(ctx, nil, cwftmplGetter, req.Template, cwts.wfDefaults, validate.ValidateOpts{Lint: true})
+	err := validate.ClusterWorkflowTemplate(ctx, nil, cwftmplGetter, req.Template, cwts.wfDefaults, validate.Opts{Lint: true})
 	if err != nil {
 		return nil, serverutils.ToStatusError(err, codes.InvalidArgument)
 	}
@@ -115,7 +115,7 @@ func (cwts *ClusterWorkflowTemplateServer) LintClusterWorkflowTemplate(ctx conte
 	return req.Template, nil
 }
 
-func (cwts *ClusterWorkflowTemplateServer) UpdateClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateUpdateRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
+func (cwts *Server) UpdateClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateUpdateRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
 	if req.Template == nil {
 		return nil, serverutils.ToStatusError(fmt.Errorf("ClusterWorkflowTemplate is not found in Request body"), codes.InvalidArgument)
 	}
@@ -127,7 +127,7 @@ func (cwts *ClusterWorkflowTemplateServer) UpdateClusterWorkflowTemplate(ctx con
 	wfClient := auth.GetWfClient(ctx)
 	cwftmplGetter := cwts.cwftmplStore.Getter(ctx)
 
-	err = validate.ValidateClusterWorkflowTemplate(ctx, nil, cwftmplGetter, req.Template, cwts.wfDefaults, validate.ValidateOpts{})
+	err = validate.ClusterWorkflowTemplate(ctx, nil, cwftmplGetter, req.Template, cwts.wfDefaults, validate.Opts{})
 	if err != nil {
 		return nil, serverutils.ToStatusError(err, codes.InvalidArgument)
 	}

--- a/server/clusterworkflowtemplate/wf_client_store.go
+++ b/server/clusterworkflowtemplate/wf_client_store.go
@@ -8,14 +8,14 @@ import (
 )
 
 // Store is a wrapper around informer
-type ClusterWorkflowTemplateClientStore struct {
+type ClientStore struct {
 }
 
-func NewClusterWorkflowTemplateClientStore() *ClusterWorkflowTemplateClientStore {
-	return &ClusterWorkflowTemplateClientStore{}
+func NewClientStore() *ClientStore {
+	return &ClientStore{}
 }
 
-func (wcs *ClusterWorkflowTemplateClientStore) Getter(ctx context.Context) templateresolution.ClusterWorkflowTemplateGetter {
+func (wcs *ClientStore) Getter(ctx context.Context) templateresolution.ClusterWorkflowTemplateGetter {
 	wfClient := auth.GetWfClient(ctx)
 	return templateresolution.WrapClusterWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 }

--- a/server/cronworkflow/cron_workflow_server.go
+++ b/server/cronworkflow/cron_workflow_server.go
@@ -37,7 +37,7 @@ func (c *cronWorkflowServiceServer) LintCronWorkflow(ctx context.Context, req *c
 	cwftmplGetter := c.cwftmplStore.Getter(ctx)
 	c.instanceIDService.Label(req.CronWorkflow)
 	creator.LabelCreator(ctx, req.CronWorkflow)
-	err := validate.ValidateCronWorkflow(ctx, wftmplGetter, cwftmplGetter, req.CronWorkflow, c.wfDefaults)
+	err := validate.CronWorkflow(ctx, wftmplGetter, cwftmplGetter, req.CronWorkflow, c.wfDefaults)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}
@@ -66,7 +66,7 @@ func (c *cronWorkflowServiceServer) CreateCronWorkflow(ctx context.Context, req 
 	creator.LabelCreator(ctx, req.CronWorkflow)
 	wftmplGetter := c.wftmplStore.Getter(ctx, req.Namespace)
 	cwftmplGetter := c.cwftmplStore.Getter(ctx)
-	err := validate.ValidateCronWorkflow(ctx, wftmplGetter, cwftmplGetter, req.CronWorkflow, c.wfDefaults)
+	err := validate.CronWorkflow(ctx, wftmplGetter, cwftmplGetter, req.CronWorkflow, c.wfDefaults)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}
@@ -93,7 +93,7 @@ func (c *cronWorkflowServiceServer) UpdateCronWorkflow(ctx context.Context, req 
 	creator.LabelActor(ctx, req.CronWorkflow, creator.ActionUpdate)
 	wftmplGetter := c.wftmplStore.Getter(ctx, req.Namespace)
 	cwftmplGetter := c.cwftmplStore.Getter(ctx)
-	if err := validate.ValidateCronWorkflow(ctx, wftmplGetter, cwftmplGetter, req.CronWorkflow, c.wfDefaults); err != nil {
+	if err := validate.CronWorkflow(ctx, wftmplGetter, cwftmplGetter, req.CronWorkflow, c.wfDefaults); err != nil {
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}
 	crWf, err := auth.GetWfClient(ctx).ArgoprojV1alpha1().CronWorkflows(req.Namespace).Update(ctx, req.CronWorkflow, metav1.UpdateOptions{})

--- a/server/cronworkflow/cron_workflow_server_test.go
+++ b/server/cronworkflow/cron_workflow_server_test.go
@@ -57,8 +57,8 @@ metadata:
 `, &unlabelled)
 
 	wfClientset := wftFake.NewSimpleClientset(&unlabelled)
-	wftmplStore := workflowtemplate.NewWorkflowTemplateClientStore()
-	cwftmplStore := clusterworkflowtemplate.NewClusterWorkflowTemplateClientStore()
+	wftmplStore := workflowtemplate.NewClientStore()
+	cwftmplStore := clusterworkflowtemplate.NewClientStore()
 	server := NewCronWorkflowServer(instanceid.NewService("my-instanceid"), wftmplStore, cwftmplStore, nil)
 	ctx := context.WithValue(logging.TestContext(t.Context()), auth.WfKey, wfClientset)
 	ctx = context.WithValue(ctx, auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}, Email: "my-sub@your.org"})

--- a/server/sync/sync_cm.go
+++ b/server/sync/sync_cm.go
@@ -16,7 +16,7 @@ import (
 
 type configMapSyncProvider struct{}
 
-var _ SyncConfigProvider = &configMapSyncProvider{}
+var _ ConfigProvider = &configMapSyncProvider{}
 
 func (s *configMapSyncProvider) createSyncLimit(ctx context.Context, req *syncpkg.CreateSyncLimitRequest) (*syncpkg.SyncLimitResponse, error) {
 	if req.Limit <= 0 {

--- a/server/sync/sync_db.go
+++ b/server/sync/sync_db.go
@@ -20,7 +20,7 @@ type dbSyncProvider struct {
 	db syncdb.SyncQueries
 }
 
-var _ SyncConfigProvider = &dbSyncProvider{}
+var _ ConfigProvider = &dbSyncProvider{}
 
 func (s *dbSyncProvider) createSyncLimit(ctx context.Context, req *syncpkg.CreateSyncLimitRequest) (*syncpkg.SyncLimitResponse, error) {
 	// since there's no permission system for db sync limits, we use the k8s RBAC check to see if the request is reasonable

--- a/server/sync/sync_server_db_test.go
+++ b/server/sync/sync_server_db_test.go
@@ -27,7 +27,7 @@ func TestDBSyncProvider(t *testing.T) {
 	mockSyncQueries := &syncdbmocks.SyncQueries{}
 	provider := &dbSyncProvider{db: mockSyncQueries}
 	server := &syncServer{
-		providers: map[syncpkg.SyncConfigType]SyncConfigProvider{
+		providers: map[syncpkg.SyncConfigType]ConfigProvider{
 			syncpkg.SyncConfigType_DATABASE: provider,
 		},
 	}

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -48,8 +48,8 @@ const (
 	workflowTemplateResyncPeriod = 20 * time.Minute
 )
 
-// WorkflowServer is the interface for the workflow server.
-type WorkflowServer interface {
+// Server is the interface for the workflow server.
+type Server interface {
 	workflowpkg.WorkflowServiceServer
 	Run(stopCh <-chan struct{})
 }
@@ -66,10 +66,10 @@ type workflowServer struct {
 	wfDefaults            *wfv1.Workflow
 }
 
-var _ WorkflowServer = &workflowServer{}
+var _ Server = &workflowServer{}
 
-// NewWorkflowServer returns a new WorkflowServer
-func NewWorkflowServer(ctx context.Context, instanceIDService instanceid.Service, offloadNodeStatusRepo sqldb.OffloadNodeStatusRepo, wfArchive sqldb.WorkflowArchive, wfClientSet versioned.Interface, wfLister store.WorkflowLister, wfStore store.WorkflowStore, wftmplStore servertypes.WorkflowTemplateStore, cwftmplStore servertypes.ClusterWorkflowTemplateStore, wfDefaults *wfv1.Workflow, namespace *string) WorkflowServer {
+// NewServer returns a new Server
+func NewServer(ctx context.Context, instanceIDService instanceid.Service, offloadNodeStatusRepo sqldb.OffloadNodeStatusRepo, wfArchive sqldb.WorkflowArchive, wfClientSet versioned.Interface, wfLister store.WorkflowLister, wfStore store.WorkflowStore, wftmplStore servertypes.WorkflowTemplateStore, cwftmplStore servertypes.ClusterWorkflowTemplateStore, wfDefaults *wfv1.Workflow, namespace *string) Server {
 	ws := &workflowServer{
 		instanceIDService:     instanceIDService,
 		offloadNodeStatusRepo: offloadNodeStatusRepo,
@@ -118,7 +118,7 @@ func (s *workflowServer) CreateWorkflow(ctx context.Context, req *workflowpkg.Wo
 	wftmplGetter := s.wftmplStore.Getter(ctx, req.Workflow.Namespace)
 	cwftmplGetter := s.cwftmplStore.Getter(ctx)
 
-	err := validate.ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, req.Workflow, s.wfDefaults, validate.ValidateOpts{})
+	err := validate.Workflow(ctx, wftmplGetter, cwftmplGetter, req.Workflow, s.wfDefaults, validate.Opts{})
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}
@@ -706,7 +706,7 @@ func (s *workflowServer) LintWorkflow(ctx context.Context, req *workflowpkg.Work
 	s.instanceIDService.Label(req.Workflow)
 	creator.LabelCreator(ctx, req.Workflow)
 
-	err := validate.ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, req.Workflow, s.wfDefaults, validate.ValidateOpts{Lint: true})
+	err := validate.Workflow(ctx, wftmplGetter, cwftmplGetter, req.Workflow, s.wfDefaults, validate.Opts{Lint: true})
 	if err != nil {
 		return nil, err
 	}
@@ -831,7 +831,7 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 	wftmplGetter := s.wftmplStore.Getter(ctx, req.Namespace)
 	cwftmplGetter := s.cwftmplStore.Getter(ctx)
 
-	err = validate.ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, s.wfDefaults, validate.ValidateOpts{Submit: true})
+	err = validate.Workflow(ctx, wftmplGetter, cwftmplGetter, wf, s.wfDefaults, validate.Opts{Submit: true})
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -660,9 +660,9 @@ func getWorkflowServer(t *testing.T) (workflowpkg.WorkflowServiceServer, context
 		panic(err)
 	}
 	namespaceAll := metav1.NamespaceAll
-	wftmplStore := workflowtemplate.NewWorkflowTemplateClientStore()
-	cwftmplStore := clusterworkflowtemplate.NewClusterWorkflowTemplateClientStore()
-	server := NewWorkflowServer(ctx, instanceIDSvc, offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll)
+	wftmplStore := workflowtemplate.NewClientStore()
+	cwftmplStore := clusterworkflowtemplate.NewClientStore()
+	server := NewServer(ctx, instanceIDSvc, offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll)
 	return server, ctx
 }
 

--- a/server/workflowtemplate/wf_client_store.go
+++ b/server/workflowtemplate/wf_client_store.go
@@ -8,14 +8,14 @@ import (
 )
 
 // Store is a wrapper around informer
-type WorkflowTemplateClientStore struct {
+type ClientStore struct {
 }
 
-func NewWorkflowTemplateClientStore() *WorkflowTemplateClientStore {
-	return &WorkflowTemplateClientStore{}
+func NewClientStore() *ClientStore {
+	return &ClientStore{}
 }
 
-func (wcs *WorkflowTemplateClientStore) Getter(ctx context.Context, namespace string) templateresolution.WorkflowTemplateNamespacedGetter {
+func (wcs *ClientStore) Getter(ctx context.Context, namespace string) templateresolution.WorkflowTemplateNamespacedGetter {
 	wfClient := auth.GetWfClient(ctx)
 	return templateresolution.WrapWorkflowTemplateInterface(wfClient.ArgoprojV1alpha1().WorkflowTemplates(namespace))
 }

--- a/server/workflowtemplate/workflow_template_server_test.go
+++ b/server/workflowtemplate/workflow_template_server_test.go
@@ -176,9 +176,9 @@ func getWorkflowTemplateServer(t *testing.T) (workflowtemplatepkg.WorkflowTempla
 	kubeClientSet := fake.NewSimpleClientset()
 	wfClientset := wftFake.NewSimpleClientset(&unlabelledObj, &wftObj1, &wftObj2)
 	ctx := context.WithValue(context.WithValue(context.WithValue(logging.TestContext(t.Context()), auth.WfKey, wfClientset), auth.KubeKey, kubeClientSet), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}, Email: "my-sub@your.org"})
-	wftmplStore := NewWorkflowTemplateClientStore()
-	cwftmplStore := clusterworkflowtemplate.NewClusterWorkflowTemplateClientStore()
-	return NewWorkflowTemplateServer(instanceid.NewService("my-instanceid"), wftmplStore, cwftmplStore), ctx
+	wftmplStore := NewClientStore()
+	cwftmplStore := clusterworkflowtemplate.NewClientStore()
+	return NewServer(instanceid.NewService("my-instanceid"), wftmplStore, cwftmplStore), ctx
 }
 
 func TestWorkflowTemplateServer_CreateWorkflowTemplate(t *testing.T) {

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -104,7 +104,7 @@ func ParseLabels(labelSpec any) (map[string]string, error) {
 }
 
 // Ensures we have a logger at the specified level
-func CmdContextWithLogger(cmd *cobra.Command, logLevel, logType string) (context.Context, logging.Logger, error) {
+func ContextWithLogger(cmd *cobra.Command, logLevel, logType string) (context.Context, logging.Logger, error) {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()

--- a/util/file/fileutil_test.go
+++ b/util/file/fileutil_test.go
@@ -173,7 +173,7 @@ func TestIsDirectory(t *testing.T) {
 
 func TestExists(t *testing.T) {
 	assert.True(t, file.Exists("/"))
-	path, err := rand.RandString(10)
+	path, err := rand.String(10)
 	require.NoError(t, err)
 	randFilePath := fmt.Sprintf("/%s", path)
 	assert.False(t, file.Exists(randFilePath))

--- a/util/json/json.go
+++ b/util/json/json.go
@@ -8,31 +8,31 @@ import (
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
-// JSONMarshaler is a type which satisfies the grpc-gateway Marshaler interface
-type JSONMarshaler struct{}
+// Marshaler is a type which satisfies the grpc-gateway Marshaler interface
+type Marshaler struct{}
 
 // ContentType implements gwruntime.Marshaler.
-func (j *JSONMarshaler) ContentType() string {
+func (j *Marshaler) ContentType() string {
 	return "application/json"
 }
 
 // Marshal implements gwruntime.Marshaler.
-func (j *JSONMarshaler) Marshal(v any) ([]byte, error) {
+func (j *Marshaler) Marshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
 // NewDecoder implements gwruntime.Marshaler.
-func (j *JSONMarshaler) NewDecoder(r io.Reader) gwruntime.Decoder {
+func (j *Marshaler) NewDecoder(r io.Reader) gwruntime.Decoder {
 	return json.NewDecoder(r)
 }
 
 // NewEncoder implements gwruntime.Marshaler.
-func (j *JSONMarshaler) NewEncoder(w io.Writer) gwruntime.Encoder {
+func (j *Marshaler) NewEncoder(w io.Writer) gwruntime.Encoder {
 	return json.NewEncoder(w)
 }
 
 // Unmarshal implements gwruntime.Marshaler.
-func (j *JSONMarshaler) Unmarshal(data []byte, v any) error {
+func (j *Marshaler) Unmarshal(data []byte, v any) error {
 	return json.Unmarshal(data, v)
 }
 
@@ -43,11 +43,11 @@ func DisallowUnknownFields(d *json.Decoder) *json.Decoder {
 	return d
 }
 
-// JSONOpt is a decoding option for decoding from JSON format.
-type JSONOpt func(*json.Decoder) *json.Decoder
+// Opt is a decoding option for decoding from JSON format.
+type Opt func(*json.Decoder) *json.Decoder
 
 // Unmarshal is a convenience wrapper around json.Unmarshal to support json decode options
-func Unmarshal(j []byte, o any, opts ...JSONOpt) error {
+func Unmarshal(j []byte, o any, opts ...Opt) error {
 	d := json.NewDecoder(bytes.NewReader(j))
 	for _, opt := range opts {
 		d = opt(d)

--- a/util/rand/rand.go
+++ b/util/rand/rand.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 )
 
-// RandString returns a cryptographically-secure pseudo-random alpha-numeric string of a given length
-func RandString(n int) (string, error) {
+// String returns a cryptographically-secure pseudo-random alpha-numeric string of a given length
+func String(n int) (string, error) {
 	bytes := make([]byte, n/2+1) // we need one extra letter to discard
 	if _, err := rand.Read(bytes); err != nil {
 		return "", err

--- a/util/rand/rand_test.go
+++ b/util/rand/rand_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRandString(t *testing.T) {
-	ss, err := RandString(10)
+func TestString(t *testing.T) {
+	ss, err := String(10)
 	require.NoError(t, err)
 	assert.Len(t, ss, 10)
-	ss, err = RandString(5)
+	ss, err = String(5)
 	require.NoError(t, err)
 	assert.Len(t, ss, 5)
 }

--- a/util/sync/db/config.go
+++ b/util/sync/db/config.go
@@ -13,8 +13,8 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/sqldb"
 )
 
-// DBConfig holds database configuration for sync operations.
-type DBConfig struct {
+// Config holds database configuration for sync operations.
+type Config struct {
 	LimitTable                string
 	StateTable                string
 	ControllerTable           string
@@ -24,8 +24,8 @@ type DBConfig struct {
 	SkipMigration             bool
 }
 
-type DBInfo struct {
-	Config  DBConfig
+type Info struct {
+	Config  Config
 	Session db.Session
 }
 
@@ -55,7 +55,7 @@ func SecondsToDurationWithDefault(value *int, defaultSeconds int) time.Duration 
 	return dur
 }
 
-func (d *DBInfo) Migrate(ctx context.Context) {
+func (d *Info) Migrate(ctx context.Context) {
 	if d.Session == nil {
 		return
 	}
@@ -75,11 +75,11 @@ func (d *DBInfo) Migrate(ctx context.Context) {
 	}
 }
 
-func DBConfigFromConfig(config *config.SyncConfig) DBConfig {
+func ConfigFromConfig(config *config.SyncConfig) Config {
 	if config == nil {
-		return DBConfig{}
+		return Config{}
 	}
-	return DBConfig{
+	return Config{
 		LimitTable:      defaultTable(config.LimitTableName, defaultLimitTableName),
 		StateTable:      defaultTable(config.StateTableName, defaultStateTableName),
 		ControllerTable: defaultTable(config.ControllerTableName, defaultControllerTableName),
@@ -91,7 +91,7 @@ func DBConfigFromConfig(config *config.SyncConfig) DBConfig {
 	}
 }
 
-func DBSessionFromConfigWithCreds(config *config.SyncConfig, username, password string) db.Session {
+func SessionFromConfigWithCreds(config *config.SyncConfig, username, password string) db.Session {
 	if config == nil {
 		return nil
 	}
@@ -103,7 +103,7 @@ func DBSessionFromConfigWithCreds(config *config.SyncConfig, username, password 
 	return dbSession
 }
 
-func DBSessionFromConfig(ctx context.Context, kubectlConfig kubernetes.Interface, namespace string, config *config.SyncConfig) db.Session {
+func SessionFromConfig(ctx context.Context, kubectlConfig kubernetes.Interface, namespace string, config *config.SyncConfig) db.Session {
 	if config == nil {
 		return nil
 	}

--- a/util/sync/db/migrate.go
+++ b/util/sync/db/migrate.go
@@ -12,7 +12,7 @@ const (
 	versionTable = "sync_schema_history"
 )
 
-func migrate(ctx context.Context, session db.Session, config *DBConfig) (err error) {
+func migrate(ctx context.Context, session db.Session, config *Config) (err error) {
 	return sqldb.Migrate(ctx, session, versionTable, []sqldb.Change{
 		sqldb.AnsiSQLChange(`create table if not exists ` + config.LimitTable + ` (
     name varchar(256) not null,

--- a/util/sync/db/queries.go
+++ b/util/sync/db/queries.go
@@ -87,12 +87,12 @@ var _ SyncQueries = &syncQueries{}
 
 // syncQueries holds all SQL query operations for the sync package
 type syncQueries struct {
-	config  DBConfig
+	config  Config
 	session db.Session
 }
 
 // NewSyncQueries creates a new syncQueries instance
-func NewSyncQueries(session db.Session, config DBConfig) SyncQueries {
+func NewSyncQueries(session db.Session, config Config) SyncQueries {
 	return &syncQueries{
 		config:  config,
 		session: session,

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -36,7 +36,7 @@ import (
 
 const nullIAMEndpoint = ""
 
-type S3Client interface {
+type Client interface {
 	// PutFile puts a single file to a bucket at the specified key
 	PutFile(bucket, key, path string) error
 
@@ -88,7 +88,7 @@ const (
 	VirtualHostedStyle
 )
 
-type S3ClientOpts struct {
+type ClientOpts struct {
 	Endpoint        string
 	AddressingStyle AddressingStyle
 	Region          string
@@ -106,13 +106,13 @@ type S3ClientOpts struct {
 }
 
 type s3client struct {
-	S3ClientOpts
+	ClientOpts
 	minioClient *minio.Client
 	//nolint: containedctx
 	ctx context.Context
 }
 
-var _ S3Client = &s3client{}
+var _ Client = &s3client{}
 
 // ArtifactDriver is a driver for AWS S3
 type ArtifactDriver struct {
@@ -133,9 +133,9 @@ type ArtifactDriver struct {
 
 var _ artifactscommon.ArtifactDriver = &ArtifactDriver{}
 
-// newS3Client instantiates a new S3 client object.
-func (s3Driver *ArtifactDriver) newS3Client(ctx context.Context) (S3Client, error) {
-	opts := S3ClientOpts{
+// newClient instantiates a new S3 client object.
+func (s3Driver *ArtifactDriver) newClient(ctx context.Context) (Client, error) {
+	opts := ClientOpts{
 		Endpoint:     s3Driver.Endpoint,
 		Region:       s3Driver.Region,
 		Secure:       s3Driver.Secure,
@@ -164,7 +164,7 @@ func (s3Driver *ArtifactDriver) newS3Client(ctx context.Context) (S3Client, erro
 		opts.Transport = tr
 	}
 
-	return NewS3Client(ctx, opts)
+	return NewClient(ctx, opts)
 }
 
 // Load downloads artifacts from S3 compliant storage
@@ -175,7 +175,7 @@ func (s3Driver *ArtifactDriver) Load(ctx context.Context, inputArtifact *wfv1.Ar
 	err := waitutil.Backoff(executorretry.ExecutorRetry(ctx),
 		func() (bool, error) {
 			log.WithFields(logging.Fields{"path": path, "key": inputArtifact.S3.Key}).Info(ctx, "S3 Load")
-			s3cli, err := s3Driver.newS3Client(ctx)
+			s3cli, err := s3Driver.newClient(ctx)
 			if err != nil {
 				return !isTransientS3Err(ctx, err), fmt.Errorf("failed to create new S3 client: %w", err)
 			}
@@ -188,7 +188,7 @@ func (s3Driver *ArtifactDriver) Load(ctx context.Context, inputArtifact *wfv1.Ar
 // loadS3Artifact downloads artifacts from an S3 compliant storage
 // returns true if the download is completed or can't be retried (non-transient error)
 // returns false if it can be retried (transient error)
-func loadS3Artifact(ctx context.Context, s3cli S3Client, inputArtifact *wfv1.Artifact, path string) (bool, error) {
+func loadS3Artifact(ctx context.Context, s3cli Client, inputArtifact *wfv1.Artifact, path string) (bool, error) {
 	origErr := s3cli.GetFile(inputArtifact.S3.Bucket, inputArtifact.S3.Key, path)
 	if origErr == nil {
 		return true, nil
@@ -217,7 +217,7 @@ func (s3Driver *ArtifactDriver) OpenStream(ctx context.Context, inputArtifact *w
 	log := logging.RequireLoggerFromContext(ctx)
 	log.WithField("key", inputArtifact.S3.Key).Info(ctx, "S3 OpenStream")
 	//nolint:contextcheck
-	s3cli, err := s3Driver.newS3Client(log.NewBackgroundContext())
+	s3cli, err := s3Driver.newClient(log.NewBackgroundContext())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new S3 client: %w", err)
 	}
@@ -225,7 +225,7 @@ func (s3Driver *ArtifactDriver) OpenStream(ctx context.Context, inputArtifact *w
 	return streamS3Artifact(ctx, s3cli, inputArtifact)
 }
 
-func streamS3Artifact(_ context.Context, s3cli S3Client, inputArtifact *wfv1.Artifact) (io.ReadCloser, error) {
+func streamS3Artifact(_ context.Context, s3cli Client, inputArtifact *wfv1.Artifact) (io.ReadCloser, error) {
 	stream, origErr := s3cli.OpenFile(inputArtifact.S3.Bucket, inputArtifact.S3.Key)
 	if origErr == nil {
 		return stream, nil
@@ -255,7 +255,7 @@ func (s3Driver *ArtifactDriver) Save(ctx context.Context, path string, outputArt
 	err := waitutil.Backoff(executorretry.ExecutorRetry(ctx),
 		func() (bool, error) {
 			log.WithFields(logging.Fields{"path": path, "key": outputArtifact.S3.Key}).Info(ctx, "S3 Save")
-			s3cli, err := s3Driver.newS3Client(ctx)
+			s3cli, err := s3Driver.newClient(ctx)
 			if err != nil {
 				return !isTransientS3Err(ctx, err), fmt.Errorf("failed to create new S3 client: %w", err)
 			}
@@ -273,7 +273,7 @@ func (s3Driver *ArtifactDriver) Delete(ctx context.Context, artifact *wfv1.Artif
 		return isTransientS3Err(ctx, err)
 	}, func() error {
 		log.WithField("key", artifact.S3.Key).Info(ctx, "S3 Delete")
-		s3cli, err := s3Driver.newS3Client(ctx)
+		s3cli, err := s3Driver.newClient(ctx)
 		if err != nil {
 			return err
 		}
@@ -302,7 +302,7 @@ func (s3Driver *ArtifactDriver) Delete(ctx context.Context, artifact *wfv1.Artif
 // saveS3Artifact uploads artifacts to an S3 compliant storage
 // returns true if the upload is completed or can't be retried (non-transient error)
 // returns false if it can be retried (transient error)
-func saveS3Artifact(ctx context.Context, s3cli S3Client, path string, outputArtifact *wfv1.Artifact) (bool, error) {
+func saveS3Artifact(ctx context.Context, s3cli Client, path string, outputArtifact *wfv1.Artifact) (bool, error) {
 	isDir, err := file.IsDirectory(path)
 	if err != nil {
 		return true, fmt.Errorf("failed to test if %s is a directory: %w", path, err)
@@ -353,7 +353,7 @@ func (s3Driver *ArtifactDriver) ListObjects(ctx context.Context, artifact *wfv1.
 	var done bool
 	err := waitutil.Backoff(executorretry.ExecutorRetry(ctx),
 		func() (bool, error) {
-			s3cli, err := s3Driver.newS3Client(ctx)
+			s3cli, err := s3Driver.newClient(ctx)
 			if err != nil {
 				return !isTransientS3Err(ctx, err), fmt.Errorf("failed to create new S3 client: %w", err)
 			}
@@ -367,7 +367,7 @@ func (s3Driver *ArtifactDriver) ListObjects(ctx context.Context, artifact *wfv1.
 // listObjects returns the files inside the directory represented by the Artifact
 // returns true if success or can't be retried (non-transient error)
 // returns false if it can be retried (transient error)
-func listObjects(ctx context.Context, s3cli S3Client, artifact *wfv1.Artifact) (bool, []string, error) {
+func listObjects(ctx context.Context, s3cli Client, artifact *wfv1.Artifact) (bool, []string, error) {
 	var files []string
 	files, err := s3cli.ListDirectory(artifact.S3.Bucket, artifact.S3.Key)
 	if err != nil {
@@ -389,7 +389,7 @@ func listObjects(ctx context.Context, s3cli S3Client, artifact *wfv1.Artifact) (
 }
 
 func (s3Driver *ArtifactDriver) IsDirectory(ctx context.Context, artifact *wfv1.Artifact) (bool, error) {
-	s3cli, err := s3Driver.newS3Client(ctx)
+	s3cli, err := s3Driver.newClient(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -397,7 +397,7 @@ func (s3Driver *ArtifactDriver) IsDirectory(ctx context.Context, artifact *wfv1.
 }
 
 // Get AWS credentials based on default order from aws SDK
-func getAWSCredentials(ctx context.Context, opts S3ClientOpts) (*credentials.Credentials, error) {
+func getAWSCredentials(ctx context.Context, opts ClientOpts) (*credentials.Credentials, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(opts.Region))
 	if err != nil {
 		return nil, err
@@ -411,7 +411,7 @@ func getAWSCredentials(ctx context.Context, opts S3ClientOpts) (*credentials.Cre
 }
 
 // GetAssumeRoleCredentials gets Assumed role credentials
-func getAssumeRoleCredentials(ctx context.Context, opts S3ClientOpts) (*credentials.Credentials, error) {
+func getAssumeRoleCredentials(ctx context.Context, opts ClientOpts) (*credentials.Credentials, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(opts.Region))
 	if err != nil {
 		return nil, err
@@ -429,7 +429,7 @@ func getAssumeRoleCredentials(ctx context.Context, opts S3ClientOpts) (*credenti
 	return credentials.NewStaticV4(value.AccessKeyID, value.SecretAccessKey, value.SessionToken), nil
 }
 
-func GetCredentials(ctx context.Context, opts S3ClientOpts) (*credentials.Credentials, error) {
+func GetCredentials(ctx context.Context, opts ClientOpts) (*credentials.Credentials, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	switch {
 	case opts.AccessKey != "" && opts.SecretKey != "":
@@ -452,15 +452,15 @@ func GetCredentials(ctx context.Context, opts S3ClientOpts) (*credentials.Creden
 }
 
 // GetDefaultTransport returns minio's default transport
-func GetDefaultTransport(opts S3ClientOpts) (*http.Transport, error) {
+func GetDefaultTransport(opts ClientOpts) (*http.Transport, error) {
 	return minio.DefaultTransport(opts.Secure)
 }
 
-// NewS3Client instantiates a new S3 client object backed
-func NewS3Client(ctx context.Context, opts S3ClientOpts) (S3Client, error) {
+// NewClient instantiates a new S3 client object backed
+func NewClient(ctx context.Context, opts ClientOpts) (Client, error) {
 	ctx, _ = logging.RequireLoggerFromContext(ctx).WithField("component", "s3_client").InContext(ctx)
 	s3cli := s3client{
-		S3ClientOpts: opts,
+		ClientOpts: opts,
 	}
 	s3cli.AccessKey = strings.TrimSpace(s3cli.AccessKey)
 	s3cli.SecretKey = strings.TrimSpace(s3cli.SecretKey)

--- a/workflow/controller/cache/cache.go
+++ b/workflow/controller/cache/cache.go
@@ -56,7 +56,7 @@ type cacheFactory struct {
 }
 
 type Factory interface {
-	GetCache(ct CacheType, name string) MemoizationCache
+	GetCache(ct Type, name string) MemoizationCache
 }
 
 func NewCacheFactory(ki kubernetes.Interface, ns string) Factory {
@@ -68,15 +68,15 @@ func NewCacheFactory(ki kubernetes.Interface, ns string) Factory {
 	}
 }
 
-type CacheType string
+type Type string
 
 const (
 	// Only config maps are currently supported for caching
-	ConfigMapCache CacheType = "ConfigMapCache"
+	ConfigMapCache Type = "ConfigMapCache"
 )
 
 // Returns a cache if it exists and creates it otherwise
-func (cf *cacheFactory) GetCache(ct CacheType, name string) MemoizationCache {
+func (cf *cacheFactory) GetCache(ct Type, name string) MemoizationCache {
 	cf.lock.RLock()
 
 	idx := string(ct) + "." + name

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4295,14 +4295,14 @@ func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) error {
 
 	// Perform one-time workflow validation
 	if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
-		validateOpts := validate.ValidateOpts{}
+		validateOpts := validate.Opts{}
 		wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTemplates(woc.wf.Namespace))
 		cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(woc.controller.wfclientset.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
 		// Validate the execution wfSpec
 		err := waitutil.Backoff(retry.DefaultRetry(ctx),
 			func() (bool, error) {
-				validationErr := validate.ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, woc.wf, woc.controller.Config.WorkflowDefaults, validateOpts)
+				validationErr := validate.Workflow(ctx, wftmplGetter, cwftmplGetter, woc.wf, woc.controller.Config.WorkflowDefaults, validateOpts)
 				if validationErr != nil {
 					return !errorsutil.IsTransientErr(ctx, validationErr), validationErr
 				}

--- a/workflow/controller/pod/queue.go
+++ b/workflow/controller/pod/queue.go
@@ -63,7 +63,7 @@ func (c *Controller) signalContainers(ctx context.Context, namespace string, pod
 			continue
 		}
 		// problems are already logged at info level, so we just ignore errors here
-		_ = signal.SignalContainer(ctx, c.restConfig, pod, container.Name, sig)
+		_ = signal.Container(ctx, c.restConfig, pod, container.Name, sig)
 	}
 	if pod.Spec.TerminationGracePeriodSeconds == nil {
 		return 30 * time.Second, nil

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -145,7 +145,7 @@ func (woc *cronWfOperationCtx) run(ctx context.Context, scheduledRuntime time.Ti
 func (woc *cronWfOperationCtx) validateCronWorkflow(ctx context.Context) error {
 	wftmplGetter := informer.NewWorkflowTemplateFromInformerGetter(woc.wftmplInformer, woc.cronWf.Namespace)
 	cwftmplGetter := informer.NewClusterWorkflowTemplateFromInformerGetter(woc.cwftmplInformer)
-	err := validate.ValidateCronWorkflow(ctx, wftmplGetter, cwftmplGetter, woc.cronWf, woc.wfDefaults)
+	err := validate.CronWorkflow(ctx, wftmplGetter, cwftmplGetter, woc.cronWf, woc.wfDefaults)
 	if err != nil {
 		woc.reportCronWorkflowError(ctx, v1alpha1.ConditionTypeSpecError, fmt.Sprint(err))
 	} else {

--- a/workflow/signal/signal.go
+++ b/workflow/signal/signal.go
@@ -16,7 +16,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
-func SignalContainer(ctx context.Context, restConfig *rest.Config, pod *corev1.Pod, container string, s syscall.Signal) error {
+func Container(ctx context.Context, restConfig *rest.Config, pod *corev1.Pod, container string, s syscall.Signal) error {
 	command := []string{"/bin/sh", "-c", "kill -%d 1"}
 
 	// If the container has the /var/run/argo volume mounted, this it will have access to `argoexec`.

--- a/workflow/sync/database_helper_test.go
+++ b/workflow/sync/database_helper_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 // createTestDBSession creates a test database session
-func createTestDBSession(ctx context.Context, t *testing.T, dbType sqldb.DBType) (syncdb.DBInfo, func(), config.SyncConfig, error) {
+func createTestDBSession(ctx context.Context, t *testing.T, dbType sqldb.DBType) (syncdb.Info, func(), config.SyncConfig, error) {
 	t.Helper()
 
 	var cfg config.SyncConfig
@@ -41,9 +41,9 @@ func createTestDBSession(ctx context.Context, t *testing.T, dbType sqldb.DBType)
 		t.Fatalf("failed to start container: %s", err)
 	}
 
-	info := syncdb.DBInfo{
-		Config:  syncdb.DBConfigFromConfig(&cfg),
-		Session: syncdb.DBSessionFromConfigWithCreds(&cfg, testDBUser, testDBPassword),
+	info := syncdb.Info{
+		Config:  syncdb.ConfigFromConfig(&cfg),
+		Session: syncdb.SessionFromConfigWithCreds(&cfg, testDBUser, testDBPassword),
 	}
 	require.NotNil(t, info.Session, "failed to create database session")
 	deferfn := func() {

--- a/workflow/sync/database_mutex.go
+++ b/workflow/sync/database_mutex.go
@@ -4,7 +4,7 @@ import (
 	syncdb "github.com/argoproj/argo-workflows/v3/util/sync/db"
 )
 
-func newDatabaseMutex(name string, dbKey string, nextWorkflow NextWorkflow, info syncdb.DBInfo) *databaseSemaphore {
+func newDatabaseMutex(name string, dbKey string, nextWorkflow NextWorkflow, info syncdb.Info) *databaseSemaphore {
 	logger := syncLogger{
 		name:     name,
 		lockType: lockTypeMutex,

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -18,14 +18,14 @@ type databaseSemaphore struct {
 	shortDBKey   string
 	nextWorkflow NextWorkflow
 	logger       loggerFn
-	info         syncdb.DBInfo
+	info         syncdb.Info
 	queries      syncdb.SyncQueries
 	isMutex      bool
 }
 
 var _ semaphore = &databaseSemaphore{}
 
-func newDatabaseSemaphore(ctx context.Context, name string, dbKey string, nextWorkflow NextWorkflow, info syncdb.DBInfo, syncLimitCacheTTL time.Duration) (*databaseSemaphore, error) {
+func newDatabaseSemaphore(ctx context.Context, name string, dbKey string, nextWorkflow NextWorkflow, info syncdb.Info, syncLimitCacheTTL time.Duration) (*databaseSemaphore, error) {
 	logger := syncLogger{
 		name:     name,
 		lockType: lockTypeSemaphore,

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -28,7 +28,7 @@ func createTestInternalSemaphore(ctx context.Context, t *testing.T, name, namesp
 }
 
 // createTestDatabaseSemaphore creates a database-backed semaphore for testing, used elsewhere
-func createTestDatabaseSemaphore(ctx context.Context, t *testing.T, name, namespace string, limit int, cacheTTL time.Duration, nextWorkflow NextWorkflow, dbType sqldb.DBType) (*databaseSemaphore, syncdb.DBInfo, func()) {
+func createTestDatabaseSemaphore(ctx context.Context, t *testing.T, name, namespace string, limit int, cacheTTL time.Duration, nextWorkflow NextWorkflow, dbType sqldb.DBType) (*databaseSemaphore, syncdb.Info, func()) {
 	t.Helper()
 	info, deferfunc, _, err := createTestDBSession(ctx, t, dbType)
 	require.NoError(t, err)

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -186,7 +186,7 @@ func SubmitWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, wfClie
 	wftmplGetter := templateresolution.WrapWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().WorkflowTemplates(namespace))
 	cwftmplGetter := templateresolution.WrapClusterWorkflowTemplateInterface(wfClientset.ArgoprojV1alpha1().ClusterWorkflowTemplates())
 
-	err = validate.ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, validate.ValidateOpts{Submit: true})
+	err = validate.Workflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, validate.Opts{Submit: true})
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -31,8 +31,8 @@ import (
 	"github.com/argoproj/argo-workflows/v3/workflow/templateresolution"
 )
 
-// ValidateOpts provides options when linting
-type ValidateOpts struct {
+// Opts provides options when linting
+type Opts struct {
 	// Lint indicates if this is performing validation in the context of linting. If true, will
 	// skip some validations which is permissible during linting but not submission (e.g. missing
 	// input parameters to the workflow)
@@ -52,7 +52,7 @@ type ValidateOpts struct {
 
 // templateValidationCtx is the context for validating a workflow spec
 type templateValidationCtx struct {
-	ValidateOpts
+	Opts
 
 	// globalParams keeps track of variables which are available the global
 	// scope and can be referenced from anywhere.
@@ -64,7 +64,7 @@ type templateValidationCtx struct {
 	wf *wfv1.Workflow
 }
 
-func newTemplateValidationCtx(wf *wfv1.Workflow, opts ValidateOpts) *templateValidationCtx {
+func newTemplateValidationCtx(wf *wfv1.Workflow, opts Opts) *templateValidationCtx {
 	globalParams := make(map[string]string)
 	globalParams[common.GlobalVarWorkflowName] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowNamespace] = placeholderGenerator.NextPlaceholder()
@@ -72,7 +72,7 @@ func newTemplateValidationCtx(wf *wfv1.Workflow, opts ValidateOpts) *templateVal
 	globalParams[common.GlobalVarWorkflowServiceAccountName] = placeholderGenerator.NextPlaceholder()
 	globalParams[common.GlobalVarWorkflowUID] = placeholderGenerator.NextPlaceholder()
 	return &templateValidationCtx{
-		ValidateOpts: opts,
+		Opts:         opts,
 		globalParams: globalParams,
 		results:      make(map[string]bool),
 		wf:           wf,
@@ -139,8 +139,8 @@ func validateHooks(hooks wfv1.LifecycleHooks, hookBaseName string) error {
 	return nil
 }
 
-// ValidateWorkflow accepts a workflow and performs validation against it.
-func ValidateWorkflow(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wf *wfv1.Workflow, wfDefaults *wfv1.Workflow, opts ValidateOpts) error {
+// Workflow accepts a workflow and performs validation against it.
+func Workflow(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wf *wfv1.Workflow, wfDefaults *wfv1.Workflow, opts Opts) error {
 	tctx := newTemplateValidationCtx(wf, opts)
 
 	tmplCtx := templateresolution.NewContext(wftmplGetter, cwftmplGetter, wf, wf, logging.RequireLoggerFromContext(ctx))
@@ -157,7 +157,7 @@ func ValidateWorkflow(ctx context.Context, wftmplGetter templateresolution.Workf
 	hasWorkflowTemplateRef := wf.Spec.WorkflowTemplateRef != nil
 
 	if hasWorkflowTemplateRef {
-		err := ValidateWorkflowTemplateRefFields(wf.Spec)
+		err := WorkflowTemplateRefFields(wf.Spec)
 		if err != nil {
 			return err
 		}
@@ -362,15 +362,15 @@ func getUniqueKeys(labelSources ...[]string) map[string]struct{} {
 	return uniqueKeys
 }
 
-func ValidateWorkflowTemplateRefFields(wfSpec wfv1.WorkflowSpec) error {
+func WorkflowTemplateRefFields(wfSpec wfv1.WorkflowSpec) error {
 	if len(wfSpec.Templates) > 0 {
 		return errors.Errorf(errors.CodeBadRequest, "Templates is invalid field in spec if workflow referred WorkflowTemplate reference")
 	}
 	return nil
 }
 
-// ValidateWorkflowTemplate accepts a workflow template and performs validation against it.
-func ValidateWorkflowTemplate(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wftmpl *wfv1.WorkflowTemplate, wfDefaults *wfv1.Workflow, opts ValidateOpts) error {
+// WorkflowTemplate accepts a workflow template and performs validation against it.
+func WorkflowTemplate(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, wftmpl *wfv1.WorkflowTemplate, wfDefaults *wfv1.Workflow, opts Opts) error {
 	if len(wftmpl.Name) > maxCharsInObjectName {
 		return fmt.Errorf("workflow template name %q must not be more than 63 characters long (currently %d)", wftmpl.Name, len(wftmpl.Name))
 	}
@@ -384,11 +384,11 @@ func ValidateWorkflowTemplate(ctx context.Context, wftmplGetter templateresoluti
 	}
 	opts.IgnoreEntrypoint = wf.Spec.Entrypoint == ""
 	opts.WorkflowTemplateValidation = true
-	return ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, opts)
+	return Workflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, opts)
 }
 
-// ValidateClusterWorkflowTemplate accepts a cluster workflow template and performs validation against it.
-func ValidateClusterWorkflowTemplate(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cwftmpl *wfv1.ClusterWorkflowTemplate, wfDefaults *wfv1.Workflow, opts ValidateOpts) error {
+// ClusterWorkflowTemplate accepts a cluster workflow template and performs validation against it.
+func ClusterWorkflowTemplate(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cwftmpl *wfv1.ClusterWorkflowTemplate, wfDefaults *wfv1.Workflow, opts Opts) error {
 	if len(cwftmpl.Name) > maxCharsInObjectName {
 		return fmt.Errorf("cluster workflow template name %q must not be more than 63 characters long (currently %d)", cwftmpl.Name, len(cwftmpl.Name))
 	}
@@ -402,11 +402,11 @@ func ValidateClusterWorkflowTemplate(ctx context.Context, wftmplGetter templater
 	}
 	opts.IgnoreEntrypoint = wf.Spec.Entrypoint == ""
 	opts.WorkflowTemplateValidation = true
-	return ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, opts)
+	return Workflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, opts)
 }
 
-// ValidateCronWorkflow validates a CronWorkflow
-func ValidateCronWorkflow(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cronWf *wfv1.CronWorkflow, wfDefaults *wfv1.Workflow) error {
+// CronWorkflow validates a CronWorkflow
+func CronWorkflow(ctx context.Context, wftmplGetter templateresolution.WorkflowTemplateNamespacedGetter, cwftmplGetter templateresolution.ClusterWorkflowTemplateGetter, cronWf *wfv1.CronWorkflow, wfDefaults *wfv1.Workflow) error {
 	// CronWorkflows have fewer max chars allowed in their name because when workflows are created from them, they
 	// are appended with the unix timestamp (`-1615836720`). This lower character allowance allows for that timestamp
 	// to still fit within the 63 character maximum.
@@ -437,7 +437,7 @@ func ValidateCronWorkflow(ctx context.Context, wftmplGetter templateresolution.W
 
 	wf := common.ConvertCronWorkflowToWorkflow(cronWf)
 
-	err := ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, ValidateOpts{})
+	err := Workflow(ctx, wftmplGetter, cwftmplGetter, wf, wfDefaults, Opts{})
 	if err != nil {
 		return errors.Errorf(errors.CodeBadRequest, "cannot validate Workflow: %s", err)
 	}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -1219,7 +1219,7 @@ func TestDagWithItemTemplateRefTmpl(t *testing.T) {
 	err := createWorkflowTemplate(ctx, wftmpl)
 	require.NoError(t, err)
 
-	err = ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.NoError(t, err)
 
 	_ = deleteWorkflowTemplate(ctx, wftmpl.Name)

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -46,14 +46,14 @@ func deleteWorkflowTemplate(ctx context.Context, name string) error {
 // its validation result.
 func validate(ctx context.Context, yamlStr string) error {
 	wf := unmarshalWf(yamlStr)
-	return ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	return Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 }
 
 // validateWorkflowTemplate is a test helper to accept WorkflowTemplate YAML as a string and return
 // its validation result.
-func validateWorkflowTemplate(ctx context.Context, yamlStr string, opts ValidateOpts) error {
+func validateWorkflowTemplate(ctx context.Context, yamlStr string, opts Opts) error {
 	wftmpl := unmarshalWftmpl(yamlStr)
-	err := ValidateWorkflowTemplate(ctx, wftmplGetter, cwftmplGetter, wftmpl, nil, opts)
+	err := WorkflowTemplate(ctx, wftmplGetter, cwftmplGetter, wftmpl, nil, opts)
 	return err
 }
 
@@ -1116,14 +1116,14 @@ func TestVolumeMountArtifactPathCollision(t *testing.T) {
 	// ensure we detect and reject path collisions
 	wf := unmarshalWf(volumeMountArtifactPathCollision)
 
-	err := ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 
 	require.ErrorContains(t, err, "already mounted")
 
 	// tweak the mount path and validation should now be successful
 	wf.Spec.Templates[0].Container.VolumeMounts[0].MountPath = "/differentpath"
 
-	err = ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 
 	require.NoError(t, err)
 }
@@ -1340,7 +1340,7 @@ func TestPodNameVariable(t *testing.T) {
 }
 
 func TestGlobalParamWithVariable(t *testing.T) {
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wfv1.MustUnmarshalWorkflow("@../../test/e2e/functional/global-outputs-variable.yaml"), nil, ValidateOpts{})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wfv1.MustUnmarshalWorkflow("@../../test/e2e/functional/global-outputs-variable.yaml"), nil, Opts{})
 
 	require.NoError(t, err)
 }
@@ -1368,9 +1368,9 @@ func TestSpecArgumentNoValue(t *testing.T) {
 	wf := unmarshalWf(specArgumentNoValue)
 
 	ctx := logging.TestContext(t.Context())
-	err := ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{Lint: true})
+	err := Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{Lint: true})
 	require.NoError(t, err)
-	err = ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 
 	require.Error(t, err)
 }
@@ -1406,7 +1406,7 @@ spec:
 // TestSpecArgumentSnakeCase we allow parameter and artifact names to be snake case
 func TestSpecArgumentSnakeCase(t *testing.T) {
 	wf := unmarshalWf(specArgumentSnakeCase)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{Lint: true})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{Lint: true})
 	require.NoError(t, err)
 }
 
@@ -1441,7 +1441,7 @@ spec:
 // TestSpecBadSequenceCountAndEnd verifies both count and end cannot be defined
 func TestSpecBadSequenceCountAndEnd(t *testing.T) {
 	wf := unmarshalWf(specBadSequenceCountAndEnd)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{Lint: true})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{Lint: true})
 	require.Error(t, err)
 }
 
@@ -1461,7 +1461,7 @@ spec:
 // TestCustomTemplateVariable verifies custom template variable
 func TestCustomTemplateVariable(t *testing.T) {
 	wf := unmarshalWf(customVariableInput)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{Lint: true})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{Lint: true})
 	require.NoError(t, err)
 }
 
@@ -1479,7 +1479,7 @@ spec:
 `
 
 func TestWorkflowTemplate(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), templateRefTarget, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), templateRefTarget, Opts{})
 	require.NoError(t, err)
 }
 
@@ -1497,7 +1497,7 @@ spec:
 `
 
 func TestWorkflowTemplateWithGlobalParams(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), templateWithGlobalParams, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), templateWithGlobalParams, Opts{})
 	require.NoError(t, err)
 }
 
@@ -1635,7 +1635,7 @@ spec:
 // TestValidResourceWorkflow verifies a workflow of a valid resource.
 func TestValidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(validResourceWorkflow)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.NoError(t, err)
 }
 
@@ -1679,11 +1679,11 @@ spec:
 func TestInvalidResourceWorkflow(t *testing.T) {
 	wf := unmarshalWf(invalidResourceWorkflow)
 	ctx := logging.TestContext(t.Context())
-	err := ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.EqualError(t, err, "templates.whalesay.resource.manifest must be a valid yaml")
 
 	wf = unmarshalWf(invalidActionResourceWorkflow)
-	err = ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.EqualError(t, err, "templates.whalesay.resource.action must be one of: get, create, apply, delete, replace, patch")
 }
 
@@ -1703,7 +1703,7 @@ spec:
 // TestIncorrectPodGCStrategy verifies pod gc strategy is correct.
 func TestIncorrectPodGCStrategy(t *testing.T) {
 	wf := unmarshalWf(invalidPodGC)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.EqualError(t, err, "podGC.strategy unknown strategy 'Foo'")
 }
 
@@ -1722,7 +1722,7 @@ spec:
     container:
       image: docker/whalesay
 `)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.EqualError(t, err, "podGC.labelSelector invalid: \"InvalidOperator\" is not a valid label selector operator")
 }
 
@@ -1824,7 +1824,7 @@ spec:
 func TestAllowPlaceholderInVariableTakenFromInputs(t *testing.T) {
 	{
 		wf := unmarshalWf(allowPlaceholderInVariableTakenFromInputs)
-		err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+		err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 		require.NoError(t, err)
 	}
 }
@@ -1882,7 +1882,7 @@ spec:
 // TestRuntimeResolutionOfVariableNames verifies an error against a workflow of an invalid resource.
 func TestRuntimeResolutionOfVariableNames(t *testing.T) {
 	wf := unmarshalWf(runtimeResolutionOfVariableNames)
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.NoError(t, err)
 }
 
@@ -2159,7 +2159,7 @@ spec:
 `
 
 func TestWorkflowTemplateWithEntrypoint(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), wfTemplateWithEntrypoint, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), wfTemplateWithEntrypoint, Opts{})
 	require.NoError(t, err)
 }
 
@@ -2502,7 +2502,7 @@ spec:
 `
 
 func TestWorkflowTemplateLabels(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), testWorkflowTemplateLabels, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), testWorkflowTemplateLabels, Opts{})
 	require.NoError(t, err)
 }
 
@@ -2701,38 +2701,38 @@ spec:
 `
 
 func TestWorkflowTemplateWithEnumValue(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValues, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValues, Opts{})
 	require.NoError(t, err)
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValues, ValidateOpts{Lint: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValues, Opts{Lint: true})
 	require.NoError(t, err)
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValues, ValidateOpts{Submit: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValues, Opts{Submit: true})
 	require.NoError(t, err)
 }
 
 func TestWorkflowTemplateWithEmptyEnumList(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithEmptyEnumList, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithEmptyEnumList, Opts{})
 	require.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithEmptyEnumList, ValidateOpts{Lint: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithEmptyEnumList, Opts{Lint: true})
 	require.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithEmptyEnumList, ValidateOpts{Submit: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithEmptyEnumList, Opts{Submit: true})
 	require.EqualError(t, err, "spec.arguments.message.enum should contain at least one value")
 }
 
 func TestWorkflowTemplateWithArgumentValueNotFromEnumList(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithArgumentValueNotFromEnumList, Opts{})
 	require.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Lint: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithArgumentValueNotFromEnumList, Opts{Lint: true})
 	require.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithArgumentValueNotFromEnumList, ValidateOpts{Submit: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTemplateWithArgumentValueNotFromEnumList, Opts{Submit: true})
 	require.EqualError(t, err, "spec.arguments.message.value should be present in spec.arguments.message.enum list")
 }
 
 func TestWorkflowTemplateWithEnumValueWithoutValue(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValuesWithoutValue, Opts{})
 	require.NoError(t, err)
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Lint: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValuesWithoutValue, Opts{Lint: true})
 	require.NoError(t, err)
-	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValuesWithoutValue, ValidateOpts{Submit: true})
+	err = validateWorkflowTemplate(logging.TestContext(t.Context()), workflowTeamplateWithEnumValuesWithoutValue, Opts{Submit: true})
 	require.EqualError(t, err, "spec.arguments.message.value or spec.arguments.message.valueFrom is required")
 }
 
@@ -2844,25 +2844,25 @@ spec:
 `
 
 func TestValidActiveDeadlineSecondsArgoVariable(t *testing.T) {
-	err := validateWorkflowTemplate(logging.TestContext(t.Context()), validActiveDeadlineSecondsArgoVariable, ValidateOpts{})
+	err := validateWorkflowTemplate(logging.TestContext(t.Context()), validActiveDeadlineSecondsArgoVariable, Opts{})
 	require.NoError(t, err)
 }
 
 func TestMaxLengthName(t *testing.T) {
 	wf := &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	err := ValidateWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err := Workflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.EqualError(t, err, "workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	wftmpl := &wfv1.WorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	err = ValidateWorkflowTemplate(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wftmpl, nil, ValidateOpts{})
+	err = WorkflowTemplate(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, wftmpl, nil, Opts{})
 	require.EqualError(t, err, "workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwftmpl := &wfv1.ClusterWorkflowTemplate{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 70)}}
-	err = ValidateClusterWorkflowTemplate(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, cwftmpl, nil, ValidateOpts{})
+	err = ClusterWorkflowTemplate(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, cwftmpl, nil, Opts{})
 	require.EqualError(t, err, "cluster workflow template name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 63 characters long (currently 70)")
 
 	cwf := &wfv1.CronWorkflow{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 60)}}
-	err = ValidateCronWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, cwf, nil)
+	err = CronWorkflow(logging.TestContext(t.Context()), wftmplGetter, cwftmplGetter, cwf, nil)
 	require.EqualError(t, err, "cron workflow name \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" must not be more than 52 characters long (currently 60)")
 }
 
@@ -2959,7 +2959,7 @@ spec:
 		invalidContainerSetTemplateWithOutputParams,
 	}
 	for _, manifest := range invalidManifests {
-		err := validateWorkflowTemplate(logging.TestContext(t.Context()), manifest, ValidateOpts{})
+		err := validateWorkflowTemplate(logging.TestContext(t.Context()), manifest, Opts{})
 		require.ErrorContains(t, err, "containerSet.containers must have a container named \"main\" for input or output")
 	}
 }
@@ -3333,7 +3333,7 @@ func TestSubstituteGlobalVariablesLabelsAnnotations(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err = ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, &wfDefaults, ValidateOpts{})
+			err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, &wfDefaults, Opts{})
 			if tt.expectedSuccess {
 				require.NoError(t, err)
 			} else {
@@ -3429,7 +3429,7 @@ func TestDynamicWorkflowTemplateRef(t *testing.T) {
 	err = createWorkflowTemplate(ctx, wftmplB)
 	require.NoError(t, err)
 
-	err = ValidateWorkflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, ValidateOpts{})
+	err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
 	require.NoError(t, err)
 
 	_ = deleteWorkflowTemplate(ctx, wftmplA.Name)


### PR DESCRIPTION
### Motivation

Improve maintainability by enabling one of the disabled revive linters which I didn't enable in #15459 

### Modifications

Rename exported identifiers that repeat their package name (e.g. validate.ValidateWorkflow -> validate.Workflow) to satisfy the revive `exported` rule, and enable the rule in .golangci.yml.

Slight refactor to clusterworkflowtemplate/informer.go to return an interface.

### Verification

CI will check.

### Documentation

This does break compatibility with anyone whos importing things, most likely validate. We make no promises about these internal interfaces though.l