### PR TITLE
POC: K8s API Aggregation

### DIFF
--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -57,8 +57,12 @@ func NewServerCommand() *cobra.Command {
 		kubeAPIQPS               float32
 		kubeAPIBurst             int
 		allowedLinkProtocol      []string
-		logFormat                string // --log-format
-		logLevel                 string // --loglevel
+		logFormat                  string // --log-format
+		logLevel                   string // --loglevel
+		enableAggregatedAPIServer  bool
+		aggregatedDBDriver         string
+		aggregatedDBDSN            string
+		aggregatedAPIServerPort    int
 	)
 
 	command := cobra.Command{
@@ -153,24 +157,28 @@ See %s`, help.ArgoServer()),
 			}
 
 			opts := apiserver.ArgoServerOpts{
-				BaseHRef:                 baseHRef,
-				TLSConfig:                tlsConfig,
-				HSTS:                     hsts,
-				Namespaced:               namespaced,
-				Namespace:                namespace,
-				Clients:                  clients,
-				RestConfig:               config,
-				AuthModes:                modes,
-				ManagedNamespace:         managedNamespace,
-				SSONamespace:             ssoNamespace,
-				ConfigName:               configMap,
-				EventOperationQueueSize:  eventOperationQueueSize,
-				EventWorkerCount:         eventWorkerCount,
-				EventAsyncDispatch:       eventAsyncDispatch,
-				XFrameOptions:            frameOptions,
-				AccessControlAllowOrigin: accessControlAllowOrigin,
-				APIRateLimit:             apiRateLimit,
-				AllowedLinkProtocol:      allowedLinkProtocol,
+				BaseHRef:                  baseHRef,
+				TLSConfig:                 tlsConfig,
+				HSTS:                      hsts,
+				Namespaced:                namespaced,
+				Namespace:                 namespace,
+				Clients:                   clients,
+				RestConfig:                config,
+				AuthModes:                 modes,
+				ManagedNamespace:          managedNamespace,
+				SSONamespace:              ssoNamespace,
+				ConfigName:                configMap,
+				EventOperationQueueSize:   eventOperationQueueSize,
+				EventWorkerCount:          eventWorkerCount,
+				EventAsyncDispatch:        eventAsyncDispatch,
+				XFrameOptions:             frameOptions,
+				AccessControlAllowOrigin:  accessControlAllowOrigin,
+				APIRateLimit:              apiRateLimit,
+				AllowedLinkProtocol:       allowedLinkProtocol,
+				EnableAggregatedAPIServer: enableAggregatedAPIServer,
+				AggregatedDBDriver:        aggregatedDBDriver,
+				AggregatedDBDSN:           aggregatedDBDSN,
+				AggregatedAPIServerPort:   aggregatedAPIServerPort,
 			}
 			browserOpenFunc := func(url string) {}
 			if enableOpenBrowser {
@@ -214,6 +222,10 @@ See %s`, help.ArgoServer()),
 	command.Flags().Float32Var(&kubeAPIQPS, "kube-api-qps", 20.0, "QPS to use while talking with kube-apiserver.")
 	command.Flags().IntVar(&kubeAPIBurst, "kube-api-burst", 30, "Burst to use while talking with kube-apiserver.")
 	command.Flags().StringVar(&logLevel, "loglevel", "info", "Set the logging level. One of: debug|info|warn|error")
+	command.Flags().BoolVar(&enableAggregatedAPIServer, "enable-aggregated-apiserver", false, "Enable the Kubernetes aggregated API server backed by SQL storage")
+	command.Flags().StringVar(&aggregatedDBDriver, "db-driver", "postgres", "Database driver for aggregated API server: sqlite or postgres")
+	command.Flags().StringVar(&aggregatedDBDSN, "db-dsn", "postgresql://argo:argo@postgres:5432/argo?sslmode=disable", "Database DSN for aggregated API server")
+	command.Flags().IntVar(&aggregatedAPIServerPort, "aggregated-api-port", 6443, "Port for the aggregated API server")
 
 	// set-up env vars for the CLI such that ARGO_* env vars can be used instead of flags
 	viper.AutomaticEnv()

--- a/docs/aggregated-apiserver.md
+++ b/docs/aggregated-apiserver.md
@@ -103,6 +103,22 @@ kubectl rollout restart deployment/workflow-controller -n argo
 
 > Prerequisites: Kubernetes 1.25+, Argo Workflows installed in the `argo` namespace, `kubectl` with `kustomize` support.
 
+> **⚠️ Important:** The `argoproj.io/v1alpha1` resource group must not have any CRDs installed. If you installed Argo from `manifests/quick-start/minimal` (or any install that includes CRDs), Kubernetes automatically creates a *local* APIService for that group which takes priority over the aggregated server. Delete any installed `argoproj.io` CRDs first:
+>
+> ```bash
+> kubectl delete crd \
+>   workflowartifactgctasks.argoproj.io \
+>   workfloweventbindings.argoproj.io \
+>   workflowtaskresults.argoproj.io \
+>   workflowtasksets.argoproj.io \
+>   workflows.argoproj.io \
+>   workflowtemplates.argoproj.io \
+>   clusterworkflowtemplates.argoproj.io \
+>   cronworkflows.argoproj.io 2>/dev/null || true
+> ```
+>
+> The aggregated server handles all `argoproj.io/v1alpha1` resources; no CRDs are needed.
+
 ```bash
 # Deploy with PostgreSQL (recommended)
 kubectl apply -k manifests/overlays/aggregated-apiserver/postgres
@@ -316,7 +332,28 @@ kubectl rollout restart deployment/workflow-controller -n argo
 
 ### `the server could not find the requested resource`
 
-The `APIService` is not registered or the server is unreachable.
+The `APIService` is either not registered, auto-managed as local (due to installed CRDs), or the server is unreachable.
+
+**Step 1** — check if the APIService points to the service (not local):
+
+```bash
+kubectl get apiservice v1alpha1.argoproj.io -o jsonpath='{.spec.service}'
+# Should return: {"name":"argo-aggregated-apiserver","namespace":"argo","port":6443}
+# If empty, the APIService is local (CRD-backed) — see below
+```
+
+**If the APIService is local** — installed CRDs are taking precedence. Delete them and re-apply:
+
+```bash
+kubectl delete crd \
+  workflowartifactgctasks.argoproj.io workfloweventbindings.argoproj.io \
+  workflowtaskresults.argoproj.io workflowtasksets.argoproj.io \
+  workflows.argoproj.io workflowtemplates.argoproj.io \
+  clusterworkflowtemplates.argoproj.io cronworkflows.argoproj.io 2>/dev/null || true
+kubectl apply -k manifests/overlays/aggregated-apiserver/postgres
+```
+
+**Step 2** — if the service is correctly set but still failing:
 
 ```bash
 kubectl get apiservice v1alpha1.argoproj.io
