### PR TITLE
fix(controller): guard realtime workflow.duration against zero StartedAt

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2667,7 +2667,7 @@ func (woc *wfOperationCtx) markWorkflowPhase(ctx context.Context, phase wfv1.Wor
 	case wfv1.WorkflowSucceeded, wfv1.WorkflowFailed, wfv1.WorkflowError:
 		woc.log.Info(ctx, "Marking workflow completed")
 		woc.wf.Status.FinishedAt = metav1.Time{Time: time.Now().UTC()}
-		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", woc.wf.Status.FinishedAt.Sub(woc.wf.Status.StartedAt.Time).Seconds())
+		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", woc.workflowDurationSeconds())
 		if woc.wf.Labels == nil {
 			woc.wf.Labels = make(map[string]string)
 		}
@@ -4377,13 +4377,21 @@ func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) (context.Context
 
 func (woc *wfOperationCtx) setGlobalRuntimeParameters() {
 	woc.globalParams[common.GlobalVarWorkflowStatus] = string(woc.wf.Status.Phase)
+	woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", woc.workflowDurationSeconds())
+}
 
-	// Update workflow duration variable
+// workflowDurationSeconds returns the workflow's elapsed duration in seconds,
+// or 0 if it has not started. Once completed, FinishedAt - StartedAt is used.
+// The IsZero guard is required to avoid time.Since saturating to MaxInt64
+// nanoseconds (~9.22e9 seconds) when StartedAt is the zero time.Time.
+func (woc *wfOperationCtx) workflowDurationSeconds() float64 {
 	if woc.wf.Status.StartedAt.IsZero() {
-		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", time.Duration(0).Seconds())
-	} else {
-		woc.globalParams[common.GlobalVarWorkflowDuration] = fmt.Sprintf("%f", time.Since(woc.wf.Status.StartedAt.Time).Seconds())
+		return 0
 	}
+	if woc.wf.Status.Phase.Completed() && !woc.wf.Status.FinishedAt.IsZero() {
+		return woc.wf.Status.FinishedAt.Time.Sub(woc.wf.Status.StartedAt.Time).Seconds()
+	}
+	return time.Since(woc.wf.Status.StartedAt.Time).Seconds()
 }
 
 func (woc *wfOperationCtx) GetShutdownStrategy() wfv1.ShutdownStrategy {

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -658,12 +658,7 @@ func (woc *wfOperationCtx) prepareDefaultMetricScope() (map[string]string, map[s
 	localScope[durationMem] = "0"
 
 	var realTimeScope = map[string]func() float64{
-		common.GlobalVarWorkflowDuration: func() float64 {
-			if woc.wf.Status.Phase.Completed() {
-				return woc.wf.Status.FinishedAt.Time.Sub(woc.wf.Status.StartedAt.Time).Seconds()
-			}
-			return time.Since(woc.wf.Status.StartedAt.Time).Seconds()
-		},
+		common.GlobalVarWorkflowDuration: woc.workflowDurationSeconds,
 	}
 
 	return localScope, realTimeScope

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -277,6 +277,22 @@ func TestResourceDurationMetricDefaultMetricScope(t *testing.T) {
 	assert.Less(t, realTimeScope["workflow.duration"](), 1.0)
 }
 
+// Regression: when realtime metrics are evaluated before Status.StartedAt has
+// been populated (the first operate cycle of a brand-new workflow), the
+// workflow.duration closure must return 0 rather than time.Since(zero-time)
+// saturating to MaxInt64 nanoseconds (~9.22e9 seconds).
+func TestRealTimeWorkflowDurationBeforeStartedAt(t *testing.T) {
+	wf := wfv1.Workflow{}
+	woc := wfOperationCtx{
+		globalParams: make(common.Parameters),
+		wf:           &wf,
+	}
+
+	_, realTimeScope := woc.prepareDefaultMetricScope()
+
+	assert.InDelta(t, 0.0, realTimeScope["workflow.duration"](), 0)
+}
+
 var optionalArgumentAndParameter = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
Weirdly can't find reports of this issue.

### Motivation

There are cases when the metric workflow.duration at the beginning of the workflow startup reports 9.22G seconds (max int) and after single time point then it works correctly.

### Modifications

The fix here is really for the code in steps.go only, it didn't guard StartedAt - the rest is just commoning up the calculation to be done once.

The realtime metric closure for workflow.duration called `time.Since` on `Status.StartedAt` without an `IsZero` check. On the first operate cycle of a brand-new workflow, `repareDefaultMetricScope` runs before `markWorkflowRunning` sets `StartedAt`, so time.Since receives the Go zero time (year 1) and saturates to MaxInt64 nanoseconds (~9.22e9 seconds). Subsequent cycles report correctly because `StartedAt` is then populated.

Extract the duration computation into `workflowDurationSeconds()` and share it across the realtime metric scope and both globalParams assignments so the IsZero guard is consistent.

### Verification

Unit test added

### Documentation

Bugfix - no docs needed

### AI

I told claude what to fix here.