### PR TITLE
fix: re-create resource template executor pod on infrastructure failure

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -190,6 +190,9 @@ const (
 	EnvVarDefaultRequeueTime = "DEFAULT_REQUEUE_TIME"
 	// EnvVarPodStatusCaptureFinalizer is used to prevent pod garbage collected before argo captures its exit status
 	EnvVarPodStatusCaptureFinalizer = "ARGO_POD_STATUS_CAPTURE_FINALIZER"
+	// EnvVarResourceTemplateRestarted indicates the executor pod is a restart (previous pod failed).
+	// Set by the controller when FailedPodRestarts > 0 for resource template pods.
+	EnvVarResourceTemplateRestarted = "ARGO_RESOURCE_TEMPLATE_RESTARTED"
 	// EnvAgentTaskWorkers is the number of task workers for the agent pod
 	EnvAgentTaskWorkers = "ARGO_AGENT_TASK_WORKERS"
 	// EnvAgentPatchRate is the rate that the Argo Agent will patch the Workflow TaskSet

--- a/workflow/common/resource.go
+++ b/workflow/common/resource.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+// ReplaceGenerateNameWithDeterministic replaces generateName with a deterministic name
+// derived from the node ID, enabling idempotent resource creation on executor pod restart.
+// Uses the same fnv32a hashing pattern as GeneratePodName and Workflow.NodeID.
+func ReplaceGenerateNameWithDeterministic(manifest, nodeID string) string {
+	obj := unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(manifest), &obj); err != nil {
+		return manifest
+	}
+	if obj.GetName() != "" || obj.GetGenerateName() == "" {
+		return manifest
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(nodeID))
+	name := fmt.Sprintf("%s%08x", obj.GetGenerateName(), h.Sum32())
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	obj.SetName(name)
+	obj.SetGenerateName("")
+	bytes, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return manifest
+	}
+	return string(bytes)
+}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1278,6 +1278,23 @@ func (woc *wfOperationCtx) podReconciliation(ctx context.Context) (bool, error) 
 				node.Daemoned = nil
 				woc.updated = true
 			}
+
+			// For resource template nodes, re-create the executor pod instead of failing.
+			// The executor is just infrastructure — the underlying resource may still be healthy.
+			if woc.shouldRestartResourceTemplatePod(ctx, &node) {
+				node.FailedPodRestarts++
+				node.Phase = wfv1.NodePending
+				node.Message = fmt.Sprintf("executor pod missing, re-creating (attempt %d)", node.FailedPodRestarts)
+				woc.log.WithFields(logging.Fields{
+					"nodeName":     node.Name,
+					"restartCount": node.FailedPodRestarts,
+				}).Info(ctx, "Resource template executor pod missing - marking as pending for re-creation")
+				woc.wf.Status.Nodes.Set(ctx, nodeID, node)
+				woc.updated = true
+				woc.requeue()
+				continue
+			}
+
 			woc.markNodeError(ctx, node.Name, argoerrors.New("", "pod deleted"))
 			// Mark all its children(container) as deleted if pod deleted
 			woc.markAllContainersDeleted(ctx, node.ID)
@@ -1449,6 +1466,21 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			}
 			// Issue a delete request by UID here in case we lost the delete request
 			// since the last call to operate() (for example: controller restart)
+			woc.controller.PodController.DeletePodByUID(ctx, pod.Namespace, pod.Name, podUID)
+		} else if woc.shouldRestartResourceTemplatePod(ctx, old) && isResourceTemplateInfraFailure(pod) {
+			// Resource template executor pod failed due to infrastructure (OOM, signal kill, eviction).
+			// The underlying resource may still be healthy — re-create the executor to resume monitoring.
+			if podUID != old.RestartingPodUID {
+				updated.FailedPodRestarts++
+				updated.RestartingPodUID = podUID
+				updated.Phase = wfv1.NodePending
+				updated.Message = fmt.Sprintf("executor pod failed (%s), re-creating (attempt %d)", pod.Status.Reason, updated.FailedPodRestarts)
+				woc.log.WithFields(logging.Fields{
+					"nodeName":     old.Name,
+					"reason":       pod.Status.Reason,
+					"restartCount": updated.FailedPodRestarts,
+				}).Info(ctx, "Resource template executor pod infra failure - marking as pending for re-creation")
+			}
 			woc.controller.PodController.DeletePodByUID(ctx, pod.Namespace, pod.Name, podUID)
 		}
 	case apiv1.PodRunning:
@@ -1848,6 +1880,30 @@ func (woc *wfOperationCtx) shouldAutoRestartPod(ctx context.Context, pod *apiv1.
 	}
 
 	return true
+}
+
+// shouldRestartResourceTemplatePod checks if a resource template's executor pod should be re-created.
+// Uses the same configurable max restart limit as FailedPodRestart (defaults to 3).
+func (woc *wfOperationCtx) shouldRestartResourceTemplatePod(ctx context.Context, node *wfv1.NodeStatus) bool {
+	if node.FailedPodRestarts >= woc.controller.Config.FailedPodRestart.GetMaxRestarts() {
+		return false
+	}
+	tmpl, err := woc.GetNodeTemplate(ctx, node)
+	return err == nil && tmpl != nil && tmpl.GetType() == wfv1.TemplateTypeResource
+}
+
+// isResourceTemplateInfraFailure checks if a pod failed due to infrastructure (OOM, signal, eviction)
+// rather than a legitimate executor error like an invalid manifest.
+func isResourceTemplateInfraFailure(pod *apiv1.Pod) bool {
+	if isRestartableReason(pod.Status.Reason) {
+		return true
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == common.MainContainerName && cs.State.Terminated != nil {
+			return cs.State.Terminated.Reason == "OOMKilled" || cs.State.Terminated.ExitCode >= 128
+		}
+	}
+	return false
 }
 
 func (woc *wfOperationCtx) createPVCs(ctx context.Context) error {
@@ -3780,6 +3836,11 @@ func (woc *wfOperationCtx) executeResource(ctx context.Context, nodeName string,
 
 	mainCtr := woc.newExecContainer(common.MainContainerName, tmpl)
 	mainCtr.Command = append([]string{"argoexec", "resource", tmpl.Resource.Action}, woc.getExecutorLogOpts(ctx)...)
+	// Signal to the executor that this is a restarted pod, so it can safely handle "already exists"
+	// errors from kubectl create (the resource was created by the previous executor run).
+	if node.FailedPodRestarts > 0 {
+		mainCtr.Env = append(mainCtr.Env, apiv1.EnvVar{Name: common.EnvVarResourceTemplateRestarted, Value: "true"})
+	}
 	_, err = woc.createWorkflowPod(ctx, nodeName, []apiv1.Container{*mainCtr}, tmpl, &createWorkflowPodOpts{onExitPod: opts.onExitTemplate, executionDeadline: opts.executionDeadline})
 	if err != nil {
 		return woc.requeueIfTransientErr(ctx, err, node.Name)

--- a/workflow/controller/pod_restart_test.go
+++ b/workflow/controller/pod_restart_test.go
@@ -291,3 +291,63 @@ func TestAnalyzePodForRestart(t *testing.T) {
 		})
 	}
 }
