### PR TITLE
fix(errors): treat kube-apiserver HTTP 500 as transient error

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -47,6 +47,7 @@ func isTransientErr(err error) bool {
 		isResourceQuotaTimeoutErr(err) ||
 		isTransientNetworkErr(err) ||
 		apierr.IsServerTimeout(err) ||
+		apierr.IsInternalError(err) ||
 		apierr.IsTimeout(err) ||
 		apierr.IsServiceUnavailable(err) ||
 		isTransientEtcdErr(err) ||

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -69,8 +69,9 @@ func TestIsTransientErr(t *testing.T) {
 		assert.Contains(t, hook.LastEntry().Msg, "Transient error")
 	})
 	t.Run("ResourceQuotaTimeoutErr", func(t *testing.T) {
-		assert.False(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New(""))))
+		assert.True(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New(""))))
 		assert.True(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New("resource quota evaluation timed out"))))
+		assert.True(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New("some other transient 500"))))
 	})
 	t.Run("ExceededQuotaErr", func(t *testing.T) {
 		assert.False(t, IsTransientErr(ctx, apierr.NewForbidden(schema.GroupResource{}, "", nil)))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14220

## Motivation
The Workflows fails immediately when the kube-apiserver returns an HTTP 500 error. 
This happens because the system does not recognize `general 500 errors` as transient, turning temporary server issues into permanent workflow failures.

https://github.com/argoproj/argo-workflows/blob/7a7e60839796b0cb3a1343f2ec0968bd2ac2d694/util/errors/errors.go#L39-L56


> There is already a function `isResourceQuotaTimeoutErr` that calls `apierr.IsInternalError(err)`, but it narrows it with a specific message check ("resource quota evaluation timed out"), so every other HTTP 500 falls through.

https://github.com/argoproj/argo-workflows/blob/7a7e60839796b0cb3a1343f2ec0968bd2ac2d694/util/errors/errors.go#L73-L75

### 5XX Http Error that are  transient for now
|Function|Http Status|
|--|--|
|IsServerTimeout| HTTP 504(specific server-timeout reasons)|
|IsServiceUnavailable| HTTP 503 |
|isResourceQuotaTimeoutErr|HTTP 500(resource quota evaluation timed out)|


<!-- TODO: Say why you made your changes. -->

## Modifications
Updates the error handling logic to classify all HTTP 500 (Internal Server Error) responses as transient, enabling automatic retries to improve workflow resilience.
**Logic Update**: Added `apierr.IsInternalError(err)` to the `isTransientErr` function to catch 500 errors. 
<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

## Verification
Updated unit tests to ensure HTTP 500 now triggers a retry and verified the fix with all existing sub-tests.

<!-- TODO: Say how you tested your changes. -->

## AI
Claude did the testing part.
<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->
