### PR TITLE
feat(controller): fix daemon display failures. Fixes #14790

### DIFF
--- a/.features/pending/15842-fix-daemon-display-failures.md
+++ b/.features/pending/15842-fix-daemon-display-failures.md
@@ -1,0 +1,8 @@
+Description: Fix daemon nodes incorrectly displayed as Failed after controlled shutdown
+Authors: [Jeremiah Trest](https://github.com/JerT33)
+Component: Controller
+Issues: 14790, 2762
+
+Daemon nodes were incorrectly marked NodeFailed by `assessNodeStatus` when their pod exited after a controlled shutdown (SIGTERM via `killDaemonedChildren`). This caused daemon nodes to display as red/Failed in the UI even when the workflow completed successfully, and could trigger spurious retries when `retryStrategy` was set, eventually failing the entire workflow.
+
+The fix checks whether `killDaemonedChildren` already cleared the `Daemoned` flag (nil = controlled shutdown) before applying NodeFailed, preserving the NodeSucceeded phase that `killDaemonedChildren` set.

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1419,19 +1419,24 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			woc.controller.tracing.ChangeNodePhase(ctx, namespacedName, updated.ID, updated.Phase, updated.Message)
 		}
 	case apiv1.PodSucceeded:
-		// if the pod is succeeded, we need to check if it is a daemoned step or not
-		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely
-		if tmpl.IsDaemon() {
-			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod succeeded. Marking it as failed")
+		// Active daemons (Daemoned==true) that exit are unexpected failures.
+		// Daemons cleared by killDaemonedChildren (Daemoned==nil) exited cleanly; preserve their phase.
+		if tmpl.IsDaemon() && (old.IsDaemoned() || !old.Phase.Completed()) {
+			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod succeeded unexpectedly. Marking it as failed")
 			updated.Phase = wfv1.NodeFailed
-		} else {
+		} else if !tmpl.IsDaemon() {
 			updated.Phase = wfv1.NodeSucceeded
 		}
 
 		updated.Daemoned = nil
 		updated.RestartingPodUID = ""
 	case apiv1.PodFailed:
-		// ignore pod failure for daemoned steps
+		// Daemon killed by killDaemonedChildren (Daemoned==nil) exited with a non-zero code (e.g. SIGTERM=143); preserve its phase.
+		if tmpl.IsDaemon() && !old.IsDaemoned() {
+			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod failed after controlled shutdown. Preserving existing phase.")
+			updated.Daemoned = nil
+			break
+		}
 		updated.Phase, updated.Message = woc.inferFailedReason(ctx, pod, tmpl)
 		woc.log.WithFields(logging.Fields{"message": updated.Message, "displayName": old.DisplayName, "templateName": wfutil.GetTemplateFromNode(*old), "pod": pod.Name}).Info(ctx, "Pod failed")
 		updated.Daemoned = nil

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1698,16 +1698,56 @@ func TestAssessNodeStatus(t *testing.T) {
 		wantPhase:   wfv1.NodeSucceeded,
 		wantMessage: "",
 	}, {
-		name: "pod failed - daemoned",
+		name: "pod failed - daemoned (unexpected failure, still active)",
 		pod: &apiv1.Pod{
 			Status: apiv1.PodStatus{
 				Phase: apiv1.PodFailed,
 			},
 		},
 		daemon:      true,
-		node:        &wfv1.NodeStatus{TemplateName: templateName},
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded, Daemoned: new(true)},
 		wantPhase:   wfv1.NodeFailed,
-		wantMessage: "can't find failed message for pod  namespace ", // daemoned nodes currently don't have a fail message
+		wantMessage: "can't find failed message for pod  namespace ",
+	}, {
+		name: "pod failed - daemon killed by SIGTERM after killDaemonedChildren (Daemoned=nil)",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodFailed,
+			},
+		},
+		daemon:    true,
+		node:      &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase: wfv1.NodeSucceeded,
+	}, {
+		name: "daemon pod succeeded unexpectedly while still active (node phase not yet set)",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodSucceeded,
+			},
+		},
+		daemon:    true,
+		node:      &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeRunning},
+		wantPhase: wfv1.NodeFailed,
+	}, {
+		name: "daemon pod succeeded unexpectedly while still active (realistic state: Phase=Succeeded, Daemoned=true)",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodSucceeded,
+			},
+		},
+		daemon:    true,
+		node:      &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded, Daemoned: new(true)},
+		wantPhase: wfv1.NodeFailed,
+	}, {
+		name: "daemon pod succeeded after killDaemonedChildren set node to Succeeded (Daemoned=nil)",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodSucceeded,
+			},
+		},
+		daemon:    true,
+		node:      &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase: wfv1.NodeSucceeded,
 	}, {
 		name: "daemon, pod running, node failed",
 		pod: &apiv1.Pod{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14790

### Motivation

Running into this described in #14790, where the daemon pod will complete successfully, however be marked as failed in the display

(todo: give more details)

### Modifications

- Add a check for if the deamon pod has been finalized yet. Only if the deamon pod hasnt been finalized yet do we mark it as failed

(todo: give more details)


### Verification

todo

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
