### PR TITLE
chore(deps): golang to 1.26

### DIFF
--- a/.devcontainer/builder/devcontainer.json
+++ b/.devcontainer/builder/devcontainer.json
@@ -14,7 +14,7 @@
 
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.25.6"
+      "version": "1.26.1"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20"

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
       - name: Upload test results
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       # windows run does not use makefile target because it does a lot more than just testing and is not cross-platform compatible
       - run: if (!(Test-Path "ui/dist/app/index.html")) { New-Item -ItemType Directory -Force -Path "ui/dist/app" | Out-Null; New-Item -ItemType File -Path "ui/dist/app/placeholder" | Out-Null }; go test -p 20 -covermode=atomic -coverprofile='coverage.out' $(go list ./... | select-string -Pattern 'github.com/argoproj/argo-workflows/v4/workflow/controller' , 'github.com/argoproj/argo-workflows/v4/server' -NotMatch)
@@ -186,7 +186,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - name: Build
         run: make ${{matrix.target}}
@@ -327,7 +327,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - name: Install Java for the SDK
         if: ${{matrix.test == 'test-java-sdk'}}
@@ -484,7 +484,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - name: Install protoc
         run: |
@@ -521,7 +521,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - run: make lint STATIC_FILES=false
       # if lint makes changes that are not in the PR, fail the build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.9
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "19"

--- a/.github/workflows/pr-feature.yaml
+++ b/.github/workflows/pr-feature.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         if: steps.check-type.outputs.is_feat == 'true'
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - name: Checkout
         if: steps.check-type.outputs.is_feat == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: Download UI artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -393,7 +393,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GIT_COMMIT=unknown
 ARG GIT_TAG=unknown
 ARG GIT_TREE_STATE=unknown
 
-FROM golang:1.25.6-alpine3.23 AS builder
+FROM golang:1.26.1-alpine3.23 AS builder
 
 # libc-dev to build openapi-gen
 RUN apk update && apk add --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ swagger: \
 $(TOOL_MOCKERY): Makefile
 # update this in Nix when upgrading it here
 ifneq ($(USE_NIX), true)
-	GOTOOLCHAIN=go1.25.6 go install github.com/vektra/mockery/v3@v3.5.1
+	GOTOOLCHAIN=go1.26.1 go install github.com/vektra/mockery/v3@v3.5.1
 endif
 $(TOOL_CONTROLLER_GEN): Makefile
 # update this in Nix when upgrading it here
@@ -582,7 +582,7 @@ manifests-validate:
 	kubectl apply --server-side --validate=strict --dry-run=server -f 'manifests/*.yaml'
 
 $(TOOL_GOLANGCI_LINT): Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.8.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.11.3
 
 .PHONY: lint lint-go lint-ui
 lint: lint-go lint-ui features-validate ## Lint the project