+
+func TestIsResourceTemplateInfraFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *apiv1.Pod
+		expected bool
+	}{
+		{
+			name:     "evicted pod",
+			pod:      &apiv1.Pod{Status: apiv1.PodStatus{Reason: "Evicted"}},
+			expected: true,
+		},
+		{
+			name: "OOMKilled main container",
+			pod: &apiv1.Pod{Status: apiv1.PodStatus{ContainerStatuses: []apiv1.ContainerStatus{
+				{Name: common.MainContainerName, State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}}},
+			}}},
+			expected: true,
+		},
+		{
+			name: "signal killed (exit 137)",
+			pod: &apiv1.Pod{Status: apiv1.PodStatus{ContainerStatuses: []apiv1.ContainerStatus{
+				{Name: common.MainContainerName, State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}},
+			}}},
+			expected: true,
+		},
+		{
+			name: "normal exit code 1 — not infra",
+			pod: &apiv1.Pod{Status: apiv1.PodStatus{ContainerStatuses: []apiv1.ContainerStatus{
+				{Name: common.MainContainerName, State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}}},
+			}}},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isResourceTemplateInfraFailure(tt.pod))
+		})
+	}
+}
+
+func TestReplaceGenerateNameWithDeterministic(t *testing.T) {
+	manifest := "apiVersion: batch/v1\nkind: Job\nmetadata:\n  generateName: test-job-\n"
+
+	// Replaces generateName with deterministic name
+	result := common.ReplaceGenerateNameWithDeterministic(manifest, "my-workflow-123")
+	assert.NotEqual(t, manifest, result)
+	assert.NotContains(t, result, "generateName")
+	assert.Contains(t, result, "name: test-job-")
+
+	// Deterministic: same inputs → same output
+	assert.Equal(t, result, common.ReplaceGenerateNameWithDeterministic(manifest, "my-workflow-123"))
+
+	// Different nodeID → different name
+	assert.NotEqual(t, result, common.ReplaceGenerateNameWithDeterministic(manifest, "my-workflow-456"))
+
+	// Fixed name left unchanged
+	fixed := "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: my-job\n"
+	assert.Equal(t, fixed, common.ReplaceGenerateNameWithDeterministic(fixed, "my-workflow-123"))
+}

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -32,10 +32,22 @@ import (
 	envutil "github.com/argoproj/argo-workflows/v4/util/env"
 	argoerr "github.com/argoproj/argo-workflows/v4/util/errors"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
+	common "github.com/argoproj/argo-workflows/v4/workflow/common"
 )
 
 // ExecResource will run kubectl action against a manifest
 func (we *WorkflowExecutor) ExecResource(ctx context.Context, action string, manifestPath string, flags []string) (string, string, string, error) {
+	// For create actions, replace generateName with a deterministic name derived from the node ID.
+	// This ensures idempotency: if the executor pod dies and restarts, kubectl create will fail
+	// with "already exists" which is handled gracefully below. Works for both inline and manifestFrom templates.
+	if action == "create" {
+		if data, err := os.ReadFile(manifestPath); err == nil {
+			if rewritten := common.ReplaceGenerateNameWithDeterministic(string(data), we.nodeID); rewritten != string(data) {
+				_ = os.WriteFile(manifestPath, []byte(rewritten), 0o600)
+			}
+		}
+	}
+
 	args, err := we.getKubectlArguments(action, manifestPath, flags)
 	if err != nil {
 		return "", "", "", err
@@ -52,15 +64,27 @@ func (we *WorkflowExecutor) ExecResource(ctx context.Context, action string, man
 		return nil
 	})
 	if err != nil {
-		var exErr *exec.ExitError
-		if errors.As(err, &exErr) {
-			errMsg := strings.TrimSpace(string(exErr.Stderr))
-			err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, errMsg)
-		} else {
-			err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, err.Error())
+		// If kubectl create fails because the resource already exists and this is a restarted
+		// executor pod (previous pod created the resource then died), retrieve the existing
+		// resource instead of failing. Only recover on restart to preserve the original "already
+		// exists" error behavior on first run.
+		if action != "create" || !isAlreadyExistsErr(err) || os.Getenv(common.EnvVarResourceTemplateRestarted) != "true" {
+			var exErr *exec.ExitError
+			if errors.As(err, &exErr) {
+				errMsg := strings.TrimSpace(string(exErr.Stderr))
+				err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, errMsg)
+			} else {
+				err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, err.Error())
+			}
+			err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, "no more retries "+err.Error())
+			return "", "", "", err
 		}
