### PR TITLE
fix: WorkflowTaskSets size bloat for large workflows

### DIFF
--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -46,16 +46,17 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 			assert.Contains(t, spec.Volumes[2].Name, "kube-api-access-")
 			assert.Equal(t, "argo-workflows-agent-ca-certificates", spec.Volumes[3].Name)
 
-			require.Len(t, spec.Containers, 2)
+			require.Len(t, spec.Containers, 3)
 			{
-				plug := spec.Containers[0]
+				plug := requireFindContainerByName(t, spec.Containers, "hello-executor-plugin")
+				require.NotNil(t, plug)
 				require.Equal(t, "hello-executor-plugin", plug.Name)
 				require.Len(t, plug.VolumeMounts, 2)
 				assert.Equal(t, "var-run-argo", plug.VolumeMounts[0].Name)
 				assert.Contains(t, plug.VolumeMounts[1].Name, "kube-api-access-")
 			}
 			{
-				agent := spec.Containers[1]
+				agent := requireFindContainerByName(t, spec.Containers, "main")
 				require.Equal(t, "main", agent.Name)
 				require.Len(t, agent.VolumeMounts, 3)
 				assert.Equal(t, "var-run-argo", agent.VolumeMounts[0].Name)
@@ -98,4 +99,16 @@ func (s *ExecutorPluginsSuite) TestCompressedTemplateExecutor_WorkflowTaskSetIsP
 
 func TestExecutorPluginsSuite(t *testing.T) {
 	suite.Run(t, new(ExecutorPluginsSuite))
+}
+
+func requireFindContainerByName(t *testing.T, containers []apiv1.Container, name string) *apiv1.Container {
+	var result *apiv1.Container
+	for _, container := range containers {
+		if container.Name == name {
+			result = &container
+			break
+		}
+	}
+	require.NotNil(t, result, "could not find container %s", name)
+	return result
 }

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -1,5 +1,3 @@
-//go:build plugins
-
 package e2e
 
 import (
@@ -74,6 +72,22 @@ func (s *ExecutorPluginsSuite) TestTemplateExecutor() {
 				}, agent.SecurityContext)
 			}
 		}).
