### PR TITLE
fix(ui): toggle filter dropdown closed when clicking anchor

### DIFF
--- a/ui/src/shared/components/dropdown/dropdown.test.tsx
+++ b/ui/src/shared/components/dropdown/dropdown.test.tsx
@@ -1,0 +1,84 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {DropDown} from './dropdown';
+
+describe('DropDown', () => {
+    beforeEach(() => {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {configurable: true, value: 50});
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {configurable: true, value: 100});
+        Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+            configurable: true,
+            value: () => ({top: 0, left: 0, bottom: 50, right: 100, width: 100, height: 50})
+        });
+    });
+
+    // DropDown reads ref.current eagerly in the component body (not in useEffect).
+    // On the initial render, refs are null so open() is a no-op.
+    // Calling rerender() with a *new* JSX element forces React to re-render
+    // the component, at which point the refs are populated.
+    function renderDropDown(anchor: React.ReactElement | ((opened: boolean) => React.ReactElement), children?: React.ReactNode) {
+        const result = render(
+            <DropDown anchor={anchor}>{children || <div>Content</div>}</DropDown>
+        );
+        result.rerender(
+            <DropDown anchor={anchor}>{children || <div>Content</div>}</DropDown>
+        );
+        return result;
+    }
+
+    it('renders anchor as JSX element', () => {
+        renderDropDown(<button>Open</button>);
+        expect(screen.getByText('Open')).toBeInTheDocument();
+    });
+
+    it('renders anchor as function and passes opened=false initially', () => {
+        const anchorFn = jest.fn((opened: boolean) => <button>{opened ? 'Close' : 'Open'}</button>);
+        renderDropDown(anchorFn);
+        expect(anchorFn).toHaveBeenCalledWith(false);
+        expect(screen.getByText('Open')).toBeInTheDocument();
+    });
+
+    it('opens dropdown on anchor click and passes opened=true to anchor function', () => {
+        const anchorFn = jest.fn((opened: boolean) => <button>{opened ? 'Close' : 'Open'}</button>);
+        renderDropDown(anchorFn);
+
+        fireEvent.click(screen.getByText('Open'));
+
+        expect(anchorFn).toHaveBeenLastCalledWith(true);
+        expect(screen.getByText('Close')).toBeInTheDocument();
+    });
+
+    it('closes dropdown when anchor is clicked while open (toggle behavior)', () => {
+        const anchorFn = jest.fn((opened: boolean) => <button data-testid='anchor'>{opened ? 'Close' : 'Open'}</button>);
+        renderDropDown(anchorFn);
+
+        fireEvent.click(screen.getByTestId('anchor'));
+        expect(screen.getByText('Close')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('anchor'));
+        expect(screen.getByText('Open')).toBeInTheDocument();
+        expect(anchorFn).toHaveBeenLastCalledWith(false);
+    });
+
+    it('opens dropdown with JSX element anchor on click', () => {
+        renderDropDown(<button>Toggle</button>);
+
+        const content = document.querySelector('.argo-dropdown__content');
+        expect(content).not.toHaveClass('opened');
+
+        fireEvent.click(screen.getByText('Toggle'));
+        expect(content).toHaveClass('opened');
+    });
+
+    it('toggles closed with JSX element anchor on second click', () => {
+        renderDropDown(<button>Toggle</button>);
+
+        const content = document.querySelector('.argo-dropdown__content');
+        fireEvent.click(screen.getByText('Toggle'));
+        expect(content).toHaveClass('opened');
+
+        fireEvent.click(screen.getByText('Toggle'));
+        expect(content).not.toHaveClass('opened');
+    });
+});

