### PR TITLE
chore(docs): update offloading args argo version

### DIFF
--- a/docs/offloading-large-workflows.md
+++ b/docs/offloading-large-workflows.md
@@ -29,7 +29,7 @@ above or look for ways to reduce the size of your workflow manifest:
 
 ## Container Arguments Offloading
 
-> v4.0 and after
+> v3.7 and after
 
 When container arguments are extremely large, Argo automatically offloads them to avoid exceeding system limits. This feature addresses two types of argument size issues:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Update the argo version in the docs for cherry-picked PR #15523 that fixes an issue with large main container args.

Signed-off-by: Anay Sharma [anay20sharma11@gmail.com](mailto:anay20sharma11@gmail.com)