### PR TITLE
fix(emissary): prevent output path traversal in saveParameter and saveArtifact

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -401,20 +401,33 @@ func saveArtifact(ctx context.Context, srcPath string) error {
 		logger.WithField("srcPath", srcPath).Info(ctx, "no need to save artifact - on overlapping volume")
 		return nil
 	}
+	// Normalize absolute paths (e.g. /tmp/artifact → tmp/artifact) so that
+	// filepath.IsLocal can validate the result, and os.Root.Create can safely
+	// write it within the outputs directory.
+	relSrc := strings.TrimPrefix(strings.TrimSuffix(srcPath, "/"), "/")
+	dstRel := relSrc + ".tgz"
+	if !filepath.IsLocal(dstRel) {
+		return fmt.Errorf("path traversal in output artifact path %q", srcPath)
+	}
+	artifactsDir := filepath.Join(varRunArgo, "outputs/artifacts")
+	dstPath := filepath.Join(artifactsDir, dstRel)
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) { // might be optional, so we ignore
 		logger.WithField("srcPath", srcPath).WithError(err).Warn(ctx, "cannot save artifact")
 		return nil
 	}
-	dstPath := filepath.Join(varRunArgo, "/outputs/artifacts/", strings.TrimSuffix(srcPath, "/")+".tgz")
 	logger.WithFields(logging.Fields{
 		"src": srcPath,
 		"dst": dstPath,
 	}).Info(ctx, "saving artifact")
-	z := filepath.Dir(dstPath)
-	if err := os.MkdirAll(z, 0o755); err != nil { // chmod rwxr-xr-x
-		return fmt.Errorf("failed to create directory %s: %w", z, err)
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil { // chmod rwxr-xr-x
+		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(dstPath), err)
 	}
-	dst, err := os.Create(dstPath)
+	root, err := os.OpenRoot(artifactsDir)
+	if err != nil {
+		return fmt.Errorf("failed to open artifacts output root: %w", err)
+	}
+	defer root.Close()
+	dst, err := root.Create(dstRel)
 	if err != nil {
 		return fmt.Errorf("failed to create destination %s: %w", dstPath, err)
 	}
@@ -435,6 +448,15 @@ func saveParameter(ctx context.Context, srcPath string) error {
 		logger.WithField("src", srcPath).Info(ctx, "no need to save parameter - on overlapping volume")
 		return nil
 	}
+	// Normalize absolute paths (e.g. /tmp/parameter → tmp/parameter) so that
+	// filepath.IsLocal can validate the result, and os.Root.Create can safely
+	// write it within the outputs directory.
+	relPath := strings.TrimPrefix(srcPath, "/")
+	if !filepath.IsLocal(relPath) {
+		return fmt.Errorf("path traversal in output parameter path %q", srcPath)
+	}
+	parametersDir := filepath.Join(varRunArgo, "outputs/parameters")
+	dstPath := filepath.Join(parametersDir, relPath)
 	src, err := os.Open(filepath.Clean(srcPath))
 	if os.IsNotExist(err) { // might be optional, so we ignore
 		logger.WithField("src", srcPath).WithError(err).Error(ctx, "cannot save parameter, does not exist")
@@ -444,16 +466,19 @@ func saveParameter(ctx context.Context, srcPath string) error {
 		return fmt.Errorf("failed to open %s: %w", srcPath, err)
 	}
 	defer func() { _ = src.Close() }()
-	dstPath := varRunArgo + "/outputs/parameters/" + srcPath
 	logger.WithFields(logging.Fields{
 		"src": srcPath,
 		"dst": dstPath,
 	}).Info(ctx, "saving parameter")
-	z := filepath.Dir(dstPath)
-	if mkdirErr := os.MkdirAll(z, 0o755); mkdirErr != nil { // chmod rwxr-xr-x
-		return fmt.Errorf("failed to create directory %s: %w", z, mkdirErr)
+	if mkdirErr := os.MkdirAll(filepath.Dir(dstPath), 0o755); mkdirErr != nil { // chmod rwxr-xr-x
+		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(dstPath), mkdirErr)
 	}
-	dst, err := os.Create(dstPath)
+	root, err := os.OpenRoot(parametersDir)
+	if err != nil {
+		return fmt.Errorf("failed to open parameters output root: %w", err)
+	}
+	defer root.Close()
+	dst, err := root.Create(relPath)
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", srcPath, err)
 	}

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -401,32 +401,35 @@ func saveArtifact(ctx context.Context, srcPath string) error {
 		logger.WithField("srcPath", srcPath).Info(ctx, "no need to save artifact - on overlapping volume")
 		return nil
 	}
