### PR TITLE
fix: correct 'taring' typo to 'tarring'. Fixes #15556

### DIFF
--- a/util/archive/archive.go
+++ b/util/archive/archive.go
@@ -25,7 +25,7 @@ func TarGzToWriter(ctx context.Context, sourcePath string, level int, w io.Write
 		return errors.InternalErrorf("getting absolute path: %v", err)
 	}
 	logger := logging.RequireLoggerFromContext(ctx)
-	logger.WithField("source", sourcePath).Info(ctx, "taring")
+	logger.WithField("source", sourcePath).Info(ctx, "tarring")
 	sourceFi, err := os.Stat(sourcePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -534,7 +534,7 @@ func (we *WorkflowExecutor) stageArchiveFile(ctx context.Context, containerName 
 		return fileName, localArtPath, nil
 	}
 	// localArtPath now points to a .tgz file, and the archive strategy is *not* tar. We need to untar it
-	logger.WithField("path", localArtPath).Info(ctx, "Untaring archive before upload")
+	logger.WithField("path", localArtPath).Info(ctx, "Untarring archive before upload")
 	unarchivedArtPath := path.Join(filepath.Dir(localArtPath), art.Name)
 	err = untar(localArtPath, unarchivedArtPath)
 	if err != nil {


### PR DESCRIPTION
Fixes #15556

### Motivation

The log messages in `util/archive/archive.go` and `workflow/executor/executor.go` contain the misspelling "taring" and "Untaring" — the correct gerund of "tar" is "tarring" and "Untarring".

### Modifications

- `util/archive/archive.go`: "taring" → "tarring"
- `workflow/executor/executor.go`: "Untaring" → "Untarring"

### Verification

No functional changes — log message text only.