### PR TITLE
fix: webhook dispatch applies template metadata

### DIFF
--- a/server/event/dispatch/operation.go
+++ b/server/event/dispatch/operation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/expr-lang/expr"
@@ -113,6 +114,18 @@ func (o *Operation) dispatch(ctx context.Context, wfeb wfv1.WorkflowEventBinding
 			return nil, fmt.Errorf("failed to validate workflow template instanceid: %w", err)
 		}
 		wf := common.NewWorkflowFromWorkflowTemplate(tmpl.GetName(), ref.ClusterScope)
+
+		// Apply workflowMetadata labels and annotations from the template
+		// at creation time, matching the CronWorkflow behavior.
+		// labelsFrom is left to the controller since it
+		// requires parameter evaluation at runtime.
+		if wmd := tmpl.GetWorkflowSpec().WorkflowMetadata; wmd != nil {
+			maps.Copy(wf.Labels, wmd.Labels)
+			if len(wmd.Annotations) > 0 {
+				maps.Copy(wf.Annotations, wmd.Annotations)
+			}
+		}
+
 		o.instanceIDService.Label(wf)
 		err = o.populateWorkflowMetadata(wf, &submit.ObjectMeta)
 		if err != nil {

--- a/server/event/dispatch/operation_test.go
+++ b/server/event/dispatch/operation_test.go
@@ -408,6 +408,69 @@ func Test_populateWorkflowMetadata(t *testing.T) {
 	assert.Equal(t, "Warning WorkflowEventBindingError failed to dispatch event: workflow name expression must evaluate to a string, not a <nil>", <-recorder.Events)
 }
 
+func TestDispatchWorkflowMetadata(t *testing.T) {
+	tmpl := &wfv1.WorkflowTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-wft", Namespace: "my-ns",
+			Labels: map[string]string{common.LabelKeyControllerInstanceID: "my-instanceid"},
+		},
+		Spec: wfv1.WorkflowSpec{
+			WorkflowMetadata: &wfv1.WorkflowMetadata{
+				Labels:      map[string]string{"env": "from-template", "template-only": "yes"},
+				Annotations: map[string]string{"note": "from-template"},
+			},
+		},
+	}
+
+	dispatch := func(t *testing.T, binding wfv1.WorkflowEventBinding) wfv1.Workflow {
+		t.Helper()
+		client := fake.NewClientset(tmpl)
+		ctx := context.WithValue(logging.TestContext(t.Context()), auth.WfKey, client)
+		ctx = context.WithValue(ctx, auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
+		op, err := NewOperation(ctx, instanceid.NewService("my-instanceid"), record.NewFakeRecorder(6),
+			[]wfv1.WorkflowEventBinding{binding}, "my-ns", "", &wfv1.Item{Value: json.RawMessage(`{}`)})
+		require.NoError(t, err)
+		require.NoError(t, op.Dispatch(ctx))
+		list, err := client.ArgoprojV1alpha1().Workflows("my-ns").List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		return list.Items[0]
+	}
+
+	t.Run("AppliesTemplateMetadata", func(t *testing.T) {
+		wf := dispatch(t, wfv1.WorkflowEventBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-wfeb", Namespace: "my-ns"},
+			Spec: wfv1.WorkflowEventBindingSpec{
+				Event: wfv1.Event{Selector: "true"},
+				Submit: &wfv1.Submit{
+					WorkflowTemplateRef: wfv1.WorkflowTemplateRef{Name: "my-wft"},
+				},
+			},
+		})
+		assert.Equal(t, "from-template", wf.Labels["env"])
+		assert.Equal(t, "yes", wf.Labels["template-only"])
+		assert.Equal(t, "from-template", wf.Annotations["note"])
+	})
+
+	t.Run("EventBindingOverridesTemplate", func(t *testing.T) {
+		wf := dispatch(t, wfv1.WorkflowEventBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-wfeb", Namespace: "my-ns"},
+			Spec: wfv1.WorkflowEventBindingSpec{
+				Event: wfv1.Event{Selector: "true"},
+				Submit: &wfv1.Submit{
+					WorkflowTemplateRef: wfv1.WorkflowTemplateRef{Name: "my-wft"},
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"env": `"from-binding"`},
+					},
+				},
+			},
+		})
+		assert.Equal(t, "from-binding", wf.Labels["env"])
+		assert.Equal(t, "yes", wf.Labels["template-only"])
+		assert.Equal(t, "from-template", wf.Annotations["note"])
+	})
+}
+
 func Test_expressionEnvironment(t *testing.T) {
 	env, err := expressionEnvironment(logging.TestContext(t.Context()), "my-ns", "my-d", &wfv1.Item{Value: []byte(`{"foo":"bar"}`)})
 	require.NoError(t, err)


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

When the webhook event handler creates a workflow from a `WorkflowTemplateRef`, it does not copy `spec.workflowMetadata.labels` or `spec.workflowMetadata.annotations` from the resolved template onto the workflow. These are only applied later asynchronously by the controller in `updateWorkflowMetadata()`.

This causes two problems:

- Label-selector watches cannot find the workflow between creation and controller reconciliation, leading to timeouts in `WaitForWorkflow()`.
- If the workflow is archived before cleanup runs (or cleanup uses label selectors), stale archived workflows without the expected labels are never cleaned up, polluting subsequent test runs. See [this](https://github.com/argoproj/argo-workflows/actions/runs/23351490877/job/67931896440?pr=15788) CI run from #15788. Overall seems to manifest into `CI / E2E Tests (test-api, mysql, true)`.

CronWorkflows already apply `workflowMetadata` at creation time.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

After fetching the WorkflowTemplate and calling `NewWorkflowFromWorkflowTemplate()`, copy `spec.workflowMetadata.labels` and `spec.workflowMetadata.annotations` from the template onto the workflow. This runs before `populateWorkflowMetadata()` so event binding metadata can still override template values. `labelsFrom` is intentionally left to the controller since it requires runtime parameter evaluation.

### Verification

<!-- TODO: Say how you tested your changes. -->

Added two unit tests that verify:

- A workflow created via webhook dispatch carries `workflowMetadata` labels and annotations from the template alongside standard dispatch labels.
- Event binding metadata takes precedence over template metadata for the same label key.
 
Both tests fail against the unfixed code and pass with the fix.

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No documentation changes needed. This aligns webhook dispatch behavior with the existing CronWorkflow behavior.