### PR TITLE
fix: argo watch and other long-running CLI commands cannot be cancelled with Ctrl+C. Fixes #15863

### DIFF
--- a/cmd/argo/commands/common/watch_test.go
+++ b/cmd/argo/commands/common/watch_test.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	workflowpkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflow"
+	wfmocks "github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflow/mocks"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+// mockWatchStream implements WorkflowService_WatchWorkflowsClient
+type mockWatchStream struct {
+	grpc.ClientStream
+	recvCh chan *workflowpkg.WorkflowWatchEvent
+}
+
+func (m *mockWatchStream) Recv() (*workflowpkg.WorkflowWatchEvent, error) {
+	// Block until an event is available; never return an error.
+	// The watch loop exits via ctx.Done(), not via Recv errors.
+	return <-m.recvCh, nil
+}
+
+func (m *mockWatchStream) Header() (metadata.MD, error) { return nil, nil }
+func (m *mockWatchStream) Trailer() metadata.MD         { return nil }
+func (m *mockWatchStream) CloseSend() error             { return nil }
+func (m *mockWatchStream) Context() context.Context     { return context.Background() }
+func (m *mockWatchStream) SendMsg(any) error            { return nil }
+func (m *mockWatchStream) RecvMsg(any) error            { return nil }
+
+func TestWatchWorkflow_ContextCancellation(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logging.NewSlogLogger(logging.Info, logging.Text))
+	ctx, cancel := context.WithCancel(ctx)
+
+	stream := &mockWatchStream{
+		recvCh: make(chan *workflowpkg.WorkflowWatchEvent),
+	}
+
+	mockClient := wfmocks.NewWorkflowServiceClient(t)
+	mockClient.On("WatchWorkflows", mock.Anything, mock.Anything).Return(stream, nil)
+
+	// Cancel the context after a short delay to simulate Ctrl+C
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- WatchWorkflow(ctx, mockClient, "default", "test-wf", GetFlags{})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "WatchWorkflow should return nil on context cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchWorkflow did not exit after context cancellation - Ctrl+C would hang")
+	}
+}

--- a/cmd/argo/commands/common/watch_test.go
+++ b/cmd/argo/commands/common/watch_test.go
@@ -18,12 +18,15 @@ import (
 // mockWatchStream implements WorkflowService_WatchWorkflowsClient
 type mockWatchStream struct {
 	grpc.ClientStream
-	recvCh chan *workflowpkg.WorkflowWatchEvent
+	recvCh      chan *workflowpkg.WorkflowWatchEvent
+	recvStarted chan struct{}
 }
 
 func (m *mockWatchStream) Recv() (*workflowpkg.WorkflowWatchEvent, error) {
-	// Block until an event is available; never return an error.
-	// The watch loop exits via ctx.Done(), not via Recv errors.
+	// Signal that Recv has started blocking, then block until an event is
+	// available; never return an error. The watch loop exits via ctx.Done(),
+	// not via Recv errors.
+	close(m.recvStarted)
 	return <-m.recvCh, nil
 }
 
@@ -39,22 +42,27 @@ func TestWatchWorkflow_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	stream := &mockWatchStream{
-		recvCh: make(chan *workflowpkg.WorkflowWatchEvent),
+		recvCh:      make(chan *workflowpkg.WorkflowWatchEvent),
+		recvStarted: make(chan struct{}),
 	}
 
 	mockClient := wfmocks.NewWorkflowServiceClient(t)
 	mockClient.On("WatchWorkflows", mock.Anything, mock.Anything).Return(stream, nil)
 
-	// Cancel the context after a short delay to simulate Ctrl+C
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
-
 	done := make(chan error, 1)
 	go func() {
 		done <- WatchWorkflow(ctx, mockClient, "default", "test-wf", GetFlags{})
 	}()
+
+	// Wait until the watch stream is actually blocking on Recv, then cancel the
+	// context to simulate Ctrl+C. This deterministically exercises cancellation
+	// while the watch is in-flight.
+	select {
+	case <-stream.recvStarted:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchWorkflow did not start the watch stream")
+	}
 
 	select {
 	case err := <-done:

--- a/cmd/argo/main.go
+++ b/cmd/argo/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	// load authentication plugin for obtaining credentials from cloud providers.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -10,7 +13,10 @@ import (
 )
 
 func main() {
-	if err := commands.NewCommand().Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	err := commands.NewCommand().ExecuteContext(ctx)
+	stop()
+	if err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixes #15863

### Motivation

`argo watch` (and other long-running CLI commands like `argo wait`, `argo logs --follow`) cannot be cancelled with Ctrl+C.

The CLI context is created from `context.Background()` with no signal-based cancellation, so the `case <-ctx.Done()` branch in the watch loop never fires on Ctrl+C.

### Modifications

**`cmd/argo/main.go`**: Use `signal.NotifyContext` + `ExecuteContext` so Ctrl+C cancels the context, allowing long-running commands to exit gracefully via `ctx.Done()`.

### Verification

- `make lint` passes with 0 issues.
- `go test ./cmd/argo/commands/common/...` — all tests pass.
- New test:
  - `TestWatchWorkflow_ContextCancellation`: verifies the watch loop exits promptly on context cancellation. The test synchronizes on the watch stream's `Recv` call before cancelling, so it deterministically exercises cancellation while the watch is in-flight.
- Manual testing: built `argo` binary, ran `argo watch`, confirmed Ctrl+C now exits immediately.

### Documentation

No documentation changes needed — this is a bug fix restoring expected CLI behavior.

### AI

Generative AI (Claude Code) was used to assist with the code, the test, and this PR description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The command-line interface now responds cleanly to interrupt and termination signals.
  - Commands exit with a failure status when an error occurs, making failures easier to detect in scripts and automation.

- **Bug Fixes**
  - Improved cancellation handling while monitoring workflows, allowing watches to stop promptly without reporting an error.
  - Interrupted workflow monitoring no longer remains blocked while waiting for updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