-		err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, "no more retries "+err.Error())
-		return "", "", "", err
+		logger := logging.RequireLoggerFromContext(ctx)
+		logger.Info(ctx, "Resource already exists from previous executor run, retrieving existing resource")
+		out, err = runKubectl(ctx, "kubectl", "get", "-f", manifestPath, "-o", "json")
+		if err != nil {
+			return "", "", "", argoerrors.Wrap(err, argoerrors.CodeBadRequest, "failed to get existing resource: "+err.Error())
+		}
 	}
 	if action == "delete" {
 		return "", "", "", nil
@@ -84,6 +108,14 @@ func (we *WorkflowExecutor) ExecResource(ctx context.Context, action string, man
 	logger := logging.RequireLoggerFromContext(ctx)
 	logger.WithFields(logging.Fields{"namespace": obj.GetNamespace(), "resource": resourceFullName, "selfLink": selfLink}).Info(ctx, "Resource")
 	return obj.GetNamespace(), resourceFullName, selfLink, nil
+}
+
+// isAlreadyExistsErr checks if a kubectl error indicates the resource already exists.
+func isAlreadyExistsErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already exists")
 }
 
 func inferObjectSelfLink(obj unstructured.Unstructured) string {

--- a/workflow/executor/resource_test.go
+++ b/workflow/executor/resource_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"runtime"
@@ -245,4 +246,11 @@ func Test_runKubectl(t *testing.T) {
 	out, err := runKubectl(ctx, "kubectl", "version", "--client=true", "--output", "json")
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "clientVersion")
+}
+
+func TestIsAlreadyExistsErr(t *testing.T) {
+	assert.False(t, isAlreadyExistsErr(nil))
+	assert.True(t, isAlreadyExistsErr(fmt.Errorf("Error from server (AlreadyExists): jobs.batch \"test-job\" already exists")))
+	assert.True(t, isAlreadyExistsErr(fmt.Errorf("resource Already Exists")))
+	assert.False(t, isAlreadyExistsErr(fmt.Errorf("connection refused")))
 }


### PR DESCRIPTION
## What Changed

When a resource template executor pod dies (OOM, eviction, node shutdown), the workflow now recovers by re-creating the executor pod instead of marking the workflow as failed.

### Approach: Deterministic Naming + `kubectl create` + Restart-Guarded Recovery

1. **Controller detects missing/failed executor pod** → marks node as `Pending` for re-creation (instead of `Error`)
2. **Executor applies deterministic resource naming** — for `create` actions with `generateName`, the executor replaces it with a deterministic `name` derived from the node ID (fnv32a hash, same pattern as `GeneratePodName`). This runs in the executor so it works for **both inline and `manifestFrom` templates** — the executor always has the manifest file on disk regardless of source.
3. **Controller signals restart via env var** — when `FailedPodRestarts > 0`, the controller sets `ARGO_RESOURCE_TEMPLATE_RESTARTED=true` on the executor container. This tells the executor it's a restart, not a first run.
4. **Executor handles "already exists" only on restart** — on restart, `kubectl create` fails with "already exists" since the resource was already created by the previous executor. The executor checks the restart env var before recovering: if set, it falls back to `kubectl get -f` to retrieve the existing resource and proceeds to `WaitResource` monitoring. On first run, "already exists" errors are propagated as-is (preserving original behavior).

This preserves the user's requested `create` action semantics — no silent switching to `apply` or other kubectl commands.

### Files Changed (6 files, 207 insertions, 8 deletions)

**`workflow/common/common.go`**
- New constant `EnvVarResourceTemplateRestarted` — env var name for restart indicator

**`workflow/common/resource.go`** (new)
- Exported `ReplaceGenerateNameWithDeterministic` — replaces `generateName:` with a deterministic `name:` using fnv32a hash of the node ID. Shared between controller tests and executor.

**`workflow/controller/operator.go`**
- `podReconciliation`: detect missing executor pod for resource templates → mark `Pending` instead of `Error`
- `assessNodeStatus`: detect infra failure (OOM, signal, eviction) → mark `Pending` + delete failed pod
- `executeResource`: set `ARGO_RESOURCE_TEMPLATE_RESTARTED=true` env var when `FailedPodRestarts > 0`
- Helpers: `shouldRestartResourceTemplatePod`, `isResourceTemplateInfraFailure`

**`workflow/executor/resource.go`**
- `ExecResource`: for `create` actions, apply deterministic naming to the manifest file before running `kubectl create`. On error, if "already exists" AND `ARGO_RESOURCE_TEMPLATE_RESTARTED=true`, fall back to `kubectl get -f` to retrieve existing resource.
- Helpers: `isAlreadyExistsErr`

**`workflow/controller/pod_restart_test.go`** — tests for infra failure detection + deterministic naming

**`workflow/executor/resource_test.go`** — test for `isAlreadyExistsErr`

### End-to-End Flow

