### PR TITLE
fix: fallback to directory-prefix deletion in artifact GC for S3. Fixes #15765

### DIFF
--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -280,26 +280,49 @@ func (s3Driver *ArtifactDriver) Delete(ctx context.Context, artifact *wfv1.Artif
 		if err != nil {
 			return err
 		}
-
-		// check suffix instead of s3cli.IsDirectory as it requires another request for file delete (most scenarios)
-		if !strings.HasSuffix(artifact.S3.Key, "/") {
-			return s3cli.Delete(artifact.S3.Bucket, artifact.S3.Key)
-		}
-
-		keys, err := s3cli.ListDirectory(artifact.S3.Bucket, artifact.S3.Key)
-		if err != nil {
-			return fmt.Errorf("unable to list files in %s: %w", artifact.S3.Key, err)
-		}
-		for _, objKey := range keys {
-			err = s3cli.Delete(artifact.S3.Bucket, objKey)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
+		return deleteS3Artifact(ctx, s3cli, artifact)
 	})
 
 	return err
+}
+
+func deleteS3Artifact(ctx context.Context, s3cli Client, artifact *wfv1.Artifact) error {
+	if strings.HasSuffix(artifact.S3.Key, "/") {
+		return deleteS3Directory(s3cli, artifact.S3.Bucket, artifact.S3.Key)
+	}
+
+	err := s3cli.Delete(artifact.S3.Bucket, artifact.S3.Key)
+	if err == nil {
+		return nil
+	}
+
+	isDir, isDirErr := s3cli.IsDirectory(artifact.S3.Bucket, artifact.S3.Key)
+	if isDirErr != nil {
+		return fmt.Errorf("failed to test if %s is a directory: %w", artifact.S3.Key, isDirErr)
+	}
+	if !isDir {
+		return err
+	}
+
+	logging.RequireLoggerFromContext(ctx).
+		WithField("key", artifact.S3.Key).
+		WithError(err).
+		Info(ctx, "Failed to delete key as object, trying directory-prefix deletion")
+	return deleteS3Directory(s3cli, artifact.S3.Bucket, artifact.S3.Key)
+}
+
+func deleteS3Directory(s3cli Client, bucket, key string) error {
+	keys, err := s3cli.ListDirectory(bucket, key)
+	if err != nil {
+		return fmt.Errorf("unable to list files in %s: %w", key, err)
+	}
+	for _, objKey := range keys {
+		err = s3cli.Delete(bucket, objKey)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // saveS3Artifact uploads artifacts to an S3 compliant storage

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -24,6 +24,10 @@ type mockClient struct {
 	files map[string][]string
 	// mockedErrs is a map where key is the function name and value is the mocked error of that function
 	mockedErrs map[string]error
+	// deleteFn allows tests to customize delete behavior per key
+	deleteFn func(bucket, key string) error
+	// deletedKeys records successful delete calls
+	deletedKeys []string
 }
 
 func newMockClient(files map[string][]string, mockedErrs map[string]error) Client {
@@ -245,7 +249,122 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 
 // Delete deletes an S3 artifact by artifact key
 func (s *mockClient) Delete(bucket, key string) error {
-	return s.getMockedErr("Delete")
+	if s.deleteFn != nil {
+		err := s.deleteFn(bucket, key)
+		if err == nil {
+			s.deletedKeys = append(s.deletedKeys, key)
+		}
+		return err
+	}
+	err := s.getMockedErr("Delete")
+	if err == nil {
+		s.deletedKeys = append(s.deletedKeys, key)
+	}
+	return err
+}
+
+func TestDeleteS3Artifact(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	t.Run("DeleteObjectSuccess", func(t *testing.T) {
+		s3client := &mockClient{
+			files:      map[string][]string{"my-bucket": {"/folder/file.txt"}},
+			mockedErrs: map[string]error{},
+		}
+
+		err := deleteS3Artifact(ctx, s3client, &wfv1.Artifact{
+			ArtifactLocation: wfv1.ArtifactLocation{
+				S3: &wfv1.S3Artifact{
+					S3Bucket: wfv1.S3Bucket{Bucket: "my-bucket"},
+					Key:      "/folder/file.txt",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"/folder/file.txt"}, s3client.deletedKeys)
+	})
+
+	t.Run("FallbackToDirectoryDeleteWithoutTrailingSlash", func(t *testing.T) {
+		s3client := &mockClient{
+			files: map[string][]string{
+				"my-bucket": {
+					"/folder/a.txt",
+					"/folder/sub/b.txt",
+				},
+			},
+			mockedErrs: map[string]error{},
+			deleteFn: func(_ string, key string) error {
+				if key == "/folder" {
+					return minio.ErrorResponse{Code: "InternalError"}
+				}
+				return nil
+			},
+		}
+
+		err := deleteS3Artifact(ctx, s3client, &wfv1.Artifact{
+			ArtifactLocation: wfv1.ArtifactLocation{
+				S3: &wfv1.S3Artifact{
+					S3Bucket: wfv1.S3Bucket{Bucket: "my-bucket"},
+					Key:      "/folder",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"/folder/a.txt", "/folder/sub/b.txt"}, s3client.deletedKeys)
+	})
+
+	t.Run("DeleteErrorWhenNotDirectory", func(t *testing.T) {
+		s3client := &mockClient{
+			files: map[string][]string{
+				"my-bucket": {
+					"/other/a.txt",
+				},
+			},
+			mockedErrs: map[string]error{},
+			deleteFn: func(_ string, key string) error {
+				if key == "/folder" {
+					return minio.ErrorResponse{Code: "InternalError"}
+				}
+				return nil
+			},
+		}
+
+		err := deleteS3Artifact(ctx, s3client, &wfv1.Artifact{
+			ArtifactLocation: wfv1.ArtifactLocation{
+				S3: &wfv1.S3Artifact{
+					S3Bucket: wfv1.S3Bucket{Bucket: "my-bucket"},
+					Key:      "/folder",
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "internal error")
+		assert.Empty(t, s3client.deletedKeys)
+	})
+
+	t.Run("DeleteDirectoryWithTrailingSlash", func(t *testing.T) {
+		s3client := &mockClient{
+			files: map[string][]string{
+				"my-bucket": {
+					"/folder/a.txt",
+					"/folder/sub/b.txt",
+				},
+			},
+			mockedErrs: map[string]error{},
+		}
+
+		err := deleteS3Artifact(ctx, s3client, &wfv1.Artifact{
+			ArtifactLocation: wfv1.ArtifactLocation{
+				S3: &wfv1.S3Artifact{
+					S3Bucket: wfv1.S3Bucket{Bucket: "my-bucket"},
+					Key:      "/folder/",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"/folder/a.txt", "/folder/sub/b.txt"}, s3client.deletedKeys)
+	})
+
 }
 
 func TestLoadS3Artifact(t *testing.T) {


### PR DESCRIPTION
## Summary

When using `archive: none` with S3-compatible storage (SeaweedFS, MinIO, etc.), the artifact GC pod calls `DeleteObject` on a directory-prefix key. Some S3-compatible backends return an internal error because the key represents a non-empty directory, not a single object. The GC pod classifies this as a transient error and **retries indefinitely**, preventing `forceFinalizerRemoval` from ever triggering and blocking workflow deletion.

## Changes

- **`workflow/artifacts/s3/s3.go`**: When `DeleteObject` fails on a key, the code now checks via `IsDirectory` whether the key is a directory prefix. If so, it falls back to `ListDirectory` + per-object `Delete` (same pattern already used by `loadS3Artifact`). Extracted `deleteS3Artifact` and `deleteS3Directory` helpers for clarity.
- **`workflow/artifacts/s3/s3_test.go`**: Added 4 test cases covering: single-object delete success, fallback to directory delete (no trailing slash), error propagation when key is not a directory, and explicit directory delete (trailing slash).

## Root Cause

The `Delete` method treated all non-fatal S3 errors as transient and retried without an upper bound. When an S3-compatible backend returns an error for `DeleteObject` on a directory key (because it cannot atomically delete a non-empty prefix), the retry loop runs forever. Since the GC pod never terminates, `forceFinalizerRemoval: true` never kicks in, and the `workflows.argoproj.io/artifact-gc` finalizer blocks workflow deletion.

## Related

- Fixes #15765
- Related to #14565 (same root cause, different symptom)
- Supersedes approach from #14631