### PR TITLE
ui: include pod template annotations in pod-scope link objects

### DIFF
--- a/ui/src/workflows/components/workflow-node-info/workflow-node-info.tsx
+++ b/ui/src/workflows/components/workflow-node-info/workflow-node-info.tsx
@@ -226,7 +226,10 @@ function WorkflowNodeSummary(props: Props) {
                         object={{
                             metadata: {
                                 namespace: props.workflow.metadata.namespace,
-                                name: podName
+                                name: podName,
+                                annotations: props.workflow.spec?.templates?.find(
+                                    t => t.name === props.node.templateName
+                                )?.metadata?.annotations
                             },
                             workflow: props.workflow,
                             status: {


### PR DESCRIPTION
## Summary

Pod-scope link URL templates support `${metadata.annotations['key']}` syntax (via `processURL` in `links.tsx`), but the `object` passed to `processURL` for pod-scope links only contained `{namespace, name}` — annotations were not included, causing all annotation references to resolve to `null`.

### Root cause

In `workflow-node-info.tsx`, the link object is constructed as:
```tsx
metadata: {
    namespace: props.workflow.metadata.namespace,
    name: podName
    // no annotations!
}
```

The `processURL` function traverses `jsonObject.metadata.annotations[key]`, which is `undefined` here, so it returns `null` (the `emptyVal` for non-workflow variables).

### Fix

Populate `metadata.annotations` from the step template's `metadata.annotations`, which is already available in the workflow spec without an extra API call:

```tsx
metadata: {
    namespace: props.workflow.metadata.namespace,
    name: podName,
    annotations: props.workflow.spec?.templates?.find(
        t => t.name === props.node.templateName
    )?.metadata?.annotations
}
```

This enables custom annotations defined on pod templates (e.g. for referencing jobset names, trace IDs, or other runtime identifiers in observability links) to be used in pod-scope link URL templates.

### Limitation

Annotation values that contain Argo template expressions (e.g. `{{workflow.creationTimestamp.s}}`) are included as-is rather than resolved. A follow-up enhancement could extend `processURL` to expand workflow-context expressions found within annotation values.


Signed-off-by: Yiran Jing <yiran@canva.com>