-	// Normalize absolute paths (e.g. /tmp/artifact → tmp/artifact) so that
-	// filepath.IsLocal can validate the result, and os.Root.Create can safely
-	// write it within the outputs directory.
-	relSrc := strings.TrimPrefix(strings.TrimSuffix(srcPath, "/"), "/")
-	dstRel := relSrc + ".tgz"
-	if !filepath.IsLocal(dstRel) {
+	// Map the (possibly absolute) source path to a path relative to the outputs
+	// directory, e.g. /tmp/artifact -> tmp/artifact. TrimLeft drops any leading
+	// slashes (including "//"); Clean collapses any in-bounds "..". IsLocal then
+	// rejects anything that would still escape (leading "..", absolute paths).
+	relSrc := filepath.Clean(strings.TrimLeft(strings.TrimSuffix(srcPath, "/"), "/"))
+	if !filepath.IsLocal(relSrc) {
 		return fmt.Errorf("path traversal in output artifact path %q", srcPath)
 	}
-	artifactsDir := filepath.Join(varRunArgo, "outputs/artifacts")
-	dstPath := filepath.Join(artifactsDir, dstRel)
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) { // might be optional, so we ignore
 		logger.WithField("srcPath", srcPath).WithError(err).Warn(ctx, "cannot save artifact")
 		return nil
 	}
+	// dstRel is relative to varRunArgo; both the directory and the file are
+	// created through a single os.Root opened at that trusted base, so a
+	// symlinked path component cannot redirect the write outside the tree.
+	dstRel := filepath.Join("outputs/artifacts", relSrc+".tgz")
+	dstPath := filepath.Join(varRunArgo, dstRel)
 	logger.WithFields(logging.Fields{
 		"src": srcPath,
 		"dst": dstPath,
 	}).Info(ctx, "saving artifact")
-	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil { // chmod rwxr-xr-x
+	root, err := os.OpenRoot(varRunArgo)
+	if err != nil {
+		return fmt.Errorf("failed to open output root %s: %w", varRunArgo, err)
+	}
+	defer func() { _ = root.Close() }()
+	if err = root.MkdirAll(filepath.Dir(dstRel), 0o755); err != nil { // chmod rwxr-xr-x
 		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(dstPath), err)
 	}
