### PR TITLE
fix: 401s when accessing artifact directories with SSO enabled. Fixes #15800

### DIFF
--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -524,7 +524,10 @@ func (a *ArtifactServer) getArtifactAndDriver(ctx context.Context, nodeID, artif
 
 func (a *ArtifactServer) setSecurityHeaders(w http.ResponseWriter) {
 	// Set strict CSP headers for defense-in-depth against XSS: https://web.dev/articles/strict-csp
-	w.Header().Add("Content-Security-Policy", env.GetString("ARGO_ARTIFACT_CONTENT_SECURITY_POLICY", "sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'"))
+	// The "allow-same-origin" is required to prevent 401s when browsing
+	// directories with SSO enabled, since otherwise the "Authorization" cookie
+	// won't be sent, since it has SameSet=Strict set.
+	w.Header().Add("Content-Security-Policy", env.GetString("ARGO_ARTIFACT_CONTENT_SECURITY_POLICY", "sandbox allow-same-origin; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'"))
 	// Mitigate clickjacking attacks
 	w.Header().Add("X-Frame-Options", env.GetString("ARGO_ARTIFACT_X_FRAME_OPTIONS", "SAMEORIGIN"))
 }

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -493,7 +493,7 @@ func TestArtifactServer_GetArtifactFile(t *testing.T) {
 				}
 				if tt.isDirectory {
 					fmt.Printf("got directory listing:\n%s\n", all)
-					assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "sandbox")
+					assert.Contains(t, recorder.Header().Get("Content-Security-Policy"), "sandbox allow-same-origin")
 					assert.Equal(t, "SAMEORIGIN", recorder.Header().Get("X-Frame-Options"))
 					// verify that the files are contained in the listing we got back
 					assert.Len(t, tt.directoryFiles, strings.Count(string(all), "<li>"))

--- a/test/e2e/argo_server_test.go
+++ b/test/e2e/argo_server_test.go
@@ -1809,7 +1809,7 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 			Contains(":) Hello Argo!")
 
 		resp.Header("Content-Security-Policy").
-			IsEqual("sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
+			IsEqual("sandbox allow-same-origin; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
 
 		resp.Header("X-Frame-Options").
 			IsEqual("SAMEORIGIN")
@@ -1825,7 +1825,7 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 			Contains(":) Hello Argo!")
 
 		resp.Header("Content-Security-Policy").
-			IsEqual("sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
+			IsEqual("sandbox allow-same-origin; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
 
 		resp.Header("X-Frame-Options").
 			IsEqual("SAMEORIGIN")
@@ -1841,7 +1841,7 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 			Contains("<a href=\"./subdirectory/\">subdirectory/</a>")
 
 		resp.Header("Content-Security-Policy").
-			IsEqual("sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
+			IsEqual("sandbox allow-same-origin; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
 
 		resp.Header("X-Frame-Options").
 			IsEqual("SAMEORIGIN")
@@ -1868,7 +1868,7 @@ func (s *ArgoServerSuite) artifactServerRetrievalTests(name string, uid types.UI
 			Contains(":) Hello Argo!")
 
 		resp.Header("Content-Security-Policy").
-			IsEqual("sandbox; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
+			IsEqual("sandbox allow-same-origin; base-uri 'none'; default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'")
 
 		resp.Header("X-Frame-Options").
 			IsEqual("SAMEORIGIN")


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15800

### Motivation
https://github.com/argoproj/argo-workflows/pull/15255 introduced a regression where you can get a 401 error when browsing artifact files inside a directory with SSO enabled.



### Modifications

This is happening because we set an `Authorization` cookie with `SameSite=Strict` after finishing the SSO process, which means it's never sent for cross-site requests. When the [sandbox CSP directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/sandbox) is used, the browser treats it as an opaque origin, so the cookie won't be sent when browsing from a directory to a file. Setting `allow-same-origin` fixes that.

### Verification


Tested by following these steps:
1. Run `make start UI=true PROFILE=sso`
2. Submit the following workflow:
```yaml
metadata:
  generateName: artifact-directories
spec:
  entrypoint: write-files
  templates:
    - name: write-files
      container:
        image: alpine:3.19
        command: [sh, -c]
        args:
          - |
            mkdir -p /workvol/out/test
            echo "hello from file 1" > /workvol/out/test/file1.txt
            echo "hello from file 2" > /workvol/out/test/file2.txt
      outputs:
        artifacts:
          - name: file1
            path: /workvol/out/test/file1.txt
            archive:
              none: {}
          - name: output-folder
            path: /workvol/out
            archive:
              none: {}
```
3. When the workflow finishes, click on the first node and then on "Inputs/Outputs"
4. Click on "output-folder" in the artifact list
5. Click on the "test/" directory
6. Click on "file1.txt". Verify you get "hello from file 1"

Recording:
[Screencast_20260418_172050.webm](https://github.com/user-attachments/assets/e11c142f-3c9a-44d4-9e1a-24ecef43ca56)


### Documentation

N/A