### PR TITLE
fix: add sudo for moving argo binary to path

### DIFF
--- a/hack/release-notes.md
+++ b/hack/release-notes.md
@@ -30,10 +30,10 @@ curl -sLO "https://github.com/argoproj/argo-workflows/releases/download/$version
 gunzip "argo-$ARGO_OS-amd64.gz"
 
 # Make binary executable
-chmod +x "argo-$ARGO_OS-amd64"
+sudo chmod +x "argo-$ARGO_OS-amd64"
 
 # Move binary to path
-mv "./argo-$ARGO_OS-amd64" /usr/local/bin/argo
+sudo mv "./argo-$ARGO_OS-amd64" /usr/local/bin/argo
 
 # Test installation
 argo version


### PR DESCRIPTION
On trying to install the argo CLI as described in the release notes, the execution of the script fails because it doesn't have enough permissions to move the binary to path.

```
❯ ./script.sh
argo-darwin-amd64 already exists -- do you wish to overwrite (y or n)? y
mv: rename ./argo-darwin-amd64 to /usr/local/bin/argo: Permission denied
./script.sh: line 20: argo: command not found
```