@@ -368,6 +405,7 @@ You are running an older build. The `setTypeMeta` fix in `pkg/storage/rest/gener
 
 ## Known Limitations
 
+- **No CRDs allowed** — all `argoproj.io/v1alpha1` CRDs must be absent from the cluster. Kubernetes automatically creates a *local* APIService (backed by etcd) when any CRD for the group is present, which takes precedence over the aggregated server. The aggregated server itself serves all resource types (including `workflowtaskresults`, `workflowtasksets`, etc.) so CRDs are not needed.
 - **SQLite is single-writer** — do not run more than 1 replica with the SQLite overlay. Use PostgreSQL for HA.
 - **`argoproj.io/v1alpha1` only** — all other resource types continue to flow through etcd. This is not a full etcd replacement.
 - **Self-signed TLS** — certificates are generated at startup. Restart the pod to regenerate. For production, provide a proper CA and certificate via a Secret and mount it into the pod.

--- a/docs/aggregated-apiserver.md
+++ b/docs/aggregated-apiserver.md
@@ -1,0 +1,376 @@
+# Argo Workflows — Aggregated API Server
+
+An optional component that registers a [Kubernetes aggregated API server](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) for the `argoproj.io/v1alpha1` group. Resources are persisted in **PostgreSQL** or **SQLite** instead of etcd, enabling long-term retention, SQL querying, and horizontal scalability.
+
+## Table of Contents
+
+- [Why](#why)
+- [Architecture](#architecture)
+- [Quick Start](#quick-start)
+- [Kustomize Overlays](#kustomize-overlays)
+  - [PostgreSQL (recommended)](#postgresql-recommended)
+  - [SQLite (dev / single-node)](#sqlite-dev--single-node)
+- [Configuration Reference](#configuration-reference)
+- [Database Schema](#database-schema)
+- [How Watch Works](#how-watch-works)
+- [Troubleshooting](#troubleshooting)
+- [Known Limitations](#known-limitations)
+
+---
+
+## Why
+
+| | CRD + etcd (default) | Aggregated API Server + SQL |
+|---|---|---|
+| Storage | etcd (≤1.5 MB/object) | PostgreSQL or SQLite — no practical limit |
+| Long-term retention | etcd fills up; requires pruning | Retain indefinitely |
+| Querying | Label/field selectors only | Full SQL — analytics, ad-hoc queries |
+| HA | etcd cluster required | PostgreSQL replication / managed RDS |
+| Backup | etcd snapshots | Standard `pg_dump` / cloud snapshots |
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                  Kubernetes API Server                    │
+│                                                          │
+│  GET /apis/argoproj.io/v1alpha1/...                      │
+│        │                                                 │
+│        │  APIService v1alpha1.argoproj.io                │
+│        ▼                                                 │
+│  Proxy → argo-aggregated-apiserver:6443                  │
+└──────────────────────────────────────────────────────────┘
+                         │
+                         ▼
+         ┌───────────────────────────────┐
+         │  SimpleAggregatedServer       │
+         │  pkg/apiserver/simpleserver   │
+         │                               │
+         │  Routes:                      │
+         │  /apis/.../namespaces/{ns}/   │
+         │    {resource}[/{name}]        │
+         │  /apis/.../{resource}         │  ← cluster-scoped
+         │  /apis  (discovery)           │
+         │  /healthz                     │
+         └───────────┬───────────────────┘
+                     │
+                     ▼
+         ┌───────────────────────────────┐
+         │  GenericStore (GORM)          │
+         │  pkg/storage/rest/            │
+         │                               │
+         │  Get / List / Create /        │
+         │  Update / Delete / Watch      │
+         └───────────┬───────────────────┘
+                     │
+           ┌─────────┴─────────┐
+           ▼                   ▼
+    ┌─────────────┐    ┌──────────────┐
+    │  PostgreSQL │    │   SQLite     │
+    │  (default)  │    │  (dev only)  │
+    └─────────────┘    └──────────────┘
+```
+
+**Resource types served** (all `argoproj.io/v1alpha1`):
+
+| Resource | Namespaced | E2E validated |
+|---|---|---|
+| `workflows` | ✓ | ✓ |
+| `workflowtemplates` | ✓ | ✓ |
+| `clusterworkflowtemplates` | | ✓ |
+| `cronworkflows` | ✓ | |
+| `workflowtasksets` | ✓ | ✓ (internal, used by workflow executor) |
+| `workflowtaskresults` | ✓ | ✓ (internal, used by workflow executor) |
+| `workflowartifactgctasks` | ✓ | |
+| `workfloweventbindings` | ✓ | |
+
+### Startup Order
+
+The aggregated server runs as a **separate Deployment** (`argo-aggregated-apiserver`). It must be ready before the workflow-controller starts, otherwise the controller's initial list/watch will fail. The readiness probe on `/apis` ensures the kube-apiserver only routes traffic once the server is healthy.
+
+If you restart both at the same time, roll the controller after the aggregated server is `1/1 Ready`:
+
+```bash
+kubectl rollout status deployment/argo-aggregated-apiserver -n argo
+kubectl rollout restart deployment/workflow-controller -n argo
+```
+
+---
+
+## Quick Start
+
+> Prerequisites: Kubernetes 1.25+, Argo Workflows installed in the `argo` namespace, `kubectl` with `kustomize` support.
+
+```bash
+# Deploy with PostgreSQL (recommended)
+kubectl apply -k manifests/overlays/aggregated-apiserver/postgres
+
+# Verify the APIService is Available
+kubectl get apiservice v1alpha1.argoproj.io
+
+# Submit a workflow and confirm it goes through the SQL backend
+kubectl create -f examples/hello-world.yaml -n argo
+kubectl get workflows -n argo
+
+# Create and reference a ClusterWorkflowTemplate
+kubectl apply -f - <<'EOF'
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: my-template
+spec:
+  templates:
+  - name: hello
+    container:
+      image: alpine:3.18
+      command: [echo, hello]
+EOF
+kubectl get clusterworkflowtemplates
+```
+
+---
+
+## Kustomize Overlays
+
+```
+manifests/
+├── base/aggregated-apiserver/          # Base resources (deployment, service, RBAC, APIService)
+├── components/aggregated-apiserver/    # Optional: patches argo-server to enable aggregated API
+└── overlays/aggregated-apiserver/
+    ├── postgres/                       # PostgreSQL-backed (recommended)
+    └── sqlite/                         # SQLite-backed (dev/single-node)
+```
+
+### PostgreSQL (recommended)
+
+**Path:** `manifests/overlays/aggregated-apiserver/postgres/`
+
+What it deploys:
+- `argo-aggregated-apiserver` Deployment — server process pointing at postgres
+- `aggregated-apiserver-postgres-dsn` Secret — DSN for the shared postgres pod
+- Reuses the postgres pod from `components/postgres` (same pod used for workflow archiving)
+- `APIService v1alpha1.argoproj.io` → routes all `argoproj.io/v1alpha1` requests here
+
+```bash
+kubectl apply -k manifests/overlays/aggregated-apiserver/postgres
+```
+
+**External database** — edit the secret before applying:
+
+```yaml
+# manifests/overlays/aggregated-apiserver/postgres/aggregated-apiserver-postgres-secret.yaml
+stringData:
+  dsn: "postgresql://myuser:mypassword@my-rds-host:5432/argo?sslmode=require"
+```
+
+Or patch it post-deploy:
+
+```bash
+kubectl create secret generic aggregated-apiserver-postgres-dsn \
+  --from-literal=dsn="postgresql://myuser:mypassword@my-rds.example.com:5432/argo?sslmode=require" \
+  -n argo --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout restart deployment/argo-aggregated-apiserver -n argo
+```
+
+### SQLite (dev / single-node)
+
+**Path:** `manifests/overlays/aggregated-apiserver/sqlite/`
+
+What it deploys:
+- `argo-aggregated-apiserver` Deployment — single replica
+- `aggregated-apiserver-sqlite` PersistentVolumeClaim — 5 Gi for the database file
+- `APIService v1alpha1.argoproj.io`
+
+```bash
+kubectl apply -k manifests/overlays/aggregated-apiserver/sqlite
+```
+
+> **⚠️ Warning:** SQLite requires exactly **1 replica**. Multiple writers to the same file will corrupt the database. For any HA setup, use PostgreSQL.
+
+To adjust the PVC size, edit `sqlite-pvc.yaml` before applying:
+
+```yaml
+spec:
+  resources:
+    requests:
+      storage: 20Gi
+```
+
+---
+
+## Configuration Reference
+
+### CLI Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--enable-aggregated-apiserver` | `false` | Enable the SQL-backed aggregated API server |
+| `--db-driver` | `sqlite` | Database driver: `sqlite` or `postgres` |
+| `--db-dsn` | `argo.db` | Database connection string or file path |
+| `--aggregated-api-port` | `6443` | TLS port the aggregated server listens on |
+
+### Environment Variables
+
+All flags can be set via environment variables:
+
+| Environment Variable | Equivalent Flag |
+|---|---|
+| `ARGO_DB_DRIVER=postgres` | `--db-driver` |
+| `ARGO_DB_DSN=postgresql://...` | `--db-dsn` |
+| `ARGO_AGGREGATED_API_PORT=6443` | `--aggregated-api-port` |
+
+The manifests inject `ARGO_DB_DSN` from the `postgres-credentials` Secret so the DSN is not exposed in pod command-line arguments.
+
+### DSN Examples
+
+```bash
+# SQLite — file path (use with sqlite overlay)
+--db-dsn /data/argo.db
+
+# SQLite — in-memory (testing only; lost on pod restart)
+--db-dsn :memory:
+
+# PostgreSQL — in-cluster (bundled postgres pod, default credentials)
+--db-dsn "postgresql://argo:argo@postgres:5432/argo?sslmode=disable"
+
+# PostgreSQL — external with TLS
+--db-dsn "postgresql://argo:argo@my-db.example.com:5432/argo?sslmode=require"
+```
+
+---
+
+## Database Schema
+
+Four tables are created automatically on first start via GORM AutoMigrate:
+
+### `resource_records`
+
+Stores every Argo resource as a JSON blob.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | int | Primary key |
+| `kind` | string | e.g. `Workflow`, `WorkflowTemplate` |
+| `namespace` | string | Kubernetes namespace (empty for cluster-scoped) |
+| `name` | string | Resource name |
+| `uid` | string | UUID, unique per resource |
+| `resource_version` | int64 | Monotonically increasing (global counter) |
+| `generation` | int64 | Spec change counter |
+| `data` | text | Full JSON serialisation |
+| `created_at` | timestamp | |
+| `updated_at` | timestamp | |
+| `deleted_at` | timestamp | Soft delete |
+
+### `resource_labels`
+
+Enables efficient label selector queries without scanning `data`.
+
+| Column | Type | Description |
+|---|---|---|
+| `resource_id` | int | FK → resource_records |
+| `key` | string | Label key |
+| `value` | string | Label value |
+
+### `resource_version_counter`
+
+Single-row table providing a global monotonic counter shared across all resource types.
+
+### `watch_events`
+
+Stores recent events for watch reconnection replay (5-minute TTL).
+
+---
+
+## How Watch Works
+
+The server implements the full Kubernetes watch protocol including the WatchList feature (k8s 1.27+):
+
+1. **Initial events** — client sends `?watch=true&sendInitialEvents=true&resourceVersionMatch=NotOlderThan`
+2. Server sends all existing objects as `ADDED` events
+3. Server sends a `BOOKMARK` with annotation `k8s.io/initial-events-end: "true"`
+4. Server streams subsequent change events as they arrive
+5. Server sends periodic `BOOKMARK` events every 30 s for reconnection support
+
+**Wire format** — the watch stream serialises events as newline-delimited JSON objects with lowercase field names (`type`, `object`) to match the Kubernetes API convention. BOOKMARK events carry the same `kind` as the resource being watched.
+
+---
+
+## Troubleshooting
+
+### Pod crashes with `strconv.ParseInt: parsing "tcp://..."` on startup
+
+Kubernetes automatically injects service environment variables for every Service in the namespace. If a Service named `argo-aggregated-apiserver` exists, k8s injects `ARGO_AGGREGATED_APISERVER_PORT=tcp://x.x.x.x:6443` which collides with viper's env binding for the old `--aggregated-apiserver-port` flag.
+
+This was fixed by renaming the flag to `--aggregated-api-port` (env: `ARGO_AGGREGATED_API_PORT`). If you see this with an older build, rebuild with the renamed flag or explicitly pass `--aggregated-api-port 6443` in the deployment args.
+
+### Controller not picking up new workflows after redeployment
+
+If you redeploy the aggregated server (e.g. change the image), the controller's watch connection may be stale. Restart it:
+
+```bash
+kubectl rollout status deployment/argo-aggregated-apiserver -n argo
+kubectl rollout restart deployment/workflow-controller -n argo
+```
+
+### `the server could not find the requested resource`
+
+The `APIService` is not registered or the server is unreachable.
+
+```bash
+kubectl get apiservice v1alpha1.argoproj.io
+# Should show: AVAILABLE True
+
+kubectl get pod -n argo -l app=argo-aggregated-apiserver
+kubectl logs -n argo -l app=argo-aggregated-apiserver | grep -i "error\|ready"
+```
+
+### APIService shows `False / ServiceUnavailable`
+
+The kube-apiserver cannot reach the aggregated server. Check:
+
+1. Pod is running: `kubectl get pod -n argo -l app=argo-aggregated-apiserver`
+2. Service exists: `kubectl get svc argo-aggregated-apiserver -n argo`
+3. Readiness probe passes: look for `serving` in the pod logs
+
+### PostgreSQL connection refused
+
+The aggregated server pod starts before postgres is ready. It retries automatically. Force a fresh start:
+
+```bash
+kubectl rollout restart deployment/argo-aggregated-apiserver -n argo
+```
+
+### `Warning: event bookmark expired` in workflow-controller logs
+
+Non-fatal. The controller's watch reconnection timer fired before a periodic BOOKMARK arrived. The controller re-lists and re-watches automatically; workflow execution is unaffected.
+
+### `Unexpected watch event object type` warning in controller logs
+
+Non-fatal cosmetic warning. Occurs every 30 s when the BOOKMARK ticker fires for secondary resource types. Workflow execution continues normally.
+
+### SQLite `database is locked`
+
+More than one replica is running with the SQLite overlay. Scale down:
+
+```bash
+kubectl scale deployment argo-aggregated-apiserver --replicas=1 -n argo
+```
+
+Or migrate to the postgres overlay.
+
+### List/get returns objects without `kind`/`apiVersion`
+
+You are running an older build. The `setTypeMeta` fix in `pkg/storage/rest/generic_store.go` ensures TypeMeta is populated on all responses. Rebuild and redeploy the image.
+
+---
+
+## Known Limitations
+
+- **SQLite is single-writer** — do not run more than 1 replica with the SQLite overlay. Use PostgreSQL for HA.
+- **`argoproj.io/v1alpha1` only** — all other resource types continue to flow through etcd. This is not a full etcd replacement.
+- **Self-signed TLS** — certificates are generated at startup. Restart the pod to regenerate. For production, provide a proper CA and certificate via a Secret and mount it into the pod.
+- **No server-side apply** — `kubectl apply --server-side` is not supported; use standard `kubectl apply`.
+- **No admission webhooks** — Argo's mutating/validating webhooks do not run in the aggregated path. Resource validation is best-effort.
+- **`--auth-mode server` only** — other auth modes are not tested with the aggregated server path.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/evilmonkeyinc/jsonpath v0.8.1
 	github.com/expr-lang/expr v1.17.8
 	github.com/gavv/httpexpect/v2 v2.17.0
+	github.com/glebarez/sqlite v1.11.0
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/go-jose/go-jose/v3 v3.0.4
 	github.com/go-openapi/jsonreference v0.21.5
