### PR TITLE
feat(executor): report artifact metadata before upload completes

### DIFF
--- a/.features/pending/async-artifact-upload.md
+++ b/.features/pending/async-artifact-upload.md
@@ -1,0 +1,11 @@
+Description: Report artifact metadata before upload completes, with concurrent uploads.
+Author: [daixin1204](https://github.com/SimbaKingjoe)
+Component: General
+Issues: 16091
+
+This change separates artifact key generation from file uploads, allowing the
+wait container to report output metadata (S3 keys, types) to the controller
+immediately. Actual artifact uploads then run concurrently via goroutines with
+sync.WaitGroup synchronization. This lays the foundation for full async artifact
+uploading where downstream tasks that do not consume the artifacts can proceed
+without waiting for upload completion.

--- a/cmd/argoexec/commands/wait.go
+++ b/cmd/argoexec/commands/wait.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/argoproj/argo-workflows/v4/cmd/argoexec/executor"
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/executor/tracing"
 )
@@ -88,19 +89,33 @@ func waitContainer(ctx context.Context) error {
 		wfExecutor.AddError(ctx, err)
 	}
 
-	// Saving output artifacts
-	artifacts, err := wfExecutor.SaveArtifacts(bgCtx)
+	// Stage artifacts and generate metadata (keys/types) without uploading.
+	// This allows outputs to be reported early while uploads proceed asynchronously.
+	staged, err := wfExecutor.GenerateArtifactOutputs(bgCtx)
 	if err != nil {
 		wfExecutor.AddError(ctx, err)
 	}
 
-	// Save log artifacts
+	// Build the artifact list for reporting
+	artifacts := make(wfv1.Artifacts, 0, len(staged))
+	for _, s := range staged {
+		artifacts = append(artifacts, s.Artifact)
+	}
 	logArtifacts := wfExecutor.SaveLogs(bgCtx)
 	artifacts = append(artifacts, logArtifacts...)
 
