### PR TITLE
chore(lint): enable whitespace linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - usestdlibvars
     - usetesting
     - wastedassign
+    - whitespace
   settings:
     revive:
       rules:

--- a/cmd/argo/commands/archive/get.go
+++ b/cmd/argo/commands/archive/get.go
@@ -54,7 +54,6 @@ func NewGetCommand() *cobra.Command {
 }
 
 func printWorkflow(wf *wfv1.Workflow, output string) {
-
 	switch output {
 	case "json":
 		output, err := json.Marshal(wf)
@@ -96,5 +95,4 @@ func printWorkflow(wf *wfv1.Workflow, output string) {
 			fmt.Printf(fmtStr, "Duration:", humanize.RelativeDuration(wf.Status.StartedAt.Time, wf.Status.FinishedAt.Time))
 		}
 	}
-
 }

--- a/cmd/argo/commands/clustertemplate/delete.go
+++ b/cmd/argo/commands/clustertemplate/delete.go
@@ -45,7 +45,6 @@ func apiServerDeleteClusterWorkflowTemplates(ctx context.Context, allWFs bool, w
 		for _, cwfTmpl := range cwftmplList.Items {
 			delWFTmplNames = append(delWFTmplNames, cwfTmpl.Name)
 		}
-
 	} else {
 		delWFTmplNames = wfTmplNames
 	}

--- a/cmd/argo/commands/lint_test.go
+++ b/cmd/argo/commands/lint_test.go
@@ -292,5 +292,4 @@ spec:
 		require.NoError(t, err)
 		assert.False(t, fatal, "should not have exited")
 	})
-
 }

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -137,7 +137,6 @@ See %s`, help.ArgoServer()),
 						return err
 					}
 				}
-
 			} else {
 				logger.Warn(ctx, "You are running in insecure mode. Learn how to enable transport layer security: https://argo-workflows.readthedocs.io/en/latest/tls/")
 			}

--- a/cmd/argo/commands/submit_test.go
+++ b/cmd/argo/commands/submit_test.go
@@ -44,7 +44,6 @@ func Test_submitWorkflows(t *testing.T) {
 			assert.Fail(t, "type is not WorkflowCreateRequest")
 		}
 		assert.Equal(t, priority, *wfC.Workflow.Spec.Priority)
-
 	})
 
 	t.Run("Submit workflow with priority set from cli", func(t *testing.T) {

--- a/cmd/argo/commands/sync/create.go
+++ b/cmd/argo/commands/sync/create.go
@@ -19,7 +19,6 @@ type cliCreateOpts struct {
 }
 
 func NewCreateCommand() *cobra.Command {
-
 	var cliCreateOpts = cliCreateOpts{}
 
 	command := &cobra.Command{

--- a/cmd/argo/commands/template/delete.go
+++ b/cmd/argo/commands/template/delete.go
@@ -54,7 +54,6 @@ func apiServerDeleteWorkflowTemplates(ctx context.Context, allWFs bool, wfTmplNa
 		for _, wfTmpl := range wftmplList.Items {
 			delWFTmplNames = append(delWFTmplNames, wfTmpl.Name)
 		}
-
 	} else {
 		delWFTmplNames = wfTmplNames
 	}

--- a/cmd/argoexec/commands/artifact/delete.go
+++ b/cmd/argoexec/commands/artifact/delete.go
@@ -46,7 +46,6 @@ func NewArtifactDeleteCommand() *cobra.Command {
 			}()
 
 			if podName, ok := os.LookupEnv(common.EnvVarArtifactGCPodHash); ok {
-
 				config, err := clientConfig.ClientConfig()
 				workflowInterface := workflow.NewForConfigOrDie(config)
 				if err != nil {
@@ -70,7 +69,6 @@ func NewArtifactDeleteCommand() *cobra.Command {
 }
 
 func deleteArtifacts(ctx context.Context, labelSelector string, artifactGCTaskInterface wfv1alpha1.WorkflowArtifactGCTaskInterface) error {
-
 	taskList, err := artifactGCTaskInterface.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return err
@@ -79,7 +77,6 @@ func deleteArtifacts(ctx context.Context, labelSelector string, artifactGCTaskIn
 	for _, task := range taskList.Items {
 		task.Status.ArtifactResultsByNode = make(map[string]v1alpha1.ArtifactResultNodeStatus)
 		for nodeName, artifactNodeSpec := range task.Spec.ArtifactsByNode {
-
 			var archiveLocation *v1alpha1.ArtifactLocation
 			artResultNodeStatus := v1alpha1.ArtifactResultNodeStatus{ArtifactResults: make(map[string]v1alpha1.ArtifactResult)}
 			if artifactNodeSpec.ArchiveLocation != nil {
@@ -133,7 +130,6 @@ type resources struct {
 }
 
 func (r resources) GetSecret(ctx context.Context, name, key string) (string, error) {
-
 	path := filepath.Join(common.SecretVolMountPath, name, key)
 	if file, ok := r.Files[path]; ok {
 		return string(file), nil

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -172,7 +172,6 @@ func NewEmissaryCommand() *cobra.Command {
 			}
 
 			cmdErr := retry.OnError(backoff, func(error) bool { return true }, func() error {
-
 				command, closer, err := startCommand(ctx, name, args, template)
 				if err != nil {
 					return fmt.Errorf("failed to start command: %w", err)
@@ -225,7 +224,6 @@ func NewEmissaryCommand() *cobra.Command {
 				}
 
 				return osspecific.Wait(command.Process)
-
 			})
 			logger.WithError(cmdErr).Info(ctx, "sub-process exited")
 

--- a/persist/sqldb/sqldb.go
+++ b/persist/sqldb/sqldb.go
@@ -9,7 +9,6 @@ func GetTableName(persistConfig *config.PersistConfig) (string, error) {
 	var tableName string
 	if persistConfig.PostgreSQL != nil {
 		tableName = persistConfig.PostgreSQL.TableName
-
 	} else if persistConfig.MySQL != nil {
 		tableName = persistConfig.MySQL.TableName
 	}

--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -662,7 +662,6 @@ func (r *workflowArchive) GetWorkflowForEstimator(ctx context.Context, namespace
 			FinishedAt: v1.Time{Time: awf.FinishedAt},
 		},
 	}, nil
-
 }
 
 func (r *workflowArchive) DeleteWorkflow(ctx context.Context, uid string) error {

--- a/pkg/apiclient/argo-server-client.go
+++ b/pkg/apiclient/argo-server-client.go
@@ -84,7 +84,6 @@ func newClientConn(opts ArgoServerOpts) (*grpc.ClientConn, error) {
 }
 
 func newContext(ctx context.Context, auth string) context.Context {
-
 	bgCtx := logging.RequireLoggerFromContext(ctx).NewBackgroundContext()
 	if auth == "" {
 		return ctx

--- a/pkg/apiclient/offline-client.go
+++ b/pkg/apiclient/offline-client.go
@@ -84,7 +84,6 @@ func newOfflineClient(ctx context.Context, paths []string) (context.Context, Cli
 					}
 					getter.(*offlineWorkflowTemplateNamespacedGetter).workflowTemplates[objName] = v
 				}
-
 			}
 			return nil
 		})

--- a/pkg/apis/workflow/v1alpha1/container_set_template_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/container_set_template_types_test.go
@@ -118,7 +118,6 @@ containers:
 `
 	err := validateContainerSetTemplate(invalidContainerSetDuplicateNames)
 	require.ErrorContains(t, err, "containers[1].name 'a' is not unique")
