### PR TITLE
perf(sqldb): batch insert archived workflow labels.

### DIFF
--- a/persist/sqldb/workflow_archive.go
+++ b/persist/sqldb/workflow_archive.go
@@ -154,16 +154,19 @@ func (r *workflowArchive) ArchiveWorkflow(ctx context.Context, wf *wfv1.Workflow
 		if err != nil {
 			return err
 		}
-		// insert the labels
-		for key, value := range wf.GetLabels() {
-			_, err := sess.Collection(archiveLabelsTableName).
-				Insert(&archivedWorkflowLabelRecord{
-					ClusterName: r.clusterName,
-					UID:         string(wf.UID),
-					Key:         key,
-					Value:       value,
-				})
-			if err != nil {
+		// insert all labels in a single multi-row INSERT
+		labels := wf.GetLabels()
+		if len(labels) > 0 {
+			uid := string(wf.UID)
+			batch := sess.SQL().
+				InsertInto(archiveLabelsTableName).
+				Columns("clustername", "uid", "name", "value").
+				Batch(len(labels))
+			for key, value := range labels {
+				batch.Values(r.clusterName, uid, key, value)
+			}
+			batch.Done()
+			if err := batch.Wait(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Use upper/db multi-row INSERT in ArchiveWorkflow instead of one INSERT per label, reducing database round-trips during archival.


Made-with: Cursor

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized workflow label archival by consolidating individual database inserts into a single batch operation for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->