### PR TITLE
fix: do not re-run `onExitNode`. Fixes #14392

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -283,9 +283,11 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 	for _, taskName := range targetTasks {
 		woc.executeDAGTask(ctx, dagCtx, taskName)
 
-		// It is possible that target tasks are not reconsidered (i.e. executeDAGTask is not called on them) once they are
-		// complete (since the DAG itself will have succeeded). To ensure that their exit handlers are run we also run them here. Note that
-		// calls to runOnExitNode are idempotent: it is fine if they are called more than once for the same task.
+		// The exit hook for each target task is started by executeDAGTask -> processTask.
+		// We only inspect the onExit node's status here to decide whether the DAG can be
+		// considered complete; calling runOnExitNode (and therefore executeTemplate) a second
+		// time on the same onExit node would re-run checkParallelism against the count this
+		// very pass just bumped.
 		taskNode := dagCtx.getTaskNode(ctx, taskName)
 
 		if taskNode != nil {
@@ -302,15 +304,10 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 				woc.markNodeError(ctx, node.Name, hookErr)
 				return node, hookErr
 			}
-			if taskNode.Fulfilled() {
-				if taskNode.Completed() {
-					hasOnExitNode, onExitNode, exitErr := woc.runOnExitNode(ctx, dagCtx.GetTask(ctx, taskName).GetExitHook(woc.execWf.Spec.Arguments), taskNode, dagCtx.boundaryID, dagCtx.tmplCtx, "tasks."+taskName, scope)
-					if exitErr != nil {
-						return node, exitErr
-					}
-					if hasOnExitNode && (onExitNode == nil || !onExitNode.Fulfilled()) {
-						onExitCompleted = false
-					}
+			if taskNode.Fulfilled() && taskNode.Completed() {
+				onExitNodeName := common.GenerateOnExitNodeName(taskNode.Name)
+				if onExitNode, err := woc.wf.GetNodeByName(onExitNodeName); err == nil && onExitNode != nil && !onExitNode.Fulfilled() {
+					onExitCompleted = false
 				}
 			}
 		}

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -306,7 +306,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			}
 			if taskNode.Fulfilled() && taskNode.Completed() {
 				onExitNodeName := common.GenerateOnExitNodeName(taskNode.Name)
-				if onExitNode, err := woc.wf.GetNodeByName(onExitNodeName); err == nil && onExitNode != nil && !onExitNode.Fulfilled() {
+				if onExitNode, onExitErr := woc.wf.GetNodeByName(onExitNodeName); onExitErr == nil && onExitNode != nil && !onExitNode.Fulfilled() {
 					onExitCompleted = false
 				}
 			}


### PR DESCRIPTION
  Fixes #14392

  ### Motivation

  `runOnExitNode` for DAG target tasks fires twice per operate: once inside `executeDAGTask` → `processTask`, and again in `executeDAG`'s target-tasks loop. The second
  pass re-enters `executeTemplate` and re-runs `checkParallelism` against an `activePods` count the first pass already bumped. With workflow `parallelism` set, that can
  return `ErrParallelismReached` and stall the exit hook.

  ### Modifications

  - Drop the `runOnExitNode` call from the target-tasks loop in `executeDAG`.
  - Build `onExitCompleted` by looking the onExit node up with `common.GenerateOnExitNodeName(taskNode.Name)` and checking `Fulfilled()`.

  ### Verification

  `go test ./workflow/controller/` passes (91s). DAG / onExit subset: 19/19.

  ### Documentation

  No user-facing behavior change, nothing to update.

  ### AI

  Investigated manually and drafted with Claude Code (Opus 4.7); I reviewed the diff.