@@ -84,9 +85,12 @@ require (
 	google.golang.org/grpc v1.79.3
 	gopkg.in/go-playground/webhooks.v5 v5.17.0
 	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/postgres v1.5.11
+	gorm.io/gorm v1.25.12
 	k8s.io/api v0.35.3
 	k8s.io/apiextensions-apiserver v0.35.3
 	k8s.io/apimachinery v0.35.3
+	k8s.io/apiserver v0.35.3
 	k8s.io/cli-runtime v0.35.3
 	k8s.io/client-go v0.35.3
 	k8s.io/gengo v0.0.0-20251215205346-5ee0d033ba5b
@@ -96,6 +100,11 @@ require (
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	sigs.k8s.io/yaml v1.6.0
 	zombiezen.com/go/sqlite v1.4.2
+)
+
+require (
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
 )
 
 require (
@@ -110,6 +119,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
@@ -122,7 +132,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
-	k8s.io/apiserver v0.35.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,10 @@ github.com/gavv/httpexpect/v2 v2.17.0 h1:nIJqt5v5e4P7/0jODpX2gtSw+pHXUqdP28Ycjqw
 github.com/gavv/httpexpect/v2 v2.17.0/go.mod h1:E8ENFlT9MZ3Si2sfM6c6ONdwXV2noBCGkhA+lkJgkP0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
+github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9gAXWo=
+github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
+github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=
+github.com/glebarez/sqlite v1.11.0/go.mod h1:h8/o8j5wiAsqSPoWELDUdJXhjAhsVliSn7bWZjOhrgQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
@@ -543,6 +547,10 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -1200,6 +1208,10 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/postgres v1.5.11 h1:ubBVAfbKEUld/twyKZ0IYn9rSQh448EdelLYk9Mv314=
+gorm.io/driver/postgres v1.5.11/go.mod h1:DX3GReXH+3FPWGrrgffdvCk3DQ1dwDPdmbenSkweRGI=
+gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
+gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/manifests/base/aggregated-apiserver/aggregated-apiserver-deployment.yaml
+++ b/manifests/base/aggregated-apiserver/aggregated-apiserver-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-aggregated-apiserver
+spec:
+  selector:
+    matchLabels:
+      app: argo-aggregated-apiserver
+  template:
+    metadata:
+      labels:
+        app: argo-aggregated-apiserver
+    spec:
+      serviceAccountName: argo-server
+      containers:
+        - name: argo-aggregated-apiserver
+          image: argoproj/argocli:simple12
+          imagePullPolicy: Never
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          args:
+            - server
+            - --auth-mode
+            - server
+            - --enable-aggregated-apiserver
+            - --db-driver
+            - sqlite
+            - --db-dsn
+            - /data/argo.db
+          ports:
+            - name: aggregated-api
+              containerPort: 6443
+          readinessProbe:
+            httpGet:
+              port: 6443
+              scheme: HTTPS
+              path: /apis
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /data
+              name: data
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}
+      securityContext:
+        runAsNonRoot: true
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/manifests/base/aggregated-apiserver/aggregated-apiserver-deployment.yaml
+++ b/manifests/base/aggregated-apiserver/aggregated-apiserver-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: argo-server
       containers:
         - name: argo-aggregated-apiserver
-          image: argoproj/argocli:simple12
+          image: argoproj/argocli:simple13
           imagePullPolicy: Never
           securityContext:
             readOnlyRootFilesystem: true

--- a/manifests/base/aggregated-apiserver/aggregated-apiserver-service.yaml
+++ b/manifests/base/aggregated-apiserver/aggregated-apiserver-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-aggregated-apiserver
+spec:
+  ports:
+    - name: aggregated-api
+      port: 6443
+      targetPort: 6443
+  selector:
+    app: argo-aggregated-apiserver

--- a/manifests/base/aggregated-apiserver/apiservice.yaml
+++ b/manifests/base/aggregated-apiserver/apiservice.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.argoproj.io
+  labels:
+    app: argo-server
+spec:
+  group: argoproj.io
+  version: v1alpha1
+  service:
+    name: argo-aggregated-apiserver
+    namespace: argo
+    port: 6443
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  insecureSkipTLSVerify: true

--- a/manifests/base/aggregated-apiserver/kustomization.yaml
+++ b/manifests/base/aggregated-apiserver/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Minimal base: SQLite with ephemeral storage (no postgres).
+# Use overlays/aggregated-apiserver/postgres for a production-ready deployment,
+# or overlays/aggregated-apiserver/sqlite for persistent SQLite.
+
+resources:
+  - aggregated-apiserver-deployment.yaml
+  - aggregated-apiserver-service.yaml
+  - apiservice.yaml

--- a/manifests/base/aggregated-apiserver/postgres/kustomization.yaml
+++ b/manifests/base/aggregated-apiserver/postgres/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - postgres-secret.yaml
+  - postgres-pvc.yaml
+  - postgres-deployment.yaml
+  - postgres-service.yaml

--- a/manifests/base/aggregated-apiserver/postgres/postgres-deployment.yaml
+++ b/manifests/base/aggregated-apiserver/postgres/postgres-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: POSTGRES_DB
+              value: argo
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: [pg_isready, -U, argo]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: data
+              subPath: postgres
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data

--- a/manifests/base/aggregated-apiserver/postgres/postgres-pvc.yaml
+++ b/manifests/base/aggregated-apiserver/postgres/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  labels:
+    app: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/manifests/base/aggregated-apiserver/postgres/postgres-secret.yaml
+++ b/manifests/base/aggregated-apiserver/postgres/postgres-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  labels:
+    app: postgres
+type: Opaque
+stringData:
+  username: argo
+  password: argo
+  dsn: "postgresql://argo:argo@postgres:5432/argo?sslmode=disable"

--- a/manifests/base/aggregated-apiserver/postgres/postgres-service.yaml
+++ b/manifests/base/aggregated-apiserver/postgres/postgres-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/manifests/overlays/aggregated-apiserver/postgres/aggregated-apiserver-postgres-patch.yaml
+++ b/manifests/overlays/aggregated-apiserver/postgres/aggregated-apiserver-postgres-patch.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-aggregated-apiserver
+spec:
+  template:
+    spec:
+      containers:
+        - name: argo-aggregated-apiserver
+          args:
+            - server
+            - --auth-mode
+            - server
+            - --enable-aggregated-apiserver
+            - --db-driver
+            - postgres
+            - --db-dsn
+            - $(ARGO_DB_DSN)
+          env:
+            - name: ARGO_DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: dsn
+          # Remove the SQLite /data volume mount — postgres needs no local storage.
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        # Remove the SQLite data volume — replaced by postgres.
+        - name: data
+          emptyDir: {}

--- a/manifests/overlays/aggregated-apiserver/postgres/kustomization.yaml
+++ b/manifests/overlays/aggregated-apiserver/postgres/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Aggregated API server backed by PostgreSQL (recommended for production).
+# Deploys a bundled postgres:15 pod and patches the server to use it.
+#
+# Deploy:
+#   kubectl apply -k manifests/overlays/aggregated-apiserver/postgres
+#
+# External database — patch the postgres-credentials Secret before applying:
+#   kubectl create secret generic postgres-credentials \
+#     --from-literal=dsn="postgresql://user:pass@my-db:5432/argo?sslmode=require" \
+#     -n argo --dry-run=client -o yaml | kubectl apply -f -
+#   kubectl apply -k manifests/overlays/aggregated-apiserver/postgres
+
+resources:
+  - ../../../base/aggregated-apiserver
+  # Postgres pod, service, PVC, and credentials Secret
+  - ../../../base/aggregated-apiserver/postgres
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argo-aggregated-apiserver
+    path: aggregated-apiserver-postgres-patch.yaml
+
+namespace: argo

--- a/manifests/overlays/aggregated-apiserver/sqlite/aggregated-apiserver-sqlite-patch.yaml
+++ b/manifests/overlays/aggregated-apiserver/sqlite/aggregated-apiserver-sqlite-patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-aggregated-apiserver
+spec:
+  template:
+    spec:
+      # SQLite only supports a single writer — ensure at most one replica.
+      # (This is enforced at the overlay level; horizontal scaling requires postgres.)
+      containers:
+        - name: argo-aggregated-apiserver
+          args:
+            - server
+            - --auth-mode
+            - server
+            - --enable-aggregated-apiserver
+            - --db-driver
+            - sqlite
+            - --db-dsn
+            - /data/argo.db
+          # Clear the postgres env var — SQLite uses a file path in args, not an env var.
+          env: []
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /data
+              name: data
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          persistentVolumeClaim:
+            claimName: aggregated-apiserver-sqlite

--- a/manifests/overlays/aggregated-apiserver/sqlite/kustomization.yaml
+++ b/manifests/overlays/aggregated-apiserver/sqlite/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Aggregated API server backed by SQLite with a persistent volume.
+# Suitable for single-node dev/test environments.
+# NOTE: SQLite does not support multiple replicas — keep replicaCount: 1.
+#
+# Deploy:
+#   kubectl apply -k manifests/overlays/aggregated-apiserver/sqlite
+
+resources:
+  - ../../../base/aggregated-apiserver
+  - sqlite-pvc.yaml
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argo-aggregated-apiserver
+    path: aggregated-apiserver-sqlite-patch.yaml
+
+namespace: argo

--- a/manifests/overlays/aggregated-apiserver/sqlite/sqlite-pvc.yaml
+++ b/manifests/overlays/aggregated-apiserver/sqlite/sqlite-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: aggregated-apiserver-sqlite
+  labels:
+    app: argo-aggregated-apiserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/pkg/apiserver/cert.go
+++ b/pkg/apiserver/cert.go
@@ -1,0 +1,51 @@
+package apiserver
+
+import (
+"crypto/rand"
+"crypto/rsa"
+"crypto/x509"
+"crypto/x509/pkix"
+"encoding/pem"
+"math/big"
+"net"
+"time"
+)
+
+func generateSelfSignedCert(hosts []string, ips []net.IP) ([]byte, []byte, error) {
+priv, err := rsa.GenerateKey(rand.Reader, 2048)
+if err != nil {
+return nil, nil, err
+}
+
+notBefore := time.Now()
+notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+if err != nil {
+return nil, nil, err
+}
+
+template := x509.Certificate{
+SerialNumber: serialNumber,
+Subject: pkix.Name{
+Organization: []string{"Argo Workflows"},
+},
+NotBefore:             notBefore,
+NotAfter:              notAfter,
+KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+BasicConstraintsValid: true,
+DNSNames:              hosts,
+IPAddresses:           ips,
+}
+
+derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+if err != nil {
+return nil, nil, err
+}
+
+certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+return certPEM, keyPEM, nil
+}

--- a/pkg/apiserver/simpleserver.go
+++ b/pkg/apiserver/simpleserver.go
@@ -1,0 +1,606 @@
+package apiserver
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	storageutil "github.com/argoproj/argo-workflows/v4/pkg/storage"
+	sqlrest "github.com/argoproj/argo-workflows/v4/pkg/storage/rest"
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/watch"
+)
+
+// SimpleAggregatedServer is a simplified HTTP server that serves the aggregated API
+// without the full k8s.io/apiserver framework complexity.
+type SimpleAggregatedServer struct {
+	db           *gorm.DB
+	watchManager *watch.Manager
+	scheme       *runtime.Scheme
+	port         int
+	server       *http.Server
+	// stores maps resource name (e.g. "workflows") to its REST storage.
+	stores map[string]rest.Storage
+}
+
+// apiResource describes a resource for discovery responses.
+type apiResource struct {
+	name         string
+	singularName string
+	namespaced   bool
+	kind         string
+}
+
+var allResources = []apiResource{
+	{"workflows", "workflow", true, "Workflow"},
+	{"workflows/status", "workflow", true, "Workflow"},
+	{"workflowtemplates", "workflowtemplate", true, "WorkflowTemplate"},
+	{"clusterworkflowtemplates", "clusterworkflowtemplate", false, "ClusterWorkflowTemplate"},
+	{"cronworkflows", "cronworkflow", true, "CronWorkflow"},
+	{"cronworkflows/status", "cronworkflow", true, "CronWorkflow"},
+	{"workflowtasksets", "workflowtaskset", true, "WorkflowTaskSet"},
+	{"workflowtasksets/status", "workflowtaskset", true, "WorkflowTaskSet"},
+	{"workflowtaskresults", "workflowtaskresult", true, "WorkflowTaskResult"},
+	{"workflowartifactgctasks", "workflowartifactgctask", true, "WorkflowArtifactGCTask"},
+	{"workflowartifactgctasks/status", "workflowartifactgctask", true, "WorkflowArtifactGCTask"},
+	{"workfloweventbindings", "workfloweventbinding", true, "WorkflowEventBinding"},
+}
+
+func NewSimpleAggregatedServer(db *gorm.DB, port int) (*SimpleAggregatedServer, error) {
+	scheme := runtime.NewScheme()
+	if err := wfv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add to scheme: %w", err)
+	}
+
+	wm := watch.NewManager(db)
+
+	stores := make(map[string]rest.Storage)
+	for k, v := range sqlrest.NewWorkflowStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewWorkflowTemplateStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewClusterWorkflowTemplateStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewCronWorkflowStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewWorkflowTaskSetStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewWorkflowTaskResultStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewWorkflowArtifactGCTaskStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+	for k, v := range sqlrest.NewWorkflowEventBindingStorage(db, wm, scheme) {
+		stores[k] = v
+	}
+
+	return &SimpleAggregatedServer{
+		db:           db,
+		watchManager: wm,
+		scheme:       scheme,
+		port:         port,
+		stores:       stores,
+	}, nil
+}
+
+func (s *SimpleAggregatedServer) Run(stopCh <-chan struct{}) error {
+	fmt.Printf("Starting Simple Aggregated API Server on port %d...\n", s.port)
+
+	mux := http.NewServeMux()
+
+	// Namespaced resource paths
+	mux.HandleFunc("/apis/argoproj.io/v1alpha1/namespaces/", s.handleNamespacedRequest)
+
+	// Cluster-scoped resource paths (e.g. clusterworkflowtemplates)
+	mux.HandleFunc("/apis/argoproj.io/v1alpha1/", s.handleClusterScopedRequest)
+
+	// Health check
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	// API group discovery
+	mux.HandleFunc("/apis/argoproj.io", func(w http.ResponseWriter, r *http.Request) {
+		apiGroup := &metav1.APIGroup{
+			TypeMeta:   metav1.TypeMeta{Kind: "APIGroup", APIVersion: "v1"},
+			Name:       "argoproj.io",
+			Versions:   []metav1.GroupVersionForDiscovery{{GroupVersion: "argoproj.io/v1alpha1", Version: "v1alpha1"}},
+			PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "argoproj.io/v1alpha1", Version: "v1alpha1"},
+		}
+		writeJSON(w, apiGroup)
+	})
+
+	// Top-level API group list
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, r *http.Request) {
+		apiList := &metav1.APIGroupList{
+			TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+			Groups: []metav1.APIGroup{
+				{
+					Name:     "argoproj.io",
+					Versions: []metav1.GroupVersionForDiscovery{{GroupVersion: "argoproj.io/v1alpha1", Version: "v1alpha1"}},
+					PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "argoproj.io/v1alpha1", Version: "v1alpha1"},
+				},
+			},
+		}
+		writeJSON(w, apiList)
+	})
+
+	// Resource list discovery — exact match required before the prefix match above
+	mux.HandleFunc("/apis/argoproj.io/v1alpha1", func(w http.ResponseWriter, r *http.Request) {
+		verbs := metav1.Verbs{"create", "delete", "get", "list", "patch", "update", "watch"}
+		resources := make([]metav1.APIResource, 0, len(allResources))
+		for _, res := range allResources {
+			// Skip sub-resources in the top-level list
+			if strings.Contains(res.name, "/") {
+				continue
+			}
+			resources = append(resources, metav1.APIResource{
+				Name:         res.name,
+				SingularName: res.singularName,
+				Namespaced:   res.namespaced,
+				Kind:         res.kind,
+				Verbs:        verbs,
+			})
+		}
+		writeJSON(w, &metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+			GroupVersion: "argoproj.io/v1alpha1",
+			APIResources: resources,
+		})
+	})
+
+	s.server = &http.Server{
+		Addr:    fmt.Sprintf("0.0.0.0:%d", s.port),
+		Handler: mux,
+	}
+
+	go func() {
+		cert, key, err := generateSelfSignedCert(
+			[]string{"argo-server", "argo-server.argo", "argo-server.argo.svc", "localhost"},
+			[]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("0.0.0.0")},
+		)
+		if err != nil {
+			fmt.Printf("ERROR: failed to generate cert: %v\n", err)
+			return
+		}
+		tlsCert, err := tls.X509KeyPair(cert, key)
+		if err != nil {
+			fmt.Printf("ERROR: failed to load cert: %v\n", err)
+			return
+		}
+		s.server.TLSConfig = &tls.Config{
+			Certificates: []tls.Certificate{tlsCert},
+			MinVersion:   tls.VersionTLS12,
+		}
+		listener, err := tls.Listen("tcp", s.server.Addr, s.server.TLSConfig)
+		if err != nil {
+			fmt.Printf("ERROR: failed to create TLS listener: %v\n", err)
+			return
+		}
+		defer listener.Close()
+		fmt.Printf("Simple Aggregated API Server READY and serving on https://0.0.0.0:%d\n", s.port)
+		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("ERROR: server error: %v\n", err)
+		}
+	}()
+
+	<-stopCh
+	fmt.Println("Shutting down Simple Aggregated API Server...")
+	return s.server.Shutdown(context.Background())
+}
+
+// handleNamespacedRequest handles /apis/argoproj.io/v1alpha1/namespaces/{ns}/{resource}[/{name}][/{subresource}]
+func (s *SimpleAggregatedServer) handleNamespacedRequest(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/apis/argoproj.io/v1alpha1/namespaces/")
+	parts := strings.SplitN(path, "/", 4)
+	if len(parts) < 2 {
+		http.Error(w, "invalid path", http.StatusBadRequest)
+		return
+	}
+	namespace := parts[0]
+	resource := parts[1]
+	var name, subresource string
+	if len(parts) > 2 {
+		name = parts[2]
+	}
+	if len(parts) > 3 {
+		subresource = parts[3]
+		resource = resource + "/" + subresource
+	}
+
+	ctx := genericapirequest.WithNamespace(context.Background(), namespace)
+	s.dispatch(w, r, ctx, namespace, resource, name)
+}
+
+// handleClusterScopedRequest handles /apis/argoproj.io/v1alpha1/{resource}[/{name}]
+// (only reached for paths that don't match the more-specific namespaced prefix).
+func (s *SimpleAggregatedServer) handleClusterScopedRequest(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/apis/argoproj.io/v1alpha1/")
+	if path == "" {
+		http.NotFound(w, r)
+		return
+	}
+	parts := strings.SplitN(path, "/", 3)
+	resource := parts[0]
+	var name string
+	if len(parts) > 1 {
+		name = parts[1]
+	}
+
+	ctx := context.Background()
+	s.dispatch(w, r, ctx, "", resource, name)
+}
+
+// dispatch routes a parsed request to the correct store and HTTP verb handler.
+func (s *SimpleAggregatedServer) dispatch(w http.ResponseWriter, r *http.Request, ctx context.Context, namespace, resource, name string) {
+	fmt.Printf("DEBUG: %s /apis/argoproj.io/v1alpha1 ns=%q resource=%q name=%q query=%q\n", r.Method, namespace, resource, name, r.URL.RawQuery)
+
+	store, ok := s.stores[resource]
+	if !ok {
+		http.Error(w, fmt.Sprintf("resource %q not found", resource), http.StatusNotFound)
+		return
+	}
+
+	q := r.URL.Query()
+
+	// Watch support: GET with ?watch=true
+	if r.Method == http.MethodGet && q.Get("watch") == "true" {
+		watcher, ok := store.(rest.Watcher)
+		if !ok {
+			http.Error(w, "watch not supported", http.StatusMethodNotAllowed)
+			return
+		}
+		lister, _ := store.(rest.Lister)
+		opts := &metainternalversion.ListOptions{}
+		if rv := q.Get("resourceVersion"); rv != "" {
+			opts.ResourceVersion = rv
+		}
+		sendInitialEvents := q.Get("sendInitialEvents") == "true"
+		// Derive the correct kind for BOOKMARK events from the allResources table.
+		kind := "Workflow"
+		for _, res := range allResources {
+			if res.name == resource {
+				kind = res.kind
+				break
+			}
+		}
+		s.serveWatch(w, r, ctx, watcher, lister, opts, sendInitialEvents, kind)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		if name != "" {
+			getter, ok := store.(rest.Getter)
+			if !ok {
+				http.Error(w, "get not supported", http.StatusMethodNotAllowed)
+				return
+			}
+			obj, err := getter.Get(ctx, name, &metav1.GetOptions{})
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeJSON(w, obj)
+		} else {
+			lister, ok := store.(rest.Lister)
+			if !ok {
+				http.Error(w, "list not supported", http.StatusMethodNotAllowed)
+				return
+			}
+			obj, err := lister.List(ctx, &metainternalversion.ListOptions{})
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeJSON(w, obj)
+		}
+
+	case http.MethodPost:
+		creater, ok := store.(rest.Creater)
+		if !ok {
+			http.Error(w, "create not supported", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to read body: %v", err), http.StatusBadRequest)
+			return
+		}
+		obj := store.New()
+		if err := json.Unmarshal(body, obj); err != nil {
+			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
+			return
+		}
+		// Ensure namespace and generated name are set.
+		if accessor, err2 := meta.Accessor(obj); err2 == nil {
+			if namespace != "" && accessor.GetNamespace() == "" {
+				accessor.SetNamespace(namespace)
+			}
+			if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+				accessor.SetName(accessor.GetGenerateName() + randomSuffix(5))
+			}
+		}
+		created, err := creater.Create(ctx, obj, nil, &metav1.CreateOptions{})
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(created)
+
+	case http.MethodPut:
+		updater, ok := store.(rest.Updater)
+		if !ok {
+			http.Error(w, "update not supported", http.StatusMethodNotAllowed)
+			return
+		}
+		if name == "" {
+			http.Error(w, "name required for update", http.StatusBadRequest)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to read body: %v", err), http.StatusBadRequest)
+			return
+		}
+		obj := store.New()
+		if err := json.Unmarshal(body, obj); err != nil {
+			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
+			return
+		}
+		updated, _, err := updater.Update(ctx, name, rest.DefaultUpdatedObjectInfo(obj), nil, nil, false, &metav1.UpdateOptions{})
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, updated)
+
+	case http.MethodPatch:
+		updater, ok := store.(rest.Updater)
+		if !ok {
+			http.Error(w, "patch not supported", http.StatusMethodNotAllowed)
+			return
+		}
+		if name == "" {
+			http.Error(w, "name required for patch", http.StatusBadRequest)
+			return
+		}
+		patchBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to read body: %v", err), http.StatusBadRequest)
+			return
+		}
+		// Fetch current object to apply patch onto.
+		getter, ok2 := store.(rest.Getter)
+		if !ok2 {
+			http.Error(w, "get not supported (required for patch)", http.StatusMethodNotAllowed)
+			return
+		}
+		existing, err := getter.Get(ctx, name, &metav1.GetOptions{})
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		existingBytes, err := json.Marshal(existing)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to marshal existing object: %v", err), http.StatusInternalServerError)
+			return
+		}
+		patchedBytes, err := strategicpatch.StrategicMergePatch(existingBytes, patchBytes, existing)
+		if err != nil {
+			// Fall back to plain merge patch
+			patchedBytes, err = applyMergePatch(existingBytes, patchBytes)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("failed to apply patch: %v", err), http.StatusBadRequest)
+				return
+			}
+		}
+		obj := store.New()
+		if err := json.Unmarshal(patchedBytes, obj); err != nil {
+			http.Error(w, fmt.Sprintf("failed to decode patched object: %v", err), http.StatusBadRequest)
+			return
+		}
+		updated, _, err := updater.Update(ctx, name, rest.DefaultUpdatedObjectInfo(obj), nil, nil, false, &metav1.UpdateOptions{})
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, updated)
+
+	case http.MethodDelete:
+		deleter, ok := store.(rest.GracefulDeleter)
+		if !ok {
+			http.Error(w, "delete not supported", http.StatusMethodNotAllowed)
+			return
+		}
+		if name == "" {
+			http.Error(w, "name required for delete", http.StatusBadRequest)
+			return
+		}
+		obj, _, err := deleter.Delete(ctx, name, nil, &metav1.DeleteOptions{})
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, obj)
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// serveWatch streams watch events as newline-delimited JSON using the k8s wire format.
+// The wire format is: {"type":"ADDED","object":{...}}.
+// When sendInitialEvents is true (WatchList protocol, k8s 1.27+), existing objects are
+// sent as ADDED events first, followed by a BOOKMARK with "k8s.io/initial-events-end".
+func (s *SimpleAggregatedServer) serveWatch(w http.ResponseWriter, r *http.Request, ctx context.Context, watcher rest.Watcher, lister rest.Lister, opts *metainternalversion.ListOptions, sendInitialEvents bool, kind string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	wi, err := watcher.Watch(ctx, opts)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	defer wi.Stop()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.WriteHeader(http.StatusOK)
+
+	enc := json.NewEncoder(w)
+	rv, _ := storageutil.CurrentResourceVersion(s.db)
+	rvStr := fmt.Sprintf("%d", rv)
+
+	bookmarkObj := func(rvs string, endOfInitial bool) json.RawMessage {
+		if endOfInitial {
+			return json.RawMessage(fmt.Sprintf(
+				`{"apiVersion":"argoproj.io/v1alpha1","kind":%q,"metadata":{"resourceVersion":%q,"annotations":{"k8s.io/initial-events-end":"true"}}}`,
+				kind, rvs,
+			))
+		}
+		return json.RawMessage(fmt.Sprintf(
+			`{"apiVersion":"argoproj.io/v1alpha1","kind":%q,"metadata":{"resourceVersion":%q}}`,
+			kind, rvs,
+		))
+	}
+
+	if sendInitialEvents && lister != nil {
+		// WatchList protocol: send all existing objects as ADDED, then end BOOKMARK.
+		list, err := lister.List(ctx, &metainternalversion.ListOptions{})
+		if err == nil {
+			items, _ := meta.ExtractList(list)
+			for _, item := range items {
+				objBytes, err := json.Marshal(item)
+				if err != nil {
+					continue
+				}
+				_ = enc.Encode(watchEvent{Type: "ADDED", Object: json.RawMessage(objBytes)})
+			}
+		}
+		_ = enc.Encode(watchEvent{Type: "BOOKMARK", Object: bookmarkObj(rvStr, true)})
+	} else {
+		_ = enc.Encode(watchEvent{Type: "BOOKMARK", Object: bookmarkObj(rvStr, false)})
+	}
+	flusher.Flush()
+
+	// Periodically send BOOKMARKs to keep the watch alive and allow reconnection.
+	bookmarkTicker := time.NewTicker(30 * time.Second)
+	defer bookmarkTicker.Stop()
+
+	for {
+		select {
+		case event, open := <-wi.ResultChan():
+			if !open {
+				return
+			}
+			objBytes, err := json.Marshal(event.Object)
+			if err != nil {
+				continue
+			}
+			_ = enc.Encode(watchEvent{
+				Type:   string(event.Type),
+				Object: json.RawMessage(objBytes),
+			})
+			flusher.Flush()
+		case <-bookmarkTicker.C:
+			if rv2, err2 := storageutil.CurrentResourceVersion(s.db); err2 == nil {
+				_ = enc.Encode(watchEvent{Type: "BOOKMARK", Object: bookmarkObj(fmt.Sprintf("%d", rv2), false)})
+				flusher.Flush()
+			}
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+// watchEvent is the k8s watch wire format with proper JSON field names.
+type watchEvent struct {
+	Type   string          `json:"type"`
+	Object json.RawMessage `json:"object"`
+}
+
+// writeJSON writes obj as JSON with application/json content type.
+func writeJSON(w http.ResponseWriter, obj interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(obj)
+}
+
+// writeError maps k8s API errors to appropriate HTTP status codes.
+func writeError(w http.ResponseWriter, err error) {
+	code := http.StatusInternalServerError
+	type statusError interface{ Status() metav1.Status }
+	if se, ok := err.(statusError); ok {
+		s := se.Status()
+		if s.Code != 0 {
+			code = int(s.Code)
+		}
+	}
+	http.Error(w, err.Error(), code)
+}
+
+// applyMergePatch performs a simple JSON merge patch (RFC 7396).
+func applyMergePatch(base, patch []byte) ([]byte, error) {
+	var baseMap, patchMap map[string]interface{}
+	if err := json.Unmarshal(base, &baseMap); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(patch, &patchMap); err != nil {
+		return nil, err
+	}
+	mergeMaps(baseMap, patchMap)
+	return json.Marshal(baseMap)
+}
+
+func mergeMaps(dst, src map[string]interface{}) {
+	for k, v := range src {
+		if v == nil {
+			delete(dst, k)
+			continue
+		}
+		if srcMap, ok := v.(map[string]interface{}); ok {
+			if dstMap, ok := dst[k].(map[string]interface{}); ok {
+				mergeMaps(dstMap, srcMap)
+				continue
+			}
+		}
+		dst[k] = v
+	}
+}
+
+func randomSuffix(n int) string {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte('a' + rnd.Intn(26))
+	}
+	return string(b)
+}

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"fmt"
+
+	"gorm.io/driver/postgres"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/models"
+)
+
+// NewDB initializes a GORM database connection and runs migrations.
+// driver must be "sqlite" or "postgres". dsn is the data source name
+// (e.g. ":memory:" or "argo.db" for sqlite, or a postgres connection string).
+func NewDB(driver, dsn string) (*gorm.DB, error) {
+	var dialector gorm.Dialector
+	switch driver {
+	case "sqlite":
+		dialector = sqlite.Open(dsn)
+	case "postgres":
+		dialector = postgres.Open(dsn)
+	default:
+		return nil, fmt.Errorf("unsupported database driver: %s (must be sqlite or postgres)", driver)
+	}
+
+	db, err := gorm.Open(dialector, &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Warn),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	if driver == "sqlite" {
+		// Enable WAL mode and foreign keys for SQLite.
+		if err := db.Exec("PRAGMA journal_mode=WAL").Error; err != nil {
+			return nil, fmt.Errorf("failed to set WAL mode: %w", err)
+		}
+		if err := db.Exec("PRAGMA foreign_keys=ON").Error; err != nil {
+			return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
+		}
+	}
+
+	if err := models.AutoMigrate(db); err != nil {
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	return db, nil
+}

--- a/pkg/storage/models/migrate.go
+++ b/pkg/storage/models/migrate.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"gorm.io/gorm"
+)
+
+// AutoMigrate creates or updates all tables using GORM auto-migration.
+func AutoMigrate(db *gorm.DB) error {
+	if err := db.AutoMigrate(
+		&ResourceRecord{},
+		&ResourceLabel{},
+		&ResourceVersionCounter{},
+		&WatchEvent{},
+	); err != nil {
+		return err
+	}
+
+	// Ensure the single-row resource version counter exists.
+	var count int64
+	if err := db.Model(&ResourceVersionCounter{}).Count(&count).Error; err != nil {
+		return err
+	}
+	if count == 0 {
+		return db.Create(&ResourceVersionCounter{ID: 1, Version: 0}).Error
+	}
+	return nil
+}

--- a/pkg/storage/models/models.go
+++ b/pkg/storage/models/models.go
@@ -1,0 +1,67 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ResourceRecord is the main table storing all Argo Workflow resources as JSON blobs
+// with queryable metadata columns.
+type ResourceRecord struct {
+	ID              uint           `gorm:"primaryKey;autoIncrement"`
+	Kind            string         `gorm:"type:varchar(64);not null;index:idx_kind_ns_name,unique"`
+	Namespace       string         `gorm:"type:varchar(256);not null;index:idx_kind_ns_name,unique"`
+	Name            string         `gorm:"type:varchar(256);not null;index:idx_kind_ns_name,unique"`
+	UID             string         `gorm:"type:varchar(128);not null;uniqueIndex"`
+	ResourceVersion int64          `gorm:"not null;index"`
+	Generation      int64          `gorm:"not null;default:1"`
+	Data            string         `gorm:"type:text;not null"`
+	CreatedAt       time.Time      `gorm:"not null"`
+	UpdatedAt       time.Time      `gorm:"not null"`
+	DeletedAt       gorm.DeletedAt `gorm:"index"`
+	Labels          []ResourceLabel `gorm:"foreignKey:ResourceID;constraint:OnDelete:CASCADE"`
+}
+
+func (ResourceRecord) TableName() string {
+	return "resource_records"
+}
+
+// ResourceLabel stores labels for resources, enabling efficient label selector queries.
+type ResourceLabel struct {
+	ID         uint   `gorm:"primaryKey;autoIncrement"`
+	ResourceID uint   `gorm:"not null;index:idx_resource_label,unique"`
+	Key        string `gorm:"type:varchar(317);not null;index:idx_resource_label,unique;index:idx_key_value"`
+	Value      string `gorm:"type:varchar(63);not null;index:idx_key_value"`
+}
+
+func (ResourceLabel) TableName() string {
+	return "resource_labels"
+}
+
+// ResourceVersionCounter is a single-row table for a global monotonic resource version counter.
+type ResourceVersionCounter struct {
+	ID      uint  `gorm:"primaryKey"`
+	Version int64 `gorm:"not null;default:0"`
+}
+
+func (ResourceVersionCounter) TableName() string {
+	return "resource_version_counter"
+}
+
+// WatchEvent stores events for watch replay on reconnection.
+type WatchEvent struct {
+	ID              uint      `gorm:"primaryKey;autoIncrement"`
+	Kind            string    `gorm:"type:varchar(64);not null;index:idx_watch_kind_ns"`
+	Namespace       string    `gorm:"type:varchar(256);not null;index:idx_watch_kind_ns"`
+	Name            string    `gorm:"type:varchar(256);not null"`
+	UID             string    `gorm:"type:varchar(128);not null"`
+	ResourceVersion int64     `gorm:"not null;index"`
+	EventType       string    `gorm:"type:varchar(16);not null"` // ADDED, MODIFIED, DELETED
+	Data            string    `gorm:"type:text;not null"`
+	CreatedAt       time.Time `gorm:"not null;index"`
+}
+
+func (WatchEvent) TableName() string {
+	return "watch_events"
+}

--- a/pkg/storage/query/selectors.go
+++ b/pkg/storage/query/selectors.go
@@ -1,0 +1,93 @@
+package query
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"gorm.io/gorm"
+)
+
+// ApplyLabelSelector adds WHERE conditions to the query based on a label selector.
+// It uses EXISTS/NOT EXISTS subqueries on the resource_labels table.
+func ApplyLabelSelector(db *gorm.DB, sel labels.Selector) *gorm.DB {
+	if sel == nil || sel.Empty() {
+		return db
+	}
+	requirements, _ := sel.Requirements()
+	for _, req := range requirements {
+		db = applyLabelRequirement(db, req)
+	}
+	return db
+}
+
+func applyLabelRequirement(db *gorm.DB, req labels.Requirement) *gorm.DB {
+	key := req.Key()
+	values := req.Values()
+
+	switch req.Operator() {
+	case selection.Equals, selection.DoubleEquals:
+		val, _ := values.PopAny()
+		return db.Where(
+			"EXISTS (SELECT 1 FROM resource_labels WHERE resource_labels.resource_id = resource_records.id AND resource_labels.key = ? AND resource_labels.value = ?)",
+			key, val,
+		)
+	case selection.NotEquals:
+		val, _ := values.PopAny()
+		return db.Where(
+			"NOT EXISTS (SELECT 1 FROM resource_labels WHERE resource_labels.resource_id = resource_records.id AND resource_labels.key = ? AND resource_labels.value = ?)",
+			key, val,
+		)
+	case selection.In:
+		vals := values.UnsortedList()
+		return db.Where(
+			"EXISTS (SELECT 1 FROM resource_labels WHERE resource_labels.resource_id = resource_records.id AND resource_labels.key = ? AND resource_labels.value IN ?)",
+			key, vals,
+		)
+	case selection.NotIn:
+		vals := values.UnsortedList()
+		return db.Where(
+			"NOT EXISTS (SELECT 1 FROM resource_labels WHERE resource_labels.resource_id = resource_records.id AND resource_labels.key = ? AND resource_labels.value IN ?)",
+			key, vals,
+		)
+	case selection.Exists:
+		return db.Where(
+			"EXISTS (SELECT 1 FROM resource_labels WHERE resource_labels.resource_id = resource_records.id AND resource_labels.key = ?)",
+			key,
+		)
+	case selection.DoesNotExist:
+		return db.Where(
+			"NOT EXISTS (SELECT 1 FROM resource_labels WHERE resource_labels.resource_id = resource_records.id AND resource_labels.key = ?)",
+			key,
+		)
+	}
+	return db
+}
+
+// ApplyFieldSelector adds WHERE conditions based on a field selector.
+// Only metadata.name and metadata.namespace are supported.
+func ApplyFieldSelector(db *gorm.DB, sel fields.Selector) *gorm.DB {
+	if sel == nil {
+		return db
+	}
+	for _, req := range sel.Requirements() {
+		switch req.Field {
+		case "metadata.name":
+			db = applyFieldCondition(db, "name", req.Operator, req.Value)
+		case "metadata.namespace":
+			db = applyFieldCondition(db, "namespace", req.Operator, req.Value)
+		}
+	}
+	return db
+}
+
+func applyFieldCondition(db *gorm.DB, column string, op selection.Operator, value string) *gorm.DB {
+	switch op {
+	case selection.Equals, selection.DoubleEquals:
+		return db.Where(fmt.Sprintf("%s = ?", column), value)
+	case selection.NotEquals:
+		return db.Where(fmt.Sprintf("%s != ?", column), value)
+	}
+	return db
+}

