### PR TITLE
fix: classify bare 5xx S3 responses as transient. Fixes #15565

### DIFF
--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -2,6 +2,9 @@ package s3
 
 import (
 	"context"
+	stderrors "errors"
+
+	"github.com/minio/minio-go/v7"
 
 	"github.com/argoproj/argo-workflows/v4/util/errors"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -32,6 +35,16 @@ func isTransientS3Err(ctx context.Context, err error) bool {
 			log.WithError(err).Error(ctx, "Transient S3 error")
 			return true
 		}
+	}
+	// When the response body is not a parsable S3 XML document (e.g. a proxy
+	// or load balancer returned a bare 5xx response), minio-go sets Code to
+	// the raw HTTP status string ("503 Service Unavailable"), which does not
+	// match any entry in s3TransientErrorCodes. Fall back to StatusCode so
+	// 5xx responses are still treated as transient per S3 retry semantics.
+	var minioErr minio.ErrorResponse
+	if stderrors.As(err, &minioErr) && minioErr.StatusCode >= 500 && minioErr.StatusCode < 600 {
+		log.WithError(err).Error(ctx, "Transient S3 error")
+		return true
 	}
 	return errors.IsTransientErr(ctx, err)
 }

--- a/workflow/artifacts/s3/errors_test.go
+++ b/workflow/artifacts/s3/errors_test.go
@@ -43,3 +43,18 @@ func TestIsTransientOSSErr(t *testing.T) {
 	requestErr := minio.ErrorResponse{Code: "RequestError"}
 	assert.True(t, isTransientS3Err(ctx, requestErr))
 }
+
+func TestIsTransientS3Err_BareHTTPStatus(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	// minio-go falls back to resp.Status as Code when the error body is not
+	// parsable S3 XML (e.g. a load balancer returned a plain 5xx response).
+	bare503 := minio.ErrorResponse{Code: "503 Service Unavailable", StatusCode: 503}
+	assert.True(t, isTransientS3Err(ctx, bare503))
+
+	bare500 := minio.ErrorResponse{Code: "500 Internal Server Error", StatusCode: 500}
+	assert.True(t, isTransientS3Err(ctx, bare500))
+
+	bare404 := minio.ErrorResponse{Code: "404 Not Found", StatusCode: 404}
+	assert.False(t, isTransientS3Err(ctx, bare404))
+}


### PR DESCRIPTION
Fixes #15565

### Motivation

When a proxy or load balancer in front of S3 returns a bare 5xx response (no S3-style XML body), `minio-go` falls back to `resp.Status` as the error `Code` (e.g. `"503 Service Unavailable"`). That string never matches anything in `s3TransientErrorCodes`, so the workflow executor logs the error as non-transient and bypasses the configured retry strategy — even though 5xx responses are retryable per [AWS S3 retry semantics](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ErrorBestPractices.html#UsingErrors-retries).

Observed in the field (from the issue):

```
level=warning msg="Non-transient error: 503 Service Unavailable"
level=info msg="Save artifact" artifactName=jobKilledFile duration=64.037342ms error="failed to put file: 503 Service Unavailable"
level=error msg="executor error: failed to put file: 503 Service Unavailable; "
```

### Modifications

- In `isTransientS3Err`, after the existing code-based check, extract the `minio.ErrorResponse` and fall back to `StatusCode`: if it is in the 5xx range, treat the error as transient.
- The existing code-based check is kept so known codes still log with their structured Code.

### Verification

Added `TestIsTransientS3Err_BareHTTPStatus` covering bare 503/500 (transient) and bare 404 (non-transient). `go test ./workflow/artifacts/s3/` and `golangci-lint run ./workflow/artifacts/s3/` both pass locally.

### Documentation

No user-facing behavior or configuration surface changes; retry behavior is now correct on the existing, documented retry strategy.

### AI

This PR (code, tests, and description) was drafted with Claude (Anthropic) under human review, per the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).