### PR TITLE
fix: change RLock to Lock in sync manager methods

### DIFF
--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -96,8 +96,8 @@ func (sm *Manager) getWorkflowKey(key string) (string, error) {
 func (sm *Manager) CheckWorkflowExistence(ctx context.Context) {
 	defer runtimeutil.HandleCrashWithContext(ctx, runtimeutil.PanicHandlers...)
 
-	sm.lock.RLock()
-	defer sm.lock.RUnlock()
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
 
 	sm.log.Debug(ctx, "Check the workflow existence")
 	for _, lock := range sm.syncLockMap {
@@ -468,8 +468,8 @@ func (sm *Manager) Release(ctx context.Context, wf *wfv1.Workflow, nodeName stri
 		return
 	}
 
-	sm.lock.RLock()
-	defer sm.lock.RUnlock()
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
 
 	holderKey := getHolderKey(wf, nodeName)
 	sm.log.WithField("holderKey", holderKey).Info(ctx, "Release")
@@ -496,8 +496,8 @@ func (sm *Manager) Release(ctx context.Context, wf *wfv1.Workflow, nodeName stri
 }
 
 func (sm *Manager) ReleaseAll(ctx context.Context, wf *wfv1.Workflow) bool {
-	sm.lock.RLock()
-	defer sm.lock.RUnlock()
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
 
 	if wf.Status.Synchronization == nil {
 		return true


### PR DESCRIPTION
Fixes #15218 

### Motivation

The `CheckWorkflowExistence`, `Release`, and `ReleaseAll` methods in the sync manager were using read locks (RLock) when they should be using write locks (Lock). These methods modify the internal state of the sync manager (accessing and potentially modifying `sm.syncLockMap`), which requires exclusive write access rather than shared read access.

### Modifications

Changed the following methods from using `RLock()`/`RUnlock()` to `Lock()`/`Unlock()`:
- `CheckWorkflowExistence()` - iterates and modifies sync lock map
- `Release()` - modifies sync lock map entries
- `ReleaseAll()` - modifies sync lock map entries

This ensures proper synchronization and prevents race conditions when multiple goroutines access these methods concurrently.

### Verification

- Code review of lock usage patterns in the sync manager
- Verify that these methods perform write operations on shared state
- Run existing tests to ensure no regressions

### Documentation

No documentation changes needed - this is an internal synchronization fix.

### AI

Co-authored with Claude