--- a/cmd/argo/commands/archive/util.go
+++ b/cmd/argo/commands/archive/util.go
@@ -60,9 +60,9 @@ func resolveUID(ctx context.Context, serviceClient workflowarchivepkg.ArchivedWo
 
 	if len(matches) > 1 {
 		var msg strings.Builder
-		msg.WriteString(fmt.Sprintf("Multiple archived workflows found with name '%s':\n", identifier))
+		fmt.Fprintf(&msg, "Multiple archived workflows found with name '%s':\n", identifier)
 		for _, wf := range matches {
-			msg.WriteString(fmt.Sprintf("  %s (Created: %s, Finished: %s)\n", wf.UID, humanize.Timestamp(wf.CreationTimestamp.Time), humanize.Timestamp(wf.Status.FinishedAt.Time)))
+			fmt.Fprintf(&msg, "  %s (Created: %s, Finished: %s)\n", wf.UID, humanize.Timestamp(wf.CreationTimestamp.Time), humanize.Timestamp(wf.Status.FinishedAt.Time))
 		}
 		msg.WriteString("Please specify the UID.")
 		return "", errors.New(msg.String())

--- a/cmd/argo/commands/cron/util.go
+++ b/cmd/argo/commands/cron/util.go
@@ -96,27 +96,27 @@ func getCronWorkflowGet(ctx context.Context, cwf *v1alpha1.CronWorkflow) string 
 	const fmtStr = "%-30s %v\n"
 
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf(fmtStr, "Name:", cwf.Name))
-	out.WriteString(fmt.Sprintf(fmtStr, "Namespace:", cwf.Namespace))
-	out.WriteString(fmt.Sprintf(fmtStr, "Created:", humanize.Timestamp(cwf.CreationTimestamp.Time)))
-	out.WriteString(fmt.Sprintf(fmtStr, "Schedules:", cwf.Spec.GetScheduleString()))
-	out.WriteString(fmt.Sprintf(fmtStr, "Suspended:", cwf.Spec.Suspend))
+	fmt.Fprintf(&out, fmtStr, "Name:", cwf.Name)
+	fmt.Fprintf(&out, fmtStr, "Namespace:", cwf.Namespace)
+	fmt.Fprintf(&out, fmtStr, "Created:", humanize.Timestamp(cwf.CreationTimestamp.Time))
+	fmt.Fprintf(&out, fmtStr, "Schedules:", cwf.Spec.GetScheduleString())
+	fmt.Fprintf(&out, fmtStr, "Suspended:", cwf.Spec.Suspend)
 	if cwf.Spec.Timezone != "" {
-		out.WriteString(fmt.Sprintf(fmtStr, "Timezone:", cwf.Spec.Timezone))
+		fmt.Fprintf(&out, fmtStr, "Timezone:", cwf.Spec.Timezone)
 	}
 	if cwf.Spec.StartingDeadlineSeconds != nil {
-		out.WriteString(fmt.Sprintf(fmtStr, "StartingDeadlineSeconds:", *cwf.Spec.StartingDeadlineSeconds))
+		fmt.Fprintf(&out, fmtStr, "StartingDeadlineSeconds:", *cwf.Spec.StartingDeadlineSeconds)
 	}
 	if cwf.Spec.ConcurrencyPolicy != "" {
-		out.WriteString(fmt.Sprintf(fmtStr, "ConcurrencyPolicy:", cwf.Spec.ConcurrencyPolicy))
+		fmt.Fprintf(&out, fmtStr, "ConcurrencyPolicy:", cwf.Spec.ConcurrencyPolicy)
 	}
 	if cwf.Status.LastScheduledTime != nil {
-		out.WriteString(fmt.Sprintf(fmtStr, "LastScheduledTime:", humanize.Timestamp(cwf.Status.LastScheduledTime.Time)))
+		fmt.Fprintf(&out, fmtStr, "LastScheduledTime:", humanize.Timestamp(cwf.Status.LastScheduledTime.Time))
 	}
 
 	next, err := GetNextRuntime(ctx, cwf)
 	if err == nil {
-		out.WriteString(fmt.Sprintf(fmtStr, "NextScheduledTime:", humanize.Timestamp(next)+" (assumes workflow-controller is in UTC)"))
+		fmt.Fprintf(&out, fmtStr, "NextScheduledTime:", humanize.Timestamp(next)+" (assumes workflow-controller is in UTC)")
 	}
 
 	if len(cwf.Status.Active) > 0 {
@@ -124,18 +124,18 @@ func getCronWorkflowGet(ctx context.Context, cwf *v1alpha1.CronWorkflow) string 
 		for _, activeWf := range cwf.Status.Active {
 			activeWfNames = append(activeWfNames, activeWf.Name)
 		}
-		out.WriteString(fmt.Sprintf(fmtStr, "Active Workflows:", strings.Join(activeWfNames, ", ")))
+		fmt.Fprintf(&out, fmtStr, "Active Workflows:", strings.Join(activeWfNames, ", "))
 	}
 	if len(cwf.Status.Conditions) > 0 {
 		out.WriteString(cwf.Status.Conditions.DisplayString(fmtStr, map[v1alpha1.ConditionType]string{v1alpha1.ConditionTypeSubmissionError: "✖"}))
 	}
 	if len(cwf.Spec.WorkflowSpec.Arguments.Parameters) > 0 {
-		out.WriteString(fmt.Sprintf(fmtStr, "Workflow Parameters:", ""))
+		fmt.Fprintf(&out, fmtStr, "Workflow Parameters:", "")
 		for _, param := range cwf.Spec.WorkflowSpec.Arguments.Parameters {
 			if !param.HasValue() {
 				continue
 			}
-			out.WriteString(fmt.Sprintf(fmtStr, "  "+param.Name+":", param.GetValue()))
+			fmt.Fprintf(&out, fmtStr, "  "+param.Name+":", param.GetValue())
 		}
 	}
 	return out.String()

--- a/cmd/argo/commands/logs.go
+++ b/cmd/argo/commands/logs.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/cmd/argo/commands/client"
 	"github.com/argoproj/argo-workflows/v4/cmd/argo/commands/common"
@@ -67,7 +66,7 @@ func NewLogsCommand() *cobra.Command {
 			}
 
 			if since > 0 {
-				logOptions.SinceSeconds = ptr.To(int64(since.Seconds()))
+				logOptions.SinceSeconds = new(int64(since.Seconds()))
 			}
 
 			if sinceTime != "" {
@@ -80,7 +79,7 @@ func NewLogsCommand() *cobra.Command {
 			}
 
 			if tailLines >= 0 {
-				logOptions.TailLines = ptr.To(tailLines)
+				logOptions.TailLines = new(tailLines)
 			}
 
 			// set-up

--- a/config/node_events_test.go
+++ b/config/node_events_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 )
 
 func TestNodeEvents_IsEnabled(t *testing.T) {
 	assert.True(t, NodeEvents{}.IsEnabled())
-	assert.False(t, NodeEvents{Enabled: ptr.To(false)}.IsEnabled())
-	assert.True(t, NodeEvents{Enabled: ptr.To(true)}.IsEnabled())
+	assert.False(t, NodeEvents{Enabled: new(false)}.IsEnabled())
+	assert.True(t, NodeEvents{Enabled: new(true)}.IsEnabled())
 }

--- a/config/workflow_events_test.go
+++ b/config/workflow_events_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 )
 
 func TestWorkflowEvents_IsEnabled(t *testing.T) {
 	assert.True(t, WorkflowEvents{}.IsEnabled())
-	assert.False(t, WorkflowEvents{Enabled: ptr.To(false)}.IsEnabled())
-	assert.True(t, WorkflowEvents{Enabled: ptr.To(true)}.IsEnabled())
+	assert.False(t, WorkflowEvents{Enabled: new(false)}.IsEnabled())
+	assert.True(t, WorkflowEvents{Enabled: new(true)}.IsEnabled())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v4
 
-go 1.25.6
+go 1.26.1
 
 require (
 	cloud.google.com/go/storage v1.61.3

--- a/hack/embeddoc/go.mod
+++ b/hack/embeddoc/go.mod
@@ -1,5 +1,5 @@
 module embeddoc
 
-go 1.25.6
+go 1.26.1
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/pkg/apis/workflow/v1alpha1/artifact_plugins_test.go
+++ b/pkg/apis/workflow/v1alpha1/artifact_plugins_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
@@ -315,7 +314,7 @@ func TestArtifacts_GetPluginNames(t *testing.T) {
 				Name:          "log-plugin",
 				Configuration: `{"bucket": "log-bucket"}`,
 			},
-			ArchiveLogs: ptr.To(true),
+			ArchiveLogs: new(true),
 		}
 
 		pluginNames := artifacts.GetPluginNames(ctx, defaultRepo, IncludeLogs, nil)
@@ -340,7 +339,7 @@ func TestArtifacts_GetPluginNames(t *testing.T) {
 			S3: &S3ArtifactRepository{
 				S3Bucket: S3Bucket{Bucket: "log-bucket"},
 			},
-			ArchiveLogs: ptr.To(true),
+			ArchiveLogs: new(true),
 		}
 
 		pluginNames := artifacts.GetPluginNames(ctx, defaultRepo, ExcludeLogs, nil)
@@ -425,7 +424,7 @@ func TestArtifacts_GetPluginNames(t *testing.T) {
 				Name:          "default-plugin",
 				Configuration: `{"bucket": "default-bucket"}`,
 			},
-			ArchiveLogs: ptr.To(true),
+			ArchiveLogs: new(true),
 		}
 
 		pluginNames := artifacts.GetPluginNames(ctx, defaultRepo, IncludeLogs, nil)
@@ -473,7 +472,7 @@ func TestArtifacts_GetPluginNames(t *testing.T) {
 				Name:          "log-plugin",
 				Configuration: `{"endpoint": "https://logs.com"}`,
 			},
-			ArchiveLogs: ptr.To(true),
+			ArchiveLogs: new(true),
 		}
 
 		pluginNames := artifacts.GetPluginNames(ctx, defaultRepo, IncludeLogs, nil)
@@ -588,7 +587,7 @@ func TestArtifacts_GetPluginNames(t *testing.T) {
 				Name:          "default-plugin",
 				Configuration: `{"default": true}`,
 			},
-			ArchiveLogs: ptr.To(true),
+			ArchiveLogs: new(true),
 		}
 
 		pluginNames := artifacts.GetPluginNames(ctx, defaultRepo, IncludeLogs, nil)
