### PR TITLE
docs: generate database migration reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,8 @@ SWAGGER_FILES := pkg/apiclient/_.primary.swagger.json \
 	pkg/apiclient/workflowtemplate/workflow-template.swagger.json \
 	pkg/apiclient/sync/sync.swagger.json
 PROTO_BINARIES := $(TOOL_PROTOC_GEN_GOGO) $(TOOL_PROTOC_GEN_GOGOFAST) $(TOOL_GOIMPORTS) $(TOOL_PROTOC_GEN_GRPC_GATEWAY) $(TOOL_PROTOC_GEN_SWAGGER) $(TOOL_CLANG_FORMAT)
-GENERATED_DOCS := docs/fields.md docs/cli/argo.md docs/workflow-controller-configmap.md docs/metrics.md docs/go-sdk-guide.md
+QUICK_GENERATED_DOCS := docs/metrics.md docs/tracing.md docs/database-migrations.md
+GENERATED_DOCS := $(QUICK_GENERATED_DOCS) docs/fields.md docs/cli/argo.md docs/workflow-controller-configmap.md docs/go-sdk-guide.md
 
 # protoc,my.proto
 define protoc
@@ -764,6 +765,9 @@ docs/tracing.md: $(TELEMETRY_BUILDER) util/telemetry/builder/values.yaml
 	@echo Rebuilding $@
 	go run ./util/telemetry/builder --tracingDocs $@
 
+docs/database-migrations.md: persist/sqldb/migrate.go util/sync/db/migrate.go hack/docs/migrations/main.go
+	GOFLAGS="$(GOFLAGS) -mod=mod" go run ./hack/docs/migrations
+
 # swagger
 pkg/apis/workflow/v1alpha1/openapi_generated.go: $(TOOL_OPENAPI_GEN) $(TYPES)
 	# These files are generated on a v4/ folder by the tool. Link them to the root folder
@@ -854,7 +858,7 @@ ifneq ($(USE_NIX), true)
 endif
 
 .PHONY: docs-spellcheck
-docs-spellcheck: $(TOOL_MDSPELL) docs/metrics.md ## Spell check docs
+docs-spellcheck: $(TOOL_MDSPELL) $(QUICK_GENERATED_DOCS) ## Spell check docs
 	# check docs for spelling mistakes
 	$(TOOL_MDSPELL) --ignore-numbers --ignore-acronyms --en-us --no-suggestions --report $(shell find docs -name '*.md' -not -name upgrading.md -not -name README.md -not -name fields.md -not -name workflow-controller-configmap.md -not -name upgrading.md -not -name executor_swagger.md -not -path '*/cli/*' -not -name tested-kubernetes-versions.md -not -name new-features.md)
 	# alphabetize spelling file -- ignore first line (comment), then sort the rest case-sensitive and remove duplicates
@@ -878,9 +882,9 @@ ifneq ($(USE_NIX), true)
 endif
 
 .PHONY: docs-lint
-docs-lint: $(TOOL_MARKDOWNLINT) docs/metrics.md
+docs-lint: $(TOOL_MARKDOWNLINT) $(QUICK_GENERATED_DOCS)
 	# lint docs
-	$(TOOL_MARKDOWNLINT) docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md --ignore docs/tested-kubernetes-versions.md --ignore docs/go-sdk-guide.md
+	$(TOOL_MARKDOWNLINT) docs --fix --ignore docs/fields.md --ignore docs/executor_swagger.md --ignore docs/cli --ignore docs/walk-through/the-structure-of-workflow-specs.md --ignore docs/tested-kubernetes-versions.md --ignore docs/go-sdk-guide.md --ignore docs/database-migrations.md
 
 $(TOOL_MKDOCS): docs/requirements.txt
 # update this in Nix when upgrading it here
@@ -890,8 +894,7 @@ ifneq ($(USE_NIX), true)
 endif
 
 .PHONY: docs
