### PR TITLE
chore: remove more unused functions

### DIFF
--- a/pkg/apis/workflow/v1alpha1/progress.go
+++ b/pkg/apis/workflow/v1alpha1/progress.go
@@ -15,10 +15,6 @@ const (
 	ProgressDefault   = Progress("0/1")
 )
 
-func NewProgress(n, m int64) (Progress, bool) {
-	return ParseProgress(fmt.Sprintf("%v/%v", n, m))
-}
-
 func ParseProgress(s string) (Progress, bool) {
 	v := Progress(s)
 	return v, v.IsValid()

--- a/pkg/apis/workflow/v1alpha1/register.go
+++ b/pkg/apis/workflow/v1alpha1/register.go
@@ -14,11 +14,6 @@ var (
 	WorkflowSchemaGroupVersionKind = schema.GroupVersionKind{Group: workflow.Group, Version: "v1alpha1", Kind: workflow.WorkflowKind}
 )
 
-// Kind takes an unqualified kind and returns back a Group qualified GroupKind
-func Kind(kind string) schema.GroupKind {
-	return SchemeGroupVersion.WithKind(kind).GroupKind()
-}
-
 // Resource takes an unqualified resource and returns a Group-qualified GroupResource.
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -119,10 +119,6 @@ func (s *gatekeeper) Context(ctx context.Context) (context.Context, error) {
 	return s.ContextWithRequest(ctx, nil)
 }
 
-func GetDynamicClient(ctx context.Context) dynamic.Interface {
-	return ctx.Value(DynamicKey).(dynamic.Interface)
-}
-
 func GetWfClient(ctx context.Context) workflow.Interface {
 	return ctx.Value(WfKey).(workflow.Interface)
 }

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -53,16 +52,6 @@ func PrintVersionMismatchWarning(ctx context.Context, clientVersion wfv1.Version
 	if serverVersion != "" && clientVersion.GitTag != "" && serverVersion != clientVersion.Version {
 		log.WithFields(logging.Fields{"clientVersion": clientVersion.Version, "serverVersion": serverVersion}).Warn(ctx, "CLI version does not match server version. This can lead to unexpected behavior.")
 	}
-}
-
-// MustIsDir returns whether or not the given filePath is a directory. Exits if path does not exist
-func MustIsDir(ctx context.Context, filePath string) bool {
-	log := logging.RequireLoggerFromContext(ctx)
-	fileInfo, err := os.Stat(filePath)
-	if err != nil {
-		log.WithError(err).WithFatal().Error(ctx, "Failed to check if file is a directory")
-	}
-	return fileInfo.IsDir()
 }
 
 // IsURL returns whether a string is a URL

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -17,13 +17,6 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/logging"
 )
 
-func IgnoreContainerNotFoundErr(err error) error {
-	if err != nil && strings.Contains(err.Error(), "container not found") {
-		return nil
-	}
-	return err
-}
-
 // IsTransientErr reports whether the error is transient and logs it.
 func IsTransientErr(ctx context.Context, err error) bool {
 	isTransient := IsTransientErrQuiet(ctx, err)

--- a/util/unstructured/unstructured.go
+++ b/util/unstructured/unstructured.go
@@ -16,13 +16,6 @@ import (
 
 const workflowPaginationLimit = 500
 
-// NewUnstructuredInformer constructs a new informer for Unstructured type.
-// Always prefer using an informer factory to get a shared informer instead of getting an independent
-// one. This reduces memory footprint and number of connections to the server.
-func NewUnstructuredInformer(ctx context.Context, resource schema.GroupVersionResource, client dynamic.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredUnstructuredInformer(ctx, resource, client, namespace, resyncPeriod, indexers, nil, nil)
-}
-
 // NewFilteredUnstructuredInformer constructs a new informer for Unstructured type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.

--- a/workflow/cron/cron_facade.go
+++ b/workflow/cron/cron_facade.go
@@ -2,8 +2,6 @@ package cron
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -72,24 +70,4 @@ func (f *cronFacade) AddJob(key, schedule string, cwoc *cronWfOperationCtx) (Sch
 		}
 		return t
 	}, nil
-}
-
-func (f *cronFacade) Load(key string) ([]*cronWfOperationCtx, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	entryIDs, ok := f.entryIDs[key]
-	if !ok {
-		return nil, fmt.Errorf("entry ID for %s not found", key)
-	}
-	cwocs := make([]*cronWfOperationCtx, len(entryIDs))
-	for i, entryID := range entryIDs {
-		entry := f.cron.Entry(entryID).Job
-		cwoc, ok := entry.(*cronWfOperationCtx)
-		if !ok {
-			return nil, fmt.Errorf("job entry ID for %s was not a *cronWfOperationCtx, was %v", key, reflect.TypeOf(entry))
-		}
-		cwocs[i] = cwoc
-	}
-
-	return cwocs, nil
 }

--- a/workflow/executor/common/common.go
+++ b/workflow/executor/common/common.go
@@ -2,11 +2,8 @@ package common
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -17,19 +14,6 @@ import (
 	envutil "github.com/argoproj/argo-workflows/v3/util/env"
 	"github.com/argoproj/argo-workflows/v3/util/logging"
 )
