### PR TITLE
fix: prevent expression injection in cherry-pick workflows

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -50,11 +50,14 @@ jobs:
 
       - name: Cherry pick commit
         id: cherry-pick
+        env:
+          MERGE_COMMIT: ${{ inputs.merge_commit_sha }}
+          VERSION_NUMBER: ${{ inputs.version_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -e
 
-          MERGE_COMMIT="${{ inputs.merge_commit_sha }}"
-          TARGET_BRANCH="release-${{ inputs.version_number }}"
+          TARGET_BRANCH="release-${VERSION_NUMBER}"
 
           echo "🍒 Cherry-picking commit $MERGE_COMMIT to branch $TARGET_BRANCH"
 
@@ -65,7 +68,7 @@ jobs:
           fi
 
           # Create new branch for cherry-pick
-          CHERRY_PICK_BRANCH="cherry-pick-${{ inputs.pr_number }}-to-${TARGET_BRANCH}"
+          CHERRY_PICK_BRANCH="cherry-pick-${PR_NUMBER}-to-${TARGET_BRANCH}"
           git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
 
           # Perform cherry-pick
@@ -89,33 +92,41 @@ jobs:
           fi
 
       - name: Create Pull Request
+        env:
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          VERSION_NUMBER: ${{ inputs.version_number }}
+          SIGNOFF: ${{ steps.cherry-pick.outputs.signoff }}
+          TARGET_BRANCH: ${{ steps.cherry-pick.outputs.target_branch }}
+          BRANCH_NAME: ${{ steps.cherry-pick.outputs.branch_name }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Create cherry-pick PR
-          TITLE="${PR_TITLE} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})"
+          TITLE="${PR_TITLE} (cherry-pick #${PR_NUMBER} for ${VERSION_NUMBER})"
           BODY=$(cat <<EOF
-          Cherry-picked ${PR_TITLE} (#${{ inputs.pr_number }})
+          Cherry-picked ${PR_TITLE} (#${PR_NUMBER})
 
-          ${{ steps.cherry-pick.outputs.signoff }}
+          ${SIGNOFF}
           EOF
           )
 
           gh pr create \
             --title "$TITLE" \
             --body "$BODY" \
-            --base "${{ steps.cherry-pick.outputs.target_branch }}" \
-            --head "${{ steps.cherry-pick.outputs.branch_name }}"
+            --base "$TARGET_BRANCH" \
+            --head "$BRANCH_NAME"
 
           # Comment on original PR
-          gh pr comment ${{ inputs.pr_number }} \
-            --body "🍒 Cherry-pick PR created for ${{ inputs.version_number }}: #$(gh pr list --head ${{ steps.cherry-pick.outputs.branch_name }} --json number --jq '.[0].number')"
-        env:
-          PR_TITLE: ${{ inputs.pr_title }}
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          gh pr comment "$PR_NUMBER" \
+            --body "🍒 Cherry-pick PR created for ${VERSION_NUMBER}: #$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')"
 
       - name: Comment on failure
         if: failure()
-        run: |
-          gh pr comment ${{ inputs.pr_number }} \
-            --body "❌ Cherry-pick failed for ${{ inputs.version_number }}. Please check the [workflow logs](https://github.com/argoproj/argo-workflows/actions/runs/${{ github.run_id }}) for details."
         env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          VERSION_NUMBER: ${{ inputs.version_number }}
+          RUN_ID: ${{ github.run_id }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body "❌ Cherry-pick failed for ${VERSION_NUMBER}. Please check the [workflow logs](https://github.com/argoproj/argo-workflows/actions/runs/${RUN_ID}) for details."

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -20,15 +20,18 @@ jobs:
     steps:
       - name: Extract cherry-pick labels
         id: extract-labels
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels) }}
         run: |
-          if [[ "${{ github.event.action }}" == "labeled" ]]; then
+          if [[ "$EVENT_ACTION" == "labeled" ]]; then
             # Label was just added - use it directly
-            LABEL_NAME="${{ github.event.label.name }}"
             VERSION="${LABEL_NAME#cherry-pick/}"
-            CHERRY_PICK_DATA='[{"label":"'$LABEL_NAME'","version":"'$VERSION'"}]'
+            CHERRY_PICK_DATA='[{"label":"'"$LABEL_NAME"'","version":"'"$VERSION"'"}]'
           else
             # PR was closed - find all cherry-pick labels
-            CHERRY_PICK_DATA=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -c '[.[] | select(.name | startswith("cherry-pick/")) | {label: .name, version: (.name | sub("cherry-pick/"; ""))}]')
+            CHERRY_PICK_DATA=$(echo "$PR_LABELS" | jq -c '[.[] | select(.name | startswith("cherry-pick/")) | {label: .name, version: (.name | sub("cherry-pick/"; ""))}]')
           fi
 
           echo "labels=$CHERRY_PICK_DATA" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Hardens the cherry-pick workflows against script injection by moving all `${{ }}` context/input interpolations out of `run:` shell scripts and into `env:` blocks.

- `cherry-pick.yml`: `github.event.action`, `github.event.label.name`, and `toJSON(github.event.pull_request.labels)` are now passed via env vars instead of being interpolated directly into the shell script
- `cherry-pick-single.yml`: all `inputs.*` and `steps.*.outputs.*` values in `run:` steps are now passed via env vars

## Why

Inline `${{ expression }}` interpolation in `run:` steps is evaluated before the shell executes, meaning a crafted value can break out of the intended string context and execute arbitrary commands. While the practical risk here is low (labels are maintainer-only, and the workflow only fires on merged PRs), the pattern is unsafe by construction and hardening it is cheap. This is consistent with the fix applied in the `feature-file-ci` PR and follows the same guidance highlighted by the Trivy supply-chain incident.

## References
- [GitHub Docs: Security hardening — Understand the risk of script injections](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)

## Test plan
- [ ] Trigger a cherry-pick by adding a `cherry-pick/v3.6` label to a merged PR — workflow should behave identically to before
- [ ] Verify the failure comment path works on a conflict scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)