### PR TITLE
fix(ui): fix error on "Graph" tab when viewing CronWorkflow and add tests. Fixes #15275

### DIFF
--- a/ui/src/shared/components/editors/graph-viewer.test.tsx
+++ b/ui/src/shared/components/editors/graph-viewer.test.tsx
@@ -1,0 +1,326 @@
+import {render, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {exampleClusterWorkflowTemplate, exampleCronWorkflow, exampleWorkflow, exampleWorkflowTemplate} from '../../examples';
+import {Workflow} from '../../models';
+import {services} from '../../services';
+import {
+    convertFromCronWorkflow,
+    generateNamePostfix,
+    getLeafNodes,
+    getStringAfterDelimiter,
+    GraphViewer,
+    parseDepends,
+    populateGraphFromWorkflow
+} from './graph-viewer';
+
+jest.mock('../../services/workflow-template-service');
+jest.mock('../../services/cluster-workflow-template-service');
+
+// GraphPanel renders SVG/canvas which is not available in jsdom; mock it to keep tests focused on GraphViewer logic.
+jest.mock('../graph/graph-panel', () => ({
+    GraphPanel: (props: {graph: {nodes: Map<string, unknown>; edges: Map<unknown, unknown>}}) => (
+        <div data-testid='graph-panel' data-node-count={props.graph.nodes.size} data-edge-count={props.graph.edges.size} />
+    )
+}));
+
+describe('parseDepends', () => {
+    it('extracts simple task names', () => {
+        expect(parseDepends('taskA && taskB')).toEqual(expect.arrayContaining(['taskA', 'taskB']));
+    });
+
+    it('handles task.Success and task.Failed suffixes', () => {
+        const result = parseDepends('taskA.Succeeded || taskB.Failed');
+        expect(result).toContain('taskA');
+        expect(result).toContain('taskB');
+        // suffixes should not appear as separate entries
+        expect(result).not.toContain('Succeeded');
+        expect(result).not.toContain('Failed');
+    });
+
+    it('deduplicates repeated task names', () => {
+        const result = parseDepends('taskA && taskA');
+        expect(result.filter(t => t === 'taskA')).toHaveLength(1);
+    });
+
+    it('returns empty array for empty string', () => {
+        expect(parseDepends('')).toEqual([]);
+    });
+});
+
+describe('generateNamePostfix', () => {
+    it('generates a string of the requested length', () => {
+        expect(generateNamePostfix(5)).toHaveLength(5);
+        expect(generateNamePostfix(10)).toHaveLength(10);
+    });
+
+    it('only contains lowercase letters and digits', () => {
+        const result = generateNamePostfix(50);
+        expect(result).toMatch(/^[a-z0-9]+$/);
+    });
+
+    it('generates different values on successive calls (probabilistic)', () => {
+        const a = generateNamePostfix(10);
+        const b = generateNamePostfix(10);
+        // Probability of collision is ~36^-10 ≈ 0
+        expect(a).not.toBe(b);
+    });
+});
+
+describe('getStringAfterDelimiter', () => {
+    it('returns the part after the last dot', () => {
+        expect(getStringAfterDelimiter('a.b.c')).toBe('c');
+    });
+
+    it('returns the whole string when there is no delimiter', () => {
+        expect(getStringAfterDelimiter('abc')).toBe('abc');
+    });
+
+    it('supports custom delimiter', () => {
+        expect(getStringAfterDelimiter('a/b/c', '/')).toBe('c');
+    });
+});
+
+describe('getLeafNodes', () => {
+    it('returns all DAG tasks that are not depended upon', () => {
+        const template = {
+            name: 'dag-tmpl',
+            dag: {
+                tasks: [
+                    {name: 'step-a', template: 'pod-tmpl'},
+                    {name: 'step-b', template: 'pod-tmpl', depends: 'step-a'}
+                ]
+            }
+        };
+        const leaves = getLeafNodes(template as any);
+        expect(leaves).toContain('step-b');
+        expect(leaves).not.toContain('step-a');
+    });
+
+    it('returns the last step group entries for a steps template', () => {
+        const template = {
+            name: 'steps-tmpl',
+            steps: [
+                [{name: 'step-0', template: 'pod-tmpl'}],
+                [{name: 'step-1a', template: 'pod-tmpl'}, {name: 'step-1b', template: 'pod-tmpl'}]
+            ]
+        };
+        const leaves = getLeafNodes(template as any);
+        expect(leaves).toContain('1.step-1a');
+        expect(leaves).toContain('1.step-1b');
+        expect(leaves).not.toContain('0.step-0');
+    });
+
+    it('returns null for a plain pod template', () => {
+        const template = {name: 'pod-tmpl', container: {image: 'alpine'}};
+        expect(getLeafNodes(template as any)).toBeNull();
+    });
+});
+
+describe('convertFromCronWorkflow', () => {
+    it('converts a CronWorkflow into a Workflow with the inner workflowSpec', () => {
+        const cron = exampleCronWorkflow('argo');
+        const result = convertFromCronWorkflow(cron);
+        expect(result.kind).toBe('Workflow');
+        expect(result.spec).toBe(cron.spec.workflowSpec);
+        expect(result.metadata).toBe(cron.metadata);
+    });
+});
+
+describe('populateGraphFromWorkflow', () => {
+    it('creates a Pod node for a single-template workflow', () => {
+        const workflow = exampleWorkflow('argo');
+        const graph = populateGraphFromWorkflow(workflow, 'test-run');
+        expect(graph.nodes.size).toBeGreaterThan(0);
+        // The single entrypoint template should be represented as a Pod node
+        const genres = Array.from(graph.nodes.values()).map((n: any) => n.genre);
+        expect(genres).toContain('Pod');
+    });
+
+    it('creates DAG nodes for a DAG workflow', () => {
+        const workflow: Workflow = {
+            metadata: {name: 'dag-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: 'dag-tmpl',
+                templates: [
+                    {
+                        name: 'dag-tmpl',
+                        dag: {
+                            tasks: [
+                                {name: 'step-a', template: 'pod-tmpl'},
+                                {name: 'step-b', template: 'pod-tmpl', depends: 'step-a'}
+                            ]
+                        }
+                    },
+                    {
+                        name: 'pod-tmpl',
+                        container: {name: 'main', image: 'alpine'}
+                    }
+                ]
+            }
+        };
+        const graph = populateGraphFromWorkflow(workflow, 'dag-wf-run');
+        const genres = Array.from(graph.nodes.values()).map((n: any) => n.genre);
+        expect(genres).toContain('DAG');
+        expect(genres).toContain('Pod');
+    });
+
+    it('creates Steps and StepGroup nodes for a steps workflow', () => {
+        const workflow: Workflow = {
+            metadata: {name: 'steps-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: 'steps-tmpl',
+                templates: [
+                    {
+                        name: 'steps-tmpl',
+                        steps: [
+                            [{name: 'step-a', template: 'pod-tmpl'}],
+                            [{name: 'step-b', template: 'pod-tmpl'}]
+                        ]
+                    },
+                    {
+                        name: 'pod-tmpl',
+                        container: {name: 'main', image: 'alpine'}
+                    }
+                ]
+            }
+        };
+        const graph = populateGraphFromWorkflow(workflow, 'steps-wf-run');
+        const genres = Array.from(graph.nodes.values()).map((n: any) => n.genre);
+        expect(genres).toContain('Steps');
+        expect(genres).toContain('StepGroup');
+        expect(genres).toContain('Pod');
+    });
+});
+
+describe('GraphViewer component', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows loading state initially for a workflow with a workflowTemplateRef', async () => {
+        const workflow: Workflow = {
+            metadata: {name: 'ref-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: '',
+                templates: [],
+                workflowTemplateRef: {name: 'my-template'}
+            } as any
+        };
+
+        jest.spyOn(services.workflowTemplate, 'get').mockReturnValue(new Promise(() => {})); // never resolves
+
+        const {getByText} = render(<GraphViewer workflowDefinition={workflow} />);
+        expect(getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('renders GraphPanel after loading a plain workflow', async () => {
+        const workflow = exampleWorkflow('argo');
+        const {getByTestId} = render(<GraphViewer workflowDefinition={workflow} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+    });
+
+    it('renders GraphPanel for a WorkflowTemplate', async () => {
+        const wft = exampleWorkflowTemplate('argo');
+        const {getByTestId} = render(<GraphViewer workflowDefinition={wft} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+    });
+
+    it('renders GraphPanel for a ClusterWorkflowTemplate', async () => {
+        const cwft = exampleClusterWorkflowTemplate();
+        const {getByTestId} = render(<GraphViewer workflowDefinition={cwft} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+    });
+
+    it('converts and renders a CronWorkflow', async () => {
+        const cron = exampleCronWorkflow('argo');
+        const {getByTestId} = render(<GraphViewer workflowDefinition={cron} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+    });
+
+    it('resolves workflowTemplateRef via service and then renders graph', async () => {
+        const wft = exampleWorkflowTemplate('argo');
+        jest.spyOn(services.workflowTemplate, 'get').mockResolvedValue(wft);
+
+        const workflow: Workflow = {
+            metadata: {name: 'ref-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: '',
+                templates: [],
+                workflowTemplateRef: {name: wft.metadata.name}
+            } as any
+        };
+
+        const {getByTestId} = render(<GraphViewer workflowDefinition={workflow} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+        expect(services.workflowTemplate.get).toHaveBeenCalledWith(wft.metadata.name, 'argo');
+    });
+
+    it('resolves clusterScope workflowTemplateRef via clusterWorkflowTemplate service', async () => {
+        const cwft = exampleClusterWorkflowTemplate();
+        jest.spyOn(services.clusterWorkflowTemplate, 'get').mockResolvedValue(cwft);
+
+        const workflow: Workflow = {
+            metadata: {name: 'cluster-ref-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: '',
+                templates: [],
+                workflowTemplateRef: {name: cwft.metadata.name, clusterScope: true}
+            } as any
+        };
+
+        const {getByTestId} = render(<GraphViewer workflowDefinition={workflow} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+        expect(services.clusterWorkflowTemplate.get).toHaveBeenCalledWith(cwft.metadata.name);
+    });
+
+    it('shows an error message when workflowTemplateRef resolution fails', async () => {
+        jest.spyOn(services.workflowTemplate, 'get').mockRejectedValue(new Error('not found'));
+
+        const workflow: Workflow = {
+            metadata: {name: 'bad-ref-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: '',
+                templates: [],
+                workflowTemplateRef: {name: 'missing-template'}
+            } as any
+        };
+
+        const {getByText} = render(<GraphViewer workflowDefinition={workflow} />);
+        await waitFor(() => {
+            expect(getByText(/not found/)).toBeInTheDocument();
+        });
+    });
+
+    it('uses generateName when metadata.name is absent', async () => {
+        const workflow: Workflow = {
+            metadata: {generateName: 'my-prefix-', namespace: 'argo'},
+            spec: {
+                entrypoint: 'argosay',
+                templates: [
+                    {
+                        name: 'argosay',
+                        container: {name: 'main', image: 'argoproj/argosay:v2'}
+                    }
+                ]
+            }
+        };
+
+        const {getByTestId} = render(<GraphViewer workflowDefinition={workflow} />);
+        await waitFor(() => {
+            expect(getByTestId('graph-panel')).toBeInTheDocument();
+        });
+    });
+});

--- a/ui/src/shared/components/editors/graph-viewer.test.tsx
+++ b/ui/src/shared/components/editors/graph-viewer.test.tsx
@@ -4,15 +4,7 @@ import React from 'react';
 import {exampleClusterWorkflowTemplate, exampleCronWorkflow, exampleWorkflow, exampleWorkflowTemplate} from '../../examples';
 import {Workflow} from '../../models';
 import {services} from '../../services';
-import {
-    convertFromCronWorkflow,
-    generateNamePostfix,
-    getLeafNodes,
-    getStringAfterDelimiter,
-    GraphViewer,
-    parseDepends,
-    populateGraphFromWorkflow
-} from './graph-viewer';
+import {convertFromCronWorkflow, getLeafNodes, getStringAfterDelimiter, GraphViewer, parseDepends, populateGraphFromWorkflow} from './graph-viewer';
 
 jest.mock('../../services/workflow-template-service');
 jest.mock('../../services/cluster-workflow-template-service');
@@ -22,6 +14,10 @@ jest.mock('../graph/graph-panel', () => ({
     GraphPanel: (props: {graph: {nodes: Map<string, unknown>; edges: Map<unknown, unknown>}}) => (
         <div data-testid='graph-panel' data-node-count={props.graph.nodes.size} data-edge-count={props.graph.edges.size} />
     )
+}));
+
+jest.mock('../loading', () => ({
+    Loading: () => <div>Loading...</div>
 }));
 
 describe('parseDepends', () => {
@@ -45,25 +41,6 @@ describe('parseDepends', () => {
 
     it('returns empty array for empty string', () => {
         expect(parseDepends('')).toEqual([]);
-    });
-});
-
-describe('generateNamePostfix', () => {
-    it('generates a string of the requested length', () => {
-        expect(generateNamePostfix(5)).toHaveLength(5);
-        expect(generateNamePostfix(10)).toHaveLength(10);
-    });
-
-    it('only contains lowercase letters and digits', () => {
-        const result = generateNamePostfix(50);
-        expect(result).toMatch(/^[a-z0-9]+$/);
-    });
-
-    it('generates different values on successive calls (probabilistic)', () => {
-        const a = generateNamePostfix(10);
-        const b = generateNamePostfix(10);
-        // Probability of collision is ~36^-10 ≈ 0
-        expect(a).not.toBe(b);
     });
 });
 
@@ -102,7 +79,10 @@ describe('getLeafNodes', () => {
             name: 'steps-tmpl',
             steps: [
                 [{name: 'step-0', template: 'pod-tmpl'}],
-                [{name: 'step-1a', template: 'pod-tmpl'}, {name: 'step-1b', template: 'pod-tmpl'}]
+                [
+                    {name: 'step-1a', template: 'pod-tmpl'},
+                    {name: 'step-1b', template: 'pod-tmpl'}
+                ]
             ]
         };
         const leaves = getLeafNodes(template as any);
@@ -130,7 +110,7 @@ describe('convertFromCronWorkflow', () => {
 describe('populateGraphFromWorkflow', () => {
     it('creates a Pod node for a single-template workflow', () => {
         const workflow = exampleWorkflow('argo');
-        const graph = populateGraphFromWorkflow(workflow, 'test-run');
+        const graph = populateGraphFromWorkflow(workflow);
         expect(graph.nodes.size).toBeGreaterThan(0);
         // The single entrypoint template should be represented as a Pod node
         const genres = Array.from(graph.nodes.values()).map((n: any) => n.genre);
@@ -159,7 +139,7 @@ describe('populateGraphFromWorkflow', () => {
                 ]
             }
         };
-        const graph = populateGraphFromWorkflow(workflow, 'dag-wf-run');
+        const graph = populateGraphFromWorkflow(workflow);
         const genres = Array.from(graph.nodes.values()).map((n: any) => n.genre);
         expect(genres).toContain('DAG');
         expect(genres).toContain('Pod');
@@ -173,10 +153,7 @@ describe('populateGraphFromWorkflow', () => {
                 templates: [
                     {
                         name: 'steps-tmpl',
-                        steps: [
-                            [{name: 'step-a', template: 'pod-tmpl'}],
-                            [{name: 'step-b', template: 'pod-tmpl'}]
-                        ]
+                        steps: [[{name: 'step-a', template: 'pod-tmpl'}], [{name: 'step-b', template: 'pod-tmpl'}]]
                     },
                     {
                         name: 'pod-tmpl',
@@ -185,11 +162,23 @@ describe('populateGraphFromWorkflow', () => {
                 ]
             }
         };
-        const graph = populateGraphFromWorkflow(workflow, 'steps-wf-run');
+        const graph = populateGraphFromWorkflow(workflow);
         const genres = Array.from(graph.nodes.values()).map((n: any) => n.genre);
         expect(genres).toContain('Steps');
         expect(genres).toContain('StepGroup');
         expect(genres).toContain('Pod');
+    });
+
+    it('gracefully handles Workflow without templates', () => {
+        const workflow: Workflow = {
+            metadata: {name: 'empty-wf', namespace: 'argo'},
+            spec: {
+                entrypoint: 'nonexistent-tmpl'
+            }
+        };
+        const graph = populateGraphFromWorkflow(workflow);
+        expect(graph.nodes.size).toBe(0);
+        expect(graph.edges.size).toBe(0);
     });
 });
 

--- a/ui/src/shared/components/editors/graph-viewer.tsx
+++ b/ui/src/shared/components/editors/graph-viewer.tsx
@@ -4,15 +4,16 @@ import {useEffect, useState} from 'react';
 import {genres} from '../../../workflows/components/workflow-dag/genres';
 import {WorkflowDagRenderOptions} from '../../../workflows/components/workflow-dag/workflow-dag';
 import {WorkflowDagRenderOptionsPanel} from '../../../workflows/components/workflow-dag/workflow-dag-render-options-panel';
-import {ClusterWorkflowTemplate, CronWorkflow, DAGTask, Template, Workflow, WorkflowStep, WorkflowTemplate } from '../../models';
+import {ClusterWorkflowTemplate, CronWorkflow, DAGTask, Template, Workflow, WorkflowStep, WorkflowTemplate} from '../../models';
 import {services} from '../../services';
+import {ErrorNotice} from '../error-notice';
 import {GraphPanel} from '../graph/graph-panel';
 import {Graph} from '../graph/types';
 import {Icon} from '../icon';
+import {Loading} from '../loading';
 
 export function GraphViewer({workflowDefinition}: {workflowDefinition: Workflow | WorkflowTemplate | ClusterWorkflowTemplate | CronWorkflow}) {
-    const [workflow, setWorkflow] = useState<Workflow | WorkflowTemplate | ClusterWorkflowTemplate>(workflowDefinition);
-    const [isLoading, setIsLoading] = useState(true);
+    const [workflow, setWorkflow] = useState<Workflow | WorkflowTemplate | ClusterWorkflowTemplate>();
     const [error, setError] = useState<Error>();
     const [state, saveOptions] = useState<WorkflowDagRenderOptions>({
         expandNodes: new Set(),
@@ -22,89 +23,56 @@ export function GraphViewer({workflowDefinition}: {workflowDefinition: Workflow 
     });
 
     useEffect(() => {
-        if ('workflowTemplateRef' in workflowDefinition.spec && isLoading) {
-            setWorkflowFromReference(workflowDefinition, setWorkflow)
-                .then(() => {
-                    setError(null);
-                    setIsLoading(false);
-                })
-                .catch(err => {
-                    setError(err);
-                });
-        } else if ('workflowSpec' in workflowDefinition.spec && isLoading) {
-            const convertedCronWorkflow = convertFromCronWorkflow(workflowDefinition as CronWorkflow);
-            setWorkflow(convertedCronWorkflow);
-            setIsLoading(false);
-        } else {
-            setIsLoading(false);
-        }
-    }, [workflow]);
-
-    if (isLoading) {
-        const currentState = error ? `${error.name}: ${error.message}` : 'Loading...';
-        return <div>{currentState}</div>;
-    }
-
-    const name = workflow.metadata.name ? `${workflow.metadata.name}-${generateNamePostfix(5)}` : `${workflow.metadata.generateName}${generateNamePostfix(5)}`;
-    const graph = populateGraphFromWorkflow(workflow, name);
+        (async () => {
+            try {
+                let convertedWorkflow = workflowDefinition;
+                if ('workflowSpec' in convertedWorkflow.spec) {
+                    convertedWorkflow = convertFromCronWorkflow(convertedWorkflow as CronWorkflow);
+                }
+                if ('workflowTemplateRef' in convertedWorkflow.spec) {
+                    convertedWorkflow = await convertWorkflowFromReference(convertedWorkflow);
+                }
+                setError(null);
+                setWorkflow(convertedWorkflow);
+            } catch (err) {
+                setError(err);
+            }
+        })();
+    }, [workflowDefinition]);
 
     return (
-        <GraphPanel
-            storageScope='graph-viewer'
-            graph={graph}
-            nodeGenresTitle={'Node Type'}
-            nodeGenres={genres}
-            nodeClassNamesTitle={'Node Phase'}
-            nodeClassNames={{Skipped: true}}
-            nodeTagsTitle={'Template'}
-            nodeTags={{[name]: true}}
-            nodeSize={64}
-            defaultIconShape='circle'
-            hideNodeTypes={false}
-            hideOptions={false}
-            options={<WorkflowDagRenderOptionsPanel {...state} onChange={workflowDagRenderOptions => saveOptions(workflowDagRenderOptions)} />}
-        />
+        <>
+            <ErrorNotice error={error} />
+            {!workflow ? (
+                <Loading />
+            ) : (
+                <GraphPanel
+                    storageScope='graph-viewer'
+                    graph={populateGraphFromWorkflow(workflow)}
+                    nodeGenresTitle={'Node Type'}
+                    nodeGenres={genres}
+                    nodeClassNamesTitle={'Node Phase'}
+                    nodeClassNames={{Skipped: true}}
+                    nodeTagsTitle={'Template'}
+                    nodeTags={{[workflow.metadata.name || workflow.metadata.generateName]: true}}
+                    nodeSize={64}
+                    defaultIconShape='circle'
+                    hideNodeTypes={false}
+                    hideOptions={false}
+                    options={<WorkflowDagRenderOptionsPanel {...state} onChange={workflowDagRenderOptions => saveOptions(workflowDagRenderOptions)} />}
+                />
+            )}
+        </>
     );
 }
 
-const defaultNodeParams: {
-    classNames: string;
-    progress: number;
-    icon: Icon;
-} = {
-    classNames: 'Skipped',
-    progress: 0,
-    icon: 'clock'
-};
-
-export function setWorkflowFromReference(
-    workflowDefinition: Workflow | WorkflowTemplate | ClusterWorkflowTemplate,
-    setWorkflow: (w: WorkflowTemplate | ClusterWorkflowTemplate) => void
-): Promise<void> {
+export function convertWorkflowFromReference(workflowDefinition: Workflow | WorkflowTemplate | ClusterWorkflowTemplate): Promise<WorkflowTemplate | ClusterWorkflowTemplate> {
     const workflowTemplateRef = workflowDefinition.spec.workflowTemplateRef;
     const referenceName = workflowTemplateRef.name;
     if ('clusterScope' in workflowTemplateRef && workflowTemplateRef.clusterScope == true) {
-        return services.clusterWorkflowTemplate
-            .get(referenceName)
-            .then(clusterWorkflowTemplate => {
-                setWorkflow(clusterWorkflowTemplate);
-            })
-            .catch(err => {
-                const explicitError = new Error(`${err.message}, no workflowTemplateRef "${referenceName}" found in clusterWorkflowTemplates`);
-                explicitError.stack = err.stack;
-                throw explicitError;
-            });
+        return services.clusterWorkflowTemplate.get(referenceName);
     } else {
-        return services.workflowTemplate
-            .get(referenceName, workflowDefinition.metadata.namespace)
-            .then(workflowTemplate => {
-                setWorkflow(workflowTemplate);
-            })
-            .catch(err => {
-                const explicitError = new Error(`${err.message}, no workflowTemplateRef "${referenceName}" found in workflowTemplates`);
-                explicitError.stack = err.stack;
-                throw explicitError;
-            });
+        return services.workflowTemplate.get(referenceName, workflowDefinition.metadata.namespace);
     }
 }
 
@@ -117,10 +85,10 @@ export function convertFromCronWorkflow(cronWorkflow: CronWorkflow): Workflow {
     };
 }
 
-export function populateGraphFromWorkflow(workflow: Workflow | WorkflowTemplate | ClusterWorkflowTemplate, name: string): Graph {
+export function populateGraphFromWorkflow(workflow: Workflow | WorkflowTemplate | ClusterWorkflowTemplate): Graph {
     const graph = new Graph();
 
-    const templates = workflow.spec.templates;
+    const templates = workflow.spec.templates || [];
     const templateMap = new Map<string, Template>();
     const templateLeafMap = new Map<string, string[]>();
     let previousSteps: string[] = [];
@@ -297,6 +265,16 @@ export function populateGraphFromWorkflow(workflow: Workflow | WorkflowTemplate 
         return '';
     }
 
+    const defaultNodeParams: {
+        classNames: string;
+        progress: number;
+        icon: Icon;
+    } = {
+        classNames: 'Skipped',
+        progress: 0,
+        icon: 'clock'
+    };
+
     const createNode = (name: string, label: string, genre: string, params = defaultNodeParams) => {
         graph.nodes.set(name, {
             label,
@@ -310,7 +288,7 @@ export function populateGraphFromWorkflow(workflow: Workflow | WorkflowTemplate 
         graph.edges.set({v: from, w: to}, edgeData);
     };
 
-    processTemplate(entrypoint, name);
+    processTemplate(entrypoint, workflow.metadata.name || workflow.metadata.generateName);
 
     return graph;
 }
@@ -324,16 +302,6 @@ export function parseDepends(dependsString: string): string[] {
     }
 
     return Array.from(taskNames);
-}
-
-export function generateNamePostfix(len: number): string {
-    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    let result = '';
-    for (let i = 0; i < len; i++) {
-        const randomIndex = Math.floor(Math.random() * chars.length);
-        result += chars[randomIndex];
-    }
-    return result;
 }
 
 export function getLeafNodes(template: Template): string[] | null {

--- a/ui/src/shared/components/editors/graph-viewer.tsx
+++ b/ui/src/shared/components/editors/graph-viewer.tsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from 'react';
 import {genres} from '../../../workflows/components/workflow-dag/genres';
 import {WorkflowDagRenderOptions} from '../../../workflows/components/workflow-dag/workflow-dag';
 import {WorkflowDagRenderOptionsPanel} from '../../../workflows/components/workflow-dag/workflow-dag-render-options-panel';
-import {ClusterWorkflowTemplate, CronWorkflow, DAGTask, Template, Workflow, WorkflowStep, WorkflowTemplate, WorkflowTemplateRef} from '../../models';
+import {ClusterWorkflowTemplate, CronWorkflow, DAGTask, Template, Workflow, WorkflowStep, WorkflowTemplate } from '../../models';
 import {services} from '../../services';
 import {GraphPanel} from '../graph/graph-panel';
 import {Graph} from '../graph/types';
@@ -20,19 +20,10 @@ export function GraphViewer({workflowDefinition}: {workflowDefinition: Workflow 
         showInvokingTemplateName: false,
         showTemplateRefsGrouping: false
     });
-    const defaultNodeParams: {
-        classNames: string;
-        progress: number;
-        icon: Icon;
-    } = {
-        classNames: 'Skipped',
-        progress: 0,
-        icon: 'clock'
-    };
 
     useEffect(() => {
         if ('workflowTemplateRef' in workflowDefinition.spec && isLoading) {
-            setWorkflowFromRefrence(workflowDefinition.spec.workflowTemplateRef)
+            setWorkflowFromReference(workflowDefinition, setWorkflow)
                 .then(() => {
                     setError(null);
                     setIsLoading(false);
@@ -74,311 +65,328 @@ export function GraphViewer({workflowDefinition}: {workflowDefinition: Workflow 
             options={<WorkflowDagRenderOptionsPanel {...state} onChange={workflowDagRenderOptions => saveOptions(workflowDagRenderOptions)} />}
         />
     );
+}
 
-    function setWorkflowFromRefrence(workflowTemplateRef: WorkflowTemplateRef): Promise<void> {
-        const referenceName = workflowTemplateRef.name;
-        if ('clusterScope' in workflowTemplateRef && workflowTemplateRef.clusterScope == true) {
-            return services.clusterWorkflowTemplate
-                .get(referenceName)
-                .then(clusterWorkflowTemplate => {
-                    setWorkflow(clusterWorkflowTemplate);
-                })
-                .catch(err => {
-                    const explicitError = new Error(`${err.message}, no workflowTemplateRef "${referenceName}" found in clusterWorkflowTemplates`);
-                    explicitError.stack = err.stack;
-                    throw explicitError;
-                });
+const defaultNodeParams: {
+    classNames: string;
+    progress: number;
+    icon: Icon;
+} = {
+    classNames: 'Skipped',
+    progress: 0,
+    icon: 'clock'
+};
+
+export function setWorkflowFromReference(
+    workflowDefinition: Workflow | WorkflowTemplate | ClusterWorkflowTemplate,
+    setWorkflow: (w: WorkflowTemplate | ClusterWorkflowTemplate) => void
+): Promise<void> {
+    const workflowTemplateRef = workflowDefinition.spec.workflowTemplateRef;
+    const referenceName = workflowTemplateRef.name;
+    if ('clusterScope' in workflowTemplateRef && workflowTemplateRef.clusterScope == true) {
+        return services.clusterWorkflowTemplate
+            .get(referenceName)
+            .then(clusterWorkflowTemplate => {
+                setWorkflow(clusterWorkflowTemplate);
+            })
+            .catch(err => {
+                const explicitError = new Error(`${err.message}, no workflowTemplateRef "${referenceName}" found in clusterWorkflowTemplates`);
+                explicitError.stack = err.stack;
+                throw explicitError;
+            });
+    } else {
+        return services.workflowTemplate
+            .get(referenceName, workflowDefinition.metadata.namespace)
+            .then(workflowTemplate => {
+                setWorkflow(workflowTemplate);
+            })
+            .catch(err => {
+                const explicitError = new Error(`${err.message}, no workflowTemplateRef "${referenceName}" found in workflowTemplates`);
+                explicitError.stack = err.stack;
+                throw explicitError;
+            });
+    }
+}
+
+export function convertFromCronWorkflow(cronWorkflow: CronWorkflow): Workflow {
+    return {
+        apiVersion: 'argoproj.io/v1alpha1',
+        kind: 'Workflow',
+        metadata: cronWorkflow.metadata,
+        spec: cronWorkflow.spec.workflowSpec
+    };
+}
+
+export function populateGraphFromWorkflow(workflow: Workflow | WorkflowTemplate | ClusterWorkflowTemplate, name: string): Graph {
+    const graph = new Graph();
+
+    const templates = workflow.spec.templates;
+    const templateMap = new Map<string, Template>();
+    const templateLeafMap = new Map<string, string[]>();
+    let previousSteps: string[] = [];
+
+    templates.forEach((template: Template) => {
+        templateMap.set(template.name, template);
+        templateLeafMap.set(template.name, getLeafNodes(template));
+    });
+
+    const entrypoint = workflow.spec.entrypoint;
+
+    function processTemplate(templateName: string, parentNodeName: string = null): void {
+        const template = templateMap.get(templateName);
+
+        if (!template) {
+            console.error(`Template "${templateName}" not found.`);
+            return;
+        }
+        if (template.dag) {
+            processDAGTemplate(template, parentNodeName);
+        } else if (template.steps) {
+            processStepsTemplate(template, parentNodeName);
         } else {
-            return services.workflowTemplate
-                .get(referenceName, workflowDefinition.metadata.namespace)
-                .then(workflowTemplate => {
-                    setWorkflow(workflowTemplate);
-                })
-                .catch(err => {
-                    const explicitError = new Error(`${err.message}, no workflowTemplateRef "${referenceName}" found in workflowTemplates`);
-                    explicitError.stack = err.stack;
-                    throw explicitError;
+            processPodTemplate(templateName, parentNodeName);
+        }
+    }
+
+    function processDAGTemplate(template: Template, parentNodeName: string) {
+        createNode(parentNodeName, getStringAfterDelimiter(parentNodeName), 'DAG');
+        template.dag.tasks.forEach((task: DAGTask) => {
+            let nodeLabel = task.name;
+            const nodeName = `${parentNodeName}.${task.name}`;
+            const retryNodeName = `${nodeName}.retry`;
+            const taskGroupName = `${nodeName}.TaskGroup`;
+            const retryStrategy = getRetryStrategy(task);
+            const executionStrategy = getExecutionStrategy(task);
+
+            if (retryStrategy) {
+                createNode(retryNodeName, nodeLabel, 'Retry');
+            }
+            if (executionStrategy) {
+                nodeLabel = `${nodeLabel}${executionStrategy}`;
+                createNode(taskGroupName, nodeLabel, 'TaskGroup');
+            }
+
+            createNode(nodeName, nodeLabel, getTaskGenre(task));
+
+            if (task.depends || task.dependencies) {
+                const dependencies = task.dependencies ? task.dependencies : parseDepends(task.depends);
+                const dependencyLabel = task.depends ? task.depends : task.dependencies.join(' && ');
+                dependencies.forEach((dep: string) => {
+                    let dependancyName = `${parentNodeName}.${dep}`;
+                    if (graph.nodes.get(dependancyName).genre == 'Pod') {
+                        if (retryStrategy) {
+                            createEdge(dependancyName, retryNodeName);
+                            dependancyName = retryNodeName;
+                        }
+                        if (executionStrategy) {
+                            createEdge(dependancyName, taskGroupName);
+                            dependancyName = taskGroupName;
+                        }
+                        createEdge(dependancyName, nodeName, dependencyLabel);
+                    } else {
+                        const depTemplate = getTemplateNameFromTask(template.dag, dep);
+                        const templateLeafNodes = templateLeafMap.get(depTemplate);
+                        if (templateLeafNodes) {
+                            templateLeafNodes.forEach((leaf: string) => {
+                                let leafNode = `${dependancyName}.${leaf}`;
+                                if (retryStrategy) {
+                                    createEdge(parentNodeName, retryNodeName);
+                                    leafNode = retryNodeName;
+                                }
+                                if (executionStrategy) {
+                                    createEdge(parentNodeName, taskGroupName);
+                                    leafNode = taskGroupName;
+                                }
+                                createEdge(leafNode, nodeName, dependencyLabel);
+                            });
+                        }
+                    }
                 });
-        }
-    }
-
-    function convertFromCronWorkflow(cronWorkflow: CronWorkflow): Workflow {
-        return {
-            apiVersion: 'argoproj.io/v1alpha1',
-            kind: 'Workflow',
-            metadata: cronWorkflow.metadata,
-            spec: cronWorkflow.spec.workflowSpec
-        };
-    }
-
-    function populateGraphFromWorkflow(workflow: Workflow, name: string): Graph {
-        const graph = new Graph();
-
-        const templates = workflow.spec.templates;
-        const templateMap = new Map();
-        const templateLeafMap = new Map();
-        let previousSteps: string[] = [];
-
-        templates.forEach((template: Template) => {
-            templateMap.set(template.name, template);
-            templateLeafMap.set(template.name, getLeafNodes(template));
-        });
-
-        const entrypoint = workflow.spec.entrypoint;
-
-        function processTemplate(templateName: string, parentNodeName: string = null): Graph {
-            const template = templateMap.get(templateName);
-
-            if (!template) {
-                console.error(`Template "${templateName}" not found.`);
-                return;
-            }
-            if (template.dag) {
-                processDAGTemplate(template, parentNodeName);
-            } else if (template.steps) {
-                processStepsTemplate(template, parentNodeName);
             } else {
-                processPodTemplate(templateName, parentNodeName);
-            }
-        }
-        function processDAGTemplate(template: Template, parentNodeName: string) {
-            createNode(parentNodeName, getStringAfterDelimiter(parentNodeName), 'DAG');
-            template.dag.tasks.forEach((task: DAGTask) => {
-                let nodeLabel = task.name;
-                const nodeName = `${parentNodeName}.${task.name}`;
-                const retryNodeName = `${nodeName}.retry`;
-                const taskGroupName = `${nodeName}.TaskGroup`;
-                const retryStrategy = getRetryStrategy(task);
-                const executionStrategy = getExecutionStrategy(task);
-
+                let newParentTaskName = parentNodeName;
                 if (retryStrategy) {
-                    createNode(retryNodeName, nodeLabel, 'Retry');
+                    createEdge(parentNodeName, retryNodeName);
+                    newParentTaskName = retryNodeName;
                 }
                 if (executionStrategy) {
-                    nodeLabel = `${nodeLabel}${executionStrategy}`;
-                    createNode(taskGroupName, nodeLabel, 'TaskGroup');
+                    createEdge(parentNodeName, taskGroupName);
+                    newParentTaskName = taskGroupName;
                 }
-
-                createNode(nodeName, nodeLabel, getTaskGenre(task));
-
-                if (task.depends || task.dependencies) {
-                    const dependencies = task.dependencies ? task.dependencies : parseDepends(task.depends);
-                    const dependencyLabel = task.depends ? task.depends : task.dependencies.join(' && ');
-                    dependencies.forEach((dep: string) => {
-                        let dependancyName = `${parentNodeName}.${dep}`;
-                        if (graph.nodes.get(dependancyName).genre == 'Pod') {
-                            if (retryStrategy) {
-                                createEdge(dependancyName, retryNodeName);
-                                dependancyName = retryNodeName;
-                            }
-                            if (executionStrategy) {
-                                createEdge(dependancyName, taskGroupName);
-                                dependancyName = taskGroupName;
-                            }
-                            createEdge(dependancyName, nodeName, dependencyLabel);
-                        } else {
-                            const depTemplate = getTemplateNameFromTask(template.dag, dep);
-                            const templateLeafNodes = templateLeafMap.get(depTemplate);
-                            if (templateLeafNodes) {
-                                templateLeafNodes.forEach((leaf: string) => {
-                                    let leafNode = `${dependancyName}.${leaf}`;
-                                    if (retryStrategy) {
-                                        createEdge(parentNodeName, retryNodeName);
-                                        leafNode = retryNodeName;
-                                    }
-                                    if (executionStrategy) {
-                                        createEdge(parentNodeName, taskGroupName);
-                                        leafNode = taskGroupName;
-                                    }
-                                    createEdge(leafNode, nodeName, dependencyLabel);
-                                });
-                            }
-                        }
-                    });
-                } else {
-                    let newParentTaskName = parentNodeName;
-                    if (retryStrategy) {
-                        createEdge(parentNodeName, retryNodeName);
-                        newParentTaskName = retryNodeName;
-                    }
-                    if (executionStrategy) {
-                        createEdge(parentNodeName, taskGroupName);
-                        newParentTaskName = taskGroupName;
-                    }
-                    createEdge(newParentTaskName, nodeName);
-                }
-
-                if (isTemplateNested(task)) {
-                    processTemplate(task.template, nodeName);
-                }
-                previousSteps = [];
-            });
-        }
-
-        function processStepsTemplate(template: Template, parentNodeName: string) {
-            if (!graph.nodes.has(parentNodeName)) {
-                createNode(parentNodeName, parentNodeName, 'Steps');
+                createEdge(newParentTaskName, nodeName);
             }
-            createEdge(parentNodeName, `${parentNodeName}.0`);
 
-            template.steps.forEach((stepGroup: WorkflowStep[], stepGroupIndex: number) => {
-                let groupName = `${parentNodeName}.${stepGroupIndex}`;
-                createNode(groupName, `[${stepGroupIndex}]`, 'StepGroup');
-                previousSteps.forEach((prevStep: string) => {
-                    createEdge(prevStep, groupName);
+            if (isTemplateNested(task)) {
+                processTemplate(task.template, nodeName);
+            }
+            previousSteps = [];
+        });
+    }
+
+    function processStepsTemplate(template: Template, parentNodeName: string) {
+        if (!graph.nodes.has(parentNodeName)) {
+            createNode(parentNodeName, parentNodeName, 'Steps');
+        }
+        createEdge(parentNodeName, `${parentNodeName}.0`);
+
+        template.steps.forEach((stepGroup: WorkflowStep[], stepGroupIndex: number) => {
+            let groupName = `${parentNodeName}.${stepGroupIndex}`;
+            createNode(groupName, `[${stepGroupIndex}]`, 'StepGroup');
+            previousSteps.forEach((prevStep: string) => {
+                createEdge(prevStep, groupName);
+            });
+            previousSteps = [];
+
+            stepGroup.forEach((step: WorkflowStep) => {
+                const nodeName = `${groupName}.${step.name}`;
+                const nodeLabel = `${step.name}${getExecutionStrategy(step)}`;
+                const retryStrategy = getRetryStrategy(step);
+                if (retryStrategy) {
+                    const retryNodeName = `${nodeName}.retry`;
+                    createNode(retryNodeName, nodeLabel, 'Retry');
+                    createEdge(groupName, retryNodeName);
+                    groupName = retryNodeName;
+                }
+
+                createNode(nodeName, nodeLabel, getTaskGenre(step));
+                createEdge(groupName, nodeName);
+                previousSteps.push(nodeName);
+
+                if (isTemplateNested(step)) {
+                    processTemplate(step.template, nodeName);
+                }
+            });
+        });
+    }
+
+    function processPodTemplate(templateName: string, parentNodeName: string) {
+        if (templateMap.size === 1) {
+            templateName = parentNodeName;
+            parentNodeName = '';
+        }
+        createEdge(parentNodeName, templateName);
+        createNode(templateName, templateName, 'Pod');
+    }
+
+    function getTaskGenre(task: DAGTask | WorkflowStep): 'Steps' | 'DAG' | 'Pod' {
+        if (templateMap.has(task.template)) {
+            const template = templateMap.get(task.template);
+            if ('steps' in template) {
+                return 'Steps';
+            } else if ('dag' in template) {
+                return 'DAG';
+            }
+        }
+        return 'Pod';
+    }
+
+    function isTemplateNested(node: DAGTask | WorkflowStep): boolean {
+        if (templateMap.has(node.template)) {
+            const template = templateMap.get(node.template);
+            return 'dag' in template || 'steps' in template;
+        }
+        return false;
+    }
+
+    function getRetryStrategy(node: DAGTask | WorkflowStep): string {
+        if (templateMap.has(node.template)) {
+            const template = templateMap.get(node.template);
+            if ('retryStrategy' in template) {
+                return `\n{retryStrategy: ${String(template.retryStrategy)}}`;
+            }
+        }
+        return '';
+    }
+
+    const createNode = (name: string, label: string, genre: string, params = defaultNodeParams) => {
+        graph.nodes.set(name, {
+            label,
+            genre,
+            ...params
+        });
+    };
+
+    const createEdge = (from: string, to: string, label?: string) => {
+        const edgeData = label ? {label: label} : {};
+        graph.edges.set({v: from, w: to}, edgeData);
+    };
+
+    processTemplate(entrypoint, name);
+
+    return graph;
+}
+
+export function parseDepends(dependsString: string): string[] {
+    const taskNameRegex = /([a-zA-Z0-9-_]+)(?:\.[a-zA-Z]+)?/g;
+    const taskNames = new Set<string>();
+    let match;
+    while ((match = taskNameRegex.exec(dependsString)) !== null) {
+        taskNames.add(match[1]);
+    }
+
+    return Array.from(taskNames);
+}
+
+export function generateNamePostfix(len: number): string {
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    let result = '';
+    for (let i = 0; i < len; i++) {
+        const randomIndex = Math.floor(Math.random() * chars.length);
+        result += chars[randomIndex];
+    }
+    return result;
+}
+
+export function getLeafNodes(template: Template): string[] | null {
+    const allTaskNames = new Set<string>();
+    const dependentTaskNames = new Set<string>();
+    let independentTasks: string[] = [];
+
+    if (template.dag) {
+        template.dag.tasks.forEach((task: DAGTask) => {
+            allTaskNames.add(task.name);
+            if (task.depends) {
+                const dependencies = parseDepends(task.depends);
+                dependencies.forEach((dep: string) => {
+                    dependentTaskNames.add(dep);
                 });
-                previousSteps = [];
-
-                stepGroup.forEach((step: WorkflowStep) => {
-                    const nodeName = `${groupName}.${step.name}`;
-                    const nodeLabel = `${step.name}${getExecutionStrategy(step)}`;
-                    const retryStrategy = getRetryStrategy(step);
-                    if (retryStrategy) {
-                        const retryNodeName = `${nodeName}.retry`;
-                        createNode(retryNodeName, nodeLabel, 'Retry');
-                        createEdge(groupName, retryNodeName);
-                        groupName = retryNodeName;
-                    }
-
-                    createNode(nodeName, nodeLabel, getTaskGenre(step));
-                    createEdge(groupName, nodeName);
-                    previousSteps.push(nodeName);
-
-                    if (isTemplateNested(step)) {
-                        processTemplate(step.template, nodeName);
-                    }
-                });
-            });
-        }
-
-        function processPodTemplate(templateName: string, parentNodeName: string) {
-            if (templateMap.size === 1) {
-                templateName = parentNodeName;
-                parentNodeName = '';
             }
-            createEdge(parentNodeName, templateName);
-            createNode(templateName, templateName, 'Pod');
-        }
-        function getTaskGenre(task: DAGTask | WorkflowStep): 'Steps' | 'DAG' | 'Pod' {
-            if (templateMap.has(task.template)) {
-                const template = templateMap.get(task.template);
-                if ('steps' in template) {
-                    return 'Steps';
-                } else if ('dag' in template) {
-                    return 'DAG';
-                }
-            }
-            return 'Pod';
-        }
+        });
+        independentTasks = Array.from(allTaskNames).filter(nodeName => !dependentTaskNames.has(nodeName));
+    } else if (template.steps) {
+        const lastStepGroupIdx = template.steps.length - 1;
+        const lastStepGroup = template.steps[lastStepGroupIdx];
 
-        function isTemplateNested(node: DAGTask | WorkflowStep): boolean {
-            if (templateMap.has(node.template)) {
-                const template = templateMap.get(node.template);
-                return 'dag' in template || 'steps' in template;
-            }
-            return false;
-        }
-
-        function getRetryStrategy(node: DAGTask | WorkflowStep): string {
-            if (templateMap.has(node.template)) {
-                const template = templateMap.get(node.template);
-                if ('retryStrategy' in template) {
-                    return `\n{retryStrategy: ${String(template.retryStrategy)}}`;
-                }
-            }
-            return '';
-        }
-
-        const createNode = (name: string, label: string, genre: string, params = defaultNodeParams) => {
-            graph.nodes.set(name, {
-                label,
-                genre,
-                ...params
-            });
-        };
-
-        const createEdge = (from: string, to: string, label?: string) => {
-            const edgeData = label ? {label: label} : {};
-            graph.edges.set({v: from, w: to}, edgeData);
-        };
-
-        processTemplate(entrypoint, name);
-
-        return graph;
-    }
-    function parseDepends(dependsString: string): string[] {
-        const taskNameRegex = /([a-zA-Z0-9-_]+)(?:\.[a-zA-Z]+)?/g;
-        const taskNames = new Set<string>();
-        let match;
-        while ((match = taskNameRegex.exec(dependsString)) !== null) {
-            taskNames.add(match[1]);
-        }
-
-        return Array.from(taskNames);
+        lastStepGroup.forEach((step: WorkflowStep) => {
+            independentTasks.push(`${lastStepGroupIdx}.${step.name}`);
+        });
     }
 
-    function generateNamePostfix(len: number): string {
-        const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-        let result = '';
-        for (let i = 0; i < len; i++) {
-            const randomIndex = Math.floor(Math.random() * chars.length);
-            result += chars[randomIndex];
-        }
-        return result;
+    return independentTasks.length > 0 ? independentTasks : null;
+}
+
+function getTemplateNameFromTask(dag: {tasks: {name: string; template: string}[]}, nodeName: string): string | null {
+    const task = dag.tasks.find(t => t.name === nodeName);
+    return task ? task.template : null;
+}
+
+function getExecutionStrategy(task: DAGTask | WorkflowStep): string {
+    let executionStrategy = '';
+
+    if (task.withItems) {
+        executionStrategy += `\n{withItems: ${String(task.withItems)}}`;
+    } else if (task.withParam) {
+        executionStrategy += `\n{withParam: ${String(task.withParam)}}`;
+    } else if (task.withSequence) {
+        executionStrategy += `\n{withSequence: ${String(task.withSequence)}}`;
     }
 
-    function getLeafNodes(template: Template) {
-        const allTaskNames = new Set<string>();
-        const dependentTaskNames = new Set<string>();
-        let independentTasks: string[] = [];
+    return executionStrategy;
+}
 
-        if (template.dag) {
-            template.dag.tasks.forEach((task: DAGTask) => {
-                allTaskNames.add(task.name);
-                if (task.depends) {
-                    const dependencies = parseDepends(task.depends);
-                    dependencies.forEach((dep: string) => {
-                        dependentTaskNames.add(dep);
-                    });
-                }
-            });
-            independentTasks = Array.from(allTaskNames).filter(nodeName => !dependentTaskNames.has(nodeName));
-        } else if (template.steps) {
-            const lastStepGroupIdx = template.steps.length - 1;
-            const lastStepGroup = template.steps[lastStepGroupIdx];
-
-            lastStepGroup.forEach((step: WorkflowStep) => {
-                independentTasks.push(`${lastStepGroupIdx}.${step.name}`);
-            });
-        }
-
-        return independentTasks ? independentTasks : null;
+export function getStringAfterDelimiter(input: string, delimiter = '.'): string {
+    const lastIndex = input.lastIndexOf(delimiter);
+    if (lastIndex === -1) {
+        return input;
     }
-
-    function getTemplateNameFromTask(dag: {tasks: {name: string; template: string}[]}, nodeName: string): string | null {
-        const task = dag.tasks.find(t => t.name === nodeName);
-        return task ? task.template : null;
-    }
-
-    function getExecutionStrategy(task: DAGTask | WorkflowStep) {
-        let executionStrategy = '';
-
-        if (task.withItems) {
-            executionStrategy += `\n{withItems: ${String(task.withItems)}}`;
-        } else if (task.withParam) {
-            executionStrategy += `\n{withParam: ${String(task.withParam)}}`;
-        } else if (task.withSequence) {
-            executionStrategy += `\n{withSequence: ${String(task.withSequence)}}`;
-        }
-
-        return executionStrategy;
-    }
-
-    function getStringAfterDelimiter(input: string, delimiter: string = '.'): string {
-        const lastIndex = input.lastIndexOf(delimiter);
-        if (lastIndex === -1) {
-            return input;
-        }
-        return input.substring(lastIndex + 1);
-    }
+    return input.substring(lastIndex + 1);
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #15275

### Motivation


When viewing a `CronWorkflow` that uses `workflowTemplateRef` to reference a `WorkflowTemplate`, clicking the "Graph" tab will generate the following error:
```
Cannot read properties of undefined (reading 'forEach')
```

Here's a minimal WorkflowTemplate and CronWorkflow to reproduce this:

```yaml

apiVersion: argoproj.io/v1alpha1
kind: WorkflowTemplate
metadata:
  name: hello-world
spec:
  entrypoint: print-message
  templates:
    - name: print-message
      container:
        image: busybox
        command: [echo]
        args: ["hello world"]
---
apiVersion: argoproj.io/v1alpha1
kind: CronWorkflow
metadata:
  name: daily-job
spec:
  schedules: ["0 2 * * *"]
  workflowSpec:
    workflowTemplateRef:
      name: hello-world
```

### Modifications

This has been present since https://github.com/argoproj/argo-workflows/pull/14034 and is happening in the `templates.forEach((template: Template) => {` line. The `templates` variable is set to `workflow.spec.templates`, and a `CronWorkflow` with `workflowTemplateRef` won't have `workflow.spec.templates` defined. The `setWorkflowFromRefrence()` function is supposed to prevent this by resolving the `workflowTemplateRef`, but because of the way the `useEffect()` block is structured, it wasn't being run.

To minimize breakage, I had Claude write a bunch of unit tests in commit 7139d8cc646d5921555c05e571812b87c393d87c. That required refactoring
`graph-viewer.tsx` a bit. This is easiest to review by ignoring whitespace (I manually edited Claude's output to structure it so the diff looks nice): https://github.com/argoproj/argo-workflows/pull/16071/changes?w=1

The error can be fixed by simply appending `|| []` to `const templates = workflow.spec.templates`, but that means the example `CronWorkflow` will show "Nothing to show". To really fix it so it shows the graph properly
required changing the `useEffect()` block. I also did some cleanup:
1. Removed the ad-hoc loading indicator and error displayer and used the standard `<Loading>` and `<ErrorNotice>` components.
2. Removed the `generateNamePostfix()` logic and simply show the workflow names without a randomly-generated suffix, since the non-determinism introduced by that complicates testing and doesn't seem useful to me.

### Verification
Unit tests and manually viewed the "Graph" tab for the example given in https://github.com/argoproj/argo-workflows/issues/15275#issuecomment-4212962064 and a bunch of others
<img width="1313" height="786" alt="image" src="https://github.com/user-attachments/assets/fcb23f4e-cc38-4d26-bf65-4298513b7847" />

### Documentation
N/A

### AI

Claude Sonnet 4.6 for generating the tests, Claude Opus 4.6 for review.