@@ -786,7 +785,7 @@ func TestArtifacts_GetPluginNames(t *testing.T) {
 					Name:          "log-plugin",
 					Configuration: `{"bucket": "log-bucket"}`,
 				},
-				ArchiveLogs: ptr.To(true),
+				ArchiveLogs: new(true),
 			}
 
 			archiveLocation := &ArtifactLocation{

--- a/pkg/apis/workflow/v1alpha1/artifact_repository_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/artifact_repository_types_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/utils/ptr"
 )
 
 func TestArtifactRepository(t *testing.T) {
@@ -16,9 +15,9 @@ func TestArtifactRepository(t *testing.T) {
 		assert.Nil(t, l)
 	})
 	t.Run("ArchiveLogs", func(t *testing.T) {
-		r := &ArtifactRepository{Artifactory: &ArtifactoryArtifactRepository{}, ArchiveLogs: ptr.To(true)}
+		r := &ArtifactRepository{Artifactory: &ArtifactoryArtifactRepository{}, ArchiveLogs: new(true)}
 		l := r.ToArtifactLocation()
-		assert.Equal(t, ptr.To(true), l.ArchiveLogs)
+		assert.Equal(t, new(true), l.ArchiveLogs)
 	})
 	t.Run("Artifactory", func(t *testing.T) {
 		r := &ArtifactRepository{Artifactory: &ArtifactoryArtifactRepository{RepoURL: "http://my-repo"}}
@@ -73,6 +72,6 @@ func TestArtifactRepository(t *testing.T) {
 
 func TestArtifactRepository_IsArchiveLogs(t *testing.T) {
 	assert.False(t, (&ArtifactRepository{}).IsArchiveLogs())
-	assert.False(t, (&ArtifactRepository{ArchiveLogs: ptr.To(false)}).IsArchiveLogs())
-	assert.True(t, (&ArtifactRepository{ArchiveLogs: ptr.To(true)}).IsArchiveLogs())
+	assert.False(t, (&ArtifactRepository{ArchiveLogs: new(false)}).IsArchiveLogs())
+	assert.True(t, (&ArtifactRepository{ArchiveLogs: new(true)}).IsArchiveLogs())
 }

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
 
 	argoerrs "github.com/argoproj/argo-workflows/v4/errors"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -608,8 +607,8 @@ func (p *ParallelSteps) UnmarshalJSON(value []byte) error {
 	// Generate a list of all the available JSON fields of the WorkflowStep struct
 	availableFields := map[string]bool{}
 	reflectType := reflect.TypeFor[WorkflowStep]()
-	for i := 0; i < reflectType.NumField(); i++ {
-		cleanString := strings.ReplaceAll(reflectType.Field(i).Tag.Get("json"), ",omitempty", "")
+	for field := range reflectType.Fields() {
+		cleanString := strings.ReplaceAll(field.Tag.Get("json"), ",omitempty", "")
 		availableFields[cleanString] = true
 	}
 
@@ -2158,7 +2157,7 @@ func (in *WorkflowStatus) MarkTaskResultIncomplete(ctx context.Context, name str
 		return
 	}
 	if node.TaskResultSynced != nil {
-		node.TaskResultSynced = ptr.To(bool(false))
+		node.TaskResultSynced = new(bool(false))
 	}
 	in.Nodes.Set(ctx, name, *node)
 }
@@ -2174,7 +2173,7 @@ func (in *WorkflowStatus) MarkTaskResultComplete(ctx context.Context, name strin
 		return
 	}
 	if node.TaskResultSynced != nil {
-		node.TaskResultSynced = ptr.To(bool(true))
+		node.TaskResultSynced = new(bool(true))
 	}
 	in.Nodes.Set(ctx, name, *node)
 }
@@ -2401,14 +2400,14 @@ func (cs *Conditions) DisplayString(fmtStr string, iconMap map[ConditionType]str
 		return fmt.Sprintf(fmtStr, "Conditions:", "None")
 	}
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf(fmtStr, "Conditions:", ""))
+	fmt.Fprintf(&out, fmtStr, "Conditions:", "")
 	for _, condition := range *cs {
 		conditionMessage := condition.Message
 		if conditionMessage == "" {
 			conditionMessage = string(condition.Status)
 		}
 		conditionPrefix := fmt.Sprintf("%s %s", iconMap[condition.Type], string(condition.Type))
-		out.WriteString(fmt.Sprintf(fmtStr, conditionPrefix, conditionMessage))
+		fmt.Fprintf(&out, fmtStr, conditionPrefix, conditionMessage)
 	}
 	return out.String()
 }

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
 )
 
 func TestWorkflows(t *testing.T) {
@@ -314,8 +313,8 @@ func TestArtifactLocation_IsArchiveLogs(t *testing.T) {
 	var l *ArtifactLocation
 	assert.False(t, l.IsArchiveLogs())
 	assert.False(t, (&ArtifactLocation{}).IsArchiveLogs())
-	assert.False(t, (&ArtifactLocation{ArchiveLogs: ptr.To(false)}).IsArchiveLogs())
-	assert.True(t, (&ArtifactLocation{ArchiveLogs: ptr.To(true)}).IsArchiveLogs())
+	assert.False(t, (&ArtifactLocation{ArchiveLogs: new(false)}).IsArchiveLogs())
+	assert.True(t, (&ArtifactLocation{ArchiveLogs: new(true)}).IsArchiveLogs())
 }
 
 func TestArtifactLocation_HasLocation(t *testing.T) {
@@ -1080,7 +1079,7 @@ func TestWorkflowSpec_GetVolumeGC(t *testing.T) {
 }
 
 func TestGetTTLStrategy(t *testing.T) {
-	spec := WorkflowSpec{TTLStrategy: &TTLStrategy{SecondsAfterCompletion: ptr.To(int32(20))}}
+	spec := WorkflowSpec{TTLStrategy: &TTLStrategy{SecondsAfterCompletion: new(int32(20))}}
 	ttl := spec.GetTTLStrategy()
 	assert.Equal(t, int32(20), *ttl.SecondsAfterCompletion)
 }
@@ -1088,11 +1087,11 @@ func TestGetTTLStrategy(t *testing.T) {
 func TestWfGetTTLStrategy(t *testing.T) {
 	wf := Workflow{}
 
-	wf.Status.StoredWorkflowSpec = &WorkflowSpec{TTLStrategy: &TTLStrategy{SecondsAfterCompletion: ptr.To(int32(20))}}
+	wf.Status.StoredWorkflowSpec = &WorkflowSpec{TTLStrategy: &TTLStrategy{SecondsAfterCompletion: new(int32(20))}}
 	result := wf.GetTTLStrategy()
 	assert.Equal(t, int32(20), *result.SecondsAfterCompletion)
 
-	wf.Spec.TTLStrategy = &TTLStrategy{SecondsAfterCompletion: ptr.To(int32(30))}
+	wf.Spec.TTLStrategy = &TTLStrategy{SecondsAfterCompletion: new(int32(30))}
 	result = wf.GetTTLStrategy()
 	assert.Equal(t, int32(30), *result.SecondsAfterCompletion)
 }
@@ -1278,7 +1277,7 @@ func TestTemplate_SaveLogsAsArtifact(t *testing.T) {
 		assert.False(t, x.SaveLogsAsArtifact())
 	})
 	t.Run("IsArchiveLogs", func(t *testing.T) {
-		x := &Template{ArchiveLocation: &ArtifactLocation{ArchiveLogs: ptr.To(true)}}
+		x := &Template{ArchiveLocation: &ArtifactLocation{ArchiveLogs: new(true)}}
 		assert.True(t, x.SaveLogsAsArtifact())
 	})
 }
@@ -1297,7 +1296,7 @@ func TestTemplate_ExcludeTemplateTypes(t *testing.T) {
 		Steps:     []ParallelSteps{steps},
 		Script:    &ScriptTemplate{Source: "test"},
 		Container: &corev1.Container{Name: "container"},
-		DAG:       &DAGTemplate{FailFast: ptr.To(true)},
+		DAG:       &DAGTemplate{FailFast: new(true)},
 		Resource:  &ResourceTemplate{Action: "Create"},
 		Data:      &Data{Source: DataSource{ArtifactPaths: &ArtifactPaths{}}},
 		Suspend:   &SuspendTemplate{Duration: "10s"},

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -5,7 +5,7 @@ This is using the code in argo-workflows codebase as an SDK to build and control
 
 ## Prerequisites
 
-- Go 1.24.10
+- Go 1.26.1
 - Access to a Kubernetes cluster with Argo Workflows installed, and able to run workflows in the `argo` namespace
 - Kubeconfig configured for cluster access
 - kubectl configured with cluster access (for Kubernetes client examples)

--- a/sdks/go/alternate_auth/go.mod
+++ b/sdks/go/alternate_auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v4/sdks/go/authentication
 
-go 1.25.6
+go 1.26.1
 
 replace github.com/argoproj/argo-workflows/v4 => ../../..
 

--- a/sdks/go/basic-workflow/go.mod
+++ b/sdks/go/basic-workflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v4/sdks/go/basic-workflow
 
-go 1.25.6
+go 1.26.1
 
 replace github.com/argoproj/argo-workflows/v4 => ../../..
 

--- a/sdks/go/grpc-client/go.mod
+++ b/sdks/go/grpc-client/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v4/sdks/go/grpc-client
 
-go 1.25.6
+go 1.26.1
 
 replace github.com/argoproj/argo-workflows/v4 => ../../..
 

--- a/sdks/go/watch-workflow/go.mod
+++ b/sdks/go/watch-workflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v4/sdks/go/watch-workflow
 
-go 1.25.6
+go 1.26.1
 
 replace github.com/argoproj/argo-workflows/v4 => ../../..
 

--- a/sdks/go/workflow-template/go.mod
+++ b/sdks/go/workflow-template/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj/argo-workflows/v4/sdks/go/workflow-template
 
-go 1.25.6
+go 1.26.1
 
 replace github.com/argoproj/argo-workflows/v4 => ../../..
 

--- a/server/apiserver/accesslog/interceptor_test.go
+++ b/server/apiserver/accesslog/interceptor_test.go
@@ -19,7 +19,7 @@ func TestInterceptor(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 	rr := httptest.NewRecorder()
 
 	handler := NewLoggingInterceptor(logger).Interceptor(realHandler)

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -129,7 +129,7 @@ func intercept(ctx context.Context, method string, target string, headers map[st
 	w := httptest.NewRecorder()
 	b := &bytes.Buffer{}
 	b.WriteString("{}")
-	r := httptest.NewRequest(method, target, b)
+	r := httptest.NewRequestWithContext(ctx, method, target, b)
 	for k, v := range headers {
 		r.Header.Set(k, v)
 	}

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/test/e2e/fixtures"
@@ -37,10 +36,10 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 			require.Len(t, pods, 1)
 			pod := pods[0]
 			spec := pod.Spec
-			assert.Equal(t, ptr.To(false), spec.AutomountServiceAccountToken)
+			assert.Equal(t, new(false), spec.AutomountServiceAccountToken)
 			assert.Equal(t, &apiv1.PodSecurityContext{
-				RunAsUser:      ptr.To(int64(8737)),
-				RunAsNonRoot:   ptr.To(true),
+				RunAsUser:      new(int64(8737)),
+				RunAsNonRoot:   new(true),
 				SeccompProfile: &apiv1.SeccompProfile{Type: "RuntimeDefault"},
 			}, spec.SecurityContext)
 			require.Len(t, spec.Volumes, 4)
@@ -65,11 +64,11 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 				assert.Contains(t, agent.VolumeMounts[1].Name, "kube-api-access-")
 				assert.Equal(t, "argo-workflows-agent-ca-certificates", agent.VolumeMounts[2].Name)
 				assert.Equal(t, &apiv1.SecurityContext{
-					RunAsUser:                ptr.To(int64(8737)),
-					RunAsNonRoot:             ptr.To(true),
-					AllowPrivilegeEscalation: ptr.To(false),
-					ReadOnlyRootFilesystem:   ptr.To(true),
-					Privileged:               ptr.To(false),
+					RunAsUser:                new(int64(8737)),
+					RunAsNonRoot:             new(true),
+					AllowPrivilegeEscalation: new(false),
+					ReadOnlyRootFilesystem:   new(true),
+					Privileged:               new(false),
 					Capabilities:             &apiv1.Capabilities{Drop: []apiv1.Capability{"ALL"}},
 					SeccompProfile:           &apiv1.SeccompProfile{Type: "RuntimeDefault"},
 				}, agent.SecurityContext)

--- a/test/e2e/fixtures/span_tree.go
+++ b/test/e2e/fixtures/span_tree.go
@@ -130,9 +130,9 @@ func (e HierarchyErrors) Error() string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%d hierarchy violation(s):\n", len(e)))
+	fmt.Fprintf(&sb, "%d hierarchy violation(s):\n", len(e))
 	for _, err := range e {
-		sb.WriteString(fmt.Sprintf("  - %s\n", err.Error()))
+		fmt.Fprintf(&sb, "  - %s\n", err.Error())
 	}
 	return sb.String()
 }

--- a/test/e2e/fixtures/when.go
+++ b/test/e2e/fixtures/when.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 
 	"github.com/upper/db/v4"
 
@@ -551,7 +550,7 @@ func (w *When) WaitForPod(condition PodCondition) *When {
 	timeout := defaultTimeout
 	watch, err := w.kubeClient.CoreV1().Pods(Namespace).Watch(
 		ctx,
-		metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + w.wf.Name, TimeoutSeconds: ptr.To(int64(timeout.Seconds()))},
+		metav1.ListOptions{LabelSelector: common.LabelKeyWorkflow + "=" + w.wf.Name, TimeoutSeconds: new(int64(timeout.Seconds()))},
 	)
 	if err != nil {
 		w.t.Fatal(err)

--- a/util/flatten/flatten_test.go
+++ b/util/flatten/flatten_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflowarchive"
 )
@@ -23,7 +22,7 @@ func Test_flatten(t *testing.T) {
 			Watch:               false,
 			AllowWatchBookmarks: true,
 			ResourceVersion:     "11",
-			TimeoutSeconds:      ptr.To(int64(22)),
+			TimeoutSeconds:      new(int64(22)),
 			Limit:               33,
 			Continue:            "44",
 		}}, map[string]string{

--- a/util/printer/workflow-printer_test.go
+++ b/util/printer/workflow-printer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 )
@@ -24,7 +23,7 @@ func TestPrintWorkflows(t *testing.T) {
 				Arguments: wfv1.Arguments{Parameters: []wfv1.Parameter{
 					{Name: "my-param", Value: wfv1.AnyStringPtr("my-value")},
 				}},
-				Priority: ptr.To(int32(2)),
+				Priority: new(int32(2)),
 				Templates: []wfv1.Template{
 					{Name: "t0", Container: &corev1.Container{}},
 				},

--- a/workflow/artifacts/azure/azure_test.go
+++ b/workflow/artifacts/azure/azure_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
@@ -97,7 +96,7 @@ func TestArtifactDriver_WithSASToken_DownloadDirectory_Subdir(t *testing.T) {
 		Protocol:      sas.ProtocolHTTPSandHTTP,
 		StartTime:     time.Now().UTC().Add(time.Second * -10),
 		ExpiryTime:    time.Now().UTC().Add(15 * time.Minute),
-		Permissions:   to.Ptr(sas.ContainerPermissions{Read: true, Write: true, List: true}).String(),
+		Permissions:   new(sas.ContainerPermissions{Read: true, Write: true, List: true}).String(),
 		ContainerName: driver.Container,
 	}.SignWithSharedKey(credential)
 	if err != nil {

--- a/workflow/common/security_context.go
+++ b/workflow/common/security_context.go
@@ -2,25 +2,24 @@ package common
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 func MinimalCtrSC() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-		Privileged:               ptr.To(false),
-		RunAsNonRoot:             ptr.To(true),
-		RunAsUser:                ptr.To(int64(8737)),
-		ReadOnlyRootFilesystem:   ptr.To(true),
-		AllowPrivilegeEscalation: ptr.To(false),
+		Privileged:               new(false),
+		RunAsNonRoot:             new(true),
+		RunAsUser:                new(int64(8737)),
+		ReadOnlyRootFilesystem:   new(true),
+		AllowPrivilegeEscalation: new(false),
 		SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
 	}
 }
 
 func MinimalPodSC() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
-		RunAsNonRoot:   ptr.To(true),
-		RunAsUser:      ptr.To(int64(8737)),
+		RunAsNonRoot:   new(true),
+		RunAsUser:      new(int64(8737)),
 		SeccompProfile: &corev1.SeccompProfile{Type: "RuntimeDefault"},
 	}
 }

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -10,7 +10,6 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/errors"
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
@@ -214,7 +213,7 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 			ImagePullSecrets:             woc.execWf.Spec.ImagePullSecrets,
 			SecurityContext:              common.MinimalPodSC(),
 			ServiceAccountName:           serviceAccountName,
-			AutomountServiceAccountToken: ptr.To(false),
+			AutomountServiceAccountToken: new(false),
 			Volumes:                      podVolumes,
 			InitContainers: []apiv1.Container{
 				*agentInitCtr,

--- a/workflow/controller/artifact_gc.go
+++ b/workflow/controller/artifact_gc.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/env"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
@@ -512,7 +511,7 @@ func (woc *wfOperationCtx) createArtifactGCPod(ctx context.Context, strategy wfv
 				},
 				VolumeMounts: volumeMounts,
 			}),
