### PR TITLE
fix: change RLock to Lock in sync manager methods (cherry-pick #15546 for 3.7)

### DIFF
--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -87,8 +87,8 @@ func (sm *Manager) getWorkflowKey(key string) (string, error) {
 func (sm *Manager) CheckWorkflowExistence(ctx context.Context) {
 	defer runtimeutil.HandleCrashWithContext(ctx, runtimeutil.PanicHandlers...)
 
-	sm.lock.RLock()
-	defer sm.lock.RUnlock()
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
 
 	log.Debug("Check the workflow existence")
 	for _, lock := range sm.syncLockMap {
@@ -460,8 +460,8 @@ func (sm *Manager) Release(ctx context.Context, wf *wfv1.Workflow, nodeName stri
 		return
 	}
 
-	sm.lock.RLock()
-	defer sm.lock.RUnlock()
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
 
 	holderKey := getHolderKey(wf, nodeName)
 	log.Infof("Release %s", holderKey)
@@ -488,8 +488,8 @@ func (sm *Manager) Release(ctx context.Context, wf *wfv1.Workflow, nodeName stri
 }
 
 func (sm *Manager) ReleaseAll(wf *wfv1.Workflow) bool {
-	sm.lock.RLock()
-	defer sm.lock.RUnlock()
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
 
 	if wf.Status.Synchronization == nil {
 		return true


### PR DESCRIPTION
Cherry-picked fix: change RLock to Lock in sync manager methods (#15546)