-
-const (
-	containerShimPrefix = "://"
-)
-
-// GetContainerID returns container ID of a ContainerStatus resource
-func GetContainerID(container string) string {
-	_, after, ok := strings.Cut(container, containerShimPrefix)
-	if !ok {
-		return container
-	}
-	return after
-}
 
 // KubernetesClientInterface is the interface to implement getContainerStatus method
 type KubernetesClientInterface interface {
@@ -146,29 +130,4 @@ func KillGracefully(ctx context.Context, c KubernetesClientInterface, containerN
 	}
 	log.WithFields(logging.Fields{"containers": strings.Join(containerNames, ",")}).Info(ctx, "Containers successfully killed")
 	return nil
-}
-
-// CopyArchive downloads files and directories as a tarball and saves it to a specified path.
-func CopyArchive(ctx context.Context, c KubernetesClientInterface, containerName, sourcePath, destPath string) error {
-	log := logging.RequireLoggerFromContext(ctx)
-	log.WithFields(logging.Fields{"container": containerName, "source": sourcePath, "dest": destPath}).Info(ctx, "Archiving")
-	b, err := c.CreateArchive(ctx, containerName, sourcePath)
-	if err != nil {
-		return err
-	}
-	f, err := os.OpenFile(filepath.Clean(destPath), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	w := gzip.NewWriter(f)
-	_, err = w.Write(b.Bytes())
-	if err != nil {
-		return err
-	}
-	err = w.Flush()
-	if err != nil {
-		return err
-	}
-	err = w.Close()
-	return err
 }

--- a/workflow/executor/osspecific/chroot_darwin.go
+++ b/workflow/executor/osspecific/chroot_darwin.go
@@ -1,8 +1,0 @@
-package osspecific
-
-import "syscall"
-
-func CallChroot() error {
-	err := syscall.Chroot(".")
-	return err
-}

--- a/workflow/executor/osspecific/chroot_linux.go
+++ b/workflow/executor/osspecific/chroot_linux.go
@@ -1,8 +1,0 @@
-package osspecific
-
-import "syscall"
-
-func CallChroot() error {
-	err := syscall.Chroot(".")
-	return err
-}

--- a/workflow/executor/osspecific/chroot_windows.go
+++ b/workflow/executor/osspecific/chroot_windows.go
@@ -1,5 +1,0 @@
-package osspecific
-
-func CallChroot() error {
-	return nil // no chroot on windows
-}

--- a/workflow/sync/common.go
+++ b/workflow/sync/common.go
@@ -14,7 +14,6 @@ type semaphore interface {
 	removeFromQueue(ctx context.Context, holderKey string) error
 	getCurrentHolders(ctx context.Context) ([]string, error)
 	getCurrentPending(ctx context.Context) ([]string, error)
-	getName() string
 	getLimit(ctx context.Context) int // Testing only
 	probeWaiting(ctx context.Context)
 	lock(ctx context.Context) bool

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -56,10 +56,6 @@ func (s *databaseSemaphore) longDBKey() string {
 	return "sem/" + s.shortDBKey
 }
 
-func (s *databaseSemaphore) getName() string {
-	return s.name
-}
-
 func (s *databaseSemaphore) getLimitFromDB(ctx context.Context, _ string) (int, error) {
 	logger := s.logger(ctx)
 	// Update the limit from the database

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -45,10 +45,6 @@ func newInternalSemaphore(ctx context.Context, name string, nextWorkflow NextWor
 	return sem, err
 }
 
-func (s *prioritySemaphore) getName() string {
-	return s.name
-}
-
 func (s *prioritySemaphore) getLimit(ctx context.Context) int {
 	limit, changed, err := s.limitGetter.get(ctx, s.name)
 	if err != nil {

--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -58,13 +58,6 @@ func (n *NullClusterWorkflowTemplateGetter) Get(_ context.Context, name string) 
 		"forbidden: User cannot get resource 'clusterworkflowtemplates' in API group argoproj.io at the cluster scope", name)
 }
 
-type NullWorkflowTemplateNamespacedGetter struct{}
-
-func (n *NullWorkflowTemplateNamespacedGetter) Get(_ context.Context, name string) (*wfv1.WorkflowTemplate, error) {
-	return nil, errors.Errorf("", "invalid spec: workflowtemplates.argoproj.io `%s` is "+
-		"forbidden: User cannot get resource 'workflowtemplates' in API group argoproj.io at the namespace scope", name)
-}
-
 // Get retrieves the WorkflowTemplate of a given name.
 func (wrapper *clusterWorkflowTemplateInterfaceWrapper) Get(ctx context.Context, name string) (*wfv1.ClusterWorkflowTemplate, error) {
 	return wrapper.clientset.Get(ctx, name, metav1.GetOptions{})


### PR DESCRIPTION
I used deadcode with claude to remove unused (but Exported) functions. Claude helped with working out the false positives - this is not intended to be exhaustive, and there isn't a good way to make this part of CI AFAIK

### Verification

Everything still compiles with just removed lines of code.