-			AutomountServiceAccountToken: ptr.To(true),
+			AutomountServiceAccountToken: new(true),
 			RestartPolicy:                corev1.RestartPolicyNever,
 		},
 	}

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/config"
 	"github.com/argoproj/argo-workflows/v4/persist/sqldb"
@@ -365,7 +364,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 func newControllerWithDefaults(ctx context.Context) (context.CancelFunc, *WorkflowController) {
 	cancel, controller := newController(ctx, func(controller *WorkflowController) {
 		controller.Config.WorkflowDefaults = &wfv1.Workflow{
-			Spec: wfv1.WorkflowSpec{HostNetwork: ptr.To(true)},
+			Spec: wfv1.WorkflowSpec{HostNetwork: new(true)},
 		}
 	})
 	return cancel, controller
@@ -383,13 +382,13 @@ func newControllerWithComplexDefaults(ctx context.Context) (context.CancelFunc, 
 				},
 			},
 			Spec: wfv1.WorkflowSpec{
-				HostNetwork:        ptr.To(true),
+				HostNetwork:        new(true),
 				Entrypoint:         "good_entrypoint",
 				ServiceAccountName: "my_service_account",
 				TTLStrategy: &wfv1.TTLStrategy{
-					SecondsAfterCompletion: ptr.To(int32(10)),
-					SecondsAfterSuccess:    ptr.To(int32(10)),
-					SecondsAfterFailure:    ptr.To(int32(10)),
+					SecondsAfterCompletion: new(int32(10)),
+					SecondsAfterSuccess:    new(int32(10)),
+					SecondsAfterFailure:    new(int32(10)),
 				},
 			},
 		}
