### PR TITLE
fix(ui): auto-recover from ChunkLoadError after deployment

### DIFF
--- a/ui/src/app-router.tsx
+++ b/ui/src/app-router.tsx
@@ -8,28 +8,33 @@ import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {Redirect, Route, Router, Switch} from 'react-router';
 
-import apiDocs from './api-docs';
-import clusterWorkflowTemplates from './cluster-workflow-templates';
-import cronWorkflows from './cron-workflows';
-import eventflow from './event-flow';
-import eventSources from './event-sources';
-import help from './help';
-import login from './login';
 import {ModalSwitch} from './modals/modal-switch';
-import plugins from './plugins';
-import reports from './reports';
-import sensors from './sensors';
 import {uiUrl} from './shared/base';
 import {ChatButton} from './shared/components/chat-button';
 import ErrorBoundary from './shared/components/error-boundary';
 import {Version} from './shared/models';
 import * as nsUtils from './shared/namespaces';
 import {services} from './shared/services';
-import userinfo from './userinfo';
+import {lazyImport} from './shared/utils/lazy-import';
 import {Widgets} from './widgets/widgets';
-import workflowEventBindings from './workflow-event-bindings';
-import workflowTemplates from './workflow-templates';
-import workflows from './workflows';
+
+// Route-level code splitting with retry logic.
+// Each module exposes a `.component` property, so we re-export it as the
+// default so React.lazy (which requires a default export) can consume it.
+const ApiDocs = React.lazy(() => lazyImport(() => import('./api-docs').then(m => ({default: m.default.component}))));
+const ClusterWorkflowTemplates = React.lazy(() => lazyImport(() => import('./cluster-workflow-templates').then(m => ({default: m.default.component}))));
+const CronWorkflows = React.lazy(() => lazyImport(() => import('./cron-workflows').then(m => ({default: m.default.component}))));
+const EventFlow = React.lazy(() => lazyImport(() => import('./event-flow').then(m => ({default: m.default.component}))));
+const EventSources = React.lazy(() => lazyImport(() => import('./event-sources').then(m => ({default: m.default.component}))));
+const Help = React.lazy(() => lazyImport(() => import('./help').then(m => ({default: m.default.component}))));
+const Login = React.lazy(() => lazyImport(() => import('./login').then(m => ({default: m.default.component}))));
+const Plugins = React.lazy(() => lazyImport(() => import('./plugins').then(m => ({default: m.default.component}))));
+const Reports = React.lazy(() => lazyImport(() => import('./reports').then(m => ({default: m.default.component}))));
+const Sensors = React.lazy(() => lazyImport(() => import('./sensors').then(m => ({default: m.default.component}))));
+const UserInfo = React.lazy(() => lazyImport(() => import('./userinfo').then(m => ({default: m.default.component}))));
+const WorkflowEventBindings = React.lazy(() => lazyImport(() => import('./workflow-event-bindings').then(m => ({default: m.default.component}))));
+const WorkflowTemplates = React.lazy(() => lazyImport(() => import('./workflow-templates').then(m => ({default: m.default.component}))));
+const Workflows = React.lazy(() => lazyImport(() => import('./workflows').then(m => ({default: m.default.component}))));
 
 const eventFlowUrl = uiUrl('event-flow');
 const sensorUrl = uiUrl('sensors');
@@ -89,7 +94,7 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
             {popupProps && <Popup {...popupProps} />}
             <Router history={history}>
                 <Switch>
-                    <Route exact={true} strict={true} path={loginUrl} component={login.component} />
+                    <Route exact={true} strict={true} path={loginUrl} component={Login} />
                     <Route path={uiUrl('widgets')} component={Widgets} />
                     <Layout
                         navBarStyle={{backgroundColor: navBarBackgroundColor}}
@@ -163,26 +168,28 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
                         version={() => <>{version ? version.version : 'unknown'}</>}>
                         <Notifications notifications={notificationsManager.notifications} />
                         <ErrorBoundary>
