### PR TITLE
fix(executor): fall back to copy when rename across volume mount fails. Fixes #16144

### DIFF
--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -340,7 +341,7 @@ func (we *WorkflowExecutor) unarchiveArtifact(ctx context.Context, art wfv1.Arti
 		err = unzip(unarchiveCtx, tempArtPath, artPath)
 		_ = os.Remove(tempArtPath)
 	default:
-		err = os.Rename(tempArtPath, artPath)
+		err = renameOrMerge(tempArtPath, artPath)
 	}
 	return err
 }
@@ -1232,7 +1233,7 @@ func unpack(srcPath string, destPath string, decompressor func(string, string) e
 		// if the tar is comprised of single file or directory,
 		// rename that file to the desired location
 		filePath := path.Join(tmpDir, files[0].Name())
-		err = os.Rename(filePath, destPath)
+		err = renameOrMerge(filePath, destPath)
 		if err != nil {
 			return argoerrs.InternalWrapError(err)
 		}
@@ -1243,12 +1244,115 @@ func unpack(srcPath string, destPath string, decompressor func(string, string) e
 	} else {
 		// the tar extracted into multiple files. In this case,
 		// just rename the temp directory to the dest path
-		err = os.Rename(tmpDir, destPath)
+		err = renameOrMerge(tmpDir, destPath)
 		if err != nil {
 			return argoerrs.InternalWrapError(err)
 		}
 	}
 	return nil
+}
+
+// renameOrMerge moves src onto dst. It first attempts os.Rename (atomic,
+// preferred). If that fails because src and dst sit on different file
+// systems (EXDEV), because dst is busy as a mount point (EBUSY), or because
+// the kernel refuses to replace the destination (EEXIST, ENOTEMPTY) — all
+// of which happen when an input artifact's destination path is itself a
+// volume mount root — it falls back to copying src's contents into dst
+// recursively and then removing src.
+//
+// Without this fallback, plugin and built-in artifact drivers that load into
+// a volume mount root cannot ever succeed: the staging path (`dst + ".tmp"`
+// or `dst + ".tmpdir"`) lives on the init container's local filesystem,
+// while dst is on the volume mount, and Rename across that boundary is
+// impossible.
+func renameOrMerge(src, dst string) error {
+	err := os.Rename(src, dst)
+	if err == nil {
+		return nil
+	}
+	if !isRenameFallbackError(err) {
+		return err
+	}
+	srcInfo, statErr := os.Lstat(src)
+	if statErr != nil {
+		return statErr
+	}
+	if err := mergeInto(src, dst, srcInfo); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isRenameFallbackError(err error) bool {
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) {
+		return false
+	}
+	switch {
+	case errors.Is(linkErr.Err, syscall.EXDEV), errors.Is(linkErr.Err, syscall.EBUSY), errors.Is(linkErr.Err, syscall.EEXIST), errors.Is(linkErr.Err, syscall.ENOTEMPTY):
+		return true
+	}
+	return false
+}
+
+// mergeInto recursively copies src into dst, then removes src. It is the
+// fallback path used by renameOrMerge when os.Rename can't perform the move
+// atomically. Directory and symlink modes are preserved; regular file
+// contents are streamed.
+func mergeInto(src, dst string, srcInfo os.FileInfo) error {
+	mode := srcInfo.Mode()
+	switch {
+	case mode&os.ModeSymlink != 0:
+		target, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		// Replace any pre-existing entry at dst so the symlink lands cleanly.
+		_ = os.Remove(dst)
+		if err := os.Symlink(target, dst); err != nil {
+			return err
+		}
+		return os.Remove(src)
+	case mode.IsDir():
+		if err := os.MkdirAll(dst, mode.Perm()); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			childSrc := filepath.Join(src, entry.Name())
+			childDst := filepath.Join(dst, entry.Name())
+			if err := renameOrMerge(childSrc, childDst); err != nil {
+				return err
+			}
+		}
+		return os.Remove(src)
+	default:
+		// Regular file (or device — we treat unsupported modes by attempting
+		// a regular copy, mirroring io.Copy's behavior).
+		in, err := os.Open(src)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			_ = out.Close()
+			return err
+		}
+		if err := out.Close(); err != nil {
+			return err
+		}
+		if err := in.Close(); err != nil {
+			return err
+		}
+		return os.Remove(src)
+	}
 }
 
 func chmod(artPath string, mode int32, recurse bool) error {

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -745,3 +745,127 @@ func TestUnzipMaliciousSymlink(t *testing.T) {
 
 	assert.Equal(t, "safe", string(content), "File outside should NOT be overwritten by unzip")
 }
+
+// TestRenameOrMerge_RenameFastPath verifies that renameOrMerge uses the
+// atomic Rename path when the destination doesn't already exist.
+func TestRenameOrMerge_RenameFastPath(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "hello.txt"), []byte("hi"), 0o644))
+
+	dst := filepath.Join(tmp, "dst")
+	require.NoError(t, renameOrMerge(src, dst))
+
+	body, err := os.ReadFile(filepath.Join(dst, "hello.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hi", string(body))
+
+	_, err = os.Stat(src)
+	assert.True(t, os.IsNotExist(err), "src should be gone after rename")
+}
+
+// TestRenameOrMerge_MergesIntoExistingDir verifies that when os.Rename fails
+// because the destination is a pre-existing directory (mimicking the
+// volume-mount case where the mount point already exists), the helper falls
+// back to recursively merging src's contents into dst.
+func TestRenameOrMerge_MergesIntoExistingDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows os.Rename returns ERROR_ACCESS_DENIED for dir-onto-dir, " +
+			"which isn't in the renameOrMerge fallback set; the rename-onto-mount " +
+			"bug this fallback addresses only manifests for Linux container runtimes")
+	}
+	tmp := t.TempDir()
+
+	src := filepath.Join(tmp, "src")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("alpha"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "nested", "b.txt"), []byte("beta"), 0o644))
+
+	// Pre-create dst as a non-empty directory so os.Rename can't atomically
+	// replace it. This is the same shape as an input artifact whose target
+	// path is a volume mount root.
+	dst := filepath.Join(tmp, "dst")
+	require.NoError(t, os.MkdirAll(dst, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "preexisting.txt"), []byte("keep"), 0o644))
+
+	require.NoError(t, renameOrMerge(src, dst))
+
+	// src is moved
+	_, err := os.Stat(src)
+	assert.True(t, os.IsNotExist(err), "src should be gone after merge")
+
+	// dst has merged contents
+	keep, err := os.ReadFile(filepath.Join(dst, "preexisting.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "keep", string(keep))
+
+	a, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", string(a))
+
+	b, err := os.ReadFile(filepath.Join(dst, "nested", "b.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "beta", string(b))
+}
+
+// TestRenameOrMerge_PreservesSymlinks verifies that the merge fallback
+// preserves symbolic links from the source tree.
+func TestRenameOrMerge_PreservesSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "real.txt"), []byte("real"), 0o644))
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(src, "link.txt")))
+
+	dst := filepath.Join(tmp, "dst")
+	require.NoError(t, os.MkdirAll(dst, 0o755))
+
+	require.NoError(t, renameOrMerge(src, dst))
+
+	info, err := os.Lstat(filepath.Join(dst, "link.txt"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "link.txt should remain a symlink")
+
+	target, err := os.Readlink(filepath.Join(dst, "link.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "real.txt", target)
+}
+
+// TestRenameOrMerge_PreservesFileMode verifies executable bits and other
+// permission bits survive the merge fallback.
+func TestRenameOrMerge_PreservesFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows os.Rename returns ERROR_ACCESS_DENIED for dir-onto-dir, " +
+			"which isn't in the renameOrMerge fallback set; the rename-onto-mount " +
+			"bug this fallback addresses only manifests for Linux container runtimes")
+	}
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+
+	scriptPath := filepath.Join(src, "run.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755))
+
+	dst := filepath.Join(tmp, "dst")
+	require.NoError(t, os.MkdirAll(dst, 0o755))
+
+	require.NoError(t, renameOrMerge(src, dst))
+
+	info, err := os.Stat(filepath.Join(dst, "run.sh"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+// TestRenameOrMerge_NonRecoverableErrorPropagates verifies that a rename
+// failure that isn't EXDEV/EBUSY/EEXIST/ENOTEMPTY (e.g. ENOENT for a
+// missing source) propagates unchanged rather than entering the fallback.
+func TestRenameOrMerge_NonRecoverableErrorPropagates(t *testing.T) {
+	tmp := t.TempDir()
+	err := renameOrMerge(filepath.Join(tmp, "does-not-exist"), filepath.Join(tmp, "dst"))
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}


### PR DESCRIPTION
Fixes #16144

### Motivation

When a `ContainerSet`-template's input artifact `path` coincides with one of the containerSet's `volumeMounts.mountPath`, the artifact init container fails with:

```
artifact <name> failed to load: rename /mainctrfs/<mount>.tmp /mainctrfs/<mount>: file exists
```

The executor stages the loaded artifact at `artPath + ".tmp"` and then `os.Rename`s it onto the destination. In the "artifact path overlaps with volume mount" branch the staging sibling lives on the init container's local filesystem while the destination is the volume mount itself — different filesystems, so the kernel refuses the rename. The same shape exists in `unpack` (it renames `<destPath>.tmpdir` onto `destPath`).

The validator at `workflow/validate/validate.go:789-803` rejects this configuration upfront for `tmpl.Container` templates, but is not applied to `tmpl.ContainerSet`, so ContainerSets get past validation and crash at runtime. See #16144 for the full reproducer and captured logs.

### Modifications

- Add a `renameOrMerge(src, dst)` helper in `workflow/executor/executor.go`. It tries `os.Rename` first; on the specific errnos that flag this cross-filesystem-onto-mount case (`EXDEV`, `EBUSY`, `EEXIST`, `ENOTEMPTY`) it falls back to recursively copying `src` into `dst` (preserving directory layout, symlink targets, and file mode bits) and then removing `src`. Other rename errors propagate unchanged.
- Use the helper at the three artifact-promotion call sites:
  - `loadArtifact` non-tar/non-zip branch.
  - `unpack` single-entry branch.
  - `unpack` multi-entry branch.
- Untar/unzip extraction into the sibling `.tmpdir` is unchanged; only the final promotion onto the destination switches to the new helper.
- I deliberately did **not** touch the validator check for `tmpl.Container`. Removing it would relax behavior beyond the bug surface; that can be done separately if maintainers want to surface the corresponding error for ContainerSet workflows differently. Happy to swap to a validator-only approach (extend the existing check to cover `tmpl.ContainerSet` too) if that's preferred.

### Verification

- New tests in `workflow/executor/executor_test.go`:
  - `TestRenameOrMerge_RenameFastPath` — atomic rename when dst doesn't exist.
  - `TestRenameOrMerge_MergesIntoExistingDir` — fallback when dst is a pre-existing non-empty directory (the volume-mount shape).
  - `TestRenameOrMerge_PreservesSymlinks` — symlink entries survive the fallback.
  - `TestRenameOrMerge_PreservesFileMode` — file permission bits (e.g. executable scripts) survive the fallback.
  - `TestRenameOrMerge_NonRecoverableErrorPropagates` — ENOENT and other unrelated errors bubble up unchanged.
- `make pre-commit` passes locally (codegen, golangci-lint, features-validate, mkdocs docs build).
- Reproduced the bug end-to-end on a local k3s cluster running argo-workflows v4.0.5 using the minimal `raw:` + `containerSet:` reproducer in #16144; with this patch applied to argoexec the same workflow runs to completion.

### Behavioural note

When the fallback runs, pre-existing files in the destination directory are **merged** with the artifact contents (entries from the staging path overwrite same-named entries at the destination). For the volume-mount case the mount is typically a fresh `emptyDir` so this is invisible, but for `persistentVolumeClaim`-backed mounts that already contain files this is a softer "merge" semantic than the original atomic rename would have provided. The existing source comment on the overlap branch ("Extracting to volume mount") already reads as "extract into", so this aligns with the documented intent — but worth calling out.

### Documentation

No user-facing behaviour or configuration changes; the existing artifact-overlap source comment already documented the intended "extract to volume mount" semantics. No docs update needed.

### AI

This PR (code, tests, and description) was drafted with Claude (Anthropic's Claude Code) under human review, per the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md).
