### PR TITLE
fix(test): prevent cascading subtest failures in ArgoServerSuite e2e tests

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -453,6 +453,7 @@ func (s *ArgoServerSuite) TestPermission() {
 		_, err = s.KubeClient.RbacV1().Roles(nsName).Create(ctx, role, metav1.CreateOptions{})
 		s.Require().NoError(err)
 	})
+	s.Require().NotEmpty(roleName, "LoadRoleYaml must succeed")
 	defer func() {
 		_ = s.KubeClient.RbacV1().Roles(nsName).Delete(ctx, roleName, metav1.DeleteOptions{})
 	}()
@@ -502,6 +503,10 @@ func (s *ArgoServerSuite) TestPermission() {
 		badToken = string(secret.Data["token"])
 	})
 
+	// Stop early if token retrieval failed to prevent cascading failures
+	s.Require().NotEmpty(goodToken, "GetGoodSAToken must succeed")
+	s.Require().NotEmpty(badToken, "GetBadSAToken must succeed")
+
 	// fake / spoofed token
 	fakeToken := "faketoken"
 
@@ -540,6 +545,9 @@ func (s *ArgoServerSuite) TestPermission() {
 			Path("$.metadata.uid").
 			Raw().(string)
 	})
+
+	// Stop early if workflow creation failed to prevent cascading failures
+	s.Require().NotEmpty(uid, "CreateWFGoodToken must succeed")
 
 	// Test list workflows with good token
 	s.Run("ListWFsGoodToken", func() {
@@ -896,6 +904,9 @@ func (s *ArgoServerSuite) TestWorkflowService() {
 			Raw()
 	})
 
+	// Stop early if workflow creation failed to prevent cascading failures
+	s.Require().NotEmpty(name, "Create must succeed")
+
 	s.Given().
 		When().
 		WaitForWorkflow(fixtures.ToBeRunning)
@@ -1089,6 +1100,10 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 		nameAliceWf = aliceWf.Path("$.metadata.name").NotNull().String().Raw()
 	})
 
+	// Stop early if workflow creation failed to prevent cascading failures
+	s.Require().NotEmpty(nameBobWf, "CreateArchivedBobWf must succeed")
+	s.Require().NotEmpty(nameAliceWf, "CreateAlice must succeed")
+
 	s.Given().When().
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameBobWf}).
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameAliceWf})
@@ -1270,6 +1285,10 @@ func (s *ArgoServerSuite) TestWorkflowArchiveServiceList() {
 		uidAliceWf = aliceWf.Path("$.metadata.uid").NotNull().String().Raw()
 		nameAliceWf = aliceWf.Path("$.metadata.name").NotNull().String().Raw()
 	})
+
+	// Stop early if workflow creation failed to prevent cascading failures
+	s.Require().NotEmpty(nameBobWf, "CreateArchivedBobWf must succeed")
+	s.Require().NotEmpty(nameAliceWf, "CreateAlice must succeed")
 
 	s.Given().When().
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameBobWf}).
@@ -1627,6 +1646,8 @@ spec:
 			String().
 			Raw()
 	})
+
+	s.Require().NotEmpty(resourceVersion, "Get must return resourceVersion")
 
 	s.Run("Update", func() {
 		s.e().PUT("/api/v1/cron-workflows/argo/test").
@@ -2327,6 +2348,8 @@ func (s *ArgoServerSuite) TestWorkflowTemplateService() {
 			Raw()
 	})
 
+	s.Require().NotEmpty(resourceVersion, "Get must return resourceVersion")
+
 	s.Run("Update", func() {
 		s.e().PUT("/api/v1/workflow-templates/argo/test").
 			WithBytes([]byte(`{"template": {
@@ -2559,6 +2582,9 @@ func (s *ArgoServerSuite) TestEventSourcesService() {
 			String().
 			Raw()
 	})
+
+	s.Require().NotEmpty(resourceVersion, "GetEventSource must return resourceVersion")
+
 	s.Run("UpdateEventSource", func() {
 		s.e().PUT("/api/v1/event-sources/argo/test-event-source").
 			WithBytes([]byte(`


### PR DESCRIPTION
## Summary
- Add `s.Require()` guards after setup subtests that populate shared closure variables (workflow names/UIDs, tokens, resourceVersions)
- When a setup subtest fails transiently, dependent subtests now get a clear early termination instead of running with empty/zero-value variables

## Motivation

Several `ArgoServerSuite` test methods use sequential subtests where early subtests create shared state (workflow names, UIDs, tokens, resourceVersions) via closure variables, and later subtests depend on that state. When a setup subtest fails (e.g., transient API error, timeout), the closure variables remain as zero values. This causes:

1. **Confusing cascading failures** — dozens of subtests fail with meaningless errors like "expected array contains element `""`" because they query with empty names/UIDs
2. **Wasted CI time** — `WaitForWorkflow` calls with empty field selectors (e.g., `metadata.name=`) timeout for minutes waiting for an impossible match
3. **Obscured root cause** — the actual transient failure in the setup subtest is buried under noise from all the cascading failures

Example: [TestWorkflowArchiveServiceList/ArchiveNameExactAlice](https://github.com/argoproj/argo-workflows/actions/runs/22648537700) failed because `CreateAlice` failed transiently, leaving `nameAliceWf=""`. The HTTP request showed `metadata.name=` (empty), and the test expected `[""]` in the response.

## Changes

Added `s.Require().NotEmpty()` guards in 7 test methods:

| Test Method | Guarded Variables |
|---|---|
| `TestPermission` | `roleName`, `goodToken`, `badToken`, `uid` |
| `TestWorkflowService` | `name` |
| `TestWorkflowServiceListArchived` | `nameBobWf`, `nameAliceWf` |
| `TestWorkflowArchiveServiceList` | `nameBobWf`, `nameAliceWf` |
| `TestCronWorkflowService` | `resourceVersion` |
| `TestWorkflowTemplateService` | `resourceVersion` |
| `TestEventSourcesService` | `resourceVersion` |

`s.Require().NotEmpty()` calls `t.FailNow()` on the parent test, stopping the entire test method immediately with a clear message like `"CreateAlice must succeed"`.

## AI

This PR was mostly generated by Claude under guidance to try to eliminate the cascade failures in this suite which are currently our worst flaking suite.