--- a/pkg/storage/rest/generic_store.go
+++ b/pkg/storage/rest/generic_store.go
@@ -1,0 +1,532 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/models"
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/query"
+	storageutil "github.com/argoproj/argo-workflows/v4/pkg/storage"
+	watchutil "github.com/argoproj/argo-workflows/v4/pkg/storage/watch"
+)
+
+// GenericStore implements the k8s apiserver registry REST interfaces backed by SQL via GORM.
+type GenericStore struct {
+	db           *gorm.DB
+	watchManager *watchutil.Manager
+	scheme       *runtime.Scheme
+	gvr          schema.GroupVersionResource
+	gvk          schema.GroupVersionKind
+	listGVK      schema.GroupVersionKind
+	newFunc      func() runtime.Object
+	newListFunc  func() runtime.Object
+	kind         string
+	namespaced   bool
+}
+
+// StoreConfig holds configuration for creating a GenericStore.
+type StoreConfig struct {
+	DB           *gorm.DB
+	WatchManager *watchutil.Manager
+	Scheme       *runtime.Scheme
+	GVR          schema.GroupVersionResource
+	GVK          schema.GroupVersionKind
+	ListGVK      schema.GroupVersionKind
+	NewFunc      func() runtime.Object
+	NewListFunc  func() runtime.Object
+	Kind         string
+	Namespaced   bool
+}
+
+// NewGenericStore creates a new GenericStore.
+func NewGenericStore(cfg StoreConfig) *GenericStore {
+	return &GenericStore{
+		db:           cfg.DB,
+		watchManager: cfg.WatchManager,
+		scheme:       cfg.Scheme,
+		gvr:          cfg.GVR,
+		gvk:          cfg.GVK,
+		listGVK:      cfg.ListGVK,
+		newFunc:      cfg.NewFunc,
+		newListFunc:  cfg.NewListFunc,
+		kind:         cfg.Kind,
+		namespaced:   cfg.Namespaced,
+	}
+}
+
+var _ rest.Getter = &GenericStore{}
+var _ rest.Lister = &GenericStore{}
+var _ rest.Creater = &GenericStore{}
+var _ rest.Updater = &GenericStore{}
+var _ rest.GracefulDeleter = &GenericStore{}
+var _ rest.Watcher = &GenericStore{}
+var _ rest.Scoper = &GenericStore{}
+
+func (s *GenericStore) New() runtime.Object {
+	return s.newFunc()
+}
+
+func (s *GenericStore) Destroy() {}
+
+func (s *GenericStore) NewList() runtime.Object {
+	return s.newListFunc()
+}
+
+func (s *GenericStore) NamespaceScoped() bool {
+	return s.namespaced
+}
+
+func (s *GenericStore) GetSingularName() string {
+	return s.gvr.Resource
+}
+
+func (s *GenericStore) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return rest.NewDefaultTableConvertor(s.gvr.GroupResource()).ConvertToTable(ctx, obj, tableOptions)
+}
+
+// Get retrieves a single resource by namespace and name.
+func (s *GenericStore) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	namespace := genericNamespace(ctx)
+
+	var record models.ResourceRecord
+	q := s.db.Where("kind = ? AND name = ?", s.kind, name)
+	if s.namespaced {
+		q = q.Where("namespace = ?", namespace)
+	}
+	if err := q.First(&record).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, errors.NewNotFound(s.gvr.GroupResource(), name)
+		}
+		return nil, errors.NewInternalError(err)
+	}
+
+	return s.deserialize(record.Data)
+}
+
+// List returns a list of resources matching the given options.
+func (s *GenericStore) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	namespace := genericNamespace(ctx)
+
+	q := s.db.Model(&models.ResourceRecord{}).Where("kind = ?", s.kind)
+	if s.namespaced && namespace != "" {
+		q = q.Where("namespace = ?", namespace)
+	}
+
+	// Apply label selector.
+	if options != nil && options.LabelSelector != nil {
+		q = query.ApplyLabelSelector(q, options.LabelSelector)
+	}
+
+	// Apply field selector.
+	if options != nil && options.FieldSelector != nil {
+		q = query.ApplyFieldSelector(q, options.FieldSelector)
+	}
+
+	// Apply limit/continue (offset-based).
+	if options != nil && options.Limit > 0 {
+		q = q.Limit(int(options.Limit))
+	}
+	if options != nil && options.Continue != "" {
+		offset, err := strconv.Atoi(options.Continue)
+		if err != nil {
+			return nil, errors.NewBadRequest("invalid continue token")
+		}
+		q = q.Offset(offset)
+	}
+
+	q = q.Order("resource_version ASC")
+
+	var records []models.ResourceRecord
+	if err := q.Find(&records).Error; err != nil {
+		return nil, errors.NewInternalError(err)
+	}
+
+	return s.buildList(records)
+}
+
+// Create stores a new resource.
+func (s *GenericStore) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, errors.NewInternalError(err)
+	}
+
+	namespace := accessor.GetNamespace()
+	name := accessor.GetName()
+	if name == "" {
+		if accessor.GetGenerateName() != "" {
+			name = accessor.GetGenerateName() + string(uuid.NewUUID())[:5]
+			accessor.SetName(name)
+		} else {
+			return nil, errors.NewBadRequest("name is required")
+		}
+	}
+
+	if createValidation != nil {
+		if err := createValidation(ctx, obj); err != nil {
+			return nil, err
+		}
+	}
+
+	// Set metadata.
+	uid := string(uuid.NewUUID())
+	accessor.SetUID(types.UID(uid))
+	now := metav1.Now()
+	accessor.SetCreationTimestamp(now)
+	accessor.SetGeneration(1)
+
+	var result runtime.Object
+	txErr := s.db.Transaction(func(tx *gorm.DB) error {
+		rv, err := storageutil.NextResourceVersion(tx)
+		if err != nil {
+			return err
+		}
+		accessor.SetResourceVersion(strconv.FormatInt(rv, 10))
+
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return err
+		}
+
+		record := models.ResourceRecord{
+			Kind:            s.kind,
+			Namespace:       namespace,
+			Name:            name,
+			UID:             uid,
+			ResourceVersion: rv,
+			Generation:      1,
+			Data:            string(data),
+		}
+		if err := tx.Create(&record).Error; err != nil {
+			return err
+		}
+
+		// Insert labels.
+		for k, v := range accessor.GetLabels() {
+			label := models.ResourceLabel{
+				ResourceID: record.ID,
+				Key:        k,
+				Value:      v,
+			}
+			if err := tx.Create(&label).Error; err != nil {
+				return err
+			}
+		}
+
+		// Insert watch event.
+		watchEvt := models.WatchEvent{
+			Kind:            s.kind,
+			Namespace:       namespace,
+			Name:            name,
+			UID:             uid,
+			ResourceVersion: rv,
+			EventType:       string(watch.Added),
+			Data:            string(data),
+		}
+		if err := tx.Create(&watchEvt).Error; err != nil {
+			return err
+		}
+
+		result = obj
+		return nil
+	})
+	if txErr != nil {
+		return nil, errors.NewInternalError(txErr)
+	}
+
+	// Notify watchers.
+	s.watchManager.Notify(s.kind, namespace, watch.Added, result, 0)
+
+	return result, nil
+}
+
+// Update modifies an existing resource with optimistic concurrency.
+func (s *GenericStore) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	namespace := genericNamespace(ctx)
+
+	var result runtime.Object
+	var created bool
+
+	txErr := s.db.Transaction(func(tx *gorm.DB) error {
+		// Load existing record.
+		var record models.ResourceRecord
+		q := tx.Where("kind = ? AND name = ?", s.kind, name)
+		if s.namespaced {
+			q = q.Where("namespace = ?", namespace)
+		}
+		err := q.First(&record).Error
+
+		if err == gorm.ErrRecordNotFound {
+			if !forceAllowCreate {
+				return errors.NewNotFound(s.gvr.GroupResource(), name)
+			}
+			// Create via update (PUT-create).
+			existing := s.newFunc()
+			updated, err := objInfo.UpdatedObject(ctx, existing)
+			if err != nil {
+				return err
+			}
+			if createValidation != nil {
+				if err := createValidation(ctx, updated); err != nil {
+					return err
+				}
+			}
+			result, err = s.Create(ctx, updated, nil, nil)
+			created = true
+			return err
+		}
+		if err != nil {
+			return err
+		}
+
+		existing, err := s.deserialize(record.Data)
+		if err != nil {
+			return err
+		}
+
+		updated, err := objInfo.UpdatedObject(ctx, existing)
+		if err != nil {
+			return err
+		}
+
+		updatedAccessor, err := meta.Accessor(updated)
+		if err != nil {
+			return err
+		}
+
+		// Optimistic concurrency check.
+		if updatedAccessor.GetResourceVersion() != "" {
+			clientRV, err := strconv.ParseInt(updatedAccessor.GetResourceVersion(), 10, 64)
+			if err != nil {
+				return errors.NewBadRequest("invalid resourceVersion")
+			}
+			if clientRV != record.ResourceVersion {
+				return errors.NewConflict(s.gvr.GroupResource(), name, fmt.Errorf("the object has been modified; please apply your changes to the latest version"))
+			}
+		}
+
+		if updateValidation != nil {
+			if err := updateValidation(ctx, updated, existing); err != nil {
+				return err
+			}
+		}
+
+		// Increment resource version.
+		rv, err := storageutil.NextResourceVersion(tx)
+		if err != nil {
+			return err
+		}
+		updatedAccessor.SetResourceVersion(strconv.FormatInt(rv, 10))
+		updatedAccessor.SetGeneration(record.Generation + 1)
+
+		data, err := json.Marshal(updated)
+		if err != nil {
+			return err
+		}
+
+		record.ResourceVersion = rv
+		record.Generation = record.Generation + 1
+		record.Data = string(data)
+		if err := tx.Save(&record).Error; err != nil {
+			return err
+		}
+
+		// Sync labels: delete old, insert new.
+		if err := tx.Where("resource_id = ?", record.ID).Delete(&models.ResourceLabel{}).Error; err != nil {
+			return err
+		}
+		for k, v := range updatedAccessor.GetLabels() {
+			label := models.ResourceLabel{
+				ResourceID: record.ID,
+				Key:        k,
+				Value:      v,
+			}
+			if err := tx.Create(&label).Error; err != nil {
+				return err
+			}
+		}
+
+		// Insert watch event.
+		watchEvt := models.WatchEvent{
+			Kind:            s.kind,
+			Namespace:       namespace,
+			Name:            name,
+			UID:             record.UID,
+			ResourceVersion: rv,
+			EventType:       string(watch.Modified),
+			Data:            string(data),
+		}
+		if err := tx.Create(&watchEvt).Error; err != nil {
+			return err
+		}
+
+		result = updated
+		return nil
+	})
+	if txErr != nil {
+		return nil, false, txErr
+	}
+
+	if !created {
+		accessor, _ := meta.Accessor(result)
+		s.watchManager.Notify(s.kind, accessor.GetNamespace(), watch.Modified, result, 0)
+	}
+
+	return result, created, nil
+}
+
+// Delete removes a resource.
+func (s *GenericStore) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	namespace := genericNamespace(ctx)
+
+	var result runtime.Object
+
+	txErr := s.db.Transaction(func(tx *gorm.DB) error {
+		var record models.ResourceRecord
+		q := tx.Where("kind = ? AND name = ?", s.kind, name)
+		if s.namespaced {
+			q = q.Where("namespace = ?", namespace)
+		}
+		if err := q.First(&record).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return errors.NewNotFound(s.gvr.GroupResource(), name)
+			}
+			return err
+		}
+
+		existing, err := s.deserialize(record.Data)
+		if err != nil {
+			return err
+		}
+
+		if deleteValidation != nil {
+			if err := deleteValidation(ctx, existing); err != nil {
+				return err
+			}
+		}
+
+		rv, err := storageutil.NextResourceVersion(tx)
+		if err != nil {
+			return err
+		}
+
+		// Delete labels (cascade should handle this, but be explicit).
+		if err := tx.Where("resource_id = ?", record.ID).Delete(&models.ResourceLabel{}).Error; err != nil {
+			return err
+		}
+
+		// Delete the record (hard delete, not soft delete for now).
+		if err := tx.Unscoped().Delete(&record).Error; err != nil {
+			return err
+		}
+
+		// Insert DELETED watch event.
+		watchEvt := models.WatchEvent{
+			Kind:            s.kind,
+			Namespace:       namespace,
+			Name:            name,
+			UID:             record.UID,
+			ResourceVersion: rv,
+			EventType:       string(watch.Deleted),
+			Data:            record.Data,
+		}
+		if err := tx.Create(&watchEvt).Error; err != nil {
+			return err
+		}
+
+		result = existing
+		return nil
+	})
+	if txErr != nil {
+		return nil, false, txErr
+	}
+
+	accessor, _ := meta.Accessor(result)
+	s.watchManager.Notify(s.kind, accessor.GetNamespace(), watch.Deleted, result, 0)
+
+	return result, true, nil
+}
+
+// Watch returns a watch.Interface that watches for changes.
+func (s *GenericStore) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	namespace := genericNamespace(ctx)
+
+	var rv int64
+	if options != nil && options.ResourceVersion != "" {
+		var err error
+		rv, err = strconv.ParseInt(options.ResourceVersion, 10, 64)
+		if err != nil {
+			return nil, errors.NewBadRequest("invalid resourceVersion")
+		}
+	}
+
+	return s.watchManager.Watch(s.kind, namespace, rv, s.scheme)
+}
+
+func (s *GenericStore) deserialize(data string) (runtime.Object, error) {
+	obj := s.newFunc()
+	if err := json.Unmarshal([]byte(data), obj); err != nil {
+		return nil, fmt.Errorf("failed to deserialize resource: %w", err)
+	}
+	// Ensure TypeMeta is always populated so kubectl and API consumers get kind/apiVersion.
+	s.setTypeMeta(obj)
+	return obj, nil
+}
+
+// setTypeMeta sets the Kind and APIVersion on obj using the store's known GVK.
+func (s *GenericStore) setTypeMeta(obj runtime.Object) {
+	type typeSetter interface {
+		SetGroupVersionKind(schema.GroupVersionKind)
+	}
+	if ts, ok := obj.(typeSetter); ok {
+		ts.SetGroupVersionKind(s.gvk)
+	}
+}
+
+func (s *GenericStore) buildList(records []models.ResourceRecord) (runtime.Object, error) {
+	list := s.newListFunc()
+
+	// Set TypeMeta on the list itself.
+	type typeSetter interface {
+		SetGroupVersionKind(schema.GroupVersionKind)
+	}
+	if ts, ok := list.(typeSetter); ok {
+		ts.SetGroupVersionKind(s.listGVK)
+	}
+
+	items := make([]runtime.Object, 0, len(records))
+	for _, r := range records {
+		obj, err := s.deserialize(r.Data)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, obj)
+	}
+
+	if err := meta.SetList(list, items); err != nil {
+		return nil, fmt.Errorf("failed to set list items: %w", err)
+	}
+
+	return list, nil
+}
+
+// genericNamespace extracts the namespace from the apiserver request context.
+func genericNamespace(ctx context.Context) string {
+	ns, _ := genericapirequest.NamespaceFrom(ctx)
+	return ns
+}

