### PR TITLE
ci: add test results artifact uploads to CI workflows

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -128,6 +128,14 @@ jobs:
           go-version: "1.25"
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: test-results-unit
+          path: test/reports/json/unit.json
+          if-no-files-found: warn
+          retention-days: 10
       - name: Upload coverage report
         # engineers just ignore this in PRs, so lets not even run it
         if: github.ref == 'refs/heads/main'
@@ -395,6 +403,14 @@ jobs:
         run: make manifests-validate
       - name: Run tests ${{matrix.test}}
         run: make ${{matrix.test}} E2E_SUITE_TIMEOUT=30m STATIC_FILES=false
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: test-results-${{matrix.test}}-${{matrix.profile}}-k8s-${{matrix.k8s_version || 'max'}}
+          path: test/reports/json/${{matrix.test}}.json
+          if-no-files-found: warn
+          retention-days: 10
 
       # failure debugging below
       - name: Failure debug - k3s logs


### PR DESCRIPTION
### Motivation

Test results are currently not being persisted as artifacts in the CI pipeline, making it difficult to review test outcomes after workflow completion. Adding artifact uploads will improve visibility into test results and aid in debugging failures.

### Modifications

Added test results artifact uploads to two CI jobs:

1. **Unit tests job**: Uploads `test/reports/json/unit.json` as `test-results-unit` artifact
2. **E2E tests job**: Uploads `test/reports/json/{test}.json` as `test-results-{test}-{profile}-k8s-{version}` artifact

Both uploads:
- Run on all outcomes (`if: ${{ always() }}`)
- Use `actions/upload-artifact@v6.0.0`
- Warn if no files are found (non-blocking)
- Retain artifacts for 10 days

### Verification

CI workflow validation - the changes are configuration-only and will be validated by GitHub Actions when the workflow runs.

### Documentation

N/A - internal CI configuration change
