### PR TITLE
fix: add metrics shutdown

### DIFF
--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -125,6 +125,9 @@ func NewRootCommand() *cobra.Command {
 				if err := wfController.ShutdownTracing(context.WithoutCancel(ctx)); err != nil {
 					log.WithError(err).Error(ctx, "Failed to shutdown tracing")
 				}
+				if err := wfController.ShutdownMetrics(context.WithoutCancel(ctx)); err != nil {
+					log.WithError(err).Error(ctx, "Failed to shutdown metrics")
+				}
 			}()
 
 			leaderElectionOff := os.Getenv("LEADER_ELECTION_DISABLE")

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -301,6 +301,11 @@ func (wfc *WorkflowController) ShutdownTracing(ctx context.Context) error {
 	return wfc.tracing.Shutdown(ctx)
 }
 
+// ShutdownMetrics flushes any remaining metrics and shuts down the meter provider.
+func (wfc *WorkflowController) ShutdownMetrics(ctx context.Context) error {
+	return wfc.metrics.Shutdown(ctx)
+}
+
 // Run starts a Workflow resource controller
 func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWorkers, podCleanupWorkers, cronWorkflowWorkers, wfArchiveWorkers int) {
 	defer runtimeutil.HandleCrashWithContext(ctx, runtimeutil.PanicHandlers...)


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #15585

## Chain of upstream PRs as of 2026-02-18

* PR #15576:
  `main` ← `tracing-dbtype`

  * PR #15582:
    `tracing-dbtype` ← `tracing-infrastructure`

    * PR #15585:
      `tracing-infrastructure` ← `tracing-spans`

      * **PR #15586 (THIS ONE)**:
        `tracing-spans` ← `metrics-shutdown`

<!-- end git-machete generated -->

### Motivation

Whilst adding tracing I noticed we didn't call shutdown on the metrics provider.

### Modifications

Mirror the tracing code, for metrics

### Verification

In general this won't make much difference to anything - unlike traces where spans will get flushed, flushing metrics shouldn't change a lot.

### Documentation

None required