### PR TITLE
fix(ui): guard missing DAG dependency nodes in GraphViewer

### DIFF
--- a/ui/src/shared/components/editors/graph-viewer.test.tsx
+++ b/ui/src/shared/components/editors/graph-viewer.test.tsx
@@ -1,0 +1,52 @@
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import {GraphViewer} from './graph-viewer';
+
+jest.mock('../graph/graph-panel', () => ({
+    GraphPanel: ({graph}: {graph?: any}) => <div data-testid='graph'>{graph ? 'rendered' : 'missing'}</div>
+}));
+
+describe('GraphViewer', () => {
+    it('does not crash when DAG dependency points to non-existing node', async () => {
+        const workflow = {
+            metadata: {
+                name: 'cronwf'
+            },
+            spec: {
+                entrypoint: 'main',
+                templates: [
+                    {
+                        name: 'main',
+                        dag: {
+                            tasks: [
+                                {
+                                    name: 'build',
+                                    template: 'build-template'
+                                },
+                                {
+                                    name: 'transform',
+                                    template: 'transform-template',
+                                    depends: 'build && analyze'
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        name: 'build-template',
+                        container: {}
+                    },
+                    {
+                        name: 'transform-template',
+                        container: {}
+                    }
+                ]
+            }
+        };
+
+        const {findByTestId} = render(<GraphViewer workflowDefinition={workflow as any} />);
+
+        const graph = await findByTestId('graph');
+        expect(graph.textContent).toBe('rendered');
+    });
+});

--- a/ui/src/shared/components/editors/graph-viewer.tsx
+++ b/ui/src/shared/components/editors/graph-viewer.tsx
@@ -166,7 +166,12 @@ export function GraphViewer({workflowDefinition}: {workflowDefinition: Workflow 
                     const dependencyLabel = task.depends ? task.depends : task.dependencies.join(' && ');
                     dependencies.forEach((dep: string) => {
                         let dependancyName = `${parentNodeName}.${dep}`;
-                        if (graph.nodes.get(dependancyName).genre == 'Pod') {
+                        const dependencyNode = graph.nodes.get(dependancyName);
+                        if (!dependencyNode) {
+                            console.error(`Dependency "${dependancyName}" not found in DAG graph. Skipping edge from "${parentNodeName}" to "${nodeName}".`);
+                            return;
+                        }
+                        if (dependencyNode.genre == 'Pod') {
                             if (retryStrategy) {
                                 createEdge(dependancyName, retryNodeName);
                                 dependancyName = retryNodeName;
@@ -178,21 +183,27 @@ export function GraphViewer({workflowDefinition}: {workflowDefinition: Workflow 
                             createEdge(dependancyName, nodeName, dependencyLabel);
                         } else {
                             const depTemplate = getTemplateNameFromTask(template.dag, dep);
-                            const templateLeafNodes = templateLeafMap.get(depTemplate);
-                            if (templateLeafNodes) {
-                                templateLeafNodes.forEach((leaf: string) => {
-                                    let leafNode = `${dependancyName}.${leaf}`;
-                                    if (retryStrategy) {
-                                        createEdge(parentNodeName, retryNodeName);
-                                        leafNode = retryNodeName;
-                                    }
-                                    if (executionStrategy) {
-                                        createEdge(parentNodeName, taskGroupName);
-                                        leafNode = taskGroupName;
-                                    }
-                                    createEdge(leafNode, nodeName, dependencyLabel);
-                                });
+                            if (!depTemplate) {
+                                console.error(`Template for dependency "${dependancyName}" not found in DAG template "${template.name}".`);
+                                return;
                             }
+                            const templateLeafNodes = templateLeafMap.get(depTemplate);
+                            if (!templateLeafNodes) {
+                                console.error(`Template leaf nodes for dependency "${dependancyName}" not found.`);
+                                return;
+                            }
+                            templateLeafNodes.forEach((leaf: string) => {
+                                let leafNode = `${dependancyName}.${leaf}`;
+                                if (retryStrategy) {
+                                    createEdge(parentNodeName, retryNodeName);
+                                    leafNode = retryNodeName;
+                                }
+                                if (executionStrategy) {
+                                    createEdge(parentNodeName, taskGroupName);
+                                    leafNode = taskGroupName;
+                                }
+                                createEdge(leafNode, nodeName, dependencyLabel);
+                            });
                         }
                     });
                 } else {


### PR DESCRIPTION
## Summary\n\nThis PR fixes a Graph Viewer crash when rendering DAG tasks with unresolved dependencies by guarding null lookup paths in dependency resolution.\n\n## Changes\n- In `GraphViewer`, guard dependency node lookups before reading `genre` in DAG tasks.\n- Skip dependency wiring when template metadata can’t be resolved instead of throwing\n  runtime errors.\n- Add regression test: `GraphViewer` rendering with a missing DAG dependency no longer throws and still renders the graph view.\n\n## Related issue\n\nCloses #15275