1. User submits workflow with `generateName: test-job-`
2. Executor reads manifest, replaces with `name: test-job-5f3b78c3` (deterministic from nodeID via [fnv32a](https://pkg.go.dev/hash/fnv))
3. Executor runs `kubectl create` → resource created
4. **Executor pod dies** (OOM, eviction, etc.)
5. Controller detects missing/failed pod → marks node `Pending`, increments `FailedPodRestarts`
6. `executeResource` re-enters → `ARGO_RESOURCE_TEMPLATE_RESTARTED=true` set on new executor container
7. New executor reads same manifest, applies same deterministic name, runs `kubectl create` → "already exists" → checks env var → falls back to `kubectl get -f` → retrieves existing resource
8. Proceeds to `WaitResource` → workflow completes normally

### Why the Restart Guard

The `isAlreadyExistsErr` recovery is guarded by the `ARGO_RESOURCE_TEMPLATE_RESTARTED` env var to preserve the original error behavior on first run. Without the guard, a user who accidentally targets an existing resource name with `kubectl create` would silently succeed instead of getting the expected "already exists" error. The guard ensures recovery only happens when the controller knows this is a restart (previous executor pod failed).

### Why This Approach

- **Preserves user semantics** — `create` stays as `create`, no silent action changes
- **Works for all manifest sources** — deterministic naming runs in the executor, so it works for both inline manifests and `manifestFrom` (artifact-loaded) templates
- **Safe recovery** — "already exists" is only recovered on restart, not on first run
- **Zero race conditions** — deterministic name is computed before any kubectl call
- **Follows existing patterns** — fnv32a hashing (same as `GeneratePodName`, `Workflow.NodeID`), env var passing (same as other `ARGO_*` env vars)
- **Minimal change** — executor-side naming + controller-side restart detection and env var

### Proof of Correctness

The fix is correct because of three independent guarantees:

1. **Deterministic naming eliminates duplicate resources.** The executor replaces `generateName` with a fixed `name` derived from the workflow node ID before running `kubectl create`. The same node ID always produces the same name ([fnv32a is deterministic](https://pkg.go.dev/hash/fnv)). This means every executor restart attempts to create the exact same resource — no orphaned duplicates.

2. **Restart guard prevents false recovery.** The `ARGO_RESOURCE_TEMPLATE_RESTARTED=true` env var is only set when `FailedPodRestarts > 0`. On first run, "already exists" errors propagate normally. On restart, the executor knows it's safe to recover because the controller confirmed a previous executor existed.

3. **`isAlreadyExistsErr` makes `kubectl create` idempotent on restart.** When the restarted executor runs `kubectl create` and the resource already exists, the [Kubernetes API returns `AlreadyExists`](https://kubernetes.io/docs/reference/using-api/api-concepts/#status-codes). The executor catches this, falls back to `kubectl get -f` to retrieve the existing resource's metadata (name, namespace, selfLink), and proceeds to `WaitResource` monitoring. The resource itself is untouched — only its status is monitored.

Together: deterministic name → same resource targeted on every restart. Restart guard → recovery only on actual restarts. `isAlreadyExistsErr` → graceful recovery when the resource was already created.

### Minikube Verification

Tested on minikube v1.35.0 (Kubernetes v1.35.0). Full test logs in PR comments.

| Step | Event |
|---|---|
| 1 | Workflow submitted, controller creates executor pod |
| 2 | Executor applies deterministic naming, creates Job `test-job-5f3b78c3`. First-run pod has NO `ARGO_RESOURCE_TEMPLATE_RESTARTED` env var |
| 3 | **Executor pod force-deleted** |
| 4 | Controller: "Resource template executor pod missing - marking as pending for re-creation" (restartCount=1) |
| 5 | Controller creates new executor pod WITH `ARGO_RESOURCE_TEMPLATE_RESTARTED=true` (15 env vars vs 14 on first run) |
| 6 | New executor: `kubectl create` → "already exists" → checks env var → `kubectl get` → retrieves existing Job |
| 7 | **Workflow Succeeded** — only 1 Job, no duplicates |

### Relevant Kubernetes Documentation

- [`kubectl create`](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/) — creates a resource, returns `AlreadyExists` if it exists
- [`generateName`](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/#ObjectMeta) — server-side random name generation
- [API error codes](https://kubernetes.io/docs/reference/using-api/api-concepts/#status-codes) — `409 Conflict` / `AlreadyExists` status

Fixes #15641

Signed-off-by: Andre Kurait <andrekurait@gmail.com>