### PR TITLE
fix(sync): variable shadowing causes semaphore holders to be lost on restart

### DIFF
--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -221,7 +221,8 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 			for _, holding := range wf.Status.Synchronization.Semaphore.Holding {
 				semaphore := sm.syncLockMap[holding.Semaphore]
 				if semaphore == nil {
-					semaphore, err := sm.initializeSemaphore(ctx, holding.Semaphore)
+					var err error
+					semaphore, err = sm.initializeSemaphore(ctx, holding.Semaphore)
 					if err != nil {
 						sm.log.WithField("semaphore", holding.Semaphore).WithError(err).Warn(ctx, "cannot initialize semaphore")
 						continue
@@ -248,7 +249,8 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 			for _, holding := range wf.Status.Synchronization.Mutex.Holding {
 				mutex := sm.syncLockMap[holding.Mutex]
 				if mutex == nil {
-					mutex, err := sm.initializeMutex(ctx, holding.Mutex)
+					var err error
+					mutex, err = sm.initializeMutex(ctx, holding.Mutex)
 					if err != nil {
 						sm.log.WithField("mutex", holding.Mutex).WithError(err).Warn(ctx, "cannot initialize mutex")
 						continue

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -385,6 +385,48 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		syncManager.Initialize(ctx, wfList.Items)
 		assert.Empty(t, syncManager.syncLockMap)
 	})
+	t.Run("InitializeMultipleWorkflowsHolding", func(t *testing.T) {
+		// This test verifies that when multiple workflows claim to hold the same semaphore
+		// (which can happen with stale status after a controller restart), ALL of their
+		// holders are registered during Initialize, not just those after the first workflow.
+		// This was a bug caused by variable shadowing in Initialize (PR #3141).
+
+		// Create a ConfigMap with semaphore limit of 3 to allow multiple holders
+		kubeClient := fake.NewSimpleClientset()
+		_, err := kubeClient.CoreV1().ConfigMaps("default").Create(ctx, &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-config"},
+			Data:       map[string]string{"workflow": "3"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		syncManager := NewLockManager(ctx, kubeClient, "", nil, GetSyncLimitFunc(kubeClient), func(key string) {
+		}, WorkflowExistenceFunc)
+
+		// Create first workflow claiming to hold the semaphore
+		wf1 := wfv1.MustUnmarshalWorkflow(wfWithStatus)
+		wf1.Name = "hello-world-one"
+		wf1.Status.Synchronization.Semaphore.Holding[0].Holders = []string{"default/hello-world-one"}
+
+		// Create second workflow also claiming to hold the same semaphore
+		wf2 := wfv1.MustUnmarshalWorkflow(wfWithStatus)
+		wf2.Name = "hello-world-two"
+		wf2.Status.Synchronization.Semaphore.Holding[0].Holders = []string{"default/hello-world-two"}
+
+		// Initialize with both workflows
+		syncManager.Initialize(ctx, []wfv1.Workflow{*wf1, *wf2})
+
+		// Verify the semaphore was created
+		assert.Len(t, syncManager.syncLockMap, 1)
+
+		// Verify BOTH holders are registered (the bug would only register the second one)
+		sem := syncManager.syncLockMap["default/ConfigMap/my-config/workflow"]
+		require.NotNil(t, sem)
+		holders, err := sem.getCurrentHolders(ctx)
+		require.NoError(t, err)
+		assert.Len(t, holders, 2, "both workflows should be registered as holders")
+		assert.Contains(t, holders, "default/hello-world-one")
+		assert.Contains(t, holders, "default/hello-world-two")
+	})
 
 	t.Run("WfLevelAcquireAndRelease", func(t *testing.T) {
 		var nextKey string


### PR DESCRIPTION
Fixes #11098

### Motivation

On restarting a workflow controller with a workflow level semaphore one more workflow was running than should be.

### Modifications

When the sync manager initializes after a controller restart, the first workflow processed for each semaphore key had its holder silently skipped due to a Go variable shadowing bug.

The code used `:=` inside the `if semaphore == nil` block, creating a new inner variable that shadowed the outer one. The inner variable was stored in the map, but the outer variable (used by the subsequent acquire loop) remained nil, causing the `semaphore != nil && semaphore.acquire(...)` check to be skipped.

This could cause more workflows to run than the semaphore limit allows after a controller restart, as the first workflow's holder was never registered in the in-memory semaphore state.

Bug has existed since the original semaphore implementation in PR #3141.

Fixes the same pattern in mutex initialization for consistency, though mutex was not affected since its acquire call was inside the if block.

### Verification

Unit test added for semaphore case. Unit test fails without the code change.

### Documentation

None required