### PR TITLE
fix: ensure that completed workflows aren't requeued by API events

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -73,7 +73,7 @@ import (
 const maxAllowedStackDepth = 100
 
 type recentlyCompletedWorkflow struct {
-	key  string
+	uid  types.UID
 	when time.Time
 }
 
@@ -781,7 +781,7 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		return true
 	}
 
-	if wf.Status.Phase != "" && wfc.checkRecentlyCompleted(wf.Name) {
+	if wf.Labels[common.LabelKeyCompleted] != "true" && wfc.checkRecentlyCompleted(wf.UID) {
 		logger.WithField("name", wf.ObjectMeta.Name).Warn(ctx, "Cache: Rejecting recently deleted")
 		return true
 	}
@@ -948,27 +948,39 @@ func (wfc *WorkflowController) cleanCompletedWorkflowsRecord() {
 
 // Records a workflow as recently completed in the list
 // if it isn't already in the list
-func (wfc *WorkflowController) recordCompletedWorkflow(key string) {
-	if !wfc.checkRecentlyCompleted(key) {
+func (wfc *WorkflowController) recordCompletedWorkflow(uid types.UID) {
+	if uid == "" {
+		return
+	}
+	if !wfc.checkRecentlyCompleted(uid) {
 		wfc.recentCompletions.mutex.Lock()
 		defer wfc.recentCompletions.mutex.Unlock()
 		wfc.recentCompletions.completions = append(wfc.recentCompletions.completions,
 			recentlyCompletedWorkflow{
-				key:  key,
+				uid:  uid,
 				when: time.Now(),
 			})
 	}
 }
 
-// Returns true if the workflow given by key is in the recently completed
+func (wfc *WorkflowController) removeRecentlyCompleted(uid types.UID) {
+	wfc.recentCompletions.mutex.Lock()
+	defer wfc.recentCompletions.mutex.Unlock()
+	wfc.recentCompletions.completions = slices.DeleteFunc(wfc.recentCompletions.completions,
+		func(w recentlyCompletedWorkflow) bool {
+			return w.uid == uid
+		})
+}
+
+// Returns true if the workflow given by uid is in the recently completed
 // list. Will perform expiry cleanup before checking.
-func (wfc *WorkflowController) checkRecentlyCompleted(key string) bool {
+func (wfc *WorkflowController) checkRecentlyCompleted(uid types.UID) bool {
 	wfc.cleanCompletedWorkflowsRecord()
 	recent := false
 	wfc.recentCompletions.mutex.RLock()
 	defer wfc.recentCompletions.mutex.RUnlock()
 	for _, val := range wfc.recentCompletions.completions {
-		if val.key == key {
+		if val.uid == uid {
 			recent = true
 			break
 		}
@@ -992,8 +1004,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 				}
 				needed := reconciliationNeeded(un)
 				if !needed {
-					key, _ := cache.MetaNamespaceKeyFunc(un)
-					wfc.recordCompletedWorkflow(key)
+					wfc.recordCompletedWorkflow(un.GetUID())
 					wfc.deleteLastSeenVersionKey(wfc.getLastSeenVersionKey(un))
 				}
 				return needed
@@ -1002,6 +1013,9 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 				// This function is called when a new to the informer object
 				// is to be added to the informer
 				AddFunc: func(obj any) {
+					if un, ok := obj.(*unstructured.Unstructured); ok {
+						wfc.removeRecentlyCompleted(un.GetUID())
+					}
 					key, err := cache.MetaNamespaceKeyFunc(obj)
 					if err == nil {
 						// for a new workflow, we do not want to rate limit its execution using AddRateLimited
@@ -1048,7 +1062,9 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 					if err == nil {
 						wfc.releaseAllWorkflowLocks(ctx, obj)
-						wfc.recordCompletedWorkflow(key)
+						if un, ok := obj.(*unstructured.Unstructured); ok {
+							wfc.recordCompletedWorkflow(un.GetUID())
+						}
 						// no need to add to the queue - this workflow is done
 						wfc.throttler.Remove(key)
 					}

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1355,4 +1356,125 @@ func TestPodSpecPatchTemplateLevel(t *testing.T) {
 	}
 	require.NotNil(t, mainContainer)
 	assert.Equal(t, "25Mi", mainContainer.Resources.Requests.Memory().String())
+}
+
+func TestProcessNextItem_RejectsCompletedWorkflowPodEventRequeue(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	wf := wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf
+  namespace: test
+  uid: spurious-requeue-uid
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+`)
+
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	assert.True(t, controller.processNextItem(ctx))
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+	require.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+	woc.operate(ctx)
+	require.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
+
+	pods, err := listPods(ctx, woc)
+	require.NoError(t, err)
+	require.NotEmpty(t, pods.Items)
+	require.NoError(t, controller.enqueueWfFromPodLabel(&pods.Items[0]))
+
+	assert.True(t, controller.processNextItem(ctx))
+
+	expectNamespacedWorkflow(ctx, controller, "test", "my-wf", func(wf *wfv1.Workflow) {
+		require.NotNil(t, wf)
+		assert.Equal(t, wfv1.WorkflowSucceeded, wf.Status.Phase)
+	})
+}
+
+func TestProcessNextItem_AllowsRetryAfterCompletion(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	wf := wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf
+  namespace: test
+  uid: retry-instance-uid
+  labels:
+    workflows.argoproj.io/completed: "true"
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+status:
+  phase: Failed
+`)
+
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	controller.recordCompletedWorkflow(wf.UID)
+
+	retried := wf.DeepCopy()
+	delete(retried.Labels, common.LabelKeyCompleted)
+	retried.Status.Phase = wfv1.WorkflowUnknown
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(retried)
+	require.NoError(t, err)
+
+	gvr := schema.GroupVersionResource{Group: workflow.Group, Version: "v1alpha1", Resource: workflow.WorkflowPlural}
+	_, err = controller.dynamicInterface.Resource(gvr).Namespace("test").Update(ctx, &unstructured.Unstructured{Object: u}, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return controller.wfQueue.Len() > 0
+	}, 2*time.Second, 50*time.Millisecond)
+	assert.True(t, controller.processNextItem(ctx))
+
+	expectNamespacedWorkflow(ctx, controller, "test", "my-wf", func(wf *wfv1.Workflow) {
+		require.NotNil(t, wf)
+		assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
+	})
+}
+
+func TestProcessNextItem_AllowsRequeueOfCompletedWorkflowWithFinalizer(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	wf := wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf
+  namespace: test
+  uid: completed-with-finalizer-uid
+  labels:
+    workflows.argoproj.io/completed: "true"
+  finalizers:
+    - workflows.argoproj.io/artifact-gc
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+status:
+  phase: Succeeded
+`)
+
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	controller.recordCompletedWorkflow(wf.UID)
+
+	assert.True(t, controller.processNextItem(ctx))
+
+	expectNamespacedWorkflow(ctx, controller, "test", "my-wf", func(wf *wfv1.Workflow) {
+		require.NotNil(t, wf)
+		assert.NotContains(t, wf.Finalizers, common.FinalizerArtifactGC)
+	})
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -824,6 +824,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		if err := woc.deleteTaskResults(ctx); err != nil {
 			woc.log.WithError(err).Warn(ctx, "failed to delete task-results")
 		}
+		woc.controller.recordCompletedWorkflow(woc.wf.UID)
 	}
 	// If Finalizer exists, requeue to make sure Finalizer can be removed.
 	if woc.wf.Status.Fulfilled() && len(woc.wf.GetFinalizers()) > 0 {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title ( (which only supports the default namespace)for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

Further improvement on #12198.

When a pod event requeues a completed workflow before the informer cache has been updated to reflect completion, the workflow will be reprocessed as if it had not executed. The second execution will result in an error, and any mutexes held by the workflow will not be released.

The previous completion guard had a bug where completed workflows in the non-default namespace would be requeued, as the guard checked Name while the Key was added to the completed list. Instead check the UID, which is guaranteed to be unique for each workflow. Workflows with Phase == "" should also be skipped if have been marked as completed.

Finalizers run when LabelKeyCompleted=true, so we continue processing the workflow even if it's marked as completed. Retried workflows have the same UID, so we need to clear retried workflows from the list of completed workflows when they are requeued.

<details>
<summary>Logs from workflow-controller showing the issue</summary>

```
{"lockType":"mutex","msg":"Lock has been released by argo/workflow-20260506-213617-437/workflow-20260506-213617-437-4077309152. Available locks: 1","_p":"F","level":"info","time":"2026-05-07T01:02:56.881Z","stream":"stderr","name":"argo/Mutex/lock-name"}
{"msg":"delete pod event","_p":"F","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-07T01:02:52.261Z","stream":"stderr","level":"info"}
{"msg":"update pod event","_p":"F","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-07T01:02:52.258Z","stream":"stderr","level":"info"}
{"msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 164h37m24s due to TTL","level":"info","_p":"F","stream":"stderr","time":"2026-05-07T01:01:11.701Z"}
{"stream":"stderr","_p":"F","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 165h17m19s due to TTL","level":"info","time":"2026-05-07T00:21:16.445Z"}
{"stream":"stderr","_p":"F","level":"info","time":"2026-05-07T00:01:16.306Z","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 165h37m19s due to TTL"}
{"msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 165h57m15s due to TTL","level":"info","_p":"F","stream":"stderr","time":"2026-05-06T23:41:20.070Z"}
{"stream":"stderr","_p":"F","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 166h17m12s due to TTL","time":"2026-05-06T23:21:23.150Z","level":"info"}
{"_p":"F","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 166h37m21s due to TTL","level":"info","stream":"stderr","time":"2026-05-06T23:01:14.743Z"}
{"stream":"stderr","level":"info","_p":"F","time":"2026-05-06T22:41:19.718Z","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 166h57m16s due to TTL"}
{"stream":"stderr","level":"info","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h17m19s due to TTL","_p":"F","time":"2026-05-06T22:21:16.029Z"}
{"level":"info","stream":"stderr","_p":"F","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h37m19s due to TTL","time":"2026-05-06T22:01:16.188Z"}
{"_p":"F","stream":"stderr","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h39m33s due to TTL","time":"2026-05-06T21:59:02.683Z","level":"info"}
{"_p":"F","level":"info","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h41m28s due to TTL","time":"2026-05-06T21:57:07.016Z","stream":"stderr"}
{"_p":"F","level":"info","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h43m23s due to TTL","time":"2026-05-06T21:55:12.538Z","stream":"stderr"}
{"_p":"F","level":"info","stream":"stderr","time":"2026-05-06T21:53:31.045Z","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h45m4s due to TTL"}
{"_p":"F","level":"info","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h46m43s due to TTL","stream":"stderr","time":"2026-05-06T21:51:52.505Z"}
{"_p":"F","level":"info","stream":"stderr","time":"2026-05-06T21:50:25.897Z","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h48m10s due to TTL"}
{"msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h49m32s due to TTL","_p":"F","stream":"stderr","time":"2026-05-06T21:49:03.928Z","level":"info"}
{"stream":"stderr","level":"info","_p":"F","time":"2026-05-06T21:47:38.271Z","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h50m57s due to TTL"}
{"stream":"stderr","_p":"F","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h53m2s due to TTL","time":"2026-05-06T21:45:33.073Z","level":"info"}
{"level":"info","stream":"stderr","_p":"F","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h54m43s due to TTL","time":"2026-05-06T21:43:52.390Z"}
{"level":"info","msg":"Queueing Succeeded workflow argo/workflow-20260506-213617-437 for delete in 167h56m17s due to TTL","_p":"F","stream":"stderr","time":"2026-05-06T21:42:18.907Z"}
{"level":"info","_p":"F","uid":"aab25e12-da39-4204-941e-0260b7687bc9","msg":"archiving workflow","stream":"stderr","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:40:47.329Z"}
{"workflow":"workflow-20260506-213617-437","level":"info","error":"must never update completed workflows","msg":"Failed to re-apply update","stream":"stderr","_p":"F","namespace":"argo","time":"2026-05-06T21:39:53.253Z"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"Re-applying updates on latest version and retrying update","namespace":"argo","time":"2026-05-06T21:39:53.246Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"warning","stream":"stderr","msg":"Error updating workflow: Operation cannot be fulfilled on workflows.argoproj.io \"workflow-20260506-213617-437\": the object has been modified; please apply your changes to the latest version and try again Conflict","namespace":"argo","time":"2026-05-06T21:39:53.246Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"reconcileAgentPod","namespace":"argo","time":"2026-05-06T21:39:53.236Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"TaskSet Reconciliation","namespace":"argo","time":"2026-05-06T21:39:53.236Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"Workflow step group node workflow-20260506-213617-437-2010936858 not yet completed","namespace":"argo","time":"2026-05-06T21:39:53.236Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"Pod node workflow-20260506-213617-437-4077309152 initialized Pending","namespace":"argo","time":"2026-05-06T21:39:53.236Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"Node workflow-20260506-213617-437[0].batch-deploy acquired synchronization lock","namespace":"argo","time":"2026-05-06T21:39:53.236Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"warning","stream":"stderr","msg":"Node was nil, will be initialized as type Skipped","namespace":"argo","time":"2026-05-06T21:39:53.234Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"StepGroup node workflow-20260506-213617-437-2010936858 initialized Running","namespace":"argo","time":"2026-05-06T21:39:53.234Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"Steps node workflow-20260506-213617-437 initialized Running","namespace":"argo","time":"2026-05-06T21:39:53.234Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"was unable to obtain node for , letting display name to be nodeName","namespace":"argo","time":"2026-05-06T21:39:53.234Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"warning","stream":"stderr","msg":"Node was nil, will be initialized as type Skipped","namespace":"argo","time":"2026-05-06T21:39:53.233Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","stream":"stderr","msg":"Updated phase  -> Running","namespace":"argo","time":"2026-05-06T21:39:53.233Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","level":"info","_p":"F","msg":"Task-result reconciliation","stream":"stderr","time":"2026-05-06T21:39:53.232Z","namespace":"argo","numObjs":1}
{"workflow":"workflow-20260506-213617-437","level":"info","_p":"F","msg":"Processing workflow","time":"2026-05-06T21:39:53.196Z","stream":"stderr","Phase":"","namespace":"argo","ResourceVersion":"4033403685"}
{"msg":"update pod event","pod":"workflow-20260506-213617-437-4077309152","_p":"F","level":"info","time":"2026-05-06T21:39:48.601Z","stream":"stderr"}
{"stream":"stderr","level":"info","_p":"F","msg":"update pod event","time":"2026-05-06T21:39:46.589Z","pod":"workflow-20260506-213617-437-4077309152"}
{"stream":"stderr","level":"info","_p":"F","msg":"update pod event","time":"2026-05-06T21:39:44.573Z","pod":"workflow-20260506-213617-437-4077309152"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","error":"must never update completed workflows","level":"info","msg":"Failed to re-apply update","_p":"F","namespace":"argo","time":"2026-05-06T21:39:33.463Z"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.456Z","msg":"Re-applying updates on latest version and retrying update"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"warning","namespace":"argo","time":"2026-05-06T21:39:33.456Z","msg":"Error updating workflow: Operation cannot be fulfilled on workflows.argoproj.io \"workflow-20260506-213617-437\": the object has been modified; please apply your changes to the latest version and try again Conflict"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.431Z","msg":"reconcileAgentPod"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.431Z","msg":"TaskSet Reconciliation"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.431Z","msg":"Workflow step group node workflow-20260506-213617-437-2010936858 not yet completed"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.431Z","msg":"Pod node workflow-20260506-213617-437-4077309152 initialized Pending"}
{"stream":"stderr","workflow":"workflow-20260506-213617-437","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.431Z","msg":"Node workflow-20260506-213617-437[0].batch-deploy acquired synchronization lock"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"warning","namespace":"argo","time":"2026-05-06T21:39:33.428Z","msg":"Node was nil, will be initialized as type Skipped"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.428Z","msg":"StepGroup node workflow-20260506-213617-437-2010936858 initialized Running"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.428Z","msg":"Steps node workflow-20260506-213617-437 initialized Running"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.428Z","msg":"was unable to obtain node for , letting display name to be nodeName"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"warning","namespace":"argo","time":"2026-05-06T21:39:33.428Z","msg":"Node was nil, will be initialized as type Skipped"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","namespace":"argo","time":"2026-05-06T21:39:33.427Z","msg":"Updated phase  -> Running"}
{"stream":"stderr","_p":"F","level":"info","numObjs":1,"msg":"Task-result reconciliation","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:39:33.427Z"}
{"stream":"stderr","Phase":"","ResourceVersion":"4033403685","workflow":"workflow-20260506-213617-437","msg":"Processing workflow","level":"info","time":"2026-05-06T21:39:33.378Z","namespace":"argo","_p":"F"}
{"stream":"stderr","_p":"F","level":"info","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-06T21:39:32.484Z","msg":"update pod event"}
{"stream":"stderr","msg":"update pod event","_p":"F","level":"info","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-06T21:39:31.476Z"}
{"stream":"stderr","msg":"update pod event","_p":"F","level":"info","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-06T21:39:29.440Z"}
{"stream":"stderr","msg":"update pod event","pod":"workflow-20260506-213617-437-4077309152","level":"info","_p":"F","time":"2026-05-06T21:39:28.450Z"}
{"stream":"stderr","msg":"insignificant pod change","key":"argo/workflow-20260506-213617-437-4077309152","_p":"F","level":"info","time":"2026-05-06T21:39:27.748Z"}
{"stream":"stderr","level":"info","_p":"F","time":"2026-05-06T21:39:26.445Z","msg":"update pod event","pod":"workflow-20260506-213617-437-4077309152"}
{"stream":"stderr","level":"info","msg":"update pod event","_p":"F","time":"2026-05-06T21:39:25.440Z","pod":"workflow-20260506-213617-437-4077309152"}
{"stream":"stderr","error":"must never update completed workflows","msg":"Failed to re-apply update","level":"info","_p":"F","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:39:24.207Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","level":"info","msg":"Re-applying updates on latest version and retrying update","namespace":"argo","time":"2026-05-06T21:39:23.661Z","_p":"F"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","level":"warning","msg":"Error updating workflow: Operation cannot be fulfilled on workflows.argoproj.io \"workflow-20260506-213617-437\": the object has been modified; please apply your changes to the latest version and try again Conflict","namespace":"argo","time":"2026-05-06T21:39:23.661Z","_p":"F"}
{"stream":"stderr","pod":"workflow-20260506-213617-437-4077309152","msg":"update pod event","_p":"F","time":"2026-05-06T21:39:23.430Z","level":"info"}
{"stream":"stderr","pod":"workflow-20260506-213617-437-4077309152","level":"info","msg":"update pod event","_p":"F","time":"2026-05-06T21:39:23.394Z"}
{"stream":"stderr","_p":"F","level":"info","msg":"reconcileAgentPod","namespace":"argo","time":"2026-05-06T21:39:23.379Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"TaskSet Reconciliation","namespace":"argo","time":"2026-05-06T21:39:23.379Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"Workflow step group node workflow-20260506-213617-437-2010936858 not yet completed","namespace":"argo","time":"2026-05-06T21:39:23.379Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"Created pod: workflow-20260506-213617-437[0].batch-deploy (workflow-20260506-213617-437-4077309152)","namespace":"argo","time":"2026-05-06T21:39:23.379Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","pod":"workflow-20260506-213617-437-4077309152","level":"info","msg":"add pod event","_p":"F","time":"2026-05-06T21:39:23.378Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","msg":"Pod node workflow-20260506-213617-437-4077309152 initialized Pending","namespace":"argo","time":"2026-05-06T21:39:22.937Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","msg":"Node workflow-20260506-213617-437[0].batch-deploy acquired synchronization lock","namespace":"argo","time":"2026-05-06T21:39:22.937Z"}
{"lockType":"mutex","stream":"stderr","name":"argo/Mutex/lock-name","level":"info","msg":"argo/Mutex/lock-name acquired by argo/workflow-20260506-213617-437/workflow-20260506-213617-437-4077309152. Lock availability: 0/1","_p":"F","time":"2026-05-06T21:39:22.937Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"warning","msg":"Node was nil, will be initialized as type Skipped","namespace":"argo","time":"2026-05-06T21:39:22.934Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","msg":"StepGroup node workflow-20260506-213617-437-2010936858 initialized Running","namespace":"argo","time":"2026-05-06T21:39:22.934Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","msg":"Steps node workflow-20260506-213617-437 initialized Running","namespace":"argo","time":"2026-05-06T21:39:22.934Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","msg":"was unable to obtain node for , letting display name to be nodeName","namespace":"argo","time":"2026-05-06T21:39:22.934Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"warning","msg":"Node was nil, will be initialized as type Skipped","namespace":"argo","time":"2026-05-06T21:39:22.934Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","_p":"F","level":"info","msg":"Updated phase  -> Running","namespace":"argo","time":"2026-05-06T21:39:22.933Z"}
{"workflow":"workflow-20260506-213617-437","stream":"stderr","level":"info","msg":"Task-result reconciliation","_p":"F","numObjs":0,"namespace":"argo","time":"2026-05-06T21:39:22.933Z"}
{"stream":"stderr","level":"info","msg":"Processing workflow","ResourceVersion":"4033403685","_p":"F","time":"2026-05-06T21:39:22.828Z","Phase":"","namespace":"argo","workflow":"workflow-20260506-213617-437"}
{"msg":"delete pod event","_p":"F","stream":"stderr","level":"info","time":"2026-05-06T21:39:05.301Z","pod":"workflow-20260506-213617-437-4077309152"}
{"msg":"update pod event","_p":"F","stream":"stderr","level":"info","time":"2026-05-06T21:39:05.296Z","pod":"workflow-20260506-213617-437-4077309152"}
{"msg":"cleaning up pod","level":"info","action":"deletePod","_p":"F","podName":"workflow-20260506-213617-437-4077309152","stream":"stderr","time":"2026-05-06T21:39:05.284Z","namespace":"argo","key":"argo/workflow-20260506-213617-437-4077309152/deletePod"}
{"after":30000000000,"podName":"workflow-20260506-213617-437-4077309152","action":"deletePod","msg":"queueing pod for cleanup after","time":"2026-05-06T21:38:35.283Z","stream":"stderr","_p":"F","namespace":"argo","level":"info"}
{"level":"info","_p":"F","msg":"Workflow update successful","workflow":"workflow-20260506-213617-437","phase":"Succeeded","stream":"stderr","resourceVersion":"4033415666","namespace":"argo","time":"2026-05-06T21:38:35.274Z"}
{"level":"info","_p":"F","msg":"Released all acquired locks","key":"workflow-20260506-213617-437","stream":"stderr","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:35.242Z"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"Marking workflow as pending archiving"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"Marking workflow completed"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"Updated phase Running -> Succeeded"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"reconcileAgentPod"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"TaskSet Reconciliation"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"node workflow-20260506-213617-437 finished: 2026-05-06 21:38:35.242468855 +0000 UTC"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"node workflow-20260506-213617-437 phase Running -> Succeeded"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"Outbound nodes of workflow-20260506-213617-437 is [workflow-20260506-213617-437-4077309152]"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"Outbound nodes of workflow-20260506-213617-437-4077309152 is [workflow-20260506-213617-437-4077309152]"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"node workflow-20260506-213617-437-2010936858 finished: 2026-05-06 21:38:35.242194682 +0000 UTC"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"node workflow-20260506-213617-437-2010936858 phase Running -> Succeeded"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:35.242Z","msg":"Step group node workflow-20260506-213617-437-2010936858 successful"}
{"level":"info","_p":"F","name":"argo/Mutex/lock-name","stream":"stderr","lockType":"mutex","time":"2026-05-06T21:38:35.242Z","msg":"Lock has been released by argo/workflow-20260506-213617-437/workflow-20260506-213617-437-4077309152. Available locks: 1"}
{"level":"info","_p":"F","stream":"stderr","time":"2026-05-06T21:38:35.242Z","msg":"Release argo/workflow-20260506-213617-437/workflow-20260506-213617-437-4077309152"}
{"level":"info","_p":"F","numObjs":1,"workflow":"workflow-20260506-213617-437","stream":"stderr","time":"2026-05-06T21:38:35.239Z","namespace":"argo","msg":"Task-result reconciliation"}
{"ResourceVersion":"4033413234","_p":"F","Phase":"Running","msg":"Processing workflow","workflow":"workflow-20260506-213617-437","stream":"stderr","time":"2026-05-06T21:38:35.238Z","namespace":"argo","level":"info"}
{"level":"info","pod":"workflow-20260506-213617-437-4077309152","stream":"stderr","time":"2026-05-06T21:38:28.993Z","_p":"F","msg":"update pod event"}
{"level":"info","pod":"workflow-20260506-213617-437-4077309152","stream":"stderr","time":"2026-05-06T21:38:26.956Z","_p":"F","msg":"update pod event"}
{"level":"info","time":"2026-05-06T21:38:25.942Z","pod":"workflow-20260506-213617-437-4077309152","stream":"stderr","_p":"F","msg":"update pod event"}
{"_p":"F","workflow":"workflow-20260506-213617-437","msg":"Workflow update successful","resourceVersion":"4033413234","level":"info","stream":"stderr","phase":"Running","namespace":"argo","time":"2026-05-06T21:38:15.839Z"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:15.812Z","msg":"reconcileAgentPod"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:15.812Z","msg":"TaskSet Reconciliation"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:15.812Z","msg":"Workflow step group node workflow-20260506-213617-437-2010936858 not yet completed"}
{"level":"info","_p":"F","workflow":"workflow-20260506-213617-437","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:15.811Z","msg":"Node workflow-20260506-213617-437[0].batch-deploy acquired synchronization lock"}
{"_p":"F","workflow":"workflow-20260506-213617-437","msg":"Task-result reconciliation","level":"info","numObjs":1,"stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:15.809Z"}
{"ResourceVersion":"4033411921","workflow":"workflow-20260506-213617-437","msg":"Processing workflow","Phase":"Running","level":"info","stream":"stderr","namespace":"argo","time":"2026-05-06T21:38:15.808Z","_p":"F"}
{"pod":"workflow-20260506-213617-437-4077309152","level":"info","stream":"stderr","_p":"F","time":"2026-05-06T21:38:13.758Z","msg":"update pod event"}
{"msg":"update pod event","pod":"workflow-20260506-213617-437-4077309152","stream":"stderr","time":"2026-05-06T21:38:12.734Z","level":"info","_p":"F"}
{"msg":"update pod event","pod":"workflow-20260506-213617-437-4077309152","stream":"stderr","time":"2026-05-06T21:38:11.724Z","level":"info","_p":"F"}
{"msg":"update pod event","_p":"F","pod":"workflow-20260506-213617-437-4077309152","stream":"stderr","time":"2026-05-06T21:38:10.742Z","level":"info"}
{"msg":"update pod event","_p":"F","stream":"stderr","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-06T21:38:10.720Z","level":"info"}
{"key":"argo/workflow-20260506-213617-437-4077309152","_p":"F","msg":"insignificant pod change","stream":"stderr","level":"info","time":"2026-05-06T21:38:10.175Z"}
{"msg":"update pod event","_p":"F","stream":"stderr","pod":"workflow-20260506-213617-437-4077309152","level":"info","time":"2026-05-06T21:38:08.705Z"}
{"stream":"stderr","_p":"F","level":"info","msg":"update pod event","time":"2026-05-06T21:38:07.685Z","pod":"workflow-20260506-213617-437-4077309152"}
{"stream":"stderr","pod":"workflow-20260506-213617-437-4077309152","level":"info","msg":"update pod event","_p":"F","time":"2026-05-06T21:38:06.051Z"}
{"_p":"F","level":"info","msg":"Workflow update successful","stream":"stderr","phase":"Running","resourceVersion":"4033411921","namespace":"argo","time":"2026-05-06T21:38:05.838Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"update pod event","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-06T21:38:05.821Z"}
{"stream":"stderr","_p":"F","level":"info","msg":"reconcileAgentPod","namespace":"argo","time":"2026-05-06T21:38:05.808Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"TaskSet Reconciliation","namespace":"argo","time":"2026-05-06T21:38:05.808Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"Workflow step group node workflow-20260506-213617-437-2010936858 not yet completed","namespace":"argo","time":"2026-05-06T21:38:05.808Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"Created pod: workflow-20260506-213617-437[0].batch-deploy (workflow-20260506-213617-437-4077309152)","namespace":"argo","time":"2026-05-06T21:38:05.808Z","workflow":"workflow-20260506-213617-437"}
{"stream":"stderr","_p":"F","level":"info","msg":"add pod event","pod":"workflow-20260506-213617-437-4077309152","time":"2026-05-06T21:38:05.807Z"}
{"stream":"stderr","_p":"F","level":"info","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.315Z","msg":"Pod node workflow-20260506-213617-437-4077309152 initialized Pending"}
{"stream":"stderr","_p":"F","level":"info","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.315Z","msg":"Node workflow-20260506-213617-437[0].batch-deploy acquired synchronization lock"}
{"stream":"stderr","_p":"F","level":"info","lockType":"mutex","msg":"argo/Mutex/lock-name acquired by argo/workflow-20260506-213617-437/workflow-20260506-213617-437-4077309152. Lock availability: 0/1","name":"argo/Mutex/lock-name","time":"2026-05-06T21:38:05.315Z"}
{"stream":"stderr","_p":"F","level":"warning","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.313Z","msg":"Node was nil, will be initialized as type Skipped"}
{"stream":"stderr","_p":"F","level":"info","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.312Z","msg":"StepGroup node workflow-20260506-213617-437-2010936858 initialized Running"}
{"stream":"stderr","_p":"F","level":"info","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.312Z","msg":"Steps node workflow-20260506-213617-437 initialized Running"}
{"stream":"stderr","_p":"F","level":"info","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.312Z","msg":"was unable to obtain node for , letting display name to be nodeName"}
{"stream":"stderr","_p":"F","level":"warning","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.312Z","msg":"Node was nil, will be initialized as type Skipped"}
{"stream":"stderr","_p":"F","level":"info","workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.311Z","msg":"Updated phase  -> Running"}
{"_p":"F","level":"info","msg":"Task-result reconciliation","stream":"stderr","numObjs":0,"workflow":"workflow-20260506-213617-437","namespace":"argo","time":"2026-05-06T21:38:05.311Z"}
 ```
</details>

### Modifications

Check the UID of the workflow for completion rather than the `Name`. This supports workflows in the non-default namespace and since the UID is guaranteed to be unique does not require checking `Phase != ""` as is necessary when using `Name` (or `Key`).

In addition, eagerly mark workflows as completed so that there is no race between pod events from the Kubernetes API and informer cache updates.

Workflows with label `LabelKeyCompleted=true` bypass the completed workflow check, allowing finalizers to run.

When workflows are retried, they are requeued with the same UID. As such, they need to be removed from the completed workflow list in the `AddFunc` informer handler. Note: I'm not entirely sure this part of the fix is correct, but the CLI retry tests failed without it (and all tests pass with it.)

### Verification

We have deployed this fix to production and seen no further mutex deadlocks caused by this issue.

### Documentation

No documentation change necessary, this is a bugfix.

### AI

Claude was used to help isolate the bug by analyzing log lines emitted by the controller. Scaffolding for tests was also generated by Claude.