### PR TITLE
fix: replace deprecated h2c.NewHandler with http.Server.Protocols

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -320,13 +320,25 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 
 	handler := grpcutil.NewMuxHandler(grpcServer, httpServer)
 
+	// Enable HTTP/1.1, HTTP/2 over TLS (via ALPN), and unencrypted HTTP/2 (h2c)
+	// so gRPC can be served alongside HTTP both with and without TLS. This
+	// replaces the deprecated h2c.NewHandler wrapper.
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+	muxServer := &http.Server{
+		Handler:   handler,
+		Protocols: protocols,
+	}
+
 	wftmplStore.Run(ctx, as.stopCh)
 	if cwftmplInformer != nil {
 		cwftmplInformer.Run(ctx, as.stopCh)
 	}
 	go eventServer.Run(ctx, as.stopCh)
 	go workflowServer.Run(as.stopCh)
-	go func() { as.checkServeErr(ctx, "httpServer", http.Serve(conn, handler)) }()
+	go func() { as.checkServeErr(ctx, "httpServer", muxServer.Serve(conn)) }()
 	url := "http://localhost" + address
 	if as.tlsConfig != nil {
 		url = "https://localhost" + address

--- a/util/grpc/mux.go
+++ b/util/grpc/mux.go
@@ -4,9 +4,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"strings"
-
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 func IncomingHeaderMatcher(key string) (string, bool) {
@@ -38,17 +35,12 @@ func IncomingHeaderMatcher(key string) (string, bool) {
 
 // NewMuxHandler returns an HTTP handler that allows serving both gRPC and
 // HTTP requests over the same port, both with and without TLS enabled.
-// From: https://pkg.go.dev/golang.org/x/net@v0.41.0/http2/h2c#NewHandler
-// "If a request is an h2c connection, it's hijacked and redirected to
-// s.ServeConn. Otherwise the returned Handler just forwards requests to h. This
-// works because h2c is designed to be parseable as valid HTTP/1, but ignored by
-// any HTTP server that does not handle h2c. Therefore we leverage the HTTP/1
-// compatible parts of the Go http library to parse and recognize h2c requests.
-// Once a request is recognized as h2c, we hijack the connection and convert it
-// to an HTTP/2 connection which is understandable to s.ServeConn. (s.ServeConn
-// understands HTTP/2 except for the h2c part of it.)"
+// It dispatches HTTP/2 requests with a gRPC content type to the gRPC handler
+// and forwards all other requests to the HTTP handler. Unencrypted HTTP/2 (h2c)
+// support is enabled by the serving [http.Server] via its Protocols field; see
+// the call site in the Argo server.
 func NewMuxHandler(grpcServerHandler http.Handler, httpServerHandler http.Handler) http.Handler {
-	return h2c.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Match against "Content-Type", which is guaranteed to start with "application/grpc" for gRPC requests.
 		// Spec: https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md
 		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
@@ -56,5 +48,5 @@ func NewMuxHandler(grpcServerHandler http.Handler, httpServerHandler http.Handle
 		} else {
 			httpServerHandler.ServeHTTP(w, r)
 		}
-	}), &http2.Server{})
+	})
 }


### PR DESCRIPTION
golang.org/x/net v0.55.0 deprecated http2/h2c.NewHandler in favour of the http.Server Protocols field for unencrypted HTTP/2, which tripped staticcheck (SA1019).

Drop the h2c wrapper from NewMuxHandler so it is a plain gRPC/HTTP dispatch handler, and enable HTTP/1.1, HTTP/2-over-TLS (ALPN) and unencrypted HTTP/2 (h2c) on the serving http.Server via Protocols. Behaviour is preserved for all transport paths the server supports.

### AI

Claude fixed this