### PR TITLE
feat: pause the running pod based on the existence of a file

### DIFF
--- a/.features/pending/pause-running-pod.md
+++ b/.features/pending/pause-running-pod.md
@@ -1,0 +1,11 @@
+Description: Pause the running pod after container exit based on file existence or environment variable
+Author: [guanguxiansheng](https://github.com/guanguxiansheng)
+Component: General
+Issues: 0
+
+When the main process in the container exits, the emissary can optionally pause instead of exiting immediately.
+This allows attaching to the pod for debugging (e.g. inspecting logs or the filesystem).
+
+Pause is triggered when either the file `{varRunArgo}/ctr/{containerName}/after-pause` exists, or the environment variable `ARGO_DEBUG_PAUSE_AFTER` is set to `"true"`.
+
+To resume and release the container, create the file `{varRunArgo}/ctr/{containerName}/after` (or remove the `after-pause` file when using file-based trigger).

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -253,7 +253,7 @@ func NewEmissaryCommand() *cobra.Command {
 			})
 			logger.WithError(cmdErr).Info(ctx, "sub-process exited")
 
-			if os.Getenv("ARGO_DEBUG_PAUSE_AFTER") == "true" {
+			if _, err := os.Stat(varRunArgo + "/ctr/" + containerName + "/after-pause"); err == nil || os.Getenv("ARGO_DEBUG_PAUSE_AFTER") == "true" {
 				for {
 					// User can create the file: /ctr/NAME_OF_THE_CONTAINER/after
 					// in order to break out of the sleep and release the container from


### PR DESCRIPTION
### Motivation

If the environment variable `ARGO_DEBUG_PAUSE_AFTER` is not configured as `true` before the Pod is created, it is impossible to pause a running Pod. However, in actual production tasks, users often need to temporarily pause running Pods for on-site analysis. In these scenarios, the Pods do not have the `ARGO_DEBUG_PAUSE_AFTER` environment variable configured in advance, so an additional method for Pod pause needs to be provided.


### Modifications

Add a way to pause a running Pod: Before emissary exits, check if the file `/var/run/argo/ctr/{containerName}/after-pause` exists; if it exists, then pause the Pod.

