### PR TITLE
fix(ui): respect target field in workflow-list scope links

### DIFF
--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -8,6 +8,7 @@ import {uiUrl} from '../../../shared/base';
 import {CostOptimisationNudge} from '../../../shared/components/cost-optimisation-nudge';
 import {ErrorNotice} from '../../../shared/components/error-notice';
 import {ExampleManifests} from '../../../shared/components/example-manifests';
+import {openLinkWithKey} from '../../../shared/components/links';
 import {Loading} from '../../../shared/components/loading';
 import {PaginationPanel} from '../../../shared/components/pagination-panel';
 import {TimestampSwitch} from '../../../shared/components/timestamp';
@@ -231,7 +232,7 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
                         ...links.map(link => ({
                             title: link.name,
                             iconClassName: 'fa fa-external-link',
-                            action: () => (window.location.href = link.url)
+                            action: () => openLinkWithKey(link.url, link.target)
                         }))
                     ]
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #16020

### Motivation

<!-- TODO: Say why you made your changes. -->

When configuring a `links` entry in `workflow-controller-configmap` with `scope: workflow-list` and `target: _blank`, the link opens in the same tab instead of a new tab. The `target` field is silently ignored.

`workflow-list` scope links were implemented using `window.location.href = link.url`, which always navigates in the current tab regardless of the `target` field. The `target` field was introduced in v4.0.0 for other scopes, but `workflow-list` was not updated at that time.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

Updated `workflow-list` scope links to use `openLinkWithKey()`, consistent with how other scopes handle the `target` field.

```diff
- action: () => (window.location.href = link.url)
+ action: () => openLinkWithKey(link.url, link.target)
```

### Verification

<!-- TODO: Say how you tested your changes. -->

Applied the following configmap and confirmed that clicking the link in the action menu on the Workflows list page opens in a new tab:

```yaml
  links: |
    - name: Examples
      scope: workflow-list
      url: https://github.com/argoproj/argo-workflows/tree/main/examples
      target: _blank
```

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

No documentation changes needed. This is a bug fix that makes the `target` field behave as already documented.

### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

Used Claude (claude-sonnet-4-6) to investigate.