### PR TITLE
fix!: resolve escaping of string values in withItems map parameters. Fixes #16061

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,43 @@ For the upgrading guide to a specific version of workflows change the documentat
 Breaking changes  typically (sometimes we don't realise they are breaking) have "!" in the commit message, as per
 the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
 
+## Upgrading to v5.0
+
+### Escaping of special characters in `withItems`
+
+Previously, when using [withItems](./fields.md#item) with strings containing characters that are escaped when JSON-encoded (e.g. newlines), the value passed to the step is incorrectly double-escaped.
+For example, the value for the following item would get translated to `multi\nline`:
+
+```yaml
+withItems:
+  - key: |
+      multi
+      line
+```
+
+Now, special characters are passed unescaped.
+If you have workflows that assume the prior behavior and unescapes such strings, they'll need to be updated.
+
+The following shell script can be used to identify workflows that are potentially impacted.
+It uses `kubectl` to iterate over every Workflow, WorkflowTemplate, ClusterWorkflowTemplate, and CronWorkflow and prints it if it uses `withItems` with affected strings.
+
+```bash
+kubectl get wf,wftmpl,clusterwftmpl,cronwf -o=template='
+{{- range .items }}
+  {{- $kind := .kind -}}
+  {{- $name := .metadata.name -}}
+  {{- range .spec.templates }}
+    {{- range .steps -}}
+      {{- range . -}}
+        {{- range .withItems }}
+{{ $kind }}/{{ $name }},{{ . | urlquery }},{{ . | js | urlquery }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}' | awk -F ',' '$2 != $3 { print $1 }'
+```
+
 ## Upgrading to v4.1
 
 ### INFORMER_WRITE_BACK environment variable removed

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3975,7 +3975,11 @@ func processItem(ctx context.Context, tmpl template.Template, name string, index
 		vals := make([]string, 0)
 		mapVal := item.GetMapVal()
 		for itemKey, itemVal := range mapVal {
-			replaceMap[varkeys.ItemByKey.Concretize(itemKey)] = fmt.Sprintf("%v", itemVal)
+			if itemVal.GetType() == wfv1.String {
+				replaceMap[varkeys.ItemByKey.Concretize(itemKey)] = itemVal.GetStrVal()
+			} else {
+				replaceMap[varkeys.ItemByKey.Concretize(itemKey)] = fmt.Sprintf("%v", itemVal)
+			}
 			vals = append(vals, fmt.Sprintf("%s:%v", itemKey, itemVal))
 		}
 		jsonByteVal, err := json.Marshal(mapVal)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7333,6 +7333,63 @@ func Test_processItem(t *testing.T) {
 	}
 }
 
+func Test_processItem_mapWithMultilineString(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	tests := []struct {
+		name          string
+		withParam     string
+		expectedParam string
+	}{
+		{
+			name:          "Map with multiline string value",
+			withParam:     `[{"key": "multi\nline\nvalue"}]`,
+			expectedParam: "multi\nline\nvalue",
+		},
+		{
+			name:          "Map with tab in string value",
+			withParam:     `[{"key": "col1\tcol2"}]`,
+			expectedParam: "col1\tcol2",
+		},
+		{
+			name:          "Map with quotes in string value",
+			withParam:     `[{"key": "say \"hello\""}]`,
+			expectedParam: `say "hello"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := wfv1.DAGTask{
+				WithParam: tt.withParam,
+				Arguments: wfv1.Arguments{
+					Parameters: []wfv1.Parameter{
+						{
+							Name:  "value",
+							Value: wfv1.AnyStringPtr("{{item.key}}"),
+						},
+					},
+				},
+			}
+
+			taskBytes, err := json.Marshal(task)
+			require.NoError(t, err)
+
+			tmpl, err := template.NewTemplate(string(taskBytes))
+			require.NoError(t, err)
+
+			var items []wfv1.Item
+			wfv1.MustUnmarshal([]byte(tt.withParam), &items)
+
+			var newTask wfv1.DAGTask
+			_, err = processItem(ctx, tmpl, "task-name", 0, items[0], &newTask, "", map[string]any{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedParam, newTask.Arguments.Parameters[0].Value.String())
+		})
+	}
+}
+
 var stepTimeoutWf = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
Fixes #16061

### Motivation

When using `withItems` with object parameters containing multi-line strings (or other special characters like tabs and quotes), the string values get incorrectly double-escaped. For example, a YAML multiline value like:

```yaml
withItems:
  - key: |
      multi
      line
```

...results in the parameter containing literal `\n` characters instead of actual newlines.

This is a continuation of #13718 which fixed escaping for top-level string items but not for string values within map items.

### Modifications

In `workflow/controller/operator.go`, the `processItem()` function now checks if a map value is of type `String` and uses `GetStrVal()` (which properly JSON-unmarshals the value) instead of `fmt.Sprintf("%v", itemVal)` (which calls `Item.String()`, then `json.Marshal()`, then strips quotes, leaving JSON escape sequences intact).

The root cause: `Item.String()` produces JSON-encoded content (e.g., `multi\nline`), which then gets further escaped by `strconv.Quote()` in the template engine to `multi\\nline`. After final `json.Unmarshal`, this becomes literal backslash-n instead of a newline.

### Verification

Added unit tests in `Test_processItem_mapWithMultilineString` covering:
- Map with multiline string value (`\n`)
- Map with tab characters (`\t`)
- Map with embedded quotes (`\"`)

All existing `Test_processItem` tests continue to pass.

### Documentation

No documentation changes needed. This is a bug fix restoring expected behavior.

### AI

Claude (Opus 4.6) helped with code review, tests, and PR description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Upgrading to v5.0” section with guidance on handling special characters in `withItems`.
  * Included a check to help identify workflows that may be affected by the behavior change.

* **Bug Fixes**
  * String values in mapped `withItems` are now passed through without unwanted extra escaping.
  * Expanded values preserve newlines, tabs, and quotes more reliably during substitution.

* **Tests**
  * Added coverage for multiline string handling in item expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->