### PR TITLE
fix(ui): retain query parameters when closing workflow side panel. Fixes #15795

### DIFF
--- a/ui/src/workflows/components/workflows-list/workflows-list.test.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.test.tsx
@@ -34,7 +34,9 @@ describe('WorkflowsList', () => {
         const submitWorkflowButton = getByRole('button', {name: 'Submit New Workflow'});
         expect(submitWorkflowButton).toBeInTheDocument();
         submitWorkflowButton.click();
-        expect(history.location.search).toBe('?namespace=argo&limit=50&sidePanel=submit-new-workflow');
+        await waitFor(() => {
+            expect(history.location.search).toBe('?namespace=argo&sidePanel=submit-new-workflow&limit=50');
+        });
 
         // Wait for close button, then press it and verify URL updates
         // TODO: use findByRole once the close button has an aria-label
@@ -46,10 +48,9 @@ describe('WorkflowsList', () => {
         closeButton.click();
 
         // Check sidePanel was removed from URL.
-        // Also, namespace is cleared out due to services.info.getInfo() being
-        // mocked to return empty body, which causes AppRouter to set namespace
-        // to empty string.
-        expect(history.location.search).toBe('?namespace=&limit=50');
+        await waitFor(() => {
+            expect(history.location.search).toBe('?namespace=argo&limit=50');
+        });
     });
 
     it('opens workflow creator with pre-filled URL parameters', async () => {
@@ -63,5 +64,35 @@ describe('WorkflowsList', () => {
 
         const parameterInput = await findByDisplayValue('test-hello');
         expect(parameterInput).toBeInTheDocument();
+    });
+
+    it('retains query parameters when side panel is closed', async () => {
+        const history = createMemoryHistory();
+        history.push('/workflows?namespace=argo&phase=Pending&label=test');
+
+        const {getByRole, container} = render(<App history={history} />);
+        expect(history.location.search).toBe('?namespace=argo&phase=Pending&label=test&limit=50');
+
+        // Click "Submit New Workflow" button and verify URL updates
+        const submitWorkflowButton = getByRole('button', {name: 'Submit New Workflow'});
+        expect(submitWorkflowButton).toBeInTheDocument();
+        submitWorkflowButton.click();
+        await waitFor(() => {
+            expect(history.location.search).toBe('?namespace=argo&sidePanel=submit-new-workflow&phase=Pending&label=test&limit=50');
+        });
+
+        // Wait for close button, then press it and verify URL updates
+        // TODO: use findByRole once the close button has an aria-label
+        const closeButton = await waitFor<HTMLElement>(() => {
+            const closeButton = container.querySelector<HTMLElement>('button.sliding-panel__close');
+            expect(closeButton).toBeInTheDocument();
+            return closeButton;
+        });
+        closeButton.click();
+
+        // Check sidePanel was removed from URL but phase remains
+        await waitFor(() => {
+            expect(history.location.search).toBe('?namespace=argo&phase=Pending&label=test&limit=50');
+        });
     });
 });

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -142,9 +142,24 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
         storage.setItem('options', options, {} as WorkflowListRenderOptions);
 
         const params = new URLSearchParams();
+        const currentParams = new URLSearchParams(history.location.search);
+
+        if (currentParams.has('namespace')) {
+            params.set('namespace', currentParams.get('namespace'));
+        }
 
         if (sidePanel) {
             params.set('sidePanel', sidePanel);
+
+            // preserve template name and parameters if sidePanel is open
+            if (currentParams.has('template')) {
+                params.append('template', currentParams.get('template'));
+            }
+            currentParams.forEach((v, k) => {
+                if (k.startsWith('parameters')) {
+                    params.append(k, v);
+                }
+            });
         }
 
         // phases


### PR DESCRIPTION
Fixes #15795

### Motivation

As part of various improvements (#15217, #15796) to the URL parameters experience, this fixes the bug where the query parameters are wiped out when closing the side panel (to submit a new workflow).

### Modifications

* Update the side panel handling code to match the workflow template page
* Retain query parameters `onClose` (by just updating the `sidePanel` variable)

### Verification

Showing parameters are retained:

https://github.com/user-attachments/assets/21dc7785-6e70-45de-bc27-27a680f504fa


Also showing that opening the side panel, closing it (by clicking off) and then using the back button of the browser reopens it:


https://github.com/user-attachments/assets/386a20d2-1443-416f-8fec-68ed6c0b39fb