### PR TITLE
fix: remove redundant WaitForWorkflow in TestInputOnMount

### DIFF
--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -37,7 +37,6 @@ func (s *ArtifactsSuite) TestInputOnMount() {
 		Workflow("@testdata/input-on-mount-workflow.yaml").
 		When().
 		SubmitWorkflow().
-		WaitForWorkflow().
 		WaitForWorkflow(fixtures.ToBeSucceeded)
 }
 


### PR DESCRIPTION
Remove redundant `WaitForWorkflow()` (ToBeDone) call before `WaitForWorkflow(fixtures.ToBeSucceeded)` in `TestInputOnMount`

This test is timing out regularly in CI
