### PR TITLE
fix(test): replace flaky sleep with WaitForPod in TestDeletingPendingPod

### DIFF
--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -55,8 +55,9 @@ func (s *FunctionalSuite) TestDeletingPendingPod() {
 		}(), "-p", `{"metadata":{"finalizers":[]}}`, "--type", "merge"}, fixtures.OutputRegexp(`pod/.* patched`)).
 		Wait(time.Second).
 		Exec("kubectl", []string{"-n", "argo", "delete", "pod", "-l", "workflows.argoproj.io/workflow"}, fixtures.OutputRegexp(`pod "pending-.*" deleted`)).
-		Wait(time.Duration(3*fixtures.EnvFactor)*time.Second). // allow 3s for reconciliation, we'll create a new pod
-		Exec("kubectl", []string{"-n", "argo", "get", "pod", "-l", "workflows.argoproj.io/workflow"}, fixtures.OutputRegexp(`pending-.*Pending`))
+		WaitForPod(fixtures.PodCondition(func(p *apiv1.Pod) bool {
+			return p.DeletionTimestamp.IsZero() && p.Status.Phase == apiv1.PodPending
+		}))
 }
 
 func (s *FunctionalSuite) TestWorkflowLevelErrorRetryPolicy() {


### PR DESCRIPTION
## Summary
- Replace flaky `Wait(3*EnvFactor seconds)` + `kubectl get pod` assertion with `WaitForPod` polling in `TestDeletingPendingPod`
- The fixed sleep was insufficient under CI load, causing intermittent "No resources found" failures when the controller hadn't yet recreated the deleted pod
- Uses the existing `WaitForPod` fixture which watches via the Kubernetes API with a proper timeout

## Test plan
- [ ] CI passes `test-corefunctional-minimal-k8s-min` suite
- [ ] `TestDeletingPendingPod` no longer fails with "No resources found" under load

Fixes: https://github.com/argoproj/argo-workflows/actions/runs/23303430981

🤖 Generated with [Claude Code](https://claude.com/claude-code)