### PR TITLE
feat: Add configurable batching for nodeResults in TaskSet patch operations to prevent etcd request size limits

### DIFF
--- a/.features/pending/feat-support-batching.md
+++ b/.features/pending/feat-support-batching.md
@@ -1,0 +1,12 @@
+Issues: 16054
+Authors: [Anton Pechenin](ntny1986@gmail.com)
+Description: Add batching support for nodeResults in TaskSet patch operations
+Component: General
+
+You can now batch nodeResults when patching Workflow TaskSets.
+This improves reliability for workflows with a large number of parallel nodes by preventing patch payloads from exceeding etcd size limits.
+
+Previously, workflows with many parallel nodes (tested with ~200), particularly when using the agent executor plugin, could generate patch requests that exceeded etcd size limits when multiple TaskSet updates occurred within a single reconciliation period.
+With batching enabled, nodeResults are split into smaller chunks and patched sequentially, keeping each request within safe size limits.
+
+For example, instead of sending a single large patch, the agent will split results into batches (e.g., 30 nodes per request), ensuring each patch stays within safe size limits.

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -194,6 +194,8 @@ const (
 	EnvAgentTaskWorkers = "ARGO_AGENT_TASK_WORKERS"
 	// EnvAgentPatchRate is the rate that the Argo Agent will patch the Workflow TaskSet
 	EnvAgentPatchRate = "ARGO_AGENT_PATCH_RATE"
+	// EnvAgentPatchBatchSize defines the maximum batch size for patching Workflow TaskSet nodes in a single request. Default 900
+	EnvAgentPatchBatchSize = "ARGO_AGENT_PATCH_BATCH_SIZE"
 
 	// Finalizer to block deletion of the workflow if deletion of artifacts fail for some reason.
 	FinalizerArtifactGC = workflow.WorkflowFullName + "/artifact-gc"

--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -147,6 +147,13 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 		})
 	}
 
