### PR TITLE
fix(test): clean up sync configmap between re-runs

### DIFF
--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -2819,6 +2819,11 @@ func (s *ArgoServerSuite) TestSyncConfigmapService() {
 	configmapName := "test-sync-cm"
 	syncKey := "test-key"
 
+	// Clean up configmap from previous runs. DeleteResources only removes
+	// configmaps labelled workflows.argoproj.io/test; this one is created
+	// by the sync API without that label, so it survives re-runs.
+	_ = s.KubeClient.CoreV1().ConfigMaps(syncNamespace).Delete(s.T().Context(), configmapName, metav1.DeleteOptions{})
+
 	s.Run("CreateSyncLimitConfigmap", func() {
 		s.e().POST("/api/v1/sync/{namespace}", syncNamespace).
 			WithJSON(syncpkg.CreateSyncLimitRequest{


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

<!-- TODO: Say why you made your changes. -->

CI test failure from #15815: https://github.com/argoproj/argo-workflows/actions/runs/23715726411/job/69082727702?pr=15815

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

The sync API creates `test-sync-cm` without the `workflows.argoproj.io/test` label, so `DeleteResources` does not remove it. On gotestsum re-runs the leftover configmap causes `CreateSyncLimit-cm-exist` to get "HTTP 409 Conflict".

Delete the configmap explicitly at the start of the test.

I think the test flakiness caused by #15816 is one way to trigger this condition. The first run fails because of it, so then the second run fails because the ConfigMap is still there from the first run.

### Verification

<!-- TODO: Say how you tested your changes. -->

Tests pass.
### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

Tests-only change, no need for a documentation update.