### PR TITLE
chore: omitempty->omitzero

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -362,7 +362,7 @@ type DatabaseConfig struct {
 	// UsernameSecret references a secret containing the database username
 	UsernameSecret apiv1.SecretKeySelector `json:"userNameSecret,omitempty"`
 	// PasswordSecret references a secret containing the database password
-	PasswordSecret apiv1.SecretKeySelector `json:"passwordSecret,omitempty"`
+	PasswordSecret apiv1.SecretKeySelector `json:"passwordSecret,omitzero"`
 }
 
 func (c DatabaseConfig) GetHostname() string {

--- a/config/sso.go
+++ b/config/sso.go
@@ -24,7 +24,7 @@ type SSOConfig struct {
 	// additional scopes (on top of "openid")
 	Scopes []string `json:"scopes,omitempty"`
 	// SessionExpiry specifies how long user sessions last
-	SessionExpiry metav1.Duration `json:"sessionExpiry,omitempty"`
+	SessionExpiry metav1.Duration `json:"sessionExpiry,omitzero"`
 	// CustomGroupClaimName will override the groups claim name
 	CustomGroupClaimName string `json:"customGroupClaimName,omitempty"`
 	// UserInfoPath specifies the path to user info endpoint

--- a/workflow/convert/legacy_types.go
+++ b/workflow/convert/legacy_types.go
@@ -161,7 +161,7 @@ type LegacyWorkflow struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 	Spec              LegacyWorkflowSpec  `json:"spec"`
-	Status            wfv1.WorkflowStatus `json:"status,omitempty"`
+	Status            wfv1.WorkflowStatus `json:"status,omitzero"`
 }
 
 // ToCurrent converts a LegacyWorkflow to the current Workflow type


### PR DESCRIPTION
### Motivation

modernize linter complains that these fields don't actually implement `omitempty` correctly but can't upgrade them itself due to possible conflicting outcomes of not having `omitempty` at all or use `omitzero`

This is just a case of silencing the comments from the linter.

### Modifications

`omitzero` should be safe for all these cases as they are just used for reading not writing.

### Verification

CI to verify

### Documentation

None required