+	if batchSize, exists := os.LookupEnv(common.EnvAgentPatchBatchSize); exists {
+		envVars = append(envVars, apiv1.EnvVar{
+			Name:  common.EnvAgentPatchBatchSize,
+			Value: batchSize,
+		})
+	}
+
 	serviceAccountName := woc.execWf.Spec.ServiceAccountName
 	tokenVolume, tokenVolumeMount, err := woc.getServiceAccountTokenVolume(ctx, serviceAccountName)
 	if err != nil {

--- a/workflow/executor/agent.go
+++ b/workflow/executor/agent.go
@@ -75,16 +75,18 @@ func (ae *AgentExecutor) Agent(ctx context.Context) error {
 
 	taskWorkers := env.LookupEnvIntOr(ctx, common.EnvAgentTaskWorkers, 16)
 	requeueTime := env.LookupEnvDurationOr(ctx, common.EnvAgentPatchRate, 10*time.Second)
+	batchSize := env.LookupEnvIntOr(ctx, common.EnvAgentPatchBatchSize, 900)
 	logger := logging.RequireLoggerFromContext(ctx)
 	logger.WithField("taskWorkers", taskWorkers).
 		WithField("requeueTime", requeueTime).
+		WithField("batchSize", batchSize).
 		Info(ctx, "Starting Agent")
 
 	taskQueue := make(chan task)
 	responseQueue := make(chan response)
 	taskSetInterface := ae.WorkflowInterface.ArgoprojV1alpha1().WorkflowTaskSets(ae.Namespace)
 
-	go ae.patchWorker(ctx, taskSetInterface, responseQueue, requeueTime)
+	go ae.patchWorker(ctx, taskSetInterface, responseQueue, requeueTime, batchSize)
 	for range taskWorkers {
 		go ae.taskWorker(ctx, taskQueue, responseQueue)
 	}
@@ -166,7 +168,7 @@ func (ae *AgentExecutor) taskWorker(ctx context.Context, taskQueue chan task, re
 	}
 }
 
-func (ae *AgentExecutor) patchWorker(ctx context.Context, taskSetInterface v1alpha1.WorkflowTaskSetInterface, responseQueue chan response, requeueTime time.Duration) {
+func (ae *AgentExecutor) patchWorker(ctx context.Context, taskSetInterface v1alpha1.WorkflowTaskSetInterface, responseQueue chan response, requeueTime time.Duration, batchSize int) {
 	ticker := time.NewTicker(requeueTime)
 	defer ticker.Stop()
 	nodeResults := map[string]wfv1.NodeResult{}
@@ -179,28 +181,7 @@ func (ae *AgentExecutor) patchWorker(ctx context.Context, taskSetInterface v1alp
 			if len(nodeResults) == 0 {
 				continue
 			}
-
-			patch, err := json.Marshal(map[string]any{"status": wfv1.WorkflowTaskSetStatus{Nodes: nodeResults}})
-			if err != nil {
-				logger.WithError(err).Error(ctx, "Generating Patch Failed")
-				continue
-			}
-
-			logger.Info(ctx, "Processing Patch")
-
-			err = retry.OnError(wait.Backoff{
-				Duration: time.Second,
-				Factor:   2,
-				Jitter:   0.1,
-				Steps:    5,
-				Cap:      30 * time.Second,
-			}, func(retryErr error) bool {
-				return errors.IsTransientErr(ctx, retryErr)
-			}, func() error {
-				_, patchErr := taskSetInterface.Patch(ctx, ae.WorkflowName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
-				return patchErr
-			})
-
+			err := patchTaskSetStatus(ctx, taskSetInterface, nodeResults, ae.WorkflowName, batchSize)
 			if err != nil && !errors.IsTransientErr(ctx, err) {
 				logger.WithError(err).
 					Error(ctx, "TaskSet Patch Failed")
@@ -217,9 +198,6 @@ func (ae *AgentExecutor) patchWorker(ctx context.Context, taskSetInterface v1alp
 				}
 				continue
 			}
-
-			// Patch was successful, clear nodeResults for next iteration
-			nodeResults = map[string]wfv1.NodeResult{}
 
 			logger.Info(ctx, "Patched TaskSet")
 		}
@@ -387,4 +365,64 @@ func (ae *AgentExecutor) executePluginTemplate(ctx context.Context, tmpl wfv1.Te
 
 func IsWorkflowCompleted(wts *wfv1.WorkflowTaskSet) bool {
 	return wts.Labels[common.LabelKeyCompleted] == "true"
+}
+
+func batchNodeResults(nodeResults map[string]wfv1.NodeResult, batchSize int) []map[string]wfv1.NodeResult {
+	keys := make([]string, 0, len(nodeResults))
+	for k := range nodeResults {
+		keys = append(keys, k)
+	}
+
+	var batches []map[string]wfv1.NodeResult
+
+	for i := 0; i < len(keys); i += batchSize {
+		end := min(i+batchSize, len(keys))
+
+		batch := make(map[string]wfv1.NodeResult, end-i)
+		for _, k := range keys[i:end] {
+			batch[k] = nodeResults[k]
+		}
+
+		batches = append(batches, batch)
+	}
+
+	return batches
+}
+
+func patchTaskSetStatus(ctx context.Context, taskSetInterface v1alpha1.WorkflowTaskSetInterface, nodeResults map[string]wfv1.NodeResult, wf string, batchSize int) error {
+	batches := batchNodeResults(nodeResults, batchSize)
+	for _, batch := range batches {
+		err := patchWorkerTaskSets(ctx, taskSetInterface, batch, wf)
+		if err != nil {
+			return err
+		}
+		for nodeID := range batch {
+			delete(nodeResults, nodeID)
+		}
+	}
+	return nil
+}
+
+func patchWorkerTaskSets(ctx context.Context, taskSetInterface v1alpha1.WorkflowTaskSetInterface, nodeResults map[string]wfv1.NodeResult, wf string) error {
+	logger := logging.RequireLoggerFromContext(ctx)
+	logger.Info(ctx, fmt.Sprintf("Patching TaskSet. Node results to patch: %d", len(nodeResults)))
+	patch, err := json.Marshal(map[string]any{"status": wfv1.WorkflowTaskSetStatus{Nodes: nodeResults}})
+	if err != nil {
+		logger.WithError(err).Error(ctx, "Generating Patch Failed")
+		return err
+	}
+
+	err = retry.OnError(wait.Backoff{
+		Duration: time.Second,
+		Factor:   2,
+		Jitter:   0.1,
+		Steps:    5,
+		Cap:      30 * time.Second,
+	}, func(retryErr error) bool {
+		return errors.IsTransientErr(ctx, retryErr)
+	}, func() error {
+		_, patchErr := taskSetInterface.Patch(ctx, wf, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+		return patchErr
+	})
+	return err
 }

--- a/workflow/executor/agent_test.go
+++ b/workflow/executor/agent_test.go
@@ -87,6 +87,80 @@ func TestAgentPluginExecuteTaskSet(t *testing.T) {
 	}
 }
 
+func TestBatchNodeResults(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     map[string]v1alpha1.NodeResult
+		batchSize int
+
+		expectBatchCount int
+		expectBatchSizes []int
+	}{
+		{
+			name:      "empty collection",
+			input:     map[string]v1alpha1.NodeResult{},
+			batchSize: 3,
+
+			expectBatchCount: 0,
+			expectBatchSizes: []int{},
+		},
+		{
+			name: "less than batch size",
+			input: map[string]v1alpha1.NodeResult{
+				"a": {}, "b": {},
+			},
+			batchSize: 3,
+
+			expectBatchCount: 1,
+			expectBatchSizes: []int{2},
+		},
+		{
+			name: "equal to batch size",
+			input: map[string]v1alpha1.NodeResult{
+				"a": {}, "b": {}, "c": {},
+			},
+			batchSize: 3,
+
+			expectBatchCount: 1,
+			expectBatchSizes: []int{3},
+		},
+		{
+			name: "greater than batch size",
+			input: map[string]v1alpha1.NodeResult{
+				"a": {}, "b": {}, "c": {}, "d": {}, "e": {},
+			},
+			batchSize: 3,
+
+			expectBatchCount: 2,
+			expectBatchSizes: []int{3, 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			batches := batchNodeResults(tc.input, tc.batchSize)
+
+			if len(batches) != tc.expectBatchCount {
+				t.Fatalf("expected %d batches, got %d", tc.expectBatchCount, len(batches))
+			}
+
+			for i, b := range batches {
+				if len(b) != tc.expectBatchSizes[i] {
+					t.Errorf("batch %d: expected size %d, got %d", i, tc.expectBatchSizes[i], len(b))
+				}
+
+				// optional: ensure no data loss
+				for k, v := range b {
+					if _, ok := tc.input[k]; !ok {
+						t.Errorf("batch %d contains unknown key %s", i, k)
+					}
+					_ = v
+				}
+			}
+		})
+	}
+}
+
 type alwaysSucceededPlugin struct {
 	requeue time.Duration
 }


### PR DESCRIPTION
Motivation

In highly parallel Argo Workflows executed via the executor plugin (tested with ~200 parallel nodes), nodeResults can accumulate within a single requeue period and produce TaskSet patch payloads that exceed etcd size limits.

This leads to patch failures with errors such as:

etcdserver: request is too large

(or slightly different variants depending on Argo version, e.g. v4.0.4).

To address this, this change introduces batching of nodeResults before patching TaskSets.

What this PR does
Introduces batching of nodeResults in TaskSet patch operations (executor plugin path)
Splits large result sets into smaller chunks before sending patch requests
Ensures each patch stays within etcd size limits
Applies patches sequentially per batch
Adds configurable batch size via environment variable (default: 1000)

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/issues/16054

Future possible improvement: split TaskSet into metadata and payload, keep metadata in etcd with a reference to the payload, and store payloads in external storage to further reduce etcd pressure.


### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->
