### PR TITLE
fix: prevent nil pointer panic in artifact server when using SA tokens

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -282,7 +282,7 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	}
 	eventRecorderManager := events.NewEventRecorderManager(as.clients.Kubernetes)
 	artifactRepositories := artifactrepositories.New(as.clients.Kubernetes, as.managedNamespace, &config.ArtifactRepository)
-	artifactServer := artifacts.NewArtifactServer(as.gatekeeper, hydrator.New(offloadRepo), wfArchive, instanceIDService, artifactRepositories, log)
+	artifactServer := artifacts.NewArtifactServer(as.gatekeeper, hydrator.New(offloadRepo), wfArchive, instanceIDService, artifactRepositories, log, as.clients.Kubernetes)
 	eventServer := event.NewController(ctx, instanceIDService, eventRecorderManager, as.eventQueueSize, as.eventWorkerCount, as.eventAsyncDispatch)
 	wfArchiveServer := workflowarchive.NewWorkflowArchiveServer(wfArchive, offloadRepo, config.WorkflowDefaults)
 

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/status"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/env"
 
 	argoerrors "github.com/argoproj/argo-workflows/v4/errors"
@@ -41,6 +42,7 @@ type ArtifactServer struct {
 	artDriverFactory     artifacts.NewDriverFunc
 	artifactRepositories artifactrepositories.Interface
 	logger               logging.Logger
+	serverKubeClient     kubernetes.Interface
 }
 
 type Direction string
@@ -50,12 +52,12 @@ const (
 	Inputs  Direction = "inputs"
 )
 
-func NewArtifactServer(authN auth.Gatekeeper, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive, instanceIDService instanceid.Service, artifactRepositories artifactrepositories.Interface, logger logging.Logger) *ArtifactServer {
-	return newArtifactServer(authN, hydrator, wfArchive, instanceIDService, artifacts.NewDriver, artifactRepositories, logger)
+func NewArtifactServer(authN auth.Gatekeeper, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive, instanceIDService instanceid.Service, artifactRepositories artifactrepositories.Interface, logger logging.Logger, serverKubeClient kubernetes.Interface) *ArtifactServer {
+	return newArtifactServer(authN, hydrator, wfArchive, instanceIDService, artifacts.NewDriver, artifactRepositories, logger, serverKubeClient)
 }
 
-func newArtifactServer(authN auth.Gatekeeper, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive, instanceIDService instanceid.Service, artDriverFactory artifacts.NewDriverFunc, artifactRepositories artifactrepositories.Interface, logger logging.Logger) *ArtifactServer {
-	return &ArtifactServer{authN, hydrator, wfArchive, instanceIDService, artDriverFactory, artifactRepositories, logger}
+func newArtifactServer(authN auth.Gatekeeper, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive, instanceIDService instanceid.Service, artDriverFactory artifacts.NewDriverFunc, artifactRepositories artifactrepositories.Interface, logger logging.Logger, serverKubeClient kubernetes.Interface) *ArtifactServer {
+	return &ArtifactServer{authN, hydrator, wfArchive, instanceIDService, artDriverFactory, artifactRepositories, logger, serverKubeClient}
 }
 
 //nolint:contextcheck
@@ -460,7 +462,7 @@ func (a *ArtifactServer) httpFromError(ctx context.Context, err error, w http.Re
 func (a *ArtifactServer) getArtifactAndDriver(ctx context.Context, nodeID, artifactName string, isInput bool, wf *wfv1.Workflow, fileName *string) (*wfv1.Artifact, common.ArtifactDriver, error) {
 	logger := logging.RequireLoggerFromContext(ctx)
 
-	kubeClient := auth.GetKubeClient(ctx)
+	kubeClient := a.serverKubeClient
 
 	var art *wfv1.Artifact
 

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -177,6 +177,10 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 		a.serverInternalError(ctx, err, w)
 		return
 	}
+	if driver == nil {
+		a.serverInternalError(ctx, fmt.Errorf("artifact driver is nil for artifact %q in node %q", artifactName, nodeID), w)
+		return
+	}
 
 	isDir := strings.HasSuffix(r.URL.Path, "/")
 
@@ -312,6 +316,10 @@ func (a *ArtifactServer) getArtifact(w http.ResponseWriter, r *http.Request, isI
 		a.serverInternalError(ctx, err, w)
 		return
 	}
+	if driver == nil {
+		a.serverInternalError(ctx, fmt.Errorf("artifact driver is nil for artifact %q in node %q", artifactName, nodeID), w)
+		return
+	}
 
 	err = a.returnArtifact(ctx, w, art, driver)
 
@@ -364,6 +372,10 @@ func (a *ArtifactServer) getArtifactByUID(w http.ResponseWriter, r *http.Request
 	art, driver, err := a.getArtifactAndDriver(ctx, nodeID, artifactName, isInput, wf, nil)
 	if err != nil {
 		a.serverInternalError(ctx, err, w)
+		return
+	}
+	if driver == nil {
+		a.serverInternalError(ctx, fmt.Errorf("artifact driver is nil for artifact %q in node %q", artifactName, nodeID), w)
 		return
 	}
 

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -51,6 +51,19 @@ type fakeArtifactDriver struct {
 	data []byte
 }
 
+// simpleArtifactDriver is a minimal driver that always succeeds without validating bucket keys.
+type simpleArtifactDriver struct {
+	artifactscommon.ArtifactDriver
+}
+
+func (a *simpleArtifactDriver) IsDirectory(_ context.Context, _ *wfv1.Artifact) (bool, error) {
+	return false, nil
+}
+
+func (a *simpleArtifactDriver) OpenStream(_ context.Context, _ *wfv1.Artifact) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader([]byte("data"))), nil
+}
+
 func (a *fakeArtifactDriver) Load(_ context.Context, _ *wfv1.Artifact, path string) error {
 	return os.WriteFile(path, a.data, 0o600)
 }
@@ -376,7 +389,7 @@ func newServer(t *testing.T) *ArtifactServer {
 		},
 	})
 
