### PR TITLE
fix: populate scope with empty values for outputs of skipped/omitted DAG ancestors

### DIFF
--- a/docs/enhanced-depends-logic.md
+++ b/docs/enhanced-depends-logic.md
@@ -68,3 +68,11 @@ depends: "A && B && C"
 ```
 
 `dag.task.continueOn` is not available when using `depends`; instead you can specify `.Failed`.
+
+## Output references from Skipped or Omitted tasks
+
+A Skipped or Omitted task never runs, so it produces no output parameters or results.
+If a downstream task references those outputs, the references resolve to empty strings.
+
+For example, if `stage-b` is Skipped because its `when` condition was false, `{{tasks.stage-b.outputs.parameters.message}}` resolves to `""`.
+The same applies when a task is Omitted because its `depends` condition was not met.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -154,6 +154,8 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `steps.<STEPNAME>.outputs.parameters.<NAME>` | Output parameter of any previous step. When the previous step uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
 | `steps.<STEPNAME>.outputs.artifacts.<NAME>` | Output artifact of any previous step |
 
+**Note:** If a step was Skipped (its `when` condition was false), output parameters and results from that step resolve to empty strings.
+
 ### DAG Templates
 
 | Variable | Description|
@@ -170,6 +172,8 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `tasks.<TASKNAME>.outputs.parameters` | When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter maps of each invocation |
 | `tasks.<TASKNAME>.outputs.parameters.<NAME>` | Output parameter of any previous task. When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
 | `tasks.<TASKNAME>.outputs.artifacts.<NAME>` | Output artifact of any previous task |
+
+**Note:** If a task was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied), output parameters and results from that task resolve to empty strings.
 
 ### HTTP Templates
 

--- a/test/e2e/functional/dag-omitted-output-ref.yaml
+++ b/test/e2e/functional/dag-omitted-output-ref.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-omitted-output-ref-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: stage-a
+            template: stage-a
+          - name: stage-b
+            template: stage-b
+            depends: "stage-a.Failed"
+          - name: stage-c
+            template: stage-c
+            depends: "stage-a && (stage-b || stage-b.Omitted)"
+            arguments:
+              parameters:
+                - name: message-from-a
+                  value: "{{tasks.stage-a.outputs.parameters.output-message}}"
+                - name: message-from-b
+                  value: "{{tasks.stage-b.outputs.parameters.output-message}}"
+    - name: stage-a
+      outputs:
+        parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/output.txt
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "hello from stage A", "/tmp/output.txt"]
+    - name: stage-b
+      outputs:
+        parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/output.txt
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "hello from stage B", "/tmp/output.txt"]
+    - name: stage-c
+      inputs:
+        parameters:
+          - name: message-from-a
+          - name: message-from-b
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "stage-c received: [{{inputs.parameters.message-from-a}}] and [{{inputs.parameters.message-from-b}}]"]

--- a/test/e2e/functional/dag-skipped-output-ref.yaml
+++ b/test/e2e/functional/dag-skipped-output-ref.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-output-ref-
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: run-stage-b
+        value: "false"
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: run-stage-b
+      dag:
+        tasks:
+          - name: stage-a
+            template: stage-a
+          - name: stage-b
+            template: stage-b
+            when: "\"{{inputs.parameters.run-stage-b}}\" == \"true\""
+          - name: stage-c
+            template: stage-c
+            depends: "stage-a && (stage-b || stage-b.Skipped)"
+            arguments:
+              parameters:
+                - name: message-from-a
+                  value: "{{tasks.stage-a.outputs.parameters.output-message}}"
+                - name: message-from-b
+                  value: "{{tasks.stage-b.outputs.parameters.output-message}}"
+    - name: stage-a
+      outputs:
+        parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/output.txt
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "hello from stage A", "/tmp/output.txt"]
+    - name: stage-b
+      outputs:
+        parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/output.txt
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "hello from stage B", "/tmp/output.txt"]
+    - name: stage-c
+      inputs:
+        parameters:
+          - name: message-from-a
+          - name: message-from-b
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "stage-c received: [{{inputs.parameters.message-from-a}}] and [{{inputs.parameters.message-from-b}}]"]

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -464,6 +464,54 @@ func (s *FunctionalSuite) TestDAGEmptyParam() {
 		})
 }
 
+func (s *FunctionalSuite) TestDAGOmittedOutputRef() {
+	s.Given().
+		Workflow("@functional/dag-omitted-output-ref.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			nodeA := status.Nodes.FindByDisplayName("stage-a")
+			if assert.NotNil(t, nodeA) {
+				assert.Equal(t, wfv1.NodeSucceeded, nodeA.Phase)
+			}
+			nodeB := status.Nodes.FindByDisplayName("stage-b")
+			if assert.NotNil(t, nodeB) {
+				assert.Equal(t, wfv1.NodeOmitted, nodeB.Phase)
+			}
+			nodeC := status.Nodes.FindByDisplayName("stage-c")
+			if assert.NotNil(t, nodeC) {
+				assert.Equal(t, wfv1.NodeSucceeded, nodeC.Phase)
+			}
+		})
+}
+
+func (s *FunctionalSuite) TestDAGSkippedOutputRef() {
+	s.Given().
+		Workflow("@functional/dag-skipped-output-ref.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			nodeA := status.Nodes.FindByDisplayName("stage-a")
+			if assert.NotNil(t, nodeA) {
+				assert.Equal(t, wfv1.NodeSucceeded, nodeA.Phase)
+			}
+			nodeB := status.Nodes.FindByDisplayName("stage-b")
+			if assert.NotNil(t, nodeB) {
+				assert.Equal(t, wfv1.NodeSkipped, nodeB.Phase)
+			}
+			nodeC := status.Nodes.FindByDisplayName("stage-c")
+			if assert.NotNil(t, nodeC) {
+				assert.Equal(t, wfv1.NodeSucceeded, nodeC.Phase)
+			}
+		})
+}
+
 // 128M is for argo executor
 func (s *FunctionalSuite) TestPendingRetryWorkflow() {
 	s.Given().

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -704,6 +704,24 @@ func (woc *wfOperationCtx) buildLocalScopeFromTask(ctx context.Context, dagCtx *
 			}
 		}
 		woc.buildLocalScope(scope, prefix, ancestorNode)
+
+		// For skipped/omitted ancestors that produced no outputs, populate scope with
+		// empty values for the template's declared output parameters. This prevents
+		// downstream tasks from getting stuck in a requeue loop when they reference
+		// outputs from a dependency that was legitimately skipped.
+		if (ancestorNode.Phase == wfv1.NodeSkipped || ancestorNode.Phase == wfv1.NodeOmitted) && ancestorNode.Outputs == nil {
+			ancestorTask := dagCtx.GetTask(ctx, ancestor)
+			_, tmpl, _, err := dagCtx.tmplCtx.ResolveTemplate(ctx, ancestorTask)
+			if err == nil && tmpl != nil {
+				for _, param := range tmpl.Outputs.Parameters {
+					key := fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name)
+					scope.addParamToScope(key, "")
+				}
+				if tmpl.Outputs.Result != nil {
+					scope.addParamToScope(fmt.Sprintf("%s.outputs.result", prefix), "")
+				}
+			}
+		}
 	}
 	return scope, nil
 }

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -3992,3 +3992,131 @@ func TestDAGWhenSkipNoRequeue(t *testing.T) {
 	require.NotNil(t, nodeB)
 	assert.Equal(t, wfv1.NodeSkipped, nodeB.Phase)
 }
+
+var dagSkippedOutputRef = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-skipped-output-ref
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: run-stage-b
+        value: "false"
+  templates:
+    - name: main
+      inputs:
+        parameters:
+          - name: run-stage-b
+      dag:
+        tasks:
+          - name: stage-a
+            template: stage-a
+          - name: stage-b
+            template: stage-b
+            when: "\"{{inputs.parameters.run-stage-b}}\" == \"true\""
+          - name: stage-c
+            template: stage-c
+            depends: "stage-a && (stage-b || stage-b.Skipped)"
+            arguments:
+              parameters:
+                - name: message-from-a
+                  value: "{{tasks.stage-a.outputs.parameters.output-message}}"
+                - name: message-from-b
+                  value: "{{tasks.stage-b.outputs.parameters.output-message}}"
+    - name: stage-a
+      outputs:
+        parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/output.txt
+      container:
+        image: alpine:3.23
+        command: [sh, -c]
+        args: ["echo 'hello from stage A' > /tmp/output.txt"]
+    - name: stage-b
+      outputs:
+        parameters:
+          - name: output-message
+            valueFrom:
+              path: /tmp/output.txt
+      container:
+        image: alpine:3.23
+        command: [sh, -c]
+        args: ["echo 'hello from stage B' > /tmp/output.txt"]
+    - name: stage-c
+      inputs:
+        parameters:
+          - name: message-from-a
+          - name: message-from-b
+      container:
+        image: alpine:3.23
+        command: [echo]
+        args: ["{{inputs.parameters.message-from-a}}", "{{inputs.parameters.message-from-b}}"]
+status:
+  phase: Running
+  startedAt: "2024-01-01T00:00:00Z"
+  nodes:
+    dag-skipped-output-ref:
+      id: dag-skipped-output-ref
+      name: dag-skipped-output-ref
+      displayName: dag-skipped-output-ref
+      type: DAG
+      templateName: main
+      templateScope: local/dag-skipped-output-ref
+      phase: Running
+      startedAt: "2024-01-01T00:00:00Z"
+      children:
+        - dag-skipped-output-ref-1381367026
+        - dag-skipped-output-ref-1364589407
+      outboundNodes:
+        - dag-skipped-output-ref-1347811788
+    dag-skipped-output-ref-1381367026:
+      id: dag-skipped-output-ref-1381367026
+      name: dag-skipped-output-ref.stage-a
+      displayName: stage-a
+      type: Pod
+      templateName: stage-a
+      templateScope: local/dag-skipped-output-ref
+      boundaryID: dag-skipped-output-ref
+      phase: Succeeded
+      startedAt: "2024-01-01T00:00:00Z"
+      finishedAt: "2024-01-01T00:00:10Z"
+      outputs:
+        parameters:
+          - name: output-message
+            value: "hello from stage A"
+    dag-skipped-output-ref-1364589407:
+      id: dag-skipped-output-ref-1364589407
+      name: dag-skipped-output-ref.stage-b
+      displayName: stage-b
+      type: Skipped
+      templateName: stage-b
+      templateScope: local/dag-skipped-output-ref
+      boundaryID: dag-skipped-output-ref
+      phase: Skipped
+      startedAt: "2024-01-01T00:00:00Z"
+      finishedAt: "2024-01-01T00:00:00Z"
+      message: when '"false" == "true"' evaluated false
+`
+
+// TestDAGSkippedOutputRef verifies that a DAG task can reference outputs from a skipped
+// dependency without causing a requeue loop.
+// Scenario: stage-a succeeds with output parameters, stage-b is skipped (when evaluates false),
+// stage-c depends on both and references outputs from both. stage-c should still be scheduled
+// even though tasks.stage-b.outputs.parameters.output-message is unresolvable.
+func TestDAGSkippedOutputRef(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(dagSkippedOutputRef)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	// stage-c should be created and pending, not stuck in a requeue loop
+	nodeC := woc.wf.Status.Nodes.FindByDisplayName("stage-c")
+	require.NotNil(t, nodeC, "stage-c should be created even though stage-b was skipped")
+	assert.Equal(t, wfv1.NodePending, nodeC.Phase)
+}


### PR DESCRIPTION
Fixes #15837

Fixes a regression in #15442 

### Motivation

When a DAG task is Skipped (`when` evaluates to false) or Omitted (`depends` condition not met), it produces no outputs.
If a downstream task references those outputs, `ReplaceStrict` can't resolve them, causing an infinite requeue loop.

### Modifications

`buildLocalScopeFromTask` now resolves the ancestor's template and populates the scope with empty strings for each declared output parameter and result when the ancestor is Skipped or Omitted.

### Verification

- Unit test `TestDAGSkippedOutputRef` — pre-set status with Skipped stage-b, verifies stage-c is created
- E2E test `TestDAGSkippedOutputRef` — full workflow with `when: "false"` on stage-b
- E2E test `TestDAGOmittedOutputRef` — stage-b omitted via `depends: "stage-a.Failed"`

### Documentation

Added a section to `docs/enhanced-depends-logic.md` explaining that output references from Skipped/Omitted tasks resolve to empty strings.
Added notes to the Steps and DAG variable tables in `docs/variables.md`.

### AI

Written with Claude