### PR TITLE
docs: document allowed fields when templateReferencing enabled

### DIFF
--- a/docs/workflow-restrictions.md
+++ b/docs/workflow-restrictions.md
@@ -12,6 +12,31 @@ Workflow Restrictions allow you to set requirements for all Workflows.
 * `templateReferencing: Strict`: Only process Workflows using `workflowTemplateRef`. You can use this to require usage of WorkflowTemplates, disallowing arbitrary Workflow execution.
 * `templateReferencing: Secure`: Same as `Strict` _plus_ enforce that a referenced WorkflowTemplate hasn't changed between operations. If a running Workflow's underlying WorkflowTemplate changes, the Workflow will error out.
 
+## Allowed Workflow Fields Under `templateReferencing`
+
+When `templateReferencing` is set to `Strict` or `Secure`, the submitted `Workflow` may only set fields that are explicitly allowed on top of the referenced `WorkflowTemplate`. Any other field present on the submission is rejected and the Workflow errors out.
+
+This prevents users from overriding security-sensitive fields defined in the `WorkflowTemplate` (such as `serviceAccountName`, `securityContext`, `volumes`, `hostNetwork`, `podSpecPatch`, or injecting additional `templates`) via their submission.
+
+The allow-listed fields are:
+
+* `arguments`
+* `entrypoint`
+* `shutdown`
+* `suspend`
+* `activeDeadlineSeconds`
+* `priority`
+* `ttlStrategy`
+* `podGC`
+* `volumeClaimGC`
+* `archiveLogs`
+* `workflowMetadata`
+* `workflowTemplateRef`
+* `metrics`
+* `artifactGC`
+
+All other fields on the submitted `Workflow` spec must be defined on the referenced `WorkflowTemplate` instead.
+
 ## Setting Workflow Restrictions
 
 You can add `workflowRestrictions` in the [`workflow-controller-configmap`](./workflow-controller-configmap.yaml).


### PR DESCRIPTION
### Motivation

GHSA-3775-99mw-8rp4 restricts workflow fields, but doesn't document them for ease of creating a GHSA patch.

### Modifications

Documentation update only.

### Verification

make docs

### Documentation

This documents an existing, if new, behaviour.

### AI

Claude pulled the list into docs and I edited it.
