### PR TITLE
fix(server): handle transient errors before ToStatusError loses type …

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -958,13 +958,16 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 		return workflow, nil
 	}
 
+	// Store the result separately: a failed Create returns an empty object, so reusing wf would
+	// feed a stripped workflow into the next retry.
+	var created *wfv1.Workflow
 	err = waitutil.Backoff(retry.DefaultRetry(ctx), func() (bool, error) {
 		var createErr error
-		wf, createErr = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		created, createErr = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
 		return !errorsutil.IsTransientErr(ctx, createErr), createErr
 	})
 	if err != nil {
-		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
+		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
-	return wf, nil
+	return created, nil
 }

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -31,10 +31,13 @@ import (
 	sutils "github.com/argoproj/argo-workflows/v4/server/utils"
 	"github.com/argoproj/argo-workflows/v4/server/workflow/store"
 	argoutil "github.com/argoproj/argo-workflows/v4/util"
+	errorsutil "github.com/argoproj/argo-workflows/v4/util/errors"
 	"github.com/argoproj/argo-workflows/v4/util/fields"
 	"github.com/argoproj/argo-workflows/v4/util/instanceid"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/logs"
+	"github.com/argoproj/argo-workflows/v4/util/retry"
+	waitutil "github.com/argoproj/argo-workflows/v4/util/wait"
 	"github.com/argoproj/argo-workflows/v4/workflow/artifactrepositories"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	"github.com/argoproj/argo-workflows/v4/workflow/creator"
@@ -138,7 +141,12 @@ func (s *workflowServer) CreateWorkflow(ctx context.Context, req *workflowpkg.Wo
 		return workflow, nil
 	}
 
-	wf, err := wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, req.Workflow, metav1.CreateOptions{})
+	var wf *wfv1.Workflow
+	err = waitutil.Backoff(retry.DefaultRetry(ctx), func() (bool, error) {
+		var createErr error
+		wf, createErr = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, req.Workflow, metav1.CreateOptions{})
+		return !errorsutil.IsTransientErr(ctx, createErr), createErr
+	})
 	logger := logging.RequireLoggerFromContext(ctx)
 	if err != nil {
 		if apierr.IsServerTimeout(err) && req.Workflow.GenerateName != "" && req.Workflow.Name != "" {
@@ -950,7 +958,11 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 		return workflow, nil
 	}
 
-	wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+	err = waitutil.Backoff(retry.DefaultRetry(ctx), func() (bool, error) {
+		var createErr error
+		wf, createErr = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		return !errorsutil.IsTransientErr(ctx, createErr), createErr
+	})
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.InvalidArgument)
 	}

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/server/workflow/store"
 	"github.com/argoproj/argo-workflows/v4/server/workflowtemplate"
 	"github.com/argoproj/argo-workflows/v4/util"
+	errorsutil "github.com/argoproj/argo-workflows/v4/util/errors"
 	"github.com/argoproj/argo-workflows/v4/util/instanceid"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/artifactrepositories"
@@ -1535,4 +1536,52 @@ func getWorkflowServerWithArtifacts(t *testing.T, template runtime.Object, defau
 	server := NewServer(ctx, instanceid.NewService("my-instanceid"), offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll, artifactRepos)
 
 	return server, ctx
+}
+
+// TestSubmitWorkflowRetriesTransientError verifies a transient Create failure (e.g. the
+// ResourceQuota 409 from #14106) is retried and the submit still succeeds with its labels intact.
+func TestSubmitWorkflowRetriesTransientError(t *testing.T) {
+	server, ctx := getWorkflowServer(t)
+	wfClient := ctx.Value(auth.WfKey).(*v1alpha.Clientset)
+
+	var attempts int
+	wfClient.PrependReactor("create", "workflows", func(action ktesting.Action) (bool, runtime.Object, error) {
+		attempts++
+		if attempts == 1 {
+			return true, nil, errorsutil.NewErrTransient("simulated transient ResourceQuota conflict")
+		}
+		// let the default chain (incl. generateNameReactor) handle the successful create
+		return false, nil, nil
+	})
+
+	wf, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
+		Namespace:     "workflows",
+		ResourceKind:  "workflowtemplate",
+		ResourceName:  "workflow-template-whalesay-template",
+		SubmitOptions: &v1alpha1.SubmitOpts{Parameters: []string{"message=hello"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, wf)
+	assert.GreaterOrEqual(t, attempts, 2, "create should have been retried after the transient error")
+	assert.Contains(t, wf.Labels, common.LabelKeyControllerInstanceID)
+}
+
+// TestSubmitWorkflowReturnsInternalOnRetryExhaustion verifies an exhausted retry returns
+// codes.Internal, not the previous InvalidArgument.
+func TestSubmitWorkflowReturnsInternalOnRetryExhaustion(t *testing.T) {
+	server, ctx := getWorkflowServer(t)
+	wfClient := ctx.Value(auth.WfKey).(*v1alpha.Clientset)
+
+	wfClient.PrependReactor("create", "workflows", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errorsutil.NewErrTransient("persistent transient failure")
+	})
+
+	_, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
+		Namespace:     "workflows",
+		ResourceKind:  "workflowtemplate",
+		ResourceName:  "workflow-template-whalesay-template",
+		SubmitOptions: &v1alpha1.SubmitOpts{Parameters: []string{"message=hello"}},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
 }


### PR DESCRIPTION
## Motivation
Kubernetes sometimes returns an HTTP 409 Conflict error when the ResourceQuota hasn't fully synchronized. This is a temporary race condition, and retrying usually fixes it. 

However, the server converts this error into a **gRPC status**, which causes the original error type to be permanently lost. Because of this, the CLI cannot recognize the conflict and incorrectly treats it as a permanent failure instead of retrying.

## Modifications
To resolve this, retry logic is implemented directly in the server's CreateWorkflow and SubmitWorkflow functions:
- Use `errorsutil.IsTransientErr` while the original error type is still available to identify the conflict.
- Apply `waitutil.Backoff` with exponential backoff.

Fixes #14106 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow creation and submission now automatically retry transient failures with backoff, improving reliability during temporary service disruptions.
  * Workflow labels are preserved when a submission succeeds after retrying.
  * Exhausted workflow-creation attempts now return a clearer internal error instead of being reported as invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->