### PR TITLE
fix(cronworkflow): prevent metadata overwrite due to stale controller state

### DIFF
--- a/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
@@ -114,6 +114,10 @@ func (c *CronWorkflow) IsUsingNewSchedule() bool {
 	return !exists || lastUsedSchedule != c.Spec.GetScheduleWithTimezoneString()
 }
 
+func (c *CronWorkflow) GetScheduleAnnotationKey() string {
+	return annotationKeyLatestSchedule
+}
+
 func (c *CronWorkflow) SetSchedule(schedule string) {
 	if c.Annotations == nil {
 		c.Annotations = map[string]string{}

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -55,6 +55,11 @@ type cronWfOperationCtx struct {
 	scheduledTimeFunc ScheduledTimeFunc
 	//nolint: containedctx
 	ctx context.Context
+	// modifiedLabels and modifiedAnnotations track metadata keys that the controller
+	// has explicitly modified during this operation. Only these keys are included
+	// in the persistUpdate patch, avoiding overwrite of externally-set metadata.
+	modifiedLabels      map[string]string
+	modifiedAnnotations map[string]string
 }
 
 func newCronWfOperationCtx(ctx context.Context, cronWorkflow *v1alpha1.CronWorkflow, wfClientset versioned.Interface,
@@ -98,7 +103,9 @@ func (woc *cronWfOperationCtx) run(ctx context.Context, scheduledRuntime time.Ti
 
 	// If the cron workflow has a schedule that was just updated, update its annotation
 	if woc.cronWf.IsUsingNewSchedule() {
-		woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleWithTimezoneString())
+		schedule := woc.cronWf.Spec.GetScheduleWithTimezoneString()
+		woc.cronWf.SetSchedule(schedule)
+		woc.setModifiedAnnotation(woc.cronWf.GetScheduleAnnotationKey(), schedule)
 	}
 
 	err := woc.validateCronWorkflow(ctx)
@@ -167,8 +174,35 @@ func getWorkflowObjectReference(wf *v1alpha1.Workflow, runWf *v1alpha1.Workflow)
 	}
 }
 
+func (woc *cronWfOperationCtx) setModifiedLabel(key, value string) {
+	if woc.modifiedLabels == nil {
+		woc.modifiedLabels = map[string]string{}
+	}
+	woc.modifiedLabels[key] = value
+}
+
+func (woc *cronWfOperationCtx) setModifiedAnnotation(key, value string) {
+	if woc.modifiedAnnotations == nil {
+		woc.modifiedAnnotations = map[string]string{}
+	}
+	woc.modifiedAnnotations[key] = value
+}
+
 func (woc *cronWfOperationCtx) persistUpdate(ctx context.Context) {
-	woc.patch(ctx, map[string]any{"status": woc.cronWf.Status, "metadata": map[string]any{"annotations": woc.cronWf.Annotations, "labels": woc.cronWf.Labels}})
+	patch := map[string]any{
+		"status": woc.cronWf.Status,
+	}
+	meta := map[string]any{}
+	if len(woc.modifiedLabels) > 0 {
+		meta["labels"] = woc.modifiedLabels
+	}
+	if len(woc.modifiedAnnotations) > 0 {
+		meta["annotations"] = woc.modifiedAnnotations
+	}
+	if len(meta) > 0 {
+		patch["metadata"] = meta
+	}
+	woc.patch(ctx, patch)
 }
 
 func (woc *cronWfOperationCtx) persistCurrentWorkflowStatus(ctx context.Context) {
@@ -555,6 +589,7 @@ func (woc *cronWfOperationCtx) setAsCompleted() {
 		woc.cronWf.Labels = map[string]string{}
 	}
 	woc.cronWf.Labels[common.LabelKeyCronWorkflowCompleted] = "true"
+	woc.setModifiedLabel(common.LabelKeyCronWorkflowCompleted, "true")
 }
 
 func inferScheduledTime(ctx context.Context) time.Time {


### PR DESCRIPTION
## Summary

Fix a race condition in the CronWorkflow controller where `metadata.labels` and `metadata.annotations` can be overwritten with stale values.

Previously, the controller used in-memory objects when performing updates after workflow execution, which could revert newer metadata changes made by external actors.

This PR ensures that:

* The controller does not overwrite user-managed metadata fields
* Only controller-owned metadata is updated when necessary
* Status updates remain unaffected

Fixes #15877

---

## Motivation

In certain scenarios, the controller may overwrite newer metadata changes due to stale in-memory state:

1. CronWorkflow execution starts
2. External actor updates metadata (labels/annotations)
3. Workflow completes
4. Controller calls `persistUpdate()` using stale metadata
5. Newer metadata gets overwritten

This leads to unexpected behavior for systems relying on labels/annotations for:

* Ownership tracking
* Deployment/versioning
* Automation / pruning logic

---

## Changes

* Avoid full overwrite of `metadata.labels` and `metadata.annotations`
* Limit metadata updates to controller-owned fields only
* Ensure patch logic does not use stale in-memory values
* Preserve external/user-managed metadata changes

---

## How to test

1. Apply a CronWorkflow:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: metadata-race-test
  labels:
    test-label: "initial"
spec:
  schedule: "* * * * *"
  concurrencyPolicy: "Forbid"
  workflowSpec:
    entrypoint: main
    templates:
    - name: main
      container:
        image: busybox
        command: ["sh", "-c"]
        args: ["sleep 10"]
```

2. While workflow is running, update labels:

```bash
kubectl patch cronworkflow metadata-race-test \
  -p '{"metadata":{"labels":{"test-label":"updated"}}}' \
  --type=merge
```

3. Wait for workflow completion

### Expected behavior

* `test-label=updated` is preserved

### Before this PR

* `test-label` is reverted to `"initial"`

---

## Checklist

* [x] I have tested with the `:latest` image tag
* [x] I have added/updated tests if applicable
* [x] I have verified that existing functionality is not broken
* [x] I have searched for similar issues and confirmed this is not a duplicate

---

## Additional context

This issue is related to controller-side ownership of metadata fields.

The fix aligns with Kubernetes best practices:

* Controllers should only manage fields they own
* Avoid blind overwrite of user-defined metadata
