### PR TITLE
fix(ui): add tooltips to tab icons

### DIFF
--- a/ui/src/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/workflows/components/workflow-details/workflow-details.tsx
@@ -499,17 +499,17 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                 },
                 tools: (
                     <div className='workflow-details__topbar-buttons'>
-                        <a className={classNames({active: tab === 'summary'})} onClick={() => setTab('summary')}>
+                        <a className={classNames({active: tab === 'summary'})} onClick={() => setTab('summary')} title='Summary'>
                             <i className='fa fa-columns' />
                             {workflow && workflow.status.conditions && hasWarningConditionBadge(workflow.status.conditions) && <span className='badge' />}
                         </a>
-                        <a className={classNames({active: tab === 'events'})} onClick={() => setTab('events')}>
+                        <a className={classNames({active: tab === 'events'})} onClick={() => setTab('events')} title='Events'>
                             <i className='fa argo-icon-notification' />
                         </a>
-                        <a className={classNames({active: tab === 'timeline'})} onClick={() => setTab('timeline')}>
+                        <a className={classNames({active: tab === 'timeline'})} onClick={() => setTab('timeline')} title='Timeline'>
                             <i className='fa argo-icon-timeline' />
                         </a>
-                        <a className={classNames({active: tab === 'workflow'})} onClick={() => setTab('workflow')}>
+                        <a className={classNames({active: tab === 'workflow'})} onClick={() => setTab('workflow')} title='Workflow'>
                             <i className='fa argo-icon-workflow' />
                         </a>
                     </div>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

### Motivation

The tab icons (Summary, Events, Timeline, Workflow) in the workflow details toolbar have no text labels or tooltips. Users unfamiliar with the icon meanings have no way to discover each tab's purpose without clicking on it.

### Modifications

Added `title` attributes to the four tab icon links in `ui/src/workflows/components/workflow-details/workflow-details.tsx`:
- Summary
- Events
- Timeline
- Workflow

This provides native browser tooltips on hover.

This brings the behavior in line with the Argo CD application details page.

### Verification

- Opened the workflow details page in a browser and confirmed that hovering over each tab icon displays the correct tooltip.

<img width="360" height="179" alt="image" src="https://github.com/user-attachments/assets/9e375565-17a6-4185-ab77-fc7f95a5b992"/>

### Documentation

No documentation update needed. This is a minor UI usability improvement with self-explanatory behavior.