### PR TITLE
feat(ui): autocomplete namespace filter from displayed resources (refs #7405)

### DIFF
--- a/.features/pending/namespace-filter-autocomplete.md
+++ b/.features/pending/namespace-filter-autocomplete.md
@@ -1,0 +1,10 @@
+Description: Autocomplete the Namespace filter from the namespaces of resources currently visible on the page
+Author: [Morgan Allen](https://github.com/callmemorgan)
+Component: UI
+Issues: 7405
+
+The Namespace filter on the workflows, workflow templates, cron workflows, sensors, event sources, event bindings, and event flow pages now autocompletes from the namespaces of resources already loaded for that page, in addition to the existing localStorage history.
+
+When the user is viewing resources across multiple namespaces (cluster-wide mode), the namespace filter dropdown now lists the namespaces present on the current page and narrows as you type. No new server endpoint or RBAC is involved — suggestions are derived from data the user already has permission to see.
+
+The managed-namespace short-circuit (where the filter renders as plain text) is unchanged.

--- a/ui/src/cron-workflows/cron-workflow-filters.tsx
+++ b/ui/src/cron-workflows/cron-workflow-filters.tsx
@@ -5,6 +5,7 @@ import {CheckboxFilter} from '../shared/components/checkbox-filter/checkbox-filt
 import {NamespaceFilter} from '../shared/components/namespace-filter';
 import {TagsInput} from '../shared/components/tags-input/tags-input';
 import * as models from '../shared/models';
+import {getUniqueNamespaces} from '../shared/namespaces';
 
 import './cron-workflow-filters.scss';
 
@@ -45,6 +46,7 @@ export function CronWorkflowFilters({cronWorkflows, namespace, labels, states, o
                         onChange={ns => {
                             onChange(ns, labels, states);
                         }}
+                        extraNamespaces={getUniqueNamespaces(cronWorkflows)}
                     />
                 </div>
                 <div className='columns small-2 xlarge-12'>

--- a/ui/src/event-flow/event-flow-page.tsx
+++ b/ui/src/event-flow/event-flow-page.tsx
@@ -256,7 +256,14 @@ export function EventFlowPage({history, location, match}: RouteComponentProps<an
                         }
                     ]
                 },
-                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} />]
+                tools: [
+                    <NamespaceFilter
+                        key='namespace-filter'
+                        value={namespace}
+                        onChange={setNamespace}
+                        extraNamespaces={nsUtils.getUniqueNamespaces([...(eventSources || []), ...(sensors || []), ...(workflows || [])])}
+                    />
+                ]
             }}>
             <ErrorNotice error={error} />
             {emptyGraph ? (

--- a/ui/src/event-sources/event-source-list.tsx
+++ b/ui/src/event-sources/event-source-list.tsx
@@ -115,7 +115,7 @@ export function EventSourceList({match, location, history}: RouteComponentProps<
                         }
                     ]
                 },
-                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} />]
+                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} extraNamespaces={nsUtils.getUniqueNamespaces(eventSources)} />]
             }}>
             <ErrorNotice error={error} />
             {loading && <Loading />}

--- a/ui/src/sensors/sensor-list.tsx
+++ b/ui/src/sensors/sensor-list.tsx
@@ -110,7 +110,7 @@ export function SensorList({match, location, history}: RouteComponentProps<any>)
                         }
                     ]
                 },
-                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} />]
+                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} extraNamespaces={nsUtils.getUniqueNamespaces(sensors)} />]
             }}>
             <ErrorNotice error={error} />
             {loading && <Loading />}

