### PR TITLE
fix(ui): enforce pagination limit on workflow-list watch stream. Fixes #16013

### DIFF
--- a/ui/src/shared/list-watch.ts
+++ b/ui/src/shared/list-watch.ts
@@ -22,6 +22,7 @@ export class ListWatch<T extends Resource> {
     private readonly onChange: (items: T[], item?: T, type?: Type) => void;
     private readonly onError: (error: Error) => void;
     private readonly sorter: (a: T, b: T) => number;
+    private readonly limit?: number;
     private items: T[];
     private retryWatch: RetryWatch<T>;
     private timeout: any;
@@ -34,18 +35,23 @@ export class ListWatch<T extends Resource> {
         onOpen: () => void, //  called, when watches is re-established after error,  so should clear any errors
         onChange: (items: T[], item?: T, type?: Type) => void, // called whenever items change, any users that changes state should use [...items]
         onError: (error: Error) => void, // called on any error
-        sorter: Sorter = sortByYouth // show the youngest first by default
+        sorter: Sorter = sortByYouth, // show the youngest first by default
+        limit?: number // optional max items to keep after watch events, matching paginated list size
     ) {
         this.onLoad = onLoad;
         this.list = list;
         this.onChange = onChange;
         this.onError = onError;
         this.sorter = sorter;
+        this.limit = limit;
         this.retryWatch = new RetryWatch<T>(
             watch,
             onOpen,
             e => {
                 this.items = mergeItem(e.object, e.type, this.items).sort(sorter);
+                if (this.limit && this.items.length > this.limit) {
+                    this.items = this.items.slice(0, this.limit);
+                }
                 onChange(this.items, e.object, e.type);
             },
             onError

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -198,7 +198,8 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
             () => setError(null),
             newWorkflows => setWorkflows([...newWorkflows]),
             err => setError(err),
-            sortByYouth
+            sortByYouth,
+            pagination.limit
         );
         listWatch.start();
 


### PR DESCRIPTION
Fixes #16013

### Motivation

On the Workflow List page, the initial `services.workflows.list()` call respects the `pagination.limit` (e.g. "Results per page" = 5), but the SSE watch stream feeds every ADDED event into `ListWatch.mergeItem()` unbounded. As new workflows are created or the admin cluster churns, the displayed list grows past the page-size setting (5 → 12 → 30 → 50+).

### Modifications

- Add an optional `limit` parameter to `ListWatch<T>`; after each watch event, if the merged list exceeds `limit`, truncate to the first `limit` items. The list is already sorted by the caller's `sorter` (youngest first for workflows), so we keep the youngest N.
- Plumb `pagination.limit` through from `workflows-list.tsx` into the `ListWatch` constructor.
- Other `ListWatch` callers (event-flow, events-panel) are unaffected — the parameter is optional.

### Verification

- `node_modules/typescript/bin/tsc --noEmit` clean for the two touched files.
- `eslint --fix` clean for the two touched files.

### Documentation

No doc changes — this restores intended behavior on an existing, documented setting (Results per page).

### AI

This PR (code and description) was drafted with Claude (Anthropic) under human review, per the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).