### PR TITLE
feat(server): allow SSO ServiceAccount to override UI default namespace

### DIFF
--- a/.features/pending/sso-default-namespace-annotation.md
+++ b/.features/pending/sso-default-namespace-annotation.md
@@ -1,0 +1,11 @@
+Description: Allow SSO ServiceAccount to override the UI default namespace per tenant
+Author: [Robert Marklund](https://github.com/euforia)
+Component: General
+Issues: 16153
+
+The SSO-mapping ServiceAccount can now declare the UI's default landing namespace via a new `workflows.argoproj.io/default-namespace` annotation.
+When set, its value replaces `serviceAccountNamespace` in the claims returned by `/api/v1/userinfo`, so the UI lands the user in their tenant namespace instead of the install namespace.
+This unblocks multi-tenant installs where SSO matching must happen in the install namespace but users only have permissions in a separate tenant namespace, and replaces the empty list and 403 errors first-time SSO users used to see.
+The annotation is opt-in: absent annotation preserves prior behavior (the ServiceAccount's own namespace is used).
+The annotation value is treated as a literal namespace name and does not expand any user's authorization — actual access is still governed by RoleBindings in the target namespace.
+Three pre-existing UI bugs that prevented the new default from taking effect on first login are fixed alongside: `getCurrentNamespace()` no longer treats a persisted empty string as authoritative, `WorkflowsList` honors `userNamespace` from `/userinfo`, and `ClusterWorkflowTemplateDetails` no longer issues a cross-namespace list that 403s for non-cluster-admin tenants.

--- a/.spelling
+++ b/.spelling
@@ -120,9 +120,12 @@ RCs
 Risc-V
 Roadmap
 RoleBinding
+RoleBindings
 SDKs
+SSO-mapping
 SageMaker
 ServiceAccount
+ServiceAccounts
 Sharding
 Singer.io
 Snyk

--- a/docs/argo-server-sso.md
+++ b/docs/argo-server-sso.md
@@ -112,6 +112,40 @@ As of Kubernetes v1.24, secrets for a service account token are no longer automa
 Therefore, service account secrets for SSO RBAC must be created manually.
 See [Service Account Secrets](service-account-secrets.md) for detailed instructions.
 
+### Per-user default UI namespace
+
+By default, the Argo UI's "current namespace" is initialized from the matched
+SSO ServiceAccount's own `metadata.namespace`. SSO-mapping ServiceAccounts
+must live in the install namespace (Argo only walks that namespace when
+matching `rbac-rule` annotations against claims), so in a multi-tenant install
+where users have permissions only in their **tenant** namespace, the UI lands
+on the install namespace where the user has no permissions and every list
+call returns 403.
+
+To override the namespace advertised to UI clients without moving the SA, set
+the `workflows.argoproj.io/default-namespace` annotation on the SSO-mapping
+ServiceAccount:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alice
+  namespace: argo                 # install ns — where SSO matching happens
+  annotations:
+    workflows.argoproj.io/rbac-rule: "preferred_username == 'alice'"
+    workflows.argoproj.io/rbac-rule-precedence: "10"
+    # When set, this is what /api/v1/userinfo's serviceAccountNamespace returns
+    # to UI clients, instead of the SA's own namespace. The UI uses this as
+    # the default for the namespace dropdown.
+    workflows.argoproj.io/default-namespace: "argo-jobs-alice"
+```
+
+The annotation value is treated as a literal namespace name. Argo Server does
+not validate that the namespace exists or that the user has permissions
+there — it only changes what the UI defaults to. The user's actual access is
+still governed by their RoleBindings in the target namespace.
+
 ## SSO RBAC Namespace Delegation
 
 > v3.3 and after

--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -279,6 +279,16 @@ func (s *gatekeeper) getClientsForServiceAccount(ctx context.Context, claims *au
 	}
 	claims.ServiceAccountName = serviceAccount.Name
 	claims.ServiceAccountNamespace = serviceAccount.Namespace
+	// Allow the SA to advertise a different "home namespace" to UI clients
+	// via the workflows.argoproj.io/default-namespace annotation. SSO-mapping
+	// SAs must live in the install namespace (only ns Argo walks for SSO
+	// rule matching), but in a multi-tenant install the user's actual
+	// permissions live in their tenant namespace. Without this override the
+	// UI's default-namespace cascade lands on the install ns, producing 403
+	// on every list call. See common.AnnotationKeyDefaultNamespace.
+	if defaultNs, ok := serviceAccount.Annotations[common.AnnotationKeyDefaultNamespace]; ok && defaultNs != "" {
+		claims.ServiceAccountNamespace = defaultNs
+	}
 	return clients, nil
 }
 

--- a/server/auth/gatekeeper_test.go
+++ b/server/auth/gatekeeper_test.go
@@ -88,6 +88,20 @@ func TestServer_GetWFClient(t *testing.T) {
 			},
 			Secrets: []corev1.ObjectReference{{Name: "user-secret"}},
 		},
+		&corev1.ServiceAccount{
+			// SA matched by a unique group; carries default-namespace
+			// annotation so the resulting claims advertise a different ns
+			// to UI clients than the SA itself lives in.
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tenant-sa", Namespace: "my-ns",
+				Annotations: map[string]string{
+					common.AnnotationKeyRBACRule:           "'tenant-group' in groups",
+					common.AnnotationKeyRBACRulePrecedence: "5",
+					common.AnnotationKeyDefaultNamespace:   "tenant-ns",
+				},
+			},
+			Secrets: []corev1.ObjectReference{{Name: "my-secret"}},
+		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "my-ns"},
 			Data: map[string][]byte{
@@ -276,6 +290,41 @@ func TestServer_GetWFClient(t *testing.T) {
 		ctx, err := g.Context(x(logging.TestContext(t.Context()), "Bearer v2:whatever"))
 		require.NoError(t, err)
 		assert.Equal(t, "my-other-sa", GetClaims(ctx).ServiceAccountName)
+	})
+	t.Run("SSO+RBAC, default-namespace annotation overrides SA namespace", func(t *testing.T) {
+		// SA `tenant-sa` lives in `my-ns` but carries the
+		// workflows.argoproj.io/default-namespace annotation pointing at
+		// `tenant-ns`. The matched SA's actual namespace is the install ns
+		// (where SSO matching always happens), but the claims returned to
+		// the UI advertise the tenant ns instead.
+		ssoIf := &ssomocks.Interface{}
+		ssoIf.On("Authorize", mock.Anything, mock.Anything).Return(&authTypes.Claims{Groups: []string{"tenant-group"}}, nil)
+		ssoIf.On("IsRBACEnabled").Return(true)
+		g, err := NewGatekeeper(Modes{SSO: true}, clients, &rest.Config{Username: "my-username"}, ssoIf, clientForAuthorization, "my-ns", "my-ns", true, resourceCache)
+		require.NoError(t, err)
+		ctx, err := g.Context(x(logging.TestContext(t.Context()), "Bearer v2:whatever"))
+		require.NoError(t, err)
+		claims := GetClaims(ctx)
+		require.NotNil(t, claims)
+		assert.Equal(t, "tenant-sa", claims.ServiceAccountName)
+		assert.Equal(t, "tenant-ns", claims.ServiceAccountNamespace,
+			"default-namespace annotation should override the SA's own namespace")
+	})
+	t.Run("SSO+RBAC, no default-namespace annotation falls back to SA namespace", func(t *testing.T) {
+		// `my-sa` has no default-namespace annotation, so claims.SA-NS
+		// is the SA's literal metadata.namespace. This is the pre-patch
+		// behavior and must stay that way for backwards compatibility.
+		ssoIf := &ssomocks.Interface{}
+		ssoIf.On("Authorize", mock.Anything, mock.Anything).Return(&authTypes.Claims{Groups: []string{"my-group"}}, nil)
+		ssoIf.On("IsRBACEnabled").Return(true)
+		g, err := NewGatekeeper(Modes{SSO: true}, clients, &rest.Config{Username: "my-username"}, ssoIf, clientForAuthorization, "my-ns", "my-ns", true, resourceCache)
+		require.NoError(t, err)
+		ctx, err := g.Context(x(logging.TestContext(t.Context()), "Bearer v2:whatever"))
+		require.NoError(t, err)
+		claims := GetClaims(ctx)
+		require.NotNil(t, claims)
+		assert.Equal(t, "my-sa", claims.ServiceAccountName)
+		assert.Equal(t, "my-ns", claims.ServiceAccountNamespace)
 	})
 	t.Run("SSO+RBAC,denied", func(t *testing.T) {
 		ssoIf := &ssomocks.Interface{}

--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-details.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-details.tsx
@@ -66,12 +66,19 @@ export function ClusterWorkflowTemplateDetails({history, location, match}: Route
     useEffect(() => {
         (async () => {
             try {
-                const workflowList = await services.workflows.list('', null, [`${models.labels.clusterWorkflowTemplate}=${name}`], {limit: 50});
+                // Listing workflows that reference this CWT. Empty namespace
+                // means "all namespaces" server-side, which only cluster-admin
+                // SSO principals are allowed. Tenant SAs are namespaced, so
+                // scope the query to the user's default namespace —
+                // getNamespaceWithDefault picks current → user → managed →
+                // 'default'. Same fallback chain WorkflowsList uses post-SSO.
                 const info = await services.info.getInfo();
+                const ns = nsUtils.getNamespaceWithDefault(info.managedNamespace);
+                const workflowList = await services.workflows.list(ns, null, [`${models.labels.clusterWorkflowTemplate}=${name}`], {limit: 50});
 
                 setWorkflows(workflowList.items);
                 setColumns(info.columns);
-                setNamespace(nsUtils.getNamespaceWithDefault(info.managedNamespace));
+                setNamespace(ns);
                 setError(null);
             } catch (err) {
                 setError(err);

--- a/ui/src/shared/namespaces.ts
+++ b/ui/src/shared/namespaces.ts
@@ -50,7 +50,14 @@ export function setCurrentNamespace(value: string) {
 }
 
 export function getCurrentNamespace() {
-    return fixLocalStorageString(localStorage.getItem(currentNamespaceKey)) ?? (getUserNamespace() || getManagedNamespace());
+    // Use `||` (not `??`) so that an empty-string `current_namespace` falls
+    // through to `getUserNamespace()`. The "all namespaces" view persists
+    // `current_namespace = ""` to localStorage; without this, a user who
+    // ever loaded that view will keep landing on `/workflows/` (empty
+    // namespace path) on subsequent fresh logins, even when the server
+    // advertises a per-user default via the
+    // `workflows.argoproj.io/default-namespace` SA annotation.
+    return fixLocalStorageString(localStorage.getItem(currentNamespaceKey)) || getUserNamespace() || getManagedNamespace();
 }
 
 // return a namespace, favoring managed namespace when set

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -62,7 +62,15 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
     const {navigation} = useContext(Context);
 
     const isFirstRender = useRef(true);
-    const [namespace, setNamespace] = useState(nsUtils.getNamespace(match.params.namespace) || '');
+    // When no namespace is in the URL path (e.g. landing from a bare
+    // `/workflows` redirect after SSO), fall back to the user's default
+    // namespace from getCurrentNamespace() — that picks up the value
+    // seeded by setUserNamespace(userInfo.serviceAccountNamespace) in
+    // app-router. Without this fallback, an SSO user with a per-user
+    // default-namespace annotation lands on `/workflows/?limit=50`
+    // (empty namespace → list-all → 403). getNamespace() alone only
+    // honors managedNamespace, not userNamespace.
+    const [namespace, setNamespace] = useState(nsUtils.getNamespace(match.params.namespace) || nsUtils.getCurrentNamespace() || '');
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel') || '');
     const [pagination, setPagination] = useState<Pagination>(() => {
         const savedPaginationLimit = storage.getItem('options', {}).paginationLimit || undefined;

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -38,6 +38,18 @@ const (
 	AnnotationKeyRBACRule           = workflow.WorkflowFullName + "/rbac-rule"
 	AnnotationKeyRBACRulePrecedence = workflow.WorkflowFullName + "/rbac-rule-precedence"
 
+	// AnnotationKeyDefaultNamespace, when set on an SSO-mapping ServiceAccount,
+	// overrides the namespace returned to clients (e.g. the UI) as the user's
+	// "home" namespace via /api/v1/userinfo's serviceAccountNamespace field.
+	// Without this annotation the UI defaults to the SA's own namespace, which
+	// in multi-tenant installs is the install namespace where the user has no
+	// permissions — every UI button then bounces them to a 403. Setting this
+	// annotation to the user's tenant namespace fixes the UI default-namespace
+	// behavior without moving the SSO-mapping SA (Argo only walks the install
+	// ns for SSO matching, so SAs MUST live there). The value is treated as a
+	// literal namespace name, not an expression. See docs/argo-server-sso.md.
+	AnnotationKeyDefaultNamespace = workflow.WorkflowFullName + "/default-namespace"
+
 	// AnnotationKeyCronWfScheduledTime is the workflow metadata annotation key containing the time when the workflow
 	// was scheduled to run by CronWorkflow.
 	AnnotationKeyCronWfScheduledTime = workflow.WorkflowFullName + "/scheduled-time"


### PR DESCRIPTION
Adds a 'workflows.argoproj.io/default-namespace' annotation, read from the matched SSO-mapping ServiceAccount in gatekeeper. When set, its value replaces ServiceAccountNamespace in the claims returned via /api/v1/userinfo, so the UI lands the user in their tenant namespace instead of the install namespace. Opt-in; absent annotation preserves prior behavior.

### Fixes
So the default namespace can be a user scoped NS and not install NS 

### Motivation
For multi tenancy with one server and oauth and dynamic provisioning 

### Modifications

### Verification
Added tests

### Documentation
Added docs

### AI
yes, opencode
