### PR TITLE
fix: retry for database transaction errors. Fixes #16101

### DIFF
--- a/workflow/sync/common.go
+++ b/workflow/sync/common.go
@@ -8,9 +8,9 @@ import (
 )
 
 type semaphore interface {
-	acquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) bool
+	acquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, error)
 	checkAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, bool, string)
-	tryAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, string)
+	tryAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, string, error)
 	release(ctx context.Context, key string) bool
 	addToQueue(ctx context.Context, holderKey string, priority int32, creationTime time.Time) error
 	removeFromQueue(ctx context.Context, holderKey string) error

--- a/workflow/sync/database_mutex_test.go
+++ b/workflow/sync/database_mutex_test.go
@@ -41,18 +41,18 @@ func TestDatabaseMutexAcquireRelease(t *testing.T) {
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow2", 0, now.Add(time.Second)))
 
 			// First acquisition should succeed
-			acquired, _ := mutex.tryAcquire(ctx, "default/workflow1", tx)
+			acquired, _, _ := mutex.tryAcquire(ctx, "default/workflow1", tx)
 			assert.True(t, acquired, "First acquisition should succeed")
 
 			// Second acquisition should fail
-			acquired, _ = mutex.tryAcquire(ctx, "default/workflow2", tx)
+			acquired, _, _ = mutex.tryAcquire(ctx, "default/workflow2", tx)
 			assert.False(t, acquired, "Second acquisition should fail")
 
 			// Release the mutex
 			mutex.release(ctx, "default/workflow1")
 
 			// Now acquisition should succeed again
-			acquired, _ = mutex.tryAcquire(ctx, "default/workflow2", tx)
+			acquired, _, _ = mutex.tryAcquire(ctx, "default/workflow2", tx)
 			assert.True(t, acquired, "Acquisition after release should succeed")
 		})
 	}
@@ -76,11 +76,11 @@ func TestDatabaseMutexQueueOrder(t *testing.T) {
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow1", 0, now))
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow2", 0, now.Add(time.Second)))
 
-			acquired, _ := mutex.tryAcquire(ctx, "default/workflow2", tx)
+			acquired, _, _ := mutex.tryAcquire(ctx, "default/workflow2", tx)
 			assert.False(t, acquired, "Second workflow should not acquire the mutex")
 
 			// Acquire the first one
-			acquired, _ = mutex.tryAcquire(ctx, "default/workflow1", tx)
+			acquired, _, _ = mutex.tryAcquire(ctx, "default/workflow1", tx)
 			assert.True(t, acquired, "First workflow should acquire the mutex")
 
 			// Release it - this should notify the next one

--- a/workflow/sync/database_mutex_test.go
+++ b/workflow/sync/database_mutex_test.go
@@ -41,18 +41,21 @@ func TestDatabaseMutexAcquireRelease(t *testing.T) {
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow2", 0, now.Add(time.Second)))
 
 			// First acquisition should succeed
-			acquired, _, _ := mutex.tryAcquire(ctx, "default/workflow1", tx)
+			acquired, _, err := mutex.tryAcquire(ctx, "default/workflow1", tx)
+			require.NoError(t, err)
 			assert.True(t, acquired, "First acquisition should succeed")
 
 			// Second acquisition should fail
-			acquired, _, _ = mutex.tryAcquire(ctx, "default/workflow2", tx)
+			acquired, _, err = mutex.tryAcquire(ctx, "default/workflow2", tx)
+			require.Error(t, err)
 			assert.False(t, acquired, "Second acquisition should fail")
 
 			// Release the mutex
 			mutex.release(ctx, "default/workflow1")
 
 			// Now acquisition should succeed again
-			acquired, _, _ = mutex.tryAcquire(ctx, "default/workflow2", tx)
+			acquired, _, err = mutex.tryAcquire(ctx, "default/workflow2", tx)
+			require.NoError(t, err)
 			assert.True(t, acquired, "Acquisition after release should succeed")
 		})
 	}
