### PR TITLE
fix: change log level because behavior is expected

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2094,7 +2094,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	node, err = woc.wf.GetNodeByName(nodeName)
 	if err != nil {
 		// Will be initialized via woc.initializeNodeOrMarkError
-		woc.log.Warn(ctx, "Node was nil, will be initialized as type Skipped")
+		woc.log.Info(ctx, "Node was nil, will be initialized as type Skipped")
 	}
 
 	if node != nil {

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -214,7 +214,7 @@ func (we *WorkflowExecutor) loadArtifact(ctx context.Context, pluginName wfv1.Ar
 
 	if !art.HasLocationOrKey() {
 		if art.Optional {
-			logger.WithField("name", art.Name).Warn(ctx, "Ignoring optional artifact which was not supplied")
+			logger.WithField("name", art.Name).Info(ctx, "Ignoring optional artifact which was not supplied")
 			return nil
 		}
 		return argoerrs.Errorf(argoerrs.CodeNotFound, "required artifact '%s' not supplied", art.Name)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes log level because behavior is expected
- skipped step using `when` 
- optional artifacts

### Motivation

do not flood with `WARN` if behavior is expected

### Modifications

change log level to `INFO`

### Verification

scan log output

### Documentation

