### PR TITLE
fix: move workflow field extraction inside s.Run closures to prevent nil pointer panic on test re-run

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1029,9 +1029,9 @@ func (s *ArgoServerSuite) TestWorkflowService() {
 }
 
 func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
-	var bobWf *httpexpect.Value
+	var uidBobWf, nameBobWf string
 	s.Run("CreateArchivedBobWf", func() {
-		bobWf = (s.e().POST("/api/v1/workflows/argo").
+		bobWf := s.e().POST("/api/v1/workflows/argo").
 			WithBytes([]byte(`{
 				  "workflow": {
 					"metadata": {
@@ -1054,16 +1054,14 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 					}
 				  }
 				}`)).
-			Expect().Status(200).JSON())
+			Expect().Status(200).JSON()
+		uidBobWf = bobWf.Path("$.metadata.uid").NotNull().String().Raw()
+		nameBobWf = bobWf.Path("$.metadata.name").NotNull().String().Raw()
 	})
-	var uidBobWf = bobWf.Path("$.metadata.uid").
-		NotNull().String().Raw()
-	var nameBobWf = bobWf.Path("$.metadata.name").
-		NotNull().String().Raw()
 
-	var aliceWf *httpexpect.Value
+	var uidAliceWf, nameAliceWf string
 	s.Run("CreateAlice", func() {
-		aliceWf = (s.e().POST("/api/v1/workflows/argo").
+		aliceWf := s.e().POST("/api/v1/workflows/argo").
 			WithBytes([]byte(`{
 				  "workflow": {
 					"metadata": {
@@ -1086,12 +1084,10 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 					}
 				  }
 				}`)).
-			Expect().Status(200).JSON())
+			Expect().Status(200).JSON()
+		uidAliceWf = aliceWf.Path("$.metadata.uid").NotNull().String().Raw()
+		nameAliceWf = aliceWf.Path("$.metadata.name").NotNull().String().Raw()
 	})
-	var uidAliceWf = aliceWf.Path("$.metadata.uid").
-		NotNull().String().Raw()
-	var nameAliceWf = aliceWf.Path("$.metadata.name").
-		NotNull().String().Raw()
 
 	s.Given().When().
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameBobWf}).
@@ -1215,9 +1211,9 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 }
 
 func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
-	var bobWf *httpexpect.Value
+	var uidBobWf, nameBobWf string
 	s.Run("CreateArchivedBobWf", func() {
-		bobWf = (s.e().POST("/api/v1/workflows/argo").
+		bobWf := s.e().POST("/api/v1/workflows/argo").
 			WithBytes([]byte(`{
 				  "workflow": {
 					"metadata": {
@@ -1240,16 +1236,14 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 					}
 				  }
 				}`)).
-			Expect().Status(200).JSON())
+			Expect().Status(200).JSON()
+		uidBobWf = bobWf.Path("$.metadata.uid").NotNull().String().Raw()
+		nameBobWf = bobWf.Path("$.metadata.name").NotNull().String().Raw()
 	})
-	var uidBobWf = bobWf.Path("$.metadata.uid").
-		NotNull().String().Raw()
-	var nameBobWf = bobWf.Path("$.metadata.name").
-		NotNull().String().Raw()
 
-	var aliceWf *httpexpect.Value
+	var uidAliceWf, nameAliceWf string
 	s.Run("CreateAlice", func() {
-		aliceWf = (s.e().POST("/api/v1/workflows/argo").
+		aliceWf := s.e().POST("/api/v1/workflows/argo").
 			WithBytes([]byte(`{
 				  "workflow": {
 					"metadata": {
@@ -1272,12 +1266,10 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 					}
 				  }
 				}`)).
-			Expect().Status(200).JSON())
+			Expect().Status(200).JSON()
+		uidAliceWf = aliceWf.Path("$.metadata.uid").NotNull().String().Raw()
+		nameAliceWf = aliceWf.Path("$.metadata.name").NotNull().String().Raw()
 	})
-	var uidAliceWf = aliceWf.Path("$.metadata.uid").
-		NotNull().String().Raw()
-	var nameAliceWf = aliceWf.Path("$.metadata.name").
-		NotNull().String().Raw()
 
 	s.Given().When().
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameBobWf}).


### PR DESCRIPTION
Fixes #15646

## What

Move workflow field extraction (`uid`, `name`) inside `s.Run()` closures in `TestWorkflowArchiveServiceList` and `TestWorkflowServiceListArchived` to prevent nil pointer panic on test re-run.

## Why

Both tests set `bobWf`/`aliceWf` inside `s.Run()` subtests but extract `uid`/`name` outside them. On re-run, the closures don't re-execute, leaving the variables nil, causing a panic at the `.Path()` call.

```go
// Before (broken):
var bobWf *httpexpect.Value
s.Run("CreateArchivedBobWf", func() {
    bobWf = s.e().POST(...).Expect().Status(200).JSON()
})
var uidBobWf = bobWf.Path("$.metadata.uid")  // panics when bobWf is nil on re-run
```

```go
// After (fixed):
var uidBobWf, nameBobWf string
s.Run("CreateArchivedBobWf", func() {
    bobWf := s.e().POST(...).Expect().Status(200).JSON()
    uidBobWf = bobWf.Path("$.metadata.uid").NotNull().String().Raw()
    nameBobWf = bobWf.Path("$.metadata.name").NotNull().String().Raw()
})
```

## CI Evidence

This test panics consistently on re-run in CI on `main`:
- https://github.com/argoproj/argo-workflows/actions/runs/22465028354
- https://github.com/argoproj/argo-workflows/actions/runs/22454215475

## Changes

**1 file changed, +20/-28 lines** — `test/e2e/argo_server_test.go`