### PR TITLE
fix: prevent double custom metric emission when retryStrategy is configured

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2038,6 +2038,19 @@ func getRetryNodeChildrenIds(node *wfv1.NodeStatus, nodes wfv1.Nodes) []string {
 	return childrenIds
 }
 
+func (woc *wfOperationCtx) hasRetryParent(node *wfv1.NodeStatus) bool {
+	for _, n := range woc.wf.Status.Nodes {
+		if n.Type == wfv1.NodeTypeRetry {
+			for _, childID := range n.Children {
+				if childID == node.ID {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func buildRetryStrategyLocalScope(node *wfv1.NodeStatus, nodes wfv1.Nodes) map[string]any {
 	localScope := make(map[string]any)
 
@@ -2538,8 +2551,10 @@ func (woc *wfOperationCtx) handleNodeFulfilled(ctx context.Context, nodeName str
 		// Check if this node completed between executions. If it did, emit metrics.
 		// We can infer that this node completed during the current operation, emit metrics
 		if prevNodeStatus, ok := woc.preExecutionNodeStatuses[node.ID]; ok && !prevNodeStatus.Fulfilled() {
-			localScope, realTimeScope := woc.prepareMetricScope(node)
-			woc.computeMetrics(ctx, processedTmpl.Metrics.Prometheus, localScope, realTimeScope, false)
+			if !woc.hasRetryParent(node) {
+				localScope, realTimeScope := woc.prepareMetricScope(node)
+				woc.computeMetrics(ctx, processedTmpl.Metrics.Prometheus, localScope, realTimeScope, false)
+			}
 		}
 	}
 	return node

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5837,6 +5837,56 @@ func TestWorkflowStatusMetric(t *testing.T) {
 	assert.Len(t, woc.wf.Status.Conditions, 2)
 }
 
+var workflowDoubleMetricWithRetry = `
+metadata:
+  name: test-double-metrics
+  namespace: default
+spec:
+  entrypoint: simple-task
+  templates:
+  - name: simple-task
+    retryStrategy:
+      limit: "2"
+      retryPolicy: Always
+    metrics:
+      prometheus:
+      - name: workflow_counter
+        help: "Counter should increment by 1"
+        labels:
+        - key: status
+          value: "{{status}}"
+        counter:
+          value: "1"
+    container:
+      image: busybox
+      command: [sh, -c]
+      args: ["exit 0"]
+`
+
+func TestCustomMetricsNotDoubleEmittedWithRetryStrategy(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(workflowDoubleMetricWithRetry)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	// First operate: Argo creates the pod node naturally
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	// Simulate pod completing successfully
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+
+	// Second operate: pod Succeeded is detected, retry node fulfills, metrics emit
+	woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
+	woc.operate(ctx)
+
+	// Counter must be exactly 1.0 — not 2.0 (the bug)
+	metricKey := "workflow_counter{status=Succeeded,}"
+	val, ok := controller.metrics.GetCustomMetricValue("workflow_counter", metricKey)
+	require.True(t, ok, "workflow_counter metric should exist after operate()")
+	assert.InDelta(t, 1.0, val, 0.1, "workflow_counter must be incremented exactly once even with retryStrategy configured")
+}
+
 func TestWorkflowConditions(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	wf := wfv1.MustUnmarshalWorkflow(`

--- a/workflow/metrics/metrics_custom.go
+++ b/workflow/metrics/metrics_custom.go
@@ -357,3 +357,21 @@ func (m *Metrics) CompleteRealtimeMetricsForWfUID(key string) {
 func (m *Metrics) DeleteRealtimeMetricsForWfUID(key string) {
 	m.handleRealtimeMetricsForWfUID(key, Delete)
 }
+
+// GetCustomMetricValue returns the current prometheusValue for a custom metric by its key.
+// This is exported for testing only.
+func (m *Metrics) GetCustomMetricValue(metricName string, key string) (float64, bool) {
+	inst := m.GetCustomMetric(metricName)
+	if inst == nil {
+		return 0, false
+	}
+	ud := customUserData(inst, false)
+	if ud == nil {
+		return 0, false
+	}
+	val := ud.GetValue(key)
+	if val == nil {
+		return 0, false
+	}
+	return val.prometheusValue, true
+}


### PR DESCRIPTION
Fixes #15526

## What changed
When `retryStrategy` is configured, custom Prometheus metrics were being emitted twice per execution — once by the Retry wrapper node in `executeTemplate`, and again by the child Pod node in `handleNodeFulfilled`.

## Fix
Added `hasRetryParent()` helper that checks if a node's parent is a `Retry`-type node. In `handleNodeFulfilled`, metric emission is skipped for child Pod nodes that have a Retry parent, since the retry wrapper already handles emission.

## Testing
Added `TestCustomMetricsNotDoubleEmittedWithRetryStrategy` which verifies the counter value is `1.0` not `2.0` after a successful execution with `retryStrategy` configured.