### PR TITLE
fix: ignore resource version (match) when continue token present

### DIFF
--- a/util/unstructured/unstructured.go
+++ b/util/unstructured/unstructured.go
@@ -31,6 +31,10 @@ func NewFilteredUnstructuredInformer(ctx context.Context, resource schema.GroupV
 				options.Limit = workflowPaginationLimit
 				for {
 					options.Continue = continueTok
+					if options.Continue != "" {
+						options.ResourceVersion = ""
+						options.ResourceVersionMatch = ""
+					}
 					unList, err := client.Resource(resource).Namespace(namespace).List(ctx, options)
 					if err != nil {
 						return nil, err

--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -297,6 +297,10 @@ func newWorkflowPodWatch(ctx context.Context, clientSet kubernetes.Interface, in
 		options.Limit = podPaginationLimit
 		for {
 			options.Continue = continueTok
+			if options.Continue != "" {
+				options.ResourceVersion = ""
+				options.ResourceVersionMatch = ""
+			}
 			podList, err := c.List(ctx, options)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
 ### Motivation

  Both the workflow and pod informers paginate inside their `ListFunc` but never clear `ResourceVersion`/`ResourceVersionMatch` between paged requests. When the reflector
  relists with a non-zero ResourceVersion (after a watch dies) in a namespace with more than 500 workflows or pods, the second paged request carries both `Continue` and
  `ResourceVersion`. The apiserver rejects it with `specifying resource version is not allowed when using continue`, the relist retries, and the controller logs fill up
  with the same error every ~30s.

  Regression from #14373.

  ### Modifications

  - `util/unstructured/unstructured.go`: clear `ResourceVersion` and `ResourceVersionMatch` once `Continue` is set.
  - `workflow/controller/pod/controller.go`: same fix in the pod ListFunc.

  ### Verification
Tests pass

  ### Documentation

  Not applicable, bug fix.

  ### AI

  Investigation was drafted with Claude (Opus 4.7).