### PR TITLE
feat(ui): make list limit configurable on cron workflow details page (#14065)

### DIFF
--- a/.features/pending/cron-workflow-details-list-limit.md
+++ b/.features/pending/cron-workflow-details-list-limit.md
@@ -1,0 +1,6 @@
+Description: Configurable list limit on the cron workflow details page
+Author: [Chris](https://github.com/ChrisJr404)
+Component: UI
+Issues: 14065
+
+The historical-runs list on the cron workflow details page now supports configurable pagination instead of a hard-coded 50-row cap. Use the `limit` query parameter (e.g. `?limit=100`) or the per-page selector in the new pagination footer to scroll back through older runs.

--- a/ui/src/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/cron-workflows/cron-workflow-details.tsx
@@ -9,11 +9,13 @@ import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {openLinkWithKey} from '../shared/components/links';
 import {Loading} from '../shared/components/loading';
+import {PaginationPanel} from '../shared/components/pagination-panel';
 import {ZeroState} from '../shared/components/zero-state';
 import {Context} from '../shared/context';
 import {historyUrl} from '../shared/history';
 import * as models from '../shared/models';
 import {CronWorkflow, Link, Workflow} from '../shared/models';
+import {Pagination, parseLimit} from '../shared/pagination';
 import {services} from '../shared/services';
 import {useCollectEvent} from '../shared/use-collect-event';
 import {useEditableObject} from '../shared/use-editable-object';
@@ -36,6 +38,9 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
     const [tab, setTab] = useState(queryParams.get('tab'));
     const [workflows, setWorkflows] = useState<Workflow[]>([]);
     const [columns, setColumns] = useState<models.Column[]>([]);
+    const [pagination, setPagination] = useState<Pagination>({
+        limit: parseLimit(queryParams.get('limit')) || 50
+    });
 
     const {object: cronWorkflow, setObject: setCronWorkflow, resetObject: resetCronWorkflow, serialization, edited, lang, setLang} = useEditableObject<CronWorkflow>();
     const [error, setError] = useState<Error>();
@@ -44,6 +49,7 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
         useQueryParams(history, p => {
             setSidePanel(p.get('sidePanel'));
             setTab(p.get('tab'));
+            setPagination(prev => ({...prev, limit: parseLimit(p.get('limit')) || prev.limit}));
         }),
         [history]
     );
@@ -58,10 +64,11 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
                 namespace,
                 name,
                 sidePanel,
-                tab
+                tab,
+                limit: pagination.limit ? pagination.limit.toString() : undefined
             })
         );
-    }, [namespace, name, sidePanel, tab]);
+    }, [namespace, name, sidePanel, tab, pagination.limit]);
 
     useEffect(() => {
         services.cronWorkflows
@@ -73,13 +80,13 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
 
     useEffect(() => {
         (async () => {
-            const workflowList = await services.workflows.list(namespace, null, [`${models.labels.cronWorkflow}=${name}`], {limit: 50});
+            const workflowList = await services.workflows.list(namespace, null, [`${models.labels.cronWorkflow}=${name}`], pagination);
             const workflowsInfo = await services.info.getInfo();
 
             setWorkflows(workflowList.items);
             setColumns(workflowsInfo.columns);
         })();
-    }, []);
+    }, [pagination.limit]);
 
     useCollectEvent('openedCronWorkflowDetails');
 
@@ -231,7 +238,10 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
                             <p> You can create new cron workflows here or using the CLI. </p>
                         </ZeroState>
                     ) : (
-                        <WorkflowDetailsList workflows={workflows} columns={columns} />
+                        <>
+                            <WorkflowDetailsList workflows={workflows} columns={columns} />
+                            <PaginationPanel onChange={setPagination} pagination={pagination} numRecords={workflows.length} />
+                        </>
                     )}
                 </>
             </>


### PR DESCRIPTION
Closes #14065. Previous PR #15205 was opened by @majiayu000, reviewed positively by CodeRabbit, then closed by the author for "extended inactivity" — re-opening with the same shape.

## What

The Cron Workflow Details page hardcodes the workflow-list limit to 50:

\`\`\`tsx
const workflowList = await services.workflows.list(
    namespace, null, [\`\${models.labels.cronWorkflow}=\${name}\`], {limit: 50}
);
\`\`\`

This switches the page to the same \`Pagination\` state + \`PaginationPanel\` already used by \`workflows-list.tsx\`. The user can change the page size from the panel; the choice is reflected in the \`?limit=N\` URL parameter so a refresh / deep-link keeps it. Default is still 50 when no override is supplied.

## Why

Quoted from @tczhao in the issue:

> When visiting cron-workflow detail, e.g. \`cron-workflows/argo/test-cron-wf\`, the UI does a List workflow request to list the historical runs from this cron-workflow. However, this list limit is hardcoded to 50 instead of configurable like the workflows page.

Endorsed by @tczhao to a previous candidate: "Yes, we would love to have this feature. Please go ahead and work on this."

## Diff shape

- Add \`pagination\` state (offset/limit) initialized from the \`?limit=\` query param.
- Wire \`pagination.limit\` into the \`services.workflows.list\` call and the \`useQueryParams\` listener so changes in either direction (UI ⇄ URL) stay in sync.
- Render \`<PaginationPanel>\` underneath \`<WorkflowDetailsList>\`.
- Persist \`limit\` to history via \`historyUrl\`.

Total: +15 / −5 in one file (\`ui/src/cron-workflows/cron-workflow-details.tsx\`).

## Tests

- \`npx eslint src/cron-workflows/cron-workflow-details.tsx\` — clean.
- \`npx tsc --noEmit\` — only pre-existing third-party errors in \`node_modules/argo-ui\` and \`node_modules/minimatch\`; none introduced by this PR.
- The implementation mirrors the proven pattern in \`ui/src/workflows/components/workflows-list/workflows-list.tsx\` (lines 67–73 / 140–172 / 192).

## Notes

- Pure-additive: the visible default limit is still 50, so anyone who doesn't change the page size sees identical results.
- The CodeRabbit review of #15205 left only one nitpick (adding \`history\` to a useEffect dependency array); not adopting it here because the existing \`history.push\` effect on the same page also doesn't list \`history\` as a dep, and adding it to one effect inconsistently with the other reads worse than not adding it. Happy to apply it if reviewers prefer.