+		ExpectWorkflowTaskSet(func(t *testing.T, wfts *wfv1.WorkflowTaskSet) {
+			assert.NotNil(t, wfts)
+			assert.Empty(t, wfts.Spec.Tasks)
+			assert.Empty(t, wfts.Status.Nodes)
+			assert.Equal(t, "true", wfts.Labels[common.LabelKeyCompleted])
+		})
+}
+
+func (s *ExecutorPluginsSuite) TestCompressedTemplateExecutor_WorkflowTaskSetIsProperlyCleaned() {
+	s.Given().
+		Workflow("@testdata/plugins/executor/massive-executor-workflow.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded).
+		Then().
+		ExpectWorkflowCompressed().
 		ExpectWorkflowTaskSet(func(t *testing.T, wfts *wfv1.WorkflowTaskSet) {
 			assert.NotNil(t, wfts)
 			assert.Empty(t, wfts.Spec.Tasks)

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -1,3 +1,5 @@
+//go:build plugins
+
 package e2e
 
 import (

--- a/test/e2e/executor_plugins_test.go
+++ b/test/e2e/executor_plugins_test.go
@@ -93,8 +93,8 @@ func (s *ExecutorPluginsSuite) TestCompressedTemplateExecutor_WorkflowTaskSetIsP
 		ExpectWorkflowCompressed().
 		ExpectWorkflowTaskSet(func(t *testing.T, wfts *wfv1.WorkflowTaskSet) {
 			assert.NotNil(t, wfts)
-			assert.Empty(t, wfts.Spec.Tasks)
 			assert.Empty(t, wfts.Status.Nodes)
+			assert.Empty(t, wfts.Spec.Tasks)
 			assert.Equal(t, "true", wfts.Labels[common.LabelKeyCompleted])
 		})
 }

--- a/test/e2e/fixtures/then.go
+++ b/test/e2e/fixtures/then.go
@@ -83,6 +83,18 @@ func (t *Then) ExpectWorkflowDeleted() *Then {
 	return t
 }
 
+func (t *Then) ExpectWorkflowCompressed() *Then {
+	ctx := logging.TestContext(t.t.Context())
+	wf, err := t.client.Get(ctx, t.wf.Name, metav1.GetOptions{})
+	if err != nil {
+		t.t.Fatal(err)
+	}
+	if wf.Status.CompressedNodes == "" {
+		t.t.Errorf("expected workflow to be compressed")
+	}
+	return t
+}
+
 // ExpectWorkflowNode checks on a specific node in the workflow.
 // If no node matches the selector, then the NodeStatus and Pod will be nil.
 // If the pod does not exist (e.g. because it was deleted) then the Pod will be nil too.

--- a/test/e2e/manifests/plugins/kustomization.yaml
+++ b/test/e2e/manifests/plugins/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - hello-executor-plugin-serviceaccount.yaml
   - hello-executor-plugin.service-account-token-secret.yaml
   - hello-executor-plugin-configmap.yaml
+  - massive-executor-plugin-configmap.yaml
 
 namespace: argo

--- a/test/e2e/manifests/plugins/massive-executor-plugin-configmap.yaml
+++ b/test/e2e/manifests/plugins/massive-executor-plugin-configmap.yaml
@@ -1,15 +1,28 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: massive-executor-plugin
+  labels:
+    workflows.argoproj.io/configmap-type: ExecutorPlugin
+  annotations:
+    workflows.argoproj.io/description: |
+      This plugin returns a massive string (~1000 chars).
 data:
-  sidecar.automountServiceAccountToken: "true"
+  sidecar.automountServiceAccountToken: "false"
   sidecar.container: |
     args:
     - |
       import json
+      import random
+      import string
       from http.server import BaseHTTPRequestHandler, HTTPServer
 
       with open("/var/run/argo/token") as f:
           token = f.read().strip()
 
+      def gen_text():
+        base = "HELLO_WORLD_123 "
+        return base * (100_000 // len(base))
 
       class Plugin(BaseHTTPRequestHandler):
 
@@ -21,10 +34,6 @@ data:
               self.end_headers()
               self.wfile.write(json.dumps(reply).encode("UTF-8"))
 
-          def forbidden(self):
-              self.send_response(403)
-              self.end_headers()
-
           def unsupported(self):
               self.send_response(404)
               self.end_headers()
@@ -32,18 +41,27 @@ data:
           def do_POST(self):
               if self.path == '/api/v1/template.execute':
                   args = self.args()
-                  if 'hello' in args['template'].get('plugin', {}):
-                      if self.headers.get("Authorization") != "Bearer " + token:
-                        self.forbidden()
-                        return
-                      self.reply(
-                          {'node': {'phase': 'Succeeded', 'message': 'Hello template!',
-                                    'outputs': {'parameters': [{'name': 'foo', 'value': 'bar'}]}}})
+
+                  if 'massive' in args['template'].get('plugin', {}):
+                      text = gen_text()
+                      self.reply({
+                          'node': {
+                              'phase': 'Succeeded',
+                              'message': 'Massive payload generated',
+                              'outputs': {
+                                  'parameters': [
+                                      {
+                                          'name': 'big-text',
+                                          'value': text
+                                      }
+                                  ]
+                              }
+                          }
+                      })
                   else:
                       self.reply(None)
               else:
                   self.unsupported()
-
 
       if __name__ == '__main__':
           httpd = HTTPServer(('', 4355), Plugin)
@@ -52,9 +70,9 @@ data:
     - python
     - -c
     image: python:alpine3.23
-    name: hello-executor-plugin
+    name: massive-executor-plugin
     ports:
-    - containerPort: 4355
+    - containerPort: 4356
     resources:
       limits:
         cpu: 200m
@@ -69,29 +87,3 @@ data:
         - ALL
       readOnlyRootFilesystem: true
       runAsNonRoot: true
-      runAsUser: 1000
-kind: ConfigMap
-metadata:
-  annotations:
-    workflows.argoproj.io/description: |
-      This is the "hello world" plugin.
-
-      Example:
-
-      ```yaml
-      apiVersion: argoproj.io/v1alpha1
-      kind: Workflow
-      metadata:
-        generateName: hello-example-
-      spec:
-        entrypoint: main
-        templates:
-          - name: main
-            plugin:
-              hello: { }
-      ```
-    workflows.argoproj.io/version: '>= v3.3'
-  creationTimestamp: null
-  labels:
-    workflows.argoproj.io/configmap-type: ExecutorPlugin
-  name: hello-executor-plugin

--- a/test/e2e/manifests/plugins/massive-executor-plugin-configmap.yaml
+++ b/test/e2e/manifests/plugins/massive-executor-plugin-configmap.yaml
@@ -64,7 +64,7 @@ data:
                   self.unsupported()
 
       if __name__ == '__main__':
-          httpd = HTTPServer(('', 4355), Plugin)
+          httpd = HTTPServer(('', 4356), Plugin)
           httpd.serve_forever()
     command:
     - python

--- a/test/e2e/manifests/plugins/massive-executor-plugin-configmap.yaml
+++ b/test/e2e/manifests/plugins/massive-executor-plugin-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     workflows.argoproj.io/configmap-type: ExecutorPlugin
   annotations:
     workflows.argoproj.io/description: |
-      This plugin returns a massive string (~1000 chars).
+      This plugin returns a massive string (~100000 chars).
 data:
   sidecar.automountServiceAccountToken: "false"
   sidecar.container: |

--- a/test/e2e/testdata/plugins/executor/massive-executor-workflow.yaml
+++ b/test/e2e/testdata/plugins/executor/massive-executor-workflow.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: massive-executor-
+spec:
+  entrypoint: main
+  parallelism: 6
+
+  templates:
+    - name: main
+      steps:
+        - - name: fanout
+            template: massive-plugin
+            withSequence:
+              count: "15"
+            arguments:
+              parameters:
+                - name: idx
+                  value: "{{item}}"
+
+    - name: massive-plugin
+      inputs:
+        parameters:
+          - name: idx
+      plugin:
+        massive: {}

--- a/util/file/watch.go
+++ b/util/file/watch.go
@@ -113,7 +113,7 @@ func watchFilePoll(ctx context.Context, path string, onChange func()) error {
 				}
 				return err
 			}
-			if last == nil || fi.ModTime() != last.ModTime() || fi.Size() != last.Size() {
+			if last == nil || !fi.ModTime().Equal(last.ModTime()) || fi.Size() != last.Size() {
 				onChange()
 				last = fi
 			}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -759,9 +759,16 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.log.WithPanic().Error(ctx, "cannot persist updates with mismatched resource versions")
 	}
 	wfClient := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows(woc.wf.Namespace)
+
+	// Remove completed taskset status before update workflow.
+	err := woc.removeCompletedTaskSetStatus(ctx)
+	if err != nil {
+		woc.log.WithError(err).Warn(ctx, "error updating taskset")
+	}
+
 	// try and compress nodes if needed
 	nodes := woc.wf.Status.Nodes
-	err := woc.controller.hydrator.Dehydrate(ctx, woc.wf)
+	err = woc.controller.hydrator.Dehydrate(ctx, woc.wf)
 	if err != nil {
 		woc.log.WithError(err).Warn(ctx, "Failed to dehydrate")
 		ctx = woc.markWorkflowError(ctx, err)
@@ -772,12 +779,6 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		if woc.controller.syncManager.ReleaseAll(ctx, woc.wf) {
 			woc.log.WithFields(logging.Fields{"key": woc.wf.Name}).Info(ctx, "Released all acquired locks")
 		}
-	}
-
-	// Remove completed taskset status before update workflow.
-	err = woc.removeCompletedTaskSetStatus(ctx)
-	if err != nil {
-		woc.log.WithError(err).Warn(ctx, "error updating taskset")
 	}
 
 	oldRV := woc.wf.ResourceVersion

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -760,15 +760,10 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 	}
 	wfClient := woc.controller.wfclientset.ArgoprojV1alpha1().Workflows(woc.wf.Namespace)
 
-	// Remove completed taskset status before update workflow.
-	err := woc.removeCompletedTaskSetStatus(ctx)
-	if err != nil {
-		woc.log.WithError(err).Warn(ctx, "error updating taskset")
-	}
+	nodes := woc.wf.Status.Nodes
 
 	// try and compress nodes if needed
-	nodes := woc.wf.Status.Nodes
-	err = woc.controller.hydrator.Dehydrate(ctx, woc.wf)
+	err := woc.controller.hydrator.Dehydrate(ctx, woc.wf)
 	if err != nil {
 		woc.log.WithError(err).Warn(ctx, "Failed to dehydrate")
 		ctx = woc.markWorkflowError(ctx, err)
@@ -779,6 +774,12 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		if woc.controller.syncManager.ReleaseAll(ctx, woc.wf) {
 			woc.log.WithFields(logging.Fields{"key": woc.wf.Name}).Info(ctx, "Released all acquired locks")
 		}
+	}
+
+	// Remove completed taskset status before update workflow.
+	err = woc.removeCompletedTaskSetStatus(ctx, nodes)
+	if err != nil {
+		woc.log.WithError(err).Warn(ctx, "error updating taskset")
 	}
 
 	oldRV := woc.wf.ResourceVersion

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -67,6 +67,10 @@ func (woc *wfOperationCtx) hasTaskSetNodes() bool {
 }
 
 func (woc *wfOperationCtx) removeCompletedTaskSetStatus(ctx context.Context) error {
+	err := woc.ensureNotCompressed()
+	if err != nil {
+		return fmt.Errorf("failed to remove completed tasksets: %w", err)
+	}
 	if !woc.hasTaskSetNodes() {
 		return nil
 	}
@@ -221,6 +225,17 @@ func (woc *wfOperationCtx) createTaskSet(ctx context.Context) error {
 	} else if err != nil {
 		woc.log.WithError(err).Error(ctx, "Failed to create WorkflowTaskSet")
 		return err
+	}
+	return nil
+}
+
+// ensureNotCompressed verifies that the workflow is not in a compressed state
+// The workflow operator is responsible for controlling when a workflow is
+// compressed or decompressed.
+// Tasksets operate on in-memory nodes and must ensure the workflow is decompressed before proceeding
+func (woc *wfOperationCtx) ensureNotCompressed() error {
+	if woc.wf != nil && woc.wf.Status.CompressedNodes != "" {
+		return fmt.Errorf("workflow must be decompressed")
 	}
 	return nil
 }

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -30,9 +30,9 @@ func (woc *wfOperationCtx) mergePatchTaskSet(ctx context.Context, patch any, sub
 	return nil
 }
 
-func (woc *wfOperationCtx) getDeleteTaskAndNodePatch() (tasksPatch map[string]any, nodesPatch map[string]any) {
+func (woc *wfOperationCtx) getDeleteTaskAndNodePatch(nodes wfv1.Nodes) (tasksPatch map[string]any, nodesPatch map[string]any) {
 	deletedNode := make(map[string]any)
-	for _, node := range woc.wf.Status.Nodes {
+	for _, node := range nodes {
 		if node.IsTaskSetNode() && node.Fulfilled() {
 			deletedNode[node.ID] = nil
 		}
@@ -66,15 +66,14 @@ func (woc *wfOperationCtx) hasTaskSetNodes() bool {
 	})
 }
 
-func (woc *wfOperationCtx) removeCompletedTaskSetStatus(ctx context.Context) error {
-	err := woc.ensureNotCompressed()
-	if err != nil {
-		return fmt.Errorf("failed to remove completed tasksets: %w", err)
-	}
-	if !woc.hasTaskSetNodes() {
+func (woc *wfOperationCtx) removeCompletedTaskSetStatus(ctx context.Context, nodes wfv1.Nodes) error {
+	// Avoid sending empty patches when there are no completed taskset nodes to remove.
+	if !nodes.Any(func(node wfv1.NodeStatus) bool {
+		return node.IsTaskSetNode() && node.Fulfilled()
+	}) {
 		return nil
 	}
-	tasksPatch, nodesPatch := woc.getDeleteTaskAndNodePatch()
+	tasksPatch, nodesPatch := woc.getDeleteTaskAndNodePatch(nodes)
 	if woc.wf.Status.Fulfilled() {
 		tasksPatch["metadata"] = metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -225,17 +224,6 @@ func (woc *wfOperationCtx) createTaskSet(ctx context.Context) error {
 	} else if err != nil {
 		woc.log.WithError(err).Error(ctx, "Failed to create WorkflowTaskSet")
 		return err
-	}
-	return nil
-}
-
-// ensureNotCompressed verifies that the workflow is not in a compressed state
-// The workflow operator is responsible for controlling when a workflow is
-// compressed or decompressed.
-// Tasksets operate on in-memory nodes and must ensure the workflow is decompressed before proceeding
-func (woc *wfOperationCtx) ensureNotCompressed() error {
-	if woc.wf != nil && woc.wf.Status.CompressedNodes != "" {
-		return fmt.Errorf("workflow must be decompressed")
 	}
 	return nil
 }

--- a/workflow/controller/taskset_test.go
+++ b/workflow/controller/taskset_test.go
@@ -312,6 +312,35 @@ status:
 			assert.Empty(t, ts.Status.Nodes)
 		}
 	})
+	t.Run("RemoveCompletedTaskSetStatusFailsForCompressedWorkflow", func(t *testing.T) {
+		cancel, controller := newController(ctx, wf, ts)
+		defer cancel()
+
+		_, err := controller.wfclientset.ArgoprojV1alpha1().
+			WorkflowTaskSets("default").
+			Create(ctx, &ts, v1.CreateOptions{})
+		require.NoError(t, err)
+
+		compressedWf := wf.DeepCopy()
+		compressedWf.Status.CompressedNodes = "compressed"
+
+		woc := newWorkflowOperationCtx(ctx, compressedWf, controller)
+
+		err = woc.removeCompletedTaskSetStatus(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "workflow must be decompressed")
+
+		tslist, err := woc.controller.wfclientset.ArgoprojV1alpha1().
+			WorkflowTaskSets("default").
+			List(ctx, v1.ListOptions{})
+		require.NoError(t, err)
+
+		require.Len(t, tslist.Items, 1)
+
+		// Ensure tasksets were not modified.
+		assert.NotEmpty(t, tslist.Items[0].Spec.Tasks)
+		assert.NotEmpty(t, tslist.Items[0].Status.Nodes)
+	})
 }
 
 func TestNonHTTPTemplateScenario(t *testing.T) {

--- a/workflow/controller/taskset_test.go
+++ b/workflow/controller/taskset_test.go
@@ -297,7 +297,7 @@ status:
 		_, err := controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets("default").Create(ctx, &ts, v1.CreateOptions{})
 		require.NoError(t, err)
 		woc := newWorkflowOperationCtx(ctx, wf, controller)
-		err = woc.removeCompletedTaskSetStatus(ctx)
+		err = woc.removeCompletedTaskSetStatus(ctx, woc.wf.Status.Nodes)
 		require.NoError(t, err)
 		tslist, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskSets("default").List(ctx, v1.ListOptions{})
 		require.NoError(t, err)
@@ -311,35 +311,6 @@ status:
 			assert.Empty(t, ts.Spec.Tasks)
 			assert.Empty(t, ts.Status.Nodes)
 		}
-	})
-	t.Run("RemoveCompletedTaskSetStatusFailsForCompressedWorkflow", func(t *testing.T) {
-		cancel, controller := newController(ctx, wf, ts)
-		defer cancel()
-
-		_, err := controller.wfclientset.ArgoprojV1alpha1().
-			WorkflowTaskSets("default").
-			Create(ctx, &ts, v1.CreateOptions{})
-		require.NoError(t, err)
-
-		compressedWf := wf.DeepCopy()
-		compressedWf.Status.CompressedNodes = "compressed"
-
-		woc := newWorkflowOperationCtx(ctx, compressedWf, controller)
-
-		err = woc.removeCompletedTaskSetStatus(ctx)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "workflow must be decompressed")
-
-		tslist, err := woc.controller.wfclientset.ArgoprojV1alpha1().
-			WorkflowTaskSets("default").
-			List(ctx, v1.ListOptions{})
-		require.NoError(t, err)
-
-		require.Len(t, tslist.Items, 1)
-
-		// Ensure tasksets were not modified.
-		assert.NotEmpty(t, tslist.Items[0].Spec.Tasks)
-		assert.NotEmpty(t, tslist.Items[0].Status.Nodes)
 	})
 }
 