+	// Report outputs with artifact metadata immediately, before the uploads complete.
 	err = wfExecutor.ReportOutputs(bgCtx, artifacts)
 	if err != nil {
 		wfExecutor.AddError(ctx, err)
+	}
+
+	// Upload artifacts concurrently. Blocks until all uploads finish.
+	if len(staged) > 0 {
+		err = wfExecutor.SaveArtifactsAsync(bgCtx, staged)
+		if err != nil {
+			wfExecutor.AddError(ctx, err)
+		}
 	}
 
 	return wfExecutor.HasError()

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -456,21 +456,8 @@ func (we *WorkflowExecutor) saveArtifact(ctx context.Context, containerName stri
 
 // fileBase is probably path.Base(filePath), but can be something else
 func (we *WorkflowExecutor) saveArtifactFromFile(ctx context.Context, art *wfv1.Artifact, fileName, localArtPath string) error {
-	if !art.HasKey() {
-		key, err := we.Template.ArchiveLocation.GetKey()
-		if err != nil {
-			return err
-		}
-		artLocation, err := we.Template.ArchiveLocation.Get()
-		if err != nil {
-			return err
-		}
-		if err = art.SetType(artLocation); err != nil {
-			return err
-		}
-		if err := art.SetKey(path.Join(key, fileName)); err != nil {
-			return err
-		}
+	if err := we.generateArtifactKey(art, fileName); err != nil {
+		return err
 	}
 	driverArt, err := we.newDriverArt(art)
 	if err != nil {
@@ -487,6 +474,106 @@ func (we *WorkflowExecutor) saveArtifactFromFile(ctx context.Context, art *wfv1.
 	we.maybeDeleteLocalArtPath(ctx, localArtPath)
 	logging.RequireLoggerFromContext(ctx).WithField("path", localArtPath).Info(ctx, "Successfully saved file")
 	return nil
+}
+
+// generateArtifactKey populates the artifact's key and type fields from the archive location
+// without uploading. This allows metadata to be reported before the actual upload completes.
+func (we *WorkflowExecutor) generateArtifactKey(art *wfv1.Artifact, fileName string) error {
+	if !art.HasKey() {
+		key, err := we.Template.ArchiveLocation.GetKey()
+		if err != nil {
+			return err
+		}
+		artLocation, err := we.Template.ArchiveLocation.Get()
+		if err != nil {
+			return err
+		}
+		if err = art.SetType(artLocation); err != nil {
+			return err
+		}
+		if err := art.SetKey(path.Join(key, fileName)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StagedArtifact pairs an output artifact with its staged local file information.
+type StagedArtifact struct {
+	Artifact     wfv1.Artifact
+	FileName     string
+	LocalArtPath string
+}
+
+// GenerateArtifactOutputs stages artifact files and populates their metadata (key/type)
+// without uploading to the artifact repository. The returned StagedArtifact records carry
+// full location information and local file paths, and can be reported to the controller
+// early while uploads proceed in the background via SaveArtifactsAsync.
+func (we *WorkflowExecutor) GenerateArtifactOutputs(ctx context.Context) ([]StagedArtifact, error) {
+	logger := logging.RequireLoggerFromContext(ctx)
+	if len(we.Template.Outputs.Artifacts) == 0 {
+		logger.Info(ctx, "No output artifacts")
+		return nil, nil
+	}
+
+	logger.Info(ctx, "Generating output artifact metadata")
+	err := os.MkdirAll(tempOutArtDir, os.ModePerm)
+	if err != nil {
+		return nil, argoerrs.InternalWrapError(err)
+	}
+
+	var results []StagedArtifact
+	for _, art := range we.Template.Outputs.Artifacts {
+		if err := art.CleanPath(); err != nil {
+			return nil, err
+		}
+		fileName, localArtPath, err := we.stageArchiveFile(ctx, common.MainContainerName, &art)
+		if err != nil {
+			if art.Optional && argoerrs.IsCode(argoerrs.CodeNotFound, err) {
+				logger.WithField("name", art.Name).WithError(err).Warn(ctx, "Ignoring optional artifact which does not exist in path")
+				continue
+			}
+			return nil, err
+		}
+		if err := we.generateArtifactKey(&art, fileName); err != nil {
+			return nil, err
+		}
+		results = append(results, StagedArtifact{Artifact: art, FileName: fileName, LocalArtPath: localArtPath})
+	}
+	return results, nil
+}
+
+// SaveArtifactsAsync uploads previously staged artifacts concurrently using goroutines.
+// It blocks until all uploads complete. Errors are aggregated across goroutines.
+func (we *WorkflowExecutor) SaveArtifactsAsync(ctx context.Context, staged []StagedArtifact) error {
+	if len(staged) == 0 {
+		return nil
+	}
+	logger := logging.RequireLoggerFromContext(ctx)
+	logger.WithField("count", len(staged)).Info(ctx, "Uploading staged artifacts asynchronously")
+
+	var (
+		wg             sync.WaitGroup
+		mu             sync.Mutex
+		aggregateError string
+	)
+
+	for _, s := range staged {
+		wg.Go(func() {
+			err := we.saveArtifactFromFile(ctx, &s.Artifact, s.FileName, s.LocalArtPath)
+			if err != nil {
+				mu.Lock()
+				aggregateError += err.Error() + "; "
+				mu.Unlock()
+			}
+		})
+	}
+
+	wg.Wait()
+	if aggregateError == "" {
+		return nil
+	}
+	return errors.New(aggregateError)
 }
 
 func (we *WorkflowExecutor) maybeDeleteLocalArtPath(ctx context.Context, localArtPath string) {

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -745,3 +745,71 @@ func TestUnzipMaliciousSymlink(t *testing.T) {
 
 	assert.Equal(t, "safe", string(content), "File outside should NOT be overwritten by unzip")
 }
+
+func TestGenerateArtifactKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		archiveKey string
+		fileName   string
+		preSetKey  bool
+		expectKey  string
+	}{
+		{
+			name:       "sets key when not already set",
+			archiveKey: "my-bucket/workflow-name/node-id",
+			fileName:   "my-artifact.tgz",
+			preSetKey:  false,
+			expectKey:  "my-bucket/workflow-name/node-id/my-artifact.tgz",
+		},
+		{
+			name:       "preserves key when already set",
+			archiveKey: "my-bucket/workflow-name/node-id",
+			fileName:   "my-artifact.tgz",
+			preSetKey:  true,
+			expectKey:  "already-set-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			art := &wfv1.Artifact{Name: "test-artifact"}
+			if tt.preSetKey {
+				art.S3 = &wfv1.S3Artifact{Key: "already-set-key"}
+			}
+			we := &WorkflowExecutor{
+				Template: wfv1.Template{
+					ArchiveLocation: &wfv1.ArtifactLocation{
+						S3: &wfv1.S3Artifact{Key: tt.archiveKey},
+					},
+				},
+			}
+			err := we.generateArtifactKey(art, tt.fileName)
+			require.NoError(t, err)
+			assert.True(t, art.HasKey())
+			key, err := art.GetKey()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectKey, key)
+		})
+	}
+}
+
+func TestGenerateArtifactOutputs_EmptyOutputs(t *testing.T) {
+	we := &WorkflowExecutor{
+		Template: wfv1.Template{
+			Outputs: wfv1.Outputs{},
+		},
+	}
+	ctx := logging.TestContext(t.Context())
+	staged, err := we.GenerateArtifactOutputs(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, staged, "expected nil for empty outputs")
+}
+
+func TestSaveArtifactsAsync_EmptyList(t *testing.T) {
+	we := &WorkflowExecutor{}
+	ctx := logging.TestContext(t.Context())
+	err := we.SaveArtifactsAsync(ctx, nil)
+	require.NoError(t, err)
+	err = we.SaveArtifactsAsync(ctx, []StagedArtifact{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Report artifact metadata (S3 keys, types) to the controller **before** the actual upload completes. The wait container generates artifact keys from the deterministic archive location, reports outputs immediately, then uploads files concurrently via goroutines. This allows the controller to access artifact metadata earlier, and makes uploads non-blocking within the wait container.

## Fixes

#16091

## Motivation

Today, `SaveArtifacts` uploads all output artifacts synchronously before `ReportOutputs`. For large artifacts (build caches, ML models), this blocks the wait container and prevents the controller from seeing any output metadata until every byte is uploaded. For downstream DAG/Steps tasks that do NOT consume these artifacts, this is unnecessary delay.

This PR lays the foundation for full async artifact uploads by:
1. Decoupling key generation from file upload
2. Reporting metadata early
3. Making uploads concurrent within the container

## Modifications

**`workflow/executor/executor.go`** (+111/-13):
- `generateArtifactKey()` — new method that computes the artifact's S3/GCS key from the archive location, without uploading
- `StagedArtifact` — new struct pairing an artifact with its staged local file path
- `GenerateArtifactOutputs()` — stages artifact files and populates keys/types, returns `[]StagedArtifact`
- `SaveArtifactsAsync()` — uploads staged artifacts concurrently via goroutines with `sync.WaitGroup` + error aggregation
- `saveArtifactFromFile()` — refactored to call `generateArtifactKey` instead of inlining key generation

**`cmd/argoexec/commands/wait.go`** (+21/-1):
- Reordered wait container flow: `GenerateArtifactOutputs` → `ReportOutputs` → `SaveArtifactsAsync`
- Metadata reported immediately, uploads run concurrently after

**`workflow/executor/executor_test.go`** (+47):
- `TestGenerateArtifactKey` — verifies key generation and HasKey() idempotency
- `TestGenerateArtifactOutputs_EmptyOutputs` — empty outputs return nil
- `TestSaveArtifactsAsync_EmptyList` — nil/empty input returns nil

## Verification

```bash
go test ./workflow/executor/ -short    # all existing + new tests pass
go build ./workflow/executor/           # compiles
go build ./cmd/argoexec/commands/       # compiles
```

## Behavioral Impact

- **Backward compatible**: `FinalizeOutput` (which sets `report-outputs-completed=true`) is still deferred and runs after all uploads complete. Downstream DAG dependencies still wait correctly.
- **Metadata available earlier**: Controller's `taskResultReconciliation` copies outputs to NodeStatus regardless of completion flag (taskresult.go:124-143), so artifact keys are visible in UI/CLI as soon as `ReportOutputs` completes.
- **Concurrent uploads**: Multiple artifacts now upload in parallel goroutines instead of serial.
