### PR TITLE
fix: prevent empty container slice panic

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -275,11 +275,14 @@ func (woc *wfOperationCtx) createWorkflowPod(ctx context.Context, nodeName strin
 
 	// Configuring default container to be used with commands like "kubectl exec/logs".
 	// Select "main" container if it's available. In other case use the last container (can happen when pod created from ContainerSet).
-	defaultContainer := pod.Spec.Containers[len(pod.Spec.Containers)-1].Name
-	for _, c := range pod.Spec.Containers {
-		if c.Name == common.MainContainerName {
-			defaultContainer = common.MainContainerName
-			break
+	defaultContainer := common.MainContainerName
+	if len(pod.Spec.Containers) > 0 {
+		defaultContainer = pod.Spec.Containers[len(pod.Spec.Containers)-1].Name
+		for _, c := range pod.Spec.Containers {
+			if c.Name == common.MainContainerName {
+				defaultContainer = common.MainContainerName
+				break
+			}
 		}
 	}
 	pod.Annotations[common.AnnotationKeyDefaultContainer] = defaultContainer


### PR DESCRIPTION
### SUMMARY

This PR fixes a potential index-out-of-range panic in `createWorkflowPod` by safely handling cases where `pod.Spec.Containers` may be empty. The change ensures default container selection logic does not assume the presence of containers.
The update is localized to `workflow/controller/workflowpod.go`.

---

### FIX

```go
// Before
defaultContainer := pod.Spec.Containers[len(pod.Spec.Containers)-1].Name

// After
defaultContainer := common.MainContainerName
if len(pod.Spec.Containers) > 0 {
    defaultContainer = pod.Spec.Containers[len(pod.Spec.Containers)-1].Name
    for _, c := range pod.Spec.Containers {
        if c.Name == common.MainContainerName {
            defaultContainer = common.MainContainerName
            break
        }
    }
}
```

---

### VERIFICATION

Verified by running workflows with both populated and empty container lists to ensure no panic occurs. Confirmed default container annotation remains correct in normal cases. Controller behavior is unchanged aside from improved safety.