-                            <Switch>
-                                <Route exact={true} strict={true} path={timelineUrl}>
-                                    <Redirect to={workflowsUrl} />
-                                </Route>
-                                <Route path={eventFlowUrl} component={eventflow.component} />
-                                <Route path={sensorUrl} component={sensors.component} />
-                                <Route path={eventSourceUrl} component={eventSources.component} />
-                                <Route path={workflowsUrl} component={workflows.component} />
-                                <Route path={workflowsEventBindingsUrl} component={workflowEventBindings.component} />
-                                <Route path={workflowTemplatesUrl} component={workflowTemplates.component} />
-                                <Route path={clusterWorkflowTemplatesUrl} component={clusterWorkflowTemplates.component} />
-                                <Route path={cronWorkflowsUrl} component={cronWorkflows.component} />
-                                <Route path={reportsUrl} component={reports.component} />
-                                <Route path={pluginsUrl} component={plugins.component} />
-                                <Route exact={true} strict={true} path={helpUrl} component={help.component} />
-                                <Route exact={true} strict={true} path={apiDocsUrl} component={apiDocs.component} />
-                                <Route exact={true} strict={true} path={userInfoUrl} component={userinfo.component} />
-                                {managedNamespace && <Redirect to={workflowsUrl} />}
-                                {namespace && <Redirect to={workflowsUrl + '/' + namespace} />}
-                            </Switch>
+                            <React.Suspense fallback={<div>Loading...</div>}>
+                                <Switch>
+                                    <Route exact={true} strict={true} path={timelineUrl}>
+                                        <Redirect to={workflowsUrl} />
+                                    </Route>
+                                    <Route path={eventFlowUrl} component={EventFlow} />
+                                    <Route path={sensorUrl} component={Sensors} />
+                                    <Route path={eventSourceUrl} component={EventSources} />
+                                    <Route path={workflowsUrl} component={Workflows} />
+                                    <Route path={workflowsEventBindingsUrl} component={WorkflowEventBindings} />
+                                    <Route path={workflowTemplatesUrl} component={WorkflowTemplates} />
+                                    <Route path={clusterWorkflowTemplatesUrl} component={ClusterWorkflowTemplates} />
+                                    <Route path={cronWorkflowsUrl} component={CronWorkflows} />
+                                    <Route path={reportsUrl} component={Reports} />
+                                    <Route path={pluginsUrl} component={Plugins} />
+                                    <Route exact={true} strict={true} path={helpUrl} component={Help} />
+                                    <Route exact={true} strict={true} path={apiDocsUrl} component={ApiDocs} />
+                                    <Route exact={true} strict={true} path={userInfoUrl} component={UserInfo} />
+                                    {managedNamespace && <Redirect to={workflowsUrl} />}
+                                    {namespace && <Redirect to={workflowsUrl + '/' + namespace} />}
+                                </Switch>
+                            </React.Suspense>
                         </ErrorBoundary>
                         <ChatButton />
                         {version && modals && <ModalSwitch version={version.version} modals={modals} />}

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import 'argo-ui/src/styles/main.scss';
 
+import {ChunkLoadErrorBoundary} from './app/chunk-load-error-boundary';
 import {AppRouter} from './app-router';
 import {ContextApis, Provider} from './shared/context';
 
@@ -22,8 +23,10 @@ export function App({history}: {history: History}) {
     };
 
     return (
-        <Provider value={providerContext}>
-            <AppRouter history={history} notificationsManager={notificationsManager} popupManager={popupManager} />
-        </Provider>
+        <ChunkLoadErrorBoundary>
+            <Provider value={providerContext}>
+                <AppRouter history={history} notificationsManager={notificationsManager} popupManager={popupManager} />
+            </Provider>
+        </ChunkLoadErrorBoundary>
     );
 }

--- a/ui/src/app/chunk-load-error-boundary.test.tsx
+++ b/ui/src/app/chunk-load-error-boundary.test.tsx
@@ -1,0 +1,30 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {ChunkLoadErrorBoundary} from './chunk-load-error-boundary';
+
+beforeEach(() => jest.spyOn(console, 'error').mockImplementation(() => {}));
+afterEach(() => jest.restoreAllMocks());
+
+describe('ChunkLoadErrorBoundary', () => {
+    it('renders children normally', () => {
+        render(
+            <ChunkLoadErrorBoundary>
+                <div>Test</div>
+            </ChunkLoadErrorBoundary>
+        );
+        expect(screen.getByText('Test')).toBeTruthy();
+    });
+
+    it('catches chunk errors', () => {
+        const ThrowError = () => {
+            throw new Error('Loading chunk 775 failed');
+        };
+        render(
+            <ChunkLoadErrorBoundary>
+                <ThrowError />
+            </ChunkLoadErrorBoundary>
+        );
+        expect(screen.getByText(/Reloading/i)).toBeTruthy();
+    });
+});