@@ -412,7 +411,7 @@ func newControllerWithDefaultsVolumeClaimTemplate(ctx context.Context) (context.
 								apiv1.ResourceStorage: resource.MustParse("1Mi"),
 							},
 						},
-						StorageClassName: ptr.To("local-path"),
+						StorageClassName: new("local-path"),
 					},
 				}},
 			},

--- a/workflow/controller/exec_control_test.go
+++ b/workflow/controller/exec_control_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -22,7 +21,7 @@ func TestKillDaemonChildrenUnmarkPod(t *testing.T) {
 				"a": v1alpha1.NodeStatus{
 					ID:         "a",
 					BoundaryID: "a",
-					Daemoned:   ptr.To(true),
+					Daemoned:   new(true),
 				},
 			},
 		},

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	argoerrors "github.com/argoproj/argo-workflows/v4/errors"
@@ -982,7 +981,7 @@ func (woc *wfOperationCtx) processNodeRetries(ctx context.Context, node *wfv1.No
 	}
 
 	if lastChildNode.IsDaemoned() {
-		node.Daemoned = ptr.To(true)
+		node.Daemoned = new(true)
 	}
 
 	if !lastChildNode.Phase.Fulfilled(lastChildNode.TaskResultSynced) {
@@ -992,7 +991,7 @@ func (woc *wfOperationCtx) processNodeRetries(ctx context.Context, node *wfv1.No
 		// last child node is still running.
 		node = woc.markNodePhase(ctx, node.Name, lastChildNode.Phase)
 		if lastChildNode.IsDaemoned() { // markNodePhase doesn't pass the Daemoned field
-			node.Daemoned = ptr.To(true)
+			node.Daemoned = new(true)
 		}
 		return node, true, nil
 	}
@@ -1465,7 +1464,7 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 				}
 				// proceed to mark node as running and daemoned
 				updated.Phase = wfv1.NodeRunning
