### PR TITLE
chore: introduce team-based CODEOWNERS and promote tico24 to docs approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,14 @@
+# Default ownership
+*          @argoproj/argo-workflows-approvers
+
 *.proto    @joibel @terrytangyuan
 
 # Documentation
-/docs/**              @argoproj/argo-workflows-approvers-docs
-/mkdocs.yml           @argoproj/argo-workflows-approvers-docs
-/.features/**/*.md    @argoproj/argo-workflows-approvers-docs
-/community/**         @argoproj/argo-workflows-approvers-docs
-/examples/README.md   @argoproj/argo-workflows-approvers-docs
-/README.md            @argoproj/argo-workflows-approvers-docs
-/CONTRIBUTING.md      @argoproj/argo-workflows-approvers-docs
-/USERS.md             @argoproj/argo-workflows-approvers-docs
+/docs/**              @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/mkdocs.yml           @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/.features/**/*.md    @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/community/**         @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/examples/README.md   @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/README.md            @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/CONTRIBUTING.md      @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/USERS.md             @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,11 @@
 *.proto    @joibel @terrytangyuan
+
+# Documentation
+/docs/**              @argoproj/argo-workflows-approvers-docs
+/mkdocs.yml           @argoproj/argo-workflows-approvers-docs
+/.features/**/*.md    @argoproj/argo-workflows-approvers-docs
+/community/**         @argoproj/argo-workflows-approvers-docs
+/examples/README.md   @argoproj/argo-workflows-approvers-docs
+/README.md            @argoproj/argo-workflows-approvers-docs
+/CONTRIBUTING.md      @argoproj/argo-workflows-approvers-docs
+/USERS.md             @argoproj/argo-workflows-approvers-docs

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,7 +19,7 @@ If this file and that one differ, then the argoproj file is the authoritative ve
 | Jesse Suen                | [jessesuen](https://github.com/jessesuen)         | Approver       | [Akuity](https://akuity.io/)                   |
 | Julie Vogelman            | [juliev0](https://github.com/juliev0)             | Approver       | [Intuit](https://www.github.com/intuit/)       |
 | Tianchu Zhao              | [tczhao](https://github.com/tczhao)               | Approver       | [Atlan](https://atlan.com/)                    |
-| Tim Collins               | [tico24](https://github.com/tico24)               | Reviewer(docs) | [Pipekit](https://pipekit.io/)                 |
+| Tim Collins               | [tico24](https://github.com/tico24)               | Approver(docs) | Independent                                    |
 | William Van Hevelingen    | [blkperl](https://github.com/blkperl)             | Reviewer       | [Acquia](https://www.acquia.com/)              |
 | Yucong Wang               | [jswxstw](https://github.com/jswxstw)             | Reviewer       | Independent                                    |
 | Eduardo Rodrigues         | [eduardodbr](https://github.com/eduardodbr)       | Reviewer       | Independent                                    |


### PR DESCRIPTION
## Summary

Establishes team-based code ownership and adds a dedicated docs-approver path:

- **Default owner**: `@argoproj/argo-workflows-approvers` for every path, so once `require_code_owner_reviews` is enabled on `main` branch protection there is always a codeowner who can satisfy the requirement.
- **Docs paths** (`/docs/`, `/mkdocs.yml`, `/.features/**/*.md`, `/community/`, `/examples/README.md`, top-level `README.md` / `CONTRIBUTING.md` / `USERS.md`): owned by `@argoproj/argo-workflows-approvers-docs` with `@argoproj/argo-workflows-approvers` as fallback — either team's approval satisfies the codeowner requirement.
- **Proto**: stays narrowed to `@joibel @terrytangyuan` so API-surface changes are reviewed by maintainers with proto expertise.
- **MAINTAINERS.md**: promote tico24 from `Reviewer(docs)` to `Approver(docs)`; affiliation updated to Independent.

Deliberately **excluded** from docs scope: `CHANGELOG*.md` (auto-generated), `MAINTAINERS.md` / `SECURITY.md` (project-leads scope), SDK / `ui/` / `hack/` / `manifests/` READMEs (engineering scope), `examples/` outside the README.

Companion to argoproj/argoproj#455, which establishes the `argo-workflows-approvers-docs` team.

## Follow-ups (not in this PR)

1. Flip `require_code_owner_reviews: true` on the `main` branch protection so this CODEOWNERS file becomes enforcing rather than advisory.
2. Grant `@argoproj/argo-workflows-approvers-docs` at least Write access to this repo (admin action; org settings).