-
 }
 
 func TestInvalidContainerSetDependencyNotFound(t *testing.T) {

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -167,7 +167,6 @@ func TestWorkflowGetArtifactGCStrategy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			workflowSpec := fmt.Sprintf(`
             apiVersion: argoproj.io/v1alpha1
             kind: Workflow
@@ -196,7 +195,6 @@ func TestWorkflowGetArtifactGCStrategy(t *testing.T) {
 			assert.Equal(t, tt.expectedStrategy, gcStrategy)
 		})
 	}
-
 }
 
 func TestArtifact_ValidatePath(t *testing.T) {
@@ -1467,7 +1465,6 @@ func TestParameterGetValue(t *testing.T) {
 	assert.NotEmpty(t, value.GetValue())
 	assert.Equal(t, "Test", value.GetValue())
 	assert.True(t, valueFrom.HasValue())
-
 }
 
 func TestTemplateIsLeaf(t *testing.T) {
@@ -1499,7 +1496,6 @@ func TestTemplateIsLeaf(t *testing.T) {
 		Steps: []ParallelSteps{},
 	}
 	assert.False(t, tmpl.IsLeaf())
-
 }
 
 func TestTemplateGetType(t *testing.T) {
@@ -1532,7 +1528,6 @@ func TestStepSpecGetExitHook(t *testing.T) {
 	step = WorkflowStep{Name: "A", Hooks: LifecycleHooks{"exit": LifecycleHook{Template: "hook"}}}
 	hooks = step.GetExitHook(step.Arguments)
 	assert.Equal(t, "hook", hooks.Template)
-
 }
 
 func TestTemplate_RetryStrategy(t *testing.T) {

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -209,7 +209,6 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 
 		key, _ := artifact.GetKey()
 		for _, object := range objects {
-
 			// object is prefixed by the key, we must trim it
 			dir, file := path.Split(strings.TrimPrefix(object, key+"/"))
 
@@ -240,7 +239,6 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 			a.httpFromError(ctx, err, w)
 		}
 	}
-
 }
 
 func (a *ArtifactServer) renderDirectoryListing(objects []string, key string) ([]byte, error) {
@@ -257,7 +255,6 @@ func (a *ArtifactServer) renderDirectoryListing(objects []string, key string) ([
 	}
 
 	for _, object := range objects {
-
 		// object is prefixed the key, we must trim it
 		dir, file := path.Split(strings.TrimPrefix(object, key+"/"))
 

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -503,7 +503,6 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 				} else {
 					assert.Equal(t, "my-data", string(all))
 				}
-
 			}
 		})
 	}

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -83,7 +83,6 @@ func NewGatekeeper(modes Modes, clients *servertypes.Clients, restConfig *rest.C
 		namespaced,
 		cache,
 	}, nil
-
 }
 
 func (s *gatekeeper) UnaryServerInterceptor() grpc.UnaryServerInterceptor {

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -360,7 +360,6 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	finalRedirectURL := cookie.Value
 	if !isValidFinalRedirectURL(cookie.Value) {
 		finalRedirectURL = s.baseHRef
-
 	}
 	http.Redirect(w, r, finalRedirectURL, http.StatusFound)
 }

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -90,7 +90,6 @@ func TestNewSsoWithIssuerAlias(t *testing.T) {
 	}
 	_, err := newSso(logging.TestContext(t.Context()), fakeOidcFactory, config, fakeClient, "/", false)
 	require.NoError(t, err)
-
 }
 func TestLoadSsoClientIdFromDifferentSecret(t *testing.T) {
 	clientIDSecret := &apiv1.Secret{

--- a/server/auth/types/claims_test.go
+++ b/server/auth/types/claims_test.go
@@ -169,7 +169,6 @@ func TestUnmarshalJSON(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-
 		claims := &Claims{}
 		err := json.Unmarshal([]byte(test.data), &claims)
 
@@ -179,7 +178,6 @@ func TestUnmarshalJSON(t *testing.T) {
 }
 
 func TestGetCustomGroup(t *testing.T) {
-
 	t.Run("NoCustomGroupSet", func(t *testing.T) {
 		claims := &Claims{}
 		_, err := claims.GetCustomGroup(("ad_groups"))

--- a/server/cache/lru_ttl_cache_test.go
+++ b/server/cache/lru_ttl_cache_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestNewTimedCache(t *testing.T) {
-
 	t.Run("NewLRUTtlCache should return a new instance", func(t *testing.T) {
 		cache := NewLRUTtlCache(time.Second, 1)
 		assert.NotNil(t, cache)
@@ -54,7 +53,6 @@ func TestNewTimedCache(t *testing.T) {
 		assert.False(t, ok)
 		currentTime = tempCurrentTime
 	})
-
 }
 
 func getTimeFunc(minutes int, sec int) func() time.Time {

--- a/server/clusterworkflowtemplate/informer.go
+++ b/server/clusterworkflowtemplate/informer.go
@@ -47,7 +47,6 @@ func NewInformer(restConfig *rest.Config) (Informer, error) {
 
 // Start informer in separate go-routine and block until cache sync
 func (cwti *informerImpl) Run(ctx context.Context, stopCh <-chan struct{}) {
-
 	go cwti.informer.Informer().Run(stopCh)
 
 	if !cache.WaitForCacheSync(

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -29,7 +29,6 @@ func NewFilesServer(baseHRef string, hsts bool, xframeOpts string, corsAllowOrig
 }
 
 func (s *FilesServer) ServerFiles(w http.ResponseWriter, r *http.Request) {
-
 	if s.xframeOpts != "" {
 		w.Header().Set("X-Frame-Options", s.xframeOpts)
 	}

--- a/server/sync/sync_server_cm_test.go
+++ b/server/sync/sync_server_cm_test.go
@@ -127,7 +127,6 @@ func Test_syncServer_CreateSyncLimit(t *testing.T) {
 	})
 
 	t.Run("ConfigMap exists with nil Data", func(t *testing.T) {
-
 		existingCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nil-data-cm",
@@ -207,7 +206,6 @@ func Test_syncServer_GetSyncLimit(t *testing.T) {
 	})
 
 	t.Run("Key doesn't exist", func(t *testing.T) {
-
 		existingCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "existing-cm",
@@ -237,7 +235,6 @@ func Test_syncServer_GetSyncLimit(t *testing.T) {
 	})
 
 	t.Run("Invalid size limit format", func(t *testing.T) {
-
 		existingCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "existing-cm",
@@ -367,7 +364,6 @@ func Test_syncServer_UpdateSyncLimit(t *testing.T) {
 	})
 
 	t.Run("Key doesn't exist", func(t *testing.T) {
-
 		existingCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "existing-cm",

--- a/server/utils/errors_test.go
+++ b/server/utils/errors_test.go
@@ -65,7 +65,6 @@ func TestNilStatus(t *testing.T) {
 }
 
 func TestArgoError(t *testing.T) {
-
 	t.Run("CodeBadRequest", func(t *testing.T) {
 		argoErr := testArgoError{argoerrors.CodeBadRequest}
 		newErr := ToStatusError(argoErr, codes.Internal)
@@ -86,7 +85,6 @@ func TestArgoError(t *testing.T) {
 		stat := status.Convert(newErr)
 		assert.Equal(t, codes.Internal, stat.Code())
 	})
-
 }
 
 func TestHTTPToStatusError(t *testing.T) {

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -573,7 +573,6 @@ func (s *workflowServer) ResumeWorkflow(ctx context.Context, req *workflowpkg.Wo
 		logger := logging.RequireLoggerFromContext(ctx)
 		logger.WithFields(logging.Fields{"name": wf.Name}).WithError(err).Warn(ctx, "Failed to resume")
 		return nil, sutils.ToStatusError(err, codes.Internal)
-
 	}
 
 	wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -225,7 +225,6 @@ func (w *archivedWorkflowServer) RetryArchivedWorkflow(ctx context.Context, req 
 
 	_, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})
 	if apierr.IsNotFound(err) {
-
 		wf, podsToDelete, err := util.FormulateRetryWorkflow(ctx, wf, req.RestartSuccessful, req.NodeFieldSelector, req.Parameters)
 		if err != nil {
 			return nil, sutils.ToStatusError(err, codes.Internal)

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -211,7 +211,6 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
 		assert.Equal(t, "1", resp.Continue)
-
 	})
 	t.Run("GetArchivedWorkflow", func(t *testing.T) {
 		allowed = false

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1798,7 +1798,6 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 
 		resp.Header("X-Frame-Options").
 			IsEqual("SAMEORIGIN")
-
 	})
 
 	// In this case, the filename specified in the request is actually a directory
@@ -1810,7 +1809,6 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 		resp.Body().
 			Contains("<a href=\"./sub-file-1\">sub-file-1</a>").
 			Contains("<a href=\"./sub-file-2\">sub-file-2</a>")
-
 	})
 
 	// In this case, the filename specified in the request is a subdirectory file
@@ -2211,7 +2209,6 @@ spec:
 			Length().
 			IsEqual(1)
 	})
-
 }
 
 // A test can simply reproduce the problem mentioned in the link https://github.com/argoproj/argo-workflows/pull/12574
@@ -2773,7 +2770,6 @@ spec:
 	j.
 		Path("$.spec.templates[0].container.args[1]").
 		IsEqual("hello \u0000")
-
 }
 
 func (s *ArgoServerSuite) TestSyncConfigmapService() {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -308,7 +308,6 @@ func (s *ArtifactsSuite) TestStoppedWorkflow() {
 			WaitForWorkflow(
 				fixtures.WorkflowCompletionOkay(true),
 				fixtures.Condition(func(wf *wfv1.Workflow) (bool, string) {
-
 					condition := "for artifacts to exist"
 
 					_, err1 := c.StatObject(ctx, "my-bucket-3", "on-deletion-wf-stopped-1", minio.StatObjectOptions{})
@@ -394,7 +393,6 @@ func (s *ArtifactsSuite) TestDeleteWorkflowPlugin() {
 }
 
 func (s *ArtifactsSuite) TestArtifactGC() {
-
 	s.Given().
 		WorkflowTemplate("@testdata/artifactgc/artgc-template.yaml").
 		WorkflowTemplate("@testdata/artifactgc/artgc-template-2.yaml").

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1860,7 +1860,6 @@ func (s *CLISuite) TestConfigMapSyncCLI() {
 				assert.Contains(t, output, "Sync limit deleted")
 			})
 	})
-
 }
 
 func (s *CLISuite) TestDBSyncCLI() {
@@ -1904,7 +1903,6 @@ func (s *CLISuite) TestDBSyncCLI() {
 				assert.Contains(t, output, "Sync limit deleted")
 			})
 	})
-
 }
 
 func (s *CLISuite) TestArchiveLabel() {

--- a/test/e2e/ns_parallelism_test.go
+++ b/test/e2e/ns_parallelism_test.go
@@ -37,7 +37,6 @@ spec:
 `
 
 func (s *NamespaceParallelismSuite) TestNamespaceParallelism() {
-
 	s.Given().
 		Workflow(wf).
 		When().

--- a/util/fields/fields_test.go
+++ b/util/fields/fields_test.go
@@ -30,7 +30,6 @@ func TestCleaner_WillExclude(t *testing.T) {
 		assert.False(t, NewCleaner("foo").WillExclude("foo.bar"))
 		assert.True(t, NewCleaner("foo").WillExclude("bar"))
 		assert.False(t, NewCleaner("foo.bar.baz").WillExclude("foo.bar"))
-
 	})
 	t.Run("Exclude", func(t *testing.T) {
 		assert.True(t, NewCleaner("-foo").WillExclude("foo"))

--- a/util/grpc/interceptor_test.go
+++ b/util/grpc/interceptor_test.go
@@ -95,7 +95,6 @@ func (msts mockServerStream) SetHeader(md metadata.MD) error {
 func (mockServerStream) SendHeader(md metadata.MD) error { return nil }
 func (mockServerStream) SetTrailer(md metadata.MD)       {}
 func (mockServerStream) Context() context.Context {
-
 	return logging.TestContext(context.Background())
 }
 func (mockServerStream) SendMsg(m any) error { return nil }

--- a/util/logs/workflow-logger.go
+++ b/util/logs/workflow-logger.go
@@ -83,12 +83,10 @@ func WorkflowLogs(ctx context.Context, wfClient versioned.Interface, kubeClient 
 	// we add selector if cli specify the pod selector when using logs
 	if req.GetSelector() != "" {
 		podListOptions = metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + req.GetName() + "," + req.GetSelector()}
-
 	} else {
 		// we create a watch on the pods labelled with the workflow name,
 		// but we also filter by pod name if that was requested
 		podListOptions = metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + req.GetName()}
-
 	}
 
 	if req.GetPodName() != "" {

--- a/util/rbac/rbac_test.go
+++ b/util/rbac/rbac_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestRBAC_AccessClusterWorkflowTemplates(t *testing.T) {
-
 	t.Run("has full access", func(t *testing.T) {
 		kubeclientset := &kubefake.Clientset{}
 		allowedVerbs := []string{"get", "list", "watch"}

--- a/util/template/template_test.go
+++ b/util/template/template_test.go
@@ -89,5 +89,4 @@ func Test_Template_Replace(t *testing.T) {
 			})
 		}
 	})
-
 }

--- a/util/tls/tls.go
+++ b/util/tls/tls.go
@@ -115,7 +115,6 @@ func GenerateX509KeyPair() (*tls.Certificate, error) {
 }
 
 func GenerateX509KeyPairTLSConfig(tlsMinVersion uint16) (*tls.Config, error) {
-
 	cer, err := GenerateX509KeyPair()
 	if err != nil {
 		return nil, err

--- a/workflow/artifacts/artifacts.go
+++ b/workflow/artifacts/artifacts.go
@@ -31,7 +31,6 @@ func NewDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 		return nil, err
 	}
 	return logging.New(drv), nil
-
 }
 
 func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (common.ArtifactDriver, error) {
@@ -207,7 +206,6 @@ func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 			Client:   &gohttp.Client{},
 		}
 		return &driver, nil
-
 	}
 	if art.HDFS != nil {
 		return hdfs.CreateDriver(ctx, ri, art.HDFS)

--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -39,7 +39,6 @@ var _ artifactscommon.ArtifactDriver = &ArtifactDriver{}
 // The container client is created with the default azblob.ClientOptions which does include retry behavior
 // for failed requests.
 func (azblobDriver *ArtifactDriver) newAzureContainerClient(ctx context.Context) (*container.Client, error) {
-
 	containerURL, err := url.Parse(azblobDriver.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse Azure Blob Storage endpoint url %s: %w", azblobDriver.Endpoint, err)

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -113,7 +113,6 @@ func TestArtifactDriver_WithSASToken_DownloadDirectory_Subdir(t *testing.T) {
 
 	// test read/write operations to the azurite container  using the container client
 	testContainerClientReadWriteOperations(t, containerClient, driver)
-
 }
 
 func testContainerClientReadWriteOperations(t *testing.T, containerClient *container.Client, driver ArtifactDriver) {

--- a/workflow/artifacts/common/load_to_stream_test.go
+++ b/workflow/artifacts/common/load_to_stream_test.go
@@ -107,7 +107,6 @@ func TestLoadToStream(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			// need to verify that a new file doesn't get written so check the /tmp directory ahead of time
 			filesBefore, err := filteredFiles(t)
 			if err != nil {

--- a/workflow/artifacts/git/git_test.go
+++ b/workflow/artifacts/git/git_test.go
@@ -27,7 +27,6 @@ func TestGitArtifactDriver_Load(t *testing.T) {
 		assert.DirExists(t, path)
 	})
 	t.Run("PrivateRepo", func(t *testing.T) {
-
 		// TODO: temp - skip private repo test for everyone
 		t.SkipNow()
 

--- a/workflow/artifacts/http/http_test.go
+++ b/workflow/artifacts/http/http_test.go
@@ -118,7 +118,6 @@ func TestSaveHTTPArtifactRedirect(t *testing.T) {
 
 			w.WriteHeader(http.StatusCreated)
 		}
-
 	}))
 	defer svr.Close()
 
@@ -137,5 +136,4 @@ func TestSaveHTTPArtifactRedirect(t *testing.T) {
 		err := driver.Save(ctx, tempFile, &art)
 		require.NoError(t, err)
 	})
-
 }

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -184,7 +184,6 @@ func ProcessArgs(ctx context.Context, tmpl *wfv1.Template, args wfv1.ArgumentsPr
 	// Performs substitutions of input artifacts
 	artifacts := newTmpl.Inputs.Artifacts
 	for i, inArt := range artifacts {
-
 		argArt := args.GetArtifactByName(inArt.Name)
 
 		if !inArt.Optional && !inArt.HasLocationOrKey() {

--- a/workflow/controller/agent_test.go
+++ b/workflow/controller/agent_test.go
@@ -170,5 +170,4 @@ func TestAssessAgentPodStatus(t *testing.T) {
 		assert.Equal(t, wfv1.NodePhase(""), nodeStatus)
 		assert.Empty(t, msg)
 	})
-
 }

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -56,7 +56,6 @@ func (woc *wfOperationCtx) addArtifactGCFinalizer(ctx context.Context) {
 }
 
 func (woc *wfOperationCtx) garbageCollectArtifacts(ctx context.Context) error {
-
 	if !artifactGCEnabled {
 		return nil
 	}
@@ -128,7 +127,6 @@ type templatesToArtifacts map[string]wfv1.ArtifactSearchResults
 
 // Artifact GC Strategy is ready: start up Pods to handle it
 func (woc *wfOperationCtx) processArtifactGCStrategy(ctx context.Context, strategy wfv1.ArtifactGCStrategy) error {
-
 	defer func() {
 		woc.wf.Status.ArtifactGCStatus.SetArtifactGCStrategyProcessed(strategy, true)
 		woc.updated = true
@@ -341,10 +339,8 @@ func (woc *wfOperationCtx) addTemplateArtifactsToTasks(ctx context.Context, podN
 		}
 
 		artifactNodeSpec.Artifacts[artifactSearchResult.Name] = artifactSearchResult.Artifact
-
 	}
 	woc.log.WithFields(logging.Fields{"template": template.Name, "task": currentTask.Name, "artifacts": artifactsByNode}).Debug(ctx, "list of artifacts pertaining to template")
-
 }
 
 // find WorkflowArtifactGCTask CRD object by name
@@ -362,7 +358,6 @@ func (woc *wfOperationCtx) getArtifactTask(taskName string) (*wfv1.WorkflowArtif
 
 // create WorkflowArtifactGCTask CRD object
 func (woc *wfOperationCtx) createWorkflowArtifactGCTask(ctx context.Context, task *wfv1.WorkflowArtifactGCTask) (*wfv1.WorkflowArtifactGCTask, error) {
-
 	// first make sure it doesn't already exist
 	foundTask, err := woc.getArtifactTask(task.Name)
 	if err != nil {
@@ -384,7 +379,6 @@ func (woc *wfOperationCtx) createWorkflowArtifactGCTask(ctx context.Context, tas
 // create the Pod which will do the deletions
 func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv1.ArtifactGCStrategy, tasks []*wfv1.WorkflowArtifactGCTask,
 	podInfo podInfo, podName string, templatesToArtList templatesToArtifacts, templatesByName map[string]*wfv1.Template) (*corev1.Pod, error) {
-
 	woc.log.WithFields(logging.Fields{"strategy": strategy, "podName": podName}).Info(ctx, "creating pod to delete artifacts")
 
 	// Pod is owned by WorkflowArtifactGCTasks, so it will die automatically when all of them have died
@@ -624,16 +618,13 @@ func (woc *wfOperationCtx) allArtifactsDeleted() bool {
 }
 
 func (woc *wfOperationCtx) findArtifactsToGC(strategy wfv1.ArtifactGCStrategy) wfv1.ArtifactSearchResults {
-
 	var results wfv1.ArtifactSearchResults
 
 	for _, n := range woc.wf.Status.Nodes {
-
 		if n.Type != wfv1.NodeTypePod {
 			continue
 		}
 		for _, a := range n.GetOutputs().GetArtifacts() {
-
 			// artifact strategy is either based on overall Workflow ArtifactGC Strategy, or
 			// if it's specified on the individual artifact level that takes priority
 			artifactStrategy := woc.execWf.GetArtifactGCStrategy(&a)
@@ -680,7 +671,6 @@ func (woc *wfOperationCtx) processCompletedArtifactGCPod(ctx context.Context, po
 				woc.log.WithField("name", task.Name).WithError(err).Error(ctx, "error deleting WorkflowArtifactGCTask")
 			}
 		}
-
 	}
 	return nil
 }
@@ -722,7 +712,6 @@ func (woc *wfOperationCtx) processCompletedWorkflowArtifactGCTask(ctx context.Co
 				}
 			}
 		}
-
 	}
 
 	return !foundGCFailure, nil
@@ -755,7 +744,6 @@ func (woc *wfOperationCtx) getArtifactGCPodInfo(artifact *wfv1.Artifact) podInfo
 
 // propagate the information from artifactGC into the podInfo
 func (woc *wfOperationCtx) updateArtifactGCPodInfo(artifactGC *wfv1.ArtifactGC, podInfo *podInfo) {
-
 	if artifactGC.ServiceAccountName != "" {
 		podInfo.serviceAccount = artifactGC.ServiceAccountName
 	}
@@ -769,5 +757,4 @@ func (woc *wfOperationCtx) updateArtifactGCPodInfo(artifactGC *wfv1.ArtifactGC, 
 		}
 		maps.Copy(podInfo.podMetadata.Annotations, artifactGC.PodMetadata.Annotations)
 	}
-
 }

--- a/workflow/controller/artifact_gc_test.go
+++ b/workflow/controller/artifact_gc_test.go
@@ -456,7 +456,6 @@ func TestProcessArtifactGCStrategy(t *testing.T) {
 	assert.Contains(t, wfat2.Spec.ArtifactsByNode, "two-artgc-8tcvt-802059674")
 	assert.Contains(t, wfat2.Spec.ArtifactsByNode["two-artgc-8tcvt-802059674"].Artifacts, "first-on-completion-2")
 	assert.NotContains(t, wfat2.Spec.ArtifactsByNode["two-artgc-8tcvt-802059674"].Artifacts, "on-deletion")
-
 }
 
 var artgcTask = `apiVersion: argoproj.io/v1alpha1
@@ -598,7 +597,6 @@ func TestProcessCompletedWorkflowArtifactGCTask(t *testing.T) {
 			true,
 		},
 	} {
-
 		node := woc.wf.Status.Nodes[expectedArtifact.nodeName]
 		artifact := node.Outputs.Artifacts.GetArtifactByName(expectedArtifact.artifactName)
 		if artifact == nil {
@@ -619,7 +617,6 @@ func TestProcessCompletedWorkflowArtifactGCTask(t *testing.T) {
 			assert.Contains(t, gcFailureCondition.Message, "something went wrong")
 		}
 	}
-
 }
 
 func TestWorkflowHasArtifactGC(t *testing.T) {
@@ -689,7 +686,6 @@ func TestWorkflowHasArtifactGC(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			workflowSpec := fmt.Sprintf(`
             apiVersion: argoproj.io/v1alpha1
             kind: Workflow
@@ -723,7 +719,6 @@ func TestWorkflowHasArtifactGC(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, hasArtifact)
 		})
 	}
-
 }
 
 func TestArtifactGCPodWithPlugins(t *testing.T) {

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -356,7 +356,6 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 				time.Sleep(5 * time.Millisecond)
 			}
 		}
-
 	}
 	return cancel, wfc
 }

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -228,7 +228,6 @@ func (d *dagContext) assessDAGPhase(ctx context.Context, targetTasks []string, n
 }
 
 func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmplCtx *templateresolution.TemplateContext, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
