### PR TITLE
fix: poll for Persisted status in TestWorkflowServiceListArchived/ListAll

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1096,15 +1096,32 @@ func (s *ArgoServerSuite) TestWorkflowServiceListArchived() {
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameBobWf}).
 		WaitForWorkflow(fixtures.ToBeArchived, metav1.ListOptions{FieldSelector: "metadata.name=" + nameAliceWf})
 
+	// Poll until the API server's internal SQLite cache has converged.
+	// WaitForWorkflow(ToBeArchived) watches K8s labels directly, but the
+	// list endpoint merges a SQLite live-store (fed by a separate informer)
+	// with the archive DB. The informer may lag behind the test's watch,
+	// causing workflows to still appear with "Pending" status from the
+	// live store instead of "Persisted" from the archive.
 	s.Run("ListAll", func() {
-		s.e().GET("/api/v1/workflows/argo").
-			WithQuery("listOptions.labelSelector", "workflows.argoproj.io/test=subject-1").
-			Expect().
-			Status(200).
-			JSON().
-			Path(`$.items[*].metadata.labels["workflows.argoproj.io/workflow-archiving-status"]`).
-			Array().
-			IsEqual([]any{"Persisted", "Persisted"})
+		s.Eventually(func() bool {
+			statuses := s.e().GET("/api/v1/workflows/argo").
+				WithQuery("listOptions.labelSelector", "workflows.argoproj.io/test=subject-1").
+				Expect().
+				Status(200).
+				JSON().
+				Path(`$.items[*].metadata.labels["workflows.argoproj.io/workflow-archiving-status"]`).
+				Array().
+				Raw()
+			if len(statuses) != 2 {
+				return false
+			}
+			for _, v := range statuses {
+				if v != "Persisted" {
+					return false
+				}
+			}
+			return true
+		}, 30*time.Second, time.Second, "expected both workflows to have Persisted archiving status")
 	})
 
 	s.Run("ListNameContainsAlice", func() {


### PR DESCRIPTION
## Summary

- Fix flaky `TestArgoServerSuite/TestWorkflowServiceListArchived/ListAll` by replacing a one-shot assertion with `assert.Eventually` polling
- The race condition occurs because `WaitForWorkflow(ToBeArchived)` watches K8s labels directly, but the `/api/v1/workflows/argo` list endpoint merges results from an internal SQLite cache (fed by a separate informer) and the archive DB — the informer can lag behind the test's watch
- The `/api/v1/archived-workflows` endpoint is **not** affected (reads directly from the archive DB, which is written before the K8s label patch)

### Root cause

Two independent K8s watch consumers race:

1. **Test's watch** (via `WaitForWorkflow`) — sees the label change to `"Archived"` and returns
2. **API server's informer** — feeds the SQLite live-store; may not have processed the same event yet

When `ListAll` runs immediately after the wait, the API server may still serve a workflow from the stale SQLite cache with `"Pending"` status instead of `"Persisted"` from the archive DB.

### Evidence

[Failed run](https://github.com/argoproj/argo-workflows/actions/runs/22484796038) response shows:
- `test-alice`: `workflow-archiving-status: "Pending"` (still in live SQLite cache)
- `test-bob`: `workflow-archiving-status: "Persisted"` (served from archive DB)

## AI

Co-authored with Claude