### PR TITLE
fix: fixed invalid JSON in template substitution, fixes #15512

### DIFF
--- a/util/template/simple_template.go
+++ b/util/template/simple_template.go
@@ -2,10 +2,10 @@ package template
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/argoproj/argo-workflows/v4/errors"
@@ -24,8 +24,11 @@ func simpleReplaceStrict(ctx context.Context, w io.Writer, tag string, replaceMa
 			if replNested, replOk := replaceMap[nestedTag]; replOk {
 				replStr, isStr := replNested.(string)
 				if isStr {
-					replStr = strconv.Quote(replStr)
-					replStr = replStr[1 : len(replStr)-1]
+					escaped, err := json.Marshal(replStr)
+					if err != nil {
+						return 0, err
+					}
+					replStr = string(escaped[1 : len(escaped)-1])
 					return w.Write([]byte("{{" + nestedTagPrefix + replStr))
 				}
 			}
@@ -54,7 +57,10 @@ func simpleReplaceStrict(ctx context.Context, w io.Writer, tag string, replaceMa
 	}
 	// The following escapes any special characters (e.g. newlines, tabs, etc...)
 	// in preparation for substitution
-	replacementStr = strconv.Quote(replacementStr)
-	replacementStr = replacementStr[1 : len(replacementStr)-1]
+	escaped, err := json.Marshal(replacementStr)
+	if err != nil {
+		return 0, err
+	}
+	replacementStr = string(escaped[1 : len(escaped)-1])
 	return w.Write([]byte(replacementStr))
 }

--- a/util/template/simple_template_test.go
+++ b/util/template/simple_template_test.go
@@ -1,0 +1,73 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+func TestReplaceWithEmoji(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	replaceMap := map[string]string{
+		"inputs.parameters.flag": "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+	}
+
+	test := toJSONString(`{{inputs.parameters.flag}}`)
+	replacement, err := Replace(ctx, test, replaceMap, false)
+
+	require.NoError(t, err, "Should not error on emoji substitution")
+	assert.Equal(t, toJSONString("🏴󠁧󠁢󠁳󠁣󠁴󠁿"), replacement, "Should preserve emoji character")
+}
+
+func TestReplaceWithSpecialCharacters(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Emoji flag",
+			input:    "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+			expected: "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+		},
+		{
+			name:     "Unicode emoji",
+			input:    "Hello 👋 World",
+			expected: "Hello 👋 World",
+		},
+		{
+			name:     "Chinese characters",
+			input:    "你好世界",
+			expected: "你好世界",
+		},
+		{
+			name:     "Arabic characters",
+			input:    "مرحبا بالعالم",
+			expected: "مرحبا بالعالم",
+		},
+		{
+			name:     "Mixed content",
+			input:    "Test 测试 🚀",
+			expected: "Test 测试 🚀",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			replaceMap := map[string]string{
+				"inputs.parameters.value": tc.input,
+			}
+			test := toJSONString(`{{inputs.parameters.value}}`)
+			replacement, err := Replace(ctx, test, replaceMap, false)
+
+			require.NoError(t, err, "Should not error on special character substitution")
+			assert.Equal(t, toJSONString(tc.expected), replacement, "Should preserve special characters")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #15512

### Motivation

Workflow template substitution fails with "invalid JSON" error when parameter values contain special Unicode characters (emoji, flags, etc.).

### Modifications

Implemented the fix suggested in the issue:
- Replaced `strconv.Quote` with `json.Marshal` in `util/template/simple_template.go`

Added unit tests to cover emoji and special Unicode characters.

### Verification
- New unit tests pass
- All existing template tests pass
- Manually tested with workflow YAML from the issue

### Documentation
No documentation changes needed - this is a bug fix.
