### PR TITLE
fix: correct TTL strategy precedence comment in gc-ttl example

### DIFF
--- a/examples/gc-ttl.yaml
+++ b/examples/gc-ttl.yaml
@@ -7,7 +7,7 @@ metadata:
   generateName: gc-ttl-
 spec:
   ttlStrategy:
-    secondsAfterCompletion: 10 # Time to live after the workflow is completed, regardless of its status (overrides secondsAfterSuccess and secondsAfterFailure).
+    secondsAfterCompletion: 10 # Time to live after the workflow is completed, regardless of its status (overridden by secondsAfterSuccess and secondsAfterFailure).
     secondsAfterSuccess: 5     # Time to live after workflow is successful
     secondsAfterFailure: 5     # Time to live after workflow fails
   entrypoint: hello-world


### PR DESCRIPTION
The comment incorrectly stated that secondsAfterCompletion 'overrides' secondsAfterSuccess and secondsAfterFailure. Based on the implementation in workflow/gccontroller/gc_controller.go, the precedence is actually the opposite: secondsAfterSuccess and secondsAfterFailure take priority over secondsAfterCompletion. The comment now correctly states 'overridden by'.

### Motivation

The comment in the `gc-ttl.yaml` example incorrectly states that `secondsAfterCompletion` "overrides" `secondsAfterSuccess` and `secondsAfterFailure`. This is misleading because the actual implementation shows the opposite behavior.

### Modifications

Changed the comment on line 10 of `examples/gc-ttl.yaml` from:
- `(overrides secondsAfterSuccess and secondsAfterFailure)`

To:
- `(overridden by secondsAfterSuccess and secondsAfterFailure)`

This correctly reflects the precedence logic implemented in `workflow/gccontroller/gc_controller.go` (lines 259-272), where `secondsAfterSuccess` and `secondsAfterFailure` take priority over `secondsAfterCompletion`.

### Verification

Reviewed the implementation in `workflow/gccontroller/gc_controller.go` which shows the switch statement checks `secondsAfterFailure` and `secondsAfterSuccess` before falling back to `secondsAfterCompletion`.

### Documentation

This is a documentation fix in an example file. The correction makes the comment accurate and helps users understand the correct precedence behavior of TTL strategy fields. No additional documentation updates needed as this only corrects an existing comment.