-	return newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), fakeArtifactDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx))
+	return newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), fakeArtifactDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx), kube)
 }
 
 func TestArtifactServer_GetArtifactFile(t *testing.T) {
@@ -844,7 +857,7 @@ func TestArtifactServer_NilDriverReturns500(t *testing.T) {
 		},
 	})
 
-	s := newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), nilDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx))
+	s := newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), nilDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx), kube)
 
 	r := &http.Request{}
 	r.URL = mustParse("/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-artifact")
@@ -853,4 +866,77 @@ func TestArtifactServer_NilDriverReturns500(t *testing.T) {
 	// This should NOT panic — it should return 500
 	s.GetArtifactFile(recorder, r)
 	assert.Equal(t, 500, recorder.Result().StatusCode)
+}
+
+func TestArtifactServer_UsesServerKubeClient(t *testing.T) {
+	gatekeeper := &authmocks.Gatekeeper{}
+	serverKube := kubefake.NewClientset() // the server's own client
+	callerKube := kubefake.NewClientset() // the caller's scoped client
+	instanceID := "my-instanceid"
+	wf := &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Name: "my-wf", Labels: map[string]string{
+			common.LabelKeyControllerInstanceID: instanceID,
+		}},
+		Spec: wfv1.WorkflowSpec{
+			Templates: []wfv1.Template{
+				{Name: "template-1"},
+			},
+		},
+		Status: wfv1.WorkflowStatus{
+			Nodes: wfv1.Nodes{
+				"my-node-1": wfv1.NodeStatus{
+					TemplateName: "template-1",
+					Outputs: &wfv1.Outputs{
+						Artifacts: wfv1.Artifacts{
+							{
+								Name: "my-artifact",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									S3: &wfv1.S3Artifact{
+										Key: "my-wf/my-node-1/my-artifact.tgz",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	argo := fakewfv1.NewClientset(wf)
+	// Context has the CALLER's kube client (limited permissions)
+	ctx := context.WithValue(context.WithValue(logging.TestContext(t.Context()), auth.KubeKey, callerKube), auth.WfKey, argo)
+	gatekeeper.On("ContextWithRequest", mock.Anything, mock.Anything).Return(ctx, nil)
+
+	a := &sqldbmocks.WorkflowArchive{}
+	a.On("GetWorkflow", mock.Anything, "my-uuid", "", "").Return(wf, nil)
+
+	// Track which resource interface the factory receives
+	var receivedResources resource.Interface
+	trackingFactory := func(_ context.Context, _ *wfv1.Artifact, ri resource.Interface) (artifactscommon.ArtifactDriver, error) {
+		receivedResources = ri
+		return &simpleArtifactDriver{}, nil
+	}
+
+	artifactRepositories := armocks.DummyArtifactRepositories(&wfv1.ArtifactRepository{
+		S3: &wfv1.S3ArtifactRepository{
+			S3Bucket: wfv1.S3Bucket{
+				Endpoint: "my-endpoint",
+				Bucket:   "my-bucket",
+			},
+		},
+	})
+
+	s := newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), trackingFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx), serverKube)
+
+	r := &http.Request{}
+	r.URL = mustParse("/artifacts/my-ns/my-wf/my-node-1/my-artifact")
+	recorder := httptest.NewRecorder()
+
+	s.GetOutputArtifact(recorder, r)
+
+	// The factory should have received the SERVER's kube client, not the caller's
+	require.NotNil(t, receivedResources, "factory should have been called")
+	res, ok := receivedResources.(resources)
+	require.True(t, ok, "expected resources type")
+	assert.Same(t, serverKube, res.kubeClient, "artifact driver should use server kube client, not caller's")
 }

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -790,3 +790,67 @@ func TestArtifactServer_httpFromError(t *testing.T) {
 	s.httpFromError(ctx, err, recorder)
 	assert.Equal(t, http.StatusNotFound, recorder.Result().StatusCode)
 }
+
+func TestArtifactServer_NilDriverReturns500(t *testing.T) {
+	gatekeeper := &authmocks.Gatekeeper{}
+	kube := kubefake.NewClientset()
+	instanceID := "my-instanceid"
+	wf := &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "my-ns", Name: "my-wf", Labels: map[string]string{
+			common.LabelKeyControllerInstanceID: instanceID,
+		}},
+		Spec: wfv1.WorkflowSpec{
+			Templates: []wfv1.Template{
+				{Name: "template-1"},
+			},
+		},
+		Status: wfv1.WorkflowStatus{
+			Nodes: wfv1.Nodes{
+				"my-node-1": wfv1.NodeStatus{
+					TemplateName: "template-1",
+					Outputs: &wfv1.Outputs{
+						Artifacts: wfv1.Artifacts{
+							{
+								Name: "my-artifact",
+								ArtifactLocation: wfv1.ArtifactLocation{
+									S3: &wfv1.S3Artifact{
+										Key: "my-wf/my-node-1/my-artifact.tgz",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	argo := fakewfv1.NewClientset(wf)
+	ctx := context.WithValue(context.WithValue(logging.TestContext(t.Context()), auth.KubeKey, kube), auth.WfKey, argo)
+	gatekeeper.On("ContextWithRequest", mock.Anything, mock.Anything).Return(ctx, nil)
+	a := &sqldbmocks.WorkflowArchive{}
+	a.On("GetWorkflow", mock.Anything, "my-uuid", "", "").Return(wf, nil)
+
+	// Factory that returns nil driver and nil error — the bug trigger
+	nilDriverFactory := func(_ context.Context, _ *wfv1.Artifact, _ resource.Interface) (artifactscommon.ArtifactDriver, error) {
+		return nil, nil
+	}
+
+	artifactRepositories := armocks.DummyArtifactRepositories(&wfv1.ArtifactRepository{
+		S3: &wfv1.S3ArtifactRepository{
+			S3Bucket: wfv1.S3Bucket{
+				Endpoint: "my-endpoint",
+				Bucket:   "my-bucket",
+			},
+		},
+	})
+
+	s := newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), nilDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx))
+
+	r := &http.Request{}
+	r.URL = mustParse("/artifact-files/my-ns/workflows/my-wf/my-node-1/outputs/my-artifact")
+	recorder := httptest.NewRecorder()
+
+	// This should NOT panic — it should return 500
+	s.GetArtifactFile(recorder, r)
+	assert.Equal(t, 500, recorder.Result().StatusCode)
+}


### PR DESCRIPTION
## Summary

The artifact server panics with a nil pointer dereference when serving archived workflow artifacts via `/artifact-files/` using a service account token (non-SSO auth). The HTTP handler crashes and returns EOF to the client.

## Root Cause

`getArtifactAndDriver` constructs the artifact driver using the **caller's** kubeClient (from auth context). When the caller is a service account with limited RBAC, the driver factory cannot access the secrets/configmaps needed to build the S3 driver (e.g., IRSA credentials), and may return `(nil, nil)`. The caller then invokes `driver.IsDirectory()` on a nil pointer.

SSO users don't hit this because their requests use the server's own kubeClient which has full access.

## Fix

1. **Nil driver guard** — All three `getArtifactAndDriver` call sites now check for nil driver and return HTTP 500 with a descriptive error instead of panicking.

2. **Use server credentials for driver construction** — The artifact driver is now constructed with the server's own kubeClient (matching SSO behavior). The caller's permissions still gate access via `validateAccess`, but the server's credentials handle storage retrieval.

## Testing

- Added `TestArtifactServer_NilDriverReturns500` — verifies 500 instead of panic when driver factory returns nil
- Added `TestArtifactServer_UsesServerKubeClient` — verifies the server's kubeClient is passed to the driver factory
- All existing tests pass

Fixes artifact EOF when using `--auth-mode=server --auth-mode=client` with S3 `useSDKCreds: true` (IRSA).