### PR TITLE
fix(docs): use server-side apply in quick-start guide for v4.0+ compatibility

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -31,7 +31,7 @@ Then, copy the commands below to apply the quick-start manifest:
 
 ```bash
 kubectl create namespace argo
-kubectl apply -n argo -f "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_WORKFLOWS_VERSION}/quick-start-minimal.yaml"
+kubectl apply --server-side -n argo -f "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_WORKFLOWS_VERSION}/quick-start-minimal.yaml"
 ```
 
 ## Install the Argo Workflows CLI


### PR DESCRIPTION
Fixes #15629

Since v4.0, the release manifests include CRDs with full validation schemas 
(instead of minimal CRDs). These CRDs are large (~10MB) and exceed the 
Kubernetes annotation size limit of 262144 bytes when applied with the 
standard `kubectl apply` command, which stores the entire manifest in the 
`kubectl.kubernetes.io/last-applied-configuration` annotation.

The fix is to use `kubectl apply --server-side`, which uses Server-Side 
Apply (SSA) and does not store the full manifest in client-side annotations, 
bypassing the size limit entirely.

This is already documented in the [installation docs](https://argo-workflows.readthedocs.io/en/latest/installation/):
> "They must be applied using server-side apply to workaround Kubernetes size limits."

However, the quick-start guide was not updated accordingly.

## Changes

- Updated `docs/quick-start.md` to use `kubectl apply --server-side` in the 
  install command.

## Checklist

- [x] Documentation updated
- [x] Fixes a regression introduced in v4.0