--- a/pkg/storage/rest/status_store.go
+++ b/pkg/storage/rest/status_store.go
@@ -1,0 +1,198 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/models"
+	storageutil "github.com/argoproj/argo-workflows/v4/pkg/storage"
+	watchutil "github.com/argoproj/argo-workflows/v4/pkg/storage/watch"
+)
+
+// StatusStore implements rest.Updater for /status subresources.
+// It loads the current object, applies the update to .Status only, and saves.
+type StatusStore struct {
+	db           *gorm.DB
+	watchManager *watchutil.Manager
+	scheme       *runtime.Scheme
+	gvr          schema.GroupVersionResource
+	kind         string
+	namespaced   bool
+	newFunc      func() runtime.Object
+}
+
+var _ rest.Updater = &StatusStore{}
+var _ rest.Getter = &StatusStore{}
+var _ rest.Scoper = &StatusStore{}
+
+// StatusStoreConfig holds configuration for creating a StatusStore.
+type StatusStoreConfig struct {
+	DB           *gorm.DB
+	WatchManager *watchutil.Manager
+	Scheme       *runtime.Scheme
+	GVR          schema.GroupVersionResource
+	Kind         string
+	Namespaced   bool
+	NewFunc      func() runtime.Object
+}
+
+// NewStatusStore creates a new StatusStore.
+func NewStatusStore(cfg StatusStoreConfig) *StatusStore {
+	return &StatusStore{
+		db:           cfg.DB,
+		watchManager: cfg.WatchManager,
+		scheme:       cfg.Scheme,
+		gvr:          cfg.GVR,
+		kind:         cfg.Kind,
+		namespaced:   cfg.Namespaced,
+		newFunc:      cfg.NewFunc,
+	}
+}
+
+func (s *StatusStore) New() runtime.Object {
+	return s.newFunc()
+}
+
+func (s *StatusStore) Destroy() {}
+
+func (s *StatusStore) NamespaceScoped() bool {
+	return s.namespaced
+}
+
+func (s *StatusStore) GetSingularName() string {
+	return s.gvr.Resource
+}
+
+// Get retrieves the current object (same as main store Get).
+func (s *StatusStore) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	namespace, _ := genericapirequest.NamespaceFrom(ctx)
+
+	var record models.ResourceRecord
+	q := s.db.Where("kind = ? AND name = ?", s.kind, name)
+	if s.namespaced {
+		q = q.Where("namespace = ?", namespace)
+	}
+	if err := q.First(&record).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, errors.NewNotFound(s.gvr.GroupResource(), name)
+		}
+		return nil, errors.NewInternalError(err)
+	}
+
+	obj := s.newFunc()
+	if err := json.Unmarshal([]byte(record.Data), obj); err != nil {
+		return nil, errors.NewInternalError(err)
+	}
+	return obj, nil
+}
+
+// Update updates only the status subresource of the object.
+func (s *StatusStore) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	namespace, _ := genericapirequest.NamespaceFrom(ctx)
+
+	var result runtime.Object
+
+	txErr := s.db.Transaction(func(tx *gorm.DB) error {
+		var record models.ResourceRecord
+		q := tx.Where("kind = ? AND name = ?", s.kind, name)
+		if s.namespaced {
+			q = q.Where("namespace = ?", namespace)
+		}
+		if err := q.First(&record).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				return errors.NewNotFound(s.gvr.GroupResource(), name)
+			}
+			return err
+		}
+
+		existing := s.newFunc()
+		if err := json.Unmarshal([]byte(record.Data), existing); err != nil {
+			return errors.NewInternalError(err)
+		}
+
+		updated, err := objInfo.UpdatedObject(ctx, existing)
+		if err != nil {
+			return err
+		}
+
+		updatedAccessor, err := meta.Accessor(updated)
+		if err != nil {
+			return err
+		}
+
+		// Optimistic concurrency check.
+		if updatedAccessor.GetResourceVersion() != "" {
+			clientRV, err := strconv.ParseInt(updatedAccessor.GetResourceVersion(), 10, 64)
+			if err != nil {
+				return errors.NewBadRequest("invalid resourceVersion")
+			}
+			if clientRV != record.ResourceVersion {
+				return errors.NewConflict(s.gvr.GroupResource(), name, fmt.Errorf("the object has been modified"))
+			}
+		}
+
+		if updateValidation != nil {
+			if err := updateValidation(ctx, updated, existing); err != nil {
+				return err
+			}
+		}
+
+		rv, err := storageutil.NextResourceVersion(tx)
+		if err != nil {
+			return err
+		}
+		updatedAccessor.SetResourceVersion(strconv.FormatInt(rv, 10))
+
+		data, err := json.Marshal(updated)
+		if err != nil {
+			return err
+		}
+
+		record.ResourceVersion = rv
+		record.Data = string(data)
+		if err := tx.Save(&record).Error; err != nil {
+			return err
+		}
+
+		// Insert watch event.
+		watchEvt := models.WatchEvent{
+			Kind:            s.kind,
+			Namespace:       namespace,
+			Name:            name,
+			UID:             record.UID,
+			ResourceVersion: rv,
+			EventType:       string(watch.Modified),
+			Data:            string(data),
+		}
+		if err := tx.Create(&watchEvt).Error; err != nil {
+			return err
+		}
+
+		result = updated
+		return nil
+	})
+	if txErr != nil {
+		return nil, false, txErr
+	}
+
+	accessor, _ := meta.Accessor(result)
+	s.watchManager.Notify(s.kind, accessor.GetNamespace(), watch.Modified, result, 0)
+
+	return result, false, nil
+}
+
+func (s *StatusStore) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	return rest.NewDefaultTableConvertor(s.gvr.GroupResource()).ConvertToTable(ctx, obj, tableOptions)
+}

