### PR TITLE
feat: add OpenAPI v3 spec generation

### DIFF
--- a/.features/pending/openapi-v3-spec.md
+++ b/.features/pending/openapi-v3-spec.md
@@ -1,0 +1,10 @@
+Component: Build and Development
+Issues: 12851
+Description: Add OpenAPI v3 spec generation from the existing swagger.json (OpenAPI v2) using getkin/kin-openapi.
+Author: [Nancy](https://github.com/nancysangani)
+
+### OpenAPI v3 Spec Generation
+
+Adds `api/openapi-spec/openapi.yaml` (OpenAPI v3.0.3) generated from the existing
+`api/openapi-spec/swagger.json` via `hack/api/openapi3/main.go`, wired into `make swagger`.
+First step toward migrating away from go-swagger which has no plans to support OpenAPI v3.

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,8 @@ swagger: \
 	manifests/base/crds/full/argoproj.io_workflows.yaml \
 	manifests \
 	api/openapi-spec/swagger.json \
-	api/jsonschema/schema.json
+	api/jsonschema/schema.json \
+	api/openapi-spec/openapi.yaml
 
 
 $(TOOL_MOCKERY): Makefile
@@ -827,6 +828,8 @@ dist/swagger.0.json: $(TOOL_SWAGGER) dist/kubeified.swagger.json
 
 api/openapi-spec/swagger.json: $(TOOL_SWAGGER) dist/swagger.0.json
 	$(TOOL_SWAGGER) flatten --with-flatten remove-unused dist/swagger.0.json -o api/openapi-spec/swagger.json
+api/openapi-spec/openapi.yaml: api/openapi-spec/swagger.json hack/api/openapi3/main.go
+	GOFLAGS="$(GOFLAGS) -mod=mod" go run ./hack/api/openapi3
 
 api/jsonschema/schema.json: api/openapi-spec/swagger.json hack/api/jsonschema/main.go
 	GOFLAGS="$(GOFLAGS) -mod=mod" go run ./hack/api/jsonschema

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -1,0 +1,14280 @@
+components:
+    schemas:
+        eventsource.CreateEventSourceRequest:
+            properties:
+                eventSource:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                namespace:
+                    type: string
+            type: object
+        eventsource.EventSourceDeletedResponse:
+            type: object
+        eventsource.EventSourceWatchEvent:
+            properties:
+                object:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                type:
+                    type: string
+            type: object
+        eventsource.LogEntry:
+            properties:
+                eventName:
+                    title: optional - the event name (e.g. `example`)
+                    type: string
+                eventSourceName:
+                    type: string
+                eventSourceType:
+                    title: optional - the event source type (e.g. `webhook`)
+                    type: string
+                level:
+                    type: string
+                msg:
+                    type: string
+                namespace:
+                    type: string
+                time:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+            title: structured log entry
+            type: object
+        eventsource.UpdateEventSourceRequest:
+            properties:
+                eventSource:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                name:
+                    type: string
+                namespace:
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPConsumeConfig:
+            properties:
+                autoAck:
+                    title: |-
+                        AutoAck when true, the server will acknowledge deliveries to this consumer prior to writing
+                        the delivery to the network
+                        +optional
+                    type: boolean
+                consumerTag:
+                    title: |-
+                        ConsumerTag is the identity of the consumer included in every delivery
+                        +optional
+                    type: string
+                exclusive:
+                    title: |-
+                        Exclusive when true, the server will ensure that this is the sole consumer from this queue
+                        +optional
+                    type: boolean
+                noLocal:
+                    title: |-
+                        NoLocal flag is not supported by RabbitMQ
+                        +optional
+                    type: boolean
+                noWait:
+                    title: |-
+                        NowWait when true, do not wait for the server to confirm the request and immediately begin deliveries
+                        +optional
+                    type: boolean
+            title: |-
+                AMQPConsumeConfig holds the configuration to immediately starts delivering queued messages
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPEventSource:
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth'
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                consume:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPConsumeConfig'
+                exchangeDeclare:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPExchangeDeclareConfig'
+                exchangeName:
+                    title: |-
+                        ExchangeName is the exchange name
+                        For more information, visit https://www.rabbitmq.com/tutorials/amqp-concepts.html
+                    type: string
+                exchangeType:
+                    title: ExchangeType is rabbitmq exchange type
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                queueBind:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPQueueBindConfig'
+                queueDeclare:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPQueueDeclareConfig'
+                routingKey:
+                    title: Routing key for bindings
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                url:
+                    title: URL for rabbitmq service
+                    type: string
+                urlSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: AMQPEventSource refers to an event-source for AMQP stream events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPExchangeDeclareConfig:
+            properties:
+                autoDelete:
+                    title: |-
+                        AutoDelete removes the exchange when no bindings are active
+                        +optional
+                    type: boolean
+                durable:
+                    title: |-
+                        Durable keeps the exchange also after the server restarts
+                        +optional
+                    type: boolean
+                internal:
+                    title: |-
+                        Internal when true does not accept publishings
+                        +optional
+                    type: boolean
+                noWait:
+                    title: |-
+                        NowWait when true does not wait for a confirmation from the server
+                        +optional
+                    type: boolean
+            title: |-
+                AMQPExchangeDeclareConfig holds the configuration for the exchange on the server
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPQueueBindConfig:
+            properties:
+                noWait:
+                    title: |-
+                        NowWait false and the queue could not be bound, the channel will be closed with an error
+                        +optional
+                    type: boolean
+            title: |-
+                AMQPQueueBindConfig holds the configuration that binds an exchange to a queue so that publishings to the
+                exchange will be routed to the queue when the publishing routing key matches the binding routing key
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPQueueDeclareConfig:
+            properties:
+                arguments:
+                    title: |-
+                        Arguments of a queue (also known as "x-arguments") used for optional features and plugins
+                        +optional
+                    type: string
+                autoDelete:
+                    title: |-
+                        AutoDelete removes the queue when no consumers are active
+                        +optional
+                    type: boolean
+                durable:
+                    title: |-
+                        Durable keeps the queue also after the server restarts
+                        +optional
+                    type: boolean
+                exclusive:
+                    title: |-
+                        Exclusive sets the queues to be accessible only by the connection that declares them and will be
+                        deleted wgen the connection closes
+                        +optional
+                    type: boolean
+                name:
+                    title: |-
+                        Name of the queue. If empty the server auto-generates a unique name for this queue
+                        +optional
+                    type: string
+                noWait:
+                    title: |-
+                        NowWait when true, the queue assumes to be declared on the server
+                        +optional
+                    type: boolean
+            title: |-
+                AMQPQueueDeclareConfig holds the configuration of a queue to hold messages and deliver to consumers.
+                Declaring creates a queue if it doesn't already exist, or ensures that an existing queue matches
+                the same parameters
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AWSLambdaTrigger:
+            properties:
+                accessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                functionName:
+                    description: FunctionName refers to the name of the function to invoke.
+                    type: string
+                invocationType:
+                    description: |-
+                        Choose from the following options.
+
+                           * RequestResponse (default) - Invoke the function synchronously. Keep
+                           the connection open until the function returns a response or times out.
+                           The API response includes the function response and additional data.
+
+                           * Event - Invoke the function asynchronously. Send events that fail multiple
+                           times to the function's dead-letter queue (if it's configured). The API
+                           response only includes a status code.
+
+                           * DryRun - Validate parameter values and verify that the user or role
+                           has permission to invoke the function.
+                        +optional
+                    type: string
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the trigger resource.
+                        +optional
+                    type: array
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                region:
+                    title: Region is AWS region
+                    type: string
+                roleARN:
+                    title: |-
+                        RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+                        +optional
+                    type: string
+                secretKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: AWSLambdaTrigger refers to specification of the trigger to invoke an AWS Lambda function
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Amount:
+            description: Amount represent a numeric amount.
+            properties:
+                value:
+                    format: byte
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ArgoWorkflowTrigger:
+            properties:
+                args:
+                    items:
+                        type: string
+                    title: Args is the list of arguments to pass to the argo CLI
+                    type: array
+                operation:
+                    title: |-
+                        Operation refers to the type of operation performed on the argo workflow resource.
+                        Default value is Submit.
+                        +optional
+                    type: string
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: Parameters is the list of parameters to pass to resolved Argo Workflow object
+                    type: array
+                source:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ArtifactLocation'
+            title: ArgoWorkflowTrigger is the trigger for the Argo Workflow
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ArtifactLocation:
+            properties:
+                configmap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                file:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.FileArtifact'
+                git:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitArtifact'
+                inline:
+                    title: Inline artifact is embedded in sensor spec as a string
+                    type: string
+                resource:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.K8SResource'
+                s3:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Artifact'
+                url:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.URLArtifact'
+            title: ArtifactLocation describes the source location for an external artifact
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureEventHubsTrigger:
+            properties:
+                fqdn:
+                    title: FQDN refers to the namespace dns of Azure Event Hubs to be used i.e. <namespace>.servicebus.windows.net
+                    type: string
+                hubName:
+                    title: HubName refers to the Azure Event Hub to send events to
+                    type: string
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the trigger resource.
+                        +optional
+                    type: array
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                sharedAccessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                sharedAccessKeyName:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: AzureEventHubsTrigger refers to specification of the Azure Event Hubs Trigger
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureEventsHubEventSource:
+            properties:
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                fqdn:
+                    title: |-
+                        FQDN of the EventHubs namespace you created
+                        More info at https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string
+                    type: string
+                hubName:
+                    title: Event Hub path/name
+                    type: string
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                sharedAccessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                sharedAccessKeyName:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: |-
+                AzureEventsHubEventSource describes the event source for azure events hub
+                More info at https://docs.microsoft.com/en-us/azure/event-hubs/
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureQueueStorageEventSource:
+            properties:
+                connectionString:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                decodeMessage:
+                    title: |-
+                        DecodeMessage specifies if all the messages should be base64 decoded.
+                        If set to true the decoding is done before the evaluation of JSONBody
+                        +optional
+                    type: boolean
+                dlq:
+                    title: |-
+                        DLQ specifies if a dead-letter queue is configured for messages that can't be processed successfully.
+                        If set to true, messages with invalid payload won't be acknowledged to allow to forward them farther to the dead-letter queue.
+                        The default value is false.
+                        +optional
+                    type: boolean
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                queueName:
+                    title: QueueName is the name of the queue
+                    type: string
+                storageAccountName:
+                    title: |-
+                        StorageAccountName is the name of the storage account where the queue is. This field is necessary to
+                        access via Azure AD (managed identity) and it is ignored if ConnectionString is set.
+                        +optional
+                    type: string
+                waitTimeInSeconds:
+                    title: |-
+                        WaitTimeInSeconds is the duration (in seconds) for which the event source waits between empty results from the queue.
+                        The default value is 3 seconds.
+                        +optional
+                    type: integer
+            title: |-
+                AzureQueueStorageEventSource describes the event source for azure queue storage
+                more info at https://learn.microsoft.com/en-us/azure/storage/queues/
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureServiceBusEventSource:
+            properties:
+                connectionString:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                deferDelete:
+                    description: |-
+                        DeferDelete controls when messages are removed from Azure Service Bus.
+                        If false (default), messages are received and deleted immediately before processing.
+                        If true, messages are locked and only deleted after successful processing, ensuring they are not lost if processing fails.
+                    type: boolean
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                fullyQualifiedNamespace:
+                    title: |-
+                        FullyQualifiedNamespace is the Service Bus namespace name (ex: myservicebus.servicebus.windows.net). This field is necessary to
+                        access via Azure AD (managed identity) and it is ignored if ConnectionString is set.
+                        +optional
+                    type: string
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                queueName:
+                    title: QueueName is the name of the Azure Service Bus Queue
+                    type: string
+                subscriptionName:
+                    title: SubscriptionName is the name of the Azure Service Bus Topic Subscription
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topicName:
+                    title: TopicName is the name of the Azure Service Bus Topic
+                    type: string
+            title: |-
+                AzureServiceBusEventSource describes the event source for azure service bus
+                More info at https://docs.microsoft.com/en-us/azure/service-bus-messaging/
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureServiceBusTrigger:
+            properties:
+                connectionString:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the trigger resource.
+                        +optional
+                    type: array
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                queueName:
+                    title: QueueName is the name of the Azure Service Bus Queue
+                    type: string
+                subscriptionName:
+                    title: SubscriptionName is the name of the Azure Service Bus Topic Subscription
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topicName:
+                    title: TopicName is the name of the Azure Service Bus Topic
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff:
+            properties:
+                duration:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Int64OrString'
+                factor:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Amount'
+                jitter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Amount'
+                steps:
+                    title: |-
+                        Exit with error after this many steps
+                        +optional
+                    type: integer
+            title: Backoff for an operation
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth:
+            properties:
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                username:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: BasicAuth contains the reference to K8s secrets that holds the username and password
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketAuth:
+            properties:
+                basic:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketBasicAuth'
+                oauthToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: BitbucketAuth holds the different auth strategies for connecting to Bitbucket
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketBasicAuth:
+            properties:
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                username:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: BitbucketBasicAuth holds the information required to authenticate user via basic auth mechanism
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketEventSource:
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketAuth'
+                deleteHookOnFinish:
+                    title: |-
+                        DeleteHookOnFinish determines whether to delete the defined Bitbucket hook once the event source is stopped.
+                        +optional
+                    type: boolean
+                events:
+                    description: Events this webhook is subscribed to.
+                    items:
+                        type: string
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will be passed along the event payload.
+                        +optional
+                    type: object
+                owner:
+                    title: |-
+                        DeprecatedOwner is the owner of the repository.
+                        Deprecated: use Repositories instead. Will be unsupported in v1.9
+                        +optional
+                    type: string
+                projectKey:
+                    title: |-
+                        DeprecatedProjectKey is the key of the project to which the repository relates
+                        Deprecated: use Repositories instead. Will be unsupported in v1.9
+                        +optional
+                    type: string
+                repositories:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketRepository'
+                    title: |-
+                        Repositories holds a list of repositories for which integration needs to set up
+                        +optional
+                    type: array
+                repositorySlug:
+                    title: |-
+                        DeprecatedRepositorySlug is a URL-friendly version of a repository name, automatically generated by Bitbucket for use in the URL
+                        Deprecated: use Repositories instead. Will be unsupported in v1.9
+                        +optional
+                    type: string
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: BitbucketEventSource describes the event source for Bitbucket
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketRepository:
+            properties:
+                owner:
+                    title: Owner is the owner of the repository
+                    type: string
+                repositorySlug:
+                    title: RepositorySlug is a URL-friendly version of a repository name, automatically generated by Bitbucket for use in the URL
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketServerEventSource:
+            properties:
+                accessToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bitbucketserverBaseURL:
+                    description: BitbucketServerBaseURL is the base URL for API requests to a custom endpoint.
+                    type: string
+                checkInterval:
+                    title: |-
+                        CheckInterval is a duration in which to wait before checking that the webhooks exist, e.g. 1s, 30m, 2h... (defaults to 1m)
+                        +optional
+                    type: string
+                deleteHookOnFinish:
+                    title: |-
+                        DeleteHookOnFinish determines whether to delete the Bitbucket Server hook for the project once the event source is stopped.
+                        +optional
+                    type: boolean
+                events:
+                    items:
+                        type: string
+                    title: |-
+                        Events are bitbucket event to listen to.
+                        Refer https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html
+                        +optional
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                oneEventPerChange:
+                    title: |-
+                        OneEventPerChange controls whether to process each change in a repo:refs_changed webhook event as a separate io.argoproj.workflow.v1alpha1. This setting is useful when multiple tags are
+                        pushed simultaneously for the same commit, and each tag needs to independently trigger an action, such as a distinct workflow in Argo Workflows. When enabled, the
+                        BitbucketServerEventSource publishes an individual BitbucketServerEventData for each change, ensuring independent processing of each tag or reference update in a
+                        single webhook event.
+                        +optional
+                    type: boolean
+                projectKey:
+                    title: |-
+                        DeprecatedProjectKey is the key of project for which integration needs to set up.
+                        Deprecated: use Repositories instead. Will be unsupported in v1.8.
+                        +optional
+                    type: string
+                projects:
+                    items:
+                        type: string
+                    title: |-
+                        Projects holds a list of projects for which integration needs to set up, this will add the webhook to all repositories in the project.
+                        +optional
+                    type: array
+                repositories:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketServerRepository'
+                    title: |-
+                        Repositories holds a list of repositories for which integration needs to set up.
+                        +optional
+                    type: array
+                repositorySlug:
+                    title: |-
+                        DeprecatedRepositorySlug is the slug of the repository for which integration needs to set up.
+                        Deprecated: use Repositories instead. Will be unsupported in v1.8.
+                        +optional
+                    type: string
+                skipBranchRefsChangedOnOpenPR:
+                    title: |-
+                        SkipBranchRefsChangedOnOpenPR bypasses the event repo:refs_changed for branches whenever there's an associated open pull request.
+                        This helps in optimizing the event handling process by avoiding unnecessary triggers for branch reference changes that are already part of a pull request under review.
+                        +optional
+                    type: boolean
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+                webhookSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: BitbucketServerEventSource refers to event-source related to Bitbucket Server events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketServerRepository:
+            properties:
+                projectKey:
+                    description: ProjectKey is the key of project for which integration needs to set up.
+                    type: string
+                repositorySlug:
+                    description: RepositorySlug is the slug of the repository for which integration needs to set up.
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.CalendarEventSource:
+            properties:
+                exclusionDates:
+                    description: ExclusionDates defines the list of DATE-TIME exceptions for recurring events.
+                    items:
+                        type: string
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                interval:
+                    title: |-
+                        Interval is a string that describes an interval duration, e.g. 1s, 30m, 2h...
+                        +optional
+                    type: string
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                persistence:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventPersistence'
+                schedule:
+                    title: |-
+                        Schedule is a cron-like expression. For reference, see: https://en.wikipedia.org/wiki/Cron
+                        +optional
+                    type: string
+                timezone:
+                    title: |-
+                        Timezone in which to run the schedule
+                        +optional
+                    type: string
+            title: |-
+                CalendarEventSource describes a time based dependency. One of the fields (schedule, interval, or recurrence) must be passed.
+                Schedule takes precedence over interval; interval takes precedence over recurrence
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.CatchupConfiguration:
+            properties:
+                enabled:
+                    title: Enabled enables to triggered the missed schedule when eventsource restarts
+                    type: boolean
+                maxDuration:
+                    title: MaxDuration holds max catchup duration
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Condition:
+            properties:
+                lastTransitionTime:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                message:
+                    title: |-
+                        Human-readable message indicating details about last transition.
+                        +optional
+                    type: string
+                reason:
+                    title: |-
+                        Unique, this should be a short, machine understandable string that gives the reason
+                        for condition's last transition. For example, "ImageNotFound"
+                        +optional
+                    type: string
+                status:
+                    title: |-
+                        Condition status, True, False or Unknown.
+                        +required
+                    type: string
+                type:
+                    title: |-
+                        Condition type.
+                        +required
+                    type: string
+            title: Condition contains details about resource state
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ConditionsResetByTime:
+            properties:
+                cron:
+                    title: 'Cron is a cron-like expression. For reference, see: https://en.wikipedia.org/wiki/Cron'
+                    type: string
+                timezone:
+                    title: +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ConditionsResetCriteria:
+            properties:
+                byTime:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ConditionsResetByTime'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ConfigMapPersistence:
+            properties:
+                createIfNotExist:
+                    title: CreateIfNotExist will create configmap if it doesn't exists
+                    type: boolean
+                name:
+                    title: Name of the configmap
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Container:
+            properties:
+                env:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvVar'
+                    title: +optional
+                    type: array
+                envFrom:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvFromSource'
+                    title: +optional
+                    type: array
+                imagePullPolicy:
+                    title: +optional
+                    type: string
+                resources:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceRequirements'
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecurityContext'
+                volumeMounts:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeMount'
+                    title: +optional
+                    type: array
+            title: Container defines customized spec for a container
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.CustomTrigger:
+            description: CustomTrigger refers to the specification of the custom trigger.
+            properties:
+                certSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                parameters:
+                    description: Parameters is the list of parameters that is applied to resolved custom trigger trigger object.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                secure:
+                    title: Secure refers to type of the connection between sensor to custom trigger gRPC
+                    type: boolean
+                serverNameOverride:
+                    description: ServerNameOverride for the secure connection between sensor and custom trigger gRPC server.
+                    type: string
+                serverURL:
+                    title: ServerURL is the url of the gRPC server that executes custom trigger
+                    type: string
+                spec:
+                    additionalProperties:
+                        type: string
+                    description: Spec is the custom trigger resource specification that custom trigger gRPC server knows how to interpret.
+                    type: object
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.DataFilter:
+            description: DataFilter describes constraints and filters for event data.
+            properties:
+                comparator:
+                    description: |-
+                        Comparator compares the event data with a user given value.
+                        Can be ">=", ">", "=", "!=", "<", or "<=".
+                        Is optional, and if left blank treated as equality "=".
+                    type: string
+                path:
+                    description: |-
+                        Path is the JSONPath of the event's (JSON decoded) data key.
+                        Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'.
+                        To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\'.
+                        See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.
+                    type: string
+                template:
+                    title: |-
+                        Template is a go-template for extracting a string from the event's data.
+                        A Template is evaluated with provided path, type and value.
+                        The templating follows the standard go-template syntax as well as sprig's extra functions.
+                        See https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                    type: string
+                type:
+                    title: Type contains the JSON type of the data
+                    type: string
+                value:
+                    description: |-
+                        Value is the allowed string values for this key.
+                        Booleans are parsed using strconv.ParseBool(),
+                        Numbers are parsed as float64 using strconv.ParseFloat(),
+                        Strings are treated as regular expressions,
+                        Nils value is ignored.
+                    items:
+                        type: string
+                    type: array
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EmailTrigger:
+            description: EmailTrigger refers to the specification of the email notification trigger.
+            properties:
+                body:
+                    title: |-
+                        Body refers to the body/content of the email send.
+                        +optional
+                    type: string
+                from:
+                    title: |-
+                        From refers to the address from which the email is send from.
+                        +optional
+                    type: string
+                host:
+                    description: Host refers to the smtp host url to which email is send.
+                    type: string
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the trigger resource.
+                        +optional
+                    type: array
+                port:
+                    title: |-
+                        Port refers to the smtp server port to which email is send.
+                        Defaults to 0.
+                        +optional
+                    type: integer
+                smtpPassword:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                subject:
+                    title: |-
+                        Subject refers to the subject line for the email send.
+                        +optional
+                    type: string
+                to:
+                    items:
+                        type: string
+                    title: |-
+                        To refers to the email addresses to which the emails are send.
+                        +optional
+                    type: array
+                username:
+                    title: |-
+                        Username refers to the username used to connect to the smtp server.
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EmitterEventSource:
+            properties:
+                broker:
+                    description: Broker URI to connect to.
+                    type: string
+                channelKey:
+                    title: ChannelKey refers to the channel key
+                    type: string
+                channelName:
+                    title: ChannelName refers to the channel name
+                    type: string
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                username:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: |-
+                EmitterEventSource describes the event source for emitter
+                More info at https://emitter.io/develop/getting-started/
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventContext:
+            properties:
+                datacontenttype:
+                    description: DataContentType - A MIME (RFC2046) string describing the media type of `data`.
+                    type: string
+                id:
+                    description: ID of the event; must be non-empty and unique within the scope of the producer.
+                    type: string
+                source:
+                    description: Source - A URI describing the event producer.
+                    type: string
+                specversion:
+                    description: SpecVersion - The version of the CloudEvents specification used by the io.argoproj.workflow.v1alpha1.
+                    type: string
+                subject:
+                    title: Subject - The subject of the event in the context of the event producer
+                    type: string
+                time:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                type:
+                    description: Type - The type of the occurrence which has happened.
+                    type: string
+            title: |-
+                EventContext holds the context of the cloudevent received from an event source.
+                +protobuf.options.(gogoproto.goproto_stringer)=false
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventDependency:
+            properties:
+                eventName:
+                    title: EventName is the name of the event
+                    type: string
+                eventSourceName:
+                    title: EventSourceName is the name of EventSource that Sensor depends on
+                    type: string
+                filters:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventDependencyFilter'
+                filtersLogicalOperator:
+                    description: |-
+                        FiltersLogicalOperator defines how different filters are evaluated together.
+                        Available values: and (&&), or (||)
+                        Is optional and if left blank treated as and (&&).
+                    type: string
+                name:
+                    title: Name is a unique name of this dependency
+                    type: string
+                transform:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventDependencyTransformer'
+            title: EventDependency describes a dependency
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventDependencyFilter:
+            description: EventDependencyFilter defines filters and constraints for a io.argoproj.workflow.v1alpha1.
+            properties:
+                context:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventContext'
+                data:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.DataFilter'
+                    title: Data filter constraints with escalation
+                    type: array
+                dataLogicalOperator:
+                    description: |-
+                        DataLogicalOperator defines how multiple Data filters (if defined) are evaluated together.
+                        Available values: and (&&), or (||)
+                        Is optional and if left blank treated as and (&&).
+                    type: string
+                exprLogicalOperator:
+                    description: |-
+                        ExprLogicalOperator defines how multiple Exprs filters (if defined) are evaluated together.
+                        Available values: and (&&), or (||)
+                        Is optional and if left blank treated as and (&&).
+                    type: string
+                exprs:
+                    description: Exprs contains the list of expressions evaluated against the event payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ExprFilter'
+                    type: array
+                script:
+                    description: Script refers to a Lua script evaluated to determine the validity of an io.argoproj.workflow.v1alpha1.
+                    type: string
+                time:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TimeFilter'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventDependencyTransformer:
+            properties:
+                jq:
+                    title: |-
+                        JQ holds the jq command applied for transformation
+                        +optional
+                    type: string
+                script:
+                    title: |-
+                        Script refers to a Lua script used to transform the event
+                        +optional
+                    type: string
+            title: EventDependencyTransformer transforms the event
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventPersistence:
+            properties:
+                catchup:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.CatchupConfiguration'
+                configMap:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ConfigMapPersistence'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource:
+            properties:
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceSpec'
+                status:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceStatus'
+            title: |-
+                EventSource is the definition of a eventsource resource
+                +genclient
+                +kubebuilder:resource:shortName=es
+                +kubebuilder:subresource:status
+                +k8s:deepcopy-gen:interfaces=io.k8s.apimachinery/pkg/runtime.Object
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter:
+            properties:
+                expression:
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceList:
+            properties:
+                items:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                    type: array
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            title: |-
+                EventSourceList is the list of eventsource resources
+                +k8s:deepcopy-gen:interfaces=io.k8s.apimachinery/pkg/runtime.Object
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceSpec:
+            properties:
+                amqp:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AMQPEventSource'
+                    title: AMQP event sources
+                    type: object
+                azureEventsHub:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureEventsHubEventSource'
+                    title: AzureEventsHub event sources
+                    type: object
+                azureQueueStorage:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureQueueStorageEventSource'
+                    title: AzureQueueStorage event source
+                    type: object
+                azureServiceBus:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureServiceBusEventSource'
+                    title: Azure Service Bus event source
+                    type: object
+                bitbucket:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketEventSource'
+                    title: Bitbucket event sources
+                    type: object
+                bitbucketserver:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BitbucketServerEventSource'
+                    title: Bitbucket Server event sources
+                    type: object
+                calendar:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.CalendarEventSource'
+                    title: Calendar event sources
+                    type: object
+                emitter:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EmitterEventSource'
+                    title: Emitter event source
+                    type: object
+                eventBusName:
+                    title: EventBusName references to a EventBus name. By default the value is "default"
+                    type: string
+                file:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.FileEventSource'
+                    title: File event sources
+                    type: object
+                generic:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GenericEventSource'
+                    title: Generic event source
+                    type: object
+                gerrit:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GerritEventSource'
+                    title: Gerrit event source
+                    type: object
+                github:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GithubEventSource'
+                    title: Github event sources
+                    type: object
+                gitlab:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitlabEventSource'
+                    title: Gitlab event sources
+                    type: object
+                hdfs:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.HDFSEventSource'
+                    title: HDFS event sources
+                    type: object
+                kafka:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.KafkaEventSource'
+                    title: Kafka event sources
+                    type: object
+                minio:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Artifact'
+                    title: Minio event sources
+                    type: object
+                mns:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.MNSEventSource'
+                    title: MNS event sources
+                    type: object
+                mqtt:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.MQTTEventSource'
+                    title: MQTT event sources
+                    type: object
+                nats:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSEventsSource'
+                    title: NATS event sources
+                    type: object
+                nsq:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NSQEventSource'
+                    title: NSQ event source
+                    type: object
+                pubSub:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PubSubEventSource'
+                    title: PubSub event sources
+                    type: object
+                pulsar:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PulsarEventSource'
+                    title: Pulsar event source
+                    type: object
+                redis:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.RedisEventSource'
+                    title: Redis event source
+                    type: object
+                redisStream:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.RedisStreamEventSource'
+                    title: Redis stream source
+                    type: object
+                replicas:
+                    title: Replicas is the event source deployment replicas
+                    type: integer
+                resource:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ResourceEventSource'
+                    title: Resource event sources
+                    type: object
+                service:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Service'
+                sftp:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SFTPEventSource'
+                    title: SFTP event sources
+                    type: object
+                slack:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackEventSource'
+                    title: Slack event sources
+                    type: object
+                sns:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SNSEventSource'
+                    title: SNS event sources
+                    type: object
+                sqs:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SQSEventSource'
+                    title: SQS event sources
+                    type: object
+                storageGrid:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StorageGridEventSource'
+                    title: StorageGrid event sources
+                    type: object
+                stripe:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StripeEventSource'
+                    title: Stripe event sources
+                    type: object
+                template:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Template'
+                webhook:
+                    additionalProperties:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookEventSource'
+                    title: Webhook event sources
+                    type: object
+            title: EventSourceSpec refers to specification of event-source resource
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceStatus:
+            properties:
+                status:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Status'
+            title: EventSourceStatus holds the status of the event-source resource
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ExprFilter:
+            properties:
+                expr:
+                    description: Expr refers to the expression that determines the outcome of the filter.
+                    type: string
+                fields:
+                    description: Fields refers to set of keys that refer to the paths within event payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PayloadField'
+                    type: array
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.FileArtifact:
+            properties:
+                path:
+                    type: string
+            title: FileArtifact contains information about an artifact in a filesystem
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.FileEventSource:
+            description: FileEventSource describes an event-source for file related events.
+            properties:
+                eventType:
+                    title: |-
+                        Type of file operations to watch
+                        Refer https://github.com/fsnotify/fsnotify/blob/master/fsnotify.go for more information
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                polling:
+                    title: Use polling instead of inotify
+                    type: boolean
+                watchPathConfig:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WatchPathConfig'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GenericEventSource:
+            description: GenericEventSource refers to a generic event source. It can be used to implement a custom event source.
+            properties:
+                authSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                config:
+                    title: Config is the event source configuration
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                insecure:
+                    description: Insecure determines the type of connection.
+                    type: boolean
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                url:
+                    description: URL of the gRPC server that implements the event source.
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GerritEventSource:
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth'
+                deleteHookOnFinish:
+                    title: |-
+                        DeleteHookOnFinish determines whether to delete the Gerrit hook for the project once the event source is stopped.
+                        +optional
+                    type: boolean
+                events:
+                    items:
+                        type: string
+                    title: |-
+                        Events are gerrit event to listen to.
+                        Refer https://gerrit-review.googlesource.com/Documentation/cmd-stream-events.html#events
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                gerritBaseURL:
+                    title: GerritBaseURL is the base URL for API requests to a custom endpoint
+                    type: string
+                hookName:
+                    title: HookName is the name of the webhook
+                    type: string
+                maxTries:
+                    title: |-
+                        MaxTries is number of attempts when posting an event to the target url
+                        +optional
+                    type: string
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                projects:
+                    description: List of project namespace paths like "whynowy/test".
+                    items:
+                        type: string
+                    type: array
+                sslVerify:
+                    title: |-
+                        SslVerify to enable ssl verification
+                        +optional
+                    type: boolean
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: GerritEventSource refers to event-source related to gerrit events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitArtifact:
+            properties:
+                branch:
+                    title: |-
+                        Branch to use to pull trigger resource
+                        +optional
+                    type: string
+                cloneDirectory:
+                    description: |-
+                        Directory to clone the repository. We clone complete directory because GitArtifact is not limited to any specific Git service providers.
+                        Hence we don't use any specific git provider client.
+                    type: string
+                creds:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitCreds'
+                filePath:
+                    title: Path to file that contains trigger resource definition
+                    type: string
+                insecureIgnoreHostKey:
+                    title: |-
+                        Whether to ignore host key
+                        +optional
+                    type: boolean
+                ref:
+                    title: |-
+                        Ref to use to pull trigger resource. Will result in a shallow clone and
+                        fetch.
+                        +optional
+                    type: string
+                remote:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitRemoteConfig'
+                sshKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                tag:
+                    title: |-
+                        Tag to use to pull trigger resource
+                        +optional
+                    type: string
+                url:
+                    title: Git URL
+                    type: string
+            title: GitArtifact contains information about an artifact stored in git
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitCreds:
+            properties:
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                username:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: GitCreds contain reference to git username and password
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitRemoteConfig:
+            properties:
+                name:
+                    description: Name of the remote to fetch from.
+                    type: string
+                urls:
+                    description: |-
+                        URLs the URLs of a remote repository. It must be non-empty. Fetch will
+                        always use the first URL, while push will use all of them.
+                    items:
+                        type: string
+                    type: array
+            title: GitRemoteConfig contains the configuration of a Git remote
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GithubAppCreds:
+            properties:
+                appID:
+                    title: AppID refers to the GitHub App ID for the application you created
+                    type: string
+                installationID:
+                    title: InstallationID refers to the Installation ID of the GitHub app you created and installed
+                    type: string
+                privateKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GithubEventSource:
+            properties:
+                active:
+                    title: |-
+                        Active refers to status of the webhook for event deliveries.
+                        https://developer.github.com/webhooks/creating/#active
+                        +optional
+                    type: boolean
+                apiToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                contentType:
+                    title: ContentType of the event delivery
+                    type: string
+                deleteHookOnFinish:
+                    title: |-
+                        DeleteHookOnFinish determines whether to delete the GitHub hook for the repository once the event source is stopped.
+                        +optional
+                    type: boolean
+                events:
+                    items:
+                        type: string
+                    title: Events refer to Github events to which the event source will subscribe
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                githubApp:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GithubAppCreds'
+                githubBaseURL:
+                    title: |-
+                        GitHub base URL (for GitHub Enterprise)
+                        +optional
+                    type: string
+                githubUploadURL:
+                    title: |-
+                        GitHub upload URL (for GitHub Enterprise)
+                        +optional
+                    type: string
+                id:
+                    title: |-
+                        Id is the webhook's id
+                        Deprecated: This is not used at all, will be removed in v1.6
+                        +optional
+                    type: string
+                insecure:
+                    title: Insecure tls verification
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                organizations:
+                    description: Organizations holds the names of organizations (used for organization level webhooks). Not required if Repositories is set.
+                    items:
+                        type: string
+                    type: array
+                owner:
+                    title: |-
+                        DeprecatedOwner refers to GitHub owner name i.e. argoproj
+                        Deprecated: use Repositories instead. Will be unsupported in v 1.6
+                        +optional
+                    type: string
+                repositories:
+                    description: |-
+                        Repositories holds the information of repositories, which uses repo owner as the key,
+                        and list of repo names as the value. Not required if Organizations is set.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.OwnedRepositories'
+                    type: array
+                repository:
+                    title: |-
+                        DeprecatedRepository refers to GitHub repo name i.e. argo-events
+                        Deprecated: use Repositories instead. Will be unsupported in v 1.6
+                        +optional
+                    type: string
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+                webhookSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: GithubEventSource refers to event-source for github related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.GitlabEventSource:
+            properties:
+                accessToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                deleteHookOnFinish:
+                    title: |-
+                        DeleteHookOnFinish determines whether to delete the GitLab hook for the project once the event source is stopped.
+                        +optional
+                    type: boolean
+                enableSSLVerification:
+                    title: |-
+                        EnableSSLVerification to enable ssl verification
+                        +optional
+                    type: boolean
+                events:
+                    description: |-
+                        Events are gitlab event to listen to.
+                        Refer https://github.com/xanzy/go-gitlab/blob/bf34eca5d13a9f4c3f501d8a97b8ac226d55e4d9/projects.go#L794.
+                    items:
+                        type: string
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                gitlabBaseURL:
+                    title: GitlabBaseURL is the base URL for API requests to a custom endpoint
+                    type: string
+                groups:
+                    items:
+                        type: string
+                    title: |-
+                        List of group IDs or group name like "test".
+                        Group level hook available in Premium and Ultimate Gitlab.
+                        +optional
+                    type: array
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                projectID:
+                    title: |-
+                        DeprecatedProjectID is the id of project for which integration needs to setup
+                        Deprecated: use Projects instead. Will be unsupported in v 1.7
+                        +optional
+                    type: string
+                projects:
+                    items:
+                        type: string
+                    title: |-
+                        List of project IDs or project namespace paths like "whynowy/test".
+                        If neither a project nor a group is defined, the EventSource will not manage webhooks.
+                        +optional
+                    type: array
+                secretToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: GitlabEventSource refers to event-source related to Gitlab events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.HDFSEventSource:
+            properties:
+                addresses:
+                    items:
+                        type: string
+                    type: array
+                checkInterval:
+                    title: CheckInterval is a string that describes an interval duration to check the directory state, e.g. 1s, 30m, 2h... (defaults to 1m)
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                hdfsUser:
+                    description: |-
+                        HDFSUser is the user to access HDFS file system.
+                        It is ignored if either ccache or keytab is used.
+                    type: string
+                krbCCacheSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                krbConfigConfigMap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                krbKeytabSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                krbRealm:
+                    description: |-
+                        KrbRealm is the Kerberos realm used with Kerberos keytab
+                        It must be set if keytab is used.
+                    type: string
+                krbServicePrincipalName:
+                    description: |-
+                        KrbServicePrincipalName is the principal name of Kerberos service
+                        It must be set if either ccache or keytab is used.
+                    type: string
+                krbUsername:
+                    description: |-
+                        KrbUsername is the Kerberos username used with Kerberos keytab
+                        It must be set if keytab is used.
+                    type: string
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                type:
+                    title: Type of file operations to watch
+                    type: string
+                watchPathConfig:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WatchPathConfig'
+            title: HDFSEventSource refers to event-source for HDFS related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.HTTPTrigger:
+            properties:
+                basicAuth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth'
+                dynamicHeaders:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Dynamic Headers for the request, sourced from the io.argoproj.workflow.v1alpha1. Same spec as Parameters.
+                        +optional
+                    type: array
+                headers:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Headers for the HTTP request.
+                        +optional
+                    type: object
+                host:
+                    title: |-
+                        Host refers to the domain name of the server (for virtual hosting).
+                        +optional
+                    type: string
+                method:
+                    title: |-
+                        Method refers to the type of the HTTP request.
+                        Refer https://golang.org/src/net/http/method.go for more io.argoproj.workflow.v1alpha1.
+                        Default value is POST.
+                        +optional
+                    type: string
+                parameters:
+                    description: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the HTTP trigger resource.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                payload:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                secureHeaders:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SecureHeader'
+                    title: |-
+                        Secure Headers stored in Kubernetes Secrets for the HTTP requests.
+                        +optional
+                    type: array
+                timeout:
+                    title: |-
+                        Timeout refers to the HTTP request timeout in seconds.
+                        Default value is 60 seconds.
+                        +optional
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                url:
+                    description: URL refers to the URL to send HTTP request to.
+                    type: string
+            title: HTTPTrigger is the trigger for the HTTP request
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Int64OrString:
+            properties:
+                int64Val:
+                    type: string
+                strVal:
+                    type: string
+                type:
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.K8SResource:
+            description: K8SResource represent arbitrary structured data.
+            properties:
+                value:
+                    format: byte
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.K8SResourcePolicy:
+            properties:
+                backoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                errorOnBackoffTimeout:
+                    title: |-
+                        ErrorOnBackoffTimeout determines whether sensor should transition to error state if the trigger policy is unable to determine
+                        the state of the resource
+                    type: boolean
+                labels:
+                    additionalProperties:
+                        type: string
+                    title: Labels required to identify whether a resource is in success state
+                    type: object
+            title: K8SResourcePolicy refers to the policy used to check the state of K8s based triggers using labels
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.KafkaConsumerGroup:
+            properties:
+                groupName:
+                    title: The name for the consumer group to use
+                    type: string
+                oldest:
+                    title: |-
+                        When starting up a new group do we want to start from the oldest event (true) or the newest event (false), defaults to false
+                        +optional
+                    type: boolean
+                rebalanceStrategy:
+                    title: |-
+                        Rebalance strategy can be one of: sticky, roundrobin, range. Range is the default.
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.KafkaEventSource:
+            properties:
+                config:
+                    description: |-
+                        Yaml format Sarama config for Kafka connection.
+                        It follows the struct of sarama.Config. See https://github.com/IBM/sarama/blob/main/config.go
+                        e.g.
+
+                        consumer:
+                          fetch:
+                            min: 1
+                        net:
+                          MaxOpenRequests: 5
+
+                        +optional
+                    type: string
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                consumerGroup:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.KafkaConsumerGroup'
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                limitEventsPerSecond:
+                    title: |-
+                        Sets a limit on how many events get read from kafka per second.
+                        +optional
+                    type: string
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                partition:
+                    title: |-
+                        Partition name
+                        +optional
+                    type: string
+                sasl:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SASLConfig'
+                schemaRegistry:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SchemaRegistryConfig'
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topic:
+                    title: Topic name
+                    type: string
+                url:
+                    title: URL to kafka cluster, multiple URLs separated by comma
+                    type: string
+                version:
+                    title: |-
+                        Specify what kafka version is being connected to enables certain features in sarama, defaults to 1.0.0
+                        +optional
+                    type: string
+            title: KafkaEventSource refers to event-source for Kafka related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.KafkaTrigger:
+            description: KafkaTrigger refers to the specification of the Kafka trigger.
+            properties:
+                compress:
+                    title: |-
+                        Compress determines whether to compress message or not.
+                        Defaults to false.
+                        If set to true, compresses message using snappy compression.
+                        +optional
+                    type: boolean
+                flushFrequency:
+                    title: |-
+                        FlushFrequency refers to the frequency in milliseconds to flush batches.
+                        Defaults to 500 milliseconds.
+                        +optional
+                    type: integer
+                headers:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Headers for the Kafka Messages.
+                        +optional
+                    type: object
+                parameters:
+                    description: Parameters is the list of parameters that is applied to resolved Kafka trigger object.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                partition:
+                    title: |-
+                        +optional
+                        DEPRECATED
+                    type: integer
+                partitioningKey:
+                    description: |-
+                        The partitioning key for the messages put on the Kafka topic.
+                        +optional.
+                    type: string
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                requiredAcks:
+                    description: |-
+                        RequiredAcks used in producer to tell the broker how many replica acknowledgements
+                        Defaults to 1 (Only wait for the leader to ack).
+                        +optional.
+                    type: integer
+                sasl:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SASLConfig'
+                schemaRegistry:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SchemaRegistryConfig'
+                secureHeaders:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SecureHeader'
+                    title: |-
+                        Secure Headers stored in Kubernetes Secrets for the Kafka messages.
+                        +optional
+                    type: array
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topic:
+                    title: |-
+                        Name of the topic.
+                        More info at https://kafka.apache.org/documentation/#intro_topics
+                    type: string
+                url:
+                    description: URL of the Kafka broker, multiple URLs separated by comma.
+                    type: string
+                version:
+                    title: |-
+                        Specify what kafka version is being connected to enables certain features in sarama, defaults to 1.0.0
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.LogTrigger:
+            properties:
+                intervalSeconds:
+                    format: uint64
+                    title: |-
+                        Only print messages every interval. Useful to prevent logging too much data for busy events.
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.MNSEventSource:
+            properties:
+                accessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                endpoint:
+                    title: |-
+                        Endpoint configures connection to a specific AlibabaCloud MNS endpoint
+                        +optional
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: +optional
+                    type: boolean
+                queue:
+                    title: Queue is AlibabaCloud MNS queue to listen to for messages
+                    type: string
+                secretKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: MNSEventSource refers to event-source for AlibabaCloud MNS related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.MQTTEventSource:
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth'
+                clientId:
+                    title: ClientID is the id of the client
+                    type: string
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topic:
+                    title: Topic name
+                    type: string
+                url:
+                    title: URL to connect to broker
+                    type: string
+            title: MQTTEventSource refers to event-source for MQTT related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Metadata:
+            properties:
+                annotations:
+                    additionalProperties:
+                        type: string
+                    type: object
+                labels:
+                    additionalProperties:
+                        type: string
+                    type: object
+            title: Metadata holds the annotations and labels of an event source pod
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSAuth:
+            properties:
+                basic:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth'
+                credential:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                nkey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                token:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: NATSAuth refers to the auth info for NATS EventSource
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSEventsSource:
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSAuth'
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                queue:
+                    title: |-
+                        Queue is the name of the queue group to subscribe as if specified. Uses QueueSubscribe
+                        logic to subscribe as queue group. If the queue is empty, uses default Subscribe logic.
+                        +optional
+                    type: string
+                subject:
+                    title: Subject holds the name of the subject onto which messages are published
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                url:
+                    title: URL to connect to NATS cluster
+                    type: string
+            title: NATSEventsSource refers to event-source for NATS related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSTrigger:
+            description: NATSTrigger refers to the specification of the NATS trigger.
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSAuth'
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                payload:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                subject:
+                    description: Name of the subject to put message on.
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                url:
+                    description: URL of the NATS cluster.
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NSQEventSource:
+            properties:
+                channel:
+                    title: Channel used for subscription
+                    type: string
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                hostAddress:
+                    title: HostAddress is the address of the host for NSQ lookup
+                    type: string
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topic:
+                    description: Topic to subscribe to.
+                    type: string
+            title: |-
+                NSQEventSource describes the event source for NSQ PubSub
+                More info at https://godoc.org/github.com/nsqio/go-nsq
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.OpenWhiskTrigger:
+            description: OpenWhiskTrigger refers to the specification of the OpenWhisk trigger.
+            properties:
+                actionName:
+                    description: Name of the action/function.
+                    type: string
+                authToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                host:
+                    description: Host URL of the OpenWhisk.
+                    type: string
+                namespace:
+                    description: |-
+                        Namespace for the action.
+                        Defaults to "_".
+                        +optional.
+                    type: string
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the trigger resource.
+                        +optional
+                    type: array
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                version:
+                    title: |-
+                        Version for the API.
+                        Defaults to v1.
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.OwnedRepositories:
+            properties:
+                names:
+                    items:
+                        type: string
+                    title: Repository names
+                    type: array
+                owner:
+                    title: Organization or user name
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PayloadField:
+            description: PayloadField binds a value at path within the event payload against a name.
+            properties:
+                name:
+                    description: Name acts as key that holds the value at the path.
+                    type: string
+                path:
+                    description: |-
+                        Path is the JSONPath of the event's (JSON decoded) data key
+                        Path is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'.
+                        To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\'.
+                        See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PubSubEventSource:
+            description: PubSubEventSource refers to event-source for GCP PubSub related events.
+            properties:
+                credentialSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                deleteSubscriptionOnFinish:
+                    title: |-
+                        DeleteSubscriptionOnFinish determines whether to delete the GCP PubSub subscription once the event source is stopped.
+                        +optional
+                    type: boolean
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                projectID:
+                    title: |-
+                        ProjectID is GCP project ID for the subscription.
+                        Required if you run Argo Events outside of GKE/GCE.
+                        (otherwise, the default value is its project)
+                        +optional
+                    type: string
+                subscriptionID:
+                    title: |-
+                        SubscriptionID is ID of subscription.
+                        Required if you use existing subscription.
+                        The default value will be auto generated hash based on this eventsource setting, so the subscription
+                        might be recreated every time you update the setting, which has a possibility of event loss.
+                        +optional
+                    type: string
+                topic:
+                    title: |-
+                        Topic to which the subscription should belongs.
+                        Required if you want the eventsource to create a new subscription.
+                        If you specify this field along with an existing subscription,
+                        it will be verified whether it actually belongs to the specified topic.
+                        +optional
+                    type: string
+                topicProjectID:
+                    title: |-
+                        TopicProjectID is GCP project ID for the topic.
+                        By default, it is same as ProjectID.
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PulsarEventSource:
+            properties:
+                authAthenzParams:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Authentication athenz parameters for the pulsar client.
+                        Refer https://github.com/apache/pulsar-client-go/blob/master/pulsar/auth/athenz.go
+                        Either token or athenz can be set to use auth.
+                        +optional
+                    type: object
+                authAthenzSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                authTokenSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                tlsAllowInsecureConnection:
+                    title: |-
+                        Whether the Pulsar client accept untrusted TLS certificate from broker.
+                        +optional
+                    type: boolean
+                tlsTrustCertsSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                tlsValidateHostname:
+                    title: |-
+                        Whether the Pulsar client verify the validity of the host name from broker.
+                        +optional
+                    type: boolean
+                topics:
+                    items:
+                        type: string
+                    title: |-
+                        Name of the topics to subscribe to.
+                        +required
+                    type: array
+                type:
+                    title: |-
+                        Type of the subscription.
+                        Only "exclusive" and "shared" is supported.
+                        Defaults to exclusive.
+                        +optional
+                    type: string
+                url:
+                    title: |-
+                        Configure the service URL for the Pulsar service.
+                        +required
+                    type: string
+            title: PulsarEventSource describes the event source for Apache Pulsar
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PulsarTrigger:
+            description: PulsarTrigger refers to the specification of the Pulsar trigger.
+            properties:
+                authAthenzParams:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Authentication athenz parameters for the pulsar client.
+                        Refer https://github.com/apache/pulsar-client-go/blob/master/pulsar/auth/athenz.go
+                        Either token or athenz can be set to use auth.
+                        +optional
+                    type: object
+                authAthenzSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                authTokenSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                connectionBackoff:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                parameters:
+                    description: Parameters is the list of parameters that is applied to resolved Kafka trigger object.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                payload:
+                    description: Payload is the list of key-value extracted from an event payload to construct the request payload.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                tlsAllowInsecureConnection:
+                    title: |-
+                        Whether the Pulsar client accept untrusted TLS certificate from broker.
+                        +optional
+                    type: boolean
+                tlsTrustCertsSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                tlsValidateHostname:
+                    title: |-
+                        Whether the Pulsar client verify the validity of the host name from broker.
+                        +optional
+                    type: boolean
+                topic:
+                    title: |-
+                        Name of the topic.
+                        See https://pulsar.apache.org/docs/en/concepts-messaging/
+                    type: string
+                url:
+                    title: |-
+                        Configure the service URL for the Pulsar service.
+                        +required
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.RateLimit:
+            properties:
+                requestsPerUnit:
+                    type: integer
+                unit:
+                    title: Defaults to Second
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.RedisEventSource:
+            properties:
+                channels:
+                    items:
+                        type: string
+                    type: array
+                db:
+                    title: |-
+                        DB to use. If not specified, default DB 0 will be used.
+                        +optional
+                    type: integer
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                hostAddress:
+                    title: HostAddress refers to the address of the Redis host/server
+                    type: string
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                namespace:
+                    title: |-
+                        Namespace to use to retrieve the password from. It should only be specified if password is declared
+                        +optional
+                    type: string
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                username:
+                    title: |-
+                        Username required for ACL style authentication if any.
+                        +optional
+                    type: string
+            title: |-
+                RedisEventSource describes an event source for the Redis PubSub.
+                More info at https://godoc.org/github.com/go-redis/redis#example-PubSub
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.RedisStreamEventSource:
+            properties:
+                consumerGroup:
+                    title: |-
+                        ConsumerGroup refers to the Redis stream consumer group that will be
+                        created on all redis streams. Messages are read through this group. Defaults to 'argo-events-cg'
+                        +optional
+                    type: string
+                db:
+                    title: |-
+                        DB to use. If not specified, default DB 0 will be used.
+                        +optional
+                    type: integer
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                hostAddress:
+                    title: HostAddress refers to the address of the Redis host/server (master instance)
+                    type: string
+                maxMsgCountPerRead:
+                    title: |-
+                        MaxMsgCountPerRead holds the maximum number of messages per stream that will be read in each XREADGROUP of all streams
+                        Example: if there are 2 streams and MaxMsgCountPerRead=10, then each XREADGROUP may read upto a total of 20 messages.
+                        Same as COUNT option in XREADGROUP(https://redis.io/topics/streams-intro). Defaults to 10
+                        +optional
+                    type: integer
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                streams:
+                    description: Streams to look for entries. XREADGROUP is used on all streams using a single consumer group.
+                    items:
+                        type: string
+                    type: array
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                username:
+                    title: |-
+                        Username required for ACL style authentication if any.
+                        +optional
+                    type: string
+            title: |-
+                RedisStreamEventSource describes an event source for
+                Redis streams (https://redis.io/topics/streams-intro)
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ResourceEventSource:
+            description: ResourceEventSource refers to a event-source for K8s resource related events.
+            properties:
+                eventTypes:
+                    description: |-
+                        EventTypes is the list of event type to watch.
+                        Possible values are - ADD, UPDATE and DELETE.
+                    items:
+                        type: string
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ResourceFilter'
+                groupVersionResource:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionResource'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                namespace:
+                    title: Namespace where resource is deployed
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ResourceFilter:
+            properties:
+                afterStart:
+                    title: |-
+                        If the resource is created after the start time then the event is treated as valid.
+                        +optional
+                    type: boolean
+                createdBy:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                fields:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Selector'
+                    title: |-
+                        Fields provide field filters similar to K8s field selector
+                        (see https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/).
+                        Unlike K8s field selector, it supports arbitrary fileds like "spec.serviceAccountName",
+                        and the value could be a string or a regex.
+                        Same as K8s field selector, operator "=", "==" and "!=" are supported.
+                        +optional
+                    type: array
+                labels:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Selector'
+                    title: |-
+                        Labels provide listing options to K8s API to watch resource/s.
+                        Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/label-selectors/ for more io.argoproj.workflow.v1alpha1.
+                        Unlike K8s field selector, multiple values are passed as comma separated values instead of list of values.
+                        Eg: value: value1,value2.
+                        Same as K8s label selector, operator "=", "==", "!=", "exists", "!", "notin", "in", "gt" and "lt"
+                        are supported
+                        +optional
+                    type: array
+                prefix:
+                    title: |-
+                        Prefix filter is applied on the resource name.
+                        +optional
+                    type: string
+            title: ResourceFilter contains K8s ObjectMeta information to further filter resource event objects
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Artifact:
+            properties:
+                accessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bucket:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Bucket'
+                caCertificate:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                endpoint:
+                    type: string
+                events:
+                    items:
+                        type: string
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Filter'
+                insecure:
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    type: object
+                region:
+                    type: string
+                secretKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: S3Artifact contains information about an S3 connection and bucket
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Bucket:
+            properties:
+                key:
+                    type: string
+                name:
+                    type: string
+            title: S3Bucket contains information to describe an S3 Bucket
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.S3Filter:
+            properties:
+                prefix:
+                    type: string
+                suffix:
+                    type: string
+            title: S3Filter represents filters to apply to bucket notifications for specifying constraints on objects
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SASLConfig:
+            properties:
+                mechanism:
+                    title: |-
+                        SASLMechanism is the name of the enabled SASL mechanism.
+                        Possible values: OAUTHBEARER, PLAIN (defaults to PLAIN).
+                        +optional
+                    type: string
+                passwordSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                userSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: SASLConfig refers to SASL configuration for a client
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SFTPEventSource:
+            description: SFTPEventSource describes an event-source for sftp related events.
+            properties:
+                address:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                eventType:
+                    title: |-
+                        Type of file operations to watch
+                        Refer https://github.com/fsnotify/fsnotify/blob/master/fsnotify.go for more information
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                password:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                pollIntervalDuration:
+                    title: |-
+                        PollIntervalDuration the interval at which to poll the SFTP server
+                        defaults to 10 seconds
+                        +optional
+                    type: string
+                sshKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                username:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                watchPathConfig:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WatchPathConfig'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SNSEventSource:
+            properties:
+                accessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                endpoint:
+                    title: |-
+                        Endpoint configures connection to a specific SNS endpoint instead of Amazons servers
+                        +optional
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                region:
+                    title: Region is AWS region
+                    type: string
+                roleARN:
+                    title: |-
+                        RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+                        +optional
+                    type: string
+                secretKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                topicArn:
+                    title: TopicArn
+                    type: string
+                validateSignature:
+                    title: |-
+                        ValidateSignature is boolean that can be set to true for SNS signature verification
+                        +optional
+                    type: boolean
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: SNSEventSource refers to event-source for AWS SNS related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SQSEventSource:
+            properties:
+                accessKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                dlq:
+                    title: |-
+                        DLQ specifies if a dead-letter queue is configured for messages that can't be processed successfully.
+                        If set to true, messages with invalid payload won't be acknowledged to allow to forward them farther to the dead-letter queue.
+                        The default value is false.
+                        +optional
+                    type: boolean
+                endpoint:
+                    title: |-
+                        Endpoint configures connection to a specific SQS endpoint instead of Amazons servers
+                        +optional
+                    type: string
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                jsonBody:
+                    title: |-
+                        JSONBody specifies that all event body payload coming from this
+                        source will be JSON
+                        +optional
+                    type: boolean
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                queue:
+                    title: Queue is AWS SQS queue to listen to for messages
+                    type: string
+                queueAccountId:
+                    title: |-
+                        QueueAccountID is the ID of the account that created the queue to monitor
+                        +optional
+                    type: string
+                region:
+                    title: Region is AWS region
+                    type: string
+                roleARN:
+                    title: |-
+                        RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+                        +optional
+                    type: string
+                secretKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                sessionToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                waitTimeSeconds:
+                    description: |-
+                        WaitTimeSeconds is The duration (in seconds) for which the call waits for a message to arrive
+                        in the queue before returning.
+                    type: string
+            title: SQSEventSource refers to event-source for AWS SQS related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SchemaRegistryConfig:
+            properties:
+                auth:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.BasicAuth'
+                schemaId:
+                    title: |-
+                        Schema ID
+                        +optional
+                    type: integer
+                url:
+                    description: Schema Registry URL.
+                    type: string
+            title: SchemaRegistryConfig refers to configuration for a client
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SecureHeader:
+            properties:
+                name:
+                    type: string
+                valueFrom:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ValueFromSource'
+            title: SecureHeader refers to HTTP Headers with auth tokens as values
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Selector:
+            description: Selector represents conditional operation to select K8s objects.
+            properties:
+                key:
+                    title: Key name
+                    type: string
+                operation:
+                    title: |-
+                        Supported operations like ==, != etc.
+                        Defaults to ==.
+                        Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for more io.argoproj.workflow.v1alpha1.
+                        +optional
+                    type: string
+                value:
+                    title: Value
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor:
+            properties:
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SensorSpec'
+                status:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SensorStatus'
+            title: |-
+                Sensor is the definition of a sensor resource
+                +genclient
+                +genclient:noStatus
+                +kubebuilder:resource:shortName=sn
+                +kubebuilder:subresource:status
+                +k8s:deepcopy-gen:interfaces=io.k8s.apimachinery/pkg/runtime.Object
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SensorList:
+            properties:
+                items:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+                    type: array
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            title: |-
+                SensorList is the list of Sensor resources
+                +k8s:deepcopy-gen:interfaces=io.k8s.apimachinery/pkg/runtime.Object
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SensorSpec:
+            properties:
+                dependencies:
+                    description: Dependencies is a list of the events that this sensor is dependent on.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventDependency'
+                    type: array
+                errorOnFailedRound:
+                    description: |-
+                        ErrorOnFailedRound if set to true, marks sensor state as `error` if the previous trigger round fails.
+                        Once sensor state is set to `error`, no further triggers will be processed.
+                    type: boolean
+                eventBusName:
+                    title: EventBusName references to a EventBus name. By default the value is "default"
+                    type: string
+                loggingFields:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        LoggingFields add additional key-value pairs when logging happens
+                        +optional
+                    type: object
+                replicas:
+                    title: Replicas is the sensor deployment replicas
+                    type: integer
+                revisionHistoryLimit:
+                    title: |-
+                        RevisionHistoryLimit specifies how many old deployment revisions to retain
+                        +optional
+                    type: integer
+                template:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Template'
+                triggers:
+                    description: Triggers is a list of the things that this sensor evokes. These are the outputs from this sensor.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Trigger'
+                    type: array
+            title: SensorSpec represents desired sensor state
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SensorStatus:
+            description: SensorStatus contains information about the status of a sensor.
+            properties:
+                status:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Status'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Service:
+            properties:
+                clusterIP:
+                    title: |-
+                        clusterIP is the IP address of the service and is usually assigned
+                        randomly by the master. If an address is specified manually and is not in
+                        use by others, it will be allocated to the service; otherwise, creation
+                        of the service will fail. This field can not be changed through updates.
+                        Valid values are "None", empty string (""), or a valid IP address. "None"
+                        can be specified for headless services when proxying is not required.
+                        More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                        +optional
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Metadata'
+                ports:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ServicePort'
+                    title: |-
+                        The list of ports that are exposed by this ClusterIP service.
+                        +patchMergeKey=port
+                        +patchStrategy=merge
+                        +listType=map
+                        +listMapKey=port
+                        +listMapKey=protocol
+                    type: array
+            title: Service holds the service information eventsource exposes
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackEventSource:
+            properties:
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                signingSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                token:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: SlackEventSource refers to event-source for Slack related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackSender:
+            properties:
+                icon:
+                    title: |-
+                        Icon is the Slack application's icon, e.g. :robot_face: or https://example.com/image.png
+                        +optional
+                    type: string
+                username:
+                    title: |-
+                        Username is the Slack application's username
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackThread:
+            properties:
+                broadcastMessageToChannel:
+                    title: |-
+                        BroadcastMessageToChannel allows to also broadcast the message from the thread to the channel
+                        +optional
+                    type: boolean
+                messageAggregationKey:
+                    title: |-
+                        MessageAggregationKey allows to aggregate the messages to a thread by some key.
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackTrigger:
+            description: SlackTrigger refers to the specification of the slack notification trigger.
+            properties:
+                attachments:
+                    title: |-
+                        Attachments is a JSON format string that represents an array of Slack attachments according to the attachments API: https://api.slack.com/reference/messaging/attachments .
+                        +optional
+                    type: string
+                blocks:
+                    title: |-
+                        Blocks is a JSON format string that represents an array of Slack blocks according to the blocks API: https://api.slack.com/reference/block-kit/blocks .
+                        +optional
+                    type: string
+                channel:
+                    title: |-
+                        Channel refers to which Slack channel to send Slack message.
+                        +optional
+                    type: string
+                message:
+                    title: |-
+                        Message refers to the message to send to the Slack channel.
+                        +optional
+                    type: string
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: |-
+                        Parameters is the list of key-value extracted from event's payload that are applied to
+                        the trigger resource.
+                        +optional
+                    type: array
+                sender:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackSender'
+                slackToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                thread:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackThread'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StandardK8STrigger:
+            properties:
+                liveObject:
+                    title: |-
+                        LiveObject specifies whether the resource should be directly fetched from K8s instead
+                        of being marshaled from the resource artifact. If set to true, the resource artifact
+                        must contain the information required to uniquely identify the resource in the cluster,
+                        that is, you must specify "apiVersion", "kind" as well as "name" and "namespace" meta
+                        data.
+                        Only valid for operation type `update`
+                        +optional
+                    type: boolean
+                operation:
+                    title: |-
+                        Operation refers to the type of operation performed on the k8s resource.
+                        Default value is Create.
+                        +optional
+                    type: string
+                parameters:
+                    description: Parameters is the list of parameters that is applied to resolved K8s trigger object.
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    type: array
+                patchStrategy:
+                    title: |-
+                        PatchStrategy controls the K8s object patching strategy when the trigger operation is specified as patch.
+                        possible values:
+                        "application/json-patch+json"
+                        "application/merge-patch+json"
+                        "application/strategic-merge-patch+json"
+                        "application/apply-patch+yaml".
+                        Defaults to "application/merge-patch+json"
+                        +optional
+                    type: string
+                source:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ArtifactLocation'
+            title: StandardK8STrigger is the standard Kubernetes resource trigger
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Status:
+            description: Status is a common structure which can be used for Status field.
+            properties:
+                conditions:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Condition'
+                    title: |-
+                        Conditions are the latest available observations of a resource's current state.
+                        +optional
+                        +patchMergeKey=type
+                        +patchStrategy=merge
+                    type: array
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StatusPolicy:
+            properties:
+                allow:
+                    items:
+                        format: int32
+                        type: integer
+                    type: array
+            title: StatusPolicy refers to the policy used to check the state of the trigger using response status
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StorageGridEventSource:
+            properties:
+                apiURL:
+                    description: APIURL is the url of the storagegrid api.
+                    type: string
+                authToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bucket:
+                    description: Name of the bucket to register notifications for.
+                    type: string
+                events:
+                    items:
+                        type: string
+                    type: array
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StorageGridFilter'
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                region:
+                    title: |-
+                        S3 region.
+                        Defaults to us-east-1
+                        +optional
+                    type: string
+                tls:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig'
+                topicArn:
+                    title: TopicArn
+                    type: string
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: StorageGridEventSource refers to event-source for StorageGrid related events
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StorageGridFilter:
+            properties:
+                prefix:
+                    type: string
+                suffix:
+                    type: string
+            title: |-
+                StorageGridFilter represents filters to apply to bucket notifications for specifying constraints on objects
+                +k8s:openapi-gen=true
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StripeEventSource:
+            properties:
+                apiKey:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                createWebhook:
+                    title: |-
+                        CreateWebhook if specified creates a new webhook programmatically.
+                        +optional
+                    type: boolean
+                eventFilter:
+                    items:
+                        type: string
+                    title: |-
+                        EventFilter describes the type of events to listen to. If not specified, all types of events will be processed.
+                        More info at https://stripe.com/docs/api/events/list
+                        +optional
+                    type: array
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                webhook:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: |-
+                StripeEventSource describes the event source for stripe webhook notifications
+                More info at https://stripe.com/docs/webhooks
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TLSConfig:
+            description: TLSConfig refers to TLS configuration for a client.
+            properties:
+                caCertSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                clientCertSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                clientKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                enabled:
+                    title: |-
+                        Enabled indicates if TLS is enabled. Added for compatibility proposes for Brokers that needs TLS without key authentication
+                        +optional
+                    type: boolean
+                insecureSkipVerify:
+                    title: |-
+                        If true, skips creation of TLSConfig with certs and creates an empty TLSConfig. (Defaults to false)
+                        +optional
+                    type: boolean
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Template:
+            properties:
+                affinity:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Affinity'
+                container:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Container'
+                imagePullSecrets:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                    title: |-
+                        ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                        If specified, these secrets will be passed to individual puller implementations for them to use. For example,
+                        in the case of docker, only DockerConfig type secrets are honored.
+                        More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        +optional
+                        +patchMergeKey=name
+                        +patchStrategy=merge
+                    type: array
+                metadata:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Metadata'
+                nodeSelector:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        +optional
+                    type: object
+                priority:
+                    title: |-
+                        The priority value. Various system components use this field to find the
+                        priority of the EventSource pod. When Priority Admission Controller is enabled,
+                        it prevents users from setting this field. The admission controller populates
+                        this field from PriorityClassName.
+                        The higher the value, the higher the priority.
+                        More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+                        +optional
+                    type: integer
+                priorityClassName:
+                    title: |-
+                        If specified, indicates the EventSource pod's priority. "system-node-critical"
+                        and "system-cluster-critical" are two special keywords which indicate the
+                        highest priorities with the former being the highest priority. Any other
+                        name must be defined by creating a PriorityClass object with that name.
+                        If not specified, the pod priority will be default or zero if there is no
+                        default.
+                        More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+                        +optional
+                    type: string
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodSecurityContext'
+                serviceAccountName:
+                    title: |-
+                        ServiceAccountName is the name of the ServiceAccount to use to run sensor pod.
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                        +optional
+                    type: string
+                tolerations:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Toleration'
+                    title: |-
+                        If specified, the pod's tolerations.
+                        +optional
+                    type: array
+                volumes:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Volume'
+                    title: |-
+                        Volumes is a list of volumes that can be mounted by containers in a io.argoproj.workflow.v1alpha1.
+                        +patchStrategy=merge
+                        +patchMergeKey=name
+                        +optional
+                    type: array
+            title: Template holds the information of a deployment template
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TimeFilter:
+            description: |-
+                TimeFilter describes a window in time.
+                It filters out events that occur outside the time limits.
+                In other words, only events that occur after Start and before Stop
+                will pass this filter.
+            properties:
+                start:
+                    description: |-
+                        Start is the beginning of a time window in UTC.
+                        Before this time, events for this dependency are ignored.
+                        Format is hh:mm:ss.
+                    type: string
+                stop:
+                    description: |-
+                        Stop is the end of a time window in UTC.
+                        After or equal to this time, events for this dependency are ignored and
+                        Format is hh:mm:ss.
+                        If it is smaller than Start, it is treated as next day of Start
+                        (e.g.: 22:00:00-01:00:00 means 22:00:00-25:00:00).
+                    type: string
+                timezone:
+                    title: |-
+                        Timezone specifies the timezone for the time window.
+                        If not specified, defaults to UTC.
+                        Format should be a valid IANA timezone name (e.g., "America/New_York", "Europe/London").
+                        +optional
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Trigger:
+            properties:
+                atLeastOnce:
+                    title: |-
+                        AtLeastOnce determines the trigger execution semantics.
+                        Defaults to false. Trigger execution will use at-most-once semantics.
+                        If set to true, Trigger execution will switch to at-least-once semantics.
+                        +kubebuilder:default=false
+                        +optional
+                    type: boolean
+                dlqTrigger:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Trigger'
+                parameters:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter'
+                    title: Parameters is the list of parameters applied to the trigger template definition
+                    type: array
+                policy:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerPolicy'
+                rateLimit:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.RateLimit'
+                retryStrategy:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Backoff'
+                template:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerTemplate'
+            title: Trigger is an action taken, output produced, an event created, a message sent
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameter:
+            properties:
+                dest:
+                    description: |-
+                        Dest is the JSONPath of a resource key.
+                        A path is a series of keys separated by a dot. The colon character can be escaped with '.'
+                        The -1 key can be used to append a value to an existing array.
+                        See https://github.com/tidwall/sjson#path-syntax for more information about how this is used.
+                    type: string
+                operation:
+                    description: |-
+                        Operation is what to do with the existing value at Dest, whether to
+                        'prepend', 'overwrite', or 'append' it.
+                    type: string
+                src:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameterSource'
+            title: TriggerParameter indicates a passed parameter to a service template
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerParameterSource:
+            properties:
+                contextKey:
+                    description: |-
+                        ContextKey is the JSONPath of the event's (JSON decoded) context key
+                        ContextKey is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'.
+                        To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\'.
+                        See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.
+                    type: string
+                contextTemplate:
+                    title: |-
+                        ContextTemplate is a go-template for extracting a string from the event's context.
+                        If a ContextTemplate is provided with a ContextKey, the template will be evaluated first and fallback to the ContextKey.
+                        The templating follows the standard go-template syntax as well as sprig's extra functions.
+                        See https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                    type: string
+                dataKey:
+                    description: |-
+                        DataKey is the JSONPath of the event's (JSON decoded) data key
+                        DataKey is a series of keys separated by a dot. A key may contain wildcard characters '*' and '?'.
+                        To access an array value use the index as the key. The dot and wildcard characters can be escaped with '\\'.
+                        See https://github.com/tidwall/gjson#path-syntax for more information on how to use this.
+                    type: string
+                dataTemplate:
+                    title: |-
+                        DataTemplate is a go-template for extracting a string from the event's data.
+                        If a DataTemplate is provided with a DataKey, the template will be evaluated first and fallback to the DataKey.
+                        The templating follows the standard go-template syntax as well as sprig's extra functions.
+                        See https://pkg.go.dev/text/template and https://masterminds.github.io/sprig/
+                    type: string
+                dependencyName:
+                    description: |-
+                        DependencyName refers to the name of the dependency. The event which is stored for this dependency is used as payload
+                        for the parameterization. Make sure to refer to one of the dependencies you have defined under Dependencies list.
+                    type: string
+                useRawData:
+                    title: |-
+                        UseRawData indicates if the value in an event at data key should be used without converting to string.
+                        When true, a number, boolean, json or string parameter may be extracted. When the field is unspecified, or explicitly
+                        false, the behavior is to turn the extracted field into a string. (e.g. when set to true, the parameter
+                        123 will resolve to the numerical type, but when false, or not provided, the string "123" will be resolved)
+                        +optional
+                    type: boolean
+                value:
+                    description: |-
+                        Value is the default literal value to use for this parameter source
+                        This is only used if the DataKey is invalid.
+                        If the DataKey is invalid and this is not defined, this param source will produce an error.
+                    type: string
+            title: TriggerParameterSource defines the source for a parameter from a event event
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerPolicy:
+            properties:
+                k8s:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.K8SResourcePolicy'
+                status:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StatusPolicy'
+            title: TriggerPolicy dictates the policy for the trigger retries
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.TriggerTemplate:
+            description: TriggerTemplate is the template that describes trigger specification.
+            properties:
+                argoWorkflow:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ArgoWorkflowTrigger'
+                awsLambda:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AWSLambdaTrigger'
+                azureEventHubs:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureEventHubsTrigger'
+                azureServiceBus:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.AzureServiceBusTrigger'
+                conditions:
+                    title: |-
+                        Conditions is the conditions to execute the trigger.
+                        For example: "(dep01 || dep02) && dep04"
+                        +optional
+                    type: string
+                conditionsReset:
+                    items:
+                        $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ConditionsResetCriteria'
+                    title: |-
+                        Criteria to reset the conditons
+                        +optional
+                    type: array
+                custom:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.CustomTrigger'
+                email:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EmailTrigger'
+                http:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.HTTPTrigger'
+                k8s:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.StandardK8STrigger'
+                kafka:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.KafkaTrigger'
+                log:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.LogTrigger'
+                name:
+                    description: Name is a unique name of the action to take.
+                    type: string
+                nats:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.NATSTrigger'
+                openWhisk:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.OpenWhiskTrigger'
+                pulsar:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.PulsarTrigger'
+                slack:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SlackTrigger'
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.URLArtifact:
+            description: URLArtifact contains information about an artifact at an HTTP endpoint.
+            properties:
+                path:
+                    title: Path is the complete URL
+                    type: string
+                verifyCert:
+                    title: VerifyCert decides whether the connection is secure or not
+                    type: boolean
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.ValueFromSource:
+            properties:
+                configMapKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                secretKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            title: ValueFromSource allows you to reference keys from either a Configmap or Secret
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WatchPathConfig:
+            properties:
+                directory:
+                    title: Directory to watch for events
+                    type: string
+                path:
+                    title: Path is relative path of object to watch with respect to the directory
+                    type: string
+                pathRegexp:
+                    title: PathRegexp is regexp of relative path of object to watch with respect to the directory
+                    type: string
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext:
+            properties:
+                authSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                endpoint:
+                    title: REST API endpoint
+                    type: string
+                maxPayloadSize:
+                    title: |-
+                        MaxPayloadSize is the maximum webhook payload size that the server will accept.
+                        Requests exceeding that limit will be rejected with "request too large" response.
+                        Default value: 1048576 (1MB).
+                        +optional
+                    type: string
+                metadata:
+                    additionalProperties:
+                        type: string
+                    title: |-
+                        Metadata holds the user defined metadata which will passed along the event payload.
+                        +optional
+                    type: object
+                method:
+                    title: |-
+                        Method is HTTP request method that indicates the desired action to be performed for a given resource.
+                        See RFC7231 Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content
+                    type: string
+                port:
+                    description: Port on which HTTP server is listening for incoming events.
+                    type: string
+                serverCertSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                serverKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                url:
+                    description: URL is the url of the server.
+                    type: string
+            title: WebhookContext holds a general purpose REST API context
+            type: object
+        github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookEventSource:
+            properties:
+                filter:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceFilter'
+                webhookContext:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.WebhookContext'
+            title: CalendarEventSource describes an HTTP based EventSource
+            type: object
+        google.protobuf.Any:
+            properties:
+                type_url:
+                    type: string
+                value:
+                    format: byte
+                    type: string
+            type: object
+        grpc.gateway.runtime.Error:
+            properties:
+                code:
+                    type: integer
+                details:
+                    items:
+                        $ref: '#/components/schemas/google.protobuf.Any'
+                    type: array
+                error:
+                    type: string
+                message:
+                    type: string
+            type: object
+        grpc.gateway.runtime.StreamError:
+            properties:
+                details:
+                    items:
+                        $ref: '#/components/schemas/google.protobuf.Any'
+                    type: array
+                grpc_code:
+                    type: integer
+                http_code:
+                    type: integer
+                http_status:
+                    type: string
+                message:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.Amount:
+            description: Amount represent a numeric amount.
+            type: number
+        io.argoproj.workflow.v1alpha1.ArchiveStrategy:
+            description: ArchiveStrategy describes how to archive files/directory when saving artifacts
+            properties:
+                none:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.NoneStrategy'
+                tar:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TarStrategy'
+                zip:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ZipStrategy'
+            type: object
+        io.argoproj.workflow.v1alpha1.ArchivedWorkflowDeletedResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.Arguments:
+            description: Arguments to a template
+            properties:
+                artifacts:
+                    description: Artifacts is the list of artifacts to pass to the template or workflow
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Artifact'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                parameters:
+                    description: Parameters is the list of parameters to pass to the template or workflow
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Parameter'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtGCStatus:
+            description: ArtGCStatus maintains state related to ArtifactGC
+            properties:
+                notSpecified:
+                    description: if this is true, we already checked to see if we need to do it and we don't
+                    type: boolean
+                podsRecouped:
+                    additionalProperties:
+                        type: boolean
+                    description: have completed Pods been processed? (mapped by Pod name) used to prevent re-processing the Status of a Pod more than once
+                    type: object
+                strategiesProcessed:
+                    additionalProperties:
+                        type: boolean
+                    description: have Pods been started to perform this strategy? (enables us not to re-process what we've already done)
+                    type: object
+            type: object
+        io.argoproj.workflow.v1alpha1.Artifact:
+            description: Artifact indicates an artifact to place at a specified path
+            properties:
+                archive:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArchiveStrategy'
+                archiveLogs:
+                    description: ArchiveLogs indicates if the container logs should be archived
+                    type: boolean
+                artifactGC:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactGC'
+                artifactory:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactoryArtifact'
+                azure:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.AzureArtifact'
+                deleted:
+                    description: Has this been deleted?
+                    type: boolean
+                from:
+                    description: From allows an artifact to reference an artifact from a previous step
+                    type: string
+                fromExpression:
+                    description: FromExpression, if defined, is evaluated to specify the value for the artifact
+                    type: string
+                gcs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GCSArtifact'
+                git:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GitArtifact'
+                globalName:
+                    description: GlobalName exports an output artifact to the global scope, making it available as '{{io.argoproj.workflow.v1alpha1.outputs.artifacts.XXXX}} and in workflow.status.outputs.artifacts
+                    type: string
+                hdfs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HDFSArtifact'
+                http:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPArtifact'
+                mode:
+                    description: mode bits to use on this file, must be a value between 0 and 0777. Set when loading input artifacts. It is recommended to set the mode value to ensure the artifact has the expected permissions in your container.
+                    type: integer
+                name:
+                    description: name of the artifact. must be unique within a template's inputs/outputs.
+                    type: string
+                optional:
+                    description: Make Artifacts optional, if Artifacts doesn't generate or exist
+                    type: boolean
+                oss:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OSSArtifact'
+                path:
+                    description: Path is the container path to the artifact
+                    type: string
+                plugin:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.PluginArtifact'
+                raw:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RawArtifact'
+                recurseMode:
+                    description: If mode is set, apply the permission recursively into the artifact if it is a folder
+                    type: boolean
+                s3:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.S3Artifact'
+                subPath:
+                    description: SubPath allows an artifact to be sourced from a subpath within the specified source
+                    type: string
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactGC:
+            description: ArtifactGC describes how to delete artifacts from completed Workflows - this is embedded into the WorkflowLevelArtifactGC, and also used for individual Artifacts to override that as needed
+            properties:
+                podMetadata:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Metadata'
+                serviceAccountName:
+                    description: ServiceAccountName is an optional field for specifying the Service Account that should be assigned to the Pod doing the deletion
+                    type: string
+                strategy:
+                    description: Strategy is the strategy to use.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactLocation:
+            description: ArtifactLocation describes a location for a single or multiple artifacts. It is used as single artifact in the context of inputs/outputs (e.g. outputs.artifacts.artname). It is also used to describe the location of multiple artifacts such as the archive location of a single workflow step, which the executor will use as a default location to store its files.
+            properties:
+                archiveLogs:
+                    description: ArchiveLogs indicates if the container logs should be archived
+                    type: boolean
+                artifactory:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactoryArtifact'
+                azure:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.AzureArtifact'
+                gcs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GCSArtifact'
+                git:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GitArtifact'
+                hdfs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HDFSArtifact'
+                http:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPArtifact'
+                oss:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OSSArtifact'
+                plugin:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.PluginArtifact'
+                raw:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RawArtifact'
+                s3:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.S3Artifact'
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactPaths:
+            description: ArtifactPaths expands a step from a collection of artifacts
+            properties:
+                archive:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArchiveStrategy'
+                archiveLogs:
+                    description: ArchiveLogs indicates if the container logs should be archived
+                    type: boolean
+                artifactGC:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactGC'
+                artifactory:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactoryArtifact'
+                azure:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.AzureArtifact'
+                deleted:
+                    description: Has this been deleted?
+                    type: boolean
+                from:
+                    description: From allows an artifact to reference an artifact from a previous step
+                    type: string
+                fromExpression:
+                    description: FromExpression, if defined, is evaluated to specify the value for the artifact
+                    type: string
+                gcs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GCSArtifact'
+                git:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GitArtifact'
+                globalName:
+                    description: GlobalName exports an output artifact to the global scope, making it available as '{{io.argoproj.workflow.v1alpha1.outputs.artifacts.XXXX}} and in workflow.status.outputs.artifacts
+                    type: string
+                hdfs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HDFSArtifact'
+                http:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPArtifact'
+                mode:
+                    description: mode bits to use on this file, must be a value between 0 and 0777. Set when loading input artifacts. It is recommended to set the mode value to ensure the artifact has the expected permissions in your container.
+                    type: integer
+                name:
+                    description: name of the artifact. must be unique within a template's inputs/outputs.
+                    type: string
+                optional:
+                    description: Make Artifacts optional, if Artifacts doesn't generate or exist
+                    type: boolean
+                oss:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OSSArtifact'
+                path:
+                    description: Path is the container path to the artifact
+                    type: string
+                plugin:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.PluginArtifact'
+                raw:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RawArtifact'
+                recurseMode:
+                    description: If mode is set, apply the permission recursively into the artifact if it is a folder
+                    type: boolean
+                s3:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.S3Artifact'
+                subPath:
+                    description: SubPath allows an artifact to be sourced from a subpath within the specified source
+                    type: string
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactRepository:
+            description: ArtifactRepository represents an artifact repository in which a controller will store its artifacts
+            properties:
+                archiveLogs:
+                    description: ArchiveLogs enables log archiving
+                    type: boolean
+                artifactory:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactoryArtifactRepository'
+                azure:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.AzureArtifactRepository'
+                gcs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GCSArtifactRepository'
+                hdfs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HDFSArtifactRepository'
+                oss:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OSSArtifactRepository'
+                plugin:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.PluginArtifactRepository'
+                s3:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.S3ArtifactRepository'
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactRepositoryRef:
+            description: ArtifactRepositoryRef is a reference to an artifact repository config map.
+            properties:
+                configMap:
+                    description: The name of the config map. Defaults to "artifact-repositories".
+                    type: string
+                key:
+                    description: The config map key. Defaults to the value of the "workflows.argoproj.io/default-artifact-repository" annotation.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactRepositoryRefStatus:
+            description: ArtifactRepositoryRefStatus is the resolved artifact repository reference with namespace io.argoproj.workflow.v1alpha1.
+            properties:
+                artifactRepository:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactRepository'
+                configMap:
+                    description: The name of the config map. Defaults to "artifact-repositories".
+                    type: string
+                default:
+                    description: If this ref represents the default artifact repository, rather than a config map.
+                    type: boolean
+                key:
+                    description: The config map key. Defaults to the value of the "workflows.argoproj.io/default-artifact-repository" annotation.
+                    type: string
+                namespace:
+                    description: The namespace of the config map. Defaults to the workflow's namespace, or the controller's namespace (if found).
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactoryArtifact:
+            description: ArtifactoryArtifact is the location of an artifactory artifact
+            properties:
+                passwordSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                url:
+                    description: URL of the artifact
+                    type: string
+                usernameSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            required:
+                - url
+            type: object
+        io.argoproj.workflow.v1alpha1.ArtifactoryArtifactRepository:
+            description: ArtifactoryArtifactRepository defines the controller configuration for an artifactory artifact repository
+            properties:
+                keyFormat:
+                    description: KeyFormat defines the format of how to store keys and can reference workflow variables.
+                    type: string
+                passwordSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                repoURL:
+                    description: RepoURL is the url for artifactory repo.
+                    type: string
+                usernameSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.AzureArtifact:
+            description: AzureArtifact is the location of an Azure Storage artifact
+            properties:
+                accountKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                blob:
+                    description: Blob is the blob name (i.e., path) in the container where the artifact resides
+                    type: string
+                container:
+                    description: Container is the container where resources will be stored
+                    type: string
+                endpoint:
+                    description: Endpoint is the service url associated with an account. It is most likely "https://<ACCOUNT_NAME>.blob.core.windows.net"
+                    type: string
+                useSDKCreds:
+                    description: UseSDKCreds tells the driver to figure out credentials based on sdk defaults.
+                    type: boolean
+            required:
+                - endpoint
+                - container
+                - blob
+            type: object
+        io.argoproj.workflow.v1alpha1.AzureArtifactRepository:
+            description: AzureArtifactRepository defines the controller configuration for an Azure Blob Storage artifact repository
+            properties:
+                accountKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                blobNameFormat:
+                    description: BlobNameFormat is defines the format of how to store blob names. Can reference workflow variables
+                    type: string
+                container:
+                    description: Container is the container where resources will be stored
+                    type: string
+                endpoint:
+                    description: Endpoint is the service url associated with an account. It is most likely "https://<ACCOUNT_NAME>.blob.core.windows.net"
+                    type: string
+                useSDKCreds:
+                    description: UseSDKCreds tells the driver to figure out credentials based on sdk defaults.
+                    type: boolean
+            required:
+                - endpoint
+                - container
+            type: object
+        io.argoproj.workflow.v1alpha1.Backoff:
+            description: Backoff is a backoff strategy to use within retryStrategy
+            properties:
+                cap:
+                    description: Cap is a limit on revised values of the duration parameter. If a multiplication by the factor parameter would make the duration exceed the cap then the duration is set to the cap
+                    type: string
+                duration:
+                    description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                    type: string
+                factor:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                maxDuration:
+                    description: MaxDuration is the maximum amount of time allowed for a workflow in the backoff strategy. It is important to note that if the workflow template includes activeDeadlineSeconds, the pod's deadline is initially set with activeDeadlineSeconds. However, when the workflow fails, the pod's deadline is then overridden by maxDuration. This ensures that the workflow does not exceed the specified maximum duration when retries are involved.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.BasicAuth:
+            description: BasicAuth describes the secret selectors required for basic authentication
+            properties:
+                passwordSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                usernameSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.Cache:
+            description: Cache is the configuration for the type of cache to be used
+            properties:
+                configMap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+            required:
+                - configMap
+            type: object
+        io.argoproj.workflow.v1alpha1.ClientCertAuth:
+            description: ClientCertAuth holds necessary information for client authentication via certificates
+            properties:
+                clientCertSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                clientKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate:
+            description: ClusterWorkflowTemplate is the definition of a workflow template resource in cluster scope
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec'
+            required:
+                - metadata
+                - spec
+            type: object
+        io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateCreateRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                template:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+            type: object
+        io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateDeleteResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateLintRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                template:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+            type: object
+        io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateList:
+            description: ClusterWorkflowTemplateList is list of ClusterWorkflowTemplate resources
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                items:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+                    type: array
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            required:
+                - metadata
+                - items
+            type: object
+        io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateUpdateRequest:
+            properties:
+                name:
+                    description: 'DEPRECATED: This field is ignored.'
+                    type: string
+                template:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+            type: object
+        io.argoproj.workflow.v1alpha1.CollectEventRequest:
+            properties:
+                name:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.CollectEventResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.Column:
+            description: Column is a custom column that will be exposed in the Workflow List View.
+            properties:
+                key:
+                    description: The key of the label or annotation, e.g., "workflows.argoproj.io/completed".
+                    type: string
+                name:
+                    description: The name of this column, e.g., "Workflow Completed".
+                    type: string
+                type:
+                    description: The type of this column, "label" or "annotation".
+                    type: string
+            required:
+                - name
+                - type
+                - key
+            type: object
+            x-kubernetes-patch-merge-key: name
+            x-kubernetes-patch-strategy: merge
+        io.argoproj.workflow.v1alpha1.Condition:
+            properties:
+                message:
+                    description: Message is the condition message
+                    type: string
+                status:
+                    description: Status is the status of the condition
+                    type: string
+                type:
+                    description: Type is the type of condition
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ContainerNode:
+            properties:
+                args:
+                    description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                command:
+                    description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                dependencies:
+                    items:
+                        type: string
+                    type: array
+                env:
+                    description: List of environment variables to set in the container. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvVar'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - name
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                envFrom:
+                    description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvFromSource'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                image:
+                    description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                    type: string
+                imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                lifecycle:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Lifecycle'
+                livenessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                name:
+                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                    type: string
+                ports:
+                    description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerPort'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: containerPort
+                    x-kubernetes-patch-strategy: merge
+                readinessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                resizePolicy:
+                    description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerResizePolicy'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                resources:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceRequirements'
+                restartPolicy:
+                    description: 'RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod''s restart policy and the container type. Additionally, setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.'
+                    type: string
+                restartPolicyRules:
+                    description: 'Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod''s RestartPolicy.'
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerRestartRule'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecurityContext'
+                startupProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                stdin:
+                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                    type: boolean
+                stdinOnce:
+                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                    type: string
+                terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                tty:
+                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                volumeDevices:
+                    description: volumeDevices is the list of block devices to be used by the container.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeDevice'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - devicePath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: devicePath
+                    x-kubernetes-patch-strategy: merge
+                volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeMount'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - mountPath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: mountPath
+                    x-kubernetes-patch-strategy: merge
+                workingDir:
+                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                    type: string
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.ContainerSetRetryStrategy:
+            description: ContainerSetRetryStrategy provides controls on how to retry a container set
+            properties:
+                duration:
+                    description: Duration is the time between each retry, examples values are "300ms", "1s" or "5m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+                    type: string
+                retries:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+            required:
+                - retries
+            type: object
+        io.argoproj.workflow.v1alpha1.ContainerSetTemplate:
+            properties:
+                containers:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ContainerNode'
+                    type: array
+                retryStrategy:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ContainerSetRetryStrategy'
+                volumeMounts:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeMount'
+                    type: array
+            required:
+                - containers
+            type: object
+        io.argoproj.workflow.v1alpha1.ContinueOn:
+            description: ContinueOn defines if a workflow should continue even if a task or step fails/errors. It can be specified if the workflow should continue when the pod errors, fails or both.
+            properties:
+                error:
+                    type: boolean
+                failed:
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.Counter:
+            description: Counter is a Counter prometheus metric
+            properties:
+                value:
+                    description: Value is the value of the metric
+                    type: string
+            required:
+                - value
+            type: object
+        io.argoproj.workflow.v1alpha1.CreateCronWorkflowRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                cronWorkflow:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.CreateS3BucketOptions:
+            description: CreateS3BucketOptions options used to determine automatic automatic bucket-creation process
+            properties:
+                objectLocking:
+                    description: ObjectLocking Enable object locking
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflow:
+            description: CronWorkflow is the definition of a scheduled workflow resource
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflowSpec'
+                status:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflowStatus'
+            required:
+                - metadata
+                - spec
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflowDeletedResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflowList:
+            description: CronWorkflowList is list of CronWorkflow resources
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                items:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    type: array
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            required:
+                - metadata
+                - items
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflowResumeRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflowSpec:
+            description: CronWorkflowSpec is the specification of a CronWorkflow
+            properties:
+                concurrencyPolicy:
+                    description: ConcurrencyPolicy is the K8s-style concurrency policy that will be used
+                    type: string
+                failedJobsHistoryLimit:
+                    description: FailedJobsHistoryLimit is the number of failed jobs to be kept at a time
+                    type: integer
+                schedules:
+                    description: 'v3.6 and after: Schedules is a list of schedules to run the Workflow in Cron format'
+                    items:
+                        type: string
+                    type: array
+                startingDeadlineSeconds:
+                    description: StartingDeadlineSeconds is the K8s-style deadline that will limit the time a CronWorkflow will be run after its original scheduled time if it is missed.
+                    type: integer
+                stopStrategy:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.StopStrategy'
+                successfulJobsHistoryLimit:
+                    description: SuccessfulJobsHistoryLimit is the number of successful jobs to be kept at a time
+                    type: integer
+                suspend:
+                    description: Suspend is a flag that will stop new CronWorkflows from running if set to true
+                    type: boolean
+                timezone:
+                    description: Timezone is the timezone against which the cron schedule will be calculated, e.g. "Asia/Tokyo". Default is machine's local time.
+                    type: string
+                when:
+                    description: 'v3.6 and after: When is an expression that determines if a run should be scheduled.'
+                    type: string
+                workflowMetadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                workflowSpec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec'
+            required:
+                - workflowSpec
+                - schedules
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflowStatus:
+            description: CronWorkflowStatus is the status of a CronWorkflow
+            properties:
+                active:
+                    description: Active is a list of active workflows stemming from this CronWorkflow
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ObjectReference'
+                    type: array
+                conditions:
+                    description: Conditions is a list of conditions the CronWorkflow may have
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Condition'
+                    type: array
+                failed:
+                    description: 'v3.6 and after: Failed counts how many times child workflows failed'
+                    type: integer
+                lastScheduledTime:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                phase:
+                    description: 'v3.6 and after: Phase is an enum of Active or Stopped. It changes to Stopped when stopStrategy.expression is true'
+                    type: string
+                succeeded:
+                    description: 'v3.6 and after: Succeeded counts how many times child workflows succeeded'
+                    type: integer
+            type: object
+        io.argoproj.workflow.v1alpha1.CronWorkflowSuspendRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.DAGTask:
+            description: 'DAGTask represents a node in the graph during DAG execution Note: CEL validation cannot check withItems (Schemaless) or inline (PreserveUnknownFields) fields.'
+            properties:
+                arguments:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Arguments'
+                continueOn:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ContinueOn'
+                dependencies:
+                    description: Dependencies are name of other targets which this depends on
+                    items:
+                        type: string
+                    type: array
+                depends:
+                    description: Depends are name of other targets which this depends on
+                    type: string
+                hooks:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LifecycleHook'
+                    description: Hooks hold the lifecycle hook which is invoked at lifecycle of task, irrespective of the success, failure, or error status of the primary task
+                    type: object
+                inline:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Template'
+                name:
+                    description: Name is the name of the target
+                    type: string
+                onExit:
+                    description: |-
+                        OnExit is a template reference which is invoked at the end of the template, irrespective of the success, failure, or error of the primary template.
+
+                        Deprecated: Use Hooks[exit].Template instead.
+                    type: string
+                template:
+                    description: Name of template to execute
+                    type: string
+                templateRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TemplateRef'
+                when:
+                    description: When is an expression in which the task should conditionally execute
+                    type: string
+                withItems:
+                    description: 'WithItems expands a task into multiple parallel tasks from the items in the list Note: The structure of WithItems is free-form, so we need "x-kubernetes-preserve-unknown-fields: true" in the validation schema.'
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Item'
+                    type: array
+                withParam:
+                    description: WithParam expands a task into multiple parallel tasks from the value in the parameter, which is expected to be a JSON list.
+                    type: string
+                withSequence:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Sequence'
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.DAGTemplate:
+            description: DAGTemplate is a template subtype for directed acyclic graph templates
+            properties:
+                failFast:
+                    description: This flag is for DAG logic. The DAG logic has a built-in "fail fast" feature to stop scheduling new steps, as soon as it detects that one of the DAG nodes is failed. Then it waits until all DAG nodes are completed before failing the DAG itself. The FailFast flag default is true,  if set to false, it will allow a DAG to run all branches of the DAG to completion (either success or failure), regardless of the failed outcomes of branches in the DAG. More info and example about this feature at https://github.com/argoproj/argo-workflows/issues/1442
+                    type: boolean
+                target:
+                    description: Target are one or more names of targets to execute in a DAG
+                    type: string
+                tasks:
+                    description: Tasks are a list of DAG tasks MaxItems is an artificial limit to limit CEL validation costs - see note at top of file
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.DAGTask'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+            required:
+                - tasks
+            type: object
+        io.argoproj.workflow.v1alpha1.Data:
+            description: Data is a data template
+            properties:
+                source:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.DataSource'
+                transformation:
+                    description: Transformation applies a set of transformations
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TransformationStep'
+                    type: array
+            required:
+                - source
+                - transformation
+            type: object
+        io.argoproj.workflow.v1alpha1.DataSource:
+            description: DataSource sources external data into a data template
+            properties:
+                artifactPaths:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactPaths'
+            type: object
+        io.argoproj.workflow.v1alpha1.Event:
+            properties:
+                selector:
+                    description: Selector (https://github.com/expr-lang/expr) that we must must match the io.argoproj.workflow.v1alpha1. E.g. `payload.message == "test"`
+                    type: string
+            required:
+                - selector
+            type: object
+        io.argoproj.workflow.v1alpha1.EventResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.ExecutorConfig:
+            description: ExecutorConfig holds configurations of an executor container.
+            properties:
+                serviceAccountName:
+                    description: ServiceAccountName specifies the service account name of the executor container.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.GCSArtifact:
+            description: GCSArtifact is the location of a GCS artifact
+            properties:
+                bucket:
+                    description: Bucket is the name of the bucket
+                    type: string
+                key:
+                    description: Key is the path in the bucket where the artifact resides
+                    type: string
+                serviceAccountKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            required:
+                - key
+            type: object
+        io.argoproj.workflow.v1alpha1.GCSArtifactRepository:
+            description: GCSArtifactRepository defines the controller configuration for a GCS artifact repository
+            properties:
+                bucket:
+                    description: Bucket is the name of the bucket
+                    type: string
+                keyFormat:
+                    description: KeyFormat defines the format of how to store keys and can reference workflow variables.
+                    type: string
+                serviceAccountKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.Gauge:
+            description: Gauge is a Gauge prometheus metric
+            properties:
+                operation:
+                    description: Operation defines the operation to apply with value and the metrics' current value
+                    type: string
+                realtime:
+                    description: Realtime emits this metric in real time if applicable
+                    type: boolean
+                value:
+                    description: Value is the value to be used in the operation with the metric's current value. If no operation is set, value is the value of the metric MaxLength is an artificial limit to limit CEL validation costs - see note at top of file
+                    type: string
+            required:
+                - value
+                - realtime
+            type: object
+        io.argoproj.workflow.v1alpha1.GetUserInfoResponse:
+            properties:
+                email:
+                    type: string
+                emailVerified:
+                    type: boolean
+                groups:
+                    items:
+                        type: string
+                    type: array
+                issuer:
+                    type: string
+                name:
+                    type: string
+                serviceAccountName:
+                    type: string
+                serviceAccountNamespace:
+                    type: string
+                subject:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.GitArtifact:
+            description: GitArtifact is the location of a git artifact
+            properties:
+                branch:
+                    description: Branch is the branch to fetch when `SingleBranch` is enabled
+                    type: string
+                depth:
+                    description: Depth specifies clones/fetches should be shallow and include the given number of commits from the branch tip
+                    type: integer
+                disableSubmodules:
+                    description: DisableSubmodules disables submodules during git clone
+                    type: boolean
+                fetch:
+                    description: Fetch specifies a number of refs that should be fetched before checkout
+                    items:
+                        type: string
+                    type: array
+                insecureIgnoreHostKey:
+                    description: InsecureIgnoreHostKey disables SSH strict host key checking during git clone
+                    type: boolean
+                insecureSkipTLS:
+                    description: InsecureSkipTLS disables server certificate verification resulting in insecure HTTPS connections
+                    type: boolean
+                passwordSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                repo:
+                    description: Repo is the git repository
+                    type: string
+                revision:
+                    description: Revision is the git commit, tag, branch to checkout
+                    type: string
+                singleBranch:
+                    description: SingleBranch enables single branch clone, using the `branch` parameter
+                    type: boolean
+                sshPrivateKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                usernameSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            required:
+                - repo
+            type: object
+        io.argoproj.workflow.v1alpha1.HDFSArtifact:
+            description: HDFSArtifact is the location of an HDFS artifact
+            properties:
+                addresses:
+                    description: Addresses is accessible addresses of HDFS name nodes
+                    items:
+                        type: string
+                    type: array
+                dataTransferProtection:
+                    description: DataTransferProtection is the protection level for HDFS data transfer. It corresponds to the dfs.data.transfer.protection configuration in HDFS.
+                    type: string
+                force:
+                    description: Force copies a file forcibly even if it exists
+                    type: boolean
+                hdfsUser:
+                    description: HDFSUser is the user to access HDFS file system. It is ignored if either ccache or keytab is used.
+                    type: string
+                krbCCacheSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                krbConfigConfigMap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                krbKeytabSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                krbRealm:
+                    description: KrbRealm is the Kerberos realm used with Kerberos keytab It must be set if keytab is used.
+                    type: string
+                krbServicePrincipalName:
+                    description: KrbServicePrincipalName is the principal name of Kerberos service It must be set if either ccache or keytab is used.
+                    type: string
+                krbUsername:
+                    description: KrbUsername is the Kerberos username used with Kerberos keytab It must be set if keytab is used.
+                    type: string
+                path:
+                    description: Path is a file path in HDFS
+                    type: string
+            required:
+                - path
+            type: object
+        io.argoproj.workflow.v1alpha1.HDFSArtifactRepository:
+            description: HDFSArtifactRepository defines the controller configuration for an HDFS artifact repository
+            properties:
+                addresses:
+                    description: Addresses is accessible addresses of HDFS name nodes
+                    items:
+                        type: string
+                    type: array
+                dataTransferProtection:
+                    description: DataTransferProtection is the protection level for HDFS data transfer. It corresponds to the dfs.data.transfer.protection configuration in HDFS.
+                    type: string
+                force:
+                    description: Force copies a file forcibly even if it exists
+                    type: boolean
+                hdfsUser:
+                    description: HDFSUser is the user to access HDFS file system. It is ignored if either ccache or keytab is used.
+                    type: string
+                krbCCacheSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                krbConfigConfigMap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                krbKeytabSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                krbRealm:
+                    description: KrbRealm is the Kerberos realm used with Kerberos keytab It must be set if keytab is used.
+                    type: string
+                krbServicePrincipalName:
+                    description: KrbServicePrincipalName is the principal name of Kerberos service It must be set if either ccache or keytab is used.
+                    type: string
+                krbUsername:
+                    description: KrbUsername is the Kerberos username used with Kerberos keytab It must be set if keytab is used.
+                    type: string
+                pathFormat:
+                    description: PathFormat is defines the format of path to store a file. Can reference workflow variables
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.HTTP:
+            properties:
+                body:
+                    description: Body is content of the HTTP Request
+                    type: string
+                bodyFrom:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPBodySource'
+                headers:
+                    description: Headers are an optional list of headers to send with HTTP requests
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPHeader'
+                    type: array
+                insecureSkipVerify:
+                    description: InsecureSkipVerify is a bool when if set to true will skip TLS verification for the HTTP client
+                    type: boolean
+                method:
+                    description: Method is HTTP methods for HTTP Request
+                    type: string
+                successCondition:
+                    description: SuccessCondition is an expression if evaluated to true is considered successful
+                    type: string
+                timeoutSeconds:
+                    description: TimeoutSeconds is request timeout for HTTP Request. Default is 30 seconds
+                    type: integer
+                url:
+                    description: URL of the HTTP Request
+                    type: string
+            required:
+                - url
+            type: object
+        io.argoproj.workflow.v1alpha1.HTTPArtifact:
+            description: HTTPArtifact allows a file served on HTTP to be placed as an input artifact in a container
+            properties:
+                auth:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPAuth'
+                headers:
+                    description: Headers are an optional list of headers to send with HTTP requests for artifacts
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Header'
+                    type: array
+                url:
+                    description: URL of the artifact
+                    type: string
+            required:
+                - url
+            type: object
+        io.argoproj.workflow.v1alpha1.HTTPAuth:
+            properties:
+                basicAuth:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.BasicAuth'
+                clientCert:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClientCertAuth'
+                oauth2:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OAuth2Auth'
+            type: object
+        io.argoproj.workflow.v1alpha1.HTTPBodySource:
+            description: HTTPBodySource contains the source of the HTTP body.
+            properties:
+                bytes:
+                    format: byte
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.HTTPHeader:
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+                valueFrom:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTPHeaderSource'
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.HTTPHeaderSource:
+            properties:
+                secretKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.Header:
+            description: Header indicate a key-value request header to be used when fetching artifacts over HTTP
+            properties:
+                name:
+                    description: Name is the header name
+                    type: string
+                value:
+                    description: Value is the literal value to use for the header
+                    type: string
+            required:
+                - name
+                - value
+            type: object
+        io.argoproj.workflow.v1alpha1.Histogram:
+            description: Histogram is a Histogram prometheus metric
+            properties:
+                buckets:
+                    description: Buckets is a list of bucket divisors for the histogram
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Amount'
+                    type: array
+                value:
+                    description: Value is the value of the metric
+                    type: string
+            required:
+                - value
+                - buckets
+            type: object
+        io.argoproj.workflow.v1alpha1.InfoResponse:
+            properties:
+                columns:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Column'
+                    type: array
+                links:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Link'
+                    type: array
+                managedNamespace:
+                    type: string
+                modals:
+                    additionalProperties:
+                        type: boolean
+                    title: which modals to show
+                    type: object
+                navColor:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.Inputs:
+            description: Inputs are the mechanism for passing parameters, artifacts, volumes from one template to another
+            properties:
+                artifacts:
+                    description: Artifact are a list of artifacts passed as inputs
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Artifact'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                parameters:
+                    description: Parameters are a list of parameters passed as inputs MaxItems is an artificial limit to limit CEL validation costs - see note at top of file
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Parameter'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+            type: object
+        io.argoproj.workflow.v1alpha1.Item:
+            description: Item expands a single workflow step into multiple parallel steps The value of Item can be a map, string, bool, or number
+        io.argoproj.workflow.v1alpha1.LabelKeys:
+            description: LabelKeys is list of keys
+            properties:
+                items:
+                    items:
+                        type: string
+                    type: array
+            type: object
+        io.argoproj.workflow.v1alpha1.LabelValueFrom:
+            properties:
+                expression:
+                    type: string
+            required:
+                - expression
+            type: object
+        io.argoproj.workflow.v1alpha1.LabelValues:
+            description: LabelValues is a list of workflow labels.
+            properties:
+                items:
+                    items:
+                        type: string
+                    type: array
+            type: object
+        io.argoproj.workflow.v1alpha1.LifecycleHook:
+            properties:
+                arguments:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Arguments'
+                expression:
+                    description: Expression is a condition expression for when a node will be retried. If it evaluates to false, the node will not be retried and the retry strategy will be ignored
+                    type: string
+                template:
+                    description: Template is the name of the template to execute by the hook
+                    type: string
+                templateRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TemplateRef'
+            type: object
+        io.argoproj.workflow.v1alpha1.Link:
+            description: Link is a link to another app.
+            properties:
+                name:
+                    description: The name of the link, E.g. "Workflow Logs" or "Pod Logs"
+                    type: string
+                scope:
+                    description: '"workflow", "pod", "pod-logs", "event-source-logs", "sensor-logs", "workflow-list" or "chat"'
+                    type: string
+                target:
+                    description: Target attribute specifies where a linked document will be opened when a user clicks on a link. E.g. "_blank", "_self". If the target is _blank, it will open in a new tab.
+                    type: string
+                url:
+                    description: The URL. Can contain "${metadata.namespace}", "${metadata.name}", "${status.startedAt}", "${status.finishedAt}" or any other element in workflow yaml, e.g. "${io.argoproj.workflow.v1alpha1.metadata.annotations.userDefinedKey}"
+                    type: string
+            required:
+                - name
+                - scope
+                - url
+                - target
+            type: object
+            x-kubernetes-patch-merge-key: name
+            x-kubernetes-patch-strategy: merge
+        io.argoproj.workflow.v1alpha1.LintCronWorkflowRequest:
+            properties:
+                cronWorkflow:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.LogEntry:
+            properties:
+                content:
+                    type: string
+                podName:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ManifestFrom:
+            properties:
+                artifact:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Artifact'
+            required:
+                - artifact
+            type: object
+        io.argoproj.workflow.v1alpha1.MemoizationStatus:
+            description: MemoizationStatus is the status of this memoized node
+            properties:
+                cacheName:
+                    description: Cache is the name of the cache that was used
+                    type: string
+                hit:
+                    description: Hit indicates whether this node was created from a cache entry
+                    type: boolean
+                key:
+                    description: Key is the name of the key used for this node's cache
+                    type: string
+            required:
+                - hit
+                - key
+                - cacheName
+            type: object
+        io.argoproj.workflow.v1alpha1.Memoize:
+            description: Memoize enables caching for the Outputs of the template.
+            properties:
+                cache:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Cache'
+                key:
+                    description: Key is the key to use as the caching key
+                    type: string
+                maxAge:
+                    description: MaxAge is the maximum age (e.g. "180s", "24h") of an entry that is still considered valid. If an entry is older than the MaxAge, it will be ignored.
+                    type: string
+            required:
+                - key
+                - cache
+                - maxAge
+            type: object
+        io.argoproj.workflow.v1alpha1.Metadata:
+            description: Metadata is pod metadata.
+            properties:
+                annotations:
+                    additionalProperties:
+                        type: string
+                    type: object
+                labels:
+                    additionalProperties:
+                        type: string
+                    type: object
+            type: object
+        io.argoproj.workflow.v1alpha1.MetricLabel:
+            description: MetricLabel is a single label for a prometheus metric
+            properties:
+                key:
+                    type: string
+                value:
+                    type: string
+            required:
+                - key
+                - value
+            type: object
+        io.argoproj.workflow.v1alpha1.Metrics:
+            description: Metrics are a list of metrics emitted from a Workflow/Template
+            properties:
+                prometheus:
+                    description: Prometheus is a list of prometheus metrics to be emitted MaxItems is an artificial limit to limit CEL validation costs - see note at top of file
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Prometheus'
+                    type: array
+            required:
+                - prometheus
+            type: object
+        io.argoproj.workflow.v1alpha1.Mutex:
+            description: Mutex holds Mutex configuration
+            properties:
+                database:
+                    description: Database specifies this is database controlled if this is set true
+                    type: boolean
+                name:
+                    description: name of the mutex
+                    type: string
+                namespace:
+                    description: 'Namespace is the namespace of the mutex, default: [namespace of workflow]'
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.MutexHolding:
+            description: MutexHolding describes the mutex and the object which is holding it.
+            properties:
+                holder:
+                    description: |-
+                        Holder is a reference to the object which holds the Mutex. Holding Scenario:
+                          1. Current workflow's NodeID which is holding the lock.
+                             e.g: ${NodeID}
+                        Waiting Scenario:
+                          1. Current workflow or other workflow NodeID which is holding the lock.
+                             e.g: ${WorkflowName}/${NodeID}
+                    type: string
+                mutex:
+                    description: 'Reference for the mutex e.g: ${namespace}/mutex/${mutexName}'
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.MutexStatus:
+            description: MutexStatus contains which objects hold  mutex locks, and which objects this workflow is waiting on to release locks.
+            properties:
+                holding:
+                    description: Holding is a list of mutexes and their respective objects that are held by mutex lock for this io.argoproj.workflow.v1alpha1.
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.MutexHolding'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                waiting:
+                    description: Waiting is a list of mutexes and their respective objects this workflow is waiting for.
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.MutexHolding'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.argoproj.workflow.v1alpha1.NodeFlag:
+            properties:
+                hooked:
+                    description: Hooked tracks whether or not this node was triggered by hook or onExit
+                    type: boolean
+                retried:
+                    description: Retried tracks whether or not this node was retried by retryStrategy
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.NodeStatus:
+            description: NodeStatus contains status information about an individual node in the workflow
+            properties:
+                boundaryID:
+                    description: BoundaryID indicates the node ID of the associated template root node in which this node belongs to
+                    type: string
+                children:
+                    description: Children is a list of child node IDs
+                    items:
+                        type: string
+                    type: array
+                daemoned:
+                    description: Daemoned tracks whether or not this node was daemoned and need to be terminated
+                    type: boolean
+                displayName:
+                    description: DisplayName is a human readable representation of the node. Unique within a template boundary
+                    type: string
+                estimatedDuration:
+                    description: EstimatedDuration in seconds.
+                    type: integer
+                failedPodRestarts:
+                    description: FailedPodRestarts tracks the number of times the pod for this node was restarted due to infrastructure failures before the main container started.
+                    type: integer
+                finishedAt:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                hostNodeName:
+                    description: HostNodeName name of the Kubernetes node on which the Pod is running, if applicable
+                    type: string
+                id:
+                    description: ID is a unique identifier of a node within the worklow It is implemented as a hash of the node name, which makes the ID deterministic
+                    type: string
+                inputs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Inputs'
+                memoizationStatus:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.MemoizationStatus'
+                message:
+                    description: A human readable message indicating details about why the node is in this condition.
+                    type: string
+                name:
+                    description: Name is unique name in the node tree used to generate the node ID
+                    type: string
+                nodeFlag:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.NodeFlag'
+                outboundNodes:
+                    description: |-
+                        OutboundNodes tracks the node IDs which are considered "outbound" nodes to a template invocation. For every invocation of a template, there are nodes which we considered as "outbound". Essentially, these are last nodes in the execution sequence to run, before the template is considered completed. These nodes are then connected as parents to a following step.
+
+                        In the case of single pod steps (i.e. container, script, resource templates), this list will be nil since the pod itself is already considered the "outbound" node. In the case of DAGs, outbound nodes are the "target" tasks (tasks with no children). In the case of steps, outbound nodes are all the containers involved in the last step group. NOTE: since templates are composable, the list of outbound nodes are carried upwards when a DAG/steps template invokes another DAG/steps template. In other words, the outbound nodes of a template, will be a superset of the outbound nodes of its last children.
+                    items:
+                        type: string
+                    type: array
+                outputs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Outputs'
+                phase:
+                    description: Phase a simple, high-level summary of where the node is in its lifecycle. Can be used as a state machine. Will be one of these values "Pending", "Running" before the node is completed, or "Succeeded", "Skipped", "Failed", "Error", or "Omitted" as a final state.
+                    type: string
+                podIP:
+                    description: PodIP captures the IP of the pod for daemoned steps
+                    type: string
+                progress:
+                    description: Progress to completion
+                    type: string
+                resourcesDuration:
+                    additionalProperties:
+                        format: int64
+                        type: integer
+                    description: ResourcesDuration is indicative, but not accurate, resource duration. This is populated when the nodes completes.
+                    type: object
+                restartingPodUID:
+                    description: RestartingPodUID tracks the UID of the pod that is currently being restarted. This prevents duplicate restart attempts when the controller processes the same failed pod multiple times. Cleared when the replacement pod starts running.
+                    type: string
+                startedAt:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                synchronizationStatus:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.NodeSynchronizationStatus'
+                taskResultSynced:
+                    description: TaskResultSynced is used to determine if the node's output has been received
+                    type: boolean
+                templateName:
+                    description: TemplateName is the template name which this node corresponds to. Not applicable to virtual nodes (e.g. Retry, StepGroup)
+                    type: string
+                templateRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TemplateRef'
+                templateScope:
+                    description: TemplateScope is the template scope in which the template of this node was retrieved.
+                    type: string
+                type:
+                    description: Type indicates type of node
+                    type: string
+            required:
+                - id
+                - name
+                - type
+            type: object
+        io.argoproj.workflow.v1alpha1.NodeSynchronizationStatus:
+            description: NodeSynchronizationStatus stores the status of a node
+            properties:
+                waiting:
+                    description: Waiting is the name of the lock that this node is waiting for
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.NoneStrategy:
+            description: NoneStrategy indicates to skip tar process and upload the files or directory tree as independent files. Note that if the artifact is a directory, the artifact driver must support the ability to save/load the directory appropriately.
+            type: object
+        io.argoproj.workflow.v1alpha1.OAuth2Auth:
+            description: OAuth2Auth holds all information for client authentication via OAuth2 tokens
+            properties:
+                clientIDSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                clientSecretSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                endpointParams:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OAuth2EndpointParam'
+                    type: array
+                scopes:
+                    items:
+                        type: string
+                    type: array
+                tokenURLSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.OAuth2EndpointParam:
+            description: OAuth2EndpointParam is an optional field that should be sent in the OAuth request.
+            properties:
+                key:
+                    description: Name is the header name
+                    type: string
+                value:
+                    description: Value is the literal value to use for the header
+                    type: string
+            required:
+                - key
+            type: object
+        io.argoproj.workflow.v1alpha1.OSSArtifact:
+            description: OSSArtifact is the location of an Alibaba Cloud OSS artifact
+            properties:
+                accessKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bucket:
+                    description: Bucket is the name of the bucket
+                    type: string
+                createBucketIfNotPresent:
+                    description: CreateBucketIfNotPresent tells the driver to attempt to create the OSS bucket for output artifacts, if it doesn't exist
+                    type: boolean
+                endpoint:
+                    description: Endpoint is the hostname of the bucket endpoint
+                    type: string
+                key:
+                    description: Key is the path in the bucket where the artifact resides
+                    type: string
+                lifecycleRule:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OSSLifecycleRule'
+                secretKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                securityToken:
+                    description: 'SecurityToken is the user''s temporary security token. For more details, check out: https://www.alibabacloud.com/help/doc-detail/100624.htm'
+                    type: string
+                useSDKCreds:
+                    description: UseSDKCreds tells the driver to figure out credentials based on sdk defaults.
+                    type: boolean
+            required:
+                - key
+            type: object
+        io.argoproj.workflow.v1alpha1.OSSArtifactRepository:
+            description: OSSArtifactRepository defines the controller configuration for an OSS artifact repository
+            properties:
+                accessKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bucket:
+                    description: Bucket is the name of the bucket
+                    type: string
+                createBucketIfNotPresent:
+                    description: CreateBucketIfNotPresent tells the driver to attempt to create the OSS bucket for output artifacts, if it doesn't exist
+                    type: boolean
+                endpoint:
+                    description: Endpoint is the hostname of the bucket endpoint
+                    type: string
+                keyFormat:
+                    description: KeyFormat defines the format of how to store keys and can reference workflow variables.
+                    type: string
+                lifecycleRule:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.OSSLifecycleRule'
+                secretKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                securityToken:
+                    description: 'SecurityToken is the user''s temporary security token. For more details, check out: https://www.alibabacloud.com/help/doc-detail/100624.htm'
+                    type: string
+                useSDKCreds:
+                    description: UseSDKCreds tells the driver to figure out credentials based on sdk defaults.
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.OSSLifecycleRule:
+            description: OSSLifecycleRule specifies how to manage bucket's lifecycle
+            properties:
+                markDeletionAfterDays:
+                    description: MarkDeletionAfterDays is the number of days before we delete objects in the bucket
+                    type: integer
+                markInfrequentAccessAfterDays:
+                    description: MarkInfrequentAccessAfterDays is the number of days before we convert the objects in the bucket to Infrequent Access (IA) storage type
+                    type: integer
+            type: object
+        io.argoproj.workflow.v1alpha1.Outputs:
+            description: Outputs hold parameters, artifacts, and results from a step
+            properties:
+                artifacts:
+                    description: Artifacts holds the list of output artifacts produced by a step
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Artifact'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                exitCode:
+                    description: ExitCode holds the exit code of a script template
+                    type: string
+                parameters:
+                    description: Parameters holds the list of output parameters produced by a step
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Parameter'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                result:
+                    description: Result holds the result (stdout) of a script or container template, or the response body of an HTTP template
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ParallelSteps:
+            items:
+                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowStep'
+            type: array
+        io.argoproj.workflow.v1alpha1.Parameter:
+            description: Parameter indicate a passed string parameter to a service template with an optional default value
+            properties:
+                default:
+                    description: Default is the default value to use for an input parameter if a value was not supplied
+                    type: string
+                description:
+                    description: Description is the parameter description
+                    type: string
+                enum:
+                    description: Enum holds a list of string values to choose from, for the actual value of the parameter
+                    items:
+                        type: string
+                    type: array
+                globalName:
+                    description: GlobalName exports an output parameter to the global scope, making it available as '{{io.argoproj.workflow.v1alpha1.outputs.parameters.XXXX}} and in workflow.status.outputs.parameters
+                    type: string
+                name:
+                    description: Name is the parameter name
+                    type: string
+                value:
+                    description: Value is the literal value to use for the parameter. If specified in the context of an input parameter, any passed values take precedence over the specified value
+                    type: string
+                valueFrom:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ValueFrom'
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.Plugin:
+            description: Plugin is an Object with exactly one key
+            type: object
+        io.argoproj.workflow.v1alpha1.PluginArtifact:
+            description: PluginArtifact is the location of a plugin artifact
+            properties:
+                configuration:
+                    description: Configuration is the plugin defined configuration for the artifact driver plugin
+                    type: string
+                connectionTimeoutSeconds:
+                    description: ConnectionTimeoutSeconds is the timeout for the artifact driver connection, overriding the driver's timeout
+                    type: integer
+                key:
+                    description: Key is the path in the artifact repository where the artifact resides
+                    type: string
+                name:
+                    description: Name is the name of the artifact driver plugin
+                    type: string
+            required:
+                - key
+            type: object
+        io.argoproj.workflow.v1alpha1.PluginArtifactRepository:
+            description: PluginArtifactRepository defines the controller configuration for a plugin artifact repository
+            properties:
+                configuration:
+                    type: string
+                keyFormat:
+                    type: string
+                name:
+                    type: string
+            required:
+                - name
+                - configuration
+            type: object
+        io.argoproj.workflow.v1alpha1.PodGC:
+            description: PodGC describes how to delete completed pods as they complete
+            properties:
+                deleteDelayDuration:
+                    description: DeleteDelayDuration specifies the duration before pods in the GC queue get deleted.
+                    type: string
+                labelSelector:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector'
+                strategy:
+                    description: Strategy is the strategy to use. One of "OnPodCompletion", "OnPodSuccess", "OnWorkflowCompletion", "OnWorkflowSuccess". If unset, does not delete Pods
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.Prometheus:
+            description: Prometheus is a prometheus metric to be emitted
+            properties:
+                counter:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Counter'
+                gauge:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Gauge'
+                help:
+                    description: Help is a string that describes the metric
+                    type: string
+                histogram:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Histogram'
+                labels:
+                    description: Labels is a list of metric labels
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.MetricLabel'
+                    type: array
+                name:
+                    description: Name is the name of the metric
+                    type: string
+                when:
+                    description: When is a conditional statement that decides when to emit the metric
+                    type: string
+            required:
+                - name
+                - help
+            type: object
+        io.argoproj.workflow.v1alpha1.RawArtifact:
+            description: RawArtifact allows raw string content to be placed as an artifact in a container
+            properties:
+                data:
+                    description: Data is the string contents of the artifact
+                    type: string
+            required:
+                - data
+            type: object
+        io.argoproj.workflow.v1alpha1.ResourceTemplate:
+            description: ResourceTemplate is a template subtype to manipulate kubernetes resources
+            properties:
+                action:
+                    description: 'Action is the action to perform to the resource. Must be one of: get, create, apply, delete, replace, patch'
+                    type: string
+                failureCondition:
+                    description: FailureCondition is a label selector expression which describes the conditions of the k8s resource in which the step was considered failed
+                    type: string
+                flags:
+                    description: |-
+                        Flags is a set of additional options passed to kubectl before submitting a resource I.e. to disable resource validation: flags: [
+                        	"--validate=false"  # disable resource validation
+                        ]
+                    items:
+                        type: string
+                    type: array
+                manifest:
+                    description: Manifest contains the kubernetes manifest
+                    type: string
+                manifestFrom:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ManifestFrom'
+                mergeStrategy:
+                    description: 'MergeStrategy is the strategy used to merge a patch. It defaults to "strategic" Must be one of: strategic, merge, json'
+                    type: string
+                setOwnerReference:
+                    description: SetOwnerReference sets the reference to the workflow on the OwnerReference of generated resource.
+                    type: boolean
+                successCondition:
+                    description: SuccessCondition is a label selector expression which describes the conditions of the k8s resource in which it is acceptable to proceed to the following step
+                    type: string
+            required:
+                - action
+            type: object
+        io.argoproj.workflow.v1alpha1.ResubmitArchivedWorkflowRequest:
+            properties:
+                memoized:
+                    type: boolean
+                name:
+                    type: string
+                namespace:
+                    type: string
+                parameters:
+                    items:
+                        type: string
+                    type: array
+                uid:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.RetryAffinity:
+            description: RetryAffinity prevents running steps on the same host.
+            properties:
+                nodeAntiAffinity:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RetryNodeAntiAffinity'
+            type: object
+        io.argoproj.workflow.v1alpha1.RetryArchivedWorkflowRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+                nodeFieldSelector:
+                    type: string
+                parameters:
+                    items:
+                        type: string
+                    type: array
+                restartSuccessful:
+                    type: boolean
+                uid:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.RetryNodeAntiAffinity:
+            description: RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed. In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+            type: object
+        io.argoproj.workflow.v1alpha1.RetryStrategy:
+            description: RetryStrategy provides controls on how to retry a workflow step
+            properties:
+                affinity:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RetryAffinity'
+                backoff:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Backoff'
+                expression:
+                    description: Expression is a condition expression for when a node will be retried. If it evaluates to false, the node will not be retried and the retry strategy will be ignored
+                    type: string
+                limit:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                retryPolicy:
+                    description: RetryPolicy is a policy of NodePhase statuses that will be retried
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.S3Artifact:
+            description: S3Artifact is the location of an S3 artifact
+            properties:
+                accessKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bucket:
+                    description: Bucket is the name of the bucket
+                    type: string
+                caSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                createBucketIfNotPresent:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CreateS3BucketOptions'
+                encryptionOptions:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.S3EncryptionOptions'
+                endpoint:
+                    description: Endpoint is the hostname of the bucket endpoint
+                    type: string
+                insecure:
+                    description: Insecure will connect to the service with TLS
+                    type: boolean
+                key:
+                    description: Key is the key in the bucket where the artifact resides
+                    type: string
+                region:
+                    description: Region contains the optional bucket region
+                    type: string
+                roleARN:
+                    description: RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+                    type: string
+                secretKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                sessionTokenSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                useSDKCreds:
+                    description: UseSDKCreds tells the driver to figure out credentials based on sdk defaults.
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.S3ArtifactRepository:
+            description: S3ArtifactRepository defines the controller configuration for an S3 artifact repository
+            properties:
+                accessKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                bucket:
+                    description: Bucket is the name of the bucket
+                    type: string
+                caSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                createBucketIfNotPresent:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CreateS3BucketOptions'
+                encryptionOptions:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.S3EncryptionOptions'
+                endpoint:
+                    description: Endpoint is the hostname of the bucket endpoint
+                    type: string
+                insecure:
+                    description: Insecure will connect to the service with TLS
+                    type: boolean
+                keyFormat:
+                    description: KeyFormat defines the format of how to store keys and can reference workflow variables.
+                    type: string
+                keyPrefix:
+                    description: |-
+                        KeyPrefix is prefix used as part of the bucket key in which the controller will store artifacts.
+
+                        Deprecated: Use KeyFormat instead.
+                    type: string
+                region:
+                    description: Region contains the optional bucket region
+                    type: string
+                roleARN:
+                    description: RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+                    type: string
+                secretKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                sessionTokenSecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+                useSDKCreds:
+                    description: UseSDKCreds tells the driver to figure out credentials based on sdk defaults.
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.S3EncryptionOptions:
+            description: S3EncryptionOptions used to determine encryption options during s3 operations
+            properties:
+                enableEncryption:
+                    description: EnableEncryption tells the driver to encrypt objects if set to true. If kmsKeyId and serverSideCustomerKeySecret are not set, SSE-S3 will be used
+                    type: boolean
+                kmsEncryptionContext:
+                    description: KmsEncryptionContext is a json blob that contains an encryption context. See https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context for more information
+                    type: string
+                kmsKeyId:
+                    description: KMSKeyId tells the driver to encrypt the object using the specified KMS Key.
+                    type: string
+                serverSideCustomerKeySecret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.argoproj.workflow.v1alpha1.ScriptTemplate:
+            description: ScriptTemplate is a template subtype to enable scripting through code steps
+            properties:
+                args:
+                    description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                command:
+                    description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                env:
+                    description: List of environment variables to set in the container. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvVar'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - name
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                envFrom:
+                    description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvFromSource'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                image:
+                    description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                    type: string
+                imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                lifecycle:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Lifecycle'
+                livenessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                name:
+                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                    type: string
+                ports:
+                    description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerPort'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: containerPort
+                    x-kubernetes-patch-strategy: merge
+                readinessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                resizePolicy:
+                    description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerResizePolicy'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                resources:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceRequirements'
+                restartPolicy:
+                    description: 'RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod''s restart policy and the container type. Additionally, setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.'
+                    type: string
+                restartPolicyRules:
+                    description: 'Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod''s RestartPolicy.'
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerRestartRule'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecurityContext'
+                source:
+                    description: Source contains the source code of the script to execute
+                    type: string
+                startupProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                stdin:
+                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                    type: boolean
+                stdinOnce:
+                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                    type: string
+                terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                tty:
+                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                volumeDevices:
+                    description: volumeDevices is the list of block devices to be used by the container.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeDevice'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - devicePath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: devicePath
+                    x-kubernetes-patch-strategy: merge
+                volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeMount'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - mountPath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: mountPath
+                    x-kubernetes-patch-strategy: merge
+                workingDir:
+                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                    type: string
+            required:
+                - image
+                - source
+            type: object
+        io.argoproj.workflow.v1alpha1.SemaphoreHolding:
+            properties:
+                holders:
+                    description: Holders stores the list of current holder names in the io.argoproj.workflow.v1alpha1.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                semaphore:
+                    description: Semaphore stores the semaphore name.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.SemaphoreRef:
+            description: SemaphoreRef is a reference of Semaphore
+            properties:
+                configMapKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                database:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SyncDatabaseRef'
+                namespace:
+                    description: 'Namespace is the namespace of the configmap, default: [namespace of workflow]'
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.SemaphoreStatus:
+            properties:
+                holding:
+                    description: Holding stores the list of resource acquired synchronization lock for workflows.
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SemaphoreHolding'
+                    type: array
+                waiting:
+                    description: Waiting indicates the list of current synchronization lock holders.
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SemaphoreHolding'
+                    type: array
+            type: object
+        io.argoproj.workflow.v1alpha1.Sequence:
+            description: Sequence expands a workflow step into numeric range
+            properties:
+                count:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                end:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                format:
+                    description: Format is a printf format string to format the value in the sequence
+                    type: string
+                start:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+            type: object
+        io.argoproj.workflow.v1alpha1.StopStrategy:
+            description: StopStrategy defines if the CronWorkflow should stop scheduling based on an expression. v3.6 and after
+            properties:
+                expression:
+                    description: 'v3.6 and after: Expression is an expression that stops scheduling workflows when true. Use the variables `cronworkflow`.`failed` or `cronworkflow`.`succeeded` to access the number of failed or successful child workflows.'
+                    type: string
+            required:
+                - expression
+            type: object
+        io.argoproj.workflow.v1alpha1.Submit:
+            properties:
+                arguments:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Arguments'
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                workflowTemplateRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateRef'
+            required:
+                - workflowTemplateRef
+            type: object
+        io.argoproj.workflow.v1alpha1.SubmitOpts:
+            description: SubmitOpts are workflow submission options
+            properties:
+                annotations:
+                    description: Annotations adds to metadata.labels
+                    type: string
+                dryRun:
+                    description: DryRun validates the workflow on the client-side without creating it. This option is not supported in API
+                    type: boolean
+                entryPoint:
+                    description: Entrypoint overrides spec.entrypoint
+                    type: string
+                generateName:
+                    description: GenerateName overrides metadata.generateName
+                    type: string
+                labels:
+                    description: Labels adds to metadata.labels
+                    type: string
+                name:
+                    description: Name overrides metadata.name
+                    type: string
+                ownerReference:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference'
+                parameters:
+                    description: Parameters passes input parameters to workflow
+                    items:
+                        type: string
+                    type: array
+                podPriorityClassName:
+                    description: Set the podPriorityClassName of the workflow
+                    type: string
+                priority:
+                    description: Priority is used if controller is configured to process limited number of workflows in parallel, higher priority workflows are processed first.
+                    type: integer
+                serverDryRun:
+                    description: ServerDryRun validates the workflow on the server-side without creating it
+                    type: boolean
+                serviceAccount:
+                    description: ServiceAccount runs all pods in the workflow using specified ServiceAccount.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.SuppliedValueFrom:
+            description: SuppliedValueFrom is a placeholder for a value to be filled in directly, either through the CLI, API, etc.
+            type: object
+        io.argoproj.workflow.v1alpha1.SuspendTemplate:
+            description: SuspendTemplate is a template subtype to suspend a workflow at a predetermined point in time
+            properties:
+                duration:
+                    description: 'Duration is the seconds to wait before automatically resuming a template. Must be a string. Default unit is seconds. Could also be a Duration, e.g.: "2m", "6h"'
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.SyncDatabaseRef:
+            properties:
+                key:
+                    type: string
+            required:
+                - key
+            type: object
+        io.argoproj.workflow.v1alpha1.Synchronization:
+            description: Synchronization holds synchronization lock configuration
+            properties:
+                mutexes:
+                    description: 'v3.6 and after: Mutexes holds the list of Mutex lock details'
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Mutex'
+                    type: array
+                semaphores:
+                    description: 'v3.6 and after: Semaphores holds the list of Semaphores configuration'
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SemaphoreRef'
+                    type: array
+            type: object
+        io.argoproj.workflow.v1alpha1.SynchronizationStatus:
+            description: SynchronizationStatus stores the status of semaphore and mutex.
+            properties:
+                mutex:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.MutexStatus'
+                semaphore:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SemaphoreStatus'
+            type: object
+        io.argoproj.workflow.v1alpha1.TTLStrategy:
+            description: TTLStrategy is the strategy for the time to live depending on if the workflow succeeded or failed
+            properties:
+                secondsAfterCompletion:
+                    description: SecondsAfterCompletion is the number of seconds to live after completion
+                    type: integer
+                secondsAfterFailure:
+                    description: SecondsAfterFailure is the number of seconds to live after failure
+                    type: integer
+                secondsAfterSuccess:
+                    description: SecondsAfterSuccess is the number of seconds to live after success
+                    type: integer
+            type: object
+        io.argoproj.workflow.v1alpha1.TarStrategy:
+            description: TarStrategy will tar and gzip the file or directory when saving
+            properties:
+                compressionLevel:
+                    description: CompressionLevel specifies the gzip compression level to use for the artifact. Defaults to gzip.DefaultCompression.
+                    type: integer
+            type: object
+        io.argoproj.workflow.v1alpha1.Template:
+            description: Template is a reusable and composable unit of execution in a workflow
+            properties:
+                activeDeadlineSeconds:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                affinity:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Affinity'
+                annotations:
+                    additionalProperties:
+                        type: string
+                    description: Annotations is a list of annotations to add to the template at runtime
+                    type: object
+                archiveLocation:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactLocation'
+                automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in pods. ServiceAccountName of ExecutorConfig must be specified if this value is false.
+                    type: boolean
+                container:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Container'
+                containerSet:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ContainerSetTemplate'
+                daemon:
+                    description: Daemon will allow a workflow to proceed to the next step so long as the container reaches readiness
+                    type: boolean
+                dag:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.DAGTemplate'
+                data:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Data'
+                executor:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ExecutorConfig'
+                failFast:
+                    description: FailFast, if specified, will fail this template if any of its child pods has failed. This is useful for when this template is expanded with `withItems`, etc.
+                    type: boolean
+                hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs that will be injected into the pod spec
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.HostAlias'
+                    type: array
+                    x-kubernetes-patch-merge-key: ip
+                    x-kubernetes-patch-strategy: merge
+                http:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.HTTP'
+                initContainers:
+                    description: InitContainers is a list of containers which run before the main container.
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.UserContainer'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                inputs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Inputs'
+                memoize:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Memoize'
+                metadata:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Metadata'
+                metrics:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Metrics'
+                name:
+                    description: Name is the name of the template
+                    type: string
+                nodeSelector:
+                    additionalProperties:
+                        type: string
+                    description: NodeSelector is a selector to schedule this step of the workflow to be run on the selected node(s). Overrides the selector set at the workflow level.
+                    type: object
+                outputs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Outputs'
+                parallelism:
+                    description: Parallelism limits the max total parallel pods that can execute at the same time within the boundaries of this template invocation. If additional steps/dag templates are invoked, the pods created by those templates will not be counted towards this total.
+                    type: integer
+                plugin:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Plugin'
+                podSpecPatch:
+                    description: PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of container fields which are not strings (e.g. resource limits).
+                    type: string
+                priorityClassName:
+                    description: PriorityClassName to apply to workflow pods.
+                    type: string
+                resource:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ResourceTemplate'
+                retryStrategy:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RetryStrategy'
+                schedulerName:
+                    description: If specified, the pod will be dispatched by specified scheduler. Or it will be dispatched by workflow scope scheduler if specified. If neither specified, the pod will be dispatched by default scheduler.
+                    type: string
+                script:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ScriptTemplate'
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodSecurityContext'
+                serviceAccountName:
+                    description: ServiceAccountName to apply to workflow pods
+                    type: string
+                sidecars:
+                    description: Sidecars is a list of containers which run alongside the main container Sidecars are automatically killed when the main container completes
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.UserContainer'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                steps:
+                    description: Steps define a series of sequential/parallel workflow steps
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ParallelSteps'
+                    type: array
+                suspend:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SuspendTemplate'
+                synchronization:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Synchronization'
+                timeout:
+                    description: Timeout allows to set the total node execution timeout duration counting from the node's start time. This duration also includes time in which the node spends in Pending state. This duration may not be applied to Step or DAG templates.
+                    type: string
+                tolerations:
+                    description: Tolerations to apply to workflow pods.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Toleration'
+                    type: array
+                    x-kubernetes-patch-merge-key: key
+                    x-kubernetes-patch-strategy: merge
+                volumes:
+                    description: Volumes is a list of volumes that can be mounted by containers in a template.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Volume'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+            type: object
+        io.argoproj.workflow.v1alpha1.TemplateRef:
+            description: TemplateRef is a reference of template resource.
+            properties:
+                clusterScope:
+                    description: ClusterScope indicates the referred template is cluster scoped (i.e. a ClusterWorkflowTemplate).
+                    type: boolean
+                name:
+                    description: Name is the resource name of the template.
+                    type: string
+                template:
+                    description: Template is the name of referred template in the resource.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.TransformationStep:
+            properties:
+                expression:
+                    description: Expression defines an expr expression to apply
+                    type: string
+            required:
+                - expression
+            type: object
+        io.argoproj.workflow.v1alpha1.UpdateCronWorkflowRequest:
+            properties:
+                cronWorkflow:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                name:
+                    description: 'DEPRECATED: This field is ignored.'
+                    type: string
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.UserContainer:
+            description: UserContainer is a container specified by a user.
+            properties:
+                args:
+                    description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                command:
+                    description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                env:
+                    description: List of environment variables to set in the container. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvVar'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - name
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                envFrom:
+                    description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvFromSource'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                image:
+                    description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                    type: string
+                imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                lifecycle:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Lifecycle'
+                livenessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                mirrorVolumeMounts:
+                    description: MirrorVolumeMounts will mount the same volumes specified in the main container to the container (including artifacts), at the same mountPaths. This enables dind daemon to partially see the same filesystem as the main container in order to use features such as docker volume binding
+                    type: boolean
+                name:
+                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                    type: string
+                ports:
+                    description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerPort'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: containerPort
+                    x-kubernetes-patch-strategy: merge
+                readinessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                resizePolicy:
+                    description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerResizePolicy'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                resources:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceRequirements'
+                restartPolicy:
+                    description: 'RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod''s restart policy and the container type. Additionally, setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.'
+                    type: string
+                restartPolicyRules:
+                    description: 'Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod''s RestartPolicy.'
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerRestartRule'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecurityContext'
+                startupProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                stdin:
+                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                    type: boolean
+                stdinOnce:
+                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                    type: string
+                terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                tty:
+                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                volumeDevices:
+                    description: volumeDevices is the list of block devices to be used by the container.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeDevice'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - devicePath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: devicePath
+                    x-kubernetes-patch-strategy: merge
+                volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeMount'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - mountPath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: mountPath
+                    x-kubernetes-patch-strategy: merge
+                workingDir:
+                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                    type: string
+            required:
+                - name
+            type: object
+        io.argoproj.workflow.v1alpha1.ValueFrom:
+            description: ValueFrom describes a location in which to obtain the value to a parameter
+            properties:
+                configMapKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                default:
+                    description: Default specifies a value to be used if retrieving the value from the specified source fails
+                    type: string
+                event:
+                    description: Selector (https://github.com/expr-lang/expr) that is evaluated against the event to get the value of the parameter. E.g. `payload.message`
+                    type: string
+                expression:
+                    description: Expression, if defined, is evaluated to specify the value for the parameter
+                    type: string
+                jqFilter:
+                    description: JQFilter expression against the resource object in resource templates
+                    type: string
+                jsonPath:
+                    description: JSONPath of a resource to retrieve an output parameter value from in resource templates
+                    type: string
+                parameter:
+                    description: Parameter reference to a step or dag task in which to retrieve an output parameter value from (e.g. '{{steps.mystep.outputs.myparam}}')
+                    type: string
+                path:
+                    description: Path in the container to retrieve an output parameter value from in container templates
+                    type: string
+                supplied:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SuppliedValueFrom'
+            type: object
+        io.argoproj.workflow.v1alpha1.Version:
+            properties:
+                buildDate:
+                    type: string
+                compiler:
+                    type: string
+                gitCommit:
+                    type: string
+                gitTag:
+                    type: string
+                gitTreeState:
+                    type: string
+                goVersion:
+                    type: string
+                platform:
+                    type: string
+                version:
+                    type: string
+            required:
+                - version
+                - buildDate
+                - gitCommit
+                - gitTag
+                - gitTreeState
+                - goVersion
+                - compiler
+                - platform
+            type: object
+        io.argoproj.workflow.v1alpha1.VolumeClaimGC:
+            description: VolumeClaimGC describes how to delete volumes from completed Workflows
+            properties:
+                strategy:
+                    description: Strategy is the strategy to use. One of "OnWorkflowCompletion", "OnWorkflowSuccess". Defaults to "OnWorkflowSuccess"
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.Workflow:
+            description: Workflow is the definition of a workflow resource
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec'
+                status:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowStatus'
+            required:
+                - metadata
+                - spec
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowCreateRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                instanceID:
+                    description: This field is no longer used.
+                    type: string
+                namespace:
+                    type: string
+                serverDryRun:
+                    type: boolean
+                workflow:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowDeleteResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowEventBinding:
+            description: WorkflowEventBinding is the definition of an event resource
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowEventBindingSpec'
+            required:
+                - metadata
+                - spec
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowEventBindingList:
+            description: WorkflowEventBindingList is list of event resources
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                items:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowEventBinding'
+                    type: array
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            required:
+                - metadata
+                - items
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowEventBindingSpec:
+            properties:
+                event:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Event'
+                submit:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Submit'
+            required:
+                - event
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowLevelArtifactGC:
+            description: WorkflowLevelArtifactGC describes how to delete artifacts from completed Workflows - this spec is used on the Workflow level
+            properties:
+                forceFinalizerRemoval:
+                    description: 'ForceFinalizerRemoval: if set to true, the finalizer will be removed in the case that Artifact GC fails'
+                    type: boolean
+                podMetadata:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Metadata'
+                podSpecPatch:
+                    description: PodSpecPatch holds strategic merge patch to apply against the artgc pod spec.
+                    type: string
+                serviceAccountName:
+                    description: ServiceAccountName is an optional field for specifying the Service Account that should be assigned to the Pod doing the deletion
+                    type: string
+                strategy:
+                    description: Strategy is the strategy to use.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowLintRequest:
+            properties:
+                namespace:
+                    type: string
+                workflow:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowList:
+            description: WorkflowList is list of Workflow resources
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                items:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    type: array
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            required:
+                - metadata
+                - items
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowMetadata:
+            properties:
+                annotations:
+                    additionalProperties:
+                        type: string
+                    type: object
+                labels:
+                    additionalProperties:
+                        type: string
+                    type: object
+                labelsFrom:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LabelValueFrom'
+                    type: object
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowResubmitRequest:
+            properties:
+                memoized:
+                    type: boolean
+                name:
+                    type: string
+                namespace:
+                    type: string
+                parameters:
+                    items:
+                        type: string
+                    type: array
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowResumeRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+                nodeFieldSelector:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowRetryRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+                nodeFieldSelector:
+                    type: string
+                parameters:
+                    items:
+                        type: string
+                    type: array
+                restartSuccessful:
+                    type: boolean
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowSetRequest:
+            properties:
+                message:
+                    type: string
+                name:
+                    type: string
+                namespace:
+                    type: string
+                nodeFieldSelector:
+                    type: string
+                outputParameters:
+                    type: string
+                phase:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowSpec:
+            description: WorkflowSpec is the specification of a Workflow.
+            properties:
+                activeDeadlineSeconds:
+                    description: Optional duration in seconds relative to the workflow start time which the workflow is allowed to run before the controller terminates the io.argoproj.workflow.v1alpha1. A value of zero is used to terminate a Running workflow
+                    type: integer
+                affinity:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Affinity'
+                archiveLogs:
+                    description: ArchiveLogs indicates if the container logs should be archived
+                    type: boolean
+                arguments:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Arguments'
+                artifactGC:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowLevelArtifactGC'
+                artifactRepositoryRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactRepositoryRef'
+                automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted in pods. ServiceAccountName of ExecutorConfig must be specified if this value is false.
+                    type: boolean
+                dnsConfig:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodDNSConfig'
+                dnsPolicy:
+                    description: Set DNS policy for workflow pods. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                    type: string
+                entrypoint:
+                    description: Entrypoint is a template reference to the starting point of the io.argoproj.workflow.v1alpha1.
+                    type: string
+                executor:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ExecutorConfig'
+                hooks:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LifecycleHook'
+                    description: Hooks holds the lifecycle hook which is invoked at lifecycle of step, irrespective of the success, failure, or error status of the primary step
+                    type: object
+                hostAliases:
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.HostAlias'
+                    type: array
+                    x-kubernetes-patch-merge-key: ip
+                    x-kubernetes-patch-strategy: merge
+                hostNetwork:
+                    description: Host networking requested for this workflow pod. Default to false.
+                    type: boolean
+                imagePullSecrets:
+                    description: 'ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                metrics:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Metrics'
+                nodeSelector:
+                    additionalProperties:
+                        type: string
+                    description: NodeSelector is a selector which will result in all pods of the workflow to be scheduled on the selected node(s). This is able to be overridden by a nodeSelector specified in the template.
+                    type: object
+                onExit:
+                    description: OnExit is a template reference which is invoked at the end of the workflow, irrespective of the success, failure, or error of the primary io.argoproj.workflow.v1alpha1.
+                    type: string
+                parallelism:
+                    description: Parallelism limits the max total parallel pods that can execute at the same time in a workflow
+                    type: integer
+                podDisruptionBudget:
+                    $ref: '#/components/schemas/io.k8s.api.policy.v1.PodDisruptionBudgetSpec'
+                podGC:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.PodGC'
+                podMetadata:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Metadata'
+                podPriorityClassName:
+                    description: PriorityClassName to apply to workflow pods.
+                    type: string
+                podSpecPatch:
+                    description: PodSpecPatch holds strategic merge patch to apply against the pod spec. Allows parameterization of container fields which are not strings (e.g. resource limits).
+                    type: string
+                priority:
+                    description: Priority is used if controller is configured to process limited number of workflows in parallel. Workflows with higher priority are processed first.
+                    type: integer
+                retryStrategy:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RetryStrategy'
+                schedulerName:
+                    description: Set scheduler name for all pods. Will be overridden if container/script template's scheduler name is set. Default scheduler will be used if neither specified.
+                    type: string
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodSecurityContext'
+                serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount to run all pods of the workflow as.
+                    type: string
+                shutdown:
+                    description: Shutdown will shutdown the workflow according to its ShutdownStrategy
+                    type: string
+                suspend:
+                    description: Suspend will suspend the workflow and prevent execution of any future steps in the workflow
+                    type: boolean
+                synchronization:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Synchronization'
+                templateDefaults:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Template'
+                templates:
+                    description: Templates is a list of workflow templates used in a workflow MaxItems is an artificial limit to limit CEL validation costs - see note at top of file
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Template'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                tolerations:
+                    description: Tolerations to apply to workflow pods.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Toleration'
+                    type: array
+                    x-kubernetes-patch-merge-key: key
+                    x-kubernetes-patch-strategy: merge
+                ttlStrategy:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TTLStrategy'
+                volumeClaimGC:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.VolumeClaimGC'
+                volumeClaimTemplates:
+                    description: VolumeClaimTemplates is a list of claims that containers are allowed to reference. The Workflow controller will create the claims at the beginning of the workflow and delete the claims upon completion of the workflow
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaim'
+                    type: array
+                volumes:
+                    description: Volumes is a list of volumes that can be mounted by containers in a io.argoproj.workflow.v1alpha1.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Volume'
+                    type: array
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                workflowMetadata:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowMetadata'
+                workflowTemplateRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateRef'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowStatus:
+            description: WorkflowStatus contains overall status information about a workflow
+            properties:
+                artifactGCStatus:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtGCStatus'
+                artifactRepositoryRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArtifactRepositoryRefStatus'
+                compressedNodes:
+                    description: Compressed and base64 decoded Nodes map
+                    type: string
+                conditions:
+                    description: Conditions is a list of conditions the Workflow may have
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Condition'
+                    type: array
+                estimatedDuration:
+                    description: EstimatedDuration in seconds.
+                    type: integer
+                finishedAt:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                message:
+                    description: A human readable message indicating details about why the workflow is in this condition.
+                    type: string
+                nodes:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.NodeStatus'
+                    description: Nodes is a mapping between a node ID and the node's status.
+                    type: object
+                offloadNodeStatusVersion:
+                    description: Whether on not node status has been offloaded to a database. If exists, then Nodes and CompressedNodes will be empty. This will actually be populated with a hash of the offloaded data.
+                    type: string
+                outputs:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Outputs'
+                persistentVolumeClaims:
+                    description: PersistentVolumeClaims tracks all PVCs that were created as part of the io.argoproj.workflow.v1alpha1. The contents of this list are drained at the end of the workflow.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Volume'
+                    type: array
+                phase:
+                    description: Phase a simple, high-level summary of where the workflow is in its lifecycle. Will be "" (Unknown), "Pending", or "Running" before the workflow is completed, and "Succeeded", "Failed" or "Error" once the workflow has completed.
+                    type: string
+                progress:
+                    description: Progress to completion
+                    type: string
+                resourcesDuration:
+                    additionalProperties:
+                        format: int64
+                        type: integer
+                    description: ResourcesDuration is the total for the workflow
+                    type: object
+                startedAt:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                storedTemplates:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Template'
+                    description: StoredTemplates is a mapping between a template ref and the node's status.
+                    type: object
+                storedWorkflowTemplateSpec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec'
+                synchronization:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SynchronizationStatus'
+                taskResultsCompletionStatus:
+                    additionalProperties:
+                        type: boolean
+                    description: TaskResultsCompletionStatus tracks task result completion status (mapped by node ID). Used to prevent premature archiving and garbage collection.
+                    type: object
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowStep:
+            description: 'WorkflowStep is a reference to a template to execute in a series of step Note: CEL validation cannot check withItems (Schemaless) or inline (PreserveUnknownFields) fields.'
+            properties:
+                arguments:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Arguments'
+                continueOn:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ContinueOn'
+                hooks:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LifecycleHook'
+                    description: Hooks holds the lifecycle hook which is invoked at lifecycle of step, irrespective of the success, failure, or error status of the primary step
+                    type: object
+                inline:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Template'
+                name:
+                    description: Name of the step
+                    type: string
+                onExit:
+                    description: |-
+                        OnExit is a template reference which is invoked at the end of the template, irrespective of the success, failure, or error of the primary template.
+
+                        Deprecated: Use Hooks[exit].Template instead.
+                    type: string
+                template:
+                    description: Template is the name of the template to execute as the step
+                    type: string
+                templateRef:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.TemplateRef'
+                when:
+                    description: When is an expression in which the step should conditionally execute
+                    type: string
+                withItems:
+                    description: 'WithItems expands a step into multiple parallel steps from the items in the list Note: The structure of WithItems is free-form, so we need "x-kubernetes-preserve-unknown-fields: true" in the validation schema.'
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Item'
+                    type: array
+                withParam:
+                    description: WithParam expands a step into multiple parallel steps from the value in the parameter, which is expected to be a JSON list.
+                    type: string
+                withSequence:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Sequence'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowStopRequest:
+            properties:
+                message:
+                    type: string
+                name:
+                    type: string
+                namespace:
+                    type: string
+                nodeFieldSelector:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowSubmitRequest:
+            properties:
+                namespace:
+                    type: string
+                resourceKind:
+                    type: string
+                resourceName:
+                    type: string
+                submitOptions:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.SubmitOpts'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowSuspendRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplate:
+            description: WorkflowTemplate is the definition of a workflow template resource
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSpec'
+            required:
+                - metadata
+                - spec
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplateCreateRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                namespace:
+                    type: string
+                template:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplateDeleteResponse:
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplateLintRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                namespace:
+                    type: string
+                template:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplateList:
+            description: WorkflowTemplateList is list of WorkflowTemplate resources
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                items:
+                    items:
+                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+                    type: array
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.io.k8s.community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta'
+            required:
+                - metadata
+                - items
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplateRef:
+            description: WorkflowTemplateRef is a reference to a WorkflowTemplate resource.
+            properties:
+                clusterScope:
+                    description: ClusterScope indicates the referred template is cluster scoped (i.e. a ClusterWorkflowTemplate).
+                    type: boolean
+                name:
+                    description: Name is the resource name of the workflow template.
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTemplateUpdateRequest:
+            properties:
+                name:
+                    description: 'DEPRECATED: This field is ignored.'
+                    type: string
+                namespace:
+                    type: string
+                template:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowTerminateRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.WorkflowWatchEvent:
+            properties:
+                object:
+                    $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                type:
+                    title: the type of change
+                    type: string
+            type: object
+        io.argoproj.workflow.v1alpha1.ZipStrategy:
+            description: ZipStrategy will unzip zipped input artifacts
+            type: object
+        io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource:
+            description: |-
+                Represents a Persistent Disk resource in AWS.
+
+                An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+            properties:
+                fsType:
+                    description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: string
+                partition:
+                    description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                    type: integer
+                readOnly:
+                    description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: boolean
+                volumeID:
+                    description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: string
+            required:
+                - volumeID
+            type: object
+        io.k8s.api.core.v1.Affinity:
+            description: Affinity is a group of affinity scheduling rules.
+            properties:
+                nodeAffinity:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.NodeAffinity'
+                podAffinity:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodAffinity'
+                podAntiAffinity:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodAntiAffinity'
+            type: object
+        io.k8s.api.core.v1.AppArmorProfile:
+            description: AppArmorProfile defines a pod or container's AppArmor settings.
+            properties:
+                localhostProfile:
+                    description: localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is "Localhost".
+                    type: string
+                type:
+                    description: |-
+                        type indicates which kind of AppArmor profile will be applied. Valid options are:
+                          Localhost - a profile pre-loaded on the node.
+                          RuntimeDefault - the container runtime's default profile.
+                          Unconfined - no AppArmor enforcement.
+                    type: string
+            required:
+                - type
+            type: object
+            x-kubernetes-unions:
+                - discriminator: type
+                  fields-to-discriminateBy:
+                    localhostProfile: LocalhostProfile
+        io.k8s.api.core.v1.AzureDiskVolumeSource:
+            description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+            properties:
+                cachingMode:
+                    description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                    type: string
+                diskName:
+                    description: diskName is the Name of the data disk in the blob storage
+                    type: string
+                diskURI:
+                    description: diskURI is the URI of data disk in the blob storage
+                    type: string
+                fsType:
+                    description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                kind:
+                    description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                    type: string
+                readOnly:
+                    description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+            required:
+                - diskName
+                - diskURI
+            type: object
+        io.k8s.api.core.v1.AzureFileVolumeSource:
+            description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+            properties:
+                readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                secretName:
+                    description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                    type: string
+                shareName:
+                    description: shareName is the azure share Name
+                    type: string
+            required:
+                - secretName
+                - shareName
+            type: object
+        io.k8s.api.core.v1.CSIVolumeSource:
+            description: Represents a source location of a volume to mount, managed by an external CSI driver
+            properties:
+                driver:
+                    description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                    type: string
+                fsType:
+                    description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                    type: string
+                nodePublishSecretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                readOnly:
+                    description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+                    type: boolean
+                volumeAttributes:
+                    additionalProperties:
+                        type: string
+                    description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                    type: object
+            required:
+                - driver
+            type: object
+        io.k8s.api.core.v1.Capabilities:
+            description: Adds and removes POSIX capabilities from running containers.
+            properties:
+                add:
+                    description: Added capabilities
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                drop:
+                    description: Removed capabilities
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.CephFSVolumeSource:
+            description: Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+            properties:
+                monitors:
+                    description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                path:
+                    description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                    type: string
+                readOnly:
+                    description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    type: boolean
+                secretFile:
+                    description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    type: string
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                user:
+                    description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    type: string
+            required:
+                - monitors
+            type: object
+        io.k8s.api.core.v1.CinderVolumeSource:
+            description: Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+            properties:
+                fsType:
+                    description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    type: string
+                readOnly:
+                    description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    type: boolean
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                volumeID:
+                    description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    type: string
+            required:
+                - volumeID
+            type: object
+        io.k8s.api.core.v1.ClusterTrustBundleProjection:
+            description: ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.
+            properties:
+                labelSelector:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector'
+                name:
+                    description: Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.
+                    type: string
+                optional:
+                    description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.
+                    type: boolean
+                path:
+                    description: Relative path from the volume root to write the bundle.
+                    type: string
+                signerName:
+                    description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.
+                    type: string
+            required:
+                - path
+            type: object
+        io.k8s.api.core.v1.ConfigMapEnvSource:
+            description: |-
+                ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+                The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+            properties:
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: Specify whether the ConfigMap must be defined
+                    type: boolean
+            type: object
+        io.k8s.api.core.v1.ConfigMapKeySelector:
+            description: Selects a key from a ConfigMap.
+            properties:
+                key:
+                    description: The key to select.
+                    type: string
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: Specify whether the ConfigMap or its key must be defined
+                    type: boolean
+            required:
+                - key
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.ConfigMapProjection:
+            description: |-
+                Adapts a ConfigMap into a projected volume.
+
+                The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+            properties:
+                items:
+                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.KeyToPath'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: optional specify whether the ConfigMap or its keys must be defined
+                    type: boolean
+            type: object
+        io.k8s.api.core.v1.ConfigMapVolumeSource:
+            description: |-
+                Adapts a ConfigMap into a volume.
+
+                The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+            properties:
+                defaultMode:
+                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                    type: integer
+                items:
+                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.KeyToPath'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: optional specify whether the ConfigMap or its keys must be defined
+                    type: boolean
+            type: object
+        io.k8s.api.core.v1.Container:
+            description: A single application container that you want to run within a pod.
+            properties:
+                args:
+                    description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                command:
+                    description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                env:
+                    description: List of environment variables to set in the container. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvVar'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - name
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: name
+                    x-kubernetes-patch-strategy: merge
+                envFrom:
+                    description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.EnvFromSource'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                image:
+                    description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                    type: string
+                imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                lifecycle:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Lifecycle'
+                livenessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                name:
+                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                    type: string
+                ports:
+                    description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerPort'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: containerPort
+                    x-kubernetes-patch-strategy: merge
+                readinessProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                resizePolicy:
+                    description: Resources resize policy for the container. This field cannot be set on ephemeral containers.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerResizePolicy'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                resources:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceRequirements'
+                restartPolicy:
+                    description: 'RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod''s restart policy and the container type. Additionally, setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.'
+                    type: string
+                restartPolicyRules:
+                    description: 'Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod''s RestartPolicy.'
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerRestartRule'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                securityContext:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecurityContext'
+                startupProbe:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Probe'
+                stdin:
+                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                    type: boolean
+                stdinOnce:
+                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                    type: string
+                terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                tty:
+                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                volumeDevices:
+                    description: volumeDevices is the list of block devices to be used by the container.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeDevice'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - devicePath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: devicePath
+                    x-kubernetes-patch-strategy: merge
+                volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeMount'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - mountPath
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: mountPath
+                    x-kubernetes-patch-strategy: merge
+                workingDir:
+                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                    type: string
+            required:
+                - image
+            type: object
+        io.k8s.api.core.v1.ContainerPort:
+            description: ContainerPort represents a network port in a single container.
+            properties:
+                containerPort:
+                    description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                    type: integer
+                hostIP:
+                    description: What host IP to bind the external port to.
+                    type: string
+                hostPort:
+                    description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                    type: integer
+                name:
+                    description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                    type: string
+                protocol:
+                    description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                    type: string
+            required:
+                - containerPort
+            type: object
+        io.k8s.api.core.v1.ContainerResizePolicy:
+            description: ContainerResizePolicy represents resource resize policy for the container.
+            properties:
+                resourceName:
+                    description: 'Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.'
+                    type: string
+                restartPolicy:
+                    description: Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.
+                    type: string
+            required:
+                - resourceName
+                - restartPolicy
+            type: object
+        io.k8s.api.core.v1.ContainerRestartRule:
+            description: ContainerRestartRule describes how a container exit is handled.
+            properties:
+                action:
+                    description: Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is "Restart" to restart the container.
+                    type: string
+                exitCodes:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes'
+            required:
+                - action
+            type: object
+        io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes:
+            description: ContainerRestartRuleOnExitCodes describes the condition for handling an exited container based on its exit codes.
+            properties:
+                operator:
+                    description: |-
+                        Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the
+                          set of specified values.
+                        - NotIn: the requirement is satisfied if the container exit code is
+                          not in the set of specified values.
+                    type: string
+                values:
+                    description: Specifies the set of values to check for container exit codes. At most 255 elements are allowed.
+                    items:
+                        format: int32
+                        type: integer
+                    type: array
+                    x-kubernetes-list-type: set
+            required:
+                - operator
+            type: object
+        io.k8s.api.core.v1.DownwardAPIProjection:
+            description: Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.
+            properties:
+                items:
+                    description: Items is a list of DownwardAPIVolume file
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.DownwardAPIVolumeFile'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.DownwardAPIVolumeFile:
+            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+            properties:
+                fieldRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ObjectFieldSelector'
+                mode:
+                    description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                    type: integer
+                path:
+                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                    type: string
+                resourceFieldRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceFieldSelector'
+            required:
+                - path
+            type: object
+        io.k8s.api.core.v1.DownwardAPIVolumeSource:
+            description: DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+            properties:
+                defaultMode:
+                    description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                    type: integer
+                items:
+                    description: Items is a list of downward API volume file
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.DownwardAPIVolumeFile'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.EmptyDirVolumeSource:
+            description: Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+            properties:
+                medium:
+                    description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    type: string
+                sizeLimit:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+            type: object
+        io.k8s.api.core.v1.EnvFromSource:
+            description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+            properties:
+                configMapRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapEnvSource'
+                prefix:
+                    description: Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.
+                    type: string
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretEnvSource'
+            type: object
+        io.k8s.api.core.v1.EnvVar:
+            description: EnvVar represents an environment variable present in a Container.
+            properties:
+                name:
+                    description: Name of the environment variable. May consist of any printable ASCII characters except '='.
+                    type: string
+                value:
+                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                    type: string
+                valueFrom:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.EnvVarSource'
+            required:
+                - name
+            type: object
+        io.k8s.api.core.v1.EnvVarSource:
+            description: EnvVarSource represents a source for the value of an EnvVar.
+            properties:
+                configMapKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapKeySelector'
+                fieldRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ObjectFieldSelector'
+                fileKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.FileKeySelector'
+                resourceFieldRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceFieldSelector'
+                secretKeyRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretKeySelector'
+            type: object
+        io.k8s.api.core.v1.EphemeralVolumeSource:
+            description: Represents an ephemeral volume that is handled by a normal storage driver.
+            properties:
+                volumeClaimTemplate:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaimTemplate'
+            type: object
+        io.k8s.api.core.v1.Event:
+            description: Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
+            properties:
+                action:
+                    description: What action was taken/failed regarding to the Regarding object.
+                    type: string
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                count:
+                    description: The number of times this event has occurred.
+                    type: integer
+                eventTime:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime'
+                firstTimestamp:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                involvedObject:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ObjectReference'
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                lastTimestamp:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                message:
+                    description: A human-readable description of the status of this operation.
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                reason:
+                    description: This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
+                    type: string
+                related:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ObjectReference'
+                reportingComponent:
+                    description: Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
+                    type: string
+                reportingInstance:
+                    description: ID of the controller instance, e.g. `kubelet-xyzf`.
+                    type: string
+                series:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.EventSeries'
+                source:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.EventSource'
+                type:
+                    description: Type of this event (Normal, Warning), new types could be added in the future
+                    type: string
+            required:
+                - metadata
+                - involvedObject
+            type: object
+            x-kubernetes-group-version-kind:
+                - group: ""
+                  kind: Event
+                  version: v1
+        io.k8s.api.core.v1.EventSeries:
+            description: EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
+            properties:
+                count:
+                    description: Number of occurrences in this series up to the last heartbeat time
+                    type: integer
+                lastObservedTime:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime'
+            type: object
+        io.k8s.api.core.v1.EventSource:
+            description: EventSource contains information for an event.
+            properties:
+                component:
+                    description: Component from which the event is generated.
+                    type: string
+                host:
+                    description: Node name on which the event is generated.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.ExecAction:
+            description: ExecAction describes a "run in container" action.
+            properties:
+                command:
+                    description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.FCVolumeSource:
+            description: Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+            properties:
+                fsType:
+                    description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                lun:
+                    description: 'lun is Optional: FC target lun number'
+                    type: integer
+                readOnly:
+                    description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                    type: boolean
+                targetWWNs:
+                    description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                wwids:
+                    description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.FileKeySelector:
+            description: FileKeySelector selects a key of the env file.
+            properties:
+                key:
+                    description: The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                    type: string
+                optional:
+                    description: |-
+                        Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.
+
+                        If optional is set to false and the specified key does not exist, an error will be returned during Pod creation.
+                    type: boolean
+                path:
+                    description: The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.
+                    type: string
+                volumeName:
+                    description: The name of the volume mount containing the env file.
+                    type: string
+            required:
+                - volumeName
+                - path
+                - key
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.FlexVolumeSource:
+            description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+            properties:
+                driver:
+                    description: driver is the name of the driver to use for this volume.
+                    type: string
+                fsType:
+                    description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                    type: string
+                options:
+                    additionalProperties:
+                        type: string
+                    description: 'options is Optional: this field holds extra command options if any.'
+                    type: object
+                readOnly:
+                    description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                    type: boolean
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+            required:
+                - driver
+            type: object
+        io.k8s.api.core.v1.FlockerVolumeSource:
+            description: Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+            properties:
+                datasetName:
+                    description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                    type: string
+                datasetUUID:
+                    description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                    type: string
+            type: object
+        io.k8s.api.core.v1.GCEPersistentDiskVolumeSource:
+            description: |-
+                Represents a Persistent Disk resource in Google Compute Engine.
+
+                A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+            properties:
+                fsType:
+                    description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: string
+                partition:
+                    description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: integer
+                pdName:
+                    description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: string
+                readOnly:
+                    description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: boolean
+            required:
+                - pdName
+            type: object
+        io.k8s.api.core.v1.GRPCAction:
+            description: GRPCAction specifies an action involving a GRPC service.
+            properties:
+                port:
+                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                    type: integer
+                service:
+                    description: |-
+                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                        If this is not specified, the default behavior is defined by gRPC.
+                    type: string
+            required:
+                - port
+            type: object
+        io.k8s.api.core.v1.GitRepoVolumeSource:
+            description: |-
+                Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+            properties:
+                directory:
+                    description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                    type: string
+                repository:
+                    description: repository is the URL
+                    type: string
+                revision:
+                    description: revision is the commit hash for the specified revision.
+                    type: string
+            required:
+                - repository
+            type: object
+        io.k8s.api.core.v1.GlusterfsVolumeSource:
+            description: Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+            properties:
+                endpoints:
+                    description: endpoints is the endpoint name that details Glusterfs topology.
+                    type: string
+                path:
+                    description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                    type: string
+                readOnly:
+                    description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                    type: boolean
+            required:
+                - endpoints
+                - path
+            type: object
+        io.k8s.api.core.v1.HTTPGetAction:
+            description: HTTPGetAction describes an action based on HTTP Get requests.
+            properties:
+                host:
+                    description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                    type: string
+                httpHeaders:
+                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.HTTPHeader'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                path:
+                    description: Path to access on the HTTP server.
+                    type: string
+                port:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                scheme:
+                    description: Scheme to use for connecting to the host. Defaults to HTTP.
+                    type: string
+            required:
+                - port
+            type: object
+        io.k8s.api.core.v1.HTTPHeader:
+            description: HTTPHeader describes a custom header to be used in HTTP probes
+            properties:
+                name:
+                    description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                    type: string
+                value:
+                    description: The header field value
+                    type: string
+            required:
+                - name
+                - value
+            type: object
+        io.k8s.api.core.v1.HostAlias:
+            description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+            properties:
+                hostnames:
+                    description: Hostnames for the above IP address.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                ip:
+                    description: IP address of the host file entry.
+                    type: string
+            required:
+                - ip
+            type: object
+        io.k8s.api.core.v1.HostPathVolumeSource:
+            description: Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+            properties:
+                path:
+                    description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                    type: string
+                type:
+                    description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                    type: string
+            required:
+                - path
+            type: object
+        io.k8s.api.core.v1.ISCSIVolumeSource:
+            description: Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+            properties:
+                chapAuthDiscovery:
+                    description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                    type: boolean
+                chapAuthSession:
+                    description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                    type: boolean
+                fsType:
+                    description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                    type: string
+                initiatorName:
+                    description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                    type: string
+                iqn:
+                    description: iqn is the target iSCSI Qualified Name.
+                    type: string
+                iscsiInterface:
+                    description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                    type: string
+                lun:
+                    description: lun represents iSCSI Target Lun number.
+                    type: integer
+                portals:
+                    description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                readOnly:
+                    description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                    type: boolean
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                targetPortal:
+                    description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                    type: string
+            required:
+                - targetPortal
+                - iqn
+                - lun
+            type: object
+        io.k8s.api.core.v1.ImageVolumeSource:
+            description: ImageVolumeSource represents a image volume resource.
+            properties:
+                pullPolicy:
+                    description: 'Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn''t present. IfNotPresent: the kubelet pulls if the reference isn''t already present on disk. Container creation will fail if the reference isn''t present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.'
+                    type: string
+                reference:
+                    description: 'Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                    type: string
+            type: object
+        io.k8s.api.core.v1.KeyToPath:
+            description: Maps a string key to a path within a volume.
+            properties:
+                key:
+                    description: key is the key to project.
+                    type: string
+                mode:
+                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                    type: integer
+                path:
+                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                    type: string
+            required:
+                - key
+                - path
+            type: object
+        io.k8s.api.core.v1.Lifecycle:
+            description: Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
+            properties:
+                postStart:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LifecycleHandler'
+                preStop:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LifecycleHandler'
+                stopSignal:
+                    description: StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name
+                    type: string
+            type: object
+        io.k8s.api.core.v1.LifecycleHandler:
+            description: LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.
+            properties:
+                exec:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ExecAction'
+                httpGet:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.HTTPGetAction'
+                sleep:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SleepAction'
+                tcpSocket:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.TCPSocketAction'
+            type: object
+        io.k8s.api.core.v1.LocalObjectReference:
+            description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+            properties:
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.ModifyVolumeStatus:
+            description: ModifyVolumeStatus represents the status object of ControllerModifyVolume operation
+            properties:
+                status:
+                    description: |-
+                        status is the status of the ControllerModifyVolume operation. It can be in any of following states:
+                         - Pending
+                           Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as
+                           the specified VolumeAttributesClass not existing.
+                         - InProgress
+                           InProgress indicates that the volume is being modified.
+                         - Infeasible
+                          Infeasible indicates that the request has been rejected as invalid by the CSI driver. To
+                        	  resolve the error, a valid VolumeAttributesClass needs to be specified.
+                        Note: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.
+                    type: string
+                targetVolumeAttributesClassName:
+                    description: targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled
+                    type: string
+            required:
+                - status
+            type: object
+        io.k8s.api.core.v1.NFSVolumeSource:
+            description: Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+            properties:
+                path:
+                    description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: string
+                readOnly:
+                    description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: boolean
+                server:
+                    description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: string
+            required:
+                - server
+                - path
+            type: object
+        io.k8s.api.core.v1.NodeAffinity:
+            description: Node affinity is a group of node affinity scheduling rules.
+            properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.PreferredSchedulingTerm'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                requiredDuringSchedulingIgnoredDuringExecution:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.NodeSelector'
+            type: object
+        io.k8s.api.core.v1.NodeSelector:
+            description: A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+            properties:
+                nodeSelectorTerms:
+                    description: Required. A list of node selector terms. The terms are ORed.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.NodeSelectorTerm'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            required:
+                - nodeSelectorTerms
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.NodeSelectorRequirement:
+            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+            properties:
+                key:
+                    description: The label key that the selector applies to.
+                    type: string
+                operator:
+                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                    type: string
+                values:
+                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+            required:
+                - key
+                - operator
+            type: object
+        io.k8s.api.core.v1.NodeSelectorTerm:
+            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+            properties:
+                matchExpressions:
+                    description: A list of node selector requirements by node's labels.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.NodeSelectorRequirement'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                matchFields:
+                    description: A list of node selector requirements by node's fields.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.NodeSelectorRequirement'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.ObjectFieldSelector:
+            description: ObjectFieldSelector selects an APIVersioned field of an object.
+            properties:
+                apiVersion:
+                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                    type: string
+                fieldPath:
+                    description: Path of the field to select in the specified API version.
+                    type: string
+            required:
+                - fieldPath
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.ObjectReference:
+            description: ObjectReference contains enough information to let you inspect or modify the referred object.
+            properties:
+                apiVersion:
+                    description: API version of the referent.
+                    type: string
+                fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.'
+                    type: string
+                kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.PersistentVolumeClaim:
+            description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+            properties:
+                apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaimSpec'
+                status:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaimStatus'
+            type: object
+            x-kubernetes-group-version-kind:
+                - group: ""
+                  kind: PersistentVolumeClaim
+                  version: v1
+        io.k8s.api.core.v1.PersistentVolumeClaimCondition:
+            description: PersistentVolumeClaimCondition contains details about state of pvc
+            properties:
+                lastProbeTime:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                lastTransitionTime:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                message:
+                    description: message is the human-readable message indicating details about last transition.
+                    type: string
+                reason:
+                    description: reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "Resizing" that means the underlying persistent volume is being resized.
+                    type: string
+                status:
+                    description: 'Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required'
+                    type: string
+                type:
+                    description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about'
+                    type: string
+            required:
+                - type
+                - status
+            type: object
+        io.k8s.api.core.v1.PersistentVolumeClaimSpec:
+            description: PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+            properties:
+                accessModes:
+                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                dataSource:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.TypedLocalObjectReference'
+                dataSourceRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.TypedObjectReference'
+                resources:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeResourceRequirements'
+                selector:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector'
+                storageClassName:
+                    description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                    type: string
+                volumeAttributesClassName:
+                    description: 'volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string or nil value indicates that no VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state, this field can be reset to its previous value (including nil) to cancel the modification. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/'
+                    type: string
+                volumeMode:
+                    description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                    type: string
+                volumeName:
+                    description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.PersistentVolumeClaimStatus:
+            description: PersistentVolumeClaimStatus is the current status of a persistent volume claim.
+            properties:
+                accessModes:
+                    description: 'accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                allocatedResourceStatuses:
+                    additionalProperties:
+                        type: string
+                    description: |-
+                        allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either:
+                        	* Un-prefixed keys:
+                        		- storage - the capacity of the volume.
+                        	* Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+                        Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.
+
+                        ClaimResourceStatus can be in any of following states:
+                        	- ControllerResizeInProgress:
+                        		State set when resize controller starts resizing the volume in control-plane.
+                        	- ControllerResizeFailed:
+                        		State set when resize has failed in resize controller with a terminal error.
+                        	- NodeResizePending:
+                        		State set when resize controller has finished resizing the volume but further resizing of
+                        		volume is needed on the node.
+                        	- NodeResizeInProgress:
+                        		State set when kubelet starts resizing the volume.
+                        	- NodeResizeFailed:
+                        		State set when resizing has failed in kubelet with a terminal error. Transient errors don't set
+                        		NodeResizeFailed.
+                        For example: if expanding a PVC for more capacity - this field can be one of the following states:
+                        	- pvc.status.allocatedResourceStatus['storage'] = "ControllerResizeInProgress"
+                             - pvc.status.allocatedResourceStatus['storage'] = "ControllerResizeFailed"
+                             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizePending"
+                             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizeInProgress"
+                             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizeFailed"
+                        When this field is not set, it means that no resize operation is in progress for the given PVC.
+
+                        A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.
+                    type: object
+                    x-kubernetes-map-type: granular
+                allocatedResources:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                    description: |-
+                        allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either:
+                        	* Un-prefixed keys:
+                        		- storage - the capacity of the volume.
+                        	* Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+                        Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.
+
+                        Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity.
+
+                        A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.
+                    type: object
+                capacity:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                    description: capacity represents the actual resources of the underlying volume.
+                    type: object
+                conditions:
+                    description: conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'Resizing'.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaimCondition'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - type
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: type
+                    x-kubernetes-patch-strategy: merge
+                currentVolumeAttributesClassName:
+                    description: currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                    type: string
+                modifyVolumeStatus:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ModifyVolumeStatus'
+                phase:
+                    description: phase represents the current phase of PersistentVolumeClaim.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.PersistentVolumeClaimTemplate:
+            description: PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.
+            properties:
+                metadata:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta'
+                spec:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaimSpec'
+            required:
+                - spec
+            type: object
+        io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource:
+            description: PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+            properties:
+                claimName:
+                    description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    type: string
+                readOnly:
+                    description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+                    type: boolean
+            required:
+                - claimName
+            type: object
+        io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource:
+            description: Represents a Photon Controller persistent disk resource.
+            properties:
+                fsType:
+                    description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                pdID:
+                    description: pdID is the ID that identifies Photon Controller persistent disk
+                    type: string
+            required:
+                - pdID
+            type: object
+        io.k8s.api.core.v1.PodAffinity:
+            description: Pod affinity is a group of inter pod affinity scheduling rules.
+            properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.WeightedPodAffinityTerm'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.PodAffinityTerm'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.PodAffinityTerm:
+            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+            properties:
+                labelSelector:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector'
+                matchLabelKeys:
+                    description: MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                mismatchLabelKeys:
+                    description: MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                namespaceSelector:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector'
+                namespaces:
+                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                topologyKey:
+                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                    type: string
+            required:
+                - topologyKey
+            type: object
+        io.k8s.api.core.v1.PodAntiAffinity:
+            description: Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+            properties:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and subtracting "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.WeightedPodAffinityTerm'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                requiredDuringSchedulingIgnoredDuringExecution:
+                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.PodAffinityTerm'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.PodCertificateProjection:
+            description: PodCertificateProjection provides a private key and X.509 certificate in the pod filesystem.
+            properties:
+                certificateChainPath:
+                    description: |-
+                        Write the certificate chain at this path in the projected volume.
+
+                        Most applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.
+                    type: string
+                credentialBundlePath:
+                    description: |-
+                        Write the credential bundle at this path in the projected volume.
+
+                        The credential bundle is a single file that contains multiple PEM blocks. The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private key.
+
+                        The remaining blocks are CERTIFICATE blocks, containing the issued certificate chain from the signer (leaf and any intermediates).
+
+                        Using credentialBundlePath lets your Pod's application code make a single atomic read that retrieves a consistent key and certificate chain.  If you project them to separate files, your application code will need to additionally check that the leaf certificate was issued to the key.
+                    type: string
+                keyPath:
+                    description: |-
+                        Write the key at this path in the projected volume.
+
+                        Most applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.
+                    type: string
+                keyType:
+                    description: |-
+                        The type of keypair Kubelet will generate for the pod.
+
+                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384", "ECDSAP521", and "ED25519".
+                    type: string
+                maxExpirationSeconds:
+                    description: |-
+                        maxExpirationSeconds is the maximum lifetime permitted for the certificate.
+
+                        Kubelet copies this value verbatim into the PodCertificateRequests it generates for this projection.
+
+                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).
+
+                        The signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.
+                    type: integer
+                signerName:
+                    description: Kubelet's generated CSRs will be addressed to this signer.
+                    type: string
+                userAnnotations:
+                    additionalProperties:
+                        type: string
+                    description: |-
+                        userAnnotations allow pod authors to pass additional information to the signer implementation.  Kubernetes does not restrict or validate this metadata in any way.
+
+                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of the PodCertificateRequest objects that Kubelet creates.
+
+                        Entries are subject to the same validation as object metadata annotations, with the addition that all keys must be domain-prefixed. No restrictions are placed on values, except an overall size limitation on the entire field.
+
+                        Signers should document the keys and values they support. Signers should deny requests that contain keys they do not recognize.
+                    type: object
+            required:
+                - signerName
+                - keyType
+            type: object
+        io.k8s.api.core.v1.PodDNSConfig:
+            description: PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
+            properties:
+                nameservers:
+                    description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                options:
+                    description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.PodDNSConfigOption'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                searches:
+                    description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.PodDNSConfigOption:
+            description: PodDNSConfigOption defines DNS resolver options of a pod.
+            properties:
+                name:
+                    description: Name is this DNS resolver option's name. Required.
+                    type: string
+                value:
+                    description: Value is this DNS resolver option's value.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.PodSecurityContext:
+            description: PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
+            properties:
+                appArmorProfile:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.AppArmorProfile'
+                fsGroup:
+                    description: |-
+                        A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                        1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                    type: integer
+                fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.'
+                    type: string
+                runAsGroup:
+                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+                    type: integer
+                runAsNonRoot:
+                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                runAsUser:
+                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+                    type: integer
+                seLinuxChangePolicy:
+                    description: |-
+                        seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod. It has no effect on nodes that do not support SELinux or to volumes does not support SELinux. Valid values are "MountOption" and "Recursive".
+
+                        "Recursive" means relabeling of all files on all Pod volumes by the container runtime. This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                        "MountOption" mounts all eligible Pod volumes with `-o context` mount option. This requires all Pods that share the same volume to use the same SELinux label. It is not possible to share the same volume among privileged and unprivileged Pods. Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their CSIDriver instance. Other volumes are always re-labelled recursively. "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                        If not specified and SELinuxMount feature gate is enabled, "MountOption" is used. If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes and "Recursive" for all other volumes.
+
+                        This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                        All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state. Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                seLinuxOptions:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SELinuxOptions'
+                seccompProfile:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SeccompProfile'
+                supplementalGroups:
+                    description: A list of groups applied to the first process run in each container, in addition to the container's primary GID and fsGroup (if specified).  If the SupplementalGroupsPolicy feature is enabled, the supplementalGroupsPolicy field determines whether these are in addition to or instead of any group memberships defined in the container image. If unspecified, no additional groups are added, though group memberships defined in the container image may still be used, depending on the supplementalGroupsPolicy field. Note that this field cannot be set when spec.os.name is windows.
+                    items:
+                        format: int64
+                        type: integer
+                    type: array
+                    x-kubernetes-list-type: atomic
+                supplementalGroupsPolicy:
+                    description: Defines how supplemental groups of the first container processes are calculated. Valid values are "Merge" and "Strict". If not specified, "Merge" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.Sysctl'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                windowsOptions:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.WindowsSecurityContextOptions'
+            type: object
+        io.k8s.api.core.v1.PortworxVolumeSource:
+            description: PortworxVolumeSource represents a Portworx volume resource.
+            properties:
+                fsType:
+                    description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                volumeID:
+                    description: volumeID uniquely identifies a Portworx volume
+                    type: string
+            required:
+                - volumeID
+            type: object
+        io.k8s.api.core.v1.PreferredSchedulingTerm:
+            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+            properties:
+                preference:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.NodeSelectorTerm'
+                weight:
+                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                    type: integer
+            required:
+                - weight
+                - preference
+            type: object
+        io.k8s.api.core.v1.Probe:
+            description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+            properties:
+                exec:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ExecAction'
+                failureThreshold:
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                    type: integer
+                grpc:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.GRPCAction'
+                httpGet:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.HTTPGetAction'
+                initialDelaySeconds:
+                    description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    type: integer
+                periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                    type: integer
+                successThreshold:
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    type: integer
+                tcpSocket:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.TCPSocketAction'
+                terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    type: integer
+                timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    type: integer
+            type: object
+        io.k8s.api.core.v1.ProjectedVolumeSource:
+            description: Represents a projected volume source
+            properties:
+                defaultMode:
+                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                    type: integer
+                sources:
+                    description: sources is the list of volume projections. Each entry in this list handles one source.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.VolumeProjection'
+                    type: array
+                    x-kubernetes-list-type: atomic
+            type: object
+        io.k8s.api.core.v1.QuobyteVolumeSource:
+            description: Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+            properties:
+                group:
+                    description: group to map volume access to Default is no group
+                    type: string
+                readOnly:
+                    description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                    type: boolean
+                registry:
+                    description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                    type: string
+                tenant:
+                    description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                    type: string
+                user:
+                    description: user to map volume access to Defaults to serivceaccount user
+                    type: string
+                volume:
+                    description: volume is a string that references an already created Quobyte volume by name.
+                    type: string
+            required:
+                - registry
+                - volume
+            type: object
+        io.k8s.api.core.v1.RBDVolumeSource:
+            description: Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+            properties:
+                fsType:
+                    description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                    type: string
+                image:
+                    description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                keyring:
+                    description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                monitors:
+                    description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                pool:
+                    description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                readOnly:
+                    description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: boolean
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                user:
+                    description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+            required:
+                - monitors
+                - image
+            type: object
+        io.k8s.api.core.v1.ResourceClaim:
+            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+            properties:
+                name:
+                    description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                    type: string
+                request:
+                    description: Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.
+                    type: string
+            required:
+                - name
+            type: object
+        io.k8s.api.core.v1.ResourceFieldSelector:
+            description: ResourceFieldSelector represents container resources (cpu, memory) and their output format
+            properties:
+                containerName:
+                    description: 'Container name: required for volumes, optional for env vars'
+                    type: string
+                divisor:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                resource:
+                    description: 'Required: resource to select'
+                    type: string
+            required:
+                - resource
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.ResourceRequirements:
+            description: ResourceRequirements describes the compute resource requirements.
+            properties:
+                claims:
+                    description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+                        This field depends on the DynamicResourceAllocation feature gate.
+
+                        This field is immutable. It can only be set for containers.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.ResourceClaim'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - name
+                    x-kubernetes-list-type: map
+                limits:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                requests:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+            type: object
+        io.k8s.api.core.v1.SELinuxOptions:
+            description: SELinuxOptions are the labels to be applied to the container
+            properties:
+                level:
+                    description: Level is SELinux level label that applies to the container.
+                    type: string
+                role:
+                    description: Role is a SELinux role label that applies to the container.
+                    type: string
+                type:
+                    description: Type is a SELinux type label that applies to the container.
+                    type: string
+                user:
+                    description: User is a SELinux user label that applies to the container.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.ScaleIOVolumeSource:
+            description: ScaleIOVolumeSource represents a persistent ScaleIO volume
+            properties:
+                fsType:
+                    description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                    type: string
+                gateway:
+                    description: gateway is the host address of the ScaleIO API Gateway.
+                    type: string
+                protectionDomain:
+                    description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                    type: string
+                readOnly:
+                    description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                sslEnabled:
+                    description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                    type: boolean
+                storageMode:
+                    description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                    type: string
+                storagePool:
+                    description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                    type: string
+                system:
+                    description: system is the name of the storage system as configured in ScaleIO.
+                    type: string
+                volumeName:
+                    description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+                    type: string
+            required:
+                - gateway
+                - system
+                - secretRef
+            type: object
+        io.k8s.api.core.v1.SeccompProfile:
+            description: SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.
+            properties:
+                localhostProfile:
+                    description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.
+                    type: string
+                type:
+                    description: |-
+                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                    type: string
+            required:
+                - type
+            type: object
+            x-kubernetes-unions:
+                - discriminator: type
+                  fields-to-discriminateBy:
+                    localhostProfile: LocalhostProfile
+        io.k8s.api.core.v1.SecretEnvSource:
+            description: |-
+                SecretEnvSource selects a Secret to populate the environment variables with.
+
+                The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+            properties:
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: Specify whether the Secret must be defined
+                    type: boolean
+            type: object
+        io.k8s.api.core.v1.SecretKeySelector:
+            description: SecretKeySelector selects a key of a Secret.
+            properties:
+                key:
+                    description: The key of the secret to select from.  Must be a valid secret key.
+                    type: string
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+            required:
+                - key
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.SecretProjection:
+            description: |-
+                Adapts a secret into a projected volume.
+
+                The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+            properties:
+                items:
+                    description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.KeyToPath'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                name:
+                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                optional:
+                    description: optional field specify whether the Secret or its key must be defined
+                    type: boolean
+            type: object
+        io.k8s.api.core.v1.SecretVolumeSource:
+            description: |-
+                Adapts a Secret into a volume.
+
+                The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+            properties:
+                defaultMode:
+                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                    type: integer
+                items:
+                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.api.core.v1.KeyToPath'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                optional:
+                    description: optional field specify whether the Secret or its keys must be defined
+                    type: boolean
+                secretName:
+                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    type: string
+            type: object
+        io.k8s.api.core.v1.SecurityContext:
+            description: SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.
+            properties:
+                allowPrivilegeEscalation:
+                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                    type: boolean
+                appArmorProfile:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.AppArmorProfile'
+                capabilities:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.Capabilities'
+                privileged:
+                    description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                procMount:
+                    description: procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                readOnlyRootFilesystem:
+                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                    type: boolean
+                runAsGroup:
+                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                    type: integer
+                runAsNonRoot:
+                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                runAsUser:
+                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                    type: integer
+                seLinuxOptions:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SELinuxOptions'
+                seccompProfile:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SeccompProfile'
+                windowsOptions:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.WindowsSecurityContextOptions'
+            type: object
+        io.k8s.api.core.v1.ServiceAccountTokenProjection:
+            description: ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+            properties:
+                audience:
+                    description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                    type: string
+                expirationSeconds:
+                    description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                    type: integer
+                path:
+                    description: path is the path relative to the mount point of the file to project the token into.
+                    type: string
+            required:
+                - path
+            type: object
+        io.k8s.api.core.v1.ServicePort:
+            description: ServicePort contains information on service's port.
+            properties:
+                appProtocol:
+                    description: |-
+                        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+                        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                        * Kubernetes-defined prefixed names:
+                          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+                    type: string
+                name:
+                    description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                    type: string
+                nodePort:
+                    description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                    type: integer
+                port:
+                    description: The port that will be exposed by this service.
+                    type: integer
+                protocol:
+                    description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                    type: string
+                targetPort:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+            required:
+                - port
+            type: object
+        io.k8s.api.core.v1.SleepAction:
+            description: SleepAction describes a "sleep" action.
+            properties:
+                seconds:
+                    description: Seconds is the number of seconds to sleep.
+                    type: integer
+            required:
+                - seconds
+            type: object
+        io.k8s.api.core.v1.StorageOSVolumeSource:
+            description: Represents a StorageOS persistent volume resource.
+            properties:
+                fsType:
+                    description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                secretRef:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.LocalObjectReference'
+                volumeName:
+                    description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                    type: string
+                volumeNamespace:
+                    description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.Sysctl:
+            description: Sysctl defines a kernel parameter to be set
+            properties:
+                name:
+                    description: Name of a property to set
+                    type: string
+                value:
+                    description: Value of a property to set
+                    type: string
+            required:
+                - name
+                - value
+            type: object
+        io.k8s.api.core.v1.TCPSocketAction:
+            description: TCPSocketAction describes an action based on opening a socket
+            properties:
+                host:
+                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                    type: string
+                port:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+            required:
+                - port
+            type: object
+        io.k8s.api.core.v1.Toleration:
+            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+            properties:
+                effect:
+                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                key:
+                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                    type: string
+                operator:
+                    description: Operator represents a key's relationship to the value. Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category. Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                    type: string
+                tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                    type: integer
+                value:
+                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                    type: string
+            type: object
+        io.k8s.api.core.v1.TypedLocalObjectReference:
+            description: TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+            properties:
+                apiGroup:
+                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                    type: string
+                kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                name:
+                    description: Name is the name of resource being referenced
+                    type: string
+            required:
+                - kind
+                - name
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.api.core.v1.TypedObjectReference:
+            description: TypedObjectReference contains enough information to let you locate the typed referenced object
+            properties:
+                apiGroup:
+                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                    type: string
+                kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                namespace:
+                    description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                    type: string
+            required:
+                - kind
+                - name
+            type: object
+        io.k8s.api.core.v1.Volume:
+            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+            properties:
+                awsElasticBlockStore:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource'
+                azureDisk:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.AzureDiskVolumeSource'
+                azureFile:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.AzureFileVolumeSource'
+                cephfs:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.CephFSVolumeSource'
+                cinder:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.CinderVolumeSource'
+                configMap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapVolumeSource'
+                csi:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.CSIVolumeSource'
+                downwardAPI:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.DownwardAPIVolumeSource'
+                emptyDir:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.EmptyDirVolumeSource'
+                ephemeral:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.EphemeralVolumeSource'
+                fc:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.FCVolumeSource'
+                flexVolume:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.FlexVolumeSource'
+                flocker:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.FlockerVolumeSource'
+                gcePersistentDisk:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource'
+                gitRepo:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.GitRepoVolumeSource'
+                glusterfs:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.GlusterfsVolumeSource'
+                hostPath:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.HostPathVolumeSource'
+                image:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ImageVolumeSource'
+                iscsi:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ISCSIVolumeSource'
+                name:
+                    description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                nfs:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.NFSVolumeSource'
+                persistentVolumeClaim:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource'
+                photonPersistentDisk:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource'
+                portworxVolume:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PortworxVolumeSource'
+                projected:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ProjectedVolumeSource'
+                quobyte:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.QuobyteVolumeSource'
+                rbd:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.RBDVolumeSource'
+                scaleIO:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ScaleIOVolumeSource'
+                secret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretVolumeSource'
+                storageos:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.StorageOSVolumeSource'
+                vsphereVolume:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource'
+            required:
+                - name
+            type: object
+        io.k8s.api.core.v1.VolumeDevice:
+            description: volumeDevice describes a mapping of a raw block device within a container.
+            properties:
+                devicePath:
+                    description: devicePath is the path inside of the container that the device will be mapped to.
+                    type: string
+                name:
+                    description: name must match the name of a persistentVolumeClaim in the pod
+                    type: string
+            required:
+                - name
+                - devicePath
+            type: object
+        io.k8s.api.core.v1.VolumeMount:
+            description: VolumeMount describes a mounting of a Volume within a container.
+            properties:
+                mountPath:
+                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                    type: string
+                mountPropagation:
+                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+                    type: string
+                name:
+                    description: This must match the Name of a Volume.
+                    type: string
+                readOnly:
+                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                    type: boolean
+                recursiveReadOnly:
+                    description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled recursively.
+
+                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                        If ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.
+
+                        If this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).
+
+                        If this field is not specified, it is treated as an equivalent of Disabled.
+                    type: string
+                subPath:
+                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                    type: string
+                subPathExpr:
+                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                    type: string
+            required:
+                - name
+                - mountPath
+            type: object
+        io.k8s.api.core.v1.VolumeProjection:
+            description: Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.
+            properties:
+                clusterTrustBundle:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ClusterTrustBundleProjection'
+                configMap:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ConfigMapProjection'
+                downwardAPI:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.DownwardAPIProjection'
+                podCertificate:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodCertificateProjection'
+                secret:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.SecretProjection'
+                serviceAccountToken:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.ServiceAccountTokenProjection'
+            type: object
+        io.k8s.api.core.v1.VolumeResourceRequirements:
+            description: VolumeResourceRequirements describes the storage resource requirements for a volume.
+            properties:
+                limits:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                requests:
+                    additionalProperties:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.api.resource.Quantity'
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+            type: object
+        io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource:
+            description: Represents a vSphere volume resource.
+            properties:
+                fsType:
+                    description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                storagePolicyID:
+                    description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                    type: string
+                storagePolicyName:
+                    description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                    type: string
+                volumePath:
+                    description: volumePath is the path that identifies vSphere volume vmdk
+                    type: string
+            required:
+                - volumePath
+            type: object
+        io.k8s.api.core.v1.WeightedPodAffinityTerm:
+            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+            properties:
+                podAffinityTerm:
+                    $ref: '#/components/schemas/io.k8s.api.core.v1.PodAffinityTerm'
+                weight:
+                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                    type: integer
+            required:
+                - weight
+                - podAffinityTerm
+            type: object
+        io.k8s.api.core.v1.WindowsSecurityContextOptions:
+            description: WindowsSecurityContextOptions contain Windows-specific options and credentials.
+            properties:
+                gmsaCredentialSpec:
+                    description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                    type: string
+                gmsaCredentialSpecName:
+                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                    type: string
+                hostProcess:
+                    description: HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.
+                    type: boolean
+                runAsUserName:
+                    description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: string
+            type: object
+        io.k8s.api.policy.v1.PodDisruptionBudgetSpec:
+            description: PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
+            properties:
+                maxUnavailable:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                minAvailable:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.util.intstr.IntOrString'
+                selector:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector'
+                unhealthyPodEvictionPolicy:
+                    description: |-
+                        UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods should be considered for eviction. Current implementation considers healthy pods, as pods that have status.conditions item with type="Ready",status="True".
+
+                        Valid policies are IfHealthyBudget and AlwaysAllow. If no policy is specified, the default behavior will be used, which corresponds to the IfHealthyBudget policy.
+
+                        IfHealthyBudget policy means that running pods (status.phase="Running"), but not yet healthy can be evicted only if the guarded application is not disrupted (status.currentHealthy is at least equal to status.desiredHealthy). Healthy pods will be subject to the PDB for eviction.
+
+                        AlwaysAllow policy means that all running pods (status.phase="Running"), but not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB is met. This means perspective running pods of a disrupted application might not get a chance to become healthy. Healthy pods will be subject to the PDB for eviction.
+
+                        Additional policies may be added in the future. Clients making eviction decisions should disallow eviction of unhealthy pods if they encounter an unrecognized policy in this field.
+                    type: string
+            type: object
+        io.k8s.apimachinery.pkg.api.resource.Quantity:
+            description: |-
+                Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                The serialization format is:
+
+                ``` <quantity>        ::= <signedNumber><suffix>
+
+                	(Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+
+                <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+
+                	(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+
+                <decimalSI>       ::= m | "" | k | M | G | T | P | E
+
+                	(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+
+                <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber> ```
+
+                No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+
+                - No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.
+
+                The sign will be omitted unless the number is negative.
+
+                Examples:
+
+                - 1.5 will be serialized as "1500m" - 1.5Gi will be serialized as "1536Mi"
+
+                Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+            type: string
+        io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions:
+            description: CreateOptions may be provided when creating an API object.
+            properties:
+                dryRun:
+                    items:
+                        type: string
+                    title: |-
+                        When present, indicates that modifications should not be
+                        persisted. An invalid or unrecognized dryRun directive will
+                        result in an error response and no further processing of the
+                        request. Valid values are:
+                        - All: all dry run stages will be processed
+                        +optional
+                        +listType=atomic
+                    type: array
+                fieldManager:
+                    title: |-
+                        fieldManager is a name associated with the actor or entity
+                        that is making these changes. The value must be less than or
+                        128 characters long, and only contain printable characters,
+                        as defined by https://golang.org/pkg/unicode/#IsPrint.
+                        +optional
+                    type: string
+                fieldValidation:
+                    title: |-
+                        fieldValidation instructs the server on how to handle
+                        objects in the request (POST/PUT/PATCH) containing unknown
+                        or duplicate fields. Valid values are:
+                        - Ignore: This will ignore any unknown fields that are silently
+                        dropped from the object, and will ignore all but the last duplicate
+                        field that the decoder encounters. This is the default behavior
+                        prior to v1.23.
+                        - Warn: This will send a warning via the standard warning response
+                        header for each unknown field that is dropped from the object, and
+                        for each duplicate field that is encountered. The request will
+                        still succeed if there are no other errors, and will only persist
+                        the last of any duplicate fields. This is the default in v1.23+
+                        - Strict: This will fail the request with a BadRequest error if
+                        any unknown fields would be dropped from the object, or if any
+                        duplicate fields are present. The error returned from the server
+                        will contain all unknown and duplicate fields encountered.
+                        +optional
+                    type: string
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1:
+            description: |-
+                FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
+
+                Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
+
+                The exact format is defined in sigs.k8s.io/structured-merge-diff
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionResource:
+            description: +protobuf.options.(gogoproto.goproto_stringer)=false
+            properties:
+                group:
+                    type: string
+                resource:
+                    type: string
+                version:
+                    type: string
+            title: |-
+                GroupVersionResource unambiguously identifies a resource.  It doesn't anonymously include GroupVersion
+                to avoid automatic coercion.  It doesn't use a GroupVersion to avoid custom marshalling
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector:
+            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+            properties:
+                matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                matchLabels:
+                    additionalProperties:
+                        type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement:
+            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+            properties:
+                key:
+                    description: key is the label key that the selector applies to.
+                    type: string
+                operator:
+                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                    type: string
+                values:
+                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+            required:
+                - key
+                - operator
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta:
+            description: ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+            properties:
+                continue:
+                    description: continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+                    type: string
+                remainingItemCount:
+                    description: remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+                    type: integer
+                resourceVersion:
+                    description: 'String that identifies the server''s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                selfLink:
+                    description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
+                    type: string
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry:
+            description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+            properties:
+                apiVersion:
+                    description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                    type: string
+                fieldsType:
+                    description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                    type: string
+                fieldsV1:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1'
+                manager:
+                    description: Manager is an identifier of the workflow managing these fields.
+                    type: string
+                operation:
+                    description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                    type: string
+                subresource:
+                    description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+                    type: string
+                time:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime:
+            description: MicroTime is version of Time with microsecond level precision.
+            format: date-time
+            type: string
+        io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta:
+            description: ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+            properties:
+                annotations:
+                    additionalProperties:
+                        type: string
+                    description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+                    type: object
+                creationTimestamp:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                deletionGracePeriodSeconds:
+                    description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                    type: integer
+                deletionTimestamp:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                finalizers:
+                    description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                    items:
+                        type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                    x-kubernetes-patch-strategy: merge
+                generateName:
+                    description: |-
+                        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                        If this field is specified and the generated name exists, the server will return a 409.
+
+                        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                    type: string
+                generation:
+                    description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                    type: integer
+                labels:
+                    additionalProperties:
+                        type: string
+                    description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+                    type: object
+                managedFields:
+                    description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry'
+                    type: array
+                    x-kubernetes-list-type: atomic
+                name:
+                    description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+                    type: string
+                namespace:
+                    description: |-
+                        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                        Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
+                    type: string
+                ownerReferences:
+                    description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                    items:
+                        $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                        - uid
+                    x-kubernetes-list-type: map
+                    x-kubernetes-patch-merge-key: uid
+                    x-kubernetes-patch-strategy: merge
+                resourceVersion:
+                    description: |-
+                        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                selfLink:
+                    description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
+                    type: string
+                uid:
+                    description: |-
+                        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                        Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                    type: string
+            type: object
+        io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference:
+            description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+            properties:
+                apiVersion:
+                    description: API version of the referent.
+                    type: string
+                blockOwnerDeletion:
+                    description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                    type: boolean
+                controller:
+                    description: If true, this reference points to the managing controller.
+                    type: boolean
+                kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+                    type: string
+                uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids'
+                    type: string
+            required:
+                - apiVersion
+                - kind
+                - name
+                - uid
+            type: object
+            x-kubernetes-map-type: atomic
+        io.k8s.apimachinery.pkg.apis.meta.v1.Time:
+            description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+            format: date-time
+            type: string
+        io.k8s.apimachinery.pkg.util.intstr.IntOrString:
+            type: string
+        sensor.CreateSensorRequest:
+            properties:
+                createOptions:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.CreateOptions'
+                namespace:
+                    type: string
+                sensor:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+            type: object
+        sensor.DeleteSensorResponse:
+            type: object
+        sensor.LogEntry:
+            properties:
+                dependencyName:
+                    title: optional - trigger dependency name
+                    type: string
+                eventContext:
+                    title: optional - Cloud Event context
+                    type: string
+                level:
+                    type: string
+                msg:
+                    type: string
+                namespace:
+                    type: string
+                sensorName:
+                    type: string
+                time:
+                    $ref: '#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time'
+                triggerName:
+                    title: optional - any trigger name
+                    type: string
+            title: structured log entry
+            type: object
+        sensor.SensorWatchEvent:
+            properties:
+                object:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+                type:
+                    type: string
+            type: object
+        sensor.UpdateSensorRequest:
+            properties:
+                name:
+                    type: string
+                namespace:
+                    type: string
+                sensor:
+                    $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+            type: object
+        sync.CreateSyncLimitRequest:
+            properties:
+                cmName:
+                    type: string
+                key:
+                    type: string
+                limit:
+                    type: integer
+                namespace:
+                    type: string
+                type:
+                    $ref: '#/components/schemas/sync.SyncConfigType'
+            type: object
+        sync.DeleteSyncLimitResponse:
+            type: object
+        sync.SyncConfigType:
+            default: CONFIGMAP
+            enum:
+                - CONFIGMAP
+                - DATABASE
+            type: string
+        sync.SyncLimitResponse:
+            properties:
+                cmName:
+                    type: string
+                key:
+                    type: string
+                limit:
+                    type: integer
+                namespace:
+                    type: string
+                type:
+                    $ref: '#/components/schemas/sync.SyncConfigType'
+            type: object
+        sync.UpdateSyncLimitRequest:
+            properties:
+                cmName:
+                    type: string
+                key:
+                    type: string
+                limit:
+                    type: integer
+                namespace:
+                    type: string
+                type:
+                    $ref: '#/components/schemas/sync.SyncConfigType'
+            type: object
+    securitySchemes:
+        BearerToken:
+            description: Bearer Token authentication
+            in: header
+            name: Authorization
+            type: apiKey
+info:
+    description: Argo Workflows is an open source container-native workflow engine for orchestrating parallel jobs on Kubernetes. For more information, please see https://argo-workflows.readthedocs.io/en/latest/
+    title: Argo Workflows API
+    version: VERSION
+openapi: 3.0.3
+paths:
+    /api/v1/archived-workflows:
+        get:
+            operationId: ArchivedWorkflowService_ListArchivedWorkflows
+            parameters:
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+                - in: query
+                  name: namePrefix
+                  schema:
+                    type: string
+                - in: query
+                  name: namespace
+                  schema:
+                    type: string
+                - description: Filter type used for name filtering. Exact | Contains | Prefix. Default to Exact.
+                  in: query
+                  name: nameFilter
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+    /api/v1/archived-workflows-label-keys:
+        get:
+            operationId: ArchivedWorkflowService_ListArchivedWorkflowLabelKeys
+            parameters:
+                - in: query
+                  name: namespace
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LabelKeys'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+    /api/v1/archived-workflows-label-values:
+        get:
+            operationId: ArchivedWorkflowService_ListArchivedWorkflowLabelValues
+            parameters:
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+                - in: query
+                  name: namespace
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LabelValues'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+    /api/v1/archived-workflows/{uid}:
+        delete:
+            operationId: ArchivedWorkflowService_DeleteArchivedWorkflow
+            parameters:
+                - in: path
+                  name: uid
+                  required: true
+                  schema:
+                    type: string
+                - in: query
+                  name: namespace
+                  schema:
+                    type: string
+                - in: query
+                  name: name
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ArchivedWorkflowDeletedResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+        get:
+            operationId: ArchivedWorkflowService_GetArchivedWorkflow
+            parameters:
+                - in: path
+                  name: uid
+                  required: true
+                  schema:
+                    type: string
+                - in: query
+                  name: namespace
+                  schema:
+                    type: string
+                - in: query
+                  name: name
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+    /api/v1/archived-workflows/{uid}/resubmit:
+        put:
+            operationId: ArchivedWorkflowService_ResubmitArchivedWorkflow
+            parameters:
+                - in: path
+                  name: uid
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ResubmitArchivedWorkflowRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+    /api/v1/archived-workflows/{uid}/retry:
+        put:
+            operationId: ArchivedWorkflowService_RetryArchivedWorkflow
+            parameters:
+                - in: path
+                  name: uid
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.RetryArchivedWorkflowRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ArchivedWorkflowService
+    /api/v1/cluster-workflow-templates:
+        get:
+            operationId: ClusterWorkflowTemplateService_ListClusterWorkflowTemplates
+            parameters:
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ClusterWorkflowTemplateService
+        post:
+            operationId: ClusterWorkflowTemplateService_CreateClusterWorkflowTemplate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateCreateRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ClusterWorkflowTemplateService
+    /api/v1/cluster-workflow-templates/{name}:
+        delete:
+            operationId: ClusterWorkflowTemplateService_DeleteClusterWorkflowTemplate
+            parameters:
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The duration in seconds before the object should be deleted. Value must be non-negative integer.
+                    The value zero indicates delete immediately. If this value is nil, the default grace period for the
+                    specified type will be used.
+                    Defaults to a per object value if not specified. zero means delete immediately.
+                    +optional.
+                  in: query
+                  name: deleteOptions.gracePeriodSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Specifies the target UID.
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.uid
+                  schema:
+                    type: string
+                - description: |-
+                    Specifies the target ResourceVersion
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7.
+                    Should the dependent objects be orphaned. If true/false, the "orphan"
+                    finalizer will be added to/removed from the object's finalizers list.
+                    Either this field or PropagationPolicy may be set, but not both.
+                    +optional.
+                  in: query
+                  name: deleteOptions.orphanDependents
+                  schema:
+                    type: boolean
+                - description: |-
+                    Whether and how garbage collection will be performed.
+                    Either this field or OrphanDependents may be set, but not both.
+                    The default policy is decided by the existing finalizer set in the
+                    metadata.finalizers and the resource-specific default policy.
+                    Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+                    allow the garbage collector to delete the dependents in the background;
+                    'Foreground' - a cascading policy that deletes all dependents in the
+                    foreground.
+                    +optional.
+                  in: query
+                  name: deleteOptions.propagationPolicy
+                  schema:
+                    type: string
+                - description: |-
+                    When present, indicates that modifications should not be
+                    persisted. An invalid or unrecognized dryRun directive will
+                    result in an error response and no further processing of the
+                    request. Valid values are:
+                    - All: all dry run stages will be processed
+                    +optional
+                    +listType=atomic.
+                  in: query
+                  name: deleteOptions.dryRun
+                  schema:
+                    items:
+                        type: string
+                    type: array
+                - description: |-
+                    if set to true, it will trigger an unsafe deletion of the resource in
+                    case the normal deletion flow fails with a corrupt object error.
+                    A resource is considered corrupt if it can not be retrieved from
+                    the underlying storage successfully because of a) its data can
+                    not be transformed e.g. decryption failure, or b) it fails
+                    to decode into an object.
+                    NOTE: unsafe deletion ignores finalizer constraints, skips
+                    precondition checks, and removes the object from the storage.
+                    WARNING: This may potentially break the cluster if the workload
+                    associated with the resource being unsafe-deleted relies on normal
+                    deletion flow. Use only if you REALLY know what you are doing.
+                    The default value is false, and the user must opt in to enable it
+                    +optional.
+                  in: query
+                  name: deleteOptions.ignoreStoreReadErrorWithClusterBreakingPotential
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateDeleteResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ClusterWorkflowTemplateService
+        get:
+            operationId: ClusterWorkflowTemplateService_GetClusterWorkflowTemplate
+            parameters:
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: getOptions.resourceVersion
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ClusterWorkflowTemplateService
+        put:
+            operationId: ClusterWorkflowTemplateService_UpdateClusterWorkflowTemplate
+            parameters:
+                - description: 'DEPRECATED: This field is ignored.'
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateUpdateRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ClusterWorkflowTemplateService
+    /api/v1/cluster-workflow-templates/lint:
+        post:
+            operationId: ClusterWorkflowTemplateService_LintClusterWorkflowTemplate
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplateLintRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.ClusterWorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - ClusterWorkflowTemplateService
+    /api/v1/cron-workflows/{namespace}:
+        get:
+            operationId: CronWorkflowService_ListCronWorkflows
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflowList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+        post:
+            operationId: CronWorkflowService_CreateCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CreateCronWorkflowRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+    /api/v1/cron-workflows/{namespace}/{name}:
+        delete:
+            operationId: CronWorkflowService_DeleteCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The duration in seconds before the object should be deleted. Value must be non-negative integer.
+                    The value zero indicates delete immediately. If this value is nil, the default grace period for the
+                    specified type will be used.
+                    Defaults to a per object value if not specified. zero means delete immediately.
+                    +optional.
+                  in: query
+                  name: deleteOptions.gracePeriodSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Specifies the target UID.
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.uid
+                  schema:
+                    type: string
+                - description: |-
+                    Specifies the target ResourceVersion
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7.
+                    Should the dependent objects be orphaned. If true/false, the "orphan"
+                    finalizer will be added to/removed from the object's finalizers list.
+                    Either this field or PropagationPolicy may be set, but not both.
+                    +optional.
+                  in: query
+                  name: deleteOptions.orphanDependents
+                  schema:
+                    type: boolean
+                - description: |-
+                    Whether and how garbage collection will be performed.
+                    Either this field or OrphanDependents may be set, but not both.
+                    The default policy is decided by the existing finalizer set in the
+                    metadata.finalizers and the resource-specific default policy.
+                    Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+                    allow the garbage collector to delete the dependents in the background;
+                    'Foreground' - a cascading policy that deletes all dependents in the
+                    foreground.
+                    +optional.
+                  in: query
+                  name: deleteOptions.propagationPolicy
+                  schema:
+                    type: string
+                - description: |-
+                    When present, indicates that modifications should not be
+                    persisted. An invalid or unrecognized dryRun directive will
+                    result in an error response and no further processing of the
+                    request. Valid values are:
+                    - All: all dry run stages will be processed
+                    +optional
+                    +listType=atomic.
+                  in: query
+                  name: deleteOptions.dryRun
+                  schema:
+                    items:
+                        type: string
+                    type: array
+                - description: |-
+                    if set to true, it will trigger an unsafe deletion of the resource in
+                    case the normal deletion flow fails with a corrupt object error.
+                    A resource is considered corrupt if it can not be retrieved from
+                    the underlying storage successfully because of a) its data can
+                    not be transformed e.g. decryption failure, or b) it fails
+                    to decode into an object.
+                    NOTE: unsafe deletion ignores finalizer constraints, skips
+                    precondition checks, and removes the object from the storage.
+                    WARNING: This may potentially break the cluster if the workload
+                    associated with the resource being unsafe-deleted relies on normal
+                    deletion flow. Use only if you REALLY know what you are doing.
+                    The default value is false, and the user must opt in to enable it
+                    +optional.
+                  in: query
+                  name: deleteOptions.ignoreStoreReadErrorWithClusterBreakingPotential
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflowDeletedResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+        get:
+            operationId: CronWorkflowService_GetCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: getOptions.resourceVersion
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+        put:
+            operationId: CronWorkflowService_UpdateCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: 'DEPRECATED: This field is ignored.'
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.UpdateCronWorkflowRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+    /api/v1/cron-workflows/{namespace}/{name}/resume:
+        put:
+            operationId: CronWorkflowService_ResumeCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflowResumeRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+    /api/v1/cron-workflows/{namespace}/{name}/suspend:
+        put:
+            operationId: CronWorkflowService_SuspendCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflowSuspendRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+    /api/v1/cron-workflows/{namespace}/lint:
+        post:
+            operationId: CronWorkflowService_LintCronWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LintCronWorkflowRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CronWorkflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - CronWorkflowService
+    /api/v1/event-sources/{namespace}:
+        get:
+            operationId: EventSourceService_ListEventSources
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSourceList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+        post:
+            operationId: EventSourceService_CreateEventSource
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/eventsource.CreateEventSourceRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+    /api/v1/event-sources/{namespace}/{name}:
+        delete:
+            operationId: EventSourceService_DeleteEventSource
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The duration in seconds before the object should be deleted. Value must be non-negative integer.
+                    The value zero indicates delete immediately. If this value is nil, the default grace period for the
+                    specified type will be used.
+                    Defaults to a per object value if not specified. zero means delete immediately.
+                    +optional.
+                  in: query
+                  name: deleteOptions.gracePeriodSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Specifies the target UID.
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.uid
+                  schema:
+                    type: string
+                - description: |-
+                    Specifies the target ResourceVersion
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7.
+                    Should the dependent objects be orphaned. If true/false, the "orphan"
+                    finalizer will be added to/removed from the object's finalizers list.
+                    Either this field or PropagationPolicy may be set, but not both.
+                    +optional.
+                  in: query
+                  name: deleteOptions.orphanDependents
+                  schema:
+                    type: boolean
+                - description: |-
+                    Whether and how garbage collection will be performed.
+                    Either this field or OrphanDependents may be set, but not both.
+                    The default policy is decided by the existing finalizer set in the
+                    metadata.finalizers and the resource-specific default policy.
+                    Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+                    allow the garbage collector to delete the dependents in the background;
+                    'Foreground' - a cascading policy that deletes all dependents in the
+                    foreground.
+                    +optional.
+                  in: query
+                  name: deleteOptions.propagationPolicy
+                  schema:
+                    type: string
+                - description: |-
+                    When present, indicates that modifications should not be
+                    persisted. An invalid or unrecognized dryRun directive will
+                    result in an error response and no further processing of the
+                    request. Valid values are:
+                    - All: all dry run stages will be processed
+                    +optional
+                    +listType=atomic.
+                  in: query
+                  name: deleteOptions.dryRun
+                  schema:
+                    items:
+                        type: string
+                    type: array
+                - description: |-
+                    if set to true, it will trigger an unsafe deletion of the resource in
+                    case the normal deletion flow fails with a corrupt object error.
+                    A resource is considered corrupt if it can not be retrieved from
+                    the underlying storage successfully because of a) its data can
+                    not be transformed e.g. decryption failure, or b) it fails
+                    to decode into an object.
+                    NOTE: unsafe deletion ignores finalizer constraints, skips
+                    precondition checks, and removes the object from the storage.
+                    WARNING: This may potentially break the cluster if the workload
+                    associated with the resource being unsafe-deleted relies on normal
+                    deletion flow. Use only if you REALLY know what you are doing.
+                    The default value is false, and the user must opt in to enable it
+                    +optional.
+                  in: query
+                  name: deleteOptions.ignoreStoreReadErrorWithClusterBreakingPotential
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/eventsource.EventSourceDeletedResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+        get:
+            operationId: EventSourceService_GetEventSource
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+        put:
+            operationId: EventSourceService_UpdateEventSource
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/eventsource.UpdateEventSourceRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.EventSource'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+    /api/v1/events/{namespace}/{discriminator}:
+        post:
+            operationId: EventService_ReceiveEvent
+            parameters:
+                - description: |-
+                    The namespace for the io.argoproj.workflow.v1alpha1. This can be empty if the client has cluster scoped permissions.
+                    If empty, then the event is "broadcast" to workflow event binding in all namespaces.
+                  in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    Optional discriminator for the io.argoproj.workflow.v1alpha1. This should almost always be empty.
+                    Used for edge-cases where the event payload alone is not provide enough information to discriminate the event.
+                    This MUST NOT be used as security mechanism, e.g. to allow two clients to use the same access token, or
+                    to support webhooks on unsecured server. Instead, use access tokens.
+                    This is made available as `discriminator` in the event binding selector (`/spec/event/selector)`
+                  in: path
+                  name: discriminator
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Item'
+                description: The event itself can be any data.
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.EventResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventService
+    /api/v1/info:
+        get:
+            operationId: InfoService_GetInfo
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.InfoResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - InfoService
+    /api/v1/sensors/{namespace}:
+        get:
+            operationId: SensorService_ListSensors
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.SensorList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+        post:
+            operationId: SensorService_CreateSensor
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/sensor.CreateSensorRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+    /api/v1/sensors/{namespace}/{name}:
+        delete:
+            operationId: SensorService_DeleteSensor
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The duration in seconds before the object should be deleted. Value must be non-negative integer.
+                    The value zero indicates delete immediately. If this value is nil, the default grace period for the
+                    specified type will be used.
+                    Defaults to a per object value if not specified. zero means delete immediately.
+                    +optional.
+                  in: query
+                  name: deleteOptions.gracePeriodSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Specifies the target UID.
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.uid
+                  schema:
+                    type: string
+                - description: |-
+                    Specifies the target ResourceVersion
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7.
+                    Should the dependent objects be orphaned. If true/false, the "orphan"
+                    finalizer will be added to/removed from the object's finalizers list.
+                    Either this field or PropagationPolicy may be set, but not both.
+                    +optional.
+                  in: query
+                  name: deleteOptions.orphanDependents
+                  schema:
+                    type: boolean
+                - description: |-
+                    Whether and how garbage collection will be performed.
+                    Either this field or OrphanDependents may be set, but not both.
+                    The default policy is decided by the existing finalizer set in the
+                    metadata.finalizers and the resource-specific default policy.
+                    Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+                    allow the garbage collector to delete the dependents in the background;
+                    'Foreground' - a cascading policy that deletes all dependents in the
+                    foreground.
+                    +optional.
+                  in: query
+                  name: deleteOptions.propagationPolicy
+                  schema:
+                    type: string
+                - description: |-
+                    When present, indicates that modifications should not be
+                    persisted. An invalid or unrecognized dryRun directive will
+                    result in an error response and no further processing of the
+                    request. Valid values are:
+                    - All: all dry run stages will be processed
+                    +optional
+                    +listType=atomic.
+                  in: query
+                  name: deleteOptions.dryRun
+                  schema:
+                    items:
+                        type: string
+                    type: array
+                - description: |-
+                    if set to true, it will trigger an unsafe deletion of the resource in
+                    case the normal deletion flow fails with a corrupt object error.
+                    A resource is considered corrupt if it can not be retrieved from
+                    the underlying storage successfully because of a) its data can
+                    not be transformed e.g. decryption failure, or b) it fails
+                    to decode into an object.
+                    NOTE: unsafe deletion ignores finalizer constraints, skips
+                    precondition checks, and removes the object from the storage.
+                    WARNING: This may potentially break the cluster if the workload
+                    associated with the resource being unsafe-deleted relies on normal
+                    deletion flow. Use only if you REALLY know what you are doing.
+                    The default value is false, and the user must opt in to enable it
+                    +optional.
+                  in: query
+                  name: deleteOptions.ignoreStoreReadErrorWithClusterBreakingPotential
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/sensor.DeleteSensorResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+        get:
+            operationId: SensorService_GetSensor
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: getOptions.resourceVersion
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+        put:
+            operationId: SensorService_UpdateSensor
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/sensor.UpdateSensorRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/github.com.argoproj.argo_events.pkg.apis.events.v1alpha1.Sensor'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+    /api/v1/stream/event-sources/{namespace}:
+        get:
+            operationId: EventSourceService_WatchEventSources
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/eventsource.EventSourceWatchEvent'
+                                title: Stream result of eventsource.EventSourceWatchEvent
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+    /api/v1/stream/event-sources/{namespace}/logs:
+        get:
+            operationId: EventSourceService_EventSourcesLogs
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: optional - only return entries for this event source.
+                  in: query
+                  name: name
+                  schema:
+                    type: string
+                - description: optional - only return entries for this event source type (e.g. `webhook`).
+                  in: query
+                  name: eventSourceType
+                  schema:
+                    type: string
+                - description: optional - only return entries for this event name (e.g. `example`).
+                  in: query
+                  name: eventName
+                  schema:
+                    type: string
+                - description: optional - only return entries where `msg` matches this regular expression.
+                  in: query
+                  name: grep
+                  schema:
+                    type: string
+                - description: |-
+                    The container for which to stream logs. Defaults to only container if there is one container in the pod.
+                    +optional.
+                  in: query
+                  name: podLogOptions.container
+                  schema:
+                    type: string
+                - description: |-
+                    Follow the log stream of the pod. Defaults to false.
+                    +optional.
+                  in: query
+                  name: podLogOptions.follow
+                  schema:
+                    type: boolean
+                - description: |-
+                    Return previous terminated container logs. Defaults to false.
+                    +optional.
+                  in: query
+                  name: podLogOptions.previous
+                  schema:
+                    type: boolean
+                - description: |-
+                    A relative time in seconds before the current time from which to show logs. If this value
+                    precedes the time a pod was started, only logs since the pod start will be returned.
+                    If this value is in the future, no logs will be returned.
+                    Only one of sinceSeconds or sinceTime may be specified.
+                    +optional.
+                  in: query
+                  name: podLogOptions.sinceSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Represents seconds of UTC time since Unix epoch
+                    1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                    9999-12-31T23:59:59Z inclusive.
+                  in: query
+                  name: podLogOptions.sinceTime.seconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Non-negative fractions of a second at nanosecond resolution. Negative
+                    second values with fractions must still have non-negative nanos values
+                    that count forward in time. Must be from 0 to 999,999,999
+                    inclusive. This field may be limited in precision depending on context.
+                  in: query
+                  name: podLogOptions.sinceTime.nanos
+                  schema:
+                    format: int32
+                    type: integer
+                - description: |-
+                    If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+                    of log output. Defaults to false.
+                    +optional.
+                  in: query
+                  name: podLogOptions.timestamps
+                  schema:
+                    type: boolean
+                - description: |-
+                    If set, the number of lines from the end of the logs to show. If not specified,
+                    logs are shown from the creation of the container or sinceSeconds or sinceTime.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +optional.
+                  in: query
+                  name: podLogOptions.tailLines
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    If set, the number of bytes to read from the server before terminating the
+                    log output. This may not display a complete final line of logging, and may return
+                    slightly more or slightly less than the specified limit.
+                    +optional.
+                  in: query
+                  name: podLogOptions.limitBytes
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    insecureSkipTLSVerifyBackend indicates that the apiserver should not confirm the validity of the
+                    serving certificate of the backend it is connecting to.  This will make the HTTPS connection between the apiserver
+                    and the backend insecure. This means the apiserver cannot verify the log data it is receiving came from the real
+                    kubelet.  If the kubelet is configured to verify the apiserver's TLS credentials, it does not mean the
+                    connection to the real kubelet is vulnerable to a man in the middle attack (e.g. an attacker could not intercept
+                    the actual log data coming from the real kubelet).
+                    +optional.
+                  in: query
+                  name: podLogOptions.insecureSkipTLSVerifyBackend
+                  schema:
+                    type: boolean
+                - description: |-
+                    Specify which container log stream to return to the client.
+                    Acceptable values are "All", "Stdout" and "Stderr". If not specified, "All" is used, and both stdout and stderr
+                    are returned interleaved.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +featureGate=PodLogsQuerySplitStreams
+                    +optional.
+                  in: query
+                  name: podLogOptions.stream
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/eventsource.LogEntry'
+                                title: Stream result of eventsource.LogEntry
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventSourceService
+    /api/v1/stream/events/{namespace}:
+        get:
+            operationId: WorkflowService_WatchEvents
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/io.k8s.api.core.v1.Event'
+                                title: Stream result of io.k8s.api.core.v1.Event
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/stream/sensors/{namespace}:
+        get:
+            operationId: SensorService_WatchSensors
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/sensor.SensorWatchEvent'
+                                title: Stream result of sensor.SensorWatchEvent
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+    /api/v1/stream/sensors/{namespace}/logs:
+        get:
+            operationId: SensorService_SensorsLogs
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: optional - only return entries for this sensor name.
+                  in: query
+                  name: name
+                  schema:
+                    type: string
+                - description: optional - only return entries for this trigger.
+                  in: query
+                  name: triggerName
+                  schema:
+                    type: string
+                - description: option - only return entries where `msg` contains this regular expressions.
+                  in: query
+                  name: grep
+                  schema:
+                    type: string
+                - description: |-
+                    The container for which to stream logs. Defaults to only container if there is one container in the pod.
+                    +optional.
+                  in: query
+                  name: podLogOptions.container
+                  schema:
+                    type: string
+                - description: |-
+                    Follow the log stream of the pod. Defaults to false.
+                    +optional.
+                  in: query
+                  name: podLogOptions.follow
+                  schema:
+                    type: boolean
+                - description: |-
+                    Return previous terminated container logs. Defaults to false.
+                    +optional.
+                  in: query
+                  name: podLogOptions.previous
+                  schema:
+                    type: boolean
+                - description: |-
+                    A relative time in seconds before the current time from which to show logs. If this value
+                    precedes the time a pod was started, only logs since the pod start will be returned.
+                    If this value is in the future, no logs will be returned.
+                    Only one of sinceSeconds or sinceTime may be specified.
+                    +optional.
+                  in: query
+                  name: podLogOptions.sinceSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Represents seconds of UTC time since Unix epoch
+                    1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                    9999-12-31T23:59:59Z inclusive.
+                  in: query
+                  name: podLogOptions.sinceTime.seconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Non-negative fractions of a second at nanosecond resolution. Negative
+                    second values with fractions must still have non-negative nanos values
+                    that count forward in time. Must be from 0 to 999,999,999
+                    inclusive. This field may be limited in precision depending on context.
+                  in: query
+                  name: podLogOptions.sinceTime.nanos
+                  schema:
+                    format: int32
+                    type: integer
+                - description: |-
+                    If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+                    of log output. Defaults to false.
+                    +optional.
+                  in: query
+                  name: podLogOptions.timestamps
+                  schema:
+                    type: boolean
+                - description: |-
+                    If set, the number of lines from the end of the logs to show. If not specified,
+                    logs are shown from the creation of the container or sinceSeconds or sinceTime.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +optional.
+                  in: query
+                  name: podLogOptions.tailLines
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    If set, the number of bytes to read from the server before terminating the
+                    log output. This may not display a complete final line of logging, and may return
+                    slightly more or slightly less than the specified limit.
+                    +optional.
+                  in: query
+                  name: podLogOptions.limitBytes
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    insecureSkipTLSVerifyBackend indicates that the apiserver should not confirm the validity of the
+                    serving certificate of the backend it is connecting to.  This will make the HTTPS connection between the apiserver
+                    and the backend insecure. This means the apiserver cannot verify the log data it is receiving came from the real
+                    kubelet.  If the kubelet is configured to verify the apiserver's TLS credentials, it does not mean the
+                    connection to the real kubelet is vulnerable to a man in the middle attack (e.g. an attacker could not intercept
+                    the actual log data coming from the real kubelet).
+                    +optional.
+                  in: query
+                  name: podLogOptions.insecureSkipTLSVerifyBackend
+                  schema:
+                    type: boolean
+                - description: |-
+                    Specify which container log stream to return to the client.
+                    Acceptable values are "All", "Stdout" and "Stderr". If not specified, "All" is used, and both stdout and stderr
+                    are returned interleaved.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +featureGate=PodLogsQuerySplitStreams
+                    +optional.
+                  in: query
+                  name: podLogOptions.stream
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/sensor.LogEntry'
+                                title: Stream result of sensor.LogEntry
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SensorService
+    /api/v1/sync/{namespace}:
+        post:
+            operationId: SyncService_CreateSyncLimit
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/sync.CreateSyncLimitRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/sync.SyncLimitResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SyncService
+    /api/v1/sync/{namespace}/{key}:
+        delete:
+            operationId: SyncService_DeleteSyncLimit
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: key
+                  required: true
+                  schema:
+                    type: string
+                - in: query
+                  name: type
+                  schema:
+                    default: CONFIGMAP
+                    enum:
+                        - CONFIGMAP
+                        - DATABASE
+                    type: string
+                - in: query
+                  name: cmName
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/sync.DeleteSyncLimitResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SyncService
+        get:
+            operationId: SyncService_GetSyncLimit
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: key
+                  required: true
+                  schema:
+                    type: string
+                - in: query
+                  name: type
+                  schema:
+                    default: CONFIGMAP
+                    enum:
+                        - CONFIGMAP
+                        - DATABASE
+                    type: string
+                - in: query
+                  name: cmName
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/sync.SyncLimitResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SyncService
+        put:
+            operationId: SyncService_UpdateSyncLimit
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: key
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/sync.UpdateSyncLimitRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/sync.SyncLimitResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - SyncService
+    /api/v1/tracking/event:
+        post:
+            operationId: InfoService_CollectEvent
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CollectEventRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.CollectEventResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - InfoService
+    /api/v1/userinfo:
+        get:
+            operationId: InfoService_GetUserInfo
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.GetUserInfoResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - InfoService
+    /api/v1/version:
+        get:
+            operationId: InfoService_GetVersion
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Version'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - InfoService
+    /api/v1/workflow-event-bindings/{namespace}:
+        get:
+            operationId: EventService_ListWorkflowEventBindings
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowEventBindingList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - EventService
+    /api/v1/workflow-events/{namespace}:
+        get:
+            operationId: WorkflowService_WatchWorkflows
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+                - in: query
+                  name: fields
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowWatchEvent'
+                                title: Stream result of io.argoproj.workflow.v1alpha1.WorkflowWatchEvent
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflow-templates/{namespace}:
+        get:
+            operationId: WorkflowTemplateService_ListWorkflowTemplates
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: query
+                  name: namePattern
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowTemplateService
+        post:
+            operationId: WorkflowTemplateService_CreateWorkflowTemplate
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateCreateRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowTemplateService
+    /api/v1/workflow-templates/{namespace}/{name}:
+        delete:
+            operationId: WorkflowTemplateService_DeleteWorkflowTemplate
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The duration in seconds before the object should be deleted. Value must be non-negative integer.
+                    The value zero indicates delete immediately. If this value is nil, the default grace period for the
+                    specified type will be used.
+                    Defaults to a per object value if not specified. zero means delete immediately.
+                    +optional.
+                  in: query
+                  name: deleteOptions.gracePeriodSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Specifies the target UID.
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.uid
+                  schema:
+                    type: string
+                - description: |-
+                    Specifies the target ResourceVersion
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7.
+                    Should the dependent objects be orphaned. If true/false, the "orphan"
+                    finalizer will be added to/removed from the object's finalizers list.
+                    Either this field or PropagationPolicy may be set, but not both.
+                    +optional.
+                  in: query
+                  name: deleteOptions.orphanDependents
+                  schema:
+                    type: boolean
+                - description: |-
+                    Whether and how garbage collection will be performed.
+                    Either this field or OrphanDependents may be set, but not both.
+                    The default policy is decided by the existing finalizer set in the
+                    metadata.finalizers and the resource-specific default policy.
+                    Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+                    allow the garbage collector to delete the dependents in the background;
+                    'Foreground' - a cascading policy that deletes all dependents in the
+                    foreground.
+                    +optional.
+                  in: query
+                  name: deleteOptions.propagationPolicy
+                  schema:
+                    type: string
+                - description: |-
+                    When present, indicates that modifications should not be
+                    persisted. An invalid or unrecognized dryRun directive will
+                    result in an error response and no further processing of the
+                    request. Valid values are:
+                    - All: all dry run stages will be processed
+                    +optional
+                    +listType=atomic.
+                  in: query
+                  name: deleteOptions.dryRun
+                  schema:
+                    items:
+                        type: string
+                    type: array
+                - description: |-
+                    if set to true, it will trigger an unsafe deletion of the resource in
+                    case the normal deletion flow fails with a corrupt object error.
+                    A resource is considered corrupt if it can not be retrieved from
+                    the underlying storage successfully because of a) its data can
+                    not be transformed e.g. decryption failure, or b) it fails
+                    to decode into an object.
+                    NOTE: unsafe deletion ignores finalizer constraints, skips
+                    precondition checks, and removes the object from the storage.
+                    WARNING: This may potentially break the cluster if the workload
+                    associated with the resource being unsafe-deleted relies on normal
+                    deletion flow. Use only if you REALLY know what you are doing.
+                    The default value is false, and the user must opt in to enable it
+                    +optional.
+                  in: query
+                  name: deleteOptions.ignoreStoreReadErrorWithClusterBreakingPotential
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateDeleteResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowTemplateService
+        get:
+            operationId: WorkflowTemplateService_GetWorkflowTemplate
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: getOptions.resourceVersion
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowTemplateService
+        put:
+            operationId: WorkflowTemplateService_UpdateWorkflowTemplate
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: 'DEPRECATED: This field is ignored.'
+                  in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateUpdateRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowTemplateService
+    /api/v1/workflow-templates/{namespace}/lint:
+        post:
+            operationId: WorkflowTemplateService_LintWorkflowTemplate
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplateLintRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTemplate'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowTemplateService
+    /api/v1/workflows/{namespace}:
+        get:
+            operationId: WorkflowService_ListWorkflows
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their labels.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.labelSelector
+                  schema:
+                    type: string
+                - description: |-
+                    A selector to restrict the list of returned objects by their fields.
+                    Defaults to everything.
+                    +optional.
+                  in: query
+                  name: listOptions.fieldSelector
+                  schema:
+                    type: string
+                - description: |-
+                    Watch for changes to the described resources and return them as a stream of
+                    add, update, and remove notifications. Specify resourceVersion.
+                    +optional.
+                  in: query
+                  name: listOptions.watch
+                  schema:
+                    type: boolean
+                - description: |-
+                    allowWatchBookmarks requests watch events with type "BOOKMARK".
+                    Servers that do not implement bookmarks may ignore this flag and
+                    bookmarks are sent at the server's discretion. Clients should not
+                    assume bookmarks are returned at any specific interval, nor may they
+                    assume the server will send any BOOKMARK event during a session.
+                    If this is not a watch, this field is ignored.
+                    +optional.
+                  in: query
+                  name: listOptions.allowWatchBookmarks
+                  schema:
+                    type: boolean
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersionMatch determines how resourceVersion is applied to list calls.
+                    It is highly recommended that resourceVersionMatch be set for list calls where
+                    resourceVersion is set
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: listOptions.resourceVersionMatch
+                  schema:
+                    type: string
+                - description: |-
+                    Timeout for the list/watch call.
+                    This limits the duration of the call, regardless of any activity or inactivity.
+                    +optional.
+                  in: query
+                  name: listOptions.timeoutSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    limit is a maximum number of responses to return for a list call. If more items exist, the
+                    server will set the `continue` field on the list metadata to a value that can be used with the
+                    same initial query to retrieve the next set of results. Setting a limit may return fewer than
+                    the requested amount of items (up to zero items) in the event all requested objects are
+                    filtered out and clients should only use the presence of the continue field to determine whether
+                    more results are available. Servers may choose not to support the limit argument and will return
+                    all of the available results. If limit is specified and the continue field is empty, clients may
+                    assume that no more results are available. This field is not supported if watch is true.
+
+                    The server guarantees that the objects returned when using continue will be identical to issuing
+                    a single list call without a limit - that is, no objects created, modified, or deleted after the
+                    first request is issued will be included in any subsequent continued requests. This is sometimes
+                    referred to as a consistent snapshot, and ensures that a client that is using limit to receive
+                    smaller chunks of a very large result can ensure they see all possible objects. If objects are
+                    updated during a chunked list the version of the object that was present at the time the first list
+                    result was calculated is returned.
+                  in: query
+                  name: listOptions.limit
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    The continue option should be set when retrieving more results from the server. Since this value is
+                    server defined, clients may only use the continue value from a previous query result with identical
+                    query parameters (except for the value of continue) and the server may reject a continue value it
+                    does not recognize. If the specified continue value is no longer valid whether due to expiration
+                    (generally five to fifteen minutes) or a configuration change on the server, the server will
+                    respond with a 410 ResourceExpired error together with a continue token. If the client needs a
+                    consistent list, it must restart their list without the continue field. Otherwise, the client may
+                    send another list request with the token received with the 410 error, the server will respond with
+                    a list starting from the next key, but from the latest snapshot, which is inconsistent from the
+                    previous list results - objects that are created, modified, or deleted after the first list request
+                    will be included in the response, as long as their keys are after the "next key".
+
+                    This field is not supported when watch is true. Clients may start a watch from the last
+                    resourceVersion value returned by the server and not miss any modifications.
+                  in: query
+                  name: listOptions.continue
+                  schema:
+                    type: string
+                - description: |-
+                    `sendInitialEvents=true` may be set together with `watch=true`.
+                    In that case, the watch stream will begin with synthetic events to
+                    produce the current state of objects in the collection. Once all such
+                    events have been sent, a synthetic "Bookmark" event  will be sent.
+                    The bookmark will report the ResourceVersion (RV) corresponding to the
+                    set of objects, and be marked with `"io.k8s.initial-events-end": "true"` annotation.
+                    Afterwards, the watch stream will proceed as usual, sending watch events
+                    corresponding to changes (subsequent to the RV) to objects watched.
+
+                    When `sendInitialEvents` option is set, we require `resourceVersionMatch`
+                    option to also be set. The semantic of the watch request is as following:
+                    - `resourceVersionMatch` = NotOlderThan
+                      is interpreted as "data at least as new as the provided `resourceVersion`"
+                      and the bookmark event is send when the state is synced
+                      to a `resourceVersion` at least as fresh as the one provided by the ListOptions.
+                      If `resourceVersion` is unset, this is interpreted as "consistent read" and the
+                      bookmark event is send when the state is synced at least to the moment
+                      when request started being processed.
+                    - `resourceVersionMatch` set to any other value or unset
+                      Invalid error is returned.
+
+                    Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward
+                    compatibility reasons) and to false otherwise.
+                    +optional
+                  in: query
+                  name: listOptions.sendInitialEvents
+                  schema:
+                    type: boolean
+                - description: Fields to be included or excluded in the response. e.g. "items.spec,items.status.phase", "-items.status.nodes".
+                  in: query
+                  name: fields
+                  schema:
+                    type: string
+                - description: Filter type used for name filtering. Exact | Contains | Prefix. Default to Exact.
+                  in: query
+                  name: nameFilter
+                  schema:
+                    type: string
+                - in: query
+                  name: createdAfter
+                  schema:
+                    type: string
+                - in: query
+                  name: finishedBefore
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowList'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+        post:
+            operationId: WorkflowService_CreateWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowCreateRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}:
+        delete:
+            operationId: WorkflowService_DeleteWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The duration in seconds before the object should be deleted. Value must be non-negative integer.
+                    The value zero indicates delete immediately. If this value is nil, the default grace period for the
+                    specified type will be used.
+                    Defaults to a per object value if not specified. zero means delete immediately.
+                    +optional.
+                  in: query
+                  name: deleteOptions.gracePeriodSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Specifies the target UID.
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.uid
+                  schema:
+                    type: string
+                - description: |-
+                    Specifies the target ResourceVersion
+                    +optional.
+                  in: query
+                  name: deleteOptions.preconditions.resourceVersion
+                  schema:
+                    type: string
+                - description: |-
+                    Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7.
+                    Should the dependent objects be orphaned. If true/false, the "orphan"
+                    finalizer will be added to/removed from the object's finalizers list.
+                    Either this field or PropagationPolicy may be set, but not both.
+                    +optional.
+                  in: query
+                  name: deleteOptions.orphanDependents
+                  schema:
+                    type: boolean
+                - description: |-
+                    Whether and how garbage collection will be performed.
+                    Either this field or OrphanDependents may be set, but not both.
+                    The default policy is decided by the existing finalizer set in the
+                    metadata.finalizers and the resource-specific default policy.
+                    Acceptable values are: 'Orphan' - orphan the dependents; 'Background' -
+                    allow the garbage collector to delete the dependents in the background;
+                    'Foreground' - a cascading policy that deletes all dependents in the
+                    foreground.
+                    +optional.
+                  in: query
+                  name: deleteOptions.propagationPolicy
+                  schema:
+                    type: string
+                - description: |-
+                    When present, indicates that modifications should not be
+                    persisted. An invalid or unrecognized dryRun directive will
+                    result in an error response and no further processing of the
+                    request. Valid values are:
+                    - All: all dry run stages will be processed
+                    +optional
+                    +listType=atomic.
+                  in: query
+                  name: deleteOptions.dryRun
+                  schema:
+                    items:
+                        type: string
+                    type: array
+                - description: |-
+                    if set to true, it will trigger an unsafe deletion of the resource in
+                    case the normal deletion flow fails with a corrupt object error.
+                    A resource is considered corrupt if it can not be retrieved from
+                    the underlying storage successfully because of a) its data can
+                    not be transformed e.g. decryption failure, or b) it fails
+                    to decode into an object.
+                    NOTE: unsafe deletion ignores finalizer constraints, skips
+                    precondition checks, and removes the object from the storage.
+                    WARNING: This may potentially break the cluster if the workload
+                    associated with the resource being unsafe-deleted relies on normal
+                    deletion flow. Use only if you REALLY know what you are doing.
+                    The default value is false, and the user must opt in to enable it
+                    +optional.
+                  in: query
+                  name: deleteOptions.ignoreStoreReadErrorWithClusterBreakingPotential
+                  schema:
+                    type: boolean
+                - in: query
+                  name: force
+                  schema:
+                    type: boolean
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowDeleteResponse'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+        get:
+            operationId: WorkflowService_GetWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    resourceVersion sets a constraint on what resource versions a request may be served from.
+                    See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for
+                    details.
+
+                    Defaults to unset
+                    +optional
+                  in: query
+                  name: getOptions.resourceVersion
+                  schema:
+                    type: string
+                - description: Fields to be included or excluded in the response. e.g. "spec,status.phase", "-status.nodes".
+                  in: query
+                  name: fields
+                  schema:
+                    type: string
+                - description: Optional UID to retrieve a specific workflow (useful for archived workflows with the same name).
+                  in: query
+                  name: uid
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/{podName}/log:
+        get:
+            operationId: WorkflowService_PodLogs
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: podName
+                  required: true
+                  schema:
+                    type: string
+                - description: |-
+                    The container for which to stream logs. Defaults to only container if there is one container in the pod.
+                    +optional.
+                  in: query
+                  name: logOptions.container
+                  schema:
+                    type: string
+                - description: |-
+                    Follow the log stream of the pod. Defaults to false.
+                    +optional.
+                  in: query
+                  name: logOptions.follow
+                  schema:
+                    type: boolean
+                - description: |-
+                    Return previous terminated container logs. Defaults to false.
+                    +optional.
+                  in: query
+                  name: logOptions.previous
+                  schema:
+                    type: boolean
+                - description: |-
+                    A relative time in seconds before the current time from which to show logs. If this value
+                    precedes the time a pod was started, only logs since the pod start will be returned.
+                    If this value is in the future, no logs will be returned.
+                    Only one of sinceSeconds or sinceTime may be specified.
+                    +optional.
+                  in: query
+                  name: logOptions.sinceSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Represents seconds of UTC time since Unix epoch
+                    1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                    9999-12-31T23:59:59Z inclusive.
+                  in: query
+                  name: logOptions.sinceTime.seconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Non-negative fractions of a second at nanosecond resolution. Negative
+                    second values with fractions must still have non-negative nanos values
+                    that count forward in time. Must be from 0 to 999,999,999
+                    inclusive. This field may be limited in precision depending on context.
+                  in: query
+                  name: logOptions.sinceTime.nanos
+                  schema:
+                    format: int32
+                    type: integer
+                - description: |-
+                    If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+                    of log output. Defaults to false.
+                    +optional.
+                  in: query
+                  name: logOptions.timestamps
+                  schema:
+                    type: boolean
+                - description: |-
+                    If set, the number of lines from the end of the logs to show. If not specified,
+                    logs are shown from the creation of the container or sinceSeconds or sinceTime.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +optional.
+                  in: query
+                  name: logOptions.tailLines
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    If set, the number of bytes to read from the server before terminating the
+                    log output. This may not display a complete final line of logging, and may return
+                    slightly more or slightly less than the specified limit.
+                    +optional.
+                  in: query
+                  name: logOptions.limitBytes
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    insecureSkipTLSVerifyBackend indicates that the apiserver should not confirm the validity of the
+                    serving certificate of the backend it is connecting to.  This will make the HTTPS connection between the apiserver
+                    and the backend insecure. This means the apiserver cannot verify the log data it is receiving came from the real
+                    kubelet.  If the kubelet is configured to verify the apiserver's TLS credentials, it does not mean the
+                    connection to the real kubelet is vulnerable to a man in the middle attack (e.g. an attacker could not intercept
+                    the actual log data coming from the real kubelet).
+                    +optional.
+                  in: query
+                  name: logOptions.insecureSkipTLSVerifyBackend
+                  schema:
+                    type: boolean
+                - description: |-
+                    Specify which container log stream to return to the client.
+                    Acceptable values are "All", "Stdout" and "Stderr". If not specified, "All" is used, and both stdout and stderr
+                    are returned interleaved.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +featureGate=PodLogsQuerySplitStreams
+                    +optional.
+                  in: query
+                  name: logOptions.stream
+                  schema:
+                    type: string
+                - in: query
+                  name: grep
+                  schema:
+                    type: string
+                - in: query
+                  name: selector
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LogEntry'
+                                title: Stream result of io.argoproj.workflow.v1alpha1.LogEntry
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            summary: 'DEPRECATED: Cannot work via HTTP if podName is an empty string. Use WorkflowLogs.'
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/log:
+        get:
+            operationId: WorkflowService_WorkflowLogs
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - in: query
+                  name: podName
+                  schema:
+                    type: string
+                - description: |-
+                    The container for which to stream logs. Defaults to only container if there is one container in the pod.
+                    +optional.
+                  in: query
+                  name: logOptions.container
+                  schema:
+                    type: string
+                - description: |-
+                    Follow the log stream of the pod. Defaults to false.
+                    +optional.
+                  in: query
+                  name: logOptions.follow
+                  schema:
+                    type: boolean
+                - description: |-
+                    Return previous terminated container logs. Defaults to false.
+                    +optional.
+                  in: query
+                  name: logOptions.previous
+                  schema:
+                    type: boolean
+                - description: |-
+                    A relative time in seconds before the current time from which to show logs. If this value
+                    precedes the time a pod was started, only logs since the pod start will be returned.
+                    If this value is in the future, no logs will be returned.
+                    Only one of sinceSeconds or sinceTime may be specified.
+                    +optional.
+                  in: query
+                  name: logOptions.sinceSeconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Represents seconds of UTC time since Unix epoch
+                    1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+                    9999-12-31T23:59:59Z inclusive.
+                  in: query
+                  name: logOptions.sinceTime.seconds
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    Non-negative fractions of a second at nanosecond resolution. Negative
+                    second values with fractions must still have non-negative nanos values
+                    that count forward in time. Must be from 0 to 999,999,999
+                    inclusive. This field may be limited in precision depending on context.
+                  in: query
+                  name: logOptions.sinceTime.nanos
+                  schema:
+                    format: int32
+                    type: integer
+                - description: |-
+                    If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line
+                    of log output. Defaults to false.
+                    +optional.
+                  in: query
+                  name: logOptions.timestamps
+                  schema:
+                    type: boolean
+                - description: |-
+                    If set, the number of lines from the end of the logs to show. If not specified,
+                    logs are shown from the creation of the container or sinceSeconds or sinceTime.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +optional.
+                  in: query
+                  name: logOptions.tailLines
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    If set, the number of bytes to read from the server before terminating the
+                    log output. This may not display a complete final line of logging, and may return
+                    slightly more or slightly less than the specified limit.
+                    +optional.
+                  in: query
+                  name: logOptions.limitBytes
+                  schema:
+                    format: int64
+                    type: string
+                - description: |-
+                    insecureSkipTLSVerifyBackend indicates that the apiserver should not confirm the validity of the
+                    serving certificate of the backend it is connecting to.  This will make the HTTPS connection between the apiserver
+                    and the backend insecure. This means the apiserver cannot verify the log data it is receiving came from the real
+                    kubelet.  If the kubelet is configured to verify the apiserver's TLS credentials, it does not mean the
+                    connection to the real kubelet is vulnerable to a man in the middle attack (e.g. an attacker could not intercept
+                    the actual log data coming from the real kubelet).
+                    +optional.
+                  in: query
+                  name: logOptions.insecureSkipTLSVerifyBackend
+                  schema:
+                    type: boolean
+                - description: |-
+                    Specify which container log stream to return to the client.
+                    Acceptable values are "All", "Stdout" and "Stderr". If not specified, "All" is used, and both stdout and stderr
+                    are returned interleaved.
+                    Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
+                    +featureGate=PodLogsQuerySplitStreams
+                    +optional.
+                  in: query
+                  name: logOptions.stream
+                  schema:
+                    type: string
+                - in: query
+                  name: grep
+                  schema:
+                    type: string
+                - in: query
+                  name: selector
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                properties:
+                                    error:
+                                        $ref: '#/components/schemas/grpc.gateway.runtime.StreamError'
+                                    result:
+                                        $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.LogEntry'
+                                title: Stream result of io.argoproj.workflow.v1alpha1.LogEntry
+                                type: object
+                    description: A successful response.(streaming responses)
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/resubmit:
+        put:
+            operationId: WorkflowService_ResubmitWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowResubmitRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/resume:
+        put:
+            operationId: WorkflowService_ResumeWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowResumeRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/retry:
+        put:
+            operationId: WorkflowService_RetryWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowRetryRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/set:
+        put:
+            operationId: WorkflowService_SetWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSetRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/stop:
+        put:
+            operationId: WorkflowService_StopWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowStopRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/suspend:
+        put:
+            operationId: WorkflowService_SuspendWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSuspendRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/{name}/terminate:
+        put:
+            operationId: WorkflowService_TerminateWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowTerminateRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/lint:
+        post:
+            operationId: WorkflowService_LintWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowLintRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /api/v1/workflows/{namespace}/submit:
+        post:
+            operationId: WorkflowService_SubmitWorkflow
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.WorkflowSubmitRequest'
+                required: true
+                x-originalParamName: body
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/io.argoproj.workflow.v1alpha1.Workflow'
+                    description: A successful response.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            tags:
+                - WorkflowService
+    /artifact-files/{namespace}/{idDiscriminator}/{id}/{nodeId}/{artifactDiscriminator}/{artifactName}:
+        get:
+            operationId: ArtifactService_GetArtifactFile
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: idDiscriminator
+                  required: true
+                  schema:
+                    enum:
+                        - workflow
+                        - archived-workflows
+                    type: string
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: nodeId
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: artifactName
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: artifactDiscriminator
+                  required: true
+                  schema:
+                    enum:
+                        - outputs
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                format: binary
+                                type: string
+                    description: An artifact file.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            summary: Get an artifact.
+            tags:
+                - ArtifactService
+    /artifacts-by-uid/{uid}/{nodeId}/{artifactName}:
+        get:
+            operationId: ArtifactService_GetOutputArtifactByUID
+            parameters:
+                - in: path
+                  name: uid
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: nodeId
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: artifactName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                format: binary
+                                type: string
+                    description: An artifact file.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            summary: Get an output artifact by UID.
+            tags:
+                - ArtifactService
+    /artifacts/{namespace}/{name}/{nodeId}/{artifactName}:
+        get:
+            operationId: ArtifactService_GetOutputArtifact
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: nodeId
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: artifactName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                format: binary
+                                type: string
+                    description: An artifact file.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            summary: Get an output artifact.
+            tags:
+                - ArtifactService
+    /input-artifacts-by-uid/{uid}/{nodeId}/{artifactName}:
+        get:
+            operationId: ArtifactService_GetInputArtifactByUID
+            parameters:
+                - in: path
+                  name: uid
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: nodeId
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: artifactName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                format: binary
+                                type: string
+                    description: An artifact file.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            summary: Get an input artifact by UID.
+            tags:
+                - ArtifactService
+    /input-artifacts/{namespace}/{name}/{nodeId}/{artifactName}:
+        get:
+            operationId: ArtifactService_GetInputArtifact
+            parameters:
+                - in: path
+                  name: namespace
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: name
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: nodeId
+                  required: true
+                  schema:
+                    type: string
+                - in: path
+                  name: artifactName
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                format: binary
+                                type: string
+                    description: An artifact file.
+                default:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/grpc.gateway.runtime.Error'
+                    description: An unexpected error response.
+            summary: Get an input artifact.
+            tags:
+                - ArtifactService
+security:
+    - BearerToken: []
+servers:
+    - url: http://localhost:2746/
+    - url: https://localhost:2746/