--- a/ui/src/app/chunk-load-error-boundary.tsx
+++ b/ui/src/app/chunk-load-error-boundary.tsx
@@ -1,0 +1,57 @@
+import {ErrorInfo} from 'react';
+import * as React from 'react';
+
+interface State {
+    error?: Error & {response?: any};
+    errorInfo?: ErrorInfo;
+    isReloading: boolean;
+}
+
+/**
+ * Error boundary specifically for handling chunk loading failures.
+ * Automatically reloads the page when a chunk fails to load.
+ * Fixes: https://github.com/argoproj/argo-workflows/issues/15640
+ */
+export class ChunkLoadErrorBoundary extends React.Component<any, State> {
+    static isChunkLoadError(error: Error): boolean {
+        return (
+            error.message.includes('Loading chunk') ||
+            error.message.includes('Failed to fetch') ||
+            error.message.includes('Failed to import') ||
+            error.message.includes('NetworkError') ||
+            error.name === 'ChunkLoadError'
+        );
+    }
+
+    static getDerivedStateFromError(error: Error) {
+        // Only handle chunk load errors; re-throw others
+        if (ChunkLoadErrorBoundary.isChunkLoadError(error)) {
+            return {error, isReloading: true};
+        }
+        throw error;
+    }
+
+    constructor(props: any) {
+        super(props);
+        this.state = {isReloading: false};
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        console.error('Chunk load error:', error, errorInfo);
+        // Auto-reload after a brief delay to allow state update
+        setTimeout(() => window.location.reload(), 100);
+    }
+
+    render() {
+        if (this.state.isReloading) {
+            return (
+                <div style={{padding: '20px', textAlign: 'center'}}>
+                    <h2>Reloading...</h2>
+                    <p>A required component failed to load. The page will reload automatically.</p>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/ui/src/shared/utils/lazy-import.test.ts
+++ b/ui/src/shared/utils/lazy-import.test.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import {lazyImport} from './lazy-import';
+
+const MockComponent: React.FC = () => null;
+
+describe('lazyImport', () => {
+    it('imports successfully', async () => {
+        const mockImport = jest.fn().mockResolvedValue({default: MockComponent});
+        const result = await lazyImport(mockImport);
+        expect(result.default).toBe(MockComponent);
+    });
+});

--- a/ui/src/shared/utils/lazy-import.ts
+++ b/ui/src/shared/utils/lazy-import.ts
@@ -1,0 +1,32 @@
+import {ComponentType} from 'react';
+
+/**
+ * Lazy import wrapper that retries loading chunks on failure.
+ * Fixes "Loading chunk X failed" errors by attempting to reload the chunk.
+ * See: https://github.com/argoproj/argo-workflows/issues/15640
+ */
+export function lazyImport<T extends ComponentType<any>>(
+    importFunc: () => Promise<{default: T}>,
+    retries: number = 3,
+    delayMs: number = 1000
+): Promise<{default: T}> {
+    return new Promise((resolve, reject) => {
+        let attemptCount = 0;
+
+        const attempt = () => {
+            attemptCount++;
+            importFunc()
+                .then(resolve)
+                .catch(error => {
+                    if (attemptCount > retries) {
+                        reject(error);
+                        return;
+                    }
+                    const delay = delayMs * attemptCount;
+                    setTimeout(attempt, delay);
+                });
+        };
+
+        attempt();
+    });
+}


### PR DESCRIPTION
## Summary
Fixes "Loading chunk X failed" errors by adding retry logic and error boundary for chunk loading failures.

## Changes
- Add `lazyImport` utility with retry mechanism
- Add `ChunkLoadErrorBoundary` that auto-reloads on chunk errors
- Add tests for both utilities

## Fixes
Closes #15640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for chunk loading failures with user-friendly reload messaging.
  * Implemented retry logic for dynamic imports with incremental backoff delays.

* **Bug Fixes**
  * Improved application stability by gracefully handling dynamic chunk load errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->