### PR TITLE
docs: add Argo project GenAI policy references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,5 +43,5 @@ Fixes #TODO
 
 ### AI
 
-<!-- TODO: Declare any use of AI tools (e.g. Copilot, Cursor, Claude, ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
-<!-- See the Argo project's GenAI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->
+<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
+<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,3 +40,8 @@ Fixes #TODO
 
 <!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
 <!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
+
+### AI
+
+<!-- TODO: Declare any use of AI tools (e.g. Copilot, Cursor, Claude, ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
+<!-- See the Argo project's GenAI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

--- a/.spelling
+++ b/.spelling
@@ -37,6 +37,8 @@ BlackRock
 Breitgand
 CRD
 CRDs
+ChatGPT
+Claude
 CloudSQL
 ClusterRoleBinding
 ClusterRoles
@@ -46,9 +48,11 @@ Codespaces
 ConfigMap
 ConfigMaps
 ContainerSet
+Copilot
 Couler
 CronWorkflow
 CronWorkflows
+Cursor
 CustomResource
 DataDog
 Dataflow
@@ -58,6 +62,7 @@ Dex
 EditorConfig
 EtcD
 EventRouter
+GenAI
 Generator
 GitOps
 Github

--- a/.spelling
+++ b/.spelling
@@ -38,7 +38,6 @@ Breitgand
 CRD
 CRDs
 ChatGPT
-Claude
 CloudSQL
 ClusterRoleBinding
 ClusterRoles
@@ -48,11 +47,9 @@ Codespaces
 ConfigMap
 ConfigMaps
 ContainerSet
-Copilot
 Couler
 CronWorkflow
 CronWorkflows
-Cursor
 CustomResource
 DataDog
 Dataflow
@@ -62,7 +59,6 @@ Dex
 EditorConfig
 EtcD
 EventRouter
-GenAI
 Generator
 GitOps
 Github

--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ See [SECURITY.md](SECURITY.md).
 
 ## Generative AI
 
-Contributions using generative AI tools must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).
+Contributions using generative AI tools must follow the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).

--- a/README.md
+++ b/README.md
@@ -162,3 +162,7 @@ Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https:
 ## Security
 
 See [SECURITY.md](SECURITY.md).
+
+## Generative AI
+
+Contributions using generative AI tools must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).

--- a/community/README.md
+++ b/community/README.md
@@ -5,4 +5,4 @@ Welcome to the Argo community!
 Argo is an open, community driven project to make it easy to use Kubernetes for getting useful work done.
 The [Argoproj Community README](https://github.com/argoproj/argoproj/blob/main/community/README.md) describes the organizational structure and governance of Argo projects including roles, responsibilities, and processes.
 
-Contributions using generative AI tools must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).
+Contributions using generative AI tools must follow the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).

--- a/community/README.md
+++ b/community/README.md
@@ -4,3 +4,5 @@ Welcome to the Argo community!
 
 Argo is an open, community driven project to make it easy to use Kubernetes for getting useful work done.
 The [Argoproj Community README](https://github.com/argoproj/argoproj/blob/main/community/README.md) describes the organizational structure and governance of Argo projects including roles, responsibilities, and processes.
+
+Contributions using generative AI tools must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,7 +97,7 @@ See [the pull request template](https://github.com/argoproj/argo-workflows/blob/
 
 #### Use of Generative AI
 
-Contributors using generative AI tools (e.g. Copilot, Cursor, Claude, ChatGPT) to help prepare contributions must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md) and declare such use in the `AI` section of the pull request template.
+Contributors using generative AI tools (for example ChatGPT) to help prepare contributions must follow the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md) and declare such use in the `AI` section of the pull request template.
 
 ### Other Contributions
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,6 +95,10 @@ No, we should not add that dependency.
 Changes without either unit or e2e tests are unlikely to be accepted.
 See [the pull request template](https://github.com/argoproj/argo-workflows/blob/main/.github/pull_request_template.md).
 
+#### Use of Generative AI
+
+Contributors using generative AI tools (e.g. Copilot, Cursor, Claude, ChatGPT) to help prepare contributions must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md) and declare such use in the `AI` section of the pull request template.
+
 ### Other Contributions
 
 * [Reviewing PRs](#reviewing-prs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -162,3 +162,7 @@ Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https:
 ## Security
 
 See [Security](security.md).
+
+## Generative AI
+
+Contributions using generative AI tools must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,4 +165,4 @@ See [Security](security.md).
 
 ## Generative AI
 
-Contributions using generative AI tools must follow the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).
+Contributions using generative AI tools must follow the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).


### PR DESCRIPTION
### Motivation

The Argo project has established a Generative AI (GenAI) policy that contributors must follow when using AI tools to prepare contributions. This change ensures that all contributors are aware of this policy and understand the requirement to declare AI tool usage.

### Modifications

- Updated the pull request template to include an `AI` section where contributors must declare any use of generative AI tools (e.g., Copilot, Cursor, Claude, ChatGPT) or state "None"
- Added GenAI policy references to multiple documentation files:
  - `README.md` (root)
  - `docs/README.md`
  - `docs/CONTRIBUTING.md` (with detailed guidance on the requirement)
  - `community/README.md`

All references link to the [Argo project GenAI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).

### Verification

Documentation changes only. No testing needed.

### Documentation

Documentation has been updated across multiple files to inform contributors about the GenAI policy requirement and where to find the full policy details.

### AI

Claude made this for me. Ha!