--- a/api/openapi-spec/openapi_test.go
+++ b/api/openapi-spec/openapi_test.go
@@ -1,0 +1,47 @@
+package openapi_spec //nolint:staticcheck
+
+import (
+	"os"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAPIV3Spec(t *testing.T) {
+	data, err := os.ReadFile("openapi.yaml")
+	require.NoError(t, err, "openapi.yaml must exist - run 'make swagger'")
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(data)
+	require.NoError(t, err, "openapi.yaml must be parseable as OpenAPI v3")
+
+	err = doc.Validate(loader.Context)
+	require.NoError(t, err, "openapi.yaml must be valid OpenAPI v3")
+
+	// Verify key Argo types exist in components/schemas
+	t.Run("io.argoproj.workflow.v1alpha1.Workflow", func(t *testing.T) {
+		_, ok := doc.Components.Schemas["io.argoproj.workflow.v1alpha1.Workflow"]
+		require.True(t, ok, "expected Workflow schema in components/schemas")
+	})
+
+	t.Run("io.argoproj.workflow.v1alpha1.CronWorkflow", func(t *testing.T) {
+		_, ok := doc.Components.Schemas["io.argoproj.workflow.v1alpha1.CronWorkflow"]
+		require.True(t, ok, "expected CronWorkflow schema in components/schemas")
+	})
+
+	t.Run("io.argoproj.workflow.v1alpha1.WorkflowTemplate", func(t *testing.T) {
+		_, ok := doc.Components.Schemas["io.argoproj.workflow.v1alpha1.WorkflowTemplate"]
+		require.True(t, ok, "expected WorkflowTemplate schema in components/schemas")
+	})
+
+	// Verify key API paths exist
+	t.Run("workflow list path", func(t *testing.T) {
+		require.NotNil(t, doc.Paths.Find("/api/v1/workflows/{namespace}"),
+			"expected workflow list path to exist")
+	})
+
+	t.Run("openapi version", func(t *testing.T) {
+		require.Equal(t, "3.0.3", doc.OpenAPI, "expected OpenAPI version 3.0.0")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/evilmonkeyinc/jsonpath v0.8.1
 	github.com/expr-lang/expr v1.17.8
 	github.com/gavv/httpexpect/v2 v2.17.0
+	github.com/getkin/kin-openapi v0.135.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/go-jose/go-jose/v3 v3.0.5
 	github.com/go-openapi/jsonreference v0.21.5
@@ -120,10 +121,15 @@ require (
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/oasdiff/yaml v0.0.9 // indirect
+	github.com/oasdiff/yaml3 v0.0.9 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0 // indirect
+	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
+	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/gaganhr94/docker-credential-acr v1.0.2 h1:0eMFjVqRUmwINbhFxb5xLTWLJpd
 github.com/gaganhr94/docker-credential-acr v1.0.2/go.mod h1:8yd2V0GhCyd17MpMxfAJzcZqldu1ghFmrUV0GS7qcGc=
 github.com/gavv/httpexpect/v2 v2.17.0 h1:nIJqt5v5e4P7/0jODpX2gtSw+pHXUqdP28YcjqwDZmE=
 github.com/gavv/httpexpect/v2 v2.17.0/go.mod h1:E8ENFlT9MZ3Si2sfM6c6ONdwXV2noBCGkhA+lkJgkP0=
+github.com/getkin/kin-openapi v0.135.0 h1:751SjYfbiwqukYuVjwYEIKNfrSwS5YpA7DZnKSwQgtg=
+github.com/getkin/kin-openapi v0.135.0/go.mod h1:6dd5FJl6RdX4usBtFBaQhk9q62Yb2J0Mk5IhUO/QqFI=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -339,6 +341,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8Wd
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.4-0.20181002190808-e7a84e9525fe h1:zn8tqiUbec4wR94o7Qj3LZCAT6uGobhEgnDRg6isG5U=
@@ -623,6 +627,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -638,6 +644,10 @@ github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oasdiff/yaml v0.0.9 h1:zQOvd2UKoozsSsAknnWoDJlSK4lC0mpmjfDsfqNwX48=
+github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
+github.com/oasdiff/yaml3 v0.0.9 h1:rWPrKccrdUm8J0F3sGuU+fuh9+1K/RdJlWF7O/9yw2g=
+github.com/oasdiff/yaml3 v0.0.9/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
@@ -663,6 +673,8 @@ github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgr
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
+github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
@@ -794,6 +806,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
+github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/upper/db/v4 v4.10.0 h1:u5fdqcFZAOwUZWtkS0ueQttecKcSpVF8qmBwZesS9nc=
 github.com/upper/db/v4 v4.10.0/go.mod h1:s3qHxKIKvqZNZBG5jrAPufMUXqCBmMdIHa7buGfR+OU=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -805,6 +819,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
+github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
+github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/hack/api/openapi3/main.go
+++ b/hack/api/openapi3/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/getkin/kin-openapi/openapi2conv"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/yaml"
+)
+
+func main() {
+	inPath := "api/openapi-spec/swagger.json"
+	outPath := "api/openapi-spec/openapi.yaml"
+
+	data, err := os.ReadFile(inPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read %s: %v\n", inPath, err)
+		os.Exit(1)
+	}
+
+	var doc2 openapi2.T
+	if err := json.Unmarshal(data, &doc2); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse swagger v2: %v\n", err)
+		os.Exit(1)
+	}
+
+	loader := openapi3.NewLoader()
+	doc3, err := openapi2conv.ToV3WithLoader(&doc2, loader, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to convert to openapi v3: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := doc3.Validate(loader.Context); err != nil {
+		fmt.Fprintf(os.Stderr, "openapi v3 validation failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	raw, err := doc3.MarshalYAML()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal openapi v3 as YAML: %v\n", err)
+		os.Exit(1)
+	}
+
+	// MarshalYAML returns interface{}, encode it properly
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode YAML: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(outPath, out, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", outPath, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s\n", outPath)
+}


### PR DESCRIPTION
## Summary
Relates to #12851

Adds `hack/api/openapi3/main.go` which reads the existing
`api/openapi-spec/swagger.json` (OpenAPI v2) and produces
`api/openapi-spec/openapi.yaml` (OpenAPI v3.0.3) using
[getkin/kin-openapi](https://github.com/getkin/kin-openapi)'s
`openapi2conv` package.

## Changes
- `hack/api/openapi3/main.go` — converter tool
- `api/openapi-spec/openapi.yaml` — generated v3 spec (committed artifact, consistent with how `swagger.json` is handled)
- `api/openapi-spec/openapi_test.go` — validates v3 spec parses and is valid
- `Makefile` — new `api/openapi-spec/openapi.yaml` target, added as dependency of `make swagger`
- `go.mod` / `go.sum` — adds `github.com/getkin/kin-openapi`

## What this does NOT change
- Existing `swagger.json` (v2) and all tooling depending on it are untouched
- `go-swagger` is not removed (follow-up PRs)
- Server-side request validation middleware is not changed (follow-up PRs)

## Testing
- `go test ./api/openapi-spec/...` passes