-docs: $(TOOL_MKDOCS) docs-spellcheck docs-lint ## Build docs
-	# TODO: This is temporarily disabled to unblock merging PRs.
+docs: $(TOOL_MKDOCS) docs-spellcheck docs-lint ## Build docs TODO: This is temporarily disabled to unblock merging PRs.
 	# docs-linkcheck
 	# copy README.md to docs/README.md
 	./hack/docs/copy-readme.sh

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,617 @@
+# Database Migrations
+
+This page lists the SQL migrations that Argo Workflows applies automatically at startup.
+Migrations are applied incrementally and tracked by a version table.
+Each migration is only run once. Do not re-order or remove entries.
+
+The table names and cluster name shown here are defaults.
+Your deployment may use different values depending on your configuration.
+
+See [Workflow Archive](workflow-archive.md) and [Synchronization](synchronization.md) for configuration details.
+
+## Steps
+
+Each migration is numbered as a `Step`. When Argo Workflows runs the automatic migration at controller startup, it records the highest applied step number in a version table (`schema_history` for the archive database,`sync_schema_history` for the sync database) and only runs steps with a higher number on subsequent starts.
+Steps may be missing where the step does nothing for the database type.
+This means steps must never be re-ordered or removed — a new schema change is always appended as a new step.
+
+If you run these statements yourself (for example, because you set `skipMigration: true` or want to manually create the schema), you are responsible for tracking which steps your database is already at.
+Argo Workflows will not detect partial manual application — it only reads the version table.
+If the version table is out of sync with the actual schema, the controller may try to re-apply steps and fail, or skip steps that you have not run.
+
+Programmatic migrations are not described here and the code needs to be consulted for those steps.
+## Archive Database
+
+### MySQL
+
+```sql
+-- Step 0
+create table if not exists argo_workflows (
+    id varchar(128) ,
+    name varchar(256),
+    phase varchar(25),
+    namespace varchar(256),
+    workflow text,
+    startedat timestamp default CURRENT_TIMESTAMP,
+    finishedat timestamp default CURRENT_TIMESTAMP,
+    creationtimestamp timestamp default CURRENT_TIMESTAMP,
+    primary key (id, namespace)
+);
+
+-- Step 1
+create unique index idx_name on argo_workflows (name);
+
+-- Step 2
+create table if not exists argo_workflow_history (
+    id varchar(128) ,
+    name varchar(256),
+    phase varchar(25),
+    namespace varchar(256),
+    workflow text,
+    startedat timestamp default CURRENT_TIMESTAMP,
+    finishedat timestamp default CURRENT_TIMESTAMP,
+    primary key (id, namespace)
+);
+
+-- Step 3
+alter table argo_workflow_history rename to argo_archived_workflows;
+
+-- Step 4
+drop index idx_name on argo_workflows;
+
+-- Step 5
+create unique index idx_name on argo_workflows(name, namespace);
+
+-- Step 6
+alter table argo_workflows drop primary key;
+
+-- Step 7
+alter table argo_workflows add primary key(name,namespace);
+
+-- Step 8
+alter table argo_archived_workflows drop primary key;
+
+-- Step 9
+alter table argo_archived_workflows add primary key(id);
+
+-- Step 10
+alter table argo_archived_workflows change column id uid varchar(128);
+
+-- Step 11
+alter table argo_archived_workflows modify column uid varchar(128) not null;
+
+-- Step 12
+alter table argo_archived_workflows modify column phase varchar(25) not null;
+
+-- Step 13
+alter table argo_archived_workflows modify column namespace varchar(256) not null;
+
+-- Step 14
+alter table argo_archived_workflows modify column workflow text not null;
+
+-- Step 15
+alter table argo_archived_workflows modify column startedat timestamp not null default CURRENT_TIMESTAMP;
+
+-- Step 16
+alter table argo_archived_workflows modify column finishedat timestamp not null default CURRENT_TIMESTAMP;
+
+-- Step 17
+alter table argo_archived_workflows add clustername varchar(64);
+
+-- Step 18
+update argo_archived_workflows set clustername = '<cluster-name>' where clustername is null;
+
+-- Step 19
+alter table argo_archived_workflows modify column clustername varchar(64) not null;
+
+-- Step 20
+alter table argo_archived_workflows drop primary key;
+
+-- Step 21
+alter table argo_archived_workflows add primary key(clustername,uid);
+
+-- Step 22
+create index argo_archived_workflows_i1 on argo_archived_workflows (clustername,namespace);
+
+-- Step 23
+alter table argo_workflows drop column phase;
+
+-- Step 24
+alter table argo_workflows drop column startedat;
+
+-- Step 25
+alter table argo_workflows drop column finishedat;
+
+-- Step 26
+alter table argo_workflows change column id uid varchar(128);
+
+-- Step 27
+alter table argo_workflows modify column uid varchar(128) not null;
+
+-- Step 28
+alter table argo_workflows modify column namespace varchar(256) not null;
+
+-- Step 29
+alter table argo_workflows add column clustername varchar(64);
+
+-- Step 30
+update argo_workflows set clustername = '<cluster-name>' where clustername is null;
+
+-- Step 31
+alter table argo_workflows modify column clustername varchar(64) not null;
+
+-- Step 32
+alter table argo_workflows add column version varchar(64);
+
+-- Step 33
+alter table argo_workflows add column nodes text;
+
+-- Step 34
+— *Programmatic migration: backfillNodes{argo_workflows}*
+
+-- Step 35
+alter table argo_workflows modify column nodes text not null;
+
+-- Step 36
+alter table argo_workflows drop column workflow;
+
+-- Step 37
+alter table argo_workflows add column updatedat timestamp not null default current_timestamp;
+
+-- Step 38
+alter table argo_workflows drop primary key;
+
+-- Step 39
+drop index idx_name on argo_workflows;
+
+-- Step 40
+alter table argo_workflows drop column name;
+
+-- Step 41
+alter table argo_workflows add primary key(clustername,uid,version);
+
+-- Step 42
+create index argo_workflows_i1 on argo_workflows (clustername,namespace);
+
+-- Step 43
+alter table argo_archived_workflows modify column workflow json not null;
+
+-- Step 44
+alter table argo_archived_workflows modify column name varchar(256) not null;
+
+-- Step 45
+create index argo_workflows_i2 on argo_workflows (clustername,namespace,updatedat);
+
+-- Step 46
+create table if not exists argo_archived_workflows_labels (
+	clustername varchar(64) not null,
+	uid varchar(128) not null,
+    name varchar(317) not null,
+    value varchar(63) not null,
+    primary key (clustername, uid, name),
+ 	foreign key (clustername, uid) references argo_archived_workflows(clustername, uid) on delete cascade
+);
+
+-- Step 47
+alter table argo_workflows modify column nodes json not null;
+
+-- Step 48
+alter table argo_archived_workflows add column instanceid varchar(64);
+
+-- Step 49
+update argo_archived_workflows set instanceid = '' where instanceid is null;
+
+-- Step 50
+alter table argo_archived_workflows modify column instanceid varchar(64) not null;
+
+-- Step 51
+drop index argo_archived_workflows_i1 on argo_archived_workflows;
+
+-- Step 52
+create index argo_archived_workflows_i1 on argo_archived_workflows (clustername,instanceid,namespace);
+
+-- Step 53
+drop index argo_workflows_i1 on argo_workflows;
+
+-- Step 54
+drop index argo_workflows_i2 on argo_workflows;
+
+-- Step 55
+create index argo_workflows_i1 on argo_workflows (clustername,namespace,updatedat);
+
+-- Step 56
+create index argo_archived_workflows_i2 on argo_archived_workflows (clustername,instanceid,finishedat);
+
+-- Step 57
+create index argo_archived_workflows_i3 on argo_archived_workflows (clustername,instanceid,name);
+
+-- Step 58
+create index argo_archived_workflows_i4 on argo_archived_workflows (startedat);
+
+-- Step 59
+create index argo_archived_workflows_labels_i1 on argo_archived_workflows_labels (name,value);
+
+-- Step 61
+drop index argo_archived_workflows_i4 on argo_archived_workflows;
+
+-- Step 62
+create index argo_archived_workflows_i4 on argo_archived_workflows (clustername, startedat);
+
+-- Step 63
+alter table argo_archived_workflows add column creationtimestamp timestamp null;
+
+-- Step 64
+update argo_archived_workflows set creationtimestamp = startedat where creationtimestamp is null;
+
+-- Step 65
+alter table argo_archived_workflows modify column creationtimestamp timestamp not null default CURRENT_TIMESTAMP;
+
+-- Step 66
+create index argo_archived_workflows_i5 on argo_archived_workflows (creationtimestamp);
+
+-- Step 67
+drop index argo_archived_workflows_i1 on argo_archived_workflows;
+
+-- Step 68
+create index argo_archived_workflows_i1 on argo_archived_workflows (clustername, instanceid, namespace, startedat DESC);
+
+```
+
+### PostgreSQL
+
+```sql
+-- Step 0
+create table if not exists argo_workflows (
+    id varchar(128) ,
+    name varchar(256),
+    phase varchar(25),
+    namespace varchar(256),
+    workflow text,
+    startedat timestamp default CURRENT_TIMESTAMP,
+    finishedat timestamp default CURRENT_TIMESTAMP,
+    creationtimestamp timestamp default CURRENT_TIMESTAMP,
+    primary key (id, namespace)
+);
+
+-- Step 1
+create unique index idx_name on argo_workflows (name);
+
+-- Step 2
+create table if not exists argo_workflow_history (
+    id varchar(128) ,
+    name varchar(256),
+    phase varchar(25),
+    namespace varchar(256),
+    workflow text,
+    startedat timestamp default CURRENT_TIMESTAMP,
+    finishedat timestamp default CURRENT_TIMESTAMP,
+    primary key (id, namespace)
+);
+
+-- Step 3
+alter table argo_workflow_history rename to argo_archived_workflows;
+
+-- Step 4
+drop index idx_name;
+
+-- Step 5
+create unique index idx_name on argo_workflows(name, namespace);
+
+-- Step 6
+alter table argo_workflows drop constraint argo_workflows_pkey;
+
+-- Step 7
+alter table argo_workflows add primary key(name,namespace);
+
+-- Step 8
+alter table argo_archived_workflows drop constraint argo_workflow_history_pkey;
+
+-- Step 9
+alter table argo_archived_workflows add primary key(id);
+
+-- Step 10
+alter table argo_archived_workflows rename column id to uid;
+
+-- Step 11
+alter table argo_archived_workflows alter column uid set not null;
+
+-- Step 12
+alter table argo_archived_workflows alter column phase set not null;
+
+-- Step 13
+alter table argo_archived_workflows alter column namespace set not null;
+
+-- Step 14
+alter table argo_archived_workflows alter column workflow set not null;
+
+-- Step 15
+alter table argo_archived_workflows alter column startedat set not null;
+
+-- Step 16
+alter table argo_archived_workflows alter column finishedat set not null;
+
+-- Step 17
+alter table argo_archived_workflows add clustername varchar(64);
+
+-- Step 18
+update argo_archived_workflows set clustername = '<cluster-name>' where clustername is null;
+
+-- Step 19
+alter table argo_archived_workflows alter column clustername set not null;
+
+-- Step 20
+alter table argo_archived_workflows drop constraint argo_archived_workflows_pkey;
+
+-- Step 21
+alter table argo_archived_workflows add primary key(clustername,uid);
+
+-- Step 22
+create index argo_archived_workflows_i1 on argo_archived_workflows (clustername,namespace);
+
+-- Step 23
+alter table argo_workflows drop column phase;
+
+-- Step 24
+alter table argo_workflows drop column startedat;
+
+-- Step 25
+alter table argo_workflows drop column finishedat;
+
+-- Step 26
+alter table argo_workflows rename column id to uid;
+
+-- Step 27
+alter table argo_workflows alter column uid set not null;
+
+-- Step 28
+alter table argo_workflows alter column namespace set not null;
+
+-- Step 29
+alter table argo_workflows add column clustername varchar(64);
+
+-- Step 30
+update argo_workflows set clustername = '<cluster-name>' where clustername is null;
+
+-- Step 31
+alter table argo_workflows alter column clustername set not null;
+
+-- Step 32
+alter table argo_workflows add column version varchar(64);
+
+-- Step 33
+alter table argo_workflows add column nodes text;
+
+-- Step 34
+— *Programmatic migration: backfillNodes{argo_workflows}*
+
+-- Step 35
+alter table argo_workflows alter column nodes set not null;
+
+-- Step 36
+alter table argo_workflows drop column workflow;
+
+-- Step 37
+alter table argo_workflows add column updatedat timestamp not null default current_timestamp;
+
+-- Step 38
+alter table argo_workflows drop constraint argo_workflows_pkey;
+
+-- Step 39
+drop index idx_name;
+
+-- Step 40
+alter table argo_workflows drop column name;
+
+-- Step 41
+alter table argo_workflows add primary key(clustername,uid,version);
+
+-- Step 42
+create index argo_workflows_i1 on argo_workflows (clustername,namespace);
+
+-- Step 43
+alter table argo_archived_workflows alter column workflow type json using workflow::json;
+
+-- Step 44
+alter table argo_archived_workflows alter column name set not null;
+
+-- Step 45
+create index argo_workflows_i2 on argo_workflows (clustername,namespace,updatedat);
+
+-- Step 46
+create table if not exists argo_archived_workflows_labels (
+	clustername varchar(64) not null,
+	uid varchar(128) not null,
+    name varchar(317) not null,
+    value varchar(63) not null,
+    primary key (clustername, uid, name),
+ 	foreign key (clustername, uid) references argo_archived_workflows(clustername, uid) on delete cascade
+);
+
+-- Step 47
+alter table argo_workflows alter column nodes type json using nodes::json;
+
+-- Step 48
+alter table argo_archived_workflows add column instanceid varchar(64);
+
+-- Step 49
+update argo_archived_workflows set instanceid = '' where instanceid is null;
+
+-- Step 50
+alter table argo_archived_workflows alter column instanceid set not null;
+
+-- Step 51
+drop index argo_archived_workflows_i1;
+
+-- Step 52
+create index argo_archived_workflows_i1 on argo_archived_workflows (clustername,instanceid,namespace);
+
+-- Step 53
+drop index argo_workflows_i1;
+
+-- Step 54
+drop index argo_workflows_i2;
+
+-- Step 55
+create index argo_workflows_i1 on argo_workflows (clustername,namespace,updatedat);
+
+-- Step 56
+create index argo_archived_workflows_i2 on argo_archived_workflows (clustername,instanceid,finishedat);
+
+-- Step 57
+create index argo_archived_workflows_i3 on argo_archived_workflows (clustername,instanceid,name);
+
+-- Step 58
+create index argo_archived_workflows_i4 on argo_archived_workflows (startedat);
+
+-- Step 59
+create index argo_archived_workflows_labels_i1 on argo_archived_workflows_labels (name,value);
+
+-- Step 60
+alter table argo_archived_workflows alter column workflow set data type jsonb using workflow::jsonb;
+
+-- Step 61
+drop index argo_archived_workflows_i4;
+
+-- Step 62
+create index argo_archived_workflows_i4 on argo_archived_workflows (clustername, startedat);
+
+-- Step 63
+alter table argo_archived_workflows add column creationtimestamp timestamp null;
+
+-- Step 64
+update argo_archived_workflows set creationtimestamp = startedat where creationtimestamp is null;
+
+-- Step 65
+alter table argo_archived_workflows alter column creationtimestamp set default CURRENT_TIMESTAMP;
+
+-- Step 66
+create index argo_archived_workflows_i5 on argo_archived_workflows (creationtimestamp);
+
+-- Step 67
+drop index argo_archived_workflows_i1;
+
+-- Step 68
+create index argo_archived_workflows_i1 on argo_archived_workflows (clustername, instanceid, namespace, startedat DESC);
+
+```
+
+## Sync Database
+
+### MySQL
+
+```sql
+-- Step 0
+create table if not exists sync_limit (
+    name varchar(256) not null,
+    sizelimit int,
+    primary key (name)
+);
+
+-- Step 1
+create unique index ilimit_name on sync_limit (name);
+
+-- Step 2
+create table if not exists sync_controller (
+    controller varchar(64) not null,
+    time timestamp,
+    primary key (controller)
+);
+
+-- Step 3
+create unique index icontroller_name on sync_controller (controller);
+
+-- Step 4
+create table if not exists sync_state (
+    name varchar(256),
+    workflowkey varchar(256),
+    controller varchar(64) not null,
+    held boolean,
+    priority int,
+    time timestamp,
+    primary key(name, workflowkey, controller)
+);
+
+-- Step 5
+create index istate_name on sync_state (name);
+
+-- Step 6
+create index istate_workflowkey on sync_state (workflowkey);
+
+-- Step 7
+create index istate_controller on sync_state (controller);
+
+-- Step 8
+create index istate_held on sync_state (held);
+
+-- Step 9
+create table if not exists sync_lock (
+    name varchar(256),
+    controller varchar(64) not null,
+    time timestamp,
+    primary key(name)
+);
+
+-- Step 10
+create unique index ilock_name on sync_lock (name);
+
+```
+
+### PostgreSQL
+
+```sql
+-- Step 0
+create table if not exists sync_limit (
+    name varchar(256) not null,
+    sizelimit int,
+    primary key (name)
+);
+
+-- Step 1
+create unique index ilimit_name on sync_limit (name);
+
+-- Step 2
+create table if not exists sync_controller (
+    controller varchar(64) not null,
+    time timestamp,
+    primary key (controller)
+);
+
+-- Step 3
+create unique index icontroller_name on sync_controller (controller);
+
+-- Step 4
+create table if not exists sync_state (
+    name varchar(256),
+    workflowkey varchar(256),
+    controller varchar(64) not null,
+    held boolean,
+    priority int,
+    time timestamp,
+    primary key(name, workflowkey, controller)
+);
+
+-- Step 5
+create index istate_name on sync_state (name);
+
+-- Step 6
+create index istate_workflowkey on sync_state (workflowkey);
+
+-- Step 7
+create index istate_controller on sync_state (controller);
+
+-- Step 8
+create index istate_held on sync_state (held);
+
+-- Step 9
+create table if not exists sync_lock (
+    name varchar(256),
+    controller varchar(64) not null,
+    time timestamp,
+    primary key(name)
+);
+
+-- Step 10
+create unique index ilock_name on sync_lock (name);
+
+```
+

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -298,6 +298,8 @@ This is done by setting up the [`SyncConfig` section](workflow-controller-config
 
 If you try to use multiple controller locks without configuring the database you will get an error.
 
+For the list of SQL statements applied during migration, see [Database Migrations](database-migrations.md).
+
 ### Limit Table
 
 This table stores the maximum number of concurrent Workflows/Templates allowed for each semaphore.

--- a/docs/workflow-archive.md
+++ b/docs/workflow-archive.md
@@ -59,6 +59,8 @@ If you know what are you doing you also have an option to skip migration:
     persistence:
       skipMigration: true
 
+For the list of SQL statements applied during migration, see [Database Migrations](database-migrations.md).
+
 ## Required database permissions
 
 ### Postgres

--- a/hack/docs/migrations/main.go
+++ b/hack/docs/migrations/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	persistsqldb "github.com/argoproj/argo-workflows/v4/persist/sqldb"
+	"github.com/argoproj/argo-workflows/v4/util/sqldb"
+	syncdb "github.com/argoproj/argo-workflows/v4/util/sync/db"
+)
+
+var dbTypes = []sqldb.DBType{sqldb.MySQL, sqldb.Postgres}
+
+type migrationSection struct {
+	title   string
+	changes func(sqldb.DBType) []sqldb.Change
+}
+
+var migrationSections = []migrationSection{
+	{
+		title: "Archive Database",
+		changes: func(dbType sqldb.DBType) []sqldb.Change {
+			return persistsqldb.MigrateChanges("<cluster-name>", "argo_workflows", dbType)
+		},
+	},
+	{
+		title: "Sync Database",
+		changes: func(_ sqldb.DBType) []sqldb.Change {
+			return syncdb.MigrateChanges(&syncdb.Config{
+				LimitTable:      "sync_limit",
+				StateTable:      "sync_state",
+				ControllerTable: "sync_controller",
+				LockTable:       "sync_lock",
+			})
+		},
+	},
+}
+
+const docHeader = `# Database Migrations
+
+This page lists the SQL migrations that Argo Workflows applies automatically at startup.
+Migrations are applied incrementally and tracked by a version table.
+Each migration is only run once. Do not re-order or remove entries.
+
+The table names and cluster name shown here are defaults.
+Your deployment may use different values depending on your configuration.
+
+See [Workflow Archive](workflow-archive.md) and [Synchronization](synchronization.md) for configuration details.
+
+## Steps
+
+Each migration is numbered as a ` + "`Step`" + `. When Argo Workflows runs the automatic migration at controller startup, it records the highest applied step number in a version table (` + "`schema_history`" + ` for the archive database,` + "`sync_schema_history`" + ` for the sync database) and only runs steps with a higher number on subsequent starts.
+Steps may be missing where the step does nothing for the database type.
+This means steps must never be re-ordered or removed — a new schema change is always appended as a new step.
+
+If you run these statements yourself (for example, because you set ` + "`skipMigration: true`" + ` or want to manually create the schema), you are responsible for tracking which steps your database is already at.
+Argo Workflows will not detect partial manual application — it only reads the version table.
+If the version table is out of sync with the actual schema, the controller may try to re-apply steps and fail, or skip steps that you have not run.
+
+Programmatic migrations are not described here and the code needs to be consulted for those steps.
+`
+
+func main() {
+	var sb strings.Builder
+
+	sb.WriteString(docHeader)
+
+	for _, section := range migrationSections {
+		fmt.Fprintf(&sb, "## %s\n\n", section.title)
+		for _, dt := range dbTypes {
+			fmt.Fprintf(&sb, "### %s\n\n", dbTypeTitle(dt))
+			sb.WriteString("```sql\n")
+			changes := section.changes(dt)
+			for i, change := range changes {
+				writeChange(&sb, i, dt, change)
+			}
+			sb.WriteString("```\n\n")
+		}
+	}
+
+	filename := "docs/database-migrations.md"
+	if err := os.WriteFile(filename, []byte(sb.String()), 0o666); err != nil {
+		panic(err)
+	}
+	fmt.Printf("Wrote %s\n", filename)
+}
+
+func dbTypeTitle(dt sqldb.DBType) string {
+	switch dt {
+	case sqldb.MySQL:
+		return "MySQL"
+	case sqldb.Postgres:
+		return "PostgreSQL"
+	default:
+		return string(dt)
+	}
+}
+
+func writeChange(sb *strings.Builder, index int, dbType sqldb.DBType, change sqldb.Change) {
+	switch c := change.(type) {
+	case sqldb.AnsiSQLChange:
+		writeSQLBlock(sb, index, string(c))
+	case sqldb.TypedChange:
+		variant, ok := c.Changes[dbType]
+		if !ok {
+			return
+		}
+		if sql, ok := variant.(sqldb.AnsiSQLChange); ok {
+			writeSQLBlock(sb, index, string(sql))
+		} else {
+			writeProgrammaticBlock(sb, index, variant)
+		}
+	default:
+		writeProgrammaticBlock(sb, index, change)
+	}
+}
+
+func writeStep(sb *strings.Builder, index int) {
+	fmt.Fprintf(sb, "-- Step %d\n", index)
+}
+
+func writeSQLBlock(sb *strings.Builder, index int, sql string) {
+	writeStep(sb, index)
+	sb.WriteString(sql)
+	sb.WriteString(";\n\n")
+}
+
+func writeProgrammaticBlock(sb *strings.Builder, index int, migration sqldb.Change) {
+	writeStep(sb, index)
+	fmt.Fprintf(sb, "— *Programmatic migration: %s*\n\n", migration)
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -266,6 +266,7 @@ nav:
           - default-workflow-specs.md
           - offloading-large-workflows.md
           - workflow-archive.md
+          - database-migrations.md
           - telemetry-configuration.md
           - deprecations.md
           - workflow-executors.md

--- a/persist/sqldb/migrate.go
+++ b/persist/sqldb/migrate.go
@@ -12,8 +12,8 @@ const (
 	versionTable = "schema_history"
 )
 
-func Migrate(ctx context.Context, session db.Session, clusterName, tableName string, dbType sqldb.DBType) (err error) {
-	return sqldb.Migrate(ctx, session, dbType, versionTable, []sqldb.Change{
+func MigrateChanges(clusterName, tableName string, dbType sqldb.DBType) []sqldb.Change {
+	return []sqldb.Change{
 		sqldb.AnsiSQLChange(`create table if not exists ` + tableName + ` (
     id varchar(128) ,
     name varchar(256),
@@ -231,5 +231,9 @@ func Migrate(ctx context.Context, session db.Session, clusterName, tableName str
 			sqldb.Postgres: sqldb.AnsiSQLChange(`drop index argo_archived_workflows_i1`),
 		}),
 		sqldb.AnsiSQLChange(`create index argo_archived_workflows_i1 on argo_archived_workflows (clustername, instanceid, namespace, startedat DESC)`),
-	})
+	}
+}
+
+func Migrate(ctx context.Context, session db.Session, clusterName, tableName string, dbType sqldb.DBType) (err error) {
+	return sqldb.Migrate(ctx, session, dbType, versionTable, MigrateChanges(clusterName, tableName, dbType))
 }

--- a/util/sqldb/migrate.go
+++ b/util/sqldb/migrate.go
@@ -13,13 +13,24 @@ type Change interface {
 	Apply(ctx context.Context, session db.Session) error
 }
 
+// TypedChanges holds database-specific alternatives for a single migration step.
 type TypedChanges map[DBType]Change
 
-func ByType(dbType DBType, changes TypedChanges) Change {
-	if change, ok := changes[dbType]; ok {
-		return change
+// TypedChange wraps a TypedChanges with a resolved DBType so it can be applied.
+type TypedChange struct {
+	DBType  DBType
+	Changes TypedChanges
+}
+
+func (tc TypedChange) Apply(ctx context.Context, session db.Session) error {
+	if change, ok := tc.Changes[tc.DBType]; ok {
+		return change.Apply(ctx, session)
 	}
 	return nil
+}
+
+func ByType(dbType DBType, changes TypedChanges) Change {
+	return TypedChange{DBType: dbType, Changes: changes}
 }
 
 func Migrate(ctx context.Context, session db.Session, dbType DBType, versionTableName string, changes []Change) error {

--- a/util/sync/db/migrate.go
+++ b/util/sync/db/migrate.go
@@ -12,8 +12,8 @@ const (
 	versionTable = "sync_schema_history"
 )
 
-func migrate(ctx context.Context, session db.Session, dbType sqldb.DBType, config *Config) (err error) {
-	return sqldb.Migrate(ctx, session, dbType, versionTable, []sqldb.Change{
+func MigrateChanges(config *Config) []sqldb.Change {
+	return []sqldb.Change{
 		sqldb.AnsiSQLChange(`create table if not exists ` + config.LimitTable + ` (
     name varchar(256) not null,
     sizelimit int,
@@ -46,5 +46,9 @@ func migrate(ctx context.Context, session db.Session, dbType sqldb.DBType, confi
     primary key(name)
 )`),
 		sqldb.AnsiSQLChange(`create unique index ilock_name on ` + config.LockTable + ` (name)`),
-	})
+	}
+}
+
+func migrate(ctx context.Context, session db.Session, dbType sqldb.DBType, config *Config) (err error) {
+	return sqldb.Migrate(ctx, session, dbType, versionTable, MigrateChanges(config))
 }


### PR DESCRIPTION
### Motivation

With database migrate set to false operators are forced to read the code to understand the database setup and migrations.

This can be (mostly) generated into documentation, so I've done that here.

### Modifications

Add a generator at hack/docs/migrate_docs.go that produces docs/database-migrations.md from the archive and sync migration change lists. The generator extracts SQL for MySQL and PostgreSQL separately by type-asserting against AnsiSQLChange and TypedChange.

To support the generator, export MigrateChanges from persist/sqldb and util/sync/db, and export TypedChange from util/sqldb so ByType returns an inspectable value.

Cross-link the new page from workflow-archive.md and synchronization.md, add it to the Configuration nav in mkdocs.yml, and wire it into the Makefile.

### Verification

Visual inspection of the new documentation.
`make docs`

### Documentation

This is really only a change aimed at documentation - a small amount of real code changed to make that pretty.
