### PR TITLE
fix(test): for "CI / Windows Unit Tests", skip TestSessionReconnect

### DIFF
--- a/util/sqldb/session_test.go
+++ b/util/sqldb/session_test.go
@@ -2,6 +2,7 @@ package sqldb
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -84,6 +85,10 @@ func setupPostgresContainer(ctx context.Context, t *testing.T) (config.DBConfig,
 }
 
 func TestSessionReconnect(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("This test uses the Linux container image and therefore cannot be performed on the Windows platform")
+	}
+
 	ctx := logging.TestContext(t.Context())
 	cfg, cancel, err := setupPostgresContainer(ctx, t)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->
- The test for `github.com/argoproj/argo-workflows/v4/util/sqldb` in "CI / Windows Unit Tests" failed.

```
--- FAIL: TestSessionReconnect (16.11s)
    session_test.go:89: 
        	Error Trace:	D:/a/argo-workflows/argo-workflows/util/sqldb/session_test.go:89
        	Error:      	Received unexpected error:
        	            	run postgres: generic container: create container: ensure default network: network create: Error response from daemon: could not find plugin bridge in v1 plugin registry: plugin not found
        	Test:       	TestSessionReconnect
FAIL
coverage: 0.0% of statements
```

- This error "could not find plugin bridge in v1 plugin registry" indicates that the Docker daemon could not create a bridge network for Linux containers, meaning the Linux container execution infrastructure is not available in that environment. This can occur on Windows if Docker is running in Windows Containers mode, or if the bridge network driver is corrupted or disabled.

- Confirmed `runs-on: windows-2022` in `.github/workflows/ci-build.yaml`.

- `TestSessionReconnect` uses the Linux-based PostgreSQL test container (postgres:17.4-alpine). On Windows CI, that assumption does not hold, which causes the test to fail for an environment-specific reason rather than due to product behavior.

For details on how to specify the test container, please refer to the following:
https://github.com/argoproj/argo-workflows/blob/main/util/sqldb/session_test.go#L30

Please refer to the following link for details regarding the supported platforms for postgres:17.4-alpine:
https://hub.docker.com/layers/library/postgres/17.4-alpine/

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- Skipped `TestSessionReconnect` when `runtime.GOOS == "windows"`.
- Added the `runtime` import required for the platform check.

### Verification

<!-- TODO: Say how you tested your changes. -->
- Confirmed the change is limited to `util/sqldb/session_test.go`.
- Verified that `TestSessionReconnect` now exits early on Windows before attempting to start the Linux container image.
- Confirmed that "CI / Windows Unit Tests" completed successfully.
   - https://github.com/argoproj/argo-workflows/actions/runs/24198259870/job/70634623467

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
- No documentation updates are required for this test-only change.