--- a/ui/src/shared/components/input-filter.test.tsx
+++ b/ui/src/shared/components/input-filter.test.tsx
@@ -1,0 +1,39 @@
+import {render} from '@testing-library/react';
+import {Autocomplete} from 'argo-ui/src/components/autocomplete/autocomplete';
+import React from 'react';
+
+import {InputFilter} from './input-filter';
+
+jest.mock('argo-ui/src/components/autocomplete/autocomplete', () => ({
+    Autocomplete: jest.fn(() => null)
+}));
+
+const lastItems = (): string[] => {
+    const mock = Autocomplete as unknown as jest.Mock;
+    const lastCall = mock.mock.calls[mock.mock.calls.length - 1];
+    return lastCall[0].items as string[];
+};
+
+describe('InputFilter', () => {
+    beforeEach(() => {
+        (Autocomplete as unknown as jest.Mock).mockClear();
+        localStorage.clear();
+    });
+
+    it('passes only the localStorage cache when extraSuggestions is undefined', () => {
+        localStorage.setItem('ns_inputs', 'argo,kube-system');
+        render(<InputFilter value='' name='ns' onChange={() => undefined} />);
+        expect(lastItems()).toEqual(['argo', 'kube-system']);
+    });
+
+    it('passes extraSuggestions ahead of the localStorage cache and dedups overlaps', () => {
+        localStorage.setItem('ns_inputs', 'argo,kube-system');
+        render(<InputFilter value='' name='ns' onChange={() => undefined} extraSuggestions={['prod', 'argo', 'staging']} />);
+        expect(lastItems()).toEqual(['prod', 'argo', 'staging', 'kube-system']);
+    });
+
+    it('handles empty localStorage and empty extraSuggestions', () => {
+        render(<InputFilter value='' name='ns' onChange={() => undefined} extraSuggestions={[]} />);
+        expect(lastItems()).toEqual([]);
+    });
+});

--- a/ui/src/shared/components/input-filter.tsx
+++ b/ui/src/shared/components/input-filter.tsx
@@ -1,5 +1,5 @@
 import {Autocomplete} from 'argo-ui/src/components/autocomplete/autocomplete';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 
 import './input-filter.scss';
 