--- a/ui/src/shared/components/dropdown/dropdown.test.tsx
+++ b/ui/src/shared/components/dropdown/dropdown.test.tsx
@@ -18,12 +18,8 @@ describe('DropDown', () => {
     // Calling rerender() with a *new* JSX element forces React to re-render
     // the component, at which point the refs are populated.
     function renderDropDown(anchor: React.ReactElement | ((opened: boolean) => React.ReactElement), children?: React.ReactNode) {
-        const result = render(
-            <DropDown anchor={anchor}>{children || <div>Content</div>}</DropDown>
-        );
-        result.rerender(
-            <DropDown anchor={anchor}>{children || <div>Content</div>}</DropDown>
-        );
+        const result = render(<DropDown anchor={anchor}>{children || <div>Content</div>}</DropDown>);
+        result.rerender(<DropDown anchor={anchor}>{children || <div>Content</div>}</DropDown>);
         return result;
     }
 

--- a/ui/src/shared/components/dropdown/dropdown.tsx
+++ b/ui/src/shared/components/dropdown/dropdown.tsx
@@ -6,7 +6,7 @@ import './dropdown.scss';
 
 export interface DropDownProps {
     isMenu?: boolean;
-    anchor: JSX.Element;
+    anchor: JSX.Element | ((opened: boolean) => JSX.Element);
     closeOnInsideClick?: boolean;
     children: ReactNode;
 }
@@ -81,10 +81,14 @@ export function DropDown({isMenu, anchor, closeOnInsideClick, children}: DropDow
             <div
                 className='argo-dropdown__anchor'
                 onClick={event => {
-                    open();
+                    if (opened) {
+                        setOpened(false);
+                    } else {
+                        open();
+                    }
                     event.stopPropagation();
                 }}>
-                {anchor}
+                {typeof anchor === 'function' ? anchor(opened) : anchor}
             </div>
             {createPortal(
                 <div className={classNames('argo-dropdown__content', {opened, 'is-menu': isMenu})} style={{top, left}} ref={contentRef}>

--- a/ui/src/shared/components/filter-drop-down.test.tsx
+++ b/ui/src/shared/components/filter-drop-down.test.tsx
@@ -1,0 +1,61 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {FilterDropDown, FilterDropSection} from './filter-drop-down';
+
+describe('FilterDropDown', () => {
+    beforeEach(() => {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {configurable: true, value: 50});
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {configurable: true, value: 100});
+        Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+            configurable: true,
+            value: () => ({top: 0, left: 0, bottom: 50, right: 100, width: 100, height: 50})
+        });
+    });
+
+    const sections: FilterDropSection[] = [
+        {
+            title: 'Status',
+            values: {Running: true, Failed: false},
+            onChange: jest.fn()
+        }
+    ];
+
+    it('renders the filter icon', () => {
+        render(<FilterDropDown sections={sections} />);
+        expect(document.querySelector('.argo-icon-filter')).toBeInTheDocument();
+    });
+
+    it('renders the chevron icon', () => {
+        render(<FilterDropDown sections={sections} />);
+        expect(document.querySelector('.fa-angle-down')).toBeInTheDocument();
+    });
+
+    it('opens dropdown and shows section title on click', () => {
+        render(<FilterDropDown sections={sections} />);
+        const anchor = document.querySelector('.argo-dropdown__anchor');
+        fireEvent.click(anchor);
+        expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+
+    it('shows checkbox labels for filter values', () => {
+        render(<FilterDropDown sections={sections} />);
+        const anchor = document.querySelector('.argo-dropdown__anchor');
+        fireEvent.click(anchor);
+        expect(screen.getByText('Failed')).toBeInTheDocument();
+        expect(screen.getByText('Running')).toBeInTheDocument();
+    });
+
+    it('calls onChange when a checkbox is toggled', () => {
+        const onChange = jest.fn();
+        const testSections: FilterDropSection[] = [{title: 'Phase', values: {Pending: false}, onChange}];
+        render(<FilterDropDown sections={testSections} />);
+
+        const anchor = document.querySelector('.argo-dropdown__anchor');
+        fireEvent.click(anchor);
+
+        const checkbox = screen.getByLabelText('Pending');
+        fireEvent.click(checkbox);
+        expect(onChange).toHaveBeenCalledWith('Pending', true);
+    });
+});

--- a/ui/src/shared/components/filter-drop-down.tsx
+++ b/ui/src/shared/components/filter-drop-down.tsx
@@ -18,12 +18,12 @@ export function FilterDropDown(props: FilterDropDownProps) {
     return (
         <DropDown
             isMenu={true}
-            anchor={
+            anchor={opened => (
                 <div className={classNames('top-bar__filter')} title='Filter'>
                     <i className='argo-icon-filter' aria-hidden='true' />
-                    <i className='fa fa-angle-down' aria-hidden='true' />
+                    <i className={`fa ${opened ? 'fa-angle-up' : 'fa-angle-down'}`} aria-hidden='true' />
                 </div>
-            }>
+            )}>
             <ul>
                 {props.sections
                     .filter(item => item.values)

--- a/ui/src/shared/components/filter-drop-down.tsx
+++ b/ui/src/shared/components/filter-drop-down.tsx
@@ -18,10 +18,10 @@ export function FilterDropDown(props: FilterDropDownProps) {
     return (
         <DropDown
             isMenu={true}
-            anchor={opened => (
+            anchor={() => (
                 <div className={classNames('top-bar__filter')} title='Filter'>
                     <i className='argo-icon-filter' aria-hidden='true' />
-                    <i className={`fa ${opened ? 'fa-angle-up' : 'fa-angle-down'}`} aria-hidden='true' />
+                    <i className='fa fa-angle-down' aria-hidden='true' />
                 </div>
             )}>
             <ul>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

<!-- TODO: Say why you made your changes. -->

Clicking the filter dropdown anchor while the menu was already open did not close it. Users had to click elsewhere to dismiss the dropdown, making the behavior less intuitive.

### Modifications

<!-- TODO: Say what changes you made. -->

- Updated `DropDown` to accept an anchor render function `(opened: boolean) => JSX.Element` in addition to a static `JSX.Element`, allowing anchors to react to the open state
- Changed the anchor click handler to toggle the dropdown closed when it is already open, instead of only opening
- Updated `FilterDropDown` to use the render function form of anchor

<!-- TODO: Attach screenshots if you changed the UI. -->

<img width="646" height="558" alt="image" src="https://github.com/user-attachments/assets/74d2672f-6c11-4b99-a53f-4dfdaf17ce8e" />

### Verification

<!-- TODO: Say how you tested your changes. -->

- Opened the filter dropdown from the top bar and confirmed the menu appears as expected
- Clicked the filter dropdown anchor again and confirmed the menu closes
- Confirmed existing DropDown usage still works when a static JSX element is passed as anchor

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No documentation updates are required.

### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

Codex, Google AI Mode