### PR TITLE
chore: better sourcemaps in development

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -26,7 +26,9 @@ const config = {
         path: __dirname + '/dist/app',
     },
 
-    devtool: isProd ? 'source-map' : 'eval',
+    // Enable source maps in production for easier debugging, but use faster eval-source-map in development for better performance
+    // Docs: https://webpack.js.org/configuration/devtool/
+    devtool: isProd ? 'source-map' : 'eval-source-map',
 
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.json', '.ttf'],


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

In development, the source maps Webpack generates contain generated code, not the original source, which can make it hard to debug frontend issues. 
<img width="1343" height="944" alt="image" src="https://github.com/user-attachments/assets/27f2c399-f03f-49eb-a8f2-a8ba11fb3c93" />

### Modifications

This updates Webpack to generate source maps that exactly match the original source via `eval-source-map` ([docs](https://webpack.js.org/configuration/devtool/)). 
<img width="1538" height="977" alt="image" src="https://github.com/user-attachments/assets/3dfbfeac-f142-42c4-908e-091fcedb96d8" />

The only downside is it's a bit slower, but we don't have enough code for that to be a big problem. This matches ArgoCD:
https://github.com/argoproj/argo-cd/blob/3f15cc6c9edfb9d9762a96495187378f13412797/ui/src/app/webpack.config.js#L136

### Verification

Verified locally at http://localhost:8080/workflows in both Firefox and Chrome

### Documentation

N/A