-
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
 		node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypeDAG, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodeRunning, opts.nodeFlag, true)
@@ -878,7 +877,6 @@ func (d *dagContext) evaluateDependsLogic(ctx context.Context, taskName string) 
 	evalScope := make(map[string]TaskResults)
 
 	for _, taskName := range d.GetTaskDependencies(ctx, taskName) {
-
 		// If the task is still running, we should not proceed.
 		depNode := d.getTaskNode(ctx, taskName)
 		if depNode == nil || !depNode.Fulfilled() || !common.CheckAllHooksFullfilled(depNode, d.wf.Status.Nodes) {
@@ -894,7 +892,6 @@ func (d *dagContext) evaluateDependsLogic(ctx context.Context, taskName string) 
 		allFailed := false
 
 		if depNode.Type == wfv1.NodeTypeTaskGroup {
-
 			allFailed = len(depNode.Children) > 0
 
 			for _, childNodeID := range depNode.Children {

--- a/workflow/controller/exit_handler.go
+++ b/workflow/controller/exit_handler.go
@@ -37,7 +37,6 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 				if err != nil {
 					return true, nil, err
 				}
-
 			}
 			onExitNode, err := woc.executeTemplate(ctx, onExitNodeName, &wfv1.WorkflowStep{Template: exitHook.Template, TemplateRef: exitHook.TemplateRef}, tmplCtx, resolvedArgs, &executeTemplateOpts{
 				boundaryID:     boundaryID,

--- a/workflow/controller/healthz_test.go
+++ b/workflow/controller/healthz_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestHealthz(t *testing.T) {
-
 	veryOldUnreconciledWF := wfv1.MustUnmarshalWorkflow(helloWorldWf)
 	veryOldUnreconciledWF.SetCreationTimestamp(metav1.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)) // a long time ago
 	veryOldUnreconciledWF.SetName(veryOldUnreconciledWF.Name + "-1")
@@ -104,5 +103,4 @@ func TestHealthz(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/workflow/controller/informer/workflow_template_convert.go
+++ b/workflow/controller/informer/workflow_template_convert.go
@@ -46,7 +46,6 @@ type WorkflowTemplateFromInformerGetter struct {
 }
 
 func (getter *WorkflowTemplateFromInformerGetter) Get(_ context.Context, name string) (*wfv1.WorkflowTemplate, error) {
-
 	obj, exists, err := getter.wftmplInformer.Informer().GetStore().GetByKey(getter.namespace + "/" + name)
 	if err != nil {
 		return nil, err

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -603,7 +603,6 @@ func (woc *wfOperationCtx) updateWorkflowMetadata(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-
 	}
 	return nil
 }
@@ -1262,7 +1261,6 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) (bool, error) 
 		// In case in the absence of nodes, collect metrics.
 		woc.controller.metrics.PodMissingEnsure(ctx, recentlyStarted, string(node.Phase))
 		if _, ok := seenPods[nodeID]; !ok {
-
 			// grace-period to allow informer sync
 			woc.log.WithFields(logging.Fields{"nodeName": node.Name, "nodePhase": node.Phase, "recentlyStarted": recentlyStarted}).Info(ctx, "Workflow pod is missing")
 			woc.controller.metrics.PodMissingInc(ctx, recentlyStarted, string(node.Phase))
@@ -1740,7 +1738,6 @@ func (woc *wfOperationCtx) inferFailedReason(ctx context.Context, pod *apiv1.Pod
 	waitContainerSucceeded := false
 
 	for _, ctr := range ctrs {
-
 		// Virtual Kubelet environment will not set the terminate on waiting container
 		// https://github.com/argoproj/argo-workflows/issues/3879
 		// https://github.com/virtual-kubelet/virtual-kubelet/blob/7f2a02291530d2df14905702e6d51500dd57640a/node/sync.go#L195-L208
@@ -2696,7 +2693,6 @@ func (woc *wfOperationCtx) hasDaemonNodes() bool {
 }
 
 func (woc *wfOperationCtx) childrenFulfilledHelper(node *wfv1.NodeStatus, cache map[string]bool) bool {
-
 	res, has := cache[node.ID]
 	if has {
 		return res
@@ -3832,7 +3828,6 @@ func (woc *wfOperationCtx) resolveInputFieldsForSuspendNode(ctx context.Context,
 	parameters := node.Inputs.Parameters
 	for i, parameter := range parameters {
 		if parameter.Value != nil {
-
 			value := parameter.Value.String()
 			tempParameter := wfv1.Parameter{}
 
@@ -3904,7 +3899,6 @@ func processItem(ctx context.Context, tmpl template.Template, name string, index
 		for itemKey, itemVal := range mapVal {
 			replaceMap[fmt.Sprintf("item.%s", itemKey)] = fmt.Sprintf("%v", itemVal)
 			vals = append(vals, fmt.Sprintf("%s:%v", itemKey, itemVal))
-
 		}
 		jsonByteVal, err := json.Marshal(mapVal)
 		if err != nil {
@@ -4054,7 +4048,6 @@ func (woc *wfOperationCtx) createTemplateContext(ctx context.Context, scope wfv1
 
 func (woc *wfOperationCtx) computeMetrics(ctx context.Context, metricList []*wfv1.Prometheus, localScope map[string]string, realTimeScope map[string]func() float64, realTimeOnly bool) {
 	for _, metricTmpl := range metricList {
-
 		// Don't process real time metrics after execution
 		if realTimeOnly && !metricTmpl.IsRealtime() {
 			continue

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -925,7 +925,6 @@ func TestSynchronizationWithStepRetry(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 const pendingWfWithShutdownStrategy = `apiVersion: argoproj.io/v1alpha1

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -595,7 +595,6 @@ spec:
 `
 
 func TestWorkflowTemplateUpdateScenario(t *testing.T) {
-
 	wf := wfv1.MustUnmarshalWorkflow(wfWithTmplRef)
 	ctx := logging.TestContext(t.Context())
 	cancel, controller := newController(ctx, wf, wfv1.MustUnmarshalWorkflowTemplate(wfTmpl))

--- a/workflow/controller/pod/cleanup.go
+++ b/workflow/controller/pod/cleanup.go
@@ -30,7 +30,6 @@ func (c *Controller) EnactAnyPodCleanup(
 	default:
 		c.queuePodForCleanup(ctx, pod.Namespace, pod.Name, action)
 	}
-
 }
 
 func determinePodCleanupAction(

--- a/workflow/controller/scope.go
+++ b/workflow/controller/scope.go
@@ -104,7 +104,6 @@ func (s *wfScope) resolveArtifact(ctx context.Context, art *wfv1.Artifact) (*wfv
 		if err != nil {
 			return nil, err
 		}
-
 	} else {
 		val, err = s.resolveVar(art.From)
 	}

--- a/workflow/controller/taskset_test.go
+++ b/workflow/controller/taskset_test.go
@@ -311,7 +311,6 @@ status:
 			assert.Empty(t, ts.Spec.Tasks)
 			assert.Empty(t, ts.Status.Nodes)
 		}
-
 	})
 }
 

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -107,7 +107,6 @@ func (woc *wfOperationCtx) processPodSpecPatch(ctx context.Context, tmpl *wfv1.T
 		podSpecPatches = append(podSpecPatches, processedTmpl.PodSpecPatch)
 	}
 	return podSpecPatches, nil
-
 }
 
 func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName string, mainCtrs []apiv1.Container, tmpl *wfv1.Template, opts *createWorkflowPodOpts) (*apiv1.Pod, error) {
@@ -1640,6 +1639,5 @@ func mirrorVolumeMounts(ctx context.Context, sourceContainer, targetContainer *a
 		}
 		logging.RequireLoggerFromContext(ctx).WithFields(logging.Fields{"name": volMnt.Name, "containerName": targetContainer.Name}).Debug(ctx, "Adding volume mount")
 		targetContainer.VolumeMounts = append(targetContainer.VolumeMounts, volMnt)
-
 	}
 }

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -657,7 +657,6 @@ func Test_createWorkflowPod_containerName(t *testing.T) {
 var emissaryCmd = []string{"/var/run/argo/argoexec", "emissary"}
 
 func Test_createWorkflowPod_emissary(t *testing.T) {
-
 	t.Run("NoCommand", func(t *testing.T) {
 		ctx := logging.TestContext(t.Context())
 		woc := newWoc(ctx)
@@ -1584,7 +1583,6 @@ func TestMainContainerCustomization(t *testing.T) {
 		}
 		pod, _ := woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
 		assert.Equal(t, "0.900", pod.Spec.Containers[1].Resources.Limits.Cpu().AsDec().String())
-
 	})
 	// If script template has limits then they take precedence over config in controller
 	t.Run("ScriptPrecedence", func(t *testing.T) {

--- a/workflow/creator/creator_test.go
+++ b/workflow/creator/creator_test.go
@@ -139,7 +139,6 @@ func TestLabelCreator(t *testing.T) {
 					assert.Falsef(t, ok, "should not have the creator label, \"%s\"", creatorLabelKey)
 				}
 			})
-
 		}
 	})
 }

--- a/workflow/executor/emissary/emissary.go
+++ b/workflow/executor/emissary/emissary.go
@@ -138,7 +138,6 @@ func (e emissary) Kill(ctx context.Context, containerNames []string, termination
 	logger := logging.RequireLoggerFromContext(ctx)
 	logger.WithFields(logging.Fields{"terminationGracePeriodDuration": terminationGracePeriodDuration, "containerNames": containerNames}).Info(ctx, "emissary: killing containers")
 	for _, containerName := range containerNames {
-
 		// allow write-access by other users, because other containers
 		// should delete the signal after receiving it
 		signalPath := filepath.Join(common.VarRunArgoPath, "ctr", containerName, "signal")

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -592,7 +592,6 @@ func TestReportOutputs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, we.errors)
 	})
-
 }
 
 func TestUntarMaliciousSymlink(t *testing.T) {

--- a/workflow/executor/resource_test.go
+++ b/workflow/executor/resource_test.go
@@ -197,7 +197,6 @@ func TestInferSelfLink(t *testing.T) {
 		Kind:    "Namespace",
 	})
 	assert.Equal(t, "api/v1/namespaces/test-name", inferObjectSelfLink(obj))
-
 }
 
 // TestResourceExecRetry tests whether Exec retries transitive errors

--- a/workflow/gccontroller/heap_test.go
+++ b/workflow/gccontroller/heap_test.go
@@ -90,5 +90,4 @@ metadata:
 	assert.Equal(t, 0, queue.Len())
 	heap.Push(queue, wf)
 	assert.Equal(t, 1, queue.Len())
-
 }

--- a/workflow/sync/multiple_test.go
+++ b/workflow/sync/multiple_test.go
@@ -314,7 +314,6 @@ func TestMutexAndSemaphore(t *testing.T) {
 		assert.Empty(t, failedLockName)
 		assert.True(t, status)
 		assert.True(t, wfUpdate)
-
 	})
 }
 func TestPriority(t *testing.T) {

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -238,7 +238,6 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 						sm.log.WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
 					}
 				}
-
 			}
 		}
 

--- a/workflow/sync/sync_manager_multiple_test.go
+++ b/workflow/sync/sync_manager_multiple_test.go
@@ -235,7 +235,6 @@ func testSyncManagersContendingForSemaphore(t *testing.T, dbType sqldb.DBType) {
 	if maxLockCount > 1 {
 		t.Errorf("Multiple locks were held simultaneously: %d", maxLockCount)
 	}
-
 }
 
 func TestSyncManagersContendingForSemaphore(t *testing.T) {

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -920,7 +920,6 @@ func TestTriggerWFWithAvailableLock(t *testing.T) {
 			assert.True(status)
 			assert.True(wfUpdate)
 			wfs = append(wfs, *wf)
-
 		}
 		for i := range 3 {
 			wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
@@ -1264,7 +1263,6 @@ status:
 		require.NotNil(t, wf.Status.Synchronization)
 		require.NotNil(t, wf.Status.Synchronization.Semaphore)
 	})
-
 }
 
 const wfV2MutexMigrationWorkflowLevel = `apiVersion: argoproj.io/v1alpha1
@@ -1598,7 +1596,6 @@ func getHoldingNameV1(holderKey string) string {
 }
 
 func TestCheckHolderVersion(t *testing.T) {
-
 	t.Run("CheckHolderKeyWithNodeName", func(t *testing.T) {
 		assert := assert.New(t)
 		wfMutex := wfv1.MustUnmarshalWorkflow(wfWithMutex)
@@ -1611,7 +1608,6 @@ func TestCheckHolderVersion(t *testing.T) {
 		keyv1 := getHoldingNameV1(key)
 		version = wfv1.CheckHolderKeyVersion(keyv1)
 		assert.Equal(wfv1.HoldingNameV1, version)
-
 	})
 
 	t.Run("CheckHolderKeyWithoutNodeName", func(t *testing.T) {
@@ -1630,7 +1626,6 @@ func TestCheckHolderVersion(t *testing.T) {
 }
 
 func TestBackgroundNotifierClearsExpiredLocks(t *testing.T) {
-
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows platforms")
 	}

--- a/workflow/util/plugin/configmap_test.go
+++ b/workflow/util/plugin/configmap_test.go
@@ -57,7 +57,6 @@ func TestToConfigMap(t *testing.T) {
 			"sidecar.automountServiceAccountToken": "true",
 			"sidecar.container":                    "name: \"\"\nports:\n- containerPort: 1234\nresources: {}\nsecurityContext: {}\n",
 		}, cm.Data)
-
 	})
 }
 

--- a/workflow/util/pod_name.go
+++ b/workflow/util/pod_name.go
@@ -66,7 +66,6 @@ func GeneratePodName(workflowName, nodeName, templateName, nodeID string, versio
 	_, _ = h.Write([]byte(nodeName))
 
 	return fmt.Sprintf("%s-%v", prefix, h.Sum32())
-
 }
 
 func ensurePodNamePrefixLength(prefix string) string {

--- a/workflow/util/pod_name_v1_test.go
+++ b/workflow/util/pod_name_v1_test.go
@@ -36,5 +36,4 @@ func TestPodNameV1(t *testing.T) {
 
 	name = GeneratePodName(longWfName, nodeName, longTemplateName, nodeID, PodNameV1)
 	assert.Equal(t, nodeID, name)
-
 }

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -548,7 +548,6 @@ func updateSuspendedNode(ctx context.Context, wfIf v1alpha1.WorkflowInterface, h
 		for nodeID, node := range wf.Status.Nodes {
 			if node.IsActiveSuspendNode() {
 				if SelectorMatchesNode(selector, node) {
-
 					// Update phase
 					if values.Phase != "" {
 						node.Phase = values.Phase
@@ -1056,7 +1055,6 @@ func resetPath(allNodes []*dagNode, startNode string) (map[string]bool, map[stri
 	}
 
 	for curr != nil {
-
 		switch {
 		case isGroupNodeType(curr.n.Type):
 			addToReset(curr.n.ID)
@@ -1148,7 +1146,6 @@ func dagSortedNodes(nodes []*dagNode, rootNodeName string) []*dagNode {
 // obtain singular path to each $node
 // reset all "reset points" to $node
 func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSuccessful bool, nodeFieldSelector string, parameters []string) (*wfv1.Workflow, []string, error) {
-
 	switch wf.Status.Phase {
 	case wfv1.WorkflowFailed, wfv1.WorkflowError:
 	case wfv1.WorkflowSucceeded:
@@ -1285,7 +1282,6 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 		}
 	}
 	for id, oldWfNode := range wf.Status.Nodes {
-
 		if !newWf.Status.Nodes.Has(id) {
 			continue
 		}

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -718,7 +718,6 @@ func TestFormulateResubmitWorkflow(t *testing.T) {
 		assert.Emptyf(t, wf.Labels[common.LabelKeyCreator], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreator)
 		assert.Emptyf(t, wf.Labels[common.LabelKeyCreatorEmail], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreatorEmail)
 		assert.Emptyf(t, wf.Labels[common.LabelKeyCreatorPreferredUsername], "should not %s label when a workflow is resubmitted by an unauthenticated request", common.LabelKeyCreatorPreferredUsername)
-
 	})
 	t.Run("OverrideParams", func(t *testing.T) {
 		wf := &wfv1.Workflow{
@@ -1158,7 +1157,6 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		wf, _, err := FormulateRetryWorkflow(logging.TestContext(t.Context()), wf, false, "", []string{"message=modified"})
 		require.NoError(t, err)
 		assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
-
 	})
 
 	t.Run("OverrideParamsSubmitFromWfTmpl", func(t *testing.T) {
@@ -1187,7 +1185,6 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "modified", wf.Spec.Arguments.Parameters[0].Value.String())
 		assert.Equal(t, "modified", wf.Status.StoredWorkflowSpec.Arguments.Parameters[0].Value.String())
-
 	})
 
 	t.Run("Fail on running workflow", func(t *testing.T) {
@@ -2295,7 +2292,6 @@ func TestStepsRetryWorkflow(t *testing.T) {
 			assert.Equal(wfv1.NodeSucceeded, node.Phase)
 		}
 	}
-
 }
 
 func TestDagConversion(t *testing.T) {
@@ -3016,7 +3012,6 @@ func TestOnExitWorkflowRetry(t *testing.T) {
 			assert.Equal(wfv1.NodeSucceeded, node.Phase)
 		}
 	}
-
 }
 
 const onExitWorkflow = `
@@ -3161,7 +3156,6 @@ func TestOnExitWorkflow(t *testing.T) {
 	assert.Len(podsToDelete, 1)
 	assert.Len(newWf.Status.Nodes, 1)
 	assert.Equal(wfv1.NodeSucceeded, newWf.Status.Nodes["retry-workflow-with-failed-exit-handler"].Phase)
-
 }
 
 const nestedDAG = `apiVersion: argoproj.io/v1alpha1
@@ -3917,7 +3911,6 @@ func TestNestedDAG(t *testing.T) {
 			assert.Equal(wfv1.NodeSucceeded, node.Phase)
 		}
 	}
-
 }
 
 const onExitPanic = `apiVersion: argoproj.io/v1alpha1

--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -511,7 +511,6 @@ func (tctx *templateValidationCtx) validateTemplate(ctx context.Context, tmpl *w
 		if err == nil {
 			return fmt.Errorf("%s has invalid duration format in timeout", newTmpl.Name)
 		}
-
 	}
 
 	templateScope := tmplCtx.GetTemplateScope()
@@ -821,7 +820,6 @@ func (tctx *templateValidationCtx) validateLeaf(scope map[string]any, tmplCtx *t
 				return errors.Errorf(errors.CodeBadRequest, "templates.%s.containerSet.containers must have a container named \"main\" for input or output", tmpl.Name)
 			}
 		}
-
 	}
 	if tmpl.Resource != nil {
 		if !placeholderGenerator.IsPlaceholder(tmpl.Resource.Action) {
@@ -1373,7 +1371,6 @@ func (tctx *templateValidationCtx) validateDAG(ctx context.Context, scope map[st
 
 	// Verify dependencies for all tasks can be resolved as well as template names
 	for _, task := range tmpl.DAG.Tasks {
-
 		if (usingDepends || len(task.Dependencies) > 0) && '0' <= task.Name[0] && task.Name[0] <= '9' {
 			return errors.Errorf(errors.CodeBadRequest, "templates.%s.tasks.%s name cannot begin with a digit when using either 'depends' or 'dependencies'", tmpl.Name, task.Name)
 		}

--- a/workflow/validate/validate_dag_test.go
+++ b/workflow/validate/validate_dag_test.go
@@ -664,7 +664,6 @@ spec:
 func TestDAGNonExistantTarget(t *testing.T) {
 	err := validate(logging.TestContext(t.Context()), dagNonexistantTarget)
 	require.ErrorContains(t, err, "target 'DOESNTEXIST' is not defined")
-
 }
 
 var dagTargetSubstitution = `


### PR DESCRIPTION
Enable the https://github.com/ultraware/whitespace linter, and let it autofix.

This is the least aggressive whitespace linter, so easiest to enable and not upset too many people. Also best enabled outside of other changes due to how many files get "fixed".

I think this makes code easier to read.