### PR TITLE
fix: configure logrus for `argoproj/pkg` internal usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sethvargo/go-limiter v1.1.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -103,7 +104,6 @@ require (
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/util/cmd/cmd.go
+++ b/util/cmd/cmd.go
@@ -121,6 +121,10 @@ func CmdContextWithLogger(cmd *cobra.Command, logLevel, logType string) (context
 	logger := logging.NewSlogLogger(level, format)
 	ctx = logging.WithLogger(ctx, logger)
 
+	// Configure logrus for argoproj/pkg which uses it internally
+	SetLogrusLevel(level)
+	SetLogrusFormatter(format)
+
 	cmd.SetContext(ctx)
 	return ctx, logger, nil
 }

--- a/util/cmd/logrus.go
+++ b/util/cmd/logrus.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/argoproj/argo-workflows/v3/util/logging"
+)
+
+// SetLogrusLevel sets the logrus log level to match the given logging.Level.
+// This is needed because argoproj/pkg uses logrus internally (e.g. stats package).
+func SetLogrusLevel(level logging.Level) {
+	switch level {
+	case logging.Debug:
+		log.SetLevel(log.DebugLevel)
+	case logging.Info:
+		log.SetLevel(log.InfoLevel)
+	case logging.Warn:
+		log.SetLevel(log.WarnLevel)
+	case logging.Error:
+		log.SetLevel(log.ErrorLevel)
+	}
+}
+
+// SetLogrusFormatter sets the logrus formatter to match the given logging.LogType.
+// This is needed because argoproj/pkg uses logrus internally (e.g. stats package).
+func SetLogrusFormatter(logType logging.LogType) {
+	timestampFormat := "2006-01-02T15:04:05.000Z"
+	switch logType {
+	case logging.JSON:
+		log.SetFormatter(&log.JSONFormatter{TimestampFormat: timestampFormat})
+	default:
+		log.SetFormatter(&log.TextFormatter{TimestampFormat: timestampFormat, FullTimestamp: true})
+	}
+}


### PR DESCRIPTION
### Motivation

The argoproj/pkg dependency uses logrus internally (e.g., in the stats package), but the application's logging configuration was only applied to the slog logger. This caused logrus to use default settings that didn't match the configured log level and format, resulting in inconsistent logging behavior.

### Modifications

- Created new `util/cmd/logrus.go` with two functions:
  - `SetLogrusLevel()`: Maps the application's `logging.Level` to logrus log levels
  - `SetLogrusFormatter()`: Maps the application's `logging.LogType` to logrus formatters (JSON or text)
- Updated `CmdContextWithLogger()` in `util/cmd/cmd.go` to call these functions when configuring logging, ensuring logrus is synchronized with the application's logging settings
- Added explicit `github.com/sirupsen/logrus` dependency to `go.mod` (moved from indirect to direct dependency)

### Verification

The changes are straightforward configuration synchronization. Existing tests that verify logging configuration will implicitly cover this change. The logrus configuration mirrors the slog configuration logic already in place.

### Documentation

No documentation updates needed. This is an internal implementation detail that ensures consistent logging behavior across all logging libraries used by dependencies.

### AI

Claude mostly wrote this
