### PR TITLE
fix(controller): error from non-target DAG tasks

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -150,6 +150,15 @@ func (d *dagContext) assessDAGPhase(ctx context.Context, targetTasks []string, n
 		targetTaskPhases[d.taskNodeID(task)] = ""
 	}
 
+	// dagTaskNodeIDs is the set of node IDs that correspond to DAG tasks. The BFS traverses the
+	// full node tree, which includes internal nodes (step groups, individual steps, retry attempts,
+	// etc.) that live inside a DAG task's template. Only DAG task nodes are allowed to
+	// overwrite the branchPhase. Internal nodes inherit their parent's phase without modification.
+	dagTaskNodeIDs := make(map[string]struct{}, len(d.tmpl.DAG.Tasks))
+	for _, task := range d.tmpl.DAG.Tasks {
+		dagTaskNodeIDs[d.taskNodeID(task.Name)] = struct{}{}
+	}
+
 	boundaryNode, err := nodes.Get(d.boundaryID)
 	if err != nil {
 		return "", err
@@ -173,9 +182,13 @@ func (d *dagContext) assessDAGPhase(ctx context.Context, targetTasks []string, n
 			return wfv1.NodeRunning, nil
 		}
 
-		// Only overwrite the branchPhase if this node completed. (If it didn't we can just inherit our parent's branchPhase).
+		// Only overwrite the branchPhase if this node is a completed DAG task. Internal nodes
+		// (step groups, steps, etc.) inherit their parent's branchPhase so that a task's
+		// Error/Failed phase is not lost when its internal children completed successfully.
 		if node.Completed() {
-			branchPhase = node.Phase
+			if _, isDAGTask := dagTaskNodeIDs[node.ID]; isDAGTask {
+				branchPhase = node.Phase
+			}
 		}
 
 		// This node is a target task, so it will not have any children. Store or deduce its phase

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -4589,3 +4589,84 @@ func TestDAGSkippedInlineExpressionFallback(t *testing.T) {
 	require.NotNil(t, in.Value)
 	assert.Equal(t, "inline-fallback", in.Value.String())
 }
+
+// TestAssessDAGPhaseErrorNodeOmittedDependent verifies that a DAG is marked Error when a non-target
+// task errors and its dependent target task is Omitted. This is a regression test for
+// https://github.com/argoproj/argo-workflows/issues/10994
+func TestAssessDAGPhaseErrorNodeOmittedDependent(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	// DAG: A -> B (B depends on A). B is the target/leaf task.
+	// A errors (e.g. output expression evaluation failure), B is Omitted.
+	dagTasks := []wfv1.DAGTask{
+		{Name: "A"},
+		{Name: "B", Depends: "A"},
+	}
+	tmpl := &wfv1.Template{
+		DAG: &wfv1.DAGTemplate{
+			Tasks: dagTasks,
+		},
+	}
+	d := &dagContext{
+		boundaryName: "test",
+		tasks:        dagTasks,
+		tmpl:         tmpl,
+		wf:           &wfv1.Workflow{ObjectMeta: metav1.ObjectMeta{Name: "test-wf"}},
+		dependencies: make(map[string][]string),
+		dependsLogic: make(map[string]string),
+		log:          logging.RequireLoggerFromContext(ctx),
+	}
+
+	boundaryID := "test"
+	d.boundaryID = boundaryID
+
+	aNodeID := d.taskNodeID("A")
+	bNodeID := d.taskNodeID("B")
+
+	// Simulate the node tree as it appears during the bug:
+	// Boundary -> A_steps (Error) -> step_group (Succeeded) -> placeholder (Skipped) -> B (Omitted)
+	// The step group's Succeeded phase overwrites branchPhase during BFS, losing A's Error.
+	stepGroupID := "step-group-1"
+	placeholderID := "placeholder-1"
+
+	nodes := wfv1.Nodes{
+		boundaryID: {
+			ID:       boundaryID,
+			Phase:    wfv1.NodeRunning,
+			Type:     wfv1.NodeTypeDAG,
+			Children: []string{aNodeID},
+		},
+		aNodeID: {
+			ID:       aNodeID,
+			Name:     "test.A",
+			Phase:    wfv1.NodeError,
+			Type:     wfv1.NodeTypeSteps,
+			Children: []string{stepGroupID},
+			Message:  "expression evaluation error",
+		},
+		stepGroupID: {
+			ID:       stepGroupID,
+			Phase:    wfv1.NodeSucceeded,
+			Type:     wfv1.NodeTypeStepGroup,
+			Children: []string{placeholderID},
+		},
+		placeholderID: {
+			ID:       placeholderID,
+			Phase:    wfv1.NodeSkipped,
+			Type:     wfv1.NodeTypeSkipped,
+			Children: []string{bNodeID},
+		},
+		bNodeID: {
+			ID:    bNodeID,
+			Name:  "test.B",
+			Phase: wfv1.NodeOmitted,
+			Type:  wfv1.NodeTypeSkipped,
+		},
+	}
+
+	targetTasks := []string{"B"}
+
+	phase, err := d.assessDAGPhase(ctx, targetTasks, nodes, false)
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeError, phase, "DAG should be Error when a non-target task errors and target task is Omitted")
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #10994

### Motivation

When a DAG task errors and its downstream dependent is omitted, the workflow should report `Error` but instead reports `Succeeded`. The BFS in `assessDAGPhase` traverses internal nodes (step groups, steps) inside a task's template. These internal nodes can complete successfully even when the task itself errored, and their `Succeeded` phase overwrites the `Error` before it reaches the omitted target task.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Scoped the `branchPhase` overwrite in `assessDAGPhase` to DAG task nodes only. A pre-computed set of DAG task node IDs is checked before allowing a completed node to overwrite `branchPhase`. Internal nodes (step groups, individual steps, retry attempts) now inherit their parent's phase without modification.

### Verification

<!-- TODO: Say how you tested your changes. -->

Includes a regression test.

Reproducer from the original issue #10994:

```bash
cat <<'EOF' | kubectl create -n argo -f - 2>&1
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: issue-10994-fix-
spec:
  entrypoint: test
  serviceAccountName: argo
  templates:
    - name: instant-dummy
      suspend:
        duration: "0.1s"
    - name: test
      dag:
        tasks:
        - name: A
          template: evaluation
          arguments:
            parameters:
              - name: INPUT
                value: "abc"
        - name: B
          depends: A
          template: instant-dummy
    - name: evaluation
      steps:
      - - name: placeholder
          template: instant-dummy
          when: "false"
      inputs:
        parameters:
          - name: INPUT
      outputs:
        parameters:
          - name: OUTPUT
            valueFrom:
              expression: "inputs.parameters.INPUT.splitList(':')[1]"
EOF
```

Print details of workflow:

```bash
kubectl get wf issue-10994-fix-dz72z -n argo -o json | python3 -c "
import json, sys
wf = json.load(sys.stdin)
print(f\"Workflow phase: {wf['status']['phase']}\")
print(f\"{'Node':<25} {'Phase':<12} {'Type':<12} Message\")
print('-' * 90)
for nid, n in wf['status']['nodes'].items():
    print(f\"{n['displayName']:<25} {n['phase']:<12} {n['type']:<12} {n.get('message','')[:50]}\")
"
```

Outputs:

```
Workflow phase: Error
Node                      Phase        Type         Message
------------------------------------------------------------------------------------------
issue-10994-fix-dz72z     Error        DAG          
B                         Omitted      Skipped      omitted: depends condition not met
A                         Error        Steps        task 'issue-10994-fix-dz72z.A' errored: invalid op
placeholder               Skipped      Skipped      when 'false' evaluated false
[0]                       Succeeded    StepGroup
```

Without the fix the output shows what was reported, so the final phase is `Succeeded` and not `Error`.

```
Workflow phase: Succeeded
Node                      Phase        Type         Message
------------------------------------------------------------------------------------------
issue-10994-main-m5xpg    Succeeded    DAG          
placeholder               Skipped      Skipped      when 'false' evaluated false
[0]                       Succeeded    StepGroup    
B                         Omitted      Skipped      omitted: depends condition not met
A                         Error        Steps        task 'issue-10994-main-m5xpg.A' errored: invalid o
```


### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No need. This is a bug fix that corrects phase reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DAG phase calculation so completed internal nodes no longer overwrite the overall branch status.
  * Ensured the final DAG outcome reflects error states correctly when a dependent task is omitted after a related task fails.

* **Tests**
  * Added a regression test covering the error-and-omitted dependency scenario to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->