### PR TITLE
fix(ui): fix mixed bold/notbold markdown in title annotations

### DIFF
--- a/ui/src/shared/components/workflows-utils.test.ts
+++ b/ui/src/shared/components/workflows-utils.test.ts
@@ -14,5 +14,6 @@ describe('escapeInvalidMarkdown', () => {
         expect(escapeInvalidMarkdown('-# subheader')).toBe('subheader');
         expect(escapeInvalidMarkdown('\nthis\nis\ntext\nwith\nline\nbreaks\n')).toBe('this is text with line breaks');
         expect(escapeInvalidMarkdown('- list item\n* list item\n1. list item')).toBe('\\- list item \\* list item 1\\. list item');
+        expect(escapeInvalidMarkdown('**bold** notbold')).toBe('**bold** notbold');
     });
 });

--- a/ui/src/workflows/utils.ts
+++ b/ui/src/workflows/utils.ts
@@ -1,7 +1,7 @@
 export function escapeInvalidMarkdown(markdown: string) {
     return markdown
-        .replace(/([-*])\s(.*\n*)/g, '\\$1 $2') // escape list items
-        .replace(/(\d)\.\s(.*\n*)/g, '$1\\. $2') // escape ordered list items
+        .replace(/^([-*])\s(.*)/gm, '\\$1 $2') // escape list items
+        .replace(/^(\d)\.\s(.*)/gm, '$1\\. $2') // escape ordered list items
         .replace(/(-#)\s/g, '') // remove subheaders
         .replace(/\n/g, ' ') // remove line breaks
         .replace(/`{3}/g, '') // remove code blocks


### PR DESCRIPTION
### Motivation

While standardising our workflow titles, I noticed a weird behaviour when mixing bold and non-bold text, where the first instance of bold markdown would be marked italics with literal asterisks. Any bold text after the beginning (e.g. after un-formatted text) behaved as expected.

<img width="470" height="248" alt="image" src="https://github.com/user-attachments/assets/7022a930-9326-4198-b778-a43af2bb282f" />

### Modifications

The `escapeInvalidMarkdown` function in `ui/src/workflows/utils.ts` has a regex intended to escape markdown list items (`- item` or `* item`), but the pattern `/([-*])\s/g` matches any `*` followed by a space anywhere in the string, not just at the start of a line.

This causes `**bold** notbold` to be transformed into `**bold*\* notbold`, which the markdown renderer interprets as italics with a literal asterisk instead of bold. 

The fix anchors the list-item and ordered-list regexes to the start of a line using `^` with the `m` (multiline) flag, so they only match actual list items.

### Verification

- `yarn eslint --ext .ts,.tsx src/workflows/utils.ts src/shared/components/workflows-utils.test.ts` - clean
- Added a test for the `**bold** notbold` scenario
- `./node_modules/.bin/jest --config jest.config.js src/shared/components/workflows-utils.test.ts` - passes