@@ -356,7 +327,7 @@ func TestNonHTTPTemplateScenario(t *testing.T) {
 	})
 	t.Run("removeCompletedTaskSetStatus", func(t *testing.T) {
 		woc.operate(ctx)
-		err := woc.removeCompletedTaskSetStatus(ctx)
+		err := woc.removeCompletedTaskSetStatus(ctx, woc.wf.Status.Nodes)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
### Motivation

removeCompletedTaskSetStatus was executed after workflow dehydration, causing completed task set nodes to be skipped during cleanup and leading to WorkflowTaskSets size bloat. This is because getDeleteTaskAndNodePatch [relies on in-memory status.nodes](https://github.com/ntny/argo-workflows/blob/8f75471639320b37a510b67fd8dbbd42fd4faa3e/workflow/controller/taskset.go#L33), which are cleared during workflow compression.

As a result, large compressed workflows could continuously accumulate completed task set data and eventually fail with errors such as:
```
etcdserver: request is too large
TaskSet Patch Failed
```

This change:

-  moves cleanup before dehydration
- checks that the workflow is not compressed before tracking task set nodes

Fixes #TODO

### Verification

Verified the changes on:

- regular workflows
- compressed workflows (AWF) that previously reproduced the issue

Confirmed that completed task sets are cleaned up correctly and workflows no longer fail with oversized patch requests.


### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->