@@ -10,11 +10,13 @@ interface InputProps {
     onChange: (input: string) => void;
     filterSuggestions?: boolean;
     autoHighlight?: boolean;
+    extraSuggestions?: string[];
 }
 
 export function InputFilter(props: InputProps) {
     const [value, setValue] = useState(props.value);
     const [localCache, setLocalCache] = useState((localStorage.getItem(props.name + '_inputs') || '').split(',').filter(item => item !== ''));
+    const items = useMemo(() => Array.from(new Set([...(props.extraSuggestions ?? []), ...localCache])), [localCache, props.extraSuggestions]);
 
     function setValueAndCache(newValue: string) {
         setLocalCache(currentCache => {
@@ -50,7 +52,7 @@ export function InputFilter(props: InputProps) {
     return (
         <div className='input-filter'>
             <Autocomplete
-                items={localCache}
+                items={items}
                 value={value}
                 onChange={(e, newValue) => setValue(newValue)}
                 onSelect={newValue => {

--- a/ui/src/shared/components/namespace-filter.tsx
+++ b/ui/src/shared/components/namespace-filter.tsx
@@ -3,5 +3,9 @@ import * as React from 'react';
 import * as nsUtils from '../namespaces';
 import {InputFilter} from './input-filter';
 
-export const NamespaceFilter = (props: {value: string; onChange: (namespace: string) => void}) =>
-    nsUtils.getManagedNamespace() ? <>{nsUtils.getManagedNamespace()}</> : <InputFilter value={props.value} name='ns' onChange={ns => props.onChange(ns)} />;
+export const NamespaceFilter = (props: {value: string; onChange: (namespace: string) => void; extraNamespaces?: string[]}) =>
+    nsUtils.getManagedNamespace() ? (
+        <>{nsUtils.getManagedNamespace()}</>
+    ) : (
+        <InputFilter value={props.value} name='ns' onChange={ns => props.onChange(ns)} extraSuggestions={props.extraNamespaces} filterSuggestions />
+    );

--- a/ui/src/shared/namespaces.ts
+++ b/ui/src/shared/namespaces.ts
@@ -62,3 +62,17 @@ export function getNamespace(namespace: string) {
 export function getNamespaceWithDefault(namespace: string) {
     return namespace || getCurrentNamespace() || getUserNamespace() || getManagedNamespace() || 'default';
 }
+
+// extract the unique, sorted set of namespaces present on a list of namespaced k8s objects
+export function getUniqueNamespaces<T extends {metadata?: {namespace?: string}}>(items: T[] | null | undefined): string[] {
+    if (!items) {
+        return [];
+    }
+    const set = new Set<string>();
+    for (const item of items) {
+        if (item.metadata?.namespace) {
+            set.add(item.metadata.namespace);
+        }
+    }
+    return Array.from(set).sort();
+}

--- a/ui/src/workflow-event-bindings/workflow-event-bindings.tsx
+++ b/ui/src/workflow-event-bindings/workflow-event-bindings.tsx
@@ -105,7 +105,7 @@ export function WorkflowEventBindings({match, location, history}: RouteComponent
                     {title: 'Workflow Event Bindings', path: uiUrl('workflow-event-bindings')},
                     {title: namespace, path: uiUrl('workflow-event-bindings/' + namespace)}
                 ],
-                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} />]
+                tools: [<NamespaceFilter key='namespace-filter' value={namespace} onChange={setNamespace} extraNamespaces={nsUtils.getUniqueNamespaces(workflowEventBindings)} />]
             }}>
             <ErrorNotice error={error} />
             {!workflowEventBindings ? (

--- a/ui/src/workflow-templates/workflow-template-filters.tsx
+++ b/ui/src/workflow-templates/workflow-template-filters.tsx
@@ -5,6 +5,7 @@ import {InputFilter} from '../shared/components/input-filter';
 import {NamespaceFilter} from '../shared/components/namespace-filter';
 import {TagsInput} from '../shared/components/tags-input/tags-input';
 import * as models from '../shared/models';
+import {getUniqueNamespaces} from '../shared/namespaces';
 
 import './workflow-template-filters.scss';
 
@@ -45,6 +46,7 @@ export function WorkflowTemplateFilters({templates, namespace, namePattern, labe
                         onChange={ns => {
                             onChange(ns, namePattern, labels);
                         }}
+                        extraNamespaces={getUniqueNamespaces(templates)}
                     />
                 </div>
                 <div className='columns small-2 xlarge-12'>

--- a/ui/src/workflows/components/workflow-filters/workflow-filters.tsx
+++ b/ui/src/workflows/components/workflow-filters/workflow-filters.tsx
@@ -13,6 +13,7 @@ import {NamespaceFilter} from '../../../shared/components/namespace-filter';
 import {TagsInput} from '../../../shared/components/tags-input/tags-input';
 import * as models from '../../../shared/models';
 import {WorkflowPhase} from '../../../shared/models';
+import {getUniqueNamespaces} from '../../../shared/namespaces';
 import {services} from '../../../shared/services';
 
 import './workflow-filters.scss';
@@ -98,7 +99,7 @@ export function WorkflowFilters(props: WorkflowFilterProps) {
             <div className='row'>
                 <div className='columns small-2 xlarge-12'>
                     <p className='wf-filters-container__title'>Namespace</p>
-                    <NamespaceFilter value={props.namespace} onChange={props.setNamespace} />
+                    <NamespaceFilter value={props.namespace} onChange={props.setNamespace} extraNamespaces={getUniqueNamespaces(props.workflows)} />
                 </div>
                 <div className='columns small-2 xlarge-12'>
                     <DropDown


### PR DESCRIPTION
Fixes #7405

### Motivation

The UI namespace filter (used on workflows, workflow templates, cron workflows, sensors, event sources, event bindings, event flow) is currently a free-text input backed only by a 5-entry localStorage history. Users with many namespaces have to retype namespace names from memory each time.

Issue #7405 has tracked this for 4+ years. In [a comment on the dup #9140](https://github.com/argoproj/argo-workflows/issues/9140#issuecomment-2432936375), @agilgur5 noted that one safe and proper way to provide namespace autocomplete is to derive suggestions from the namespaces of workflows the user has already loaded — since the user already has `list` permission on those namespaces, this leaks no information beyond k8s RBAC's existing answer.

That's what this PR does, generalized to every page that uses the shared `NamespaceFilter`.

### Modifications

- `shared/components/input-filter.tsx` gains an optional `extraSuggestions?: string[]` prop. Suggestions are merged with the existing localStorage cache (extras first, then history, deduped) and passed to `Autocomplete`.
- `shared/components/namespace-filter.tsx` gains a matching `extraNamespaces?: string[]` prop and enables `filterSuggestions` so typing narrows the merged list. The managed-namespace short-circuit is unchanged.
- `shared/namespaces.ts` gets a `getUniqueNamespaces` helper that extracts the unique sorted set of namespaces present on any list of namespaced k8s objects.
- 7 callers of `NamespaceFilter` now pass `extraNamespaces` derived from the resource list each page already loads:
  - workflows list → `props.workflows`
  - workflow templates list → `templates` prop
  - cron workflows list → `cronWorkflows` prop
  - workflow event bindings → `workflowEventBindings` state
  - event sources list → `eventSources` state
  - sensors list → `sensors` state
  - event flow → combined `eventSources + sensors + workflows`
- `reports/reports-filters.tsx` does not have a resource list in scope (it's a pure filter component), so it keeps the existing free-text + localStorage behavior. Its parent could be wired through in a follow-up, but it's intentionally out of scope here.
- New unit test for `InputFilter` covers the merge/dedup/order/empty-state behavior.

No server, RBAC, or manifest changes — the data piped into autocomplete is data the page has already loaded under the user's existing `list` permissions. Cluster-wide list responses already include `metadata.namespace` per item (e.g., `workflow-template-list.tsx:90`), which is what populates the suggestions.

This is purposefully a small fix. Some honest limitations:
- It does not surface empty namespaces (no resources visible).
- It does not give first-paint suggestions before the first list request lands.
- It does not change behavior in managed-namespace mode (filter still doesn't render at all).

Those limitations could be addressed by a future server-side `ListNamespaces` endpoint, which would be a separate design discussion involving manifest/RBAC changes — explicitly out of scope here. This PR aims to ship the maintainer-endorsed pragmatic improvement first.

Scope note: PR #13628 (open, @MasonM) adds a namespace input to the UserInfo page for SSO RBAC namespace delegation. That's a different page and a different concern — no overlap with this change.

### Verification

- `yarn --cwd ui lint` passes.
- `yarn --cwd ui test` passes; new test cases in `input-filter.test.tsx` cover:
  1. `extraSuggestions` undefined → behavior identical to before (only the localStorage cache appears in `Autocomplete.items`).
  2. `extraSuggestions` present → suggestions appear first, then the localStorage cache, deduped.
  3. Empty `extraSuggestions` → empty items list.
- Manual smoke: ran `yarn --cwd ui start` and confirmed that on `/workflows`, `/workflow-templates`, `/cron-workflows`, `/sensors`, `/event-sources`, `/workflow-event-bindings`, `/event-flow` the Namespace field's autocomplete now lists the namespaces of currently-visible resources and narrows them as you type. Confirmed `--managed-namespace=foo` still short-circuits to a plain `foo` label.

### Documentation

No user-facing documentation change required — this is a UX improvement to an existing filter with no new configuration, flag, or API surface.

### AI

Claude (Anthropic) was used to:
- Survey existing `NamespaceFilter` callers and confirm what data each had in scope.
- Verify existing helpers (`util/auth.CanIArgo`, `server/auth.CanI`) and their callers.
- Audit the draft for technical accuracy against the actual codebase, including verifying the argo-server's default ClusterRole grants (which informed scoping this PR to a UI-only change and deferring server-side `ListNamespaces` to a separate design discussion).
- Draft this PR description and the unit test.

All code in this PR was reviewed by the author before commit.