-	root, err := os.OpenRoot(artifactsDir)
-	if err != nil {
-		return fmt.Errorf("failed to open artifacts output root: %w", err)
-	}
-	defer root.Close()
 	dst, err := root.Create(dstRel)
 	if err != nil {
 		return fmt.Errorf("failed to create destination %s: %w", dstPath, err)
@@ -448,15 +451,19 @@ func saveParameter(ctx context.Context, srcPath string) error {
 		logger.WithField("src", srcPath).Info(ctx, "no need to save parameter - on overlapping volume")
 		return nil
 	}
-	// Normalize absolute paths (e.g. /tmp/parameter → tmp/parameter) so that
-	// filepath.IsLocal can validate the result, and os.Root.Create can safely
-	// write it within the outputs directory.
-	relPath := strings.TrimPrefix(srcPath, "/")
-	if !filepath.IsLocal(relPath) {
+	// Map the (possibly absolute) source path to a path relative to the outputs
+	// directory, e.g. /tmp/parameter -> tmp/parameter. TrimLeft drops any leading
+	// slashes (including "//"); Clean collapses any in-bounds "..". IsLocal then
+	// rejects anything that would still escape (leading "..", absolute paths).
+	relSrc := filepath.Clean(strings.TrimLeft(srcPath, "/"))
+	if !filepath.IsLocal(relSrc) {
 		return fmt.Errorf("path traversal in output parameter path %q", srcPath)
 	}
-	parametersDir := filepath.Join(varRunArgo, "outputs/parameters")
-	dstPath := filepath.Join(parametersDir, relPath)
+	// dstRel is relative to varRunArgo; both the directory and the file are
+	// created through a single os.Root opened at that trusted base, so a
+	// symlinked path component cannot redirect the write outside the tree.
+	dstRel := filepath.Join("outputs/parameters", relSrc)
+	dstPath := filepath.Join(varRunArgo, dstRel)
 	src, err := os.Open(filepath.Clean(srcPath))
 	if os.IsNotExist(err) { // might be optional, so we ignore
 		logger.WithField("src", srcPath).WithError(err).Error(ctx, "cannot save parameter, does not exist")
@@ -470,15 +477,15 @@ func saveParameter(ctx context.Context, srcPath string) error {
 		"src": srcPath,
 		"dst": dstPath,
 	}).Info(ctx, "saving parameter")
-	if mkdirErr := os.MkdirAll(filepath.Dir(dstPath), 0o755); mkdirErr != nil { // chmod rwxr-xr-x
+	root, err := os.OpenRoot(varRunArgo)
+	if err != nil {
+		return fmt.Errorf("failed to open output root %s: %w", varRunArgo, err)
+	}
+	defer func() { _ = root.Close() }()
+	if mkdirErr := root.MkdirAll(filepath.Dir(dstRel), 0o755); mkdirErr != nil { // chmod rwxr-xr-x
 		return fmt.Errorf("failed to create directory %s: %w", filepath.Dir(dstPath), mkdirErr)
 	}
-	root, err := os.OpenRoot(parametersDir)
-	if err != nil {
-		return fmt.Errorf("failed to open parameters output root: %w", err)
-	}
-	defer root.Close()
-	dst, err := root.Create(relPath)
+	dst, err := root.Create(dstRel)
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", srcPath, err)
 	}

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -401,20 +401,24 @@ func saveArtifact(ctx context.Context, srcPath string) error {
 		logger.WithField("srcPath", srcPath).Info(ctx, "no need to save artifact - on overlapping volume")
 		return nil
 	}
+	// A missing output is optional and silently skipped; run this before the
+	// traversal guard so a nonexistent optional output never fails the step,
+	// regardless of the shape of its path (matches the pre-guard behavior).
+	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+		logger.WithField("srcPath", srcPath).WithError(err).Warn(ctx, "cannot save artifact")
+		return nil
+	}
 	// Map the (possibly absolute) source path to a path relative to the outputs
-	// directory, e.g. /tmp/artifact -> tmp/artifact. TrimLeft drops any leading
-	// slashes (including "//"); Clean collapses any in-bounds "..". IsLocal then
-	// rejects anything that would still escape (leading "..", absolute paths).
-	relSrc := filepath.Clean(strings.TrimLeft(strings.TrimSuffix(srcPath, "/"), "/"))
+	// directory, e.g. /tmp/artifact -> tmp/artifact. TrimLeft/TrimRight drop any
+	// leading/trailing separators ("/" and "\" for Windows parity); Clean
+	// collapses any in-bounds "..". IsLocal then rejects anything that would
+	// still escape (leading "..", absolute/rooted paths, Windows reserved names).
+	relSrc := filepath.Clean(strings.TrimLeft(strings.TrimRight(srcPath, `/\`), `/\`))
 	// relSrc == "." means srcPath was "/", empty, or cleaned away by ".." (e.g.
 	// "/tmp/.."); that is never a valid single output path and, for artifacts,
 	// would otherwise tar the whole source root, so reject it alongside escapes.
 	if relSrc == "." || !filepath.IsLocal(relSrc) {
 		return fmt.Errorf("path traversal in output artifact path %q", srcPath)
-	}
-	if _, err := os.Stat(srcPath); os.IsNotExist(err) { // might be optional, so we ignore
-		logger.WithField("srcPath", srcPath).WithError(err).Warn(ctx, "cannot save artifact")
-		return nil
 	}
 	// dstRel is relative to varRunArgo; both the directory and the file are
 	// created through a single os.Root opened at that trusted base, so a
@@ -454,11 +458,24 @@ func saveParameter(ctx context.Context, srcPath string) error {
 		logger.WithField("src", srcPath).Info(ctx, "no need to save parameter - on overlapping volume")
 		return nil
 	}
+	// A missing output is optional and silently skipped; open the source before
+	// the traversal guard so a nonexistent optional output never fails the step,
+	// regardless of the shape of its path (matches the pre-guard behavior).
+	src, err := os.Open(filepath.Clean(srcPath))
+	if os.IsNotExist(err) {
+		logger.WithField("src", srcPath).WithError(err).Error(ctx, "cannot save parameter, does not exist")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", srcPath, err)
+	}
+	defer func() { _ = src.Close() }()
 	// Map the (possibly absolute) source path to a path relative to the outputs
-	// directory, e.g. /tmp/parameter -> tmp/parameter. TrimLeft drops any leading
-	// slashes (including "//"); Clean collapses any in-bounds "..". IsLocal then
-	// rejects anything that would still escape (leading "..", absolute paths).
-	relSrc := filepath.Clean(strings.TrimLeft(srcPath, "/"))
+	// directory, e.g. /tmp/parameter -> tmp/parameter. TrimLeft/TrimRight drop any
+	// leading/trailing separators ("/" and "\" for Windows parity); Clean
+	// collapses any in-bounds "..". IsLocal then rejects anything that would
+	// still escape (leading "..", absolute/rooted paths, Windows reserved names).
+	relSrc := filepath.Clean(strings.TrimLeft(strings.TrimRight(srcPath, `/\`), `/\`))
 	// relSrc == "." means srcPath was "/", empty, or cleaned away by ".." (e.g.
 	// "/tmp/.."); that is never a valid single output path, so reject it
 	// alongside escapes.
@@ -470,15 +487,6 @@ func saveParameter(ctx context.Context, srcPath string) error {
 	// symlinked path component cannot redirect the write outside the tree.
 	dstRel := filepath.Join("outputs/parameters", relSrc)
 	dstPath := filepath.Join(varRunArgo, dstRel)
-	src, err := os.Open(filepath.Clean(srcPath))
-	if os.IsNotExist(err) { // might be optional, so we ignore
-		logger.WithField("src", srcPath).WithError(err).Error(ctx, "cannot save parameter, does not exist")
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to open %s: %w", srcPath, err)
-	}
-	defer func() { _ = src.Close() }()
 	logger.WithFields(logging.Fields{
 		"src": srcPath,
 		"dst": dstPath,
@@ -493,7 +501,7 @@ func saveParameter(ctx context.Context, srcPath string) error {
 	}
 	dst, err := root.Create(dstRel)
 	if err != nil {
-		return fmt.Errorf("failed to create %s: %w", srcPath, err)
+		return fmt.Errorf("failed to create %s: %w", dstPath, err)
 	}
 	defer func() { _ = dst.Close() }()
 	if _, err = io.Copy(dst, src); err != nil {

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -406,7 +406,10 @@ func saveArtifact(ctx context.Context, srcPath string) error {
 	// slashes (including "//"); Clean collapses any in-bounds "..". IsLocal then
 	// rejects anything that would still escape (leading "..", absolute paths).
 	relSrc := filepath.Clean(strings.TrimLeft(strings.TrimSuffix(srcPath, "/"), "/"))
-	if !filepath.IsLocal(relSrc) {
+	// relSrc == "." means srcPath was "/", empty, or cleaned away by ".." (e.g.
+	// "/tmp/.."); that is never a valid single output path and, for artifacts,
+	// would otherwise tar the whole source root, so reject it alongside escapes.
+	if relSrc == "." || !filepath.IsLocal(relSrc) {
 		return fmt.Errorf("path traversal in output artifact path %q", srcPath)
 	}
 	if _, err := os.Stat(srcPath); os.IsNotExist(err) { // might be optional, so we ignore
@@ -456,7 +459,10 @@ func saveParameter(ctx context.Context, srcPath string) error {
 	// slashes (including "//"); Clean collapses any in-bounds "..". IsLocal then
 	// rejects anything that would still escape (leading "..", absolute paths).
 	relSrc := filepath.Clean(strings.TrimLeft(srcPath, "/"))
-	if !filepath.IsLocal(relSrc) {
+	// relSrc == "." means srcPath was "/", empty, or cleaned away by ".." (e.g.
+	// "/tmp/.."); that is never a valid single output path, so reject it
+	// alongside escapes.
+	if relSrc == "." || !filepath.IsLocal(relSrc) {
 		return fmt.Errorf("path traversal in output parameter path %q", srcPath)
 	}
 	// dstRel is relative to varRunArgo; both the directory and the file are

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -202,6 +203,52 @@ func TestEmissary(t *testing.T) {
 		data, err = os.ReadFile(varRunArgo + "/outputs/artifacts/tmp/artifact.tgz")
 		require.NoError(t, err)
 		assert.NotEmpty(t, string(data)) // data is tgz format
+	})
+}
+
+func TestSaveParameterPathTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	varRunArgo = tmp
+	ctx := logging.TestContext(t.Context())
+
+	srcFile := "result.txt"
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, srcFile), []byte("hello"), 0o644))
+
+	t.Run("LegitimateRelativePath", func(t *testing.T) {
+		err := saveParameter(ctx, srcFile)
+		require.NoError(t, err)
+	})
+	t.Run("TraversalToArgoexec", func(t *testing.T) {
+		err := saveParameter(ctx, "../../argoexec")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
+	})
+	t.Run("TraversalToSidecarExitCode", func(t *testing.T) {
+		err := saveParameter(ctx, "../../ctr/sidecar/exitcode")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
+	})
+	t.Run("TraversalToTemplate", func(t *testing.T) {
+		err := saveParameter(ctx, "../template")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
+	})
+}
+
+func TestSaveArtifactPathTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	varRunArgo = tmp
+	ctx := logging.TestContext(t.Context())
+
+	t.Run("TraversalToArgoexec", func(t *testing.T) {
+		err := saveArtifact(ctx, "../../argoexec")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
+	})
+	t.Run("TraversalToSidecarExitCode", func(t *testing.T) {
+		err := saveArtifact(ctx, "../../ctr/sidecar/exitcode")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
 	})
 }
 

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -208,20 +208,35 @@ func TestEmissary(t *testing.T) {
 	})
 }
 
-func TestSaveParameterPathTraversal(t *testing.T) {
-	tmp := t.TempDir()
-	varRunArgo = tmp
+// setupTraversalTest nests varRunArgo two levels under a fresh tempdir and
+// creates existing out-of-bounds targets reachable via escaping paths, so the
+// guard is exercised on real (existing) sources rather than skipped as missing
+// (the existence check runs before the guard). It returns the outer root.
+func setupTraversalTest(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	varRunArgo = filepath.Join(root, "run", "argo")
+	require.NoError(t, os.MkdirAll(varRunArgo, 0o755))
 	template = &wfv1.Template{} // isolate from any template left by other tests
+	t.Chdir(varRunArgo)         // sources open relative to varRunArgo
+	// "../../x" from run/argo resolves to root/x; "../x" resolves to run/x.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "argoexec"), []byte("x"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "ctr/sidecar"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ctr/sidecar/exitcode"), []byte("0"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "run/template"), []byte("{}"), 0o644))
+	return root
+}
+
+func TestSaveParameterPathTraversal(t *testing.T) {
+	setupTraversalTest(t)
 	ctx := logging.TestContext(t.Context())
-	// Open source paths relative to tmp so legitimate writes resolve there.
-	t.Chdir(tmp)
 
 	t.Run("LegitimateRelativePath", func(t *testing.T) {
 		require.NoError(t, os.WriteFile("result.txt", []byte("hello"), 0o644))
 		err := saveParameter(ctx, "result.txt")
 		require.NoError(t, err)
 		// The write path must actually run: the parameter is copied under outputs/parameters.
-		data, err := os.ReadFile(filepath.Join(tmp, "outputs/parameters/result.txt"))
+		data, err := os.ReadFile(filepath.Join(varRunArgo, "outputs/parameters/result.txt"))
 		require.NoError(t, err)
 		assert.Equal(t, "hello", string(data))
 	})
@@ -231,10 +246,11 @@ func TestSaveParameterPathTraversal(t *testing.T) {
 		// sub/../sub/p.txt cleans to sub/p.txt, which stays in bounds and must succeed.
 		err := saveParameter(ctx, "sub/../sub/p.txt")
 		require.NoError(t, err)
-		data, err := os.ReadFile(filepath.Join(tmp, "outputs/parameters/sub/p.txt"))
+		data, err := os.ReadFile(filepath.Join(varRunArgo, "outputs/parameters/sub/p.txt"))
 		require.NoError(t, err)
 		assert.Equal(t, "world", string(data))
 	})
+	// Escaping paths whose source EXISTS must be rejected by the guard.
 	t.Run("TraversalToArgoexec", func(t *testing.T) {
 		err := saveParameter(ctx, "../../argoexec")
 		require.Error(t, err)
@@ -250,26 +266,31 @@ func TestSaveParameterPathTraversal(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path traversal")
 	})
+	t.Run("NonexistentTraversalSkipped", func(t *testing.T) {
+		// A missing optional output is skipped even when its path is traversal-shaped.
+		err := saveParameter(ctx, "../../does-not-exist")
+		require.NoError(t, err)
+	})
 	t.Run("RootPathCleansToDot", func(t *testing.T) {
-		// "/" and "x/.." both clean to "." which filepath.IsLocal accepts; the
-		// guard must still reject them (never a valid single output path).
-		for _, p := range []string{"/", "/tmp/..", ""} {
+		// "/" and "/tmp/.." both clean to "." (which filepath.IsLocal accepts) and
+		// both exist, so the guard must still reject them.
+		for _, p := range []string{"/", "/tmp/.."} {
 			err := saveParameter(ctx, p)
 			require.Error(t, err, "expected rejection for %q", p)
 			assert.Contains(t, err.Error(), "path traversal")
 		}
 	})
-	t.Run("SymlinkedDestComponentBlocked", func(t *testing.T) {
+	t.Run("SymlinkedEscapingDestBlocked", func(t *testing.T) {
 		// "escape/p.txt" passes the lexical guard (IsLocal), so it reaches the
-		// filesystem layer. If the main container planted outputs/parameters/escape
-		// as a symlink out of the tree, the os.Root write must refuse to follow it.
-		// This is the only test that exercises the os.Root sandbox: reverting to
-		// os.Create/os.MkdirAll would let this write escape and must fail here.
+		// filesystem layer. os.Root refuses to follow a destination symlink that
+		// ESCAPES the tree — that is the guarantee os.Root provides (in-root
+		// symlinks are not covered). Reverting to os.Create/os.MkdirAll would let
+		// this write escape, so this pins the sandbox.
 		external := t.TempDir() // outside varRunArgo
 		require.NoError(t, os.MkdirAll("escape", 0o755))
 		require.NoError(t, os.WriteFile("escape/p.txt", []byte("data"), 0o644))
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "outputs/parameters"), 0o755))
-		require.NoError(t, os.Symlink(external, filepath.Join(tmp, "outputs/parameters/escape")))
+		require.NoError(t, os.MkdirAll(filepath.Join(varRunArgo, "outputs/parameters"), 0o755))
+		require.NoError(t, os.Symlink(external, filepath.Join(varRunArgo, "outputs/parameters/escape")))
 
 		err := saveParameter(ctx, "escape/p.txt")
 		require.Error(t, err)
@@ -278,18 +299,15 @@ func TestSaveParameterPathTraversal(t *testing.T) {
 }
 
 func TestSaveArtifactPathTraversal(t *testing.T) {
-	tmp := t.TempDir()
-	varRunArgo = tmp
-	template = &wfv1.Template{} // isolate from any template left by other tests
+	setupTraversalTest(t)
 	ctx := logging.TestContext(t.Context())
-	t.Chdir(tmp)
 
 	t.Run("LegitimateAbsolutePath", func(t *testing.T) {
-		require.NoError(t, os.WriteFile(filepath.Join(tmp, "artifact"), []byte("hello"), 0o644))
-		err := saveArtifact(ctx, filepath.Join(tmp, "artifact"))
+		require.NoError(t, os.WriteFile(filepath.Join(varRunArgo, "artifact"), []byte("hello"), 0o644))
+		err := saveArtifact(ctx, filepath.Join(varRunArgo, "artifact"))
 		require.NoError(t, err)
 		// The tarball must actually be written under outputs/artifacts.
-		data, err := os.ReadFile(filepath.Join(tmp, "outputs/artifacts", strings.TrimPrefix(tmp, "/"), "artifact.tgz"))
+		data, err := os.ReadFile(filepath.Join(varRunArgo, "outputs/artifacts", strings.TrimPrefix(varRunArgo, "/"), "artifact.tgz"))
 		require.NoError(t, err)
 		assert.NotEmpty(t, data) // tgz content
 	})
@@ -299,7 +317,7 @@ func TestSaveArtifactPathTraversal(t *testing.T) {
 		// dir/../dir/a cleans to dir/a, in bounds, must succeed and write the tarball.
 		err := saveArtifact(ctx, "dir/../dir/a")
 		require.NoError(t, err)
-		data, err := os.ReadFile(filepath.Join(tmp, "outputs/artifacts/dir/a.tgz"))
+		data, err := os.ReadFile(filepath.Join(varRunArgo, "outputs/artifacts/dir/a.tgz"))
 		require.NoError(t, err)
 		assert.NotEmpty(t, data)
 	})
@@ -318,26 +336,27 @@ func TestSaveArtifactPathTraversal(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path traversal")
 	})
+	t.Run("NonexistentTraversalSkipped", func(t *testing.T) {
+		err := saveArtifact(ctx, "../../does-not-exist")
+		require.NoError(t, err)
+	})
 	t.Run("RootPathCleansToDot", func(t *testing.T) {
-		// "/" cleans to "."; without the guard this would tar the whole source
-		// root. "/tmp/.." and "" also clean to "." and must be rejected.
-		for _, p := range []string{"/", "/tmp/..", ""} {
+		// "/" and "/tmp/.." both clean to "." and exist; without the guard "/"
+		// would tar the whole source root. Both must be rejected.
+		for _, p := range []string{"/", "/tmp/.."} {
 			err := saveArtifact(ctx, p)
 			require.Error(t, err, "expected rejection for %q", p)
 			assert.Contains(t, err.Error(), "path traversal")
 		}
 	})
-	t.Run("SymlinkedDestComponentBlocked", func(t *testing.T) {
-		// "escape/a" passes the lexical guard (IsLocal), so it reaches the
-		// filesystem layer. If the main container planted outputs/artifacts/escape
-		// as a symlink out of the tree, the os.Root write must refuse to follow it.
-		// This is the only test that exercises the os.Root sandbox: reverting to
-		// os.Create/os.MkdirAll would let this write escape and must fail here.
+	t.Run("SymlinkedEscapingDestBlocked", func(t *testing.T) {
+		// See the saveParameter twin: os.Root blocks a destination symlink that
+		// escapes the tree; this pins that guarantee for artifacts.
 		external := t.TempDir() // outside varRunArgo
 		require.NoError(t, os.MkdirAll("escape", 0o755))
 		require.NoError(t, os.WriteFile("escape/a", []byte("data"), 0o644))
-		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "outputs/artifacts"), 0o755))
-		require.NoError(t, os.Symlink(external, filepath.Join(tmp, "outputs/artifacts/escape")))
+		require.NoError(t, os.MkdirAll(filepath.Join(varRunArgo, "outputs/artifacts"), 0o755))
+		require.NoError(t, os.Symlink(external, filepath.Join(varRunArgo, "outputs/artifacts/escape")))
 
 		err := saveArtifact(ctx, "escape/a")
 		require.Error(t, err)

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -211,8 +211,8 @@ func TestEmissary(t *testing.T) {
 // setupTraversalTest nests varRunArgo two levels under a fresh tempdir and
 // creates existing out-of-bounds targets reachable via escaping paths, so the
 // guard is exercised on real (existing) sources rather than skipped as missing
-// (the existence check runs before the guard). It returns the outer root.
-func setupTraversalTest(t *testing.T) string {
+// (the existence check runs before the guard).
+func setupTraversalTest(t *testing.T) {
 	t.Helper()
 	root := t.TempDir()
 	varRunArgo = filepath.Join(root, "run", "argo")
@@ -224,7 +224,6 @@ func setupTraversalTest(t *testing.T) string {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "ctr/sidecar"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "ctr/sidecar/exitcode"), []byte("0"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "run/template"), []byte("{}"), 0o644))
-	return root
 }
 
 func TestSaveParameterPathTraversal(t *testing.T) {

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -250,6 +250,15 @@ func TestSaveParameterPathTraversal(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path traversal")
 	})
+	t.Run("RootPathCleansToDot", func(t *testing.T) {
+		// "/" and "x/.." both clean to "." which filepath.IsLocal accepts; the
+		// guard must still reject them (never a valid single output path).
+		for _, p := range []string{"/", "/tmp/..", ""} {
+			err := saveParameter(ctx, p)
+			require.Error(t, err, "expected rejection for %q", p)
+			assert.Contains(t, err.Error(), "path traversal")
+		}
+	})
 }
 
 func TestSaveArtifactPathTraversal(t *testing.T) {
@@ -287,6 +296,15 @@ func TestSaveArtifactPathTraversal(t *testing.T) {
 		err := saveArtifact(ctx, "../../ctr/sidecar/exitcode")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path traversal")
+	})
+	t.Run("RootPathCleansToDot", func(t *testing.T) {
+		// "/" cleans to "."; without the guard this would tar the whole source
+		// root. "/tmp/.." and "" also clean to "." and must be rejected.
+		for _, p := range []string{"/", "/tmp/..", ""} {
+			err := saveArtifact(ctx, p)
+			require.Error(t, err, "expected rejection for %q", p)
+			assert.Contains(t, err.Error(), "path traversal")
+		}
 	})
 }
 

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	cmdutil "github.com/argoproj/argo-workflows/v4/util/cmd"
 	"github.com/argoproj/argo-workflows/v4/util/errors"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -209,14 +211,29 @@ func TestEmissary(t *testing.T) {
 func TestSaveParameterPathTraversal(t *testing.T) {
 	tmp := t.TempDir()
 	varRunArgo = tmp
+	template = &wfv1.Template{} // isolate from any template left by other tests
 	ctx := logging.TestContext(t.Context())
-
-	srcFile := "result.txt"
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, srcFile), []byte("hello"), 0o644))
+	// Open source paths relative to tmp so legitimate writes resolve there.
+	t.Chdir(tmp)
 
 	t.Run("LegitimateRelativePath", func(t *testing.T) {
-		err := saveParameter(ctx, srcFile)
+		require.NoError(t, os.WriteFile("result.txt", []byte("hello"), 0o644))
+		err := saveParameter(ctx, "result.txt")
 		require.NoError(t, err)
+		// The write path must actually run: the parameter is copied under outputs/parameters.
+		data, err := os.ReadFile(filepath.Join(tmp, "outputs/parameters/result.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(data))
+	})
+	t.Run("LegitimateInternalDotDot", func(t *testing.T) {
+		require.NoError(t, os.MkdirAll("sub", 0o755))
+		require.NoError(t, os.WriteFile("sub/p.txt", []byte("world"), 0o644))
+		// sub/../sub/p.txt cleans to sub/p.txt, which stays in bounds and must succeed.
+		err := saveParameter(ctx, "sub/../sub/p.txt")
+		require.NoError(t, err)
+		data, err := os.ReadFile(filepath.Join(tmp, "outputs/parameters/sub/p.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "world", string(data))
 	})
 	t.Run("TraversalToArgoexec", func(t *testing.T) {
 		err := saveParameter(ctx, "../../argoexec")
@@ -238,8 +255,29 @@ func TestSaveParameterPathTraversal(t *testing.T) {
 func TestSaveArtifactPathTraversal(t *testing.T) {
 	tmp := t.TempDir()
 	varRunArgo = tmp
+	template = &wfv1.Template{} // isolate from any template left by other tests
 	ctx := logging.TestContext(t.Context())
+	t.Chdir(tmp)
 
+	t.Run("LegitimateAbsolutePath", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "artifact"), []byte("hello"), 0o644))
+		err := saveArtifact(ctx, filepath.Join(tmp, "artifact"))
+		require.NoError(t, err)
+		// The tarball must actually be written under outputs/artifacts.
+		data, err := os.ReadFile(filepath.Join(tmp, "outputs/artifacts", strings.TrimPrefix(tmp, "/"), "artifact.tgz"))
+		require.NoError(t, err)
+		assert.NotEmpty(t, data) // tgz content
+	})
+	t.Run("LegitimateInternalDotDot", func(t *testing.T) {
+		require.NoError(t, os.MkdirAll("dir", 0o755))
+		require.NoError(t, os.WriteFile("dir/a", []byte("hi"), 0o644))
+		// dir/../dir/a cleans to dir/a, in bounds, must succeed and write the tarball.
+		err := saveArtifact(ctx, "dir/../dir/a")
+		require.NoError(t, err)
+		data, err := os.ReadFile(filepath.Join(tmp, "outputs/artifacts/dir/a.tgz"))
+		require.NoError(t, err)
+		assert.NotEmpty(t, data)
+	})
 	t.Run("TraversalToArgoexec", func(t *testing.T) {
 		err := saveArtifact(ctx, "../../argoexec")
 		require.Error(t, err)

--- a/cmd/argoexec/commands/emissary_test.go
+++ b/cmd/argoexec/commands/emissary_test.go
@@ -259,6 +259,22 @@ func TestSaveParameterPathTraversal(t *testing.T) {
 			assert.Contains(t, err.Error(), "path traversal")
 		}
 	})
+	t.Run("SymlinkedDestComponentBlocked", func(t *testing.T) {
+		// "escape/p.txt" passes the lexical guard (IsLocal), so it reaches the
+		// filesystem layer. If the main container planted outputs/parameters/escape
+		// as a symlink out of the tree, the os.Root write must refuse to follow it.
+		// This is the only test that exercises the os.Root sandbox: reverting to
+		// os.Create/os.MkdirAll would let this write escape and must fail here.
+		external := t.TempDir() // outside varRunArgo
+		require.NoError(t, os.MkdirAll("escape", 0o755))
+		require.NoError(t, os.WriteFile("escape/p.txt", []byte("data"), 0o644))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "outputs/parameters"), 0o755))
+		require.NoError(t, os.Symlink(external, filepath.Join(tmp, "outputs/parameters/escape")))
+
+		err := saveParameter(ctx, "escape/p.txt")
+		require.Error(t, err)
+		require.NoFileExists(t, filepath.Join(external, "p.txt")) // must not escape the tree
+	})
 }
 
 func TestSaveArtifactPathTraversal(t *testing.T) {
@@ -297,6 +313,11 @@ func TestSaveArtifactPathTraversal(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path traversal")
 	})
+	t.Run("TraversalToTemplate", func(t *testing.T) {
+		err := saveArtifact(ctx, "../template")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path traversal")
+	})
 	t.Run("RootPathCleansToDot", func(t *testing.T) {
 		// "/" cleans to "."; without the guard this would tar the whole source
 		// root. "/tmp/.." and "" also clean to "." and must be rejected.
@@ -305,6 +326,22 @@ func TestSaveArtifactPathTraversal(t *testing.T) {
 			require.Error(t, err, "expected rejection for %q", p)
 			assert.Contains(t, err.Error(), "path traversal")
 		}
+	})
+	t.Run("SymlinkedDestComponentBlocked", func(t *testing.T) {
+		// "escape/a" passes the lexical guard (IsLocal), so it reaches the
+		// filesystem layer. If the main container planted outputs/artifacts/escape
+		// as a symlink out of the tree, the os.Root write must refuse to follow it.
+		// This is the only test that exercises the os.Root sandbox: reverting to
+		// os.Create/os.MkdirAll would let this write escape and must fail here.
+		external := t.TempDir() // outside varRunArgo
+		require.NoError(t, os.MkdirAll("escape", 0o755))
+		require.NoError(t, os.WriteFile("escape/a", []byte("data"), 0o644))
+		require.NoError(t, os.MkdirAll(filepath.Join(tmp, "outputs/artifacts"), 0o755))
+		require.NoError(t, os.Symlink(external, filepath.Join(tmp, "outputs/artifacts/escape")))
+
+		err := saveArtifact(ctx, "escape/a")
+		require.Error(t, err)
+		require.NoFileExists(t, filepath.Join(external, "a.tgz")) // must not escape the tree
 	})
 }
 


### PR DESCRIPTION
## Summary

Both `saveParameter` and `saveArtifact` built destination paths without
enforcing that the result stays inside `/var/run/argo/outputs/`.

`saveParameter` used raw string concatenation:
```go
// vulnerable
dstPath := varRunArgo + "/outputs/parameters/" + srcPath
```

A workflow spec with valueFrom.path: "../../ctr/containerB/exitcode"
resolves to /var/run/argo/ctr/containerB/exitcode — a world-writable
directory (created 0o777 by design for non-root containers) — letting
one container in a ContainerSet falsify another container's exit code
and bypass DAG dependency checks.

saveArtifact had the same issue: a traversal path resolves outside outputs/artifacts/ regardless of the .tgz suffix appended to the filename

## Fix

Add a filepath.Join + strings.HasPrefix bounds check in both
functions. The check is placed before os.Open/os.Stat so traversal
paths are rejected even when the source file does not yet exist.

## Tests

Added TestSaveParameterPathTraversal and TestSaveArtifactPathTraversal
covering:

- Legitimate absolute paths → allowed
- ../../argoexec traversal → blocked
- ../../ctr/sidecar/exitcode traversal → blocked
- ../template traversal → blocked

Fixes https://github.com/argoproj/argo-workflows/security/advisories/GHSA-r9w2-rp4m-gwr9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how artifacts and parameters are persisted to prevent path traversal and symlink escape from writing outside the expected output directories.
  * Optional outputs that are missing are now safely skipped.
* **Tests**
  * Added coverage for path traversal and symlink-escape scenarios for both artifacts and parameters, verifying allowed in-tree mappings and rejecting unsafe inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->