-				updated.Daemoned = ptr.To(true)
+				updated.Daemoned = new(true)
 				if !old.IsDaemoned() {
 					woc.log.WithField("nodeId", old.ID).Info(ctx, "Node became daemoned")
 				}
@@ -1534,7 +1533,7 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		if updated.Outputs == nil {
 			updated.Outputs = &wfv1.Outputs{}
 		}
-		updated.Outputs.ExitCode = ptr.To(fmt.Sprint(*exitCode))
+		updated.Outputs.ExitCode = new(fmt.Sprint(*exitCode))
 	}
 
 	waitContainerCleanedUp := true
@@ -1631,7 +1630,7 @@ func hasRequiredArtifacts(artifacts []wfv1.Artifact) bool {
 func getExitCode(pod *apiv1.Pod) *int32 {
 	for _, c := range pod.Status.ContainerStatuses {
 		if c.Name == common.MainContainerName && c.State.Terminated != nil {
-			return ptr.To(c.State.Terminated.ExitCode)
+			return new(c.State.Terminated.ExitCode)
 		}
 	}
 	return nil
@@ -2496,7 +2495,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 		if !node.Phase.Fulfilled(node.TaskResultSynced) && node.IsDaemoned() {
 			retryNode = woc.markNodePhase(ctx, retryNodeName, node.Phase)
 			if node.IsDaemoned() { // markNodePhase doesn't pass the Daemoned field
-				retryNode.Daemoned = ptr.To(true)
+				retryNode.Daemoned = new(true)
 			}
 		}
 		node = retryNode

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -25,7 +25,6 @@ import (
 	batchfake "k8s.io/client-go/kubernetes/typed/batch/v1/fake"
 	corefake "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-workflows/v4/config"
@@ -6588,7 +6587,7 @@ func TestConfigMapCacheSaveOperate(t *testing.T) {
 		Parameters: []wfv1.Parameter{
 			{Name: "hello", Value: wfv1.AnyStringPtr("foobar")},
 		},
-		ExitCode: ptr.To("0"),
+		ExitCode: new("0"),
 	}
 
 	woc.operate(ctx)

--- a/workflow/controller/operator_wfdefault_test.go
+++ b/workflow/controller/operator_wfdefault_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -247,7 +246,7 @@ func TestWFDefaultWithWFTAndWf(t *testing.T) {
 		controller.Config.WorkflowDefaults = wfDefault
 
 		ttlStrategy := wfv1.TTLStrategy{
-			SecondsAfterCompletion: ptr.To(int32(10)),
+			SecondsAfterCompletion: new(int32(10)),
 		}
 
 		wf := wfv1.Workflow{
@@ -284,7 +283,7 @@ func TestWFDefaultWithWFTAndWf(t *testing.T) {
 		}
 
 		ttlStrategy := wfv1.TTLStrategy{
-			SecondsAfterCompletion: ptr.To(int32(10)),
+			SecondsAfterCompletion: new(int32(10)),
 		}
 
 		wf := wfv1.Workflow{

--- a/workflow/controller/operator_workflow_template_ref_test.go
+++ b/workflow/controller/operator_workflow_template_ref_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util"
@@ -442,7 +441,7 @@ func TestWorkflowTemplateRefWithShutdownAndSuspend(t *testing.T) {
 		wf1 := woc.wf.DeepCopy()
 		// Updating Pod state
 		makePodsPhase(ctx, woc, apiv1.PodPending)
-		wf1.Spec.Suspend = ptr.To(true)
+		wf1.Spec.Suspend = new(true)
 		woc1 := newWorkflowOperationCtx(ctx, wf1, controller)
 		woc1.operate(ctx)
 		assert.NotNil(t, woc1.wf.Status.StoredWorkflowSpec.Suspend)

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -19,7 +19,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/config"
 	"github.com/argoproj/argo-workflows/v4/errors"
@@ -895,7 +894,7 @@ func (woc *wfOperationCtx) newExecContainer(name string, tmpl *wfv1.Template) *a
 		// TODO: always set RO FS once #10787 is fixed
 		exec.SecurityContext.ReadOnlyRootFilesystem = nil
 		if exec.Name != common.InitContainerName && exec.Name != common.WaitContainerName {
-			exec.SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)
+			exec.SecurityContext.ReadOnlyRootFilesystem = new(true)
 		}
 	}
 	if woc.controller.Config.KubeConfig != nil {

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -17,7 +17,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/config"
 	"github.com/argoproj/argo-workflows/v4/errors"
@@ -514,7 +513,7 @@ func TestConditionalAddArchiveLocationArchiveLogs(t *testing.T) {
 			},
 			KeyFormat: "path/in/bucket",
 		},
-		ArchiveLogs: ptr.To(true),
+		ArchiveLogs: new(true),
 	})
 	woc.operate(ctx)
 	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
@@ -586,12 +585,12 @@ func TestConditionalAddArchiveLocationTemplateArchiveLogs(t *testing.T) {
 			wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
 			if tt.workflowArchiveLog != "" {
 				workflowArchiveLog, _ := strconv.ParseBool(tt.workflowArchiveLog)
-				wf.Spec.ArchiveLogs = ptr.To(workflowArchiveLog)
+				wf.Spec.ArchiveLogs = new(workflowArchiveLog)
 			}
 			if tt.templateArchiveLog != "" {
 				templateArchiveLog, _ := strconv.ParseBool(tt.templateArchiveLog)
 				wf.Spec.Templates[0].ArchiveLocation = &wfv1.ArtifactLocation{
-					ArchiveLogs: ptr.To(templateArchiveLog),
+					ArchiveLogs: new(templateArchiveLog),
 				}
 			}
 			ctx := logging.TestContext(t.Context())
@@ -599,7 +598,7 @@ func TestConditionalAddArchiveLocationTemplateArchiveLogs(t *testing.T) {
 			defer cancel()
 			woc := newWorkflowOperationCtx(ctx, wf, controller)
 			setArtifactRepository(woc.controller, &wfv1.ArtifactRepository{
-				ArchiveLogs: ptr.To(tt.controllerArchiveLog),
+				ArchiveLogs: new(tt.controllerArchiveLog),
 				S3: &wfv1.S3ArtifactRepository{
 					S3Bucket: wfv1.S3Bucket{
 						Bucket: "foo",
@@ -1464,7 +1463,7 @@ func TestPodSpecPatch(t *testing.T) {
 	woc = newWoc(ctx, *wf)
 	mainCtr = woc.execWf.Spec.Templates[0].Container
 	pod, _ = woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
-	assert.Equal(t, ptr.To(true), pod.Spec.Containers[1].SecurityContext.RunAsNonRoot)
+	assert.Equal(t, new(true), pod.Spec.Containers[1].SecurityContext.RunAsNonRoot)
 	assert.Equal(t, apiv1.Capability("ALL"), pod.Spec.Containers[1].SecurityContext.Capabilities.Add[0])
 	assert.Equal(t, []apiv1.Capability(nil), pod.Spec.Containers[1].SecurityContext.Capabilities.Drop)
 

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
@@ -74,7 +73,7 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 
 	cronWf.Status.LastScheduledTime = &v1.Time{Time: time.Now().Add(-1 * time.Minute)}
 	// StartingDeadlineSeconds is after the current second, so cron should be run
-	cronWf.Spec.StartingDeadlineSeconds = ptr.To(int64(35))
+	cronWf.Spec.StartingDeadlineSeconds = new(int64(35))
 	woc := &cronWfOperationCtx{
 		cronWf: &cronWf,
 		log:    logging.RequireLoggerFromContext(ctx),
@@ -86,7 +85,7 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 	assert.Equal(t, inferScheduledTime(ctx).Unix(), missedExecutionTime.Unix())
 
 	// StartingDeadlineSeconds is not after the current second, so cron should not be run
-	cronWf.Spec.StartingDeadlineSeconds = ptr.To(int64(25))
+	cronWf.Spec.StartingDeadlineSeconds = new(int64(25))
 	woc = &cronWfOperationCtx{
 		cronWf: &cronWf,
 		log:    logging.RequireLoggerFromContext(ctx),
@@ -112,7 +111,7 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 	cronWf.Status.LastScheduledTime = &v1.Time{Time: cronWf.Status.LastScheduledTime.In(testLocation)}
 
 	// StartingDeadlineSeconds is after the current second, so cron should be run
-	cronWf.Spec.StartingDeadlineSeconds = ptr.To(int64(35))
+	cronWf.Spec.StartingDeadlineSeconds = new(int64(35))
 	woc = &cronWfOperationCtx{
 		cronWf: &cronWf,
 		log:    logging.RequireLoggerFromContext(ctx),
@@ -125,7 +124,7 @@ func TestRunOutstandingWorkflows(t *testing.T) {
 	assert.Equal(t, inferScheduledTime(ctx).Unix(), missedExecutionTime.Unix())
 
 	// StartingDeadlineSeconds is not after the current second, so cron should not be run
-	cronWf.Spec.StartingDeadlineSeconds = ptr.To(int64(25))
+	cronWf.Spec.StartingDeadlineSeconds = new(int64(25))
 	woc = &cronWfOperationCtx{
 		cronWf: &cronWf,
 		log:    logging.RequireLoggerFromContext(ctx),

--- a/workflow/executor/agent.go
+++ b/workflow/executor/agent.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	workflow "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned"
@@ -268,7 +267,7 @@ func (ae *AgentExecutor) executeHTTPTemplate(ctx context.Context, tmpl wfv1.Temp
 		return 0, err
 	}
 
-	outputs := wfv1.Outputs{Result: ptr.To(string(bodyBytes))}
+	outputs := wfv1.Outputs{Result: new(string(bodyBytes))}
 	phase := wfv1.NodeSucceeded
 	message := ""
 	if tmpl.HTTP.SuccessCondition == "" {

--- a/workflow/executor/common/common_test.go
+++ b/workflow/executor/common/common_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 type MockKC struct {
@@ -59,7 +58,7 @@ func TestTerminatePodWithContainerName(t *testing.T) {
 				Name: "foo",
 			},
 			Spec: v1.PodSpec{
-				ShareProcessNamespace: ptr.To(true),
+				ShareProcessNamespace: new(true),
 			},
 		},
 		getContainerStatusContainerStatus: &v1.ContainerStatus{

--- a/workflow/executor/data.go
+++ b/workflow/executor/data.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/utils/ptr"
-
 	"github.com/argoproj/argo-workflows/v4/workflow/data"
 )
 
@@ -31,7 +29,7 @@ func (we *WorkflowExecutor) Data(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	we.Template.Outputs.Result = ptr.To(string(out))
+	we.Template.Outputs.Result = new(string(out))
 	err = we.ReportOutputs(ctx, nil)
 	if err != nil {
 		return err

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	argofake "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
@@ -563,7 +562,7 @@ func TestSaveLogs(t *testing.T) {
 		require.NoError(t, err)
 		templateWithArchiveLogs := wfv1.Template{
 			ArchiveLocation: &wfv1.ArtifactLocation{
-				ArchiveLogs: ptr.To(true),
+				ArchiveLogs: new(true),
 			},
 		}
 		we := WorkflowExecutor{

--- a/workflow/metrics/metrics_test.go
+++ b/workflow/metrics/metrics_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -118,7 +117,7 @@ func TestRealtimeMetricGC(t *testing.T) {
 		Labels: labels,
 		Help:   "None",
 		Gauge: &wfv1.Gauge{
-			Realtime: ptr.To(true),
+			Realtime: new(true),
 		}},
 		wfKey,
 		func() float64 { return 1.0 },
@@ -196,7 +195,7 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 		Help:   "hello",
 		Gauge: &wfv1.Gauge{
 			Value:     "1.0",
-			Realtime:  ptr.To(true),
+			Realtime:  new(true),
 			Operation: wfv1.GaugeOperationAdd,
 		},
 	}, "123", func() float64 { return 0.0 })
@@ -223,7 +222,7 @@ func TestRealTimeMetricDeletion(t *testing.T) {
 		Help:   "hello",
 		Gauge: &wfv1.Gauge{
 			Value:     "1.0",
-			Realtime:  ptr.To(true),
+			Realtime:  new(true),
 			Operation: wfv1.GaugeOperationAdd,
 		},
 	}, "456", nil)

--- a/workflow/metrics/work_queue.go
+++ b/workflow/metrics/work_queue.go
@@ -5,7 +5,6 @@ import (
 
 	"go.opentelemetry.io/otel/metric"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/util/telemetry"
 )
@@ -180,7 +179,7 @@ func (m *Metrics) NewLongestRunningProcessorSecondsMetric(name string) workqueue
 }
 
 func (m *Metrics) newObservableGaugeMetric(name string, inst telemetry.BuiltinInstrument, observe func(context.Context, metric.Observer, float64, string)) queueMetric {
-	valuePtr := ptr.To(float64(0.0))
+	valuePtr := new(float64(0.0))
 	metric := queueMetric{
 		value:           valuePtr,
 		set:             func(val float64) { *valuePtr = val },

--- a/workflow/sync/multiple_test.go
+++ b/workflow/sync/multiple_test.go
@@ -11,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 )
@@ -330,7 +329,7 @@ func TestPriority(t *testing.T) {
 `)
 		wfhigh := wflow.DeepCopy()
 		wfhigh.Name = "priorityhigh"
-		wfhigh.Spec.Priority = ptr.To(int32(5))
+		wfhigh.Spec.Priority = new(int32(5))
 		wf1 := templatedWorkflow("one",
 			`    mutexes:
        - name: two

--- a/workflow/sync/mutex_test.go
+++ b/workflow/sync/mutex_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	fakewfclientset "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
@@ -162,7 +161,7 @@ func TestMutexLock(t *testing.T) {
 		assert.True(t, wfUpdate)
 
 		wf2.Name = "three"
-		wf2.Spec.Priority = ptr.To(int32(5))
+		wf2.Spec.Priority = new(int32(5))
 		holderKey2 := getHolderKey(wf2, "")
 		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf2, "", wf2.Spec.Synchronization)
 		require.NoError(t, err)
@@ -246,7 +245,7 @@ func TestMutexLock(t *testing.T) {
 
 		wf2.Name = "three"
 		wf2.Namespace = "three"
-		wf2.Spec.Priority = ptr.To(int32(5))
+		wf2.Spec.Priority = new(int32(5))
 		holderKey2 := getHolderKey(wf2, "")
 		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf2, "", wf2.Spec.Synchronization)
 		require.NoError(t, err)

--- a/workflow/sync/sync_manager_multiple_test.go
+++ b/workflow/sync/sync_manager_multiple_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 
@@ -128,20 +127,20 @@ func testSyncManagersSemaphoreAcquisitionWithPriorityForDB(t *testing.T, dbType 
 	// Create 4 workflows
 	wf01 := wfv1.MustUnmarshalWorkflow(wfWithDatabaseSemaphore)
 	wf01.CreationTimestamp = metav1.Time{Time: time.Now().Add(-4 * time.Second)}
-	wf01.Spec.Priority = ptr.To(int32(1))
+	wf01.Spec.Priority = new(int32(1))
 	wf01.Name = "wf-01"
 	wf02 := wf01.DeepCopy()
 	wf02.CreationTimestamp = metav1.Time{Time: time.Now().Add(-3 * time.Second)}
 	wf02.Name = "wf-02"
-	wf02.Spec.Priority = ptr.To(int32(2))
+	wf02.Spec.Priority = new(int32(2))
 	wf03 := wf01.DeepCopy()
 	wf03.CreationTimestamp = metav1.Time{Time: time.Now().Add(-2 * time.Second)}
 	wf03.Name = "wf-03"
-	wf03.Spec.Priority = ptr.To(int32(3))
+	wf03.Spec.Priority = new(int32(3))
 	wf04 := wf01.DeepCopy()
 	wf04.CreationTimestamp = metav1.Time{Time: time.Now().Add(-1 * time.Second)}
 	wf04.Name = "wf-04"
-	wf04.Spec.Priority = ptr.To(int32(4))
+	wf04.Spec.Priority = new(int32(4))
 
 	// wf-01 acquires lock as first to appear
 	checkCanAcquire(ctx, t, syncMgr1, wf01)

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -16,7 +16,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 
 	"github.com/argoproj/argo-workflows/v4/config"
 	argoErr "github.com/argoproj/argo-workflows/v4/errors"
@@ -466,7 +465,7 @@ func TestSemaphoreWfLevel(t *testing.T) {
 		assert.True(t, wfUpdate)
 
 		wf2.Name = "three"
-		wf2.Spec.Priority = ptr.To(int32(5))
+		wf2.Spec.Priority = new(int32(5))
 		holderKey2 := getHolderKey(wf2, "")
 		status, wfUpdate, msg, failedLockName, err = syncManager.TryAcquire(ctx, wf2, "", wf2.Spec.Synchronization)
 		require.NoError(t, err)
@@ -763,7 +762,7 @@ func TestSemaphoreSizeCache(t *testing.T) {
 		mock := mockGetSyncLimit{}
 		mock.outputSize = 10
 		config := config.SyncConfig{
-			SemaphoreLimitCacheSeconds: ptr.To(int64(1)),
+			SemaphoreLimitCacheSeconds: new(int64(1)),
 		}
 
 		syncManager := NewLockManager(ctx, kube, "", &config, mock.getSyncLimit, func(key string) {
@@ -851,7 +850,7 @@ func TestSemaphoreSizeCache(t *testing.T) {
 		mock.outputSize = 10
 
 		config := config.SyncConfig{
-			SemaphoreLimitCacheSeconds: ptr.To(int64(1)),
+			SemaphoreLimitCacheSeconds: new(int64(1)),
 		}
 
 		syncManager := NewLockManager(ctx, kube, "", &config, mock.getSyncLimit, func(key string) {

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers/internalinterfaces"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/argoproj/argo-workflows/v4/workflow/creator"
@@ -374,7 +373,7 @@ func SuspendWorkflow(ctx context.Context, wfIf v1alpha1.WorkflowInterface, workf
 			return false, errSuspendedCompletedWorkflow
 		}
 		if wf.Spec.Suspend == nil || !*wf.Spec.Suspend {
-			wf.Spec.Suspend = ptr.To(true)
+			wf.Spec.Suspend = new(true)
 			creator.LabelActor(ctx, wf, creator.ActionSuspend)
 			_, err := wfIf.Update(ctx, wf, metav1.UpdateOptions{})
 			if apierr.IsConflict(err) {


### PR DESCRIPTION
### Motivation

Keeping up to date with go

### Modifications

Bumped golang to 1.26.1 and golangci-lint to 2.11.3 (both latest at time of writing).

Ran the linter and all the code changes are autofixes.

### Verification

Lint+test locally, relying on CI.

### Documentation

None required