### PR TITLE
fix: added error boundary to reload on chunk load error

### DIFF
--- a/ui/src/shared/components/error-boundary.test.tsx
+++ b/ui/src/shared/components/error-boundary.test.tsx
@@ -26,7 +26,7 @@ describe('ErrorBoundary', () => {
         originalLocation = window.location;
         Object.defineProperty(window, 'location', {
             configurable: true,
-            value: {...originalLocation, reload: reloadMock},
+            value: {...originalLocation, reload: reloadMock}
         });
         // React logs caught errors via console.error; suppress so test output stays readable.
         consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -35,7 +35,7 @@ describe('ErrorBoundary', () => {
     afterEach(() => {
         Object.defineProperty(window, 'location', {
             configurable: true,
-            value: originalLocation,
+            value: originalLocation
         });
         consoleErrorSpy.mockRestore();
     });
@@ -44,7 +44,7 @@ describe('ErrorBoundary', () => {
         render(
             <ErrorBoundary>
                 <Thrower error={makeChunkLoadError()} />
-            </ErrorBoundary>,
+            </ErrorBoundary>
         );
 
         expect(reloadMock).toHaveBeenCalledTimes(1);
@@ -57,7 +57,7 @@ describe('ErrorBoundary', () => {
         render(
             <ErrorBoundary>
                 <Thrower error={err} />
-            </ErrorBoundary>,
+            </ErrorBoundary>
         );
 
         expect(reloadMock).toHaveBeenCalledTimes(1);
@@ -69,7 +69,7 @@ describe('ErrorBoundary', () => {
         render(
             <ErrorBoundary>
                 <Thrower error={makeChunkLoadError()} />
-            </ErrorBoundary>,
+            </ErrorBoundary>
         );
 
         expect(reloadMock).not.toHaveBeenCalled();
@@ -82,7 +82,7 @@ describe('ErrorBoundary', () => {
         render(
             <ErrorBoundary>
                 <Thrower error={new Error('Something else broke')} />
-            </ErrorBoundary>,
+            </ErrorBoundary>
         );
 
         expect(reloadMock).not.toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe('ErrorBoundary', () => {
         render(
             <ErrorBoundary>
                 <div>healthy child</div>
-            </ErrorBoundary>,
+            </ErrorBoundary>
         );
 
         expect(screen.getByText('healthy child')).toBeInTheDocument();

--- a/ui/src/shared/components/error-boundary.test.tsx
+++ b/ui/src/shared/components/error-boundary.test.tsx
@@ -1,0 +1,103 @@
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import ErrorBoundary from './error-boundary';
+
+const CHUNK_RELOAD_KEY = 'argo-chunk-reload-attempted';
+
+function Thrower({error}: {error: Error}): JSX.Element {
+    throw error;
+}
+
+function makeChunkLoadError(): Error {
+    const err = new Error('Loading chunk 775 failed.');
+    err.name = 'ChunkLoadError';
+    return err;
+}
+
+describe('ErrorBoundary', () => {
+    let reloadMock: jest.Mock;
+    let originalLocation: Location;
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        sessionStorage.clear();
+        reloadMock = jest.fn();
+        originalLocation = window.location;
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {...originalLocation, reload: reloadMock},
+        });
+        // React logs caught errors via console.error; suppress so test output stays readable.
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: originalLocation,
+        });
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('reloads once when a lazy chunk fails to load', () => {
+        render(
+            <ErrorBoundary>
+                <Thrower error={makeChunkLoadError()} />
+            </ErrorBoundary>,
+        );
+
+        expect(reloadMock).toHaveBeenCalledTimes(1);
+        expect(sessionStorage.getItem(CHUNK_RELOAD_KEY)).toBe('1');
+    });
+
+    it('detects ChunkLoadError by message even when error.name is generic', () => {
+        const err = new Error('Loading chunk 42 failed. (missing: https://x/42.abc.js)');
+
+        render(
+            <ErrorBoundary>
+                <Thrower error={err} />
+            </ErrorBoundary>,
+        );
+
+        expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reload again if a chunk fails after a previous reload attempt', () => {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+
+        render(
+            <ErrorBoundary>
+                <Thrower error={makeChunkLoadError()} />
+            </ErrorBoundary>,
+        );
+
+        expect(reloadMock).not.toHaveBeenCalled();
+        expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('Loading chunk 775 failed');
+    });
+
+    it('clears the reload flag and renders the error panel for non-chunk errors', () => {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+
+        render(
+            <ErrorBoundary>
+                <Thrower error={new Error('Something else broke')} />
+            </ErrorBoundary>,
+        );
+
+        expect(reloadMock).not.toHaveBeenCalled();
+        expect(sessionStorage.getItem(CHUNK_RELOAD_KEY)).toBeNull();
+        expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('Something else broke');
+    });
+
+    it('renders children unchanged when no error is thrown', () => {
+        render(
+            <ErrorBoundary>
+                <div>healthy child</div>
+            </ErrorBoundary>,
+        );
+
+        expect(screen.getByText('healthy child')).toBeInTheDocument();
+        expect(reloadMock).not.toHaveBeenCalled();
+    });
+});

--- a/ui/src/shared/components/error-boundary.tsx
+++ b/ui/src/shared/components/error-boundary.tsx
@@ -8,6 +8,12 @@ interface State {
     errorInfo?: ErrorInfo;
 }
 
+const CHUNK_RELOAD_KEY = 'argo-chunk-reload-attempted';
+
+function isChunkLoadError(error: Error): boolean {
+    return error?.name === 'ChunkLoadError' || /Loading chunk \S+ failed/.test(error?.message ?? '');
+}
+
 export default class ErrorBoundary extends React.Component<any, State> {
     public static getDerivedStateFromError(error: Error) {
         return {error};
@@ -19,6 +25,14 @@ export default class ErrorBoundary extends React.Component<any, State> {
     }
 
     public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        // After a redeploy, an open tab still references chunk hashes from the previous build,
+        // so lazy import() 404s. Reload once to fetch the new index.html and current chunk manifest.
+        if (isChunkLoadError(error) && !sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+            sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+            window.location.reload();
+            return;
+        }
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
         this.setState({error, errorInfo});
     }
 

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -23,7 +23,9 @@ const config = {
     },
     output: {
         filename: '[name].[contenthash].js',
+        chunkFilename: '[name].[contenthash].js',
         path: __dirname + '/dist/app',
+        publicPath: base,
     },
 
     // Enable source maps in production for easier debugging, but use faster eval-source-map in development for better performance


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15640

### Motivation

We need to catch react errors and reload the page

### Modifications
All it is, is just a simple error boundary

### Verification

The UI works as it did before 

### Documentation
N/A
### AI

Claude helped me