@@ -76,11 +79,13 @@ func TestDatabaseMutexQueueOrder(t *testing.T) {
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow1", 0, now))
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow2", 0, now.Add(time.Second)))
 
-			acquired, _, _ := mutex.tryAcquire(ctx, "default/workflow2", tx)
+			acquired, _, err := mutex.tryAcquire(ctx, "default/workflow2", tx)
+			require.Error(t, err)
 			assert.False(t, acquired, "Second workflow should not acquire the mutex")
 
 			// Acquire the first one
-			acquired, _, _ = mutex.tryAcquire(ctx, "default/workflow1", tx)
+			acquired, _, err = mutex.tryAcquire(ctx, "default/workflow1", tx)
+			require.NoError(t, err)
 			assert.True(t, acquired, "First workflow should acquire the mutex")
 
 			// Release it - this should notify the next one

--- a/workflow/sync/database_mutex_test.go
+++ b/workflow/sync/database_mutex_test.go
@@ -47,7 +47,7 @@ func TestDatabaseMutexAcquireRelease(t *testing.T) {
 
 			// Second acquisition should fail
 			acquired, _, err = mutex.tryAcquire(ctx, "default/workflow2", tx)
-			require.Error(t, err)
+			require.NoError(t, err)
 			assert.False(t, acquired, "Second acquisition should fail")
 
 			// Release the mutex
@@ -80,7 +80,7 @@ func TestDatabaseMutexQueueOrder(t *testing.T) {
 			require.NoError(t, mutex.addToQueue(ctx, "default/workflow2", 0, now.Add(time.Second)))
 
 			acquired, _, err := mutex.tryAcquire(ctx, "default/workflow2", tx)
-			require.Error(t, err)
+			require.NoError(t, err)
 			assert.False(t, acquired, "Second workflow should not acquire the mutex")
 
 			// Acquire the first one

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -323,25 +323,25 @@ func (s *databaseSemaphore) checkAcquire(ctx context.Context, holderKey string, 
 	return true, false, ""
 }
 
-func (s *databaseSemaphore) acquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) bool {
+func (s *databaseSemaphore) acquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, error) {
 	logger := s.logger(ctx)
 	limit := s.getLimit(ctx)
 	existing, err := s.currentHoldersSession(ctx, tx)
 	if err != nil {
 		logger.WithField("key", holderKey).WithError(err).Error(ctx, "Failed to acquire lock")
-		return false
+		return false, err
 	}
 	if len(existing) < limit {
 		pending, err := s.queries.GetPendingInQueue(ctx, tx, s.longDBKey(), holderKey, s.info.Config.ControllerName)
 		if err != nil {
 			logger.WithField("key", holderKey).WithError(err).Error(ctx, "Failed to acquire lock")
-			return false
+			return false, err
 		}
 		if len(pending) > 0 {
 			err := s.queries.UpdateStateToHeld(ctx, tx, s.longDBKey(), holderKey, s.info.Config.ControllerName)
 			if err != nil {
 				logger.WithField("key", holderKey).WithError(err).Error(ctx, "Failed to acquire lock")
-				return false
+				return false, err
 			}
 		} else {
 			record := &syncdb.StateRecord{
@@ -353,14 +353,14 @@ func (s *databaseSemaphore) acquire(ctx context.Context, holderKey string, tx *s
 			err := s.queries.InsertHeldState(ctx, tx, record)
 			if err != nil {
 				logger.WithField("key", holderKey).WithError(err).Error(ctx, "Failed to acquire lock")
-				return false
+				return false, err
 			}
 		}
 		logger.WithFields(logging.Fields{
 			"key":    holderKey,
 			"result": true,
 		}).Info(ctx, "Acquire succeeded")
-		return true
+		return true, nil
 	}
 	logger.WithFields(logging.Fields{
 		"key":             holderKey,
@@ -369,10 +369,10 @@ func (s *databaseSemaphore) acquire(ctx context.Context, holderKey string, tx *s
 		"current_holders": len(existing),
 		"limit":           limit,
 	}).Info(ctx, "Acquire failed")
-	return false
+	return false, nil
 }
 
-func (s *databaseSemaphore) tryAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, string) {
+func (s *databaseSemaphore) tryAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, string, error) {
 	logger := s.logger(ctx)
 	acq, already, msg := s.checkAcquire(ctx, holderKey, tx)
 	if already {
@@ -381,7 +381,7 @@ func (s *databaseSemaphore) tryAcquire(ctx context.Context, holderKey string, tx
 			"result":  true,
 			"message": msg,
 		}).Info(ctx, "tryAcquire - already held")
-		return true, msg
+		return true, msg, nil
 	}
 	if !acq {
 		logger.WithFields(logging.Fields{
@@ -389,22 +389,24 @@ func (s *databaseSemaphore) tryAcquire(ctx context.Context, holderKey string, tx
 			"result":  false,
 			"message": msg,
 		}).Info(ctx, "tryAcquire - cannot acquire")
-		return false, msg
+		return false, msg, nil
 	}
-	if s.acquire(ctx, holderKey, tx) {
+	acquired, err := s.acquire(ctx, holderKey, tx)
+	if acquired {
 		logger.WithFields(logging.Fields{
 			"key":    holderKey,
 			"result": true,
 		}).Info(ctx, "tryAcquire succeeded")
 		s.notifyWaiters(ctx)
-		return true, ""
+		return true, "", nil
 	}
 	logger.WithFields(logging.Fields{
 		"key":     holderKey,
 		"result":  false,
 		"message": msg,
+		"error":   err,
 	}).Info(ctx, "tryAcquire failed")
-	return false, msg
+	return false, msg, err
 }
 
 func (s *databaseSemaphore) expireLocks(ctx context.Context) {

--- a/workflow/sync/database_semaphore_test.go
+++ b/workflow/sync/database_semaphore_test.go
@@ -54,7 +54,7 @@ func TestInactiveControllerDBSemaphore(t *testing.T) {
 
 			// Try to acquire - this should fail because the controller is considered inactive
 			tx := info.SessionProxy
-			acquired, _ := s.tryAcquire(ctx, "foo/wf-01", tx)
+			acquired, _, _ := s.tryAcquire(ctx, "foo/wf-01", tx)
 			assert.False(t, acquired, "Semaphore should not be acquired when controller is marked as inactive")
 
 			// Now update the controller heartbeat to be current
@@ -65,7 +65,7 @@ func TestInactiveControllerDBSemaphore(t *testing.T) {
 			require.NoError(t, err)
 
 			// Try again - now it should work
-			acquired, _ = s.tryAcquire(ctx, "foo/wf-01", tx)
+			acquired, _, _ = s.tryAcquire(ctx, "foo/wf-01", tx)
 			assert.True(t, acquired, "Semaphore should be acquired when controller is alive")
 		})
 	}
@@ -109,7 +109,7 @@ func TestOtherControllerDBSemaphore(t *testing.T) {
 
 			// Try to acquire - this should fail because the other controller's item is first in line
 			tx := info.SessionProxy
-			acquired, _ := s.tryAcquire(ctx, "foo/our-wf-01", tx)
+			acquired, _, _ := s.tryAcquire(ctx, "foo/our-wf-01", tx)
 			assert.False(t, acquired, "Semaphore should not be acquired when another controller's item is first in queue")
 
 			// Now mark the other controller as inactive by setting its timestamp to be old
@@ -121,7 +121,7 @@ func TestOtherControllerDBSemaphore(t *testing.T) {
 			require.NoError(t, err)
 
 			// Try again - now it should work because the other controller is considered inactive
-			acquired, _ = s.tryAcquire(ctx, "foo/our-wf-01", tx)
+			acquired, _, _ = s.tryAcquire(ctx, "foo/our-wf-01", tx)
 			assert.True(t, acquired, "Semaphore should be acquired when other controller is marked as inactive")
 
 			// Verify the semaphore is now held by our workflow
@@ -171,7 +171,7 @@ func TestDifferentSemaphoreDBSemaphore(t *testing.T) {
 
 			// Try to acquire - this should succeed because the other cluster's item is for a different semaphore
 			tx := info.SessionProxy
-			acquired, _ := s.tryAcquire(ctx, "foo/our-wf-01", tx)
+			acquired, _, _ := s.tryAcquire(ctx, "foo/our-wf-01", tx)
 			assert.True(t, acquired, "Semaphore should be acquired when another cluster's item is for a different semaphore")
 
 			// Verify the semaphore is now held by our workflow
@@ -206,38 +206,38 @@ func TestMutexAndSemaphoreWithSameName(t *testing.T) {
 			// Mutex workflow 1
 			tx := info.SessionProxy
 			require.NoError(t, mutex.addToQueue(ctx, "foo/wf-mutex-1", 0, now))
-			mutexAcquired1, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-1", tx)
+			mutexAcquired1, _, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-1", tx)
 			assert.True(t, mutexAcquired1, "Mutex should be acquired by first workflow")
 
 			// Semaphore workflow 1
 			require.NoError(t, semaphore.addToQueue(ctx, "foo/wf-sem-1", 0, now))
-			semAcquired1, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-1", tx)
+			semAcquired1, _, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-1", tx)
 			assert.True(t, semAcquired1, "Semaphore should be acquired by first workflow")
 
 			// Verify the mutex can't be acquired again
 			require.NoError(t, mutex.addToQueue(ctx, "foo/wf-mutex-2", 0, now))
-			mutexAcquired2, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-2", tx)
+			mutexAcquired2, _, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-2", tx)
 			assert.False(t, mutexAcquired2, "Mutex should not be acquired by second workflow")
 
 			// But the semaphore can still be acquired (limit=2)
 			require.NoError(t, semaphore.addToQueue(ctx, "foo/wf-sem-2", 0, now))
-			semAcquired2, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-2", tx)
+			semAcquired2, _, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-2", tx)
 			assert.True(t, semAcquired2, "Semaphore should be acquired by second workflow")
 
 			// But not a third time (because limit=2)
 			require.NoError(t, semaphore.addToQueue(ctx, "foo/wf-sem-3", 0, now))
-			semAcquired3, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-3", tx)
+			semAcquired3, _, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-3", tx)
 			assert.False(t, semAcquired3, "Semaphore should not be acquired by third workflow (at capacity)")
 
 			// Now release the mutex
 			mutex.release(ctx, "foo/wf-mutex-1")
 
 			// The mutex should be acquirable now
-			mutexAcquired2Again, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-2", tx)
+			mutexAcquired2Again, _, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-2", tx)
 			assert.True(t, mutexAcquired2Again, "Mutex should be acquired after release")
 
 			// But this shouldn't affect the semaphore's capacity
-			semAcquired3Again, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-3", tx)
+			semAcquired3Again, _, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-3", tx)
 			assert.False(t, semAcquired3Again, "Semaphore should still be at capacity")
 
 			// Now release one of the semaphore holders
@@ -245,16 +245,16 @@ func TestMutexAndSemaphoreWithSameName(t *testing.T) {
 			assert.True(t, released, "Semaphore should be released successfully")
 
 			// Now we should be able to acquire the semaphore once
-			semAcquired3Again, _ = semaphore.tryAcquire(ctx, "foo/wf-sem-3", tx)
+			semAcquired3Again, _, _ = semaphore.tryAcquire(ctx, "foo/wf-sem-3", tx)
 			assert.True(t, semAcquired3Again, "Semaphore should be acquired after release")
 
 			// But not a fourth time (still at capacity with 2 holders)
 			require.NoError(t, semaphore.addToQueue(ctx, "foo/wf-sem-4", 0, now))
-			semAcquired4, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-4", tx)
+			semAcquired4, _, _ := semaphore.tryAcquire(ctx, "foo/wf-sem-4", tx)
 			assert.False(t, semAcquired4, "Semaphore should not be acquired fourth time (at capacity again)")
 
 			// The mutex should still be held
-			mutexAcquired3, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-3", tx)
+			mutexAcquired3, _, _ := mutex.tryAcquire(ctx, "foo/wf-mutex-3", tx)
 			assert.False(t, mutexAcquired3, "Mutex should still be held by another workflow")
 
 			// Verify by checking the database directly

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -164,12 +164,12 @@ func (s *prioritySemaphore) removeFromQueue(ctx context.Context, holderKey strin
 	return nil
 }
 
-func (s *prioritySemaphore) acquire(_ context.Context, holderKey string, _ *sqldb.SessionProxy) bool {
+func (s *prioritySemaphore) acquire(_ context.Context, holderKey string, _ *sqldb.SessionProxy) (bool, error) {
 	if s.semaphore.TryAcquire(1) {
 		s.lockHolder[holderKey] = true
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 func isSameWorkflowNodeKeys(firstKey, secondKey string) bool {
@@ -231,16 +231,17 @@ func (s *prioritySemaphore) checkAcquire(ctx context.Context, holderKey string, 
 	return false, false, waitingMsg
 }
 
-func (s *prioritySemaphore) tryAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, string) {
+func (s *prioritySemaphore) tryAcquire(ctx context.Context, holderKey string, tx *sqldb.SessionProxy) (bool, string, error) {
 	logger := s.logger(ctx)
 	acq, already, msg := s.checkAcquire(ctx, holderKey, tx)
 	if already {
-		return true, msg
+		return true, msg, nil
 	}
 	if !acq {
-		return false, msg
+		return false, msg, nil
 	}
-	if s.acquire(ctx, holderKey, tx) {
+	acquired, _ := s.acquire(ctx, holderKey, tx)
+	if acquired {
 		s.pending.pop()
 		limit := s.getLimit(ctx)
 		logger.WithFields(logging.Fields{
@@ -250,10 +251,10 @@ func (s *prioritySemaphore) tryAcquire(ctx context.Context, holderKey string, tx
 			"limit":     limit,
 		}).Info(ctx, "acquired")
 		s.notifyWaiters(ctx)
-		return true, ""
+		return true, "", nil
 	}
 	logger.WithField("lockHolder", s.lockHolder).Debug(ctx, "Current semaphore Holders")
-	return false, msg
+	return false, msg, nil
 }
 
 func (s *prioritySemaphore) probeWaiting(_ context.Context) {}

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -108,20 +108,20 @@ func testTryAcquireSemaphore(t *testing.T, factory semaphoreFactory) {
 	require.NoError(t, s.addToQueue(ctx, "default/wf-04", 0, now.Add(3*time.Second)))
 	// verify only the first in line is allowed to acquired the semaphore
 	var acquired bool
-	acquired, _ = s.tryAcquire(ctx, "default/wf-04", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-04", tx)
 	assert.False(t, acquired)
-	acquired, _ = s.tryAcquire(ctx, "default/wf-03", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-03", tx)
 	assert.False(t, acquired)
-	acquired, _ = s.tryAcquire(ctx, "default/wf-02", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-02", tx)
 	assert.False(t, acquired)
-	acquired, _ = s.tryAcquire(ctx, "default/wf-01", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-01", tx)
 	assert.True(t, acquired)
 	// now that wf-01 obtained it, wf-02 can
-	acquired, _ = s.tryAcquire(ctx, "default/wf-02", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-02", tx)
 	assert.True(t, acquired)
-	acquired, _ = s.tryAcquire(ctx, "default/wf-03", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-03", tx)
 	assert.False(t, acquired)
-	acquired, _ = s.tryAcquire(ctx, "default/wf-04", tx)
+	acquired, _, _ = s.tryAcquire(ctx, "default/wf-04", tx)
 	assert.False(t, acquired)
 }
 
@@ -155,7 +155,7 @@ func testNotifyWaitersAcquire(t *testing.T, factory semaphoreFactory) {
 	require.NoError(t, s.addToQueue(ctx, "default/wf-03", 0, now.Add(2*time.Second)))
 
 	tx := sessionProxy
-	acquired, _ := s.tryAcquire(ctx, "default/wf-01", tx)
+	acquired, _, _ := s.tryAcquire(ctx, "default/wf-01", tx)
 	assert.True(t, acquired)
 
 	assert.Len(t, notified, 2)
@@ -201,7 +201,7 @@ func testNotifyWorkflowFromTemplateSemaphore(t *testing.T, factory semaphoreFact
 	require.NoError(t, s.addToQueue(ctx, "foo/wf-02/nodeid-456", 0, now.Add(time.Second)))
 
 	tx := sessionProxy
-	acquired, _ := s.tryAcquire(ctx, "foo/wf-01/nodeid-123", tx)
+	acquired, _, _ := s.tryAcquire(ctx, "foo/wf-01/nodeid-123", tx)
 	assert.True(t, acquired)
 
 	assert.Len(t, notified, 1)

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -13,6 +13,7 @@ import (
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/argoproj/argo-workflows/v4/config"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
@@ -244,8 +245,10 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 						continue
 					}
 					key := getUpgradedKey(&wf, holders, level)
-					if sem != nil && sem.acquire(ctx, key, sm.dbInfo.SessionProxy) {
-						sm.log.WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
+					if sem != nil {
+						if acquired, _ := sem.acquire(ctx, key, sm.dbInfo.SessionProxy); acquired {
+							sm.log.WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
+						}
 					}
 				}
 			}
@@ -268,7 +271,7 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 							continue
 						}
 						key := getUpgradedKey(&wf, holding.Holder, level)
-						mutex.acquire(ctx, key, sm.dbInfo.SessionProxy)
+						_, _ = mutex.acquire(ctx, key, sm.dbInfo.SessionProxy)
 					}
 					sm.syncLockMap[holding.Mutex] = mutex
 				}
@@ -320,48 +323,59 @@ func (sm *Manager) TryAcquire(ctx context.Context, wf *wfv1.Workflow, nodeName s
 		var updated bool
 		var already bool
 		var msg string
-		var lastErr error
-		for retryCounter := range 5 {
-			err = sm.dbInfo.SessionProxy.TxWith(ctx, func(sp *sqldb.SessionProxy) error {
-				sm.log.WithFields(logging.Fields{
-					"holderKey": holderKey,
-					"attempt":   retryCounter + 1,
-				}).Info(ctx, "TryAcquire - starting transaction")
-				var txErr error
-				already, updated, msg, failedLockName, txErr = sm.tryAcquireImpl(ctx, wf, sp, holderKey, failedLockName, syncItems, lockKeys)
-				sm.log.WithFields(logging.Fields{
-					"holderKey": holderKey,
-					"attempt":   retryCounter + 1,
-				}).Info(ctx, "TryAcquire - transaction completed")
-				return txErr
-			}, &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: false})
-			if err == nil {
-				return already, updated, msg, failedLockName, nil
-			}
-			lastErr = err
-			// Check if this is a serialization error
-			if strings.Contains(err.Error(), "serialization") ||
-				strings.Contains(err.Error(), "dependencies") ||
-				strings.Contains(err.Error(), "deadlock") ||
-				strings.Contains(err.Error(), "rollback") {
-				sm.log.WithFields(logging.Fields{
-					"holderKey": holderKey,
-					"attempt":   retryCounter + 1,
-					"error":     err,
-				}).Info(ctx, "TryAcquire - serialization conflict, retrying")
-				continue
-			}
+		// Backoff bounds: sm.lock is held for the whole loop, so cap each sleep
+		// modestly. Jitter prevents a fleet of replicas from retrying in lockstep
+		// after a shared conflict burst.
+		backoff := wait.Backoff{
+			Steps:    5,
+			Duration: 10 * time.Millisecond,
+			Factor:   2.0,
+			Jitter:   0.5,
+			Cap:      600 * time.Millisecond,
+		}
+		attempt := 0
+		err = retry.OnError(backoff, isRetryableSyncError, func() error {
+			attempt++
 			sm.log.WithFields(logging.Fields{
 				"holderKey": holderKey,
-				"attempt":   retryCounter + 1,
-				"error":     err,
-			}).Info(ctx, "TryAcquire - tx failed")
-			// For other errors, return immediately
+				"attempt":   attempt,
+			}).Info(ctx, "TryAcquire - starting transaction")
+			txErr := sm.dbInfo.SessionProxy.TxWith(ctx, func(sp *sqldb.SessionProxy) error {
+				var implErr error
+				already, updated, msg, failedLockName, implErr = sm.tryAcquireImpl(ctx, wf, sp, holderKey, failedLockName, syncItems, lockKeys)
+				return implErr
+			}, &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: false})
+			if txErr != nil {
+				sm.log.WithFields(logging.Fields{
+					"holderKey": holderKey,
+					"attempt":   attempt,
+					"error":     txErr,
+					"retryable": isRetryableSyncError(txErr),
+				}).Info(ctx, "TryAcquire - transaction failed")
+			}
+			return txErr
+		})
+		if err != nil {
 			return false, false, "", failedLockName, err
 		}
-		return false, false, "", failedLockName, fmt.Errorf("failed after %d retries: %w", 5, lastErr)
+		return already, updated, msg, failedLockName, nil
 	}
 	return sm.tryAcquireImpl(ctx, wf, nil, holderKey, failedLockName, syncItems, lockKeys)
+}
+
+// isRetryableSyncError reports whether a TryAcquire transaction failure should
+// be retried. Matches PostgreSQL SERIALIZABLE conflict (40001), deadlock
+// (40P01), and explicit rollback messages by substring against the driver's
+// text.
+func isRetryableSyncError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "serialization") ||
+		strings.Contains(s, "dependencies") ||
+		strings.Contains(s, "deadlock") ||
+		strings.Contains(s, "rollback")
 }
 
 func (sm *Manager) prepAcquire(ctx context.Context, wf *wfv1.Workflow, holderKey string, syncItems []*syncItem, lockKeys []string) (bool, string, string, error) {
@@ -433,7 +447,15 @@ func (sm *Manager) tryAcquireImpl(ctx context.Context, wf *wfv1.Workflow, tx *sq
 		for i, lockKey := range lockKeys {
 			lock := sm.syncLockMap[lockKey]
 			var acquired bool
-			acquired, msg = lock.tryAcquire(ctx, holderKey, tx)
+			var acquireErr error
+			acquired, msg, acquireErr = lock.tryAcquire(ctx, holderKey, tx)
+			if acquireErr != nil {
+				// Surface the underlying error so callers (e.g. TryAcquire's
+				// retry loop) can decide whether it is retryable. Transient
+				// database errors like PostgreSQL SQLSTATE 40001 must reach
+				// the retry detector untouched.
+				return false, false, "", failedLockName, acquireErr
+			}
 			if !acquired {
 				return false, false, "", failedLockName, fmt.Errorf("bug: failed to acquire something that should have been checked: %s", msg)
 			}

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -246,8 +246,12 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 					}
 					key := getUpgradedKey(&wf, holders, level)
 					if sem != nil {
-						if acquired, err := sem.acquire(ctx, key, sm.dbInfo.SessionProxy); acquired {
-							sm.log.WithError(err).WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
+						acquired, acquireErr := sem.acquire(ctx, key, sm.dbInfo.SessionProxy)
+						if acquired {
+							sm.log.WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
+						}
+						if acquireErr != nil {
+							sm.log.WithError(err).Error(ctx, "was unable to obtain lock due to error")
 						}
 					}
 				}

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -246,8 +246,8 @@ func (sm *Manager) Initialize(ctx context.Context, wfs []wfv1.Workflow) {
 					}
 					key := getUpgradedKey(&wf, holders, level)
 					if sem != nil {
-						if acquired, _ := sem.acquire(ctx, key, sm.dbInfo.SessionProxy); acquired {
-							sm.log.WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
+						if acquired, err := sem.acquire(ctx, key, sm.dbInfo.SessionProxy); acquired {
+							sm.log.WithError(err).WithFields(logging.Fields{"key": key, "semaphore": holding.Semaphore}).Info(ctx, "Lock acquired")
 						}
 					}
 				}


### PR DESCRIPTION
 Fixes #16101
 
 ### Motivation

  Workflows using database-backed mutexes or semaphores fail permanently on PostgreSQL SQLSTATE 40001 during lock acquisition. 40001 is a normal serializable-isolation
  conflict; the retry loop in `TryAcquire` is built for it but never fires.

  `databaseSemaphore.acquire` drops the SQL error and returns plain `false`. `tryAcquireImpl` wraps the bare failure as `bug: failed to acquire something that should have
  been checked: ` (empty payload). The retry detector substring-matches `serialization`/`dependencies`/`deadlock`/`rollback` against that string, finds nothing, and gives
  up after one attempt.

  ### Modifications

  - `acquire` returns `(bool, error)`; `tryAcquire` returns `(bool, string, error)`. SQL error propagates.
  - `tryAcquireImpl` returns the underlying error directly. The `bug:` wrap stays for its original case: `(false, nil)` after `checkAcquire` approved.
  - Retry loop rewritten with `retry.OnError` and `wait.Backoff{Duration: 10ms, Factor: 2, Steps: 5, Jitter: 0.5, Cap: 600ms}`. Old loop had zero delay; jitter avoids
  replica lockstep.
  - Substring check extracted into `isRetryableSyncError`.
  - `prioritySemaphore` and the `semaphore` interface updated to match. In-memory `acquire` returns nil error. `Initialize` callers still drop the error — pre-existing,
  separate change.

  ### Verification
Test pass

  ### Documentation

  None needed.

  ### AI

  Claude Code (Claude Opus 4.7) used for investigation, tests, fix, and this description. Reviewed by hand; `Cap` raised from 200ms to 600ms during review.