### PR TITLE
fix(templates): prevent inline placeholder leak

### DIFF
--- a/workflow/templateresolution/context.go
+++ b/workflow/templateresolution/context.go
@@ -219,7 +219,23 @@ func (tplCtx *TemplateContext) resolveTemplateImpl(ctx context.Context, tmplHold
 				tplCtx.log.Debug(ctx, "Stored the template")
 				templateStored = true
 			}
-			err = tplCtx.workflow.SetStoredInlineTemplate(scope, resourceName, newTmpl)
+			// For inline sub-templates, use the referenced resource's scope
+			// rather than the caller's scope. When a Workflow (scope=Local)
+			// references a WorkflowTemplate via templateRef, the inline
+			// sub-templates belong to that WorkflowTemplate and must be
+			// stored with its scope. Local scope skips storage, so without
+			// this the first write comes from a copy already contaminated
+			// by validation placeholder substitution.
+			inlineScope := scope
+			inlineResourceName := resourceName
+			if tmplRef := tmplHolder.GetTemplateRef(); tmplRef != nil {
+				inlineScope = wfv1.ResourceScopeNamespaced
+				if tmplRef.ClusterScope {
+					inlineScope = wfv1.ResourceScopeCluster
+				}
+				inlineResourceName = tmplRef.Name
+			}
+			err = tplCtx.workflow.SetStoredInlineTemplate(inlineScope, inlineResourceName, newTmpl)
 			if err != nil {
 				tplCtx.log.WithError(err).Error(ctx, "Failed to store the inline template")
 			}

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -3461,6 +3461,88 @@ func TestDynamicWorkflowTemplateRef(t *testing.T) {
 	_ = deleteWorkflowTemplate(ctx, wftmplB.Name)
 }
 
+var inlineWorkflowTemplate14329 = `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: test-inline-template-14329
+spec:
+  templates:
+  - inputs:
+      parameters:
+      - name: params1
+      - name: params2
+    name: main
+    steps:
+    - - name: inline-main
+        arguments:
+          parameters:
+          - name: params1
+            value: '{{inputs.parameters.params1}}'
+          - name: params2
+            value: '{{inputs.parameters.params2}}'
+        inline:
+          inputs:
+            parameters:
+            - name: params1
+            - name: params2
+          script:
+            command:
+            - sh
+            image: alpine:3.18
+            source: |
+              echo PARAM1={{inputs.parameters.params1}}
+              echo PARAM2={{inputs.parameters.params2}}
+`
+
+var inlineWorkflow14329 = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: test-inline-
+spec:
+  arguments:
+    parameters:
+    - name: params1
+      value: foo1
+    - name: params2
+      value: bar1
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - arguments:
+          parameters:
+          - name: params1
+            value: '{{workflow.parameters.params1}}'
+          - name: params2
+            value: '{{workflow.parameters.params2}}'
+        name: inline
+        templateRef:
+          name: test-inline-template-14329
+          template: main
+`
+
+func TestInlineTemplateNotContaminatedByPlaceholders(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wftmpl := wfv1.MustUnmarshalWorkflowTemplate(inlineWorkflowTemplate14329)
+	err := createWorkflowTemplate(ctx, wftmpl)
+	require.NoError(t, err)
+	defer func() { _ = deleteWorkflowTemplate(ctx, wftmpl.Name) }()
+
+	wf := wfv1.MustUnmarshalWorkflow(inlineWorkflow14329)
+	err = Workflow(ctx, wftmplGetter, cwftmplGetter, wf, nil, Opts{})
+	require.NoError(t, err)
+
+	for key, tmpl := range wf.Status.StoredTemplates {
+		if tmpl.Script != nil {
+			if strings.Contains(tmpl.Script.Source, "placeholder") {
+				t.Errorf("stored template %q has placeholder-contaminated script source: %s", key, tmpl.Script.Source)
+			}
+		}
+	}
+}
+
 var parameterizedGlobalArtifactsWorkflow = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->


Fixes #14329

## Motivation

When a Workflow references a WorkflowTemplate via `templateRef`, and that template contains inline sub-templates with `inputs.parameter`, the parameter variables get replaced with internal placeholder strings (`__argo__internal__placeholder-N`) at submission time. The contaminated values leak into `storedTemplates` and are then executed by pods instead of the actual parameter values.

The root cause is a scope mismatch in when resolving the template. The caller's scope ("Local" for a Workflow) is used when storing inline sub-templates in `SetStoredInlineTemplate`. Then `resolveTemplateReference` returns `false` for Local scope, so inline sub-templates are never pre-stored. After `ProcessArgs` substitutes validation placeholders into the working copy, the contaminated inline templates are stored as the first write. Any subsequent write won't overwrite them in `SetStoredTemplate`.

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Use the referenced resource's scope (Namespaced or Cluster) for `SetStoredInlineTemplate` instead of the caller's scope. This ensures clean inline templates are stored before `ProcessArgs`.

### Verification

<!-- TODO: Say how you tested your changes. -->

Added a regression test that matches the scenario from #14329. The test asserts that no stored template contains the substring placeholder in its script source. The test fails against `main` branch:

```
=== RUN   TestInlineTemplateNotContaminatedByPlaceholders
    validate_test.go:3540: stored template "namespaced/test-inline-template-14329/inline/inline-main" has placeholder-contaminated script source: echo PARAM1=__argo__internal__placeholder-12
        echo PARAM2=__argo__internal__placeholder-13
--- FAIL: TestInlineTemplateNotContaminatedByPlaceholders (0.00s)
```

Also verified end-to-end on a local kind cluster. Apply the WorkflowTemplate:

```bash
kubectl -n argo apply -f - <<'EOF'
apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: test-inline-template
spec:
  templates:
  - name: main
    inputs:
      parameters:
      - name: params1
      - name: params2
    steps:
    - - name: inline-main
        arguments:
          parameters:
          - name: params1
            value: "{{inputs.parameters.params1}}"
          - name: params2
            value: "{{inputs.parameters.params2}}"
        inline:
          inputs:
            parameters:
            - name: params1
            - name: params2
          script:
            image: alpine:3.18
            command: [sh]
            source: |
              echo "PARAM1={{inputs.parameters.params1}}"
              echo "PARAM2={{inputs.parameters.params2}}"
EOF
```

Then submit a Workflow that references it:
```bash
kubectl -n argo create -f - <<'EOF'
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: test-inline-
spec:
  arguments:
    parameters:
    - name: params1
      value: foo1
    - name: params2
      value: bar1
  entrypoint: main
  serviceAccountName: default
  templates:
  - name: main
    steps:
    - - name: inline
        arguments:
          parameters:
          - name: params1
            value: "{{workflow.parameters.params1}}"
          - name: params2
            value: "{{workflow.parameters.params2}}"
        templateRef:
          name: test-inline-template
          template: main
EOF
```

Without the fix the pod outputs literal placeholder strings:
```
PARAM1=__argo__internal__placeholder-12
PARAM2=__argo__internal__placeholder-13
```

With the fix the pod outputs the actual parameter values:
```
PARAM1=foo1
PARAM2=bar1
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No documentation changes needed. This is a bugfix to internal template resolution logic.