--- a/pkg/storage/rest/stores.go
+++ b/pkg/storage/rest/stores.go
@@ -1,0 +1,145 @@
+package rest
+
+import (
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	watchutil "github.com/argoproj/argo-workflows/v4/pkg/storage/watch"
+)
+
+var gv = schema.GroupVersion{Group: workflow.Group, Version: workflow.Version}
+
+func newStoreConfig(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme, resource, kind string, namespaced bool, newFunc func() runtime.Object, newListFunc func() runtime.Object) StoreConfig {
+	return StoreConfig{
+		DB:           db,
+		WatchManager: wm,
+		Scheme:       scheme,
+		GVR:          gv.WithResource(resource),
+		GVK:          gv.WithKind(kind),
+		ListGVK:      gv.WithKind(kind + "List"),
+		NewFunc:      newFunc,
+		NewListFunc:  newListFunc,
+		Kind:         kind,
+		Namespaced:   namespaced,
+	}
+}
+
+func newStatusStoreConfig(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme, resource, kind string, namespaced bool, newFunc func() runtime.Object) StatusStoreConfig {
+	return StatusStoreConfig{
+		DB:           db,
+		WatchManager: wm,
+		Scheme:       scheme,
+		GVR:          gv.WithResource(resource),
+		Kind:         kind,
+		Namespaced:   namespaced,
+		NewFunc:      newFunc,
+	}
+}
+
+// NewWorkflowStorage returns storage for workflows and workflows/status.
+func NewWorkflowStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.WorkflowPlural, workflow.WorkflowKind, true,
+		func() runtime.Object { return &wfv1.Workflow{} },
+		func() runtime.Object { return &wfv1.WorkflowList{} },
+	)
+	statusCfg := newStatusStoreConfig(db, wm, scheme, workflow.WorkflowPlural, workflow.WorkflowKind, true,
+		func() runtime.Object { return &wfv1.Workflow{} },
+	)
+	return map[string]rest.Storage{
+		"workflows":        NewGenericStore(cfg),
+		"workflows/status": NewStatusStore(statusCfg),
+	}
+}
+
+// NewWorkflowTemplateStorage returns storage for workflowtemplates.
+func NewWorkflowTemplateStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.WorkflowTemplatePlural, workflow.WorkflowTemplateKind, true,
+		func() runtime.Object { return &wfv1.WorkflowTemplate{} },
+		func() runtime.Object { return &wfv1.WorkflowTemplateList{} },
+	)
+	return map[string]rest.Storage{
+		"workflowtemplates": NewGenericStore(cfg),
+	}
+}
+
+// NewClusterWorkflowTemplateStorage returns storage for clusterworkflowtemplates (cluster-scoped).
+func NewClusterWorkflowTemplateStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.ClusterWorkflowTemplatePlural, workflow.ClusterWorkflowTemplateKind, false,
+		func() runtime.Object { return &wfv1.ClusterWorkflowTemplate{} },
+		func() runtime.Object { return &wfv1.ClusterWorkflowTemplateList{} },
+	)
+	return map[string]rest.Storage{
+		"clusterworkflowtemplates": NewGenericStore(cfg),
+	}
+}
+
+// NewCronWorkflowStorage returns storage for cronworkflows and cronworkflows/status.
+func NewCronWorkflowStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.CronWorkflowPlural, workflow.CronWorkflowKind, true,
+		func() runtime.Object { return &wfv1.CronWorkflow{} },
+		func() runtime.Object { return &wfv1.CronWorkflowList{} },
+	)
+	statusCfg := newStatusStoreConfig(db, wm, scheme, workflow.CronWorkflowPlural, workflow.CronWorkflowKind, true,
+		func() runtime.Object { return &wfv1.CronWorkflow{} },
+	)
+	return map[string]rest.Storage{
+		"cronworkflows":        NewGenericStore(cfg),
+		"cronworkflows/status": NewStatusStore(statusCfg),
+	}
+}
+
+// NewWorkflowTaskSetStorage returns storage for workflowtasksets and workflowtasksets/status.
+func NewWorkflowTaskSetStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.WorkflowTaskSetPlural, workflow.WorkflowTaskSetKind, true,
+		func() runtime.Object { return &wfv1.WorkflowTaskSet{} },
+		func() runtime.Object { return &wfv1.WorkflowTaskSetList{} },
+	)
+	statusCfg := newStatusStoreConfig(db, wm, scheme, workflow.WorkflowTaskSetPlural, workflow.WorkflowTaskSetKind, true,
+		func() runtime.Object { return &wfv1.WorkflowTaskSet{} },
+	)
+	return map[string]rest.Storage{
+		"workflowtasksets":        NewGenericStore(cfg),
+		"workflowtasksets/status": NewStatusStore(statusCfg),
+	}
+}
+
+// NewWorkflowTaskResultStorage returns storage for workflowtaskresults.
+func NewWorkflowTaskResultStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, "workflowtaskresults", workflow.WorkflowTaskResultKind, true,
+		func() runtime.Object { return &wfv1.WorkflowTaskResult{} },
+		func() runtime.Object { return &wfv1.WorkflowTaskResultList{} },
+	)
+	return map[string]rest.Storage{
+		"workflowtaskresults": NewGenericStore(cfg),
+	}
+}
+
+// NewWorkflowArtifactGCTaskStorage returns storage for workflowartifactgctasks and workflowartifactgctasks/status.
+func NewWorkflowArtifactGCTaskStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.WorkflowArtifactGCTaskPlural, workflow.WorkflowArtifactGCTaskKind, true,
+		func() runtime.Object { return &wfv1.WorkflowArtifactGCTask{} },
+		func() runtime.Object { return &wfv1.WorkflowArtifactGCTaskList{} },
+	)
+	statusCfg := newStatusStoreConfig(db, wm, scheme, workflow.WorkflowArtifactGCTaskPlural, workflow.WorkflowArtifactGCTaskKind, true,
+		func() runtime.Object { return &wfv1.WorkflowArtifactGCTask{} },
+	)
+	return map[string]rest.Storage{
+		"workflowartifactgctasks":        NewGenericStore(cfg),
+		"workflowartifactgctasks/status": NewStatusStore(statusCfg),
+	}
+}
+
+// NewWorkflowEventBindingStorage returns storage for workfloweventbindings.
+func NewWorkflowEventBindingStorage(db *gorm.DB, wm *watchutil.Manager, scheme *runtime.Scheme) map[string]rest.Storage {
+	cfg := newStoreConfig(db, wm, scheme, workflow.WorkflowEventBindingPlural, workflow.WorkflowEventBindingKind, true,
+		func() runtime.Object { return &wfv1.WorkflowEventBinding{} },
+		func() runtime.Object { return &wfv1.WorkflowEventBindingList{} },
+	)
+	return map[string]rest.Storage{
+		"workfloweventbindings": NewGenericStore(cfg),
+	}
+}

--- a/pkg/storage/version.go
+++ b/pkg/storage/version.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/models"
+)
+
+// NextResourceVersion atomically increments the global resource version counter
+// and returns the new value. Must be called within a transaction.
+func NextResourceVersion(tx *gorm.DB) (int64, error) {
+	var counter models.ResourceVersionCounter
+
+	// Use FOR UPDATE on Postgres, exclusive transaction on SQLite.
+	result := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&counter, 1)
+	if result.Error != nil {
+		// Fallback for SQLite which doesn't support SELECT FOR UPDATE.
+		result = tx.First(&counter, 1)
+		if result.Error != nil {
+			return 0, fmt.Errorf("failed to read resource version counter: %w", result.Error)
+		}
+	}
+
+	counter.Version++
+	if err := tx.Save(&counter).Error; err != nil {
+		return 0, fmt.Errorf("failed to increment resource version counter: %w", err)
+	}
+
+	return counter.Version, nil
+}
+
+// CurrentResourceVersion returns the current (non-incrementing) resource version.
+func CurrentResourceVersion(db *gorm.DB) (int64, error) {
+	var counter models.ResourceVersionCounter
+	if err := db.First(&counter, 1).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read resource version counter: %w", err)
+	}
+	return counter.Version, nil
+}

--- a/pkg/storage/watch/manager.go
+++ b/pkg/storage/watch/manager.go
@@ -1,0 +1,130 @@
+package watch
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/storage/models"
+)
+
+const (
+	defaultBufferSize    = 100
+	defaultCleanupTTL    = 5 * time.Minute
+	defaultCleanupPeriod = 1 * time.Minute
+)
+
+// Manager manages active watchers and fan-out of events.
+type Manager struct {
+	db       *gorm.DB
+	mu       sync.RWMutex
+	watchers map[uint64]*watcher
+	nextID   atomic.Uint64
+}
+
+// NewManager creates a new WatchManager.
+func NewManager(db *gorm.DB) *Manager {
+	return &Manager{
+		db:       db,
+		watchers: make(map[uint64]*watcher),
+	}
+}
+
+// Watch starts watching for events matching the given kind and namespace.
+// If resourceVersion > 0, it replays missed events from the watch_events table.
+func (m *Manager) Watch(kind, namespace string, resourceVersion int64, scheme *runtime.Scheme) (watch.Interface, error) {
+	id := m.nextID.Add(1)
+
+	w := newWatcher(id, kind, namespace, defaultBufferSize, m.removeWatcher)
+
+	// Replay missed events if a resource version was provided.
+	if resourceVersion > 0 {
+		var events []models.WatchEvent
+		query := m.db.Where("kind = ? AND resource_version > ?", kind, resourceVersion).
+			Order("resource_version ASC")
+		if namespace != "" {
+			query = query.Where("namespace = ?", namespace)
+		}
+		if err := query.Find(&events).Error; err != nil {
+			return nil, err
+		}
+		for _, evt := range events {
+			obj, err := deserializeEvent(evt.Data)
+			if err != nil {
+				continue
+			}
+			w.send(watch.Event{
+				Type:   watch.EventType(evt.EventType),
+				Object: obj,
+			})
+		}
+	}
+
+	m.mu.Lock()
+	m.watchers[id] = w
+	m.mu.Unlock()
+
+	return w, nil
+}
+
+// Notify fans out an event to all matching watchers.
+func (m *Manager) Notify(kind, namespace string, eventType watch.EventType, obj runtime.Object, rv int64) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	event := watch.Event{
+		Type:   eventType,
+		Object: obj,
+	}
+
+	for _, w := range m.watchers {
+		if w.kind != kind {
+			continue
+		}
+		if w.ns != "" && w.ns != namespace {
+			continue
+		}
+		w.send(event)
+	}
+}
+
+// StartCleanup starts a background goroutine that deletes old watch events.
+func (m *Manager) StartCleanup(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(defaultCleanupPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cutoff := time.Now().Add(-defaultCleanupTTL)
+				m.db.Where("created_at < ?", cutoff).Delete(&models.WatchEvent{})
+			}
+		}
+	}()
+}
+
+func (m *Manager) removeWatcher(id uint64) {
+	m.mu.Lock()
+	if w, ok := m.watchers[id]; ok {
+		close(w.ch)
+		delete(m.watchers, id)
+	}
+	m.mu.Unlock()
+}
+
+func deserializeEvent(data string) (runtime.Object, error) {
+	obj := &unstructured.Unstructured{}
+	if err := json.Unmarshal([]byte(data), &obj.Object); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/pkg/storage/watch/watcher.go
+++ b/pkg/storage/watch/watcher.go
@@ -1,0 +1,60 @@
+package watch
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// watcher implements watch.Interface backed by a Go channel.
+type watcher struct {
+	id     uint64
+	kind   string
+	ns     string
+	ch     chan watch.Event
+	done   chan struct{}
+	stop   sync.Once
+	remove func(uint64)
+}
+
+func newWatcher(id uint64, kind, namespace string, bufferSize int, remove func(uint64)) *watcher {
+	return &watcher{
+		id:     id,
+		kind:   kind,
+		ns:     namespace,
+		ch:     make(chan watch.Event, bufferSize),
+		done:   make(chan struct{}),
+		remove: remove,
+	}
+}
+
+func (w *watcher) ResultChan() <-chan watch.Event {
+	return w.ch
+}
+
+func (w *watcher) Stop() {
+	w.stop.Do(func() {
+		w.remove(w.id)
+		close(w.done)
+	})
+}
+
+// send sends an event to the watcher, dropping it if the watcher is stopped or the buffer is full.
+func (w *watcher) send(event watch.Event) bool {
+	select {
+	case <-w.done:
+		return false
+	default:
+	}
+
+	select {
+	case w.ch <- event:
+		return true
+	case <-w.done:
+		return false
+	default:
+		// Buffer full, drop event. In production you'd want to handle this
+		// more gracefully (e.g. close the watcher with an error).
+		return false
+	}
+}

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -35,6 +35,7 @@ import (
 	argo "github.com/argoproj/argo-workflows/v4"
 	aggregatedapiserver "github.com/argoproj/argo-workflows/v4/pkg/apiserver"
 	storageutil "github.com/argoproj/argo-workflows/v4/pkg/storage"
+	"gorm.io/gorm"
 	"github.com/argoproj/argo-workflows/v4/config"
 	persist "github.com/argoproj/argo-workflows/v4/persist/sqldb"
 	clusterwftemplatepkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/clusterworkflowtemplate"
@@ -282,39 +283,44 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	log.Info(ctx, "TRACE: About to get resourceCacheNamespace")
 	resourceCacheNamespace := getResourceCacheNamespace(as.managedNamespace)
 	
-	// Start the aggregated API server BEFORE creating informers if enabled
-	// This ensures the API is available when informers try to connect
+	// Start the aggregated API server BEFORE creating informers if enabled.
+	// This ensures the API is available when informers try to connect.
 	if as.enableAggregatedAPIServer {
-		log.Info(ctx, "AGGREGATED API SERVER ENABLED - starting simple server (before informers)")
-		
-		// Initialize database
-		db, dbErr := storageutil.NewDB(as.aggregatedDBDriver, as.aggregatedDBDSN)
-		if dbErr != nil {
-			log.WithError(dbErr).Error(ctx, "Failed to initialize database - aggregated API server will not start")
-			// Continue without aggregated API server
-		} else {
-			// Create stop channel for aggregated server
-			aggStopCh := make(chan struct{})
-			
-			go func() {
-				log.Info(ctx, "Inside aggregated API server goroutine")
-				
-				// Use SimpleAggregatedServer
-				aggServer, aggErr := aggregatedapiserver.NewSimpleAggregatedServer(db, as.aggregatedAPIServerPort)
-				if aggErr != nil {
-					log.WithError(aggErr).Error(ctx, "Failed to create aggregated API server")
-					return
-				}
-				log.WithField("port", as.aggregatedAPIServerPort).Info(ctx, "Starting simple aggregated API server")
-				if aggErr = aggServer.Run(aggStopCh); aggErr != nil {
-					log.WithError(aggErr).Error(ctx, "Aggregated API server stopped")
-				}
-			}()
-			// Give the aggregated API server a moment to start before informers try to connect
-			log.Info(ctx, "Waiting 5 seconds for aggregated API server to initialize...")
-			time.Sleep(5 * time.Second)
-			log.Info(ctx, "Proceeding with informer creation")
+		log.Info(ctx, "Aggregated API server enabled — connecting to database")
+
+		// Retry DB connection so a slow-starting postgres pod doesn't cause a
+		// permanent failure. The pod exits after max retries so Kubernetes will
+		// restart it with backoff.
+		const dbMaxRetries = 30
+		const dbRetryInterval = 2 * time.Second
+		var db *gorm.DB
+		var dbErr error
+		for i := 1; i <= dbMaxRetries; i++ {
+			db, dbErr = storageutil.NewDB(as.aggregatedDBDriver, as.aggregatedDBDSN)
+			if dbErr == nil {
+				break
+			}
+			log.WithError(dbErr).WithField("attempt", i).Warn(ctx, "Database not ready, retrying...")
+			time.Sleep(dbRetryInterval)
 		}
+		if dbErr != nil {
+			log.WithError(dbErr).WithFatal().Error(ctx, "Failed to connect to database after retries — exiting so Kubernetes can restart")
+		}
+
+		aggStopCh := make(chan struct{})
+		go func() {
+			aggServer, aggErr := aggregatedapiserver.NewSimpleAggregatedServer(db, as.aggregatedAPIServerPort)
+			if aggErr != nil {
+				log.WithError(aggErr).WithFatal().Error(ctx, "Failed to create aggregated API server")
+			}
+			log.WithField("port", as.aggregatedAPIServerPort).Info(ctx, "Starting aggregated API server")
+			if aggErr = aggServer.Run(aggStopCh); aggErr != nil {
+				log.WithError(aggErr).WithFatal().Error(ctx, "Aggregated API server stopped unexpectedly")
+			}
+		}()
+		// Give the aggregated API server a moment to start before informers try to connect.
+		log.Info(ctx, "Waiting 5 seconds for aggregated API server to initialize...")
+		time.Sleep(5 * time.Second)
 	}
 	
 	log.Info(ctx, "TRACE: About to create wftmplStore informer")

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/utils/env"
 
 	argo "github.com/argoproj/argo-workflows/v4"
+	aggregatedapiserver "github.com/argoproj/argo-workflows/v4/pkg/apiserver"
+	storageutil "github.com/argoproj/argo-workflows/v4/pkg/storage"
 	"github.com/argoproj/argo-workflows/v4/config"
 	persist "github.com/argoproj/argo-workflows/v4/persist/sqldb"
 	clusterwftemplatepkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/clusterworkflowtemplate"
@@ -105,8 +107,12 @@ type argoServer struct {
 	accessControlAllowOrigin string
 	apiRateLimiter           limiter.Store
 	allowedLinkProtocol      []string
-	cache                    *cache.ResourceCache
-	restConfig               *rest.Config
+	cache                      *cache.ResourceCache
+	restConfig                 *rest.Config
+	enableAggregatedAPIServer  bool
+	aggregatedDBDriver         string
+	aggregatedDBDSN            string
+	aggregatedAPIServerPort    int
 }
 
 type ArgoServerOpts struct {
@@ -129,6 +135,11 @@ type ArgoServerOpts struct {
 	AccessControlAllowOrigin string
 	APIRateLimit             uint64
 	AllowedLinkProtocol      []string
+	// Aggregated API server options
+	EnableAggregatedAPIServer bool
+	AggregatedDBDriver        string
+	AggregatedDBDSN           string
+	AggregatedAPIServerPort   int
 }
 
 func init() {
@@ -199,8 +210,12 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (Server, error) {
 		accessControlAllowOrigin: opts.AccessControlAllowOrigin,
 		apiRateLimiter:           store,
 		allowedLinkProtocol:      opts.AllowedLinkProtocol,
-		cache:                    resourceCache,
-		restConfig:               opts.RestConfig,
+		cache:                      resourceCache,
+		restConfig:                 opts.RestConfig,
+		enableAggregatedAPIServer:  opts.EnableAggregatedAPIServer,
+		aggregatedDBDriver:         opts.AggregatedDBDriver,
+		aggregatedDBDSN:            opts.AggregatedDBDSN,
+		aggregatedAPIServerPort:    opts.AggregatedAPIServerPort,
 	}, nil
 }
 
@@ -237,8 +252,11 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	}
 
 	log.WithFields(argo.GetVersion().Fields()).WithField("instanceID", config.InstanceID).Info(ctx, "Starting Argo Server")
+	log.WithField("enableAggregatedAPIServer_FLAG", as.enableAggregatedAPIServer).Info(ctx, "TRACE: After Starting Argo Server log")
 
+	log.Info(ctx, "TRACE: About to create instanceIDService")
 	instanceIDService := instanceid.NewService(config.InstanceID)
+	log.Info(ctx, "TRACE: About to setup persistence")
 	offloadRepo := persist.ExplosiveOffloadNodeStatusRepo
 	wfArchive := persist.NullWorkflowArchive
 	persistence := config.Persistence
@@ -261,7 +279,45 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 		// disable the archiving - and still read old records
 		wfArchive = persist.NewWorkflowArchive(session, persistence.GetClusterName(), as.managedNamespace, instanceIDService, dbType)
 	}
+	log.Info(ctx, "TRACE: About to get resourceCacheNamespace")
 	resourceCacheNamespace := getResourceCacheNamespace(as.managedNamespace)
+	
+	// Start the aggregated API server BEFORE creating informers if enabled
+	// This ensures the API is available when informers try to connect
+	if as.enableAggregatedAPIServer {
+		log.Info(ctx, "AGGREGATED API SERVER ENABLED - starting simple server (before informers)")
+		
+		// Initialize database
+		db, dbErr := storageutil.NewDB(as.aggregatedDBDriver, as.aggregatedDBDSN)
+		if dbErr != nil {
+			log.WithError(dbErr).Error(ctx, "Failed to initialize database - aggregated API server will not start")
+			// Continue without aggregated API server
+		} else {
+			// Create stop channel for aggregated server
+			aggStopCh := make(chan struct{})
+			
+			go func() {
+				log.Info(ctx, "Inside aggregated API server goroutine")
+				
+				// Use SimpleAggregatedServer
+				aggServer, aggErr := aggregatedapiserver.NewSimpleAggregatedServer(db, as.aggregatedAPIServerPort)
+				if aggErr != nil {
+					log.WithError(aggErr).Error(ctx, "Failed to create aggregated API server")
+					return
+				}
+				log.WithField("port", as.aggregatedAPIServerPort).Info(ctx, "Starting simple aggregated API server")
+				if aggErr = aggServer.Run(aggStopCh); aggErr != nil {
+					log.WithError(aggErr).Error(ctx, "Aggregated API server stopped")
+				}
+			}()
+			// Give the aggregated API server a moment to start before informers try to connect
+			log.Info(ctx, "Waiting 5 seconds for aggregated API server to initialize...")
+			time.Sleep(5 * time.Second)
+			log.Info(ctx, "Proceeding with informer creation")
+		}
+	}
+	
+	log.Info(ctx, "TRACE: About to create wftmplStore informer")
 	wftmplStore, err := workflowtemplate.NewInformer(as.restConfig, resourceCacheNamespace)
 	if err != nil {
 		log.WithFatal().Error(ctx, err.Error())
@@ -333,6 +389,8 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	log.WithField("url", url).Info(ctx, "Argo Server started successfully")
 	browserOpenFunc(url)
 
+	// Aggregated API server already started earlier (before informers) if enabled
+	
 	<-as.stopCh
 }
 


### PR DESCRIPTION
This PR is just a POC. I wanted to see if it was possible to refactor AWF to use K8s API Aggregation to store CRs in a sql database instead of etcd. It turns out: it is. Unsurprisingly, this is almost entirely LLM generated, though it required a crap ton of redirection. Don't bother reading it line-by-line. The [readme](https://github.com/droctothorpe/argo-workflows/blob/b35cab1b63b1a8197fc682e7259d81925d0eaff4/docs/aggregated-apiserver.md) provides a good overview. [This](https://k8s.info/docs/expert/api-aggregation) is a useful reference as well.

There are undoubtedly tons of drawbacks, but this approach theoretically solves for persistence, eliminates the need for workflow archives, eliminates the need for node status offloading, and overcomes the etcd `--max-request-bytes` limit. 

If there's a real appetite for this feature, I'm happy to move it beyond just a POC. 