### PR TITLE
fix(ui): preserve URL params for workflow submission prefilling. Fixes #15566

### DIFF
--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -48,7 +48,21 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
     );
 
     useEffect(() => {
-        history.push(historyUrl('cluster-workflow-templates/{name}', {name, sidePanel, tab}));
+        const currentParams = new URLSearchParams(location.search);
+        const extraSearchParams = new URLSearchParams();
+        currentParams.forEach((value, key) => {
+            if (key.startsWith('parameters[') || key === 'entrypoint' || key === 'labels') {
+                extraSearchParams.set(key, value);
+            }
+        });
+        history.push(
+            historyUrl('cluster-workflow-templates/{name}', {
+                name,
+                sidePanel,
+                tab,
+                extraSearchParams: extraSearchParams.toString() ? extraSearchParams : null
+            })
+        );
     }, [name, sidePanel, tab]);
 
     useEffect(() => {

--- a/ui/src/workflow-templates/workflow-template-details.tsx
+++ b/ui/src/workflow-templates/workflow-template-details.tsx
@@ -51,12 +51,20 @@ export function WorkflowTemplateDetails({history, location, match}: RouteCompone
             isFirstRender.current = false;
             return;
         }
+        const currentParams = new URLSearchParams(location.search);
+        const extraSearchParams = new URLSearchParams();
+        currentParams.forEach((value, key) => {
+            if (key.startsWith('parameters[') || key === 'entrypoint' || key === 'labels') {
+                extraSearchParams.set(key, value);
+            }
+        });
         history.push(
             historyUrl('workflow-templates/{namespace}/{name}', {
                 namespace,
                 name,
                 sidePanel,
-                tab
+                tab,
+                extraSearchParams: extraSearchParams.toString() ? extraSearchParams : null
             })
         );
     }, [namespace, name, sidePanel, tab]);

--- a/ui/src/workflows/components/submit-workflow-panel.test.ts
+++ b/ui/src/workflows/components/submit-workflow-panel.test.ts
@@ -1,0 +1,73 @@
+import {createBrowserHistory} from 'history';
+
+describe('SubmitWorkflowPanel URL parsing', () => {
+    describe('entrypoint parsing', () => {
+        it('should extract entrypoint from URL', () => {
+            const history = createBrowserHistory();
+            history.location.search = '?sidePanel=submit&entrypoint=my-entrypoint';
+            const queryParams = new URLSearchParams(history.location.search);
+            const entrypoint = queryParams.get('entrypoint');
+            expect(entrypoint).toEqual('my-entrypoint');
+        });
+
+        it('should return null when entrypoint is not provided', () => {
+            const history = createBrowserHistory();
+            history.location.search = '?sidePanel=submit';
+            const queryParams = new URLSearchParams(history.location.search);
+            const entrypoint = queryParams.get('entrypoint');
+            expect(entrypoint).toBeNull();
+        });
+    });
+
+    describe('labels parsing', () => {
+        it('should extract and split labels from URL', () => {
+            const history = createBrowserHistory();
+            history.location.search = '?sidePanel=submit&labels=key1=value1,key2=value2';
+            const queryParams = new URLSearchParams(history.location.search);
+            const urlLabels = queryParams.get('labels');
+            const labels = urlLabels ? urlLabels.split(',').filter(l => l.trim()) : ['submit-from-ui=true'];
+            expect(labels).toEqual(['key1=value1', 'key2=value2']);
+        });
+
+        it('should return default label when labels not provided', () => {
+            const history = createBrowserHistory();
+            history.location.search = '?sidePanel=submit';
+            const queryParams = new URLSearchParams(history.location.search);
+            const urlLabels = queryParams.get('labels');
+            const labels = urlLabels ? urlLabels.split(',').filter(l => l.trim()) : ['submit-from-ui=true'];
+            expect(labels).toEqual(['submit-from-ui=true']);
+        });
+
+        it('should handle URL-encoded labels', () => {
+            const history = createBrowserHistory();
+            history.location.search = '?sidePanel=submit&labels=submit-from-ui%3Dtrue,custom%3Dvalue';
+            const queryParams = new URLSearchParams(history.location.search);
+            const urlLabels = queryParams.get('labels');
+            const labels = urlLabels ? urlLabels.split(',').filter(l => l.trim()) : ['submit-from-ui=true'];
+            expect(labels).toEqual(['submit-from-ui=true', 'custom=value']);
+        });
+    });
+
+    describe('combined parameters', () => {
+        it('should handle all URL parameters together', () => {
+            const history = createBrowserHistory();
+            history.location.search = '?sidePanel=submit&entrypoint=retry&parameters[namespace]=development&parameters[action]=retry&labels=submit-from-ui=true';
+            const queryParams = new URLSearchParams(history.location.search);
+
+            expect(queryParams.get('sidePanel')).toEqual('submit');
+            expect(queryParams.get('entrypoint')).toEqual('retry');
+            expect(queryParams.get('labels')).toEqual('submit-from-ui=true');
+            const parameters: {[key: string]: string} = {};
+            queryParams.forEach((value, key) => {
+                const match = key.match(/^parameters\[(.*?)\]$/);
+                if (match) {
+                    parameters[match[1]] = value;
+                }
+            });
+            expect(parameters).toEqual({
+                namespace: 'development',
+                action: 'retry'
+            });
+        });
+    });
+});


### PR DESCRIPTION
The useEffect hooks in workflow-template-details and cluster-workflow-template-details were stripping parameters[...], entrypoint, and labels query params when updating the URL, preventing the SubmitWorkflowPanel from reading them.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15566

### Motivation

PR #13922 (from #12124) added the ability to prefill workflow parameters via URL query params when submitting workflows. However, this was not propagated to the WorkflowTemplate and ClusterWorkflowTemplate detail pages. The useEffect hooks in those pages overwrite the URL when updating the sidePanel state, stripping parameters[...], entrypoint, and labels query params before the SubmitWorkflowPanel can read them.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- workflow-template-details.tsx / cluster-workflow-template-details.tsx: Preserve parameters[...], entrypoint, and labels query params when updating the URL
- submit-workflow-panel.tsx: Add support for prefilling entrypoint (?entrypoint=name) and labels (?labels=key=val,key2=val2) from URL query params
- submit-workflow-panel.test.ts: Add tests for URL parameter parsing

### Verification
- UI lint (eslint --fix + tsc --noEmit) passes
- All 78 UI tests pass, including new tests for URL parameter parsing
- Manually
<img width="1620" height="686" alt="image" src="https://github.com/user-attachments/assets/b619ebd1-a8db-4f23-af6f-6daa2c1b9215" />

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
