### PR TITLE
fix(ui): sort user info groups alphabetically for readability

### DIFF
--- a/ui/src/userinfo/user-info.test.tsx
+++ b/ui/src/userinfo/user-info.test.tsx
@@ -1,0 +1,36 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import requests from '../shared/services/requests';
+import {UserInfo} from './user-info';
+
+jest.mock('../shared/services/requests');
+jest.mock('argo-ui/src/components/page/page', () => ({
+    Page: ({children}: any) => <div>{children}</div>
+}));
+
+describe('UserInfo', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        const base = document.createElement('base');
+        base.setAttribute('href', '/');
+        document.head.appendChild(base);
+    });
+
+    afterEach(() => {
+        document.querySelector('base')?.remove();
+    });
+
+    // Verify that groups are displayed in alphabetical order regardless of the API response order
+    test('displays groups sorted alphabetically', async () => {
+        // API returns groups in unsorted order
+        jest.spyOn(requests, 'get').mockResolvedValue({body: {groups: ['zeta', 'alpha', 'beta']}} as any);
+
+        render(<UserInfo />);
+
+        // Groups should be rendered as sorted: "alpha, beta, zeta"
+        await waitFor(() => {
+            expect(screen.getByText('alpha, beta, zeta')).toBeInTheDocument();
+        });
+    });
+});

--- a/ui/src/userinfo/user-info.tsx
+++ b/ui/src/userinfo/user-info.tsx
@@ -49,7 +49,8 @@ export function UserInfo() {
                         {userInfo.groups && userInfo.groups.length > 0 && (
                             <dl>
                                 <dt>Groups:</dt>
-                                <dd>{userInfo.groups.join(', ')}</dd>
+                                {/* Sort alphabetically to ensure readability when there are many groups */}
+                                <dd>{[...userInfo.groups].sort().join(', ')}</dd>
                             </dl>
                         )}
                         {userInfo.name && (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

The User Info page displays the user's group memberships as returned by the API. When a user belongs to many groups, the unsorted list makes it difficult to find a specific group or visually scan the list. Sorting the groups alphabetically improves readability.

In my environment, over 20 LDAP groups are displayed on the User Info page, making it particularly hard to locate a specific group without alphabetical ordering.

<img width="147" height="68" alt="image" src="https://github.com/user-attachments/assets/6a9fa5cc-b41d-463a-a3b9-f8aaaf1bbfcf" />

### Modifications

- **`ui/src/userinfo/user-info.tsx`**: Changed the groups display to sort a shallow copy of the array alphabetically before joining, i.e. `[...userInfo.groups].sort().join(', ')` instead of `userInfo.groups.join(', ')`.
- **`ui/src/userinfo/user-info.test.tsx`** (new): Added a unit test that verifies groups returned in an unsorted order from the API are rendered in alphabetical order.

### Verification

- Added a unit test (`user-info.test.tsx`) that mocks the API response with unsorted groups (`['zeta', 'alpha', 'beta']`) and asserts they are rendered as `alpha, beta, zeta`.
- Manually verified on the User Info page that groups appear in alphabetical order.

<img width="135" height="58" alt="image" src="https://github.com/user-attachments/assets/d2baebf2-d1a2-4ea1-9dc2-567c9ebb4591" />

### Documentation

No documentation update is needed. This is a minor UI display improvement with no user-facing configuration or API changes.