### PR TITLE
fix: upgrade Go to 1.25.7 to resolve CVE-2025-68121

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v3
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/storage v1.60.0


### PR DESCRIPTION
## Summary
Upgrades Go version from 1.25.6 to 1.25.7 to fix a CRITICAL vulnerability in the Go standard library.

## CVE Fixed
CVE-2025-68121 (CRITICAL): crypto/tls session resumption vulnerability

## Vulnerability Findings

### Trivy Scan Command
```
trivy image --severity HIGH,CRITICAL quay.io/argoproj/workflow-controller:latest
```

### Before Fix
```
Found: CVE-2025-68121 in Go stdlib
```

### After Fix
Go 1.25.7 contains patches for CVE-2025-68121.

This is a minimal patch-level version bump fix.