### PR TITLE
fix: resolve race conditions in cron controller. Fixes #12625

### DIFF
--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/argoproj/pkg/sync"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -55,13 +55,31 @@ type Controller struct {
 	eventRecorderManager events.EventRecorderManager
 	cronWorkflowWorkers  int
 	logger               logging.Logger
+	wfInformer           cache.SharedIndexInformer
 }
 
 const (
 	cronWorkflowResyncPeriod = 20 * time.Minute
+	cronwfIndex              = "cronworkflow"
 )
 
-var cronSyncPeriod time.Duration
+var (
+	cronSyncPeriod time.Duration
+	indexes        = cache.Indexers{
+		cronwfIndex: func(rawObj any) ([]string, error) {
+			obj, err := meta.Accessor(rawObj)
+			if err != nil {
+				return []string{}, err
+			}
+
+			owner := v1.GetControllerOf(obj)
+			if owner == nil || owner.Kind != workflow.CronWorkflowKind {
+				return []string{}, nil
+			}
+			return []string{string(owner.UID)}, nil
+		},
+	}
+)
 
 func init() {
 	// this make sure we support timezones
@@ -112,18 +130,27 @@ func (cc *Controller) Run(ctx context.Context) {
 		cc.logger.WithFatal().Error(ctx, err.Error())
 	}
 
-	wfInformer := util.NewWorkflowInformer(ctx, cc.dynamicInterface, cc.managedNamespace, cronWorkflowResyncPeriod,
+	cc.wfInformer = util.NewWorkflowInformer(ctx, cc.dynamicInterface, cc.managedNamespace, cronWorkflowResyncPeriod,
 		func(options *v1.ListOptions) { wfInformerListOptionsFunc(options, cc.instanceID) },
 		func(options *v1.ListOptions) { wfInformerListOptionsFunc(options, cc.instanceID) },
-		cache.Indexers{})
-	go wfInformer.Run(ctx.Done())
+		indexes,
+	)
+	go cc.wfInformer.Run(ctx.Done())
 
-	cc.wfLister = util.NewWorkflowLister(ctx, wfInformer)
+	cc.wfLister = util.NewWorkflowLister(ctx, cc.wfInformer)
 
 	cc.cron.Start()
 	defer cc.cron.Stop()
 
 	go cc.cronWfInformer.Informer().Run(ctx.Done())
+
+	if !cache.WaitForCacheSync(
+		ctx.Done(),
+		cc.wfInformer.HasSynced,
+		cc.cronWfInformer.Informer().HasSynced,
+	) {
+		cc.logger.WithFatal().Error(ctx, "Timed out waiting for caches to sync")
+	}
 
 	go wait.UntilWithContext(ctx, cc.syncAll, cronSyncPeriod)
 
@@ -179,7 +206,7 @@ func (cc *Controller) processNextCronItem(ctx context.Context) bool {
 	}
 	ctx = wfctx.InjectObjectMeta(ctx, &cronWf.ObjectMeta)
 
-	cronWorkflowOperationCtx := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults)
+	cronWorkflowOperationCtx := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults, cc.keyLock)
 
 	err = cronWorkflowOperationCtx.validateCronWorkflow(ctx)
 	if err != nil {
@@ -264,27 +291,9 @@ func (cc *Controller) syncAll(ctx context.Context) {
 
 	cc.logger.Debug(ctx, "Syncing all CronWorkflows")
 
-	workflows, err := cc.wfLister.List()
-	if err != nil {
-		return
-	}
-	groupedWorkflows := groupWorkflows(workflows)
-
-	cronWorkflows := cc.cronWfInformer.Informer().GetStore().List()
-	for _, obj := range cronWorkflows {
-		un, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			cc.logger.Error(ctx, "Unable to convert object to unstructured when syncing CronWorkflows")
-			continue
-		}
-		cronWf := &v1alpha1.CronWorkflow{}
-		err := util.FromUnstructuredObj(un, cronWf)
-		if err != nil {
-			cc.logger.WithError(err).Error(ctx, "Unable to convert unstructured to CronWorkflow when syncing CronWorkflows")
-			continue
-		}
-
-		err = cc.syncCronWorkflow(ctx, cronWf, groupedWorkflows[cronWf.UID])
+	keys := cc.cronWfInformer.Informer().GetStore().ListKeys()
+	for _, key := range keys {
+		err := cc.syncCronWorkflow(ctx, key)
 		if err != nil {
 			cc.logger.WithError(err).Error(ctx, "Unable to sync CronWorkflow")
 			continue
@@ -292,34 +301,41 @@ func (cc *Controller) syncAll(ctx context.Context) {
 	}
 }
 
-func (cc *Controller) syncCronWorkflow(ctx context.Context, cronWf *v1alpha1.CronWorkflow, workflows []v1alpha1.Workflow) error {
-	key := cronWf.Namespace + "/" + cronWf.Name
+func (cc *Controller) syncCronWorkflow(ctx context.Context, key string) error {
 	cc.keyLock.Lock(key)
 	defer cc.keyLock.Unlock(key)
 
-	cwoc := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults)
-	err := cwoc.enforceHistoryLimit(ctx, workflows)
+	obj, _, err := cc.cronWfInformer.Informer().GetStore().GetByKey(key)
 	if err != nil {
 		return err
 	}
-	err = cwoc.reconcileActiveWfs(ctx, workflows)
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("key in index is not an unstructured")
+	}
+
+	cronWf := &v1alpha1.CronWorkflow{}
+	err = util.FromUnstructuredObj(un, cronWf)
+	if err != nil {
+		return err
+	}
+
+	wfs, err := cc.wfLister.ListByIndex(cronwfIndex, string(cronWf.UID))
+	if err != nil {
+		return err
+	}
+
+	cwoc := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults, cc.keyLock)
+	err = cwoc.enforceHistoryLimit(ctx, wfs)
+	if err != nil {
+		return err
+	}
+	err = cwoc.reconcileActiveWfs(ctx, wfs)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func groupWorkflows(wfs []*v1alpha1.Workflow) map[types.UID][]v1alpha1.Workflow {
-	cwfChildren := make(map[types.UID][]v1alpha1.Workflow)
-	for _, wf := range wfs {
-		owner := v1.GetControllerOf(wf)
-		if owner == nil || owner.Kind != workflow.CronWorkflowKind {
-			continue
-		}
-		cwfChildren[owner.UID] = append(cwfChildren[owner.UID], *wf)
-	}
-	return cwfChildren
 }
 
 func cronWfInformerListOptionsFunc(options *v1.ListOptions, instanceID string) {

--- a/workflow/cron/controller_test.go
+++ b/workflow/cron/controller_test.go
@@ -1,0 +1,148 @@
+package cron
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/argoproj/pkg/sync"
+	"github.com/robfig/cron/v3"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	fakewfclientset "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/scheme"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+	"github.com/argoproj/argo-workflows/v4/util/telemetry"
+	"github.com/argoproj/argo-workflows/v4/workflow/metrics"
+	"github.com/argoproj/argo-workflows/v4/workflow/util"
+)
+
+var secondParser = cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+// create new controller configured with fake clients.
+func newTestCronWorkflowController(t *testing.T) (context.Context, context.CancelFunc, *Controller) {
+	objects := []runtime.Object{}
+	wfClientset := fakewfclientset.NewSimpleClientset(objects...)
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
+	ctx, cancel := context.WithCancel(t.Context())
+	ctx = logging.TestContext(ctx)
+
+	testMetrics, err := metrics.New(logging.TestContext(t.Context()), telemetry.TestScopeName, telemetry.TestScopeName, &telemetry.MetricsConfig{}, metrics.Callbacks{})
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	cc := &Controller{
+		wfClientset:      wfClientset,
+		namespace:        "default",
+		managedNamespace: "default",
+		instanceID:       "test",
+		keyLock:          sync.NewKeyLock(),
+		dynamicInterface: dynamicClient,
+		cronWfQueue:      testMetrics.RateLimiterWithBusyWorkers(ctx, workqueue.DefaultTypedControllerRateLimiter[string](), "cron_wf_queue"),
+		metrics:          testMetrics,
+	}
+
+	cc.cronWfInformer = dynamicinformer.NewFilteredDynamicSharedInformerFactory(cc.dynamicInterface, cronWorkflowResyncPeriod,
+		cc.managedNamespace, func(_ *metav1.ListOptions) {}).
+		ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.CronWorkflowPlural})
+	_ = cc.addCronWorkflowInformerHandler(ctx)
+	go cc.cronWfInformer.Informer().Run(ctx.Done())
+
+	cc.wfInformer = util.NewWorkflowInformer(ctx, cc.dynamicInterface, cc.managedNamespace, cronWorkflowResyncPeriod,
+		func(_ *metav1.ListOptions) {}, func(_ *metav1.ListOptions) {}, indexes)
+	go cc.wfInformer.Run(ctx.Done())
+	cc.wfLister = util.NewWorkflowLister(ctx, cc.wfInformer)
+
+	for _, c := range []cache.SharedIndexInformer{
+		cc.wfInformer,
+		cc.cronWfInformer.Informer(),
+	} {
+		for !c.HasSynced() {
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	return ctx, cancel, cc
+}
+
+var helloWf = `
+  apiVersion: argoproj.io/v1alpha1
+  kind: CronWorkflow
+  metadata:
+    name: hello-world
+  spec:
+    schedules:
+      - "* * * * *"
+    concurrencyPolicy: Replace
+    startingDeadlineSeconds: 120
+    workflowSpec:
+      entrypoint: whalesay
+      templates:
+        - name: whalesay
+          container:
+            image: argoproj/argosay:v2
+`
+
+// Ensure that cron job runs are blocked by the keyLock being held.
+func TestCronJobRace(t *testing.T) {
+	ctx, cancel, cc := newTestCronWorkflowController(t)
+	defer cancel()
+
+	var cronWf v1alpha1.CronWorkflow
+	v1alpha1.MustUnmarshal([]byte(helloWf), &cronWf)
+	cwf, err := cc.wfClientset.ArgoprojV1alpha1().CronWorkflows("default").Create(ctx, &cronWf, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating cronworkflow: %s", err.Error())
+	}
+	un, err := util.CronToUnstructured(cwf)
+	if err != nil {
+		t.Fatalf("error converting to unstructured: %s", err.Error())
+	}
+	err = cc.cronWfInformer.Informer().GetStore().Add(un)
+	if err != nil {
+		t.Fatalf("error adding cronworkflow to informer cache: %s", err.Error())
+	}
+	cwoc := newCronWfOperationCtx(ctx, cwf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults, cc.keyLock)
+
+	// start cron scheduler with second resolution schedule support to make the test run quicker.
+	cron := newCronFacade(cron.WithParser(secondParser))
+	cron.Start()
+	defer cron.Stop()
+	key, err := cache.MetaNamespaceKeyFunc(cwf)
+	if err != nil {
+		t.Fatalf("error getting key from cronworkflow: %s", err.Error())
+	}
+
+	// Lock is held until test ends which should prevent the cron run from mutating the cronworkflow.
+	// This emulates an active execution of processNextCronItem or syncCronWorkflow.
+	cc.keyLock.Lock(key)
+	defer cc.keyLock.Unlock(key)
+
+	// Schedule job to run every second
+	_, err = cron.AddJob(key, "* * * * * *", cwoc)
+	if err != nil {
+		t.Fatalf("error adding cron job: %s", err.Error())
+	}
+	// Sleep for slightly longer than a second to let the job attempt to run.
+	time.Sleep(1*time.Second + 50*time.Millisecond)
+	cron.Delete(key)
+
+	afterCwf, err := cc.wfClientset.ArgoprojV1alpha1().CronWorkflows("default").Get(ctx, "hello-world", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error: %s", err.Error())
+	}
+
+	// Since the lock is still held this should still be 0
+	if len(afterCwf.Status.Active) > 0 {
+		t.Errorf("cronworkflow has non-empty .status.active")
+	}
+}

--- a/workflow/cron/cron_facade.go
+++ b/workflow/cron/cron_facade.go
@@ -18,9 +18,9 @@ type cronFacade struct {
 
 type ScheduledTimeFunc func(ctx context.Context) time.Time
 
-func newCronFacade() *cronFacade {
+func newCronFacade(opts ...cron.Option) *cronFacade {
 	return &cronFacade{
-		cron:     cron.New(),
+		cron:     cron.New(opts...),
 		entryIDs: make(map[string][]cron.EntryID),
 	}
 }

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/Knetic/govaluate"
+	"github.com/argoproj/pkg/sync"
 	"github.com/robfig/cron/v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	argoerrs "github.com/argoproj/argo-workflows/v4/errors"
 
@@ -54,12 +56,13 @@ type cronWfOperationCtx struct {
 	// scheduledTimeFunc returns the last scheduled time when it is called
 	scheduledTimeFunc ScheduledTimeFunc
 	//nolint: containedctx
-	ctx context.Context
+	ctx     context.Context
+	keylock sync.KeyLock
 }
 
 func newCronWfOperationCtx(ctx context.Context, cronWorkflow *v1alpha1.CronWorkflow, wfClientset versioned.Interface,
 	metrics *metrics.Metrics, wftmplInformer wfextvv1alpha1.WorkflowTemplateInformer,
-	cwftmplInformer wfextvv1alpha1.ClusterWorkflowTemplateInformer, wfDefaults *v1alpha1.Workflow,
+	cwftmplInformer wfextvv1alpha1.ClusterWorkflowTemplateInformer, wfDefaults *v1alpha1.Workflow, keyLock sync.KeyLock,
 ) *cronWfOperationCtx {
 	log := logging.RequireLoggerFromContext(ctx)
 	return &cronWfOperationCtx{
@@ -74,6 +77,7 @@ func newCronWfOperationCtx(ctx context.Context, cronWorkflow *v1alpha1.CronWorkf
 			"workflow":  cronWorkflow.Name,
 			"namespace": cronWorkflow.Namespace,
 		}),
+		keylock: keyLock,
 		metrics: metrics,
 		// inferScheduledTime returns an inferred scheduled time based on the current time and only works if it is called
 		// within 59 seconds of the scheduled time. Here it acts as a placeholder until it is replaced by a similar
@@ -88,6 +92,13 @@ func newCronWfOperationCtx(ctx context.Context, cronWorkflow *v1alpha1.CronWorkf
 // Run handles the running of a cron workflow
 // It fits the github.com/robfig/cron.Job interface
 func (woc *cronWfOperationCtx) Run() {
+	key, err := cache.MetaNamespaceKeyFunc(woc.cronWf)
+	if err != nil {
+		woc.log.Error(woc.ctx, "failed to get key for object")
+		return
+	}
+	woc.keylock.Lock(key)
+	defer woc.keylock.Unlock(key)
 	woc.run(woc.ctx, woc.scheduledTimeFunc(woc.ctx))
 }
 
@@ -360,7 +371,7 @@ type fulfilledWfsPhase struct {
 	phase     v1alpha1.WorkflowPhase
 }
 
-func (woc *cronWfOperationCtx) reconcileActiveWfs(ctx context.Context, workflows []v1alpha1.Workflow) error {
+func (woc *cronWfOperationCtx) reconcileActiveWfs(ctx context.Context, workflows []*v1alpha1.Workflow) error {
 	updated := false
 	currentWfsFulfilled := make(map[types.UID]fulfilledWfsPhase, len(workflows))
 	for _, wf := range workflows {
@@ -370,7 +381,7 @@ func (woc *cronWfOperationCtx) reconcileActiveWfs(ctx context.Context, workflows
 		}
 		if !woc.cronWf.Status.HasActiveUID(wf.UID) && !wf.Status.Fulfilled() {
 			updated = true
-			woc.cronWf.Status.Active = append(woc.cronWf.Status.Active, getWorkflowObjectReference(&wf, &wf))
+			woc.cronWf.Status.Active = append(woc.cronWf.Status.Active, getWorkflowObjectReference(wf, wf))
 		}
 	}
 
@@ -407,11 +418,11 @@ func (woc *cronWfOperationCtx) removeFromActiveList(uid types.UID) {
 	woc.cronWf.Status.Active = newActive
 }
 
-func (woc *cronWfOperationCtx) enforceHistoryLimit(ctx context.Context, workflows []v1alpha1.Workflow) error {
+func (woc *cronWfOperationCtx) enforceHistoryLimit(ctx context.Context, workflows []*v1alpha1.Workflow) error {
 	woc.log.WithField("name", woc.cronWf.Name).Debug(ctx, "Enforcing history limit")
 
-	var successfulWorkflows []v1alpha1.Workflow
-	var failedWorkflows []v1alpha1.Workflow
+	var successfulWorkflows []*v1alpha1.Workflow
+	var failedWorkflows []*v1alpha1.Workflow
 	for _, wf := range workflows {
 		if wf.Labels[common.LabelKeyCronWorkflow] != woc.cronWf.Name {
 			continue
@@ -445,7 +456,7 @@ func (woc *cronWfOperationCtx) enforceHistoryLimit(ctx context.Context, workflow
 	return nil
 }
 
-func (woc *cronWfOperationCtx) deleteOldestWorkflows(ctx context.Context, jobList []v1alpha1.Workflow, workflowsToKeep int) error {
+func (woc *cronWfOperationCtx) deleteOldestWorkflows(ctx context.Context, jobList []*v1alpha1.Workflow, workflowsToKeep int) error {
 	if workflowsToKeep >= len(jobList) {
 		return nil
 	}

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/argoproj/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,6 +227,11 @@ func (f fakeLister) List() ([]*v1alpha1.Workflow, error) {
 	return nil, nil
 }
 
+func (f fakeLister) ListByIndex(_, _ string) ([]*v1alpha1.Workflow, error) {
+	// Do nothing
+	return nil, nil
+}
+
 var _ util.WorkflowLister = &fakeLister{}
 
 var invalidWf = `
@@ -271,6 +277,7 @@ func TestCronWorkflowConditionSubmissionError(t *testing.T) {
 		metrics:           testMetrics,
 		scheduledTimeFunc: inferScheduledTime,
 		ctx:               ctx,
+		keylock:           sync.NewKeyLock(),
 	}
 	woc.Run()
 
@@ -354,6 +361,7 @@ func TestScheduleTimeParam(t *testing.T) {
 		metrics:           testMetrics,
 		scheduledTimeFunc: inferScheduledTime,
 		ctx:               ctx,
+		keylock:           sync.NewKeyLock(),
 	}
 	woc.Run()
 	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(ctx, v1.ListOptions{})
@@ -539,6 +547,7 @@ func TestMultipleSchedules(t *testing.T) {
 		metrics:           testMetrics,
 		scheduledTimeFunc: inferScheduledTime,
 		ctx:               ctx,
+		keylock:           sync.NewKeyLock(),
 	}
 	woc.Run()
 	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(ctx, v1.ListOptions{})

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -100,6 +100,7 @@ func InstanceIDRequirement(instanceID string) labels.Requirement {
 // an Unstructured informer and converting objects to workflows. Ignores objects that failed to convert.
 type WorkflowLister interface {
 	List() ([]*wfv1.Workflow, error)
+	ListByIndex(string, string) ([]*wfv1.Workflow, error)
 }
 
 type workflowLister struct {
@@ -113,6 +114,24 @@ func (l *workflowLister) List() ([]*wfv1.Workflow, error) {
 		wf, err := FromUnstructured(m.(*unstructured.Unstructured))
 		if err != nil {
 			l.log.WithField("workflow", m).WithError(err).Warn(context.Background(), "Failed to unmarshal workflow object")
+			continue
+		}
+		workflows = append(workflows, wf)
+	}
+	return workflows, nil
+}
+
+func (l *workflowLister) ListByIndex(index, key string) ([]*wfv1.Workflow, error) {
+	workflows := make([]*wfv1.Workflow, 0)
+	objs, err := l.informer.GetIndexer().ByIndex(index, key)
+	if err != nil {
+		return workflows, err
+	}
+
+	for _, m := range objs {
+		wf, err := FromUnstructured(m.(*unstructured.Unstructured))
+		if err != nil {
+			l.log.WithField("workflow", m).WithError(err).Warn(context.Background(), "Failed to unmarshal workflow")
 			continue
 		}
 		workflows = append(workflows, wf)
@@ -165,6 +184,19 @@ func ToUnstructured(wf *wfv1.Workflow) (*unstructured.Unstructured, error) {
 	un := &unstructured.Unstructured{Object: obj}
 	// we need to add these values so that the `EventRecorder` does not error
 	un.SetKind(workflow.WorkflowKind)
+	un.SetAPIVersion(workflow.APIVersion)
+	return un, nil
+}
+
+// CronToUnstructured converts a cronworkflow to an Unstructured object
+func CronToUnstructured(cwf *wfv1.CronWorkflow) (*unstructured.Unstructured, error) {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cwf)
+	if err != nil {
+		return nil, err
+	}
+	un := &unstructured.Unstructured{Object: obj}
+	// we need to add these values so that the `EventRecorder` does not error
+	un.SetKind(workflow.CronWorkflowKind)
 	un.SetAPIVersion(workflow.APIVersion)
 	return un, nil
 }

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1357,6 +1357,15 @@ func TestToUnstructured(t *testing.T) {
 	assert.Equal(t, workflow.Version, gv.Version)
 }
 
+func TestCronToUnstructured(t *testing.T) {
+	un, err := CronToUnstructured(&wfv1.CronWorkflow{})
+	require.NoError(t, err)
+	gv := un.GetObjectKind().GroupVersionKind()
+	assert.Equal(t, workflow.CronWorkflowKind, gv.Kind)
+	assert.Equal(t, workflow.Group, gv.Group)
+	assert.Equal(t, workflow.Version, gv.Version)
+}
+
 func TestGetTemplateFromNode(t *testing.T) {
 	cases := []struct {
 		inputNode            wfv1.NodeStatus


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #12625

### Motivation

<!-- TODO: Say why you made your changes. -->
Fixes race conditions in the cronworkflow controller which can lead to repeated workflow failures.

When the cron engine starts a scheduled job the corresponding cronworkflow key lock isn't acquired. This allows for cases where other paths in the controller can operate on a cwf that is actively being processed. Without this lock being held the same cwf can be attempted to processed concurrently leading to conflicts and spurious workflow terminations.

The controller sync process can run into a read before lock issue due to the sequencing of listing the current set of cronworkflows prior to acquiring the key lock. This can result in the sync process operating on stale data.

See [this comment](https://github.com/argoproj/argo-workflows/issues/12625#issuecomment-3500012379) on the related issue for more details.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
* Changes how the cron controller `syncAll` flow handles processing objects to resolve a read before lock bug.
* Adds missing locking to cron engine job entry method `cronWfOperationCtx.Run`.

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
N/A