### PR TITLE
feat(ui): add dark mode support

### DIFF
--- a/.features/pending/dark-mode.md
+++ b/.features/pending/dark-mode.md
@@ -1,0 +1,12 @@
+Description: Add dark mode support to the UI
+Authors: [Clint Moyer](https://github.com/clintmoyer)
+Component: UI
+Issues: 5037
+
+Dark mode allows users to switch between light, dark, and system-preference themes.
+The theme selector is available on the User Info page with three options: Light, Dark, and System.
+
+The theme preference is persisted to localStorage and automatically applied on page load.
+When "System" is selected, the UI follows the operating system's color scheme preference.
+
+This feature matches the dark mode implementation in Argo CD.

--- a/ui/src/app-router.tsx
+++ b/ui/src/app-router.tsx
@@ -25,6 +25,8 @@ import ErrorBoundary from './shared/components/error-boundary';
 import {Version} from './shared/models';
 import * as nsUtils from './shared/namespaces';
 import {services} from './shared/services';
+import {ThemeContext} from './shared/theme-context';
+import {useTheme} from './shared/use-theme';
 import userinfo from './userinfo';
 import {Widgets} from './widgets/widgets';
 import workflowEventBindings from './workflow-event-bindings';
@@ -53,6 +55,7 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
     const [version, setVersion] = useState<Version>();
     const [namespace, setNamespace] = useState<string>();
     const [navBarBackgroundColor, setNavBarBackgroundColor] = useState<string>();
+    const {theme, resolvedTheme, setTheme} = useTheme();
     const setError = (error: Error) => {
         notificationsManager.show({
             content: 'Failed to load version/info ' + error,
@@ -85,13 +88,14 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
     const managedNamespace = nsUtils.getManagedNamespace();
     const namespaceSuffix = managedNamespace ? '' : '/' + (namespace || '');
     return (
-        <>
+        <ThemeContext.Provider value={{theme, resolvedTheme, setTheme}}>
             {popupProps && <Popup {...popupProps} />}
             <Router history={history}>
                 <Switch>
                     <Route exact={true} strict={true} path={loginUrl} component={login.component} />
                     <Route path={uiUrl('widgets')} component={Widgets} />
                     <Layout
+                        theme={resolvedTheme}
                         navBarStyle={{backgroundColor: navBarBackgroundColor}}
                         navItems={[
                             {
@@ -189,6 +193,6 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
                     </Layout>
                 </Switch>
             </Router>
-        </>
+        </ThemeContext.Provider>
     );
 }

--- a/ui/src/cron-workflows/cron-workflow-filters.scss
+++ b/ui/src/cron-workflows/cron-workflow-filters.scss
@@ -1,20 +1,27 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .wf-filters-container {
     overflow: visible;
     position: relative;
     border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
     padding: 0 1em 0.75em 1em;
     margin: 12px 0;
-    background-color: white;
+
+    @include themify($themes) {
+        box-shadow: 1px 1px 3px themed('shadow');
+        background-color: themed('background-2');
+    }
 }
 
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
-    color: #6d7f8b;
     text-transform: uppercase;
+
+    @include themify($themes) {
+        color: themed('light-argo-gray-6');
+    }
 }
 
 .wf-filters-container__title {

--- a/ui/src/help/help.scss
+++ b/ui/src/help/help.scss
@@ -1,19 +1,31 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .help-box {
     min-height: 530px;
     margin: 30px 10px;
     padding: 80px 40px;
     text-align: center;
-    background-color: #fff;
-    box-shadow: 0 0 3px rgba(#000,.3);
+
+    @include themify($themes) {
+        background-color: themed('background-2');
+        box-shadow: 0 0 3px themed('shadow');
+    }
 
     &__ico {
         width: 180px;
         height: 180px;
         margin: 0 auto;
         background-size: 100%;
-        opacity: .5;
+
+        .theme-light & {
+            opacity: .5;
+        }
+
+        .theme-dark & {
+            opacity: .7;
+            filter: invert(1);
+        }
 
         &--manual {
             background-image: url('assets/images/User-Manual-200.png');
@@ -37,6 +49,10 @@
     h3 {
         margin: 40px 0 60px;
         font-size: 22px;
+
+        @include themify($themes) {
+            color: themed('text-1');
+        }
     }
 
     a {

--- a/ui/src/login/login.scss
+++ b/ui/src/login/login.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 $logoPath: '../assets/images/argologo.svg';
 $logoNegativePath: '../assets/images/argo.png';
@@ -41,10 +42,13 @@ $contentMinWidth: 560px;
         width: 40%;
         margin: 0 auto;
         padding: 40px;
-        background-color: #fff;
         position: relative;
         float: right;
         min-height: 100vh;
+
+        @include themify($themes) {
+            background-color: themed('background-2');
+        }
 
         .width-control {
             max-width: 200px;

--- a/ui/src/reports/reports-filters.scss
+++ b/ui/src/reports/reports-filters.scss
@@ -1,20 +1,27 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .wf-filters-container {
     overflow: visible;
     position: relative;
     border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
     padding: 0 1em 0.75em 1em;
     margin: 12px 0;
-    background-color: white;
+
+    @include themify($themes) {
+        box-shadow: 1px 1px 3px themed('shadow');
+        background-color: themed('background-2');
+    }
 }
 
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
-    color: #6d7f8b;
     text-transform: uppercase;
+
+    @include themify($themes) {
+        color: themed('light-argo-gray-6');
+    }
 }
 
 .wf-filters-container__title {

--- a/ui/src/reports/reports.tsx
+++ b/ui/src/reports/reports.tsx
@@ -17,6 +17,7 @@ import {Footnote} from '../shared/footnote';
 import {historyUrl} from '../shared/history';
 import * as nsUtils from '../shared/namespaces';
 import {services} from '../shared/services';
+import {useThemeContext} from '../shared/theme-context';
 import {useCollectEvent} from '../shared/use-collect-event';
 import {ReportFilters} from './reports-filters';
 import {workflowsToChartData} from './workflows-to-chart-data';
@@ -31,6 +32,8 @@ const limit = 100;
 export function Reports({match, location, history}: RouteComponentProps<any>) {
     const queryParams = new URLSearchParams(location.search);
     const {navigation} = useContext(Context);
+    const {resolvedTheme} = useThemeContext();
+    const chartFontColor = resolvedTheme === 'dark' ? '#e0e0e0' : '#666';
 
     // state for URL, query, and label parameters
     const isFirstRender = useRef(true);
@@ -70,14 +73,14 @@ export function Reports({match, location, history}: RouteComponentProps<any>) {
                     'items.status.finishedAt',
                     'items.status.resourcesDuration'
                 ]);
-                const newCharts = workflowsToChartData(list.items || [], limit);
+                const newCharts = workflowsToChartData(list.items || [], limit, chartFontColor);
                 setCharts(newCharts);
                 setError(null);
             } catch (newError) {
                 setError(newError);
             }
         })();
-    }, [namespace, labels.toString()]); // referential equality, so use values, not refs
+    }, [namespace, labels.toString(), chartFontColor]); // referential equality, so use values, not refs
 
     useCollectEvent('openedReports');
 

--- a/ui/src/reports/workflows-to-chart-data.ts
+++ b/ui/src/reports/workflows-to-chart-data.ts
@@ -1,7 +1,7 @@
 import {denominator} from '../shared/duration';
 import {getColorForNodePhase, Workflow} from '../shared/models';
 
-export function workflowsToChartData(workflows: Workflow[], limit: number) {
+export function workflowsToChartData(workflows: Workflow[], limit: number, fontColor: string = '#666') {
     const filteredWorkflows = workflows
         .filter(wf => !!wf.status.finishedAt)
         .map(wf => ({
@@ -53,20 +53,23 @@ export function workflowsToChartData(workflows: Workflow[], limit: number) {
             options: {
                 title: {
                     display: true,
-                    text: 'Duration'
+                    text: 'Duration',
+                    fontColor
                 },
                 legend: {display: false},
                 scales: {
-                    xAxes: [{}],
+                    xAxes: [{ticks: {fontColor}, scaleLabel: {fontColor}}],
                     yAxes: [
                         {
                             id: 'duration',
                             ticks: {
-                                beginAtZero: true
+                                beginAtZero: true,
+                                fontColor
                             },
                             scaleLabel: {
                                 display: true,
-                                labelString: 'Duration (seconds)'
+                                labelString: 'Duration (seconds)',
+                                fontColor
                             }
                         }
                     ]
@@ -104,18 +107,24 @@ export function workflowsToChartData(workflows: Workflow[], limit: number) {
             options: {
                 title: {
                     display: true,
-                    text: 'Resources (not available for archived workflows)'
+                    text: 'Resources (not available for archived workflows)',
+                    fontColor
+                },
+                legend: {
+                    labels: {fontColor}
                 },
                 scales: {
-                    xAxes: [{}],
+                    xAxes: [{ticks: {fontColor}, scaleLabel: {fontColor}}],
                     yAxes: Object.keys(resourceData).map(resource => ({
                         id: resource,
                         ticks: {
-                            beginAtZero: true
+                            beginAtZero: true,
+                            fontColor
                         },
                         scaleLabel: {
                             display: true,
-                            labelString: resource + ' (' + denominator(resource) + ')'
+                            labelString: resource + ' (' + denominator(resource) + ')',
+                            fontColor
                         }
                     }))
                 }

--- a/ui/src/shared/components/graph/graph-panel.scss
+++ b/ui/src/shared/components/graph/graph-panel.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 @keyframes pulse {
   0% {
@@ -33,19 +34,27 @@
   margin: 10px;
   padding: 10px;
   display: inline-block;
-  background-color: white;
-  box-shadow: 1px 1px 3px $argo-color-gray-5;
   position: fixed;
+
+  @include themify($themes) {
+    background-color: themed('background-2');
+    box-shadow: 1px 1px 3px themed('shadow');
+  }
 
   div.argo-dropdown, a {
     padding: 5px;
-    color: $argo-color-gray-6;
     border: 1px solid transparent;
     border-radius: 5px;
 
+    @include themify($themes) {
+      color: themed('light-argo-gray-6');
+    }
+
     &.active {
-      background-color: $argo-color-gray-3;
-      border: 1px solid $argo-color-gray-4;
+      @include themify($themes) {
+        background-color: themed('background-1');
+        border: 1px solid themed('border');
+      }
     }
   }
 }
@@ -67,7 +76,9 @@
     dominant-baseline: central;
 
     &.node-label {
-      fill: $argo-color-gray-8;
+      @include themify($themes) {
+        fill: themed('text-2');
+      }
     }
   }
 
@@ -138,7 +149,9 @@
 
   .edge {
     text {
-      fill: $argo-color-gray-8;
+      @include themify($themes) {
+        fill: themed('text-2');
+      }
     }
 
     .line {

--- a/ui/src/shared/components/modal/modal.scss
+++ b/ui/src/shared/components/modal/modal.scss
@@ -1,3 +1,5 @@
+@import 'node_modules/argo-ui/src/styles/theme';
+
 .modal {
   position: fixed; /* Stay in place */
   z-index: 12; /* Sit on top */
@@ -12,24 +14,33 @@
 
 /* Modal Content/Box */
 .modal-content {
-  background-color: white;
   border-radius: 10px;
   margin: 15% auto; /* 15% from the top and centered */
   padding: 20px;
-  border: 1px solid gray;
   width: 60%; /* Could be more or less, depending on screen size */
+
+  @include themify($themes) {
+    background-color: themed('background-2');
+    border: 1px solid themed('border');
+  }
 }
 
 .modal-close {
-  color: gray;
   float: right;
   font-size: 28px;
   font-weight: bold;
+
+  @include themify($themes) {
+    color: themed('text-2');
+  }
 }
 
 .modal-close:hover,
 .modal-close:focus {
-  color: black;
   text-decoration: none;
   cursor: pointer;
+
+  @include themify($themes) {
+    color: themed('text-1');
+  }
 }

--- a/ui/src/shared/components/suspense-monaco-editor.tsx
+++ b/ui/src/shared/components/suspense-monaco-editor.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type {MonacoEditorProps} from 'react-monaco-editor';
 import type MonacoEditor from 'react-monaco-editor';
 
+import {useThemeContext} from '../theme-context';
 import {Loading} from './loading';
 
 // lazy load Monaco Editor as it is a gigantic component (which can be split into a separate bundle)
@@ -14,9 +15,12 @@ const LazyMonacoEditor = React.lazy(() => {
 const noop = () => {}; // tslint:disable-line:no-empty
 
 export const SuspenseMonacoEditor = React.forwardRef(function InnerMonacoEditor(props: MonacoEditorProps, ref: React.MutableRefObject<MonacoEditor>) {
+    const {resolvedTheme} = useThemeContext();
+    const monacoTheme = resolvedTheme === 'dark' ? 'vs-dark' : 'vs';
+
     return (
         <React.Suspense fallback={<Loading />}>
-            <LazyMonacoEditor ref={ref} editorWillUnmount={noop} {...props} />
+            <LazyMonacoEditor ref={ref} editorWillUnmount={noop} theme={monacoTheme} {...props} />
         </React.Suspense>
     );
 });

--- a/ui/src/shared/components/tags-input/tags-input.scss
+++ b/ui/src/shared/components/tags-input/tags-input.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .tags-input {
     padding: 0 4px;
@@ -31,8 +32,6 @@
     &__tag {
         position: relative;
         display: inline-block;
-        background: $argo-color-gray-3;
-        box-shadow: 1px 1px 3px $argo-color-gray-5;
         border-radius: 5px;
         padding: 4px;
         padding: 4px 15px 4px 4px;
@@ -44,6 +43,12 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         vertical-align: middle;
+
+        @include themify($themes) {
+            background: themed('background-2');
+            box-shadow: 1px 1px 3px themed('shadow');
+            color: themed('text-1');
+        }
 
         i {
             position: absolute;

--- a/ui/src/shared/components/theme-selector.scss
+++ b/ui/src/shared/components/theme-selector.scss
@@ -1,0 +1,24 @@
+@import 'node_modules/argo-ui/src/styles/config';
+
+.theme-selector {
+    display: flex;
+    gap: 0.5em;
+    flex-wrap: wrap;
+
+    &__button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5em;
+
+        &--selected {
+            background-color: $argo-color-teal-5;
+            color: $white-color;
+            border-color: $argo-color-teal-5;
+
+            &:hover {
+                background-color: $argo-color-teal-6;
+                border-color: $argo-color-teal-6;
+            }
+        }
+    }
+}

--- a/ui/src/shared/components/theme-selector.tsx
+++ b/ui/src/shared/components/theme-selector.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import {useThemeContext} from '../theme-context';
+import {ThemeValue} from '../use-theme';
+
+import './theme-selector.scss';
+
+interface ThemeOption {
+    value: ThemeValue;
+    label: string;
+    icon: string;
+}
+
+const themeOptions: ThemeOption[] = [
+    {value: 'light', label: 'Light', icon: 'fa-sun'},
+    {value: 'dark', label: 'Dark', icon: 'fa-moon'},
+    {value: 'auto', label: 'System', icon: 'fa-desktop'}
+];
+
+export function ThemeSelector() {
+    const {theme, setTheme} = useThemeContext();
+
+    return (
+        <div className='theme-selector'>
+            {themeOptions.map(option => (
+                <button
+                    key={option.value}
+                    className={`argo-button argo-button--base-o theme-selector__button ${theme === option.value ? 'theme-selector__button--selected' : ''}`}
+                    onClick={() => setTheme(option.value)}
+                    title={option.label}>
+                    <i className={`fa ${option.icon}`} /> {option.label}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/ui/src/shared/theme-context.ts
+++ b/ui/src/shared/theme-context.ts
@@ -1,0 +1,19 @@
+import {createContext, useContext} from 'react';
+
+import {ThemeValue} from './use-theme';
+
+export interface ThemeContextValue {
+    theme: ThemeValue;
+    resolvedTheme: 'light' | 'dark';
+    setTheme: (theme: ThemeValue) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function useThemeContext(): ThemeContextValue {
+    const context = useContext(ThemeContext);
+    if (!context) {
+        throw new Error('useThemeContext must be used within a ThemeContext.Provider');
+    }
+    return context;
+}

--- a/ui/src/shared/use-theme.test.ts
+++ b/ui/src/shared/use-theme.test.ts
@@ -1,0 +1,188 @@
+import {act, renderHook} from '@testing-library/react';
+
+import {ThemeValue, useTheme} from './use-theme';
+
+describe('useTheme', () => {
+    const STORAGE_KEY = 'argo-workflows-theme';
+    let mockMatchMedia: jest.Mock;
+    let mediaQueryListeners: Array<(e: MediaQueryListEvent) => void>;
+
+    beforeEach(() => {
+        localStorage.clear();
+        mediaQueryListeners = [];
+
+        mockMatchMedia = jest.fn().mockImplementation((query: string) => ({
+            matches: query === '(prefers-color-scheme: dark)' ? false : false,
+            media: query,
+            addEventListener: (_event: string, listener: (e: MediaQueryListEvent) => void) => {
+                mediaQueryListeners.push(listener);
+            },
+            removeEventListener: (_event: string, listener: (e: MediaQueryListEvent) => void) => {
+                mediaQueryListeners = mediaQueryListeners.filter(l => l !== listener);
+            }
+        }));
+
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: mockMatchMedia
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('initial state', () => {
+        it('defaults to auto theme when no stored value', () => {
+            const {result} = renderHook(() => useTheme());
+
+            expect(result.current.theme).toBe('auto');
+            expect(result.current.resolvedTheme).toBe('light');
+        });
+
+        it('reads stored theme from localStorage', () => {
+            localStorage.setItem(STORAGE_KEY, 'dark');
+
+            const {result} = renderHook(() => useTheme());
+
+            expect(result.current.theme).toBe('dark');
+            expect(result.current.resolvedTheme).toBe('dark');
+        });
+
+        it('ignores invalid stored values', () => {
+            localStorage.setItem(STORAGE_KEY, 'invalid-theme');
+
+            const {result} = renderHook(() => useTheme());
+
+            expect(result.current.theme).toBe('auto');
+        });
+    });
+
+    describe('setTheme', () => {
+        it('updates theme state', () => {
+            const {result} = renderHook(() => useTheme());
+
+            act(() => {
+                result.current.setTheme('dark');
+            });
+
+            expect(result.current.theme).toBe('dark');
+            expect(result.current.resolvedTheme).toBe('dark');
+        });
+
+        it('persists theme to localStorage', () => {
+            const {result} = renderHook(() => useTheme());
+
+            act(() => {
+                result.current.setTheme('light');
+            });
+
+            expect(localStorage.getItem(STORAGE_KEY)).toBe('light');
+        });
+
+        it.each(['light', 'dark', 'auto'] as ThemeValue[])('handles %s theme', theme => {
+            const {result} = renderHook(() => useTheme());
+
+            act(() => {
+                result.current.setTheme(theme);
+            });
+
+            expect(result.current.theme).toBe(theme);
+            expect(localStorage.getItem(STORAGE_KEY)).toBe(theme);
+        });
+    });
+
+    describe('system theme detection', () => {
+        it('detects dark system preference', () => {
+            mockMatchMedia.mockImplementation((query: string) => ({
+                matches: query === '(prefers-color-scheme: dark)',
+                media: query,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn()
+            }));
+
+            const {result} = renderHook(() => useTheme());
+
+            expect(result.current.theme).toBe('auto');
+            expect(result.current.resolvedTheme).toBe('dark');
+        });
+
+        it('detects light system preference', () => {
+            mockMatchMedia.mockImplementation((query: string) => ({
+                matches: false,
+                media: query,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn()
+            }));
+
+            const {result} = renderHook(() => useTheme());
+
+            expect(result.current.theme).toBe('auto');
+            expect(result.current.resolvedTheme).toBe('light');
+        });
+
+        it('responds to system theme changes', () => {
+            const {result} = renderHook(() => useTheme());
+
+            expect(result.current.resolvedTheme).toBe('light');
+
+            act(() => {
+                mediaQueryListeners.forEach(listener => {
+                    listener({matches: true} as MediaQueryListEvent);
+                });
+            });
+
+            expect(result.current.resolvedTheme).toBe('dark');
+        });
+
+        it('cleans up event listener on unmount', () => {
+            const removeEventListener = jest.fn();
+            mockMatchMedia.mockImplementation(() => ({
+                matches: false,
+                addEventListener: jest.fn(),
+                removeEventListener
+            }));
+
+            const {unmount} = renderHook(() => useTheme());
+
+            unmount();
+
+            expect(removeEventListener).toHaveBeenCalled();
+        });
+    });
+
+    describe('resolvedTheme', () => {
+        it('returns explicit theme when not auto', () => {
+            const {result} = renderHook(() => useTheme());
+
+            act(() => {
+                result.current.setTheme('dark');
+            });
+
+            expect(result.current.resolvedTheme).toBe('dark');
+
+            act(() => {
+                result.current.setTheme('light');
+            });
+
+            expect(result.current.resolvedTheme).toBe('light');
+        });
+
+        it('returns system theme when auto', () => {
+            mockMatchMedia.mockImplementation((query: string) => ({
+                matches: query === '(prefers-color-scheme: dark)',
+                media: query,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn()
+            }));
+
+            const {result} = renderHook(() => useTheme());
+
+            act(() => {
+                result.current.setTheme('auto');
+            });
+
+            expect(result.current.resolvedTheme).toBe('dark');
+        });
+    });
+});

--- a/ui/src/shared/use-theme.ts
+++ b/ui/src/shared/use-theme.ts
@@ -1,0 +1,58 @@
+import {useCallback, useEffect, useState} from 'react';
+
+export type ThemeValue = 'light' | 'dark' | 'auto';
+
+const STORAGE_KEY = 'argo-workflows-theme';
+
+function getSystemTheme(): 'light' | 'dark' {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return 'light';
+}
+
+function getStoredTheme(): ThemeValue {
+    if (typeof window !== 'undefined') {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (stored === 'light' || stored === 'dark' || stored === 'auto') {
+            return stored;
+        }
+    }
+    return 'auto';
+}
+
+export interface UseThemeResult {
+    theme: ThemeValue;
+    resolvedTheme: 'light' | 'dark';
+    setTheme: (theme: ThemeValue) => void;
+}
+
+export function useTheme(): UseThemeResult {
+    const [theme, setThemeState] = useState<ThemeValue>(getStoredTheme);
+    const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(getSystemTheme);
+
+    const setTheme = useCallback((newTheme: ThemeValue) => {
+        setThemeState(newTheme);
+        if (typeof window !== 'undefined') {
+            window.localStorage.setItem(STORAGE_KEY, newTheme);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.matchMedia) {
+            return;
+        }
+
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const handleChange = (e: MediaQueryListEvent) => {
+            setSystemTheme(e.matches ? 'dark' : 'light');
+        };
+
+        mediaQuery.addEventListener('change', handleChange);
+        return () => mediaQuery.removeEventListener('change', handleChange);
+    }, []);
+
+    const resolvedTheme = theme === 'auto' ? systemTheme : theme;
+
+    return {theme, resolvedTheme, setTheme};
+}

--- a/ui/src/userinfo/user-info.tsx
+++ b/ui/src/userinfo/user-info.tsx
@@ -5,6 +5,7 @@ import {useEffect, useState} from 'react';
 import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {Notice} from '../shared/components/notice';
+import {ThemeSelector} from '../shared/components/theme-selector';
 import {GetUserInfoResponse} from '../shared/models';
 import {services} from '../shared/services';
 import {CliHelp} from './cli-help';
@@ -87,6 +88,12 @@ export function UserInfo() {
                 <a className='argo-button argo-button--base-o' href={uiUrl('login')}>
                     <i className='fa fa-shield-alt' /> Login / Logout
                 </a>
+            </Notice>
+            <Notice>
+                <h3>
+                    <i className='fa fa-palette' /> Theme
+                </h3>
+                <ThemeSelector />
             </Notice>
             <CliHelp />
         </Page>

--- a/ui/src/workflow-templates/workflow-template-filters.scss
+++ b/ui/src/workflow-templates/workflow-template-filters.scss
@@ -1,20 +1,27 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .wf-filters-container {
     overflow: visible;
     position: relative;
     border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
     padding: 0 1em 0.75em 1em;
     margin: 12px 0;
-    background-color: white;
+
+    @include themify($themes) {
+        box-shadow: 1px 1px 3px themed('shadow');
+        background-color: themed('background-2');
+    }
 }
 
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
-    color: #6d7f8b;
     text-transform: uppercase;
+
+    @include themify($themes) {
+        color: themed('light-argo-gray-6');
+    }
 }
 
 .wf-filters-container__title {

--- a/ui/src/workflows/components/workflow-dag/workflow-dag.scss
+++ b/ui/src/workflows/components/workflow-dag/workflow-dag.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 @import 'node_modules/@fortawesome/fontawesome-free/scss/variables';
 @import 'node_modules/@fortawesome/fontawesome-free/scss/mixins';
 
@@ -7,18 +8,27 @@
   margin: 10px;
   padding: 10px;
   display: inline-block;
-  background-color: white;
-  box-shadow: 1px 1px 3px $argo-color-gray-5;
+
+  @include themify($themes) {
+    background-color: themed('background-2');
+    box-shadow: 1px 1px 3px themed('shadow');
+  }
 
   a {
     padding: 10px;
-    color: $argo-color-gray-6;
+
+    @include themify($themes) {
+      color: themed('light-argo-gray-6');
+    }
 
     &.active {
-      background-color: $argo-color-gray-3;
-      border: 1px solid $argo-color-gray-4;
       border-radius: 5px;
       cursor: default;
+
+      @include themify($themes) {
+        background-color: themed('background-1');
+        border: 1px solid themed('border');
+      }
     }
   }
 }
@@ -41,6 +51,10 @@
     text-anchor: middle;
     font-family: sans-serif;
     text-rendering: optimizeLegibility;
+
+    @include themify($themes) {
+      fill: themed('text-1');
+    }
   }
 
   .node {

--- a/ui/src/workflows/components/workflow-details/workflow-details.scss
+++ b/ui/src/workflows/components/workflow-details/workflow-details.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .workflow-details {
 
@@ -105,9 +106,12 @@
   }
 
   &__attribute-grid {
-    color: $argo-color-gray-8;
     display: grid;
     grid-template-columns: auto minmax(50%, 1fr);
+
+    @include themify($themes) {
+      color: themed('text-2');
+    }
 
     &>* {
       align-items: center;
@@ -121,7 +125,9 @@
     }
 
     &>*:not(:nth-last-child(-n+2)) {
-      border-bottom: 1px solid $argo-color-gray-3;
+      @include themify($themes) {
+        border-bottom: 1px solid themed('border');
+      }
     }
 
     pre {
@@ -151,15 +157,18 @@
 }
 
 .row.header {
-  color: $argo-color-gray-8;
-  background-color: $argo-color-gray-1;
-  border-bottom: 1px solid $argo-color-gray-5;
   display: flex;
   line-height: 1.2em;
   padding: 4px 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @include themify($themes) {
+    color: themed('text-2');
+    background-color: themed('background-1');
+    border-bottom: 1px solid themed('border');
+  }
 
   &:hover {
     overflow: visible;
@@ -204,14 +213,19 @@
 }
 
 .artifact-row {
-  color: $argo-color-gray-8;
   display: flex;
-  border-bottom: 1px solid $argo-color-gray-5;
   padding: 8px 0;
   text-align: left;
 
+  @include themify($themes) {
+    color: themed('text-2');
+    border-bottom: 1px solid themed('border');
+  }
+
   &:hover {
-    background-color: $argo-color-gray-3;
+    @include themify($themes) {
+      background-color: themed('background-1');
+    }
   }
 
   .columns {

--- a/ui/src/workflows/components/workflow-filters/workflow-filters.scss
+++ b/ui/src/workflows/components/workflow-filters/workflow-filters.scss
@@ -1,20 +1,27 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .wf-filters-container {
     overflow: visible;
     position: relative;
     border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
     padding: 0 1em 0.75em 1em;
     margin: 12px 0;
-    background-color: white;
+
+    @include themify($themes) {
+        box-shadow: 1px 1px 3px themed('shadow');
+        background-color: themed('background-2');
+    }
 }
 
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
-    color: #6d7f8b;
     text-transform: uppercase;
+
+    @include themify($themes) {
+        color: themed('light-argo-gray-6');
+    }
 }
 
 .wf-filters-container__title {

--- a/ui/src/workflows/components/workflow-labels/workflow-labels.scss
+++ b/ui/src/workflows/components/workflow-labels/workflow-labels.scss
@@ -1,7 +1,8 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .wf-row-labels {
-  display: flex; 
+  display: flex;
   flex-wrap: wrap;
   align-items: center;
   height: 100%;
@@ -10,7 +11,6 @@
 
   .tag {
     line-height: normal;
-    background-color: $argo-color-gray-3;
     border-radius: 3px;
     height: auto;
     margin: $gutter 0;
@@ -18,6 +18,10 @@
     display: flex;
     overflow: hidden;
     cursor: pointer;
+
+    @include themify($themes) {
+      background-color: themed('background-2');
+    }
 
     &:hover {
       .key {
@@ -33,7 +37,9 @@
     }
 
     .key {
-      color: $argo-color-gray-6;
+      @include themify($themes) {
+        color: themed('text-2');
+      }
     }
 
     .value {

--- a/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.scss
+++ b/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.scss
@@ -1,3 +1,5 @@
+@import 'node_modules/argo-ui/src/styles/theme';
+
 .workflow-logs-viewer {
   .select {
     width: auto;
@@ -9,7 +11,10 @@
   max-height: 800px;
   padding: 10px;
   margin: 10px;
-  background-color: white;
+
+  @include themify($themes) {
+    background-color: themed('background-2');
+  }
 }
 
 .log-menu {

--- a/ui/src/workflows/components/workflow-node-info/workflow-node-info.scss
+++ b/ui/src/workflows/components/workflow-node-info/workflow-node-info.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .workflow-node-info {
     height: calc(100vh - 2 * #{$top-bar-height});
@@ -54,9 +55,12 @@
 
     &__sidecar {
         text-transform: uppercase;
-        border-top: 1px solid $argo-color-gray-5;
         cursor: pointer;
         font-size: 0.8em;
+
+        @include themify($themes) {
+            border-top: 1px solid themed('border');
+        }
 
         span {
             color: $argo-color-teal-5;
@@ -68,21 +72,27 @@
         }
 
         &:last-child {
-            border-bottom: 1px solid $argo-color-gray-5;
             padding: 1em 0;
+
+            @include themify($themes) {
+                border-bottom: 1px solid themed('border');
+            }
         }
     }
 
     .row.header {
-        color: $argo-color-gray-8;
-        background-color: $argo-color-gray-1;
-        border-bottom: 1px solid $argo-color-gray-5;
         display: flex;
         line-height: 1.2em;
         padding: 4px 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+
+        @include themify($themes) {
+            color: themed('text-2');
+            background-color: themed('background-1');
+            border-bottom: 1px solid themed('border');
+        }
 
         &:hover {
             overflow: visible;
@@ -127,14 +137,19 @@
     }
 
     .artifact-row {
-        color: $argo-color-gray-8;
         display: flex;
-        border-bottom: 1px solid $argo-color-gray-5;
         padding: 8px 0;
         text-align: left;
 
+        @include themify($themes) {
+            color: themed('text-2');
+            border-bottom: 1px solid themed('border');
+        }
+
         &:hover {
-            background-color: $argo-color-gray-3;
+            @include themify($themes) {
+                background-color: themed('background-1');
+            }
         }
 
         .columns {

--- a/ui/src/workflows/components/workflows-list/workflows-list.scss
+++ b/ui/src/workflows/components/workflows-list/workflows-list.scss
@@ -1,4 +1,5 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .workflows-list {
     padding: 1em;
@@ -117,11 +118,14 @@
         overflow: hidden;
         position: relative;
         border-radius: $border-radius;
-        box-shadow: 1px 1px 3px $argo-color-gray-5;
         padding: 0 1em 0.75em 1em;
         margin: 33px 0;
-        background-color: white;
         transition: max-height 0.25s cubic-bezier(0, 1, 0, 1);
+
+        @include themify($themes) {
+            box-shadow: 1px 1px 3px themed('shadow');
+            background-color: themed('background-2');
+        }
 
         ul,
         a,

--- a/ui/src/workflows/components/workflows-summary-container/workflows-summary-container.scss
+++ b/ui/src/workflows/components/workflows-summary-container/workflows-summary-container.scss
@@ -1,15 +1,19 @@
 @import 'node_modules/argo-ui/src/styles/config';
+@import 'node_modules/argo-ui/src/styles/theme';
 
 .wf-summary-container {
-    color:  $argo-color-gray-6;
     padding: 5px 0px;
     overflow: visible;
     position: relative;
     border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
     padding: 0 1em 0.75em 1em;
     margin: 12px 0;
-    background-color: white;
+
+    @include themify($themes) {
+        color: themed('text-1');
+        box-shadow: 1px 1px 3px themed('shadow');
+        background-color: themed('background-2');
+    }
 
     &__title {
         width: 100%;
@@ -20,8 +24,11 @@
         border: 0;
         margin: 0;
         margin-top: 1em;
-        color: #6d7f8b;
         text-transform: uppercase;
+
+        @include themify($themes) {
+            color: themed('light-argo-gray-6');
+        }
     }
 
     &__text{


### PR DESCRIPTION
Fixes #5037

### Motivation

Dark mode is a highly requested feature already implemented in ArgoCD. This adds support to Argo Workflows.

### Modifications

**New files:**
- `ui/src/shared/use-theme.ts` - Hook for theme state management
- `ui/src/shared/theme-context.ts` - React context for theme state
- `ui/src/shared/components/theme-selector.tsx` - Theme selector component with Light/Dark/System buttons
- `ui/src/shared/components/theme-selector.scss` - Styles for theme selector
- `ui/src/shared/use-theme.test.ts` - Unit tests for useTheme hook

**Modified files:**
- `ui/src/app-router.tsx` - Added ThemeContext.Provider and pass theme to layout
- `ui/src/userinfo/user-info.tsx` - Added ThemeSelector component
- `ui/src/shared/components/suspense-monaco-editor.tsx` - Monaco theme switching
- SCSS files updated to use `themify()` mixin for dark mode support

**Screenshots:**

| Workflows List | Workflow Details |
|----------------|------------------|
| ![wf-list](https://github.com/user-attachments/assets/1e80f152-af44-4f7d-a877-7fd990fc1110) | ![wf-details](https://github.com/user-attachments/assets/b84652dd-1d03-470a-a89f-91c94b682918) |

| User Info (Theme Selector) | Help Page |
|---------------------------|-----------|
| ![userinfo](https://github.com/user-attachments/assets/7b50ebea-1b88-462b-be28-8891b3b11072) | ![help](https://github.com/user-attachments/assets/ecb1f18b-6aff-4cce-96e0-73b86f00996b) |

### Verification

- `yarn lint` - passes
- `yarn test` - tests pass
- `yarn build` - builds successfully
- Manual testing in browser:
  - Theme persists across page refresh
  - System preference detection works
  - All major pages render correctly in dark mode
  - Monaco editor switches theme appropriately

### Documentation

Theme selector is discoverable on the User Info page directly from the sidebar. This matches the Argo CD placement of the theme toggle. Using it is self-explanatory with Light/Dark/System button options.