### PR TITLE
fix(test): skip flaky workflow-template retry-with-steps example

### DIFF
--- a/examples/workflow-template/retry-with-steps.yaml
+++ b/examples/workflow-template/retry-with-steps.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: workflow-template-retry-with-steps-
+  labels:
+    workflows.argoproj.io/no-test: "flaky"
 spec:
   entrypoint: retry-with-steps
   templates:


### PR DESCRIPTION
## Summary
- Add `workflows.argoproj.io/no-test: "flaky"` label to `examples/workflow-template/retry-with-steps.yaml` to skip it in E2E tests
- The top-level `examples/retry-with-steps.yaml` (same test with inline templates) is already marked `no-test: flaky` — this applies the same treatment to the workflow-template variant

## Root Cause
The example references `workflow-template-random-fail-template` which exits with a 66% failure rate (`random.choice([0, 1, 1])`), with `retryStrategy.limit: 10`. Under CI resource contention (~80+ parallel workflows on a single K3s node), the workflow frequently cannot complete all 3 steps (each with retries) within the 90s `E2E_WAIT_TIMEOUT`.

Example failure from [run 22192242089](https://github.com/argoproj/argo-workflows/actions/runs/22192242089):
```
hello1(0)  Pod  4s  main: Error (exit code 1)
hello1(1)  Pod  5s  main: Error (exit code 1)
hello1(2)  Pod  5s  main: Error (exit code 1)
hello1(3)  Pod  8s  main: Error (exit code 1)
hello1(4)  Pod  7s  main: Error (exit code 1)
hello1(5)  Pod  6s  main: Error (exit code 1)
hello1(6)  Pod  0s  (still running at timeout)
examples_test.go:151: timeout after 1m30s waiting for condition
```

## AI

Yeah, Claude did this