### PR TITLE
fix: use workflow key for semaphore nextWorkflow callback (cherry-pick #15558 for 4.0)

### DIFF
--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -309,7 +309,7 @@ func (s *databaseSemaphore) checkAcquire(ctx context.Context, holderKey string, 
 	if !isSameWorkflowNodeKeys(holderKey, queue[0].Key) {
 		// Enqueue the queue[0] workflow if lock is available
 		if len(holders) < limit {
-			s.nextWorkflow(queue[0].Key)
+			s.nextWorkflow(workflowKey(queue[0].Key))
 		}
 		logger.WithFields(logging.Fields{
 			"key":          holderKey,

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -217,3 +217,40 @@ func TestNotifyWorkflowFromTemplateSemaphore(t *testing.T) {
 		})
 	}
 }
+
+// testCheckAcquireNotifiesCorrectKeyForTemplateSemaphore verifies that when a non-front workflow
+// calls checkAcquire, the front workflow is re-queued using the workflow-level key
+// (namespace/workflow), not the raw template-level key (namespace/workflow/nodeid).
+func testCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t *testing.T, factory semaphoreFactory) {
+	t.Helper()
+	ctx := logging.TestContext(t.Context())
+	notified := make(map[string]bool)
+	nextWorkflow := func(key string) {
+		notified[key] = true
+	}
+
+	s, dbSession, cleanup := factory(ctx, t, "bar", "foo", 2, nextWorkflow)
+	defer cleanup()
+
+	now := time.Now()
+	require.NoError(t, s.addToQueue(ctx, "foo/wf-01/node-aaa", 0, now))
+	require.NoError(t, s.addToQueue(ctx, "foo/wf-02/node-bbb", 0, now.Add(time.Second)))
+
+	tx := &transaction{db: &dbSession}
+	// wf-02 is not first in queue, so checkAcquire should notify the front (wf-01)
+	// via nextWorkflow with the workflow-level key, not the template-level key
+	acquired, _, _ := s.checkAcquire(ctx, "foo/wf-02/node-bbb", tx)
+	assert.False(t, acquired)
+
+	assert.True(t, notified["foo/wf-01"], "nextWorkflow should receive workflow key 'foo/wf-01', not template key 'foo/wf-01/node-aaa'")
+	assert.False(t, notified["foo/wf-01/node-aaa"], "nextWorkflow should not receive raw template-level key")
+}
+
+// TestCheckAcquireNotifiesCorrectKeyForTemplateSemaphore runs the checkAcquire template key test for all implementations
+func TestCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t *testing.T) {
+	for name, factory := range semaphoreFactories {
+		t.Run(name, func(t *testing.T) {
+			testCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t, factory)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-picked fix: use workflow key for semaphore nextWorkflow callback (#15558)