### PR TITLE
fix!: drop values when skipped arguments are being substituted

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -315,6 +315,12 @@ Workflow is the definition of a workflow resource
 
 - [`sidecar.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`status-reference.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml)
 
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
@@ -800,6 +806,12 @@ WorkflowSpec is the specification of a Workflow.
 
 - [`sidecar.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`status-reference.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml)
 
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
@@ -1266,6 +1278,12 @@ CronWorkflowSpec is the specification of a CronWorkflow
 
 - [`sidecar.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`status-reference.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml)
 
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
@@ -1569,6 +1587,10 @@ Arguments to a template
 - [`scripts-javascript.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-javascript.yaml)
 
 - [`scripts-python.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-python.yaml)
+
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
 
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
 
@@ -2098,6 +2120,12 @@ Outputs hold parameters, artifacts, and results from a step
 
 - [`pod-spec-from-previous-step.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/pod-spec-from-previous-step.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`suspend-template-outputs.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/suspend-template-outputs.yaml)
 
 - [`webhdfs-input-output-artifacts.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/webhdfs-input-output-artifacts.yaml)
@@ -2462,6 +2490,12 @@ Parameter indicate a passed string parameter to a service template with an optio
 
 - [`scripts-python.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-python.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
 
 - [`steps-daemon-retry-strategy.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/steps-daemon-retry-strategy.yaml)
@@ -2762,6 +2796,12 @@ DAGTemplate is a template subtype for directed acyclic graph templates
 
 - [`resubmit.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/resubmit.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`dag.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-template/dag.yaml)
 
 - [`templates.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-template/templates.yaml)
@@ -3060,6 +3100,10 @@ Inputs are the mechanism for passing parameters, artifacts, volumes from one tem
 - [`scripts-javascript.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-javascript.yaml)
 
 - [`scripts-python.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/scripts-python.yaml)
+
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
 
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
 
@@ -3902,6 +3946,12 @@ ValueFrom describes a location in which to obtain the value to a parameter
 
 - [`secrets.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/secrets.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`suspend-template-outputs.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/suspend-template-outputs.yaml)
 
 - [`event-consumer-workfloweventbinding.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-event-binding/event-consumer-workfloweventbinding.yaml)
@@ -4181,6 +4231,12 @@ DAGTask represents a node in the graph during DAG execution Note: CEL validation
 - [`pod-spec-from-previous-step.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/pod-spec-from-previous-step.yaml)
 
 - [`resubmit.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/resubmit.yaml)
+
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
 
 - [`dag.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-template/dag.yaml)
 
@@ -4809,6 +4865,12 @@ _No description available_
 
 - [`secrets.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/secrets.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`suspend-template-outputs.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/suspend-template-outputs.yaml)
 
 - [`event-consumer-workfloweventbinding.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/workflow-event-binding/event-consumer-workfloweventbinding.yaml)
@@ -5197,6 +5259,12 @@ ObjectMeta is metadata that all persisted resources must have, which includes al
 - [`sidecar-nginx.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar-nginx.yaml)
 
 - [`sidecar.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar.yaml)
+
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
 
 - [`status-reference.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml)
 
@@ -5814,6 +5882,12 @@ A single application container that you want to run within a pod.
 - [`sidecar-nginx.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar-nginx.yaml)
 
 - [`sidecar.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar.yaml)
+
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
 
 - [`status-reference.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml)
 
@@ -6835,6 +6909,12 @@ ImageVolumeSource represents a image volume resource.
 
 - [`sidecar.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/sidecar.yaml)
 
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
+
 - [`status-reference.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/status-reference.yaml)
 
 - [`step-level-timeout.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/step-level-timeout.yaml)
@@ -7127,6 +7207,12 @@ EnvVarSource represents a source for the value of an EnvVar.
 - [`pod-spec-from-previous-step.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/pod-spec-from-previous-step.yaml)
 
 - [`secrets.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/secrets.yaml)
+
+- [`consumer-input-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/consumer-input-default.yaml)
+
+- [`expression-fallback.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/expression-fallback.yaml)
+
+- [`producer-output-default.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/skipped-output-defaults/producer-output-default.yaml)
 
 - [`suspend-template-outputs.yaml`](https://github.com/argoproj/argo-workflows/blob/main/examples/suspend-template-outputs.yaml)
 

--- a/docs/lifecyclehook.md
+++ b/docs/lifecyclehook.md
@@ -23,6 +23,8 @@ In other words, a `LifecycleHook` functions like an [exit handler](https://githu
 - [`templateRef`](fields.md#templateref)
 - [`arguments`](https://github.com/argoproj/argo-workflows/blob/main/examples/conditionals.yaml)
 
+Hook arguments and expressions that reference outputs of a skipped or omitted step resolve according to [Outputs of Skipped and Omitted Nodes](variables.md#outputs-of-skipped-and-omitted-nodes).
+
 ## Unsupported conditions
 
 - [`outputs`](fields.md#outputs) are not usable since `LifecycleHook` executes during execution time and `outputs` are not produced until the step is completed. You can use outputs from previous steps, just not the one you're hooking into. If you'd like to use outputs create an exit handler instead - all the status variable are available there so you can still conditionally decide what to do.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -25,6 +25,7 @@ If the producing template declares a `valueFrom.default` for the output, referen
 Otherwise the output is treated as absent: an argument that is purely such a reference lets the consuming input's `default` apply, and expression tags see `nil` so `??` fallbacks work.
 A reference that handles the absence in none of these ways — a simple tag such as `{{tasks.producer.outputs.parameters.msg}}` with no consumer input default, or an expression that does not handle the `nil` (for example a bare `{{= tasks.producer.outputs.parameters.msg}}` without `??`) — fails the node with a terminal error instead of leaving the workflow stuck.
 To handle the absence, declare a `valueFrom.default` on the producer's output, a `default` on the consuming input, or use a `??` expression fallback.
+This applies uniformly wherever such a reference appears, including `spec.volumes` and artifact `subPath` fields; only steps and tasks whose own `when` evaluates to false tolerate unhandled absent references, since they never run.
 
 See [Outputs of Skipped and Omitted Nodes](variables.md#outputs-of-skipped-and-omitted-nodes) for the full rules.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -14,11 +14,11 @@ This variable controlled whether to write workflow updates back to the informer 
 Alternative mechanisms now prevent reprocessing, making both behaviors unnecessary.
 If you have this variable set, it can be safely removed from your configuration.
 
-## Upgrading to v4.0.6 and v3.7.15
+## Upgrading to v4.0.7 and v3.7.16
 
 ### Outputs of skipped and omitted steps and tasks now resolve
 
-In v4.0.5, v3.7.14, and earlier, referencing an output parameter of a step or task that was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied) could leave the consumer stuck: simple tag references requeued forever and expression references failed.
+In v4.0.6, v3.7.15, and earlier, referencing an output parameter of a step or task that was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied) could leave the consumer stuck: simple tag references requeued forever and expression references failed.
 
 These references now resolve deterministically.
 If the producing template declares a `valueFrom.default` for the output, references resolve to that default.
@@ -28,6 +28,17 @@ To handle the absence, declare a `valueFrom.default` on the producer's output, a
 This applies uniformly wherever such a reference appears, including `spec.volumes` and artifact `subPath` fields; only steps and tasks whose own `when` evaluates to false tolerate unhandled absent references, since they never run.
 
 See [Outputs of Skipped and Omitted Nodes](variables.md#outputs-of-skipped-and-omitted-nodes) for the full rules.
+
+There is no configuration flag or environment variable to opt out: the new behavior applies to every workflow on upgrade.
+To keep the old empty-string behavior, handle the absence as described above (a producer `valueFrom.default`, a consumer input `default`, or a `??` fallback) before upgrading.
+
+### Template output parameter expressions that evaluate to `nil` now fail
+
+This change also applies when no node was skipped or omitted.
+A template `outputs.parameters` entry whose `valueFrom.expression` evaluates to `nil` previously produced the literal string `<nil>`.
+It now fails the node with a terminal error unless that output parameter declares a `valueFrom.default`.
+Expressions can return `nil` even when the referenced steps all ran, for example a missing map key (`someMap['absent']`) or a `find()` with no match.
+To keep a value, declare a `valueFrom.default` on the output parameter, or rewrite the expression to handle `nil` (for example with `??`).
 
 ## Upgrading to v4.0
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -14,6 +14,20 @@ This variable controlled whether to write workflow updates back to the informer 
 Alternative mechanisms now prevent reprocessing, making both behaviors unnecessary.
 If you have this variable set, it can be safely removed from your configuration.
 
+## Upgrading to v4.0.6 and v3.7.15
+
+### Outputs of skipped and omitted steps and tasks now resolve
+
+In v4.0.5, v3.7.14, and earlier, referencing an output parameter of a step or task that was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied) could leave the consumer stuck: simple tag references requeued forever and expression references failed.
+
+These references now resolve deterministically.
+If the producing template declares a `valueFrom.default` for the output, references resolve to that default.
+Otherwise the output is treated as absent: an argument that is purely such a reference lets the consuming input's `default` apply, and expression tags see `nil` so `??` fallbacks work.
+A reference that handles the absence in none of these ways — a simple tag such as `{{tasks.producer.outputs.parameters.msg}}` with no consumer input default, or an expression that does not handle the `nil` (for example a bare `{{= tasks.producer.outputs.parameters.msg}}` without `??`) — fails the node with a terminal error instead of leaving the workflow stuck.
+To handle the absence, declare a `valueFrom.default` on the producer's output, a `default` on the consuming input, or use a `??` expression fallback.
+
+See [Outputs of Skipped and Omitted Nodes](variables.md#outputs-of-skipped-and-omitted-nodes) for the full rules.
+
 ## Upgrading to v4.0
 
 ### Deprecations

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -189,7 +189,8 @@ References to its declared output parameters and `outputs.result` resolve as fol
     * In template outputs, a `valueFrom.default` declared on the aggregating output parameter applies when its `valueFrom.parameter` reference is absent or its `valueFrom.expression` fails.
 1. An unhandled reference to an absent output fails the node with a terminal error (it is not retried): a simple tag such as `{{steps.producer.outputs.parameters.msg}}` with no consumer input default, a bare `{{= steps.producer.outputs.parameters.msg}}`, or an operation on the `nil` such as `+ '-suffix'`.
 
-These rules apply wherever the reference appears: step and task arguments, `when` clauses, [`LifecycleHook`](lifecyclehook.md) and exit handler arguments and expressions, and the enclosing template's `outputs.parameters`.
+These rules apply wherever the reference appears: step and task arguments, `when` clauses, [`LifecycleHook`](lifecyclehook.md) and exit handler arguments and expressions, the enclosing template's `outputs.parameters`, `spec.volumes`, and artifact `subPath` fields.
+The exception is a step or task whose own `when` evaluates to false: it never runs, so absent references in its body are left unresolved instead of failing the workflow.
 
 A legitimately empty output is **not** absent: if the producer ran and wrote an empty string, `??` does not fire and the empty string is substituted.
 For the same reason, an expression comparison such as `{{= steps.producer.outputs.parameters.msg == ''}}` is false when the producer was skipped, because `nil` is not equal to `''`.

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -154,7 +154,7 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `steps.<STEPNAME>.outputs.parameters.<NAME>` | Output parameter of any previous step. When the previous step uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
 | `steps.<STEPNAME>.outputs.artifacts.<NAME>` | Output artifact of any previous step |
 
-**Note:** If a step was Skipped (its `when` condition was false), output parameters and results from that step resolve to empty strings.
+**Note:** If a step was Skipped (its `when` condition was false), references to its outputs resolve according to the rules in [Outputs of Skipped and Omitted Nodes](#outputs-of-skipped-and-omitted-nodes).
 
 ### DAG Templates
 
@@ -173,7 +173,29 @@ sprig.trim(inputs.parameters['my-string-param'])
 | `tasks.<TASKNAME>.outputs.parameters.<NAME>` | Output parameter of any previous task. When the previous task uses `withItems` or `withParams`, this contains a JSON array of the output parameter values of each invocation |
 | `tasks.<TASKNAME>.outputs.artifacts.<NAME>` | Output artifact of any previous task |
 
-**Note:** If a task was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied), output parameters and results from that task resolve to empty strings.
+**Note:** If a task was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied), references to its outputs resolve according to the rules in [Outputs of Skipped and Omitted Nodes](#outputs-of-skipped-and-omitted-nodes).
+
+### Outputs of Skipped and Omitted Nodes
+
+> v3.7.15, v4.0.6, and after
+
+A step or task that was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied) never ran, so it produced no outputs.
+References to its declared output parameters and `outputs.result` resolve as follows:
+
+1. If the producing template declares a `valueFrom.default` for the output parameter, every reference resolves to that default.
+1. Otherwise the output is *absent*, which is not the same as an empty string. An absent output must be handled by one of the following, or the referencing node fails with a terminal error:
+    * If an argument consists solely of such a reference and the consuming template's input parameter declares a `default`, the argument is omitted so that input default applies.
+    * An expression tag sees the value as `nil`. Use the `??` operator to choose a fallback, e.g. `{{= steps.producer.outputs.parameters.msg ?? 'fallback'}}`.
+    * In template outputs, a `valueFrom.default` declared on the aggregating output parameter applies when its `valueFrom.parameter` reference is absent or its `valueFrom.expression` fails.
+1. An unhandled reference to an absent output fails the node with a terminal error (it is not retried): a simple tag such as `{{steps.producer.outputs.parameters.msg}}` with no consumer input default, a bare `{{= steps.producer.outputs.parameters.msg}}`, or an operation on the `nil` such as `+ '-suffix'`.
+
+These rules apply wherever the reference appears: step and task arguments, `when` clauses, [`LifecycleHook`](lifecyclehook.md) and exit handler arguments and expressions, and the enclosing template's `outputs.parameters`.
+
+A legitimately empty output is **not** absent: if the producer ran and wrote an empty string, `??` does not fire and the empty string is substituted.
+For the same reason, an expression comparison such as `{{= steps.producer.outputs.parameters.msg == ''}}` is false when the producer was skipped, because `nil` is not equal to `''`.
+Declare `valueFrom.default: ""` on the producer's output if you want a skipped output to behave exactly like an empty one.
+
+See the [skipped output defaults examples](https://github.com/argoproj/argo-workflows/tree/main/examples/skipped-output-defaults) for runnable workflows demonstrating each rule.
 
 ### HTTP Templates
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -177,7 +177,7 @@ sprig.trim(inputs.parameters['my-string-param'])
 
 ### Outputs of Skipped and Omitted Nodes
 
-> v3.7.15, v4.0.6, and after
+> v3.7.16, v4.0.7, and after
 
 A step or task that was Skipped (its `when` condition was false) or Omitted (its `depends` condition was not satisfied) never ran, so it produced no outputs.
 References to its declared output parameters and `outputs.result` resolve as follows:

--- a/docs/walk-through/output-parameters.md
+++ b/docs/walk-through/output-parameters.md
@@ -45,6 +45,9 @@ spec:
 
 DAG templates use the tasks prefix to refer to another task, for example `{{tasks.generate-parameter.outputs.parameters.hello-param}}`.
 
+If the producing step or task was skipped or omitted, you can declare a `valueFrom.default` on its output parameter to provide a value for that case.
+See [Outputs of Skipped and Omitted Nodes](../variables.md#outputs-of-skipped-and-omitted-nodes) for how such references resolve.
+
 ## `result` output parameter
 
 For script and container templates, the `result` output parameter captures up to 256 kb of the standard output.

--- a/examples/skipped-output-defaults/consumer-input-default.yaml
+++ b/examples/skipped-output-defaults/consumer-input-default.yaml
@@ -1,0 +1,46 @@
+# Consumer's own input default applies when a skipped producer declares no output default.
+#
+# `producer` never runs (when: "false") and its output parameter `msg` declares NO default. `consumer`
+# references that (absent) output, but its own input parameter `in` declares a default. Rather than the
+# skipped reference clobbering that default with an empty string, the consumer's input default applies.
+#
+# Expected: consumer logs "consumer got: [fallback-from-input]".
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: consumer-input-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false"                      # -> Skipped, produces no real output
+          - name: consumer
+            template: consume
+            depends: "producer.Succeeded || producer.Skipped"
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{tasks.producer.outputs.parameters.msg}}"
+
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt               # NOTE: no default here
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]
+
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+            default: "fallback-from-input"     # <- applies because the reference was to a skipped output
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/examples/skipped-output-defaults/expression-fallback.yaml
+++ b/examples/skipped-output-defaults/expression-fallback.yaml
@@ -1,0 +1,36 @@
+# An expression can detect a skipped output's absence and choose a fallback with `??`.
+#
+# `producer` never runs (when: "false") and its output parameter `msg` declares NO default, so it
+# resolves to an absent (nil) optional rather than an empty string. The DAG's own output `result` is
+# computed by a ValueFrom.Expression that uses expr-lang's nil-coalescing operator `??`, letting the
+# author decide the fallback. A real empty output ("") would NOT trigger `??` — only true absence does.
+#
+# Expected: the workflow's output parameter `result` resolves to "expr-fallback".
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: expression-fallback-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false"                      # -> Skipped, produces no real output
+      outputs:
+        parameters:
+          - name: result
+            valueFrom:
+              expression: "tasks.producer.outputs.parameters.msg ?? 'expr-fallback'"
+
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt               # NOTE: no default -> absent (nil) when skipped
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]

--- a/examples/skipped-output-defaults/producer-output-default.yaml
+++ b/examples/skipped-output-defaults/producer-output-default.yaml
@@ -1,0 +1,46 @@
+# Producer output default flows to a downstream consumer when the producer is skipped.
+#
+# `producer` never runs (when: "false") so it produces no outputs. Because its output parameter
+# `msg` declares a `valueFrom.default`, any task that references `{{tasks.producer.outputs.parameters.msg}}`
+# receives that declared default ("hello-from-producer") instead of an empty string.
+#
+# Expected: consumer logs "consumer got: [hello-from-producer]".
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: producer-output-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false"                      # -> Skipped, produces no real output
+          - name: consumer
+            template: consume
+            depends: "producer.Succeeded || producer.Skipped"
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{tasks.producer.outputs.parameters.msg}}"
+
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt
+              default: "hello-from-producer"   # <- used when the node is skipped/omitted
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]
+
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional/dag-skipped-artifact-subpath-ref.yaml
+++ b/test/e2e/functional/dag-skipped-artifact-subpath-ref.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-artifact-subpath-ref-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: artifact-producer
+            template: produce-artifact
+          - name: param-producer
+            template: produce-param
+            when: "false" # -> Skipped, produces no real output and declares no default
+          - name: consumer
+            template: consume
+            depends: "artifact-producer && (param-producer.Succeeded || param-producer.Skipped)"
+            arguments:
+              artifacts:
+                - name: data
+                  from: "{{tasks.artifact-producer.outputs.artifacts.out}}"
+                  subPath: "{{tasks.param-producer.outputs.parameters.dir}}"
+    - name: produce-artifact
+      outputs:
+        artifacts:
+          - name: out
+            path: /tmp/message
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "hello", "/tmp/message"]
+    - name: produce-param
+      outputs:
+        parameters:
+          - name: dir
+            valueFrom:
+              path: /tmp/dir.txt # NOTE: no default here
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "subdir", "/tmp/dir.txt"]
+    - name: consume
+      inputs:
+        artifacts:
+          - name: data
+            path: /tmp/in
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumed"]

--- a/test/e2e/functional/dag-skipped-consumer-default.yaml
+++ b/test/e2e/functional/dag-skipped-consumer-default.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-consumer-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+          - name: consumer
+            template: consume
+            depends: "producer.Succeeded || producer.Skipped"
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{tasks.producer.outputs.parameters.msg}}"
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt # NOTE: no default here
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+            default: "fallback-from-input" # <- applies because the reference was to a skipped output
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional/dag-skipped-producer-default.yaml
+++ b/test/e2e/functional/dag-skipped-producer-default.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-producer-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+          - name: consumer
+            template: consume
+            depends: "producer.Succeeded || producer.Skipped"
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{tasks.producer.outputs.parameters.msg}}"
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt
+              default: "hello-from-producer" # <- used when the node is skipped/omitted
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional/dag-skipped-volume-default.yaml
+++ b/test/e2e/functional/dag-skipped-volume-default.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-volume-default-
+spec:
+  entrypoint: main
+  volumes:
+    - name: cfg
+      configMap:
+        name: "{{tasks.producer.outputs.parameters.cm-name}}"
+        optional: true
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+          - name: consumer
+            template: consume
+            depends: "producer.Succeeded || producer.Skipped"
+    - name: produce
+      outputs:
+        parameters:
+          - name: cm-name
+            valueFrom:
+              path: /tmp/out.txt
+              default: "rescued-config" # <- substituted into spec.volumes when the node is skipped
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-config", "/tmp/out.txt"]
+    - name: consume
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "hello"]
+        volumeMounts:
+          - name: cfg
+            mountPath: /cfg

--- a/test/e2e/functional/dag-skipped-withparam-default.yaml
+++ b/test/e2e/functional/dag-skipped-withparam-default.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-withparam-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+          - name: consumer
+            template: consume
+            depends: "producer.Succeeded || producer.Skipped"
+            withParam: "{{tasks.producer.outputs.parameters.items}}"
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{item}}"
+    - name: produce
+      outputs:
+        parameters:
+          - name: items
+            valueFrom:
+              path: /tmp/out.txt
+              default: '["a","b"]' # <- expansion source when the node is skipped
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", '["real"]', "/tmp/out.txt"]
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional/steps-skipped-consumer-default.yaml
+++ b/test/e2e/functional/steps-skipped-consumer-default.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-skipped-consumer-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+        - - name: consumer
+            template: consume
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{steps.producer.outputs.parameters.msg}}"
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt # NOTE: no default here
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+            default: "fallback-from-input" # <- applies because the reference was to a skipped output
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional/steps-skipped-producer-default.yaml
+++ b/test/e2e/functional/steps-skipped-producer-default.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-skipped-producer-default-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+        - - name: consumer
+            template: consume
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{steps.producer.outputs.parameters.msg}}"
+    - name: produce
+      outputs:
+        parameters:
+          - name: msg
+            valueFrom:
+              path: /tmp/out.txt
+              default: "hello-from-producer" # <- used when the node is skipped/omitted
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "real-value", "/tmp/out.txt"]
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional/steps-skipped-withparam-ref.yaml
+++ b/test/e2e/functional/steps-skipped-withparam-ref.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-skipped-withparam-ref-
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: producer
+            template: produce
+            when: "false" # -> Skipped, produces no real output
+        - - name: consumer
+            template: consume
+            withParam: "{{steps.producer.outputs.parameters.items}}"
+            arguments:
+              parameters:
+                - name: in
+                  value: "{{item}}"
+    - name: produce
+      outputs:
+        parameters:
+          - name: items
+            valueFrom:
+              path: /tmp/out.txt # NOTE: no default here
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", '["real"]', "/tmp/out.txt"]
+    - name: consume
+      inputs:
+        parameters:
+          - name: in
+      container:
+        image: argoproj/argosay:v2
+        args: ["echo", "consumer got: [{{inputs.parameters.in}}]"]

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -657,7 +657,8 @@ func (s *FunctionalSuite) TestStepsSkippedWithParamRef() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowError, status.Phase)
+			// the errored step group rolls up to the steps template as Failed (not Error)
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 			producer := status.Nodes.FindByDisplayName("producer")
 			if assert.NotNil(t, producer) {
 				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
@@ -688,7 +689,8 @@ func (s *FunctionalSuite) TestStepsSkippedOutputRef() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowError, status.Phase)
+			// the errored step group rolls up to the steps template as Failed (not Error)
+			assert.Equal(t, wfv1.WorkflowFailed, status.Phase)
 			nodeJob1 := status.Nodes.FindByDisplayName("job1")
 			if assert.NotNil(t, nodeJob1) {
 				assert.Equal(t, wfv1.NodeSucceeded, nodeJob1.Phase)

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -464,6 +465,9 @@ func (s *FunctionalSuite) TestDAGEmptyParam() {
 		})
 }
 
+// TestDAGOmittedOutputRef tests that referencing an output parameter of an omitted task with no
+// producer valueFrom.default and no consumer input default fails the consuming task terminally
+// rather than requeuing forever.
 func (s *FunctionalSuite) TestDAGOmittedOutputRef() {
 	s.Given().
 		Workflow("@functional/dag-omitted-output-ref.yaml").
@@ -472,7 +476,7 @@ func (s *FunctionalSuite) TestDAGOmittedOutputRef() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			assert.Equal(t, wfv1.WorkflowError, status.Phase)
 			nodeA := status.Nodes.FindByDisplayName("stage-a")
 			if assert.NotNil(t, nodeA) {
 				assert.Equal(t, wfv1.NodeSucceeded, nodeA.Phase)
@@ -483,11 +487,15 @@ func (s *FunctionalSuite) TestDAGOmittedOutputRef() {
 			}
 			nodeC := status.Nodes.FindByDisplayName("stage-c")
 			if assert.NotNil(t, nodeC) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeC.Phase)
+				assert.Equal(t, wfv1.NodeError, nodeC.Phase)
+				assert.Contains(t, nodeC.Message, "absent optional")
 			}
 		})
 }
 
+// TestDAGSkippedOutputRef tests that referencing an output parameter of a skipped task with no
+// producer valueFrom.default and no consumer input default fails the consuming task terminally
+// rather than requeuing forever.
 func (s *FunctionalSuite) TestDAGSkippedOutputRef() {
 	s.Given().
 		Workflow("@functional/dag-skipped-output-ref.yaml").
@@ -496,7 +504,7 @@ func (s *FunctionalSuite) TestDAGSkippedOutputRef() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			assert.Equal(t, wfv1.WorkflowError, status.Phase)
 			nodeA := status.Nodes.FindByDisplayName("stage-a")
 			if assert.NotNil(t, nodeA) {
 				assert.Equal(t, wfv1.NodeSucceeded, nodeA.Phase)
@@ -507,14 +515,171 @@ func (s *FunctionalSuite) TestDAGSkippedOutputRef() {
 			}
 			nodeC := status.Nodes.FindByDisplayName("stage-c")
 			if assert.NotNil(t, nodeC) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeC.Phase)
+				assert.Equal(t, wfv1.NodeError, nodeC.Phase)
+				assert.Contains(t, nodeC.Message, "absent optional")
 			}
 		})
 }
 
-// TestStepsSkippedOutputRef tests that output references to skipped steps resolve to empty strings
-// rather than causing an unresolvable reference error. NodeOmitted is not exercised here because
-// that phase arises in DAG templates, not steps; the fix covers both phases in the same code path.
+// TestDAGSkippedProducerOutputDefault tests that when a skipped task's output parameter declares a
+// valueFrom.default, a downstream reference to that output resolves to the declared default.
+func (s *FunctionalSuite) TestDAGSkippedProducerOutputDefault() {
+	s.Given().
+		Workflow("@functional/dag-skipped-producer-default.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			consumer := status.Nodes.FindByDisplayName("consumer")
+			if assert.NotNil(t, consumer) {
+				assert.Equal(t, wfv1.NodeSucceeded, consumer.Phase)
+				if assert.NotNil(t, consumer.Inputs) && assert.Len(t, consumer.Inputs.Parameters, 1) {
+					assert.Equal(t, "hello-from-producer", consumer.Inputs.Parameters[0].Value.String())
+				}
+			}
+		})
+}
+
+// TestDAGSkippedConsumerInputDefault tests that when a skipped task's output parameter has no
+// valueFrom.default, an argument that is purely that reference is dropped so the consuming
+// template's own input default applies.
+func (s *FunctionalSuite) TestDAGSkippedConsumerInputDefault() {
+	s.Given().
+		Workflow("@functional/dag-skipped-consumer-default.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			consumer := status.Nodes.FindByDisplayName("consumer")
+			if assert.NotNil(t, consumer) {
+				assert.Equal(t, wfv1.NodeSucceeded, consumer.Phase)
+				if assert.NotNil(t, consumer.Inputs) && assert.Len(t, consumer.Inputs.Parameters, 1) {
+					assert.Equal(t, "fallback-from-input", consumer.Inputs.Parameters[0].Value.String())
+				}
+			}
+		})
+}
+
+// TestDAGSkippedVolumeRefProducerDefault tests that a spec.volumes entry referencing a skipped
+// task's output parameter resolves to the producer's valueFrom.default, so the consuming pod is
+// created with a valid volume.
+func (s *FunctionalSuite) TestDAGSkippedVolumeRefProducerDefault() {
+	s.Given().
+		Workflow("@functional/dag-skipped-volume-default.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			consumer := status.Nodes.FindByDisplayName("consumer")
+			if assert.NotNil(t, consumer) {
+				assert.Equal(t, wfv1.NodeSucceeded, consumer.Phase)
+			}
+		})
+}
+
+// TestDAGSkippedArtifactSubPathRef tests that an artifact subPath referencing an output parameter
+// of a skipped task with no producer valueFrom.default fails the consuming task terminally rather
+// than silently resolving to an empty subPath.
+func (s *FunctionalSuite) TestDAGSkippedArtifactSubPathRef() {
+	s.Given().
+		Workflow("@functional/dag-skipped-artifact-subpath-ref.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowError, status.Phase)
+			producer := status.Nodes.FindByDisplayName("param-producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			consumer := status.Nodes.FindByDisplayName("consumer")
+			if assert.NotNil(t, consumer) {
+				assert.Equal(t, wfv1.NodeError, consumer.Phase)
+				assert.Contains(t, consumer.Message, "absent optional")
+			}
+		})
+}
+
+// TestDAGSkippedWithParamProducerDefault tests that a withParam sourced from a skipped task's
+// output parameter expands using the producer's valueFrom.default.
+func (s *FunctionalSuite) TestDAGSkippedWithParamProducerDefault() {
+	s.Given().
+		Workflow("@functional/dag-skipped-withparam-default.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			for i, item := range []string{"a", "b"} {
+				child := status.Nodes.FindByDisplayName(fmt.Sprintf("consumer(%d:%s)", i, item))
+				if assert.NotNil(t, child, "expanded child for item %q should exist", item) {
+					assert.Equal(t, wfv1.NodeSucceeded, child.Phase)
+					if assert.NotNil(t, child.Inputs) && assert.Len(t, child.Inputs.Parameters, 1) {
+						assert.Equal(t, item, child.Inputs.Parameters[0].Value.String())
+					}
+				}
+			}
+		})
+}
+
+// TestStepsSkippedWithParamRef tests that a withParam sourced from a skipped step's output
+// parameter with no producer valueFrom.default fails the step group terminally rather than
+// requeuing forever or expanding to nothing.
+func (s *FunctionalSuite) TestStepsSkippedWithParamRef() {
+	s.Given().
+		Workflow("@functional/steps-skipped-withparam-ref.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowError, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			// the step group expanding from the absent output errors before consumer nodes exist
+			var errored *wfv1.NodeStatus
+			for _, node := range status.Nodes {
+				if node.Phase == wfv1.NodeError {
+					errored = &node
+					break
+				}
+			}
+			if assert.NotNil(t, errored, "a node should fail terminally on the absent optional") {
+				assert.Contains(t, errored.Message, "absent optional")
+			}
+		})
+}
+
+// TestStepsSkippedOutputRef tests that a "when" clause referencing an output parameter of a
+// skipped step with no producer valueFrom.default fails the step group terminally rather than
+// requeuing forever. NodeOmitted is not exercised here because that phase arises in DAG templates,
+// not steps; both phases share the same code path.
 func (s *FunctionalSuite) TestStepsSkippedOutputRef() {
 	s.Given().
 		Workflow("@functional/steps-skipped-output-ref.yaml").
@@ -523,7 +688,7 @@ func (s *FunctionalSuite) TestStepsSkippedOutputRef() {
 		WaitForWorkflow().
 		Then().
 		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
-			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			assert.Equal(t, wfv1.WorkflowError, status.Phase)
 			nodeJob1 := status.Nodes.FindByDisplayName("job1")
 			if assert.NotNil(t, nodeJob1) {
 				assert.Equal(t, wfv1.NodeSucceeded, nodeJob1.Phase)
@@ -533,10 +698,67 @@ func (s *FunctionalSuite) TestStepsSkippedOutputRef() {
 			if assert.NotNil(t, nodeJob2) {
 				assert.Equal(t, wfv1.NodeSkipped, nodeJob2.Phase)
 			}
-			// job2-error-handler runs: job2 output resolves to "" so "" != "SUCCESS" is true
-			nodeHandler := status.Nodes.FindByDisplayName("job2-error-handler")
-			if assert.NotNil(t, nodeHandler) {
-				assert.Equal(t, wfv1.NodeSucceeded, nodeHandler.Phase)
+			// the step group referencing job2's absent output errors before the handler node exists
+			var errored *wfv1.NodeStatus
+			for _, node := range status.Nodes {
+				if node.Phase == wfv1.NodeError {
+					errored = &node
+					break
+				}
+			}
+			if assert.NotNil(t, errored, "a node should fail terminally on the absent optional") {
+				assert.Contains(t, errored.Message, "absent optional")
+			}
+		})
+}
+
+// TestStepsSkippedProducerOutputDefault tests that when a skipped step's output parameter declares
+// a valueFrom.default, a downstream reference to that output resolves to the declared default.
+func (s *FunctionalSuite) TestStepsSkippedProducerOutputDefault() {
+	s.Given().
+		Workflow("@functional/steps-skipped-producer-default.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			consumer := status.Nodes.FindByDisplayName("consumer")
+			if assert.NotNil(t, consumer) {
+				assert.Equal(t, wfv1.NodeSucceeded, consumer.Phase)
+				if assert.NotNil(t, consumer.Inputs) && assert.Len(t, consumer.Inputs.Parameters, 1) {
+					assert.Equal(t, "hello-from-producer", consumer.Inputs.Parameters[0].Value.String())
+				}
+			}
+		})
+}
+
+// TestStepsSkippedConsumerInputDefault tests that when a skipped step's output parameter has no
+// valueFrom.default, an argument that is purely that reference is dropped so the consuming
+// template's own input default applies.
+func (s *FunctionalSuite) TestStepsSkippedConsumerInputDefault() {
+	s.Given().
+		Workflow("@functional/steps-skipped-consumer-default.yaml").
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow().
+		Then().
+		ExpectWorkflow(func(t *testing.T, _ *metav1.ObjectMeta, status *wfv1.WorkflowStatus) {
+			assert.Equal(t, wfv1.WorkflowSucceeded, status.Phase)
+			producer := status.Nodes.FindByDisplayName("producer")
+			if assert.NotNil(t, producer) {
+				assert.Equal(t, wfv1.NodeSkipped, producer.Phase)
+			}
+			consumer := status.Nodes.FindByDisplayName("consumer")
+			if assert.NotNil(t, consumer) {
+				assert.Equal(t, wfv1.NodeSucceeded, consumer.Phase)
+				if assert.NotNil(t, consumer.Inputs) && assert.Len(t, consumer.Inputs.Parameters, 1) {
+					assert.Equal(t, "fallback-from-input", consumer.Inputs.Parameters[0].Value.String())
+				}
 			}
 		})
 }

--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -8,14 +8,13 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/ast"
-	"github.com/expr-lang/expr/file"
 	"github.com/expr-lang/expr/parser"
-	"github.com/expr-lang/expr/parser/lexer"
 
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/maps"
@@ -40,10 +39,33 @@ var (
 	}
 )
 
+// missingVarsInEnv returns the identifiers referenced by the expression that are absent from env
+// (a present-but-nil leaf counts as present). Errors if the expression cannot be parsed.
+func missingVarsInEnv(expression string, env map[string]any) ([]string, error) {
+	identifiers, err := getIdentifiers(expression)
+	if err != nil {
+		return nil, err
+	}
+	var missing []string
+	for _, id := range identifiers {
+		if !hasVarInEnv(env, id) {
+			missing = append(missing, id)
+		}
+	}
+	return missing, nil
+}
+
+// anyVarNotInEnv returns the first late-binding variable (variablesToCheck) that the expression
+// references but env lacks, or nil if there is none.
 func anyVarNotInEnv(expression string, env map[string]any) *string {
-	for _, variable := range variablesToCheck {
-		if hasVariableInExpression(expression, variable) && !hasVarInEnv(env, variable) {
-			return &variable
+	missing, err := missingVarsInEnv(expression, env)
+	if err != nil {
+		// Unparseable expressions can't be checked; compile/run will surface the error.
+		return nil
+	}
+	for _, id := range missing {
+		if slices.Contains(variablesToCheck, id) {
+			return &id
 		}
 	}
 	return nil
@@ -58,17 +80,10 @@ func expressionReplaceStrict(ctx context.Context, w io.Writer, expression string
 		return expressionReplaceCore(ctx, w, expression, env, false)
 	}
 
-	identifiers, err := getIdentifiers(unmarshalledExpression)
+	missingIdentifiers, err := missingVarsInEnv(unmarshalledExpression, env)
 	if err != nil {
 		// If we can't parse, we can't check variables. Fallback to expressionReplaceCore(false) to report syntax error.
 		return expressionReplaceCore(ctx, w, expression, env, false)
-	}
-
-	missingIdentifiers := []string{}
-	for _, id := range identifiers {
-		if !hasVarInEnv(env, id) {
-			missingIdentifiers = append(missingIdentifiers, id)
-		}
 	}
 
 	for _, id := range missingIdentifiers {
@@ -226,57 +241,6 @@ func EnvMap(replaceMap map[string]string) map[string]any {
 		envMap[k] = v
 	}
 	return envMap
-}
-
-func searchTokens(haystack []lexer.Token, needle []lexer.Token) bool {
-	if len(needle) > len(haystack) {
-		return false
-	}
-	if len(needle) == 0 {
-		return true
-	}
-outer:
-	for i := 0; i <= len(haystack)-len(needle); i++ {
-		for j := range needle {
-			if haystack[i+j].String() != needle[j].String() {
-				continue outer
-			}
-		}
-		return true
-	}
-	return false
-}
-
-func filterEOF(toks []lexer.Token) []lexer.Token {
-	newToks := []lexer.Token{}
-	for _, tok := range toks {
-		if tok.Kind != lexer.EOF {
-			newToks = append(newToks, tok)
-		}
-	}
-	return newToks
-}
-
-// hasVariableInExpression checks if an expression contains a variable.
-// This function is somewhat cursed and I have attempted my best to
-// remove this curse, but it still exists.
-// The strings.Contains is needed because the lexer doesn't do
-// any whitespace processing (workflow .status will be seen as workflow.status)
-func hasVariableInExpression(expression, variable string) bool {
-	if !strings.Contains(expression, variable) {
-		return false
-	}
-	tokens, err := lexer.Lex(file.NewSource(expression))
-	if err != nil {
-		return false
-	}
-	variableTokens, err := lexer.Lex(file.NewSource(variable))
-	if err != nil {
-		return false
-	}
-	variableTokens = filterEOF(variableTokens)
-
-	return searchTokens(tokens, variableTokens)
 }
 
 // hasVarInEnv checks if a parameter is in env or not

--- a/util/template/expression_template_test.go
+++ b/util/template/expression_template_test.go
@@ -3,9 +3,8 @@ package template
 import (
 	"testing"
 
-	"github.com/expr-lang/expr/file"
-	"github.com/expr-lang/expr/parser/lexer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_hasVarInEnv(t *testing.T) {
@@ -100,29 +99,57 @@ func Test_hasVarInEnv(t *testing.T) {
 	})
 }
 
-func Test_hasVariableInExpression(t *testing.T) {
-	assert.True(t, hasVariableInExpression("retries", "retries"))
-	assert.True(t, hasVariableInExpression("retries + 1", "retries"))
-	assert.True(t, hasVariableInExpression("sprig(retries)", "retries"))
-	assert.True(t, hasVariableInExpression("sprig(retries + 1) * 64", "retries"))
-	assert.False(t, hasVariableInExpression("foo", "retries"))
-	assert.False(t, hasVariableInExpression("retriesCustom + 1", "retries"))
-	assert.True(t, hasVariableInExpression("item", "item"))
-	assert.False(t, hasVariableInExpression("foo", "item"))
-	assert.True(t, hasVariableInExpression("sprig.upper(item)", "item"))
+func Test_anyVarNotInEnv(t *testing.T) {
+	emptyEnv := map[string]any{}
+	missing := func(expression string) *string { return anyVarNotInEnv(expression, emptyEnv) }
+
+	t.Run("late-binding variables detected when absent", func(t *testing.T) {
+		for _, expression := range []string{
+			"retries",
+			"retries + 1",
+			"sprig(retries)",
+			"sprig(retries + 1) * 64",
+			"item",
+			"sprig.upper(item)",
+			`workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"`,
+		} {
+			assert.NotNil(t, missing(expression), expression)
+		}
+	})
+
+	t.Run("unrelated identifiers do not match", func(t *testing.T) {
+		for _, expression := range []string{
+			"foo",
+			"retriesCustom + 1",
+		} {
+			assert.Nil(t, missing(expression), expression)
+		}
+	})
+
+	t.Run("string literal is not an identifier", func(t *testing.T) {
+		assert.Nil(t, missing(`"workflow.status" == "Succeeded" ? "SUCCESSFUL" : "FAILED"`))
+	})
+
+	t.Run("present in env is not reported", func(t *testing.T) {
+		env := map[string]any{"retries": 1}
+		assert.Nil(t, anyVarNotInEnv("retries + 1", env))
+	})
 }
 
-func Test_hasWorkflowParameters(t *testing.T) {
-	expression := `workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"`
-	exprToks, _ := lexer.Lex(file.NewSource(expression))
-	variableToks, _ := lexer.Lex(file.NewSource("workflow.status"))
-	variableToks = filterEOF(variableToks)
-	assert.True(t, searchTokens(exprToks, variableToks))
-	assert.True(t, hasVariableInExpression(expression, "workflow.status"))
-
-	assert.False(t, hasVariableInExpression(expression, "workflow status"))
-	assert.False(t, hasVariableInExpression(expression, "workflow .status"))
-
-	expression = `"workflow.status" == "Succeeded" ? "SUCCESSFUL" : "FAILED"`
-	assert.False(t, hasVariableInExpression(expression, "workflow .status"))
+func Test_missingVarsInEnv(t *testing.T) {
+	t.Run("nil leaf counts as present", func(t *testing.T) {
+		env := map[string]any{"tasks": map[string]any{"a": map[string]any{"out": nil}}}
+		missing, err := missingVarsInEnv("tasks.a.out ?? 'x'", env)
+		require.NoError(t, err)
+		assert.Empty(t, missing)
+	})
+	t.Run("missing identifiers reported", func(t *testing.T) {
+		missing, err := missingVarsInEnv("foo + bar", map[string]any{"foo": "1"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"bar"}, missing)
+	})
+	t.Run("unparseable errors", func(t *testing.T) {
+		_, err := missingVarsInEnv("foo +", map[string]any{})
+		require.Error(t, err)
+	})
 }

--- a/util/template/replace.go
+++ b/util/template/replace.go
@@ -24,8 +24,21 @@ func IsMissingVariableErr(err error) bool {
 	return false
 }
 
-// Replace takes a json-formatted string and performs variable replacement.
-func Replace(ctx context.Context, s string, replaceMap map[string]string, allowUnresolved bool) (string, error) {
+// ToAnyMap widens a string map for use with Replace. Callers that track absent optionals
+// (skipped/omitted node outputs) build a map[string]any directly so nil entries survive.
+func ToAnyMap(m map[string]string) map[string]any {
+	anyMap := make(map[string]any, len(m))
+	for k, v := range m {
+		anyMap[k] = v
+	}
+	return anyMap
+}
+
+// Replace takes a json-formatted string and performs variable replacement. Values are raw: a nil
+// entry marks an absent optional (a skipped/omitted node's output with no default), and a simple
+// tag resolving to nil is a terminal error regardless of allowUnresolved, which only governs tags
+// whose key is missing entirely.
+func Replace(ctx context.Context, s string, replaceMap map[string]any, allowUnresolved bool) (string, error) {
 	if !json.Valid([]byte(s)) {
 		return "", errors.New("cannot do template replacements with invalid JSON")
 	}
@@ -34,11 +47,7 @@ func Replace(ctx context.Context, s string, replaceMap map[string]string, allowU
 	if err != nil {
 		return "", err
 	}
-	interReplaceMap := make(map[string]any)
-	for k, v := range replaceMap {
-		interReplaceMap[k] = v
-	}
-	replacedString, err := t.Replace(ctx, interReplaceMap, allowUnresolved)
+	replacedString, err := t.Replace(ctx, replaceMap, allowUnresolved)
 	if err != nil {
 		return s, err
 	}

--- a/util/template/replace.go
+++ b/util/template/replace.go
@@ -50,9 +50,13 @@ func Replace(ctx context.Context, s string, replaceMap map[string]string, allowU
 	return replacedString, nil
 }
 
-// ReplaceStrict behaves like Replace but enforces that tags starting with any of strictPrefixes MUST be resolved,
-// even if allowUnresolved behavior is otherwise active (implicit).
-func ReplaceStrict(ctx context.Context, s string, replaceMap map[string]string, strictPrefixes []string) (string, error) {
+// ReplaceStrictAny behaves like Replace but enforces that tags starting with any of strictPrefixes
+// MUST be resolved, even if allowUnresolved behavior is otherwise active (implicit). It takes raw
+// values, preserving nil entries so that expression tags can distinguish an absent (nil) value from
+// an empty string (e.g. via `??`). A simple tag resolving to a nil value is a terminal error (not a
+// missing-variable error): an absent optional must be handled by a producer default, a consumer
+// input default (dropping the argument before substitution), or an expression fallback.
+func ReplaceStrictAny(ctx context.Context, s string, replaceMap map[string]any, strictPrefixes []string) (string, error) {
 	if !json.Valid([]byte(s)) {
 		return "", errors.New("cannot do template replacements with invalid JSON")
 	}
@@ -61,11 +65,7 @@ func ReplaceStrict(ctx context.Context, s string, replaceMap map[string]string, 
 	if err != nil {
 		return "", err
 	}
-	interReplaceMap := make(map[string]any)
-	for k, v := range replaceMap {
-		interReplaceMap[k] = v
-	}
-	replacedString, err := t.ReplaceStrict(ctx, interReplaceMap, strictPrefixes)
+	replacedString, err := t.ReplaceStrict(ctx, replaceMap, strictPrefixes)
 	if err != nil {
 		return s, err
 	}

--- a/util/template/replace_test.go
+++ b/util/template/replace_test.go
@@ -23,7 +23,7 @@ func Test_Replace(t *testing.T) {
 	})
 	t.Run("Simple", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
-			r, err := Replace(ctx, toJSONString("{{foo}}"), map[string]string{"foo": "bar"}, false)
+			r, err := Replace(ctx, toJSONString("{{foo}}"), map[string]any{"foo": "bar"}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString("bar"), r)
 		})
@@ -40,28 +40,28 @@ func Test_Replace(t *testing.T) {
 	})
 	t.Run("Expression", func(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
-			r, err := Replace(ctx, toJSONString("{{=foo}}"), map[string]string{"foo": "bar"}, false)
+			r, err := Replace(ctx, toJSONString("{{=foo}}"), map[string]any{"foo": "bar"}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString("bar"), r)
 		})
 		t.Run("Valid With Variadic Sprig Expression", func(t *testing.T) {
-			r, err := Replace(ctx, toJSONString("{{=sprig.dig('status', nil, workflow)}}"), map[string]string{"workflow.status": "Succeeded"}, false)
+			r, err := Replace(ctx, toJSONString("{{=sprig.dig('status', nil, workflow)}}"), map[string]any{"workflow.status": "Succeeded"}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString("Succeeded"), r)
 		})
 		t.Run("Valid WorkflowStatus", func(t *testing.T) {
-			replaced, err := Replace(ctx, toJSONString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.status": "Succeeded"}, false)
+			replaced, err := Replace(ctx, toJSONString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), map[string]any{"workflow.status": "Succeeded"}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString(`SUCCESSFUL`), replaced)
-			replaced, err = Replace(ctx, toJSONString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.status": "Failed"}, false)
+			replaced, err = Replace(ctx, toJSONString(`{{=workflow.status == "Succeeded" ? "SUCCESSFUL" : "FAILED"}}`), map[string]any{"workflow.status": "Failed"}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString(`FAILED`), replaced)
 		})
 		t.Run("Valid WorkflowFailures", func(t *testing.T) {
-			replaced, err := Replace(ctx, toJSONString(`{{=workflow.failures == "{\"foo\":\"bar\"}" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.failures": `{"foo":"bar"}`}, false)
+			replaced, err := Replace(ctx, toJSONString(`{{=workflow.failures == "{\"foo\":\"bar\"}" ? "SUCCESSFUL" : "FAILED"}}`), map[string]any{"workflow.failures": `{"foo":"bar"}`}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString(`SUCCESSFUL`), replaced)
-			replaced, err = Replace(ctx, toJSONString(`{{=workflow.failures == "{\"foo\":\"bar\"}" ? "SUCCESSFUL" : "FAILED"}}`), map[string]string{"workflow.failures": `{"foo":"barr"}`}, false)
+			replaced, err = Replace(ctx, toJSONString(`{{=workflow.failures == "{\"foo\":\"bar\"}" ? "SUCCESSFUL" : "FAILED"}}`), map[string]any{"workflow.failures": `{"foo":"barr"}`}, false)
 			require.NoError(t, err)
 			assert.Equal(t, toJSONString(`FAILED`), replaced)
 		})
@@ -107,7 +107,7 @@ func Test_Replace(t *testing.T) {
 
 func TestNestedReplaceString(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
-	replaceMap := map[string]string{"inputs.parameters.message": "hello world"}
+	replaceMap := map[string]any{"inputs.parameters.message": "hello world"}
 
 	test := toJSONString(`{{- with secret "{{inputs.parameters.message}}" -}}
     {{ .Data.data.gitcreds }}
@@ -159,7 +159,7 @@ func TestNestedReplaceString(t *testing.T) {
 
 func TestReplaceStringWithWhiteSpace(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
-	replaceMap := map[string]string{"inputs.parameters.message": "hello world"}
+	replaceMap := map[string]any{"inputs.parameters.message": "hello world"}
 
 	test := toJSONString(`{{ inputs.parameters.message }}`)
 	replacement, err := Replace(ctx, test, replaceMap, true)
@@ -169,7 +169,7 @@ func TestReplaceStringWithWhiteSpace(t *testing.T) {
 
 func TestReplaceStringWithExpression(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
-	replaceMap := map[string]string{"inputs.parameters.message": "hello world"}
+	replaceMap := map[string]any{"inputs.parameters.message": "hello world"}
 
 	test := toJSONString(`test {{= sprig.trunc(5, inputs.parameters.message) }}`)
 	replacement, err := Replace(ctx, test, replaceMap, true)

--- a/util/template/replace_test.go
+++ b/util/template/replace_test.go
@@ -181,3 +181,84 @@ func TestReplaceStringWithExpression(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, toJSONString("test world"), replacement)
 }
+
+// TestReplaceStrictAnyNilValues verifies the absent-optional (nil) semantics: expression tags can
+// distinguish a present-but-nil value (skipped step output with no default) from an empty string
+// via ??, and a simple tag resolving to nil is a terminal error (not a missing-variable requeue).
+func TestReplaceStrictAnyNilValues(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	replaceMap := map[string]any{
+		"tasks.producer.outputs.parameters.msg": nil,
+		"tasks.other.outputs.parameters.msg":    "real",
+	}
+
+	t.Run("ExpressionFallbackFires", func(t *testing.T) {
+		r, err := ReplaceStrictAny(ctx, toJSONString(`{{= tasks.producer.outputs.parameters.msg ?? 'fallback'}}`), replaceMap, []string{"tasks", "steps"})
+		require.NoError(t, err)
+		assert.Equal(t, toJSONString("fallback"), r)
+	})
+	t.Run("ExpressionFallbackNotFiredForEmptyString", func(t *testing.T) {
+		emptyValueMap := map[string]any{"tasks.producer.outputs.parameters.msg": ""}
+		r, err := ReplaceStrictAny(ctx, toJSONString(`{{= tasks.producer.outputs.parameters.msg ?? 'fallback'}}`), emptyValueMap, []string{"tasks", "steps"})
+		require.NoError(t, err)
+		assert.Equal(t, toJSONString(""), r)
+	})
+	t.Run("BareExpressionRefNilErrors", func(t *testing.T) {
+		_, err := ReplaceStrictAny(ctx, toJSONString(`{{= tasks.producer.outputs.parameters.msg}}`), replaceMap, []string{"tasks", "steps"})
+		require.Error(t, err)
+	})
+	t.Run("SimpleTagAbsentValueErrors", func(t *testing.T) {
+		_, err := ReplaceStrictAny(ctx, toJSONString(`pre-{{tasks.producer.outputs.parameters.msg}}-post`), replaceMap, []string{"tasks", "steps"})
+		require.ErrorContains(t, err, "absent optional")
+		assert.False(t, IsMissingVariableErr(err), "absent optional must be terminal, not a requeue")
+	})
+	t.Run("SimpleTagEmptyStringStillSubstitutes", func(t *testing.T) {
+		emptyValueMap := map[string]any{"tasks.producer.outputs.parameters.msg": ""}
+		r, err := ReplaceStrictAny(ctx, toJSONString(`pre-{{tasks.producer.outputs.parameters.msg}}-post`), emptyValueMap, []string{"tasks", "steps"})
+		require.NoError(t, err)
+		assert.Equal(t, toJSONString("pre--post"), r)
+	})
+	t.Run("RealValueStillWins", func(t *testing.T) {
+		r, err := ReplaceStrictAny(ctx, toJSONString(`{{= tasks.other.outputs.parameters.msg ?? 'fallback'}}`), replaceMap, []string{"tasks", "steps"})
+		require.NoError(t, err)
+		assert.Equal(t, toJSONString("real"), r)
+	})
+	t.Run("MissingStrictIdentifierStillErrors", func(t *testing.T) {
+		_, err := ReplaceStrictAny(ctx, toJSONString(`{{= tasks.unknown.outputs.parameters.msg}}`), replaceMap, []string{"tasks", "steps"})
+		require.Error(t, err)
+	})
+}
+
+// TestReplaceStrictAnyNilNestedTag verifies that a nested tag whose value is a present-but-nil
+// absent optional (a skipped step's defaultless output) is a terminal resolution error: the
+// composite outer tag cannot meaningfully resolve from an absent value, and the error must not be
+// classified as a missing-variable error (which would requeue forever). A real empty string nested
+// value still collapses as before.
+func TestReplaceStrictAnyNilNestedTag(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	const input = `{{outer-{{steps.x.outputs.parameters.key}}}}`
+
+	t.Run("AbsentNestedValueErrors", func(t *testing.T) {
+		replaceMap := map[string]any{
+			"steps.x.outputs.parameters.key": nil, // skipped, no producer default
+			"outer-":                         "resolved-outer",
+		}
+		_, err := ReplaceStrictAny(ctx, toJSONString(input), replaceMap, []string{"tasks", "steps"})
+		require.Error(t, err)
+		assert.False(t, IsMissingVariableErr(err), "absent nested value must be terminal, not a requeue")
+	})
+
+	t.Run("EmptyNestedValueStillCollapses", func(t *testing.T) {
+		replaceMap := map[string]any{
+			"steps.x.outputs.parameters.key": "", // produced a real empty string
+			"outer-":                         "resolved-outer",
+		}
+		pass1, err := ReplaceStrictAny(ctx, toJSONString(input), replaceMap, []string{"tasks", "steps"})
+		require.NoError(t, err)
+		assert.Equal(t, toJSONString("{{outer-}}"), pass1)
+
+		pass2, err := ReplaceStrictAny(ctx, pass1, replaceMap, []string{"tasks", "steps"})
+		require.NoError(t, err)
+		assert.Equal(t, toJSONString("resolved-outer"), pass2)
+	})
+}

--- a/util/template/simple_template.go
+++ b/util/template/simple_template.go
@@ -22,6 +22,13 @@ func simpleReplaceStrict(ctx context.Context, w io.Writer, tag string, replaceMa
 			nestedTagPrefix := tag[:index]
 			nestedTag := tag[index+2:]
 			if replNested, replOk := replaceMap[nestedTag]; replOk {
+				if replNested == nil {
+					// A present-but-nil nested value is an absent optional (a skipped node's output
+					// with no default): the composite outer tag cannot meaningfully resolve from an
+					// absent value. Fail terminally — the message must NOT match IsMissingVariableErr,
+					// which would requeue forever.
+					return 0, errors.Errorf(errors.CodeBadRequest, "unable to substitute nested tag {{%s}}: %q is an absent optional", tag, nestedTag)
+				}
 				replStr, isStr := replNested.(string)
 				if isStr {
 					replStr = strconv.Quote(replStr)
@@ -48,6 +55,14 @@ func simpleReplaceStrict(ctx context.Context, w io.Writer, tag string, replaceMa
 		return fmt.Fprintf(w, "{{%s}}", tag)
 	}
 
+	if replacement == nil {
+		// A present-but-nil value is a genuinely absent optional (a skipped/omitted node's output
+		// with no default) that nothing handled: no producer valueFrom.default, no consumer input
+		// default (which would have dropped the argument before substitution), no expression `??`
+		// fallback. Fail terminally — the message must NOT match IsMissingVariableErr, which would
+		// requeue forever.
+		return 0, errors.Errorf(errors.CodeBadRequest, "unable to substitute {{%s}}: output is an absent optional (skipped/omitted node with no default)", tag)
+	}
 	replacementStr, isStr := replacement.(string)
 	if !isStr {
 		return 0, errors.Errorf(errors.CodeBadRequest, "failed to resolve {{%s}} to string", tag)

--- a/util/template/template_test.go
+++ b/util/template/template_test.go
@@ -14,7 +14,7 @@ type SimpleValue struct {
 	Value string `json:"value,omitempty"`
 }
 
-func processTemplate(t *testing.T, tmpl SimpleValue, replaceMap map[string]string) SimpleValue {
+func processTemplate(t *testing.T, tmpl SimpleValue, replaceMap map[string]any) SimpleValue {
 	tmplBytes, err := json.Marshal(tmpl)
 	require.NoError(t, err)
 	ctx := logging.TestContext(t.Context())
@@ -47,7 +47,7 @@ func Test_Template_Replace(t *testing.T) {
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				tmpl := SimpleValue{Value: tc.input}
-				newTmpl := processTemplate(t, tmpl, map[string]string{})
+				newTmpl := processTemplate(t, tmpl, map[string]any{})
 				assert.Equal(t, tc.want, newTmpl.Value)
 			})
 		}
@@ -56,10 +56,10 @@ func Test_Template_Replace(t *testing.T) {
 	t.Run("SimpleWithEscapedCharacters", func(t *testing.T) {
 		testCases := map[string]struct {
 			input, want string
-			replaceMap  map[string]string
+			replaceMap  map[string]any
 		}{
-			"SimpleSingleQuoteAsString": {input: `{{customParam}}`, want: `This is ' John`, replaceMap: map[string]string{"customParam": `This is ' John`}},
-			"SimpleDoubleQuoteAsString": {input: `{{customParam}}`, want: `This is " John`, replaceMap: map[string]string{"customParam": `This is " John`}},
+			"SimpleSingleQuoteAsString": {input: `{{customParam}}`, want: `This is ' John`, replaceMap: map[string]any{"customParam": `This is ' John`}},
+			"SimpleDoubleQuoteAsString": {input: `{{customParam}}`, want: `This is " John`, replaceMap: map[string]any{"customParam": `This is " John`}},
 		}
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
@@ -84,7 +84,7 @@ func Test_Template_Replace(t *testing.T) {
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				tmpl := SimpleValue{Value: tc.input}
-				newTmpl := processTemplate(t, tmpl, map[string]string{})
+				newTmpl := processTemplate(t, tmpl, map[string]any{})
 				assert.Equal(t, tc.want, newTmpl.Value)
 			})
 		}
@@ -96,7 +96,7 @@ func Test_Template_Replace(t *testing.T) {
 		ctx := logging.TestContext(t.Context())
 		// Input must be valid JSON.
 		input := `{"key": "{{outer-{{inner}}}}"}`
-		replaceMap := map[string]string{
+		replaceMap := map[string]any{
 			"inner":        "suffix",
 			"outer-suffix": "final-value",
 		}
@@ -125,7 +125,7 @@ func Test_Template_Replace(t *testing.T) {
 		// Value: "{{A {{B {{C}}}}}}"
 		// JSON: {"key": "..."}
 		input := `{"key": "{{A {{B {{C}}}}}}"}`
-		replaceMap := map[string]string{
+		replaceMap := map[string]any{
 			"C":      "valC",
 			"B valC": "valB",  // The tag becomes "{{B valC}}" -> resolves to "valB"
 			"A valB": "final", // The tag becomes "{{A valB}}" -> resolves to "final"

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -298,6 +298,16 @@ const (
 	ArgoProgressPath = VarRunArgoPath + "/progress"
 
 	ConfigMapName = "workflow-controller-configmap"
+
+	// AbsentOptionalArgumentValue marks an argument whose value was a single pure reference to a
+	// skipped/omitted node's output with no producer valueFrom.default (an absent optional). The
+	// controller's reference resolution writes it (wfScope.markAbsentOptionalArgs) so that textual
+	// substitution succeeds where the raw absent value would be a terminal error; ProcessArgs
+	// interprets it at consumption time — when the consumed template is fully resolved — as
+	// "unsupplied", letting the input's own default apply and failing terminally when there is
+	// none. It is an internal controller contract: user-supplied values are never expected to
+	// collide with it, and a collision merely makes the argument behave as if it were omitted.
+	AbsentOptionalArgumentValue = "__argo-internal.absent-optional-output__"
 )
 
 // AnnotationKeyKillCmd specifies the command to use to kill to container, useful for injected sidecars

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -170,7 +170,18 @@ func ProcessArgs(ctx context.Context, tmpl *wfv1.Template, args wfv1.ArgumentsPr
 
 		// overwrite value from argument (if supplied)
 		argParam := args.GetParameterByName(inParam.Name)
-		overwriteWithArguments(argParam, &inParam)
+		if argParam != nil && argParam.Value != nil && argParam.Value.String() == AbsentOptionalArgumentValue {
+			// The argument was a pure reference to a skipped/omitted node's output with no producer
+			// default (see AbsentOptionalArgumentValue): treat it as unsupplied so the input's own
+			// default (already applied above) or ValueFrom source takes over. With neither, the
+			// absence is unhandled — fail terminally with the real cause; the message must not
+			// match template.IsMissingVariableErr, which would requeue forever.
+			if inParam.Value == nil && inParam.ValueFrom == nil {
+				return nil, errors.Errorf(errors.CodeBadRequest, "inputs.parameters.%s: argument references an absent optional (skipped/omitted node output with no default)", inParam.Name)
+			}
+		} else {
+			overwriteWithArguments(argParam, &inParam)
+		}
 
 		// substitute configmap string and get value from store
 		err := substituteAndGetConfigMapValue(ctx, &inParam, globalParams, namespace, configMapStore)

--- a/workflow/common/util.go
+++ b/workflow/common/util.go
@@ -226,7 +226,7 @@ func SubstituteParams(ctx context.Context, tmpl *wfv1.Template, globalParams, lo
 		return nil, errors.InternalWrapError(err)
 	}
 	// First replace globals & locals, then replace inputs because globals could be referenced in the inputs
-	replaceMap := globalParams.Merge(localParams)
+	replaceMap := template.ToAnyMap(globalParams.Merge(localParams))
 	globalReplacedTmplStr, err := template.Replace(ctx, string(tmplBytes), replaceMap, true)
 	if err != nil {
 		return nil, err

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -11,6 +11,7 @@ import (
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
+	"github.com/argoproj/argo-workflows/v4/util/template"
 )
 
 const (
@@ -362,4 +363,63 @@ func TestOverridableTemplateInputParamsValueFrom(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, newTmpl)
 	assert.Equal(t, newTmpl.Inputs.Parameters[0].Value.String(), overrideConfigMapValue)
+}
+
+// TestProcessArgsAbsentOptional pins the three branches of the AbsentOptionalArgumentValue handling:
+// the sentinel marks an argument that was a pure reference to a skipped/omitted node's output with no
+// producer default, and ProcessArgs must treat it as unsupplied. The terminal "neither" branch must
+// NOT look like a missing-variable error, otherwise the controller would requeue forever.
+func TestProcessArgsAbsentOptional(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	paramName := "in"
+
+	sentinelArgs := wfv1.Inputs{Parameters: []wfv1.Parameter{
+		{Name: paramName, Value: wfv1.AnyStringPtr(AbsentOptionalArgumentValue)},
+	}}
+
+	globalParams := make(map[string]string)
+	localParams := make(map[string]string)
+
+	configMapKey := "config-map-key"
+	configMapValue := "config-map-value"
+	configMapStore := mockConfigMapStore{}
+	configMapStore.getByKey = func(key string) (any, bool, error) {
+		return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{LabelKeyConfigMapType: LabelValueTypeConfigMapParameter}},
+			Data: map[string]string{configMapKey: configMapValue},
+		}, true, nil
+	}
+
+	t.Run("input default applies", func(t *testing.T) {
+		tmpl := wfv1.Template{}
+		tmpl.Inputs.Parameters = []wfv1.Parameter{{Name: paramName, Default: wfv1.AnyStringPtr("fallback")}}
+		newTmpl, err := ProcessArgs(ctx, &tmpl, &sentinelArgs, globalParams, localParams, false, "", configMapStore)
+		require.NoError(t, err)
+		require.NotNil(t, newTmpl)
+		assert.Equal(t, "fallback", newTmpl.Inputs.Parameters[0].Value.String())
+	})
+
+	t.Run("input valueFrom applies", func(t *testing.T) {
+		tmpl := wfv1.Template{}
+		tmpl.Inputs.Parameters = []wfv1.Parameter{{Name: paramName, ValueFrom: &wfv1.ValueFrom{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "config-map-name"},
+				Key:                  configMapKey,
+			},
+		}}}
+		newTmpl, err := ProcessArgs(ctx, &tmpl, &sentinelArgs, globalParams, localParams, false, "", configMapStore)
+		require.NoError(t, err)
+		require.NotNil(t, newTmpl)
+		assert.Equal(t, configMapValue, newTmpl.Inputs.Parameters[0].Value.String())
+	})
+
+	t.Run("no default nor valueFrom fails terminally without requeue", func(t *testing.T) {
+		tmpl := wfv1.Template{}
+		tmpl.Inputs.Parameters = []wfv1.Parameter{{Name: paramName}}
+		_, err := ProcessArgs(ctx, &tmpl, &sentinelArgs, globalParams, localParams, false, "", configMapStore)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absent optional")
+		// Must NOT match IsMissingVariableErr, which would requeue the node forever.
+		assert.False(t, template.IsMissingVariableErr(err))
+	})
 }

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -574,7 +574,7 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 		connectDependencies(nodeName)
 		return
 	}
-	expandedTasks, err := expandTask(ctx, *newTask, woc.globalParams.Merge(scope.getParameters()))
+	expandedTasks, err := expandTask(ctx, *newTask, scope.getParametersAny(woc.globalParams))
 	if err != nil {
 		_, _ = woc.initializeNode(ctx, nodeName, wfv1.NodeTypeSkipped, dagTemplateScope, task, dagCtx.boundaryID, wfv1.NodeError, &wfv1.NodeFlag{}, true, err.Error())
 		connectDependencies(nodeName)
@@ -722,7 +722,7 @@ func (woc *wfOperationCtx) resolveDependencyReferences(ctx context.Context, dagC
 
 	// Perform replacement
 	// Replace woc.volumes
-	err = woc.substituteParamsInVolumes(ctx, scope.getParameters())
+	err = woc.substituteParamsInVolumes(ctx, scope.getParametersAny(nil))
 	if err != nil {
 		return nil, err
 	}
@@ -858,7 +858,7 @@ func (d *dagContext) findLeafTaskNames(ctx context.Context, tasks []wfv1.DAGTask
 // We want to be lazy with expanding. Unfortunately this is not quite possible as the When field might rely on
 // expansion to work with the shouldExecute function. To address this we apply a trick, we try to expand, if we fail, we then
 // check shouldExecute, if shouldExecute returns false, we continue on as normal else error out
-func expandTask(ctx context.Context, task wfv1.DAGTask, globalScope map[string]string) ([]wfv1.DAGTask, error) {
+func expandTask(ctx context.Context, task wfv1.DAGTask, globalScope map[string]any) ([]wfv1.DAGTask, error) {
 	var err error
 	var items []wfv1.Item
 	switch {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -776,14 +776,11 @@ func (woc *wfOperationCtx) resolveDependencyReferences(ctx context.Context, dagC
 		}
 	}
 
-	// Drop arguments that are pure references to a skipped/omitted dependency's output with no
-	// producer default when the consumed template declares its own input default, BEFORE substitution:
-	// the argument becomes unsupplied so the input default applies, while any absent-optional
-	// reference left in place fails substitution with a terminal error. When-false tasks returned
-	// early above and are never processed (they don't execute, and their template may be unresolvable).
-	if err = woc.dropSkippedDefaultedArgs(ctx, dagCtx.tmplCtx, &tempTask, &tempTask.Arguments, scope); err != nil {
-		return nil, err
-	}
+	// Replace arguments that are pure references to a skipped/omitted dependency's output with no
+	// producer default with a sentinel BEFORE substitution; common.ProcessArgs interprets it as
+	// "unsupplied" at consumption time so the consumed template's input default applies (or fails
+	// terminally if it has none). When-false tasks returned early above and never execute.
+	scope.markAbsentOptionalArgs(&tempTask.Arguments)
 
 	taskBytes, err := json.Marshal(tempTask)
 	if err != nil {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -359,6 +359,9 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 			}
 		}
 		woc.buildLocalScope(scope, prefix, taskNode)
+		// Skipped/omitted tasks produced no Outputs; populate their declared output parameters so that
+		// DAG-level output aggregation (parameter refs and ValueFrom.Expression) can resolve them.
+		woc.addSkippedNodeOutputsToScope(ctx, dagCtx.tmplCtx, scope, prefix, taskNode, &task, false)
 		woc.addOutputsToGlobalScope(ctx, taskNode.Outputs)
 	}
 	outputs, err := woc.getTemplateOutputsFromScope(ctx, tmpl, scope)
@@ -702,23 +705,9 @@ func (woc *wfOperationCtx) buildLocalScopeFromTask(ctx context.Context, dagCtx *
 		}
 		woc.buildLocalScope(scope, prefix, ancestorNode)
 
-		// For skipped/omitted ancestors that produced no outputs, populate scope with
-		// empty values for the template's declared output parameters. This prevents
-		// downstream tasks from getting stuck in a requeue loop when they reference
-		// outputs from a dependency that was legitimately skipped.
-		if (ancestorNode.Phase == wfv1.NodeSkipped || ancestorNode.Phase == wfv1.NodeOmitted) && ancestorNode.Outputs == nil {
-			ancestorTask := dagCtx.GetTask(ctx, ancestor)
-			_, tmpl, _, err := dagCtx.tmplCtx.ResolveTemplate(ctx, ancestorTask)
-			if err == nil && tmpl != nil {
-				for _, param := range tmpl.Outputs.Parameters {
-					key := fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name)
-					scope.addSkippedParamToScope(key)
-				}
-				if tmpl.Outputs.Result != nil {
-					scope.addSkippedParamToScope(fmt.Sprintf("%s.outputs.result", prefix))
-				}
-			}
-		}
+		// For skipped/omitted ancestors that produced no outputs, populate scope with their template's
+		// declared output parameters so downstream references resolve instead of requeuing forever.
+		woc.addSkippedNodeOutputsToScope(ctx, dagCtx.tmplCtx, scope, prefix, ancestorNode, dagCtx.GetTask(ctx, ancestor), false)
 	}
 	return scope, nil
 }
@@ -745,7 +734,8 @@ func (woc *wfOperationCtx) resolveDependencyReferences(ctx context.Context, dagC
 	originalHooks := tempTask.Hooks
 	tempTask.Hooks = nil
 
-	mergedParams := woc.globalParams.Merge(scope.getParameters())
+	// nil-preserving view so expression tags can apply `??` fallbacks to skipped/omitted outputs
+	mergedParams := scope.getParametersAny(woc.globalParams)
 
 	// Resolve the "when" clause first to check if this task should execute before resolving the full task.
 	// This avoids unnecessary requeues when a task won't execute but other fields have unresolved references.
@@ -756,7 +746,7 @@ func (woc *wfOperationCtx) resolveDependencyReferences(ctx context.Context, dagC
 			return nil, argoerrors.InternalWrapError(err)
 		}
 		var resolvedWhenStr string
-		resolvedWhenStr, err = template.ReplaceStrict(ctx, string(whenBytes), mergedParams, []string{"tasks", "steps"})
+		resolvedWhenStr, err = template.ReplaceStrictAny(ctx, string(whenBytes), mergedParams, []string{"tasks", "steps"})
 		if err != nil {
 			if template.IsMissingVariableErr(err) {
 				woc.requeue()
@@ -786,6 +776,15 @@ func (woc *wfOperationCtx) resolveDependencyReferences(ctx context.Context, dagC
 		}
 	}
 
+	// Drop arguments that are pure references to a skipped/omitted dependency's output with no
+	// producer default when the consumed template declares its own input default, BEFORE substitution:
+	// the argument becomes unsupplied so the input default applies, while any absent-optional
+	// reference left in place fails substitution with a terminal error. When-false tasks returned
+	// early above and are never processed (they don't execute, and their template may be unresolvable).
+	if err = woc.dropSkippedDefaultedArgs(ctx, dagCtx.tmplCtx, &tempTask, &tempTask.Arguments, scope); err != nil {
+		return nil, err
+	}
+
 	taskBytes, err := json.Marshal(tempTask)
 	if err != nil {
 		return nil, argoerrors.InternalWrapError(err)
@@ -794,7 +793,7 @@ func (woc *wfOperationCtx) resolveDependencyReferences(ctx context.Context, dagC
 	// If they are not resolved, it indicates a missing output (e.g. due to race condition), and we should error out
 	// rather than leaving the tag unresolved (which would result in incorrect workflow execution).
 	// We allow other variables (like {{item}}) to remain unresolved for later expansion.
-	newTaskStr, err := template.ReplaceStrict(ctx, string(taskBytes), mergedParams, []string{"tasks", "steps"})
+	newTaskStr, err := template.ReplaceStrictAny(ctx, string(taskBytes), mergedParams, []string{"tasks", "steps"})
 	if err != nil {
 		if template.IsMissingVariableErr(err) {
 			woc.requeue()

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -4345,10 +4345,10 @@ spec:
 `
 
 // TestDAGSkippedRefDynamicTemplateName verifies that a task whose templateRef is itself templated
-// ("{{item.*}}", resolved only at expansion) fails terminally — not with a requeue — when an
-// argument references a skipped defaultless output: the skipped-arg default handling cannot resolve
-// the consumed template at that point, so the absent optional survives into substitution and is a
-// terminal error (add a producer valueFrom.default or a `??` expression fallback to handle it).
+// ("{{item.*}}", resolved only at expansion) is still rescued by the consumed template's input
+// default when an argument references a skipped defaultless output: the argument is marked with the
+// absent-optional sentinel before substitution and ProcessArgs interprets it at consumption time,
+// when the dynamic templateRef has been resolved.
 func TestDAGSkippedRefDynamicTemplateName(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	cancel, controller := newController(ctx, wfv1.MustUnmarshalWorkflow(dagSkippedRefDynamicTemplateName), wfv1.MustUnmarshalWorkflowTemplate(skippedRefConsumeWorkflowTemplate))
@@ -4361,10 +4361,20 @@ func TestDAGSkippedRefDynamicTemplateName(t *testing.T) {
 	require.NotNil(t, producer)
 	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
 
-	consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
-	require.NotNil(t, consumer)
-	assert.Equal(t, wfv1.NodeError, consumer.Phase, "an unhandled absent optional must fail the task terminally")
-	assert.Contains(t, consumer.Message, "absent optional")
+	var consumer *wfv1.NodeStatus
+	for _, node := range woc.wf.Status.Nodes {
+		assert.NotEqual(t, wfv1.NodeError, node.Phase, "node %q should not error: %s", node.DisplayName, node.Message)
+		if strings.HasPrefix(node.DisplayName, "consumer(") {
+			n := node
+			consumer = &n
+		}
+	}
+	require.NotNil(t, consumer, "consumer should be scheduled even though producer was skipped")
+	require.NotNil(t, consumer.Inputs)
+	in := consumer.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	assert.Equal(t, "FALLBACK", in.Value.String())
 }
 
 // dagSkippedInputDefaultSuppressed mirrors default-demo.yaml: the producer is skipped and its

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -223,7 +223,7 @@ func TestExpandTaskWithParam(t *testing.T) {
 		WithParam: `[1234, "foo\tbar", true, []]`,
 	}
 
-	expanded, err := expandTask(ctx, task, map[string]string{})
+	expanded, err := expandTask(ctx, task, map[string]any{})
 	require.NoError(t, err)
 	require.Len(t, expanded, 4)
 

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -4101,11 +4101,12 @@ status:
       message: when '"false" == "true"' evaluated false
 `
 
-// TestDAGSkippedOutputRef verifies that a DAG task can reference outputs from a skipped
-// dependency without causing a requeue loop.
+// TestDAGSkippedOutputRef verifies that a DAG task referencing the output of a skipped dependency
+// does not cause a requeue loop: the reference is an absent optional (no producer valueFrom.default,
+// no consumer input default, no `??` fallback), so the task fails terminally with a clear message
+// instead of either requeuing forever or silently receiving an empty string.
 // Scenario: stage-a succeeds with output parameters, stage-b is skipped (when evaluates false),
-// stage-c depends on both and references outputs from both. stage-c should still be scheduled
-// even though tasks.stage-b.outputs.parameters.output-message is unresolvable.
+// stage-c depends on both and references outputs from both.
 func TestDAGSkippedOutputRef(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	wf := wfv1.MustUnmarshalWorkflow(dagSkippedOutputRef)
@@ -4115,10 +4116,331 @@ func TestDAGSkippedOutputRef(t *testing.T) {
 
 	woc.operate(ctx)
 
-	// stage-c should be created and pending, not stuck in a requeue loop
+	// stage-c must resolve to a terminal error, not get stuck in a requeue loop
 	nodeC := woc.wf.Status.Nodes.FindByDisplayName("stage-c")
 	require.NotNil(t, nodeC, "stage-c should be created even though stage-b was skipped")
-	assert.Equal(t, wfv1.NodePending, nodeC.Phase)
+	assert.Equal(t, wfv1.NodeError, nodeC.Phase, "an unhandled absent optional must fail the task terminally")
+	assert.Contains(t, nodeC.Message, "absent optional")
+}
+
+var dagSkippedOutputDefault = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-output-default-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: producer
+        template: produce
+        when: "false"
+      - name: consumer
+        template: consume
+        depends: "producer.Succeeded || producer.Skipped"
+        arguments:
+          parameters:
+          - name: in
+            value: "{{tasks.producer.outputs.parameters.msg}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+          default: "default-from-producer"
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+  - name: consume
+    inputs:
+      parameters:
+      - name: in
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.in}}"]
+`
+
+// TestDAGSkippedOutputDefault verifies that when a DAG task is skipped and its template declares
+// an output parameter with a valueFrom.default, a downstream task referencing that output in its
+// INPUT receives the producer's declared default instead of an empty string.
+func TestDAGSkippedOutputDefault(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(dagSkippedOutputDefault)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
+	require.NotNil(t, consumer, "consumer should be scheduled even though producer was skipped")
+	require.NotNil(t, consumer.Inputs)
+	in := consumer.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	assert.Equal(t, "default-from-producer", in.Value.String())
+}
+
+var dagSkippedOutputDefaultAggregate = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-skipped-output-default-aggregate
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: producer
+        template: produce
+        when: "false"
+    outputs:
+      parameters:
+      - name: result
+        valueFrom:
+          parameter: "{{tasks.producer.outputs.parameters.msg}}"
+          default: "default-from-aggregator"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+          default: "default-from-producer"
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+`
+
+// TestDAGSkippedOutputDefaultAggregate verifies the precedence decision: when a skipped producer
+// declares an output valueFrom.default AND the aggregating template's output parameter declares its
+// own valueFrom.default, the producer's default wins (it populates scope as a real value, so the
+// aggregator's skipped-fallback never fires).
+func TestDAGSkippedOutputDefaultAggregate(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(dagSkippedOutputDefaultAggregate)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	dagNode := woc.wf.Status.Nodes.FindByDisplayName("dag-skipped-output-default-aggregate")
+	require.NotNil(t, dagNode)
+	require.NotNil(t, dagNode.Outputs)
+	require.Len(t, dagNode.Outputs.Parameters, 1)
+	assert.Equal(t, "default-from-producer", dagNode.Outputs.Parameters[0].Value.String())
+}
+
+var dagSkippedOutputExprDefaultAggregate = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-skipped-output-expr-default-aggregate
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: producer
+        template: produce
+        when: "false"
+    outputs:
+      parameters:
+      - name: result
+        valueFrom:
+          expression: "tasks.producer.outputs.parameters.msg"
+          default: "default-from-aggregator"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+`
+
+// TestDAGSkippedOutputExprDefaultAggregate verifies that a ValueFrom.Expression referencing a skipped
+// defaultless output WITHOUT handling the absent (nil) optional mirrors the inline {{= ...}} semantics:
+// the expression fails to resolve, and the output parameter's own valueFrom.default applies via the
+// error fallback (instead of silently emitting "").
+func TestDAGSkippedOutputExprDefaultAggregate(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(dagSkippedOutputExprDefaultAggregate)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	dagNode := woc.wf.Status.Nodes.FindByDisplayName("dag-skipped-output-expr-default-aggregate")
+	require.NotNil(t, dagNode)
+	require.NotNil(t, dagNode.Outputs)
+	require.Len(t, dagNode.Outputs.Parameters, 1)
+	assert.Equal(t, "default-from-aggregator", dagNode.Outputs.Parameters[0].Value.String())
+}
+
+var dagSkippedRefDynamicTemplateName = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-skipped-ref-dynamic-template
+  namespace: default
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: producer
+        template: produce
+        when: "false"
+      - name: consumer
+        templateRef:
+          name: "{{item.wftmpl}}"
+          template: "{{item.tmpl}}"
+        withItems:
+        - { wftmpl: "skipped-ref-consume", tmpl: "consume" }
+        depends: "producer.Succeeded || producer.Skipped"
+        arguments:
+          parameters:
+          - name: in
+            value: "{{tasks.producer.outputs.parameters.msg}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+`
+
+// TestDAGSkippedRefDynamicTemplateName verifies that a task whose templateRef is itself templated
+// ("{{item.*}}", resolved only at expansion) fails terminally — not with a requeue — when an
+// argument references a skipped defaultless output: the skipped-arg default handling cannot resolve
+// the consumed template at that point, so the absent optional survives into substitution and is a
+// terminal error (add a producer valueFrom.default or a `??` expression fallback to handle it).
+func TestDAGSkippedRefDynamicTemplateName(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx, wfv1.MustUnmarshalWorkflow(dagSkippedRefDynamicTemplateName), wfv1.MustUnmarshalWorkflowTemplate(skippedRefConsumeWorkflowTemplate))
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wfv1.MustUnmarshalWorkflow(dagSkippedRefDynamicTemplateName), controller)
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
+	require.NotNil(t, consumer)
+	assert.Equal(t, wfv1.NodeError, consumer.Phase, "an unhandled absent optional must fail the task terminally")
+	assert.Contains(t, consumer.Message, "absent optional")
+}
+
+// dagSkippedInputDefaultSuppressed mirrors default-demo.yaml: the producer is skipped and its
+// output parameter declares NO valueFrom.default; the consumer references that output in its input,
+// and the consumer's input declares its own default. This is the case where the skipped-marker "" is
+// written into scope, substituted into the consumer's argument, and then clobbers the input default.
+var dagSkippedInputDefaultSuppressed = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-skipped-input-default-suppressed
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: producer
+        template: produce
+        when: "false"
+      - name: consumer
+        template: consume
+        depends: "producer.Succeeded || producer.Skipped"
+        arguments:
+          parameters:
+          - name: in
+            value: "{{tasks.producer.outputs.parameters.msg}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt   # NOTE: no valueFrom.default here
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+  - name: consume
+    inputs:
+      parameters:
+      - name: in
+        default: "FALLBACK-FROM-INPUT"
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.in}}"]
+`
+
+// TestDAGSkippedInputDefaultUsed verifies that when a producer is skipped and its output declares NO
+// valueFrom.default, a consumer referencing that output in its input falls back to the consumer's OWN
+// input default rather than receiving the empty skipped-marker.
+func TestDAGSkippedInputDefaultUsed(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(dagSkippedInputDefaultSuppressed)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
+	require.NotNil(t, consumer, "consumer should be scheduled even though producer was skipped")
+	require.NotNil(t, consumer.Inputs)
+	in := consumer.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	// The skipped reference must NOT clobber the consumer's own input default.
+	assert.Equal(t, "FALLBACK-FROM-INPUT", in.Value.String(),
+		"a skipped output reference should fall back to the consumer's input default")
 }
 
 var dagWhenExprSkipEval = `
@@ -4187,4 +4509,73 @@ func TestDAGWhenExprSkipEval(t *testing.T) {
 	nodeB := woc.wf.Status.Nodes.FindByDisplayName("B")
 	require.NotNil(t, nodeB)
 	assert.Equal(t, wfv1.NodeSkipped, nodeB.Phase)
+}
+
+var dagSkippedInlineExpressionFallback = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: dag-skipped-inline-expr-fallback-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: producer
+        template: produce
+        when: "false"
+      - name: consumer
+        template: consume
+        depends: "producer.Succeeded || producer.Skipped"
+        arguments:
+          parameters:
+          - name: in
+            value: "{{= tasks.producer.outputs.parameters.msg ?? 'inline-fallback'}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+  - name: consume
+    inputs:
+      parameters:
+      - name: in
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.in}}"]
+`
+
+// TestDAGSkippedInlineExpressionFallback verifies that an inline {{= ... ?? ...}} expression in a
+// task argument sees a skipped/omitted dependency's defaultless output as nil (absent), so the ??
+// fallback applies, instead of the empty-string flattening that previously made ?? a no-op.
+func TestDAGSkippedInlineExpressionFallback(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(dagSkippedInlineExpressionFallback)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
+	require.NotNil(t, consumer, "consumer should be scheduled even though producer was skipped")
+	require.NotNil(t, consumer.Inputs)
+	in := consumer.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	assert.Equal(t, "inline-fallback", in.Value.String())
 }

--- a/workflow/controller/examples_skipped_defaults_test.go
+++ b/workflow/controller/examples_skipped_defaults_test.go
@@ -1,0 +1,87 @@
+package controller
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func operateExample(t *testing.T, file string) *wfOperationCtx {
+	t.Helper()
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	t.Cleanup(cancel)
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	data, err := os.ReadFile(file)
+	require.NoError(t, err)
+	wf := wfv1.MustUnmarshalWorkflow(data)
+	wf, err = wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+	return woc
+}
+
+// TestExamplesSkippedOutputDefaults verifies the example workflows under
+// examples/skipped-output-defaults/ resolve the consumer input as documented.
+func TestExamplesSkippedOutputDefaults(t *testing.T) {
+	cases := []struct {
+		file string
+		want string
+	}{
+		{"../../examples/skipped-output-defaults/producer-output-default.yaml", "hello-from-producer"},
+		{"../../examples/skipped-output-defaults/consumer-input-default.yaml", "fallback-from-input"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			woc := operateExample(t, tc.file)
+
+			producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+			require.NotNil(t, producer)
+			require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+			consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
+			require.NotNil(t, consumer)
+			require.NotNil(t, consumer.Inputs)
+			in := consumer.Inputs.GetParameterByName("in")
+			require.NotNil(t, in)
+			require.NotNil(t, in.Value)
+			assert.Equal(t, tc.want, in.Value.String())
+		})
+	}
+}
+
+// TestExampleExpressionFallback verifies the expression-fallback example: a skipped output with no
+// default resolves to nil so the DAG output's ValueFrom.Expression can fall back via `??`.
+func TestExampleExpressionFallback(t *testing.T) {
+	woc := operateExample(t, "../../examples/skipped-output-defaults/expression-fallback.yaml")
+
+	// The DAG's root node carries the aggregated template outputs.
+	var dag *wfv1.NodeStatus
+	for _, n := range woc.wf.Status.Nodes {
+		if n.Type == wfv1.NodeTypeDAG && n.BoundaryID == "" {
+			node := n
+			dag = &node
+			break
+		}
+	}
+	require.NotNil(t, dag)
+	require.NotNil(t, dag.Outputs)
+	var result *wfv1.Parameter
+	for i := range dag.Outputs.Parameters {
+		if dag.Outputs.Parameters[i].Name == "result" {
+			result = &dag.Outputs.Parameters[i]
+			break
+		}
+	}
+	require.NotNil(t, result)
+	require.NotNil(t, result.Value)
+	assert.Equal(t, "expr-fallback", result.Value.String())
+}

--- a/workflow/controller/exit_handler.go
+++ b/workflow/controller/exit_handler.go
@@ -35,7 +35,7 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 			hookStep := &wfv1.WorkflowStep{Template: exitHook.Template, TemplateRef: exitHook.TemplateRef}
 			resolvedArgs := exitHook.Arguments
 			if !resolvedArgs.IsEmpty() {
-				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, tmplCtx, hookStep, exitHook.Arguments, prefix, outputs, scope)
+				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, exitHook.Arguments, prefix, outputs, scope)
 				if err != nil {
 					return true, nil, err
 				}
@@ -52,7 +52,7 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 	return false, nil, nil
 }
 
-func (woc *wfOperationCtx) resolveExitTmplArgument(ctx context.Context, tmplCtx *templateresolution.TemplateContext, holder wfv1.TemplateReferenceHolder, args wfv1.Arguments, prefix string, outputs *wfv1.Outputs, scope *wfScope) (wfv1.Arguments, error) {
+func (woc *wfOperationCtx) resolveExitTmplArgument(ctx context.Context, args wfv1.Arguments, prefix string, outputs *wfv1.Outputs, scope *wfScope) (wfv1.Arguments, error) {
 	if scope == nil {
 		scope = createScope(nil)
 	}
@@ -70,11 +70,9 @@ func (woc *wfOperationCtx) resolveExitTmplArgument(ctx context.Context, tmplCtx 
 	}
 
 	// Mirror task/step argument handling: a pure reference to a skipped/omitted output with no
-	// producer default is dropped BEFORE substitution when the hook template declares its own input
-	// default, so that default applies; an absent-optional reference left in place fails substitution.
-	if err := woc.dropSkippedDefaultedArgs(ctx, tmplCtx, holder, &args, scope); err != nil {
-		return args, err
-	}
+	// producer default is replaced with a sentinel BEFORE substitution; common.ProcessArgs treats
+	// it as unsupplied so the hook template's own input default applies (or fails terminally).
+	scope.markAbsentOptionalArgs(&args)
 
 	stepBytes, err := json.Marshal(args)
 	if err != nil {

--- a/workflow/controller/exit_handler.go
+++ b/workflow/controller/exit_handler.go
@@ -23,7 +23,8 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 		execute := true
 		var err error
 		if exitHook.Expression != "" {
-			execute, err = argoexpr.EvalBool(exitHook.Expression, env.GetFuncMap(template.EnvMap(woc.globalParams.Merge(scope.getParameters()))))
+			// nil-preserving view so expressions can apply `??` fallbacks to skipped/omitted outputs
+			execute, err = argoexpr.EvalBool(exitHook.Expression, env.GetFuncMap(scope.getParametersAny(woc.globalParams)))
 			if err != nil {
 				return true, nil, err
 			}
@@ -31,14 +32,15 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 		if execute {
 			woc.log.WithField("lifeCycleHook", exitHook).Info(ctx, "Running OnExit handler")
 			onExitNodeName := common.GenerateOnExitNodeName(parentNode.Name)
+			hookStep := &wfv1.WorkflowStep{Template: exitHook.Template, TemplateRef: exitHook.TemplateRef}
 			resolvedArgs := exitHook.Arguments
 			if !resolvedArgs.IsEmpty() {
-				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, exitHook.Arguments, prefix, outputs, scope)
+				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, tmplCtx, hookStep, exitHook.Arguments, prefix, outputs, scope)
 				if err != nil {
 					return true, nil, err
 				}
 			}
-			onExitNode, err := woc.executeTemplate(ctx, onExitNodeName, &wfv1.WorkflowStep{Template: exitHook.Template, TemplateRef: exitHook.TemplateRef}, tmplCtx, resolvedArgs, &executeTemplateOpts{
+			onExitNode, err := woc.executeTemplate(ctx, onExitNodeName, hookStep, tmplCtx, resolvedArgs, &executeTemplateOpts{
 				boundaryID:     boundaryID,
 				onExitTemplate: true,
 				nodeFlag:       &wfv1.NodeFlag{Hooked: true},
@@ -50,7 +52,7 @@ func (woc *wfOperationCtx) runOnExitNode(ctx context.Context, exitHook *wfv1.Lif
 	return false, nil, nil
 }
 
-func (woc *wfOperationCtx) resolveExitTmplArgument(ctx context.Context, args wfv1.Arguments, prefix string, outputs *wfv1.Outputs, scope *wfScope) (wfv1.Arguments, error) {
+func (woc *wfOperationCtx) resolveExitTmplArgument(ctx context.Context, tmplCtx *templateresolution.TemplateContext, holder wfv1.TemplateReferenceHolder, args wfv1.Arguments, prefix string, outputs *wfv1.Outputs, scope *wfScope) (wfv1.Arguments, error) {
 	if scope == nil {
 		scope = createScope(nil)
 	}
@@ -67,11 +69,20 @@ func (woc *wfOperationCtx) resolveExitTmplArgument(ctx context.Context, args wfv
 		}
 	}
 
+	// Mirror task/step argument handling: a pure reference to a skipped/omitted output with no
+	// producer default is dropped BEFORE substitution when the hook template declares its own input
+	// default, so that default applies; an absent-optional reference left in place fails substitution.
+	if err := woc.dropSkippedDefaultedArgs(ctx, tmplCtx, holder, &args, scope); err != nil {
+		return args, err
+	}
+
 	stepBytes, err := json.Marshal(args)
 	if err != nil {
 		return args, err
 	}
-	newStepStr, err := template.Replace(ctx, string(stepBytes), woc.globalParams.Merge(scope.getParameters()), true)
+	// nil-preserving view (and no strict prefixes, preserving the allow-unresolved behavior) so
+	// expression tags can apply `??` fallbacks to skipped/omitted outputs, mirroring task/step args
+	newStepStr, err := template.ReplaceStrictAny(ctx, string(stepBytes), scope.getParametersAny(woc.globalParams), nil)
 	if err != nil {
 		return args, err
 	}

--- a/workflow/controller/hooks.go
+++ b/workflow/controller/hooks.go
@@ -68,7 +68,8 @@ func (woc *wfOperationCtx) executeTmplLifeCycleHook(ctx context.Context, scope *
 		if hook.Expression == "" {
 			return false, errors.Errorf(errors.CodeBadRequest, "Expression required for hook %s", hookNodeName)
 		}
-		execute, err := argoexpr.EvalBool(hook.Expression, env.GetFuncMap(template.EnvMap(woc.globalParams.Merge(scope.getParameters()))))
+		// nil-preserving view so expressions can apply `??` fallbacks to skipped/omitted outputs
+		execute, err := argoexpr.EvalBool(hook.Expression, env.GetFuncMap(scope.getParametersAny(woc.globalParams)))
 		if err != nil {
 			return false, err
 		}
@@ -79,15 +80,16 @@ func (woc *wfOperationCtx) executeTmplLifeCycleHook(ctx context.Context, scope *
 				outputs = lastChildNode.Outputs
 			}
 			woc.log.WithField("lifeCycleHook", hookName).WithField("node", hookNodeName).WithField("hookName", hookName).Info(ctx, "Running hooks")
+			hookStep := &wfv1.WorkflowStep{Template: hook.Template, TemplateRef: hook.TemplateRef}
 			resolvedArgs := hook.Arguments
 			var err error
 			if !resolvedArgs.IsEmpty() && outputs != nil {
-				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, hook.Arguments, prefix, outputs, scope)
+				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, tmplCtx, hookStep, hook.Arguments, prefix, outputs, scope)
 				if err != nil {
 					return false, err
 				}
 			}
-			hookNode, err := woc.executeTemplate(ctx, hookNodeName, &wfv1.WorkflowStep{Template: hook.Template, TemplateRef: hook.TemplateRef}, tmplCtx, resolvedArgs, &executeTemplateOpts{
+			hookNode, err := woc.executeTemplate(ctx, hookNodeName, hookStep, tmplCtx, resolvedArgs, &executeTemplateOpts{
 				boundaryID: boundaryID,
 				nodeFlag:   &wfv1.NodeFlag{Hooked: true},
 			})

--- a/workflow/controller/hooks.go
+++ b/workflow/controller/hooks.go
@@ -84,7 +84,7 @@ func (woc *wfOperationCtx) executeTmplLifeCycleHook(ctx context.Context, scope *
 			resolvedArgs := hook.Arguments
 			var err error
 			if !resolvedArgs.IsEmpty() && outputs != nil {
-				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, tmplCtx, hookStep, hook.Arguments, prefix, outputs, scope)
+				resolvedArgs, err = woc.resolveExitTmplArgument(ctx, hook.Arguments, prefix, outputs, scope)
 				if err != nil {
 					return false, err
 				}

--- a/workflow/controller/hooks_test.go
+++ b/workflow/controller/hooks_test.go
@@ -1258,3 +1258,88 @@ spec:
 	assert.Nil(t, node.NodeFlag)
 	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
 }
+
+var stepsSkippedRefExitHook = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: steps-skipped-ref-exit-hook
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: producer
+        template: produce
+        when: "false"
+    - - name: work
+        template: simple
+        hooks:
+          exit:
+            template: consume
+            arguments:
+              parameters:
+              - name: in
+                value: "{{steps.producer.outputs.parameters.msg}}"
+              - name: in2
+                value: "{{= steps.producer.outputs.parameters.msg ?? 'hook-fallback'}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+  - name: simple
+    container:
+      image: alpine:3.23
+      command: [echo, "hello"]
+  - name: consume
+    inputs:
+      parameters:
+      - name: in
+        default: "FALLBACK"
+      - name: in2
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.in}} {{inputs.parameters.in2}}"]
+`
+
+// TestExitHookSkippedOutputAbsenceSemantics verifies that hook/exit-handler arguments mirror the
+// task/step absence semantics for a skipped node's defaultless output: a pure reference is dropped
+// so the hook template's own input default applies, and an inline `??` expression sees the absent
+// (nil) optional and falls back, instead of both being clobbered with "".
+func TestExitHookSkippedOutputAbsenceSemantics(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(stepsSkippedRefExitHook)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx) // producer skipped, work pod created
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+	woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
+	woc.operate(ctx) // work succeeded -> exit hook fires
+
+	hook := woc.wf.Status.Nodes.FindByDisplayName("work.onExit")
+	require.NotNil(t, hook, "exit hook should run")
+	require.NotNil(t, hook.Inputs)
+
+	in := hook.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	assert.Equal(t, "FALLBACK", in.Value.String(), "hook template's own input default must apply for a skipped defaultless ref")
+
+	in2 := hook.Inputs.GetParameterByName("in2")
+	require.NotNil(t, in2)
+	require.NotNil(t, in2.Value)
+	assert.Equal(t, "hook-fallback", in2.Value.String(), "?? must fire on the absent optional in hook arguments")
+}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"os"
 	"reflect"
@@ -358,7 +359,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		return
 	}
 
-	err = woc.substituteParamsInVolumes(ctx, woc.globalParams)
+	err = woc.substituteParamsInVolumes(ctx, template.ToAnyMap(woc.globalParams))
 	if err != nil {
 		woc.log.WithError(err).Error(ctx, "volumes global param substitution error")
 		woc.markWorkflowError(ctx, err)
@@ -3920,12 +3921,10 @@ func addRawOutputFields(node *wfv1.NodeStatus, tmpl *wfv1.Template) *wfv1.NodeSt
 	return node
 }
 
-func processItem(ctx context.Context, tmpl template.Template, name string, index int, item wfv1.Item, obj any, whenCondition string, globalScope map[string]string) (string, error) {
+func processItem(ctx context.Context, tmpl template.Template, name string, index int, item wfv1.Item, obj any, whenCondition string, globalScope map[string]any) (string, error) {
 	replaceMap := make(map[string]any)
 	// Start with the global scope
-	for k, v := range globalScope {
-		replaceMap[k] = v
-	}
+	maps.Copy(replaceMap, globalScope)
 	var newName string
 
 	switch item.GetType() {
@@ -3973,7 +3972,16 @@ func processItem(ctx context.Context, tmpl template.Template, name string, index
 	// The parameterised when will get handle by the task-expansion
 	proceed, err := shouldExecute(whenCondition)
 	if err == nil && !proceed {
-		newStepStr, err = tmpl.Replace(ctx, replaceMap, true)
+		// The step/task will never execute, so absent optionals (nil scope values for
+		// skipped/omitted outputs) in its body must not fail the group: drop them so their
+		// tags are left unresolved instead of erroring terminally.
+		lenientMap := make(map[string]any, len(replaceMap))
+		for k, v := range replaceMap {
+			if v != nil {
+				lenientMap[k] = v
+			}
+		}
+		newStepStr, err = tmpl.Replace(ctx, lenientMap, true)
 	} else {
 		newStepStr, err = tmpl.Replace(ctx, replaceMap, false)
 	}
@@ -4050,7 +4058,7 @@ func expandSequence(seq *wfv1.Sequence) ([]wfv1.Item, error) {
 	return items, nil
 }
 
-func (woc *wfOperationCtx) substituteParamsInVolumes(ctx context.Context, params map[string]string) error {
+func (woc *wfOperationCtx) substituteParamsInVolumes(ctx context.Context, params map[string]any) error {
 	if woc.volumes == nil {
 		return nil
 	}
@@ -4093,7 +4101,7 @@ func (woc *wfOperationCtx) createTemplateContext(ctx context.Context, scope wfv1
 	}
 }
 
-func (woc *wfOperationCtx) computeMetrics(ctx context.Context, metricList []*wfv1.Prometheus, localScope map[string]string, realTimeScope map[string]func() float64, realTimeOnly bool) {
+func (woc *wfOperationCtx) computeMetrics(ctx context.Context, metricList []*wfv1.Prometheus, localScope map[string]any, realTimeScope map[string]func() float64, realTimeOnly bool) {
 	for _, metricTmpl := range metricList {
 		// Don't process real time metrics after execution
 		if realTimeOnly && !metricTmpl.IsRealtime() {
@@ -4534,7 +4542,7 @@ func (woc *wfOperationCtx) substituteGlobalVariables(ctx context.Context, params
 		return err
 	}
 
-	resolveSpec, err := template.Replace(ctx, string(wfSpec), params, true)
+	resolveSpec, err := template.Replace(ctx, string(wfSpec), template.ToAnyMap(params), true)
 	if err != nil {
 		return err
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3320,6 +3320,12 @@ func (woc *wfOperationCtx) getTemplateOutputsFromScope(ctx context.Context, tmpl
 				// The referenced step was skipped/omitted and produced no output; use the declared default.
 				val = param.ValueFrom.Default.String()
 			}
+			if val == nil {
+				// Skipped/omitted output with no default anywhere — neither the producer's
+				// valueFrom.default nor this aggregating parameter's own — is an unhandled absent
+				// optional: fail terminally, mirroring simple-tag substitution semantics.
+				return nil, argoerrors.Errorf(argoerrors.CodeBadRequest, "output parameter %q: %q is an absent optional (skipped/omitted node output with no default)", param.Name, param.ValueFrom.Parameter)
+			}
 			param.Value = wfv1.AnyStringPtr(val)
 			param.ValueFrom = nil
 			outputs.Parameters = append(outputs.Parameters, param)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7323,7 +7323,7 @@ func Test_processItem(t *testing.T) {
 			wfv1.MustUnmarshal([]byte(tt.withParam), &items)
 
 			var newTask wfv1.DAGTask
-			newTaskName, err := processItem(ctx, tmpl, "task-name", 0, items[0], &newTask, "", map[string]string{})
+			newTaskName, err := processItem(ctx, tmpl, "task-name", 0, items[0], &newTask, "", map[string]any{})
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedName, newTaskName)

--- a/workflow/controller/scope.go
+++ b/workflow/controller/scope.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/expr-lang/expr"
 
@@ -13,20 +14,19 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/expr/env"
 	"github.com/argoproj/argo-workflows/v4/util/template"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
+	"github.com/argoproj/argo-workflows/v4/workflow/templateresolution"
 )
 
 // wfScope contains the current scope of variables available when executing a template
 type wfScope struct {
-	tmpl           *wfv1.Template
-	scope          map[string]any
-	skippedOutputs map[string]bool
+	tmpl  *wfv1.Template
+	scope map[string]any
 }
 
 func createScope(tmpl *wfv1.Template) *wfScope {
 	scope := &wfScope{
-		tmpl:           tmpl,
-		scope:          make(map[string]any),
-		skippedOutputs: make(map[string]bool),
+		tmpl:  tmpl,
+		scope: make(map[string]any),
 	}
 	if tmpl != nil {
 		for _, param := range scope.tmpl.Inputs.Parameters {
@@ -45,9 +45,31 @@ func createScope(tmpl *wfv1.Template) *wfScope {
 func (s *wfScope) getParameters() common.Parameters {
 	params := make(common.Parameters)
 	for key, val := range s.scope {
-		valStr, ok := val.(string)
-		if ok {
-			params[key] = valStr
+		switch v := val.(type) {
+		case string:
+			params[key] = v
+		case nil:
+			// Skipped/omitted optional output: nil for expression consumers, but "" here so plain
+			// string substitution can still resolve the reference and keep the node live.
+			params[key] = ""
+		}
+	}
+	return params
+}
+
+// getParametersAny returns the scope's parameters merged over the given globals, preserving nil
+// (absent optional) values so expression tags can distinguish absent from empty (e.g. via `??`).
+// A simple tag resolving to a nil value is a terminal substitution error; arguments rescued by a
+// consumer input default must be dropped before substitution (see dropSkippedDefaultedArgs).
+func (s *wfScope) getParametersAny(globals common.Parameters) map[string]any {
+	params := make(map[string]any, len(globals)+len(s.scope))
+	for key, val := range globals {
+		params[key] = val
+	}
+	for key, val := range s.scope {
+		switch val.(type) {
+		case string, nil:
+			params[key] = val
 		}
 	}
 	return params
@@ -61,12 +83,127 @@ func (s *wfScope) addArtifactToScope(key string, artifact wfv1.Artifact) {
 	s.scope[key] = artifact
 }
 
-// addSkippedParamToScope registers a parameter key with an empty value to satisfy reference
-// resolution for skipped/omitted steps, and marks it so callers can distinguish it from a
-// legitimately empty output.
+// addSkippedParamToScope registers a parameter key for a skipped/omitted step's output that declared
+// no default. The value is stored as nil (an absent optional) so structured consumers and expressions
+// can tell it apart from a legitimately empty output (e.g. `ref ?? "fallback"`). A simple tag
+// resolving to the nil is a terminal substitution error unless the referencing argument was dropped
+// in favor of a consumer input default (dropSkippedDefaultedArgs); getParameters still flattens it
+// to "" for the legacy string-map paths (volumes, item expansion). nil is stored ONLY by this
+// method, so a present-but-nil scope value is the definition of "skipped with no default".
 func (s *wfScope) addSkippedParamToScope(key string) {
-	s.scope[key] = ""
-	s.skippedOutputs[key] = true
+	s.scope[key] = nil
+}
+
+// absentOptionalRef reports whether an argument value is a single pure reference (e.g.
+// "{{tasks.x.outputs.parameters.y}}") to a key holding an absent optional, i.e. a skipped/omitted
+// node output that declared no producer default. A brace-less literal that merely spells out a
+// scope key is data, not a reference, and composite values like "x-{{key}}-y" or nested tags are
+// not pure references. nil is only ever written by addSkippedParamToScope, so a present-but-nil
+// value identifies the skipped placeholder.
+func (s *wfScope) absentOptionalRef(v string) bool {
+	if !strings.HasPrefix(v, "{{") || !strings.HasSuffix(v, "}}") {
+		return false
+	}
+	key := strings.TrimSpace(v[2 : len(v)-2])
+	if strings.Contains(key, "{{") || strings.Contains(key, "}}") {
+		return false
+	}
+	val, ok := s.scope[key]
+	return ok && val == nil
+}
+
+// dropSkippedDefaultedArgs removes arguments that are pure references to a skipped/omitted node's
+// output with no producer default (an absent optional, nil in scope) WHEN the consumed template
+// declares its own input default for that parameter. It must run BEFORE substitution: dropping the
+// argument makes it indistinguishable from an unsupplied one, so the consumer's input default
+// applies through the normal path, while any absent-optional reference left in place fails
+// substitution with a terminal error.
+func (woc *wfOperationCtx) dropSkippedDefaultedArgs(ctx context.Context, tmplCtx *templateresolution.TemplateContext, holder wfv1.TemplateReferenceHolder, args *wfv1.Arguments, scope *wfScope) error {
+	candidates := make(map[string]bool)
+	for _, p := range args.Parameters {
+		if p.Value != nil && scope.absentOptionalRef(p.Value.String()) {
+			candidates[p.Name] = true
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	// Resolve the consumed template once to learn which of those inputs have their own default. The
+	// template may not be resolvable at this point (e.g. a "{{item.*}}" templateRef that only resolves
+	// at expansion); this handling is best-effort sugar, so skip it rather than failing here — the
+	// surviving reference will fail substitution with a terminal absent-optional error.
+	_, tmpl, _, err := tmplCtx.ResolveTemplate(ctx, holder)
+	if err != nil || tmpl == nil {
+		woc.log.WithError(err).WithField("template", holder.GetTemplateName()).
+			Debug(ctx, "could not resolve consumed template; skipping skipped-arg default handling")
+		return nil
+	}
+	if err := woc.mergedTemplateDefaultsInto(tmpl); err != nil {
+		return err
+	}
+	// Build a fresh slice: args may alias a step/task still shared with the caller.
+	kept := make([]wfv1.Parameter, 0, len(args.Parameters))
+	for _, p := range args.Parameters {
+		if candidates[p.Name] {
+			if in := tmpl.Inputs.GetParameterByName(p.Name); in != nil && in.Default != nil {
+				continue // drop: the argument becomes unsupplied, the consumer's own input default applies
+			}
+		}
+		kept = append(kept, p)
+	}
+	args.Parameters = kept
+	return nil
+}
+
+// addSkippedNodeOutputsToScope populates scope with the declared output parameters of a skipped or
+// omitted node that produced no outputs, so downstream references — task/step inputs, when-clauses, and
+// DAG/steps output aggregation (including ValueFrom.Expression) — resolve to the producer's declared
+// default or to an absent (nil) optional instead of requeuing forever; an unhandled absent optional
+// fails terminally rather than leaving the workflow stuck. No-op for any node
+// that actually produced outputs. includeArtifacts additionally registers empty placeholders for the
+// template's declared output artifacts: steps relies on this to keep artifact references resolvable,
+// while DAG deliberately leaves them unresolved (resolveDependencyReferences omits optional artifacts
+// and errors on required ones).
+func (woc *wfOperationCtx) addSkippedNodeOutputsToScope(ctx context.Context, tmplCtx *templateresolution.TemplateContext, scope *wfScope, prefix string, node *wfv1.NodeStatus, tmplHolder wfv1.TemplateReferenceHolder, includeArtifacts bool) {
+	if node == nil || node.Outputs != nil {
+		return
+	}
+	if node.Phase != wfv1.NodeSkipped && node.Phase != wfv1.NodeOmitted {
+		return
+	}
+	_, tmpl, _, err := tmplCtx.ResolveTemplate(ctx, tmplHolder)
+	if err != nil {
+		woc.log.WithError(err).Debug(ctx, "failed to resolve template for skipped node, outputs will not be populated in scope")
+		return
+	}
+	if tmpl == nil {
+		return
+	}
+	for _, param := range tmpl.Outputs.Parameters {
+		key := fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name)
+		scope.addSkippedOutputParamToScope(key, param.ValueFrom)
+	}
+	if includeArtifacts {
+		for _, artifact := range tmpl.Outputs.Artifacts {
+			key := fmt.Sprintf("%s.outputs.artifacts.%s", prefix, artifact.Name)
+			scope.addArtifactToScope(key, wfv1.Artifact{})
+		}
+	}
+	if tmpl.Outputs.Result != nil {
+		scope.addSkippedParamToScope(fmt.Sprintf("%s.outputs.result", prefix))
+	}
+}
+
+// addSkippedOutputParamToScope registers an output parameter of a skipped/omitted node. If the
+// producing template declared a valueFrom.default for the parameter, that default is used as the
+// scope value so every consumer (task inputs and template-output aggregation alike) sees it.
+// Otherwise it falls back to addSkippedParamToScope's nil (absent optional) behavior.
+func (s *wfScope) addSkippedOutputParamToScope(key string, valueFrom *wfv1.ValueFrom) {
+	if valueFrom != nil && valueFrom.Default != nil {
+		s.addParamToScope(key, valueFrom.Default.String())
+		return
+	}
+	s.addSkippedParamToScope(key)
 }
 
 // resolveVar resolves a parameter or artifact and additionally returns the unwrapped tag
@@ -95,10 +232,20 @@ func (s *wfScope) resolveParameter(p *wfv1.ValueFrom) (any, bool, error) {
 			return nil, false, err
 		}
 		val, err := expr.Run(program, env)
-		return val, false, err
+		if err != nil {
+			return nil, false, err
+		}
+		if val == nil {
+			// A nil result is an unhandled absent optional (e.g. a skipped node's defaultless output
+			// referenced without `??`). Mirror the inline {{= ...}} semantics and treat it as a
+			// resolution failure; the caller's error path applies valueFrom.default when declared.
+			return nil, false, errors.Errorf(errors.CodeBadRequest, "failed to evaluate expression %q", p.Expression)
+		}
+		return val, false, nil
 	}
-	tag, val, err := s.resolveVar(p.Parameter)
-	return val, s.skippedOutputs[tag], err
+	_, val, err := s.resolveVar(p.Parameter)
+	// nil is only ever stored by addSkippedParamToScope, so it identifies a skipped placeholder.
+	return val, err == nil && val == nil, err
 }
 
 func (s *wfScope) resolveArtifact(ctx context.Context, art *wfv1.Artifact) (*wfv1.Artifact, error) {

--- a/workflow/controller/scope.go
+++ b/workflow/controller/scope.go
@@ -44,7 +44,7 @@ func createScope(tmpl *wfv1.Template) *wfScope {
 // getParametersAny returns the scope's parameters merged over the given globals, preserving nil
 // (absent optional) values so expression tags can distinguish absent from empty (e.g. via `??`).
 // A simple tag resolving to a nil value is a terminal substitution error; arguments rescued by a
-// consumer input default must be dropped before substitution (see dropSkippedDefaultedArgs).
+// consumer input default are replaced with a sentinel before substitution (see markAbsentOptionalArgs).
 func (s *wfScope) getParametersAny(globals common.Parameters) map[string]any {
 	params := make(map[string]any, len(globals)+len(s.scope))
 	for key, val := range globals {
@@ -70,8 +70,8 @@ func (s *wfScope) addArtifactToScope(key string, artifact wfv1.Artifact) {
 // addSkippedParamToScope registers a parameter key for a skipped/omitted step's output that declared
 // no default. The value is stored as nil (an absent optional) so structured consumers and expressions
 // can tell it apart from a legitimately empty output (e.g. `ref ?? "fallback"`). A simple tag
-// resolving to the nil is a terminal substitution error unless the referencing argument was dropped
-// in favor of a consumer input default (dropSkippedDefaultedArgs); this applies uniformly to every
+// resolving to the nil is a terminal substitution error unless the referencing argument was replaced
+// with a sentinel for ProcessArgs to interpret (markAbsentOptionalArgs); this applies uniformly to every
 // substitution surface (arguments, when clauses, volumes, artifact subPath, item expansion). nil is
 // stored ONLY by this method, so a present-but-nil scope value is the definition of "skipped with
 // no default".
@@ -97,47 +97,29 @@ func (s *wfScope) absentOptionalRef(v string) bool {
 	return ok && val == nil
 }
 
-// dropSkippedDefaultedArgs removes arguments that are pure references to a skipped/omitted node's
-// output with no producer default (an absent optional, nil in scope) WHEN the consumed template
-// declares its own input default for that parameter. It must run BEFORE substitution: dropping the
-// argument makes it indistinguishable from an unsupplied one, so the consumer's input default
-// applies through the normal path, while any absent-optional reference left in place fails
-// substitution with a terminal error.
-func (woc *wfOperationCtx) dropSkippedDefaultedArgs(ctx context.Context, tmplCtx *templateresolution.TemplateContext, holder wfv1.TemplateReferenceHolder, args *wfv1.Arguments, scope *wfScope) error {
-	candidates := make(map[string]bool)
-	for _, p := range args.Parameters {
-		if p.Value != nil && scope.absentOptionalRef(p.Value.String()) {
-			candidates[p.Name] = true
-		}
-	}
-	if len(candidates) == 0 {
-		return nil
-	}
-	// Resolve the consumed template once to learn which of those inputs have their own default. The
-	// template may not be resolvable at this point (e.g. a "{{item.*}}" templateRef that only resolves
-	// at expansion); this handling is best-effort sugar, so skip it rather than failing here — the
-	// surviving reference will fail substitution with a terminal absent-optional error.
-	_, tmpl, _, err := tmplCtx.ResolveTemplate(ctx, holder)
-	if err != nil || tmpl == nil {
-		woc.log.WithError(err).WithField("template", holder.GetTemplateName()).
-			Debug(ctx, "could not resolve consumed template; skipping skipped-arg default handling")
-		return nil
-	}
-	if err := woc.mergedTemplateDefaultsInto(tmpl); err != nil {
-		return err
-	}
-	// Build a fresh slice: args may alias a step/task still shared with the caller.
-	kept := make([]wfv1.Parameter, 0, len(args.Parameters))
-	for _, p := range args.Parameters {
-		if candidates[p.Name] {
-			if in := tmpl.Inputs.GetParameterByName(p.Name); in != nil && in.Default != nil {
-				continue // drop: the argument becomes unsupplied, the consumer's own input default applies
+// markAbsentOptionalArgs replaces arguments that are pure references to a skipped/omitted node's
+// output with no producer default (an absent optional, nil in scope) with the
+// common.AbsentOptionalArgumentValue sentinel, BEFORE substitution. The sentinel survives textual
+// substitution — where the raw absent value would be a terminal error — and is interpreted by
+// common.ProcessArgs at consumption time, when the consumed template is fully resolved (even for
+// dynamic "{{item.*}}" templateRefs): the argument is treated as unsupplied so the input's own
+// default applies, and an input with no default fails terminally. Composite values like
+// "x-{{ref}}-y" are not pure references and still fail substitution. Builds a fresh Parameters
+// slice: args may alias a step/task still shared with the caller.
+func (s *wfScope) markAbsentOptionalArgs(args *wfv1.Arguments) {
+	var marked []wfv1.Parameter
+	for i, p := range args.Parameters {
+		if p.Value != nil && s.absentOptionalRef(p.Value.String()) {
+			if marked == nil {
+				marked = make([]wfv1.Parameter, len(args.Parameters))
+				copy(marked, args.Parameters)
 			}
+			marked[i].Value = wfv1.AnyStringPtr(common.AbsentOptionalArgumentValue)
 		}
-		kept = append(kept, p)
 	}
-	args.Parameters = kept
-	return nil
+	if marked != nil {
+		args.Parameters = marked
+	}
 }
 
 // addSkippedNodeOutputsToScope populates scope with the declared output parameters of a skipped or

--- a/workflow/controller/scope.go
+++ b/workflow/controller/scope.go
@@ -41,22 +41,6 @@ func createScope(tmpl *wfv1.Template) *wfScope {
 	return scope
 }
 
-// getParameters returns a map of strings intended to be used simple string substitution
-func (s *wfScope) getParameters() common.Parameters {
-	params := make(common.Parameters)
-	for key, val := range s.scope {
-		switch v := val.(type) {
-		case string:
-			params[key] = v
-		case nil:
-			// Skipped/omitted optional output: nil for expression consumers, but "" here so plain
-			// string substitution can still resolve the reference and keep the node live.
-			params[key] = ""
-		}
-	}
-	return params
-}
-
 // getParametersAny returns the scope's parameters merged over the given globals, preserving nil
 // (absent optional) values so expression tags can distinguish absent from empty (e.g. via `??`).
 // A simple tag resolving to a nil value is a terminal substitution error; arguments rescued by a
@@ -87,9 +71,10 @@ func (s *wfScope) addArtifactToScope(key string, artifact wfv1.Artifact) {
 // no default. The value is stored as nil (an absent optional) so structured consumers and expressions
 // can tell it apart from a legitimately empty output (e.g. `ref ?? "fallback"`). A simple tag
 // resolving to the nil is a terminal substitution error unless the referencing argument was dropped
-// in favor of a consumer input default (dropSkippedDefaultedArgs); getParameters still flattens it
-// to "" for the legacy string-map paths (volumes, item expansion). nil is stored ONLY by this
-// method, so a present-but-nil scope value is the definition of "skipped with no default".
+// in favor of a consumer input default (dropSkippedDefaultedArgs); this applies uniformly to every
+// substitution surface (arguments, when clauses, volumes, artifact subPath, item expansion). nil is
+// stored ONLY by this method, so a present-but-nil scope value is the definition of "skipped with
+// no default".
 func (s *wfScope) addSkippedParamToScope(key string) {
 	s.scope[key] = nil
 }
@@ -292,7 +277,7 @@ func (s *wfScope) resolveArtifact(ctx context.Context, art *wfv1.Artifact) (*wfv
 			return copyArt, errors.New(errors.CodeBadRequest, "failed to marshal artifact subpath for templating")
 		}
 
-		resolvedSubPathAsJSON, err := template.Replace(ctx, string(subPathAsJSON), s.getParameters(), true)
+		resolvedSubPathAsJSON, err := template.Replace(ctx, string(subPathAsJSON), s.getParametersAny(nil), true)
 		if err != nil {
 			return nil, err
 		}

--- a/workflow/controller/scope_test.go
+++ b/workflow/controller/scope_test.go
@@ -340,7 +340,7 @@ func TestSkippedOptionalExpressionResolution(t *testing.T) {
 // TestAbsentOptionalRefRequiresTag verifies that absentOptionalRef only matches a real pure
 // "{{...}}" reference: a literal argument value that merely spells out a scope key is data, not a
 // reference, and must not be treated as a skipped-output ref (which would get the argument silently
-// dropped); composite and nested values are not pure references either.
+// replaced with the absent-optional sentinel); composite and nested values are not pure references either.
 func TestAbsentOptionalRefRequiresTag(t *testing.T) {
 	const ref = "tasks.producer.outputs.parameters.msg"
 	scope := createScope(nil)

--- a/workflow/controller/scope_test.go
+++ b/workflow/controller/scope_test.go
@@ -305,3 +305,53 @@ func TestResolveParameters(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("5", result)
 }
+
+// TestSkippedOptionalExpressionResolution verifies the *string/nil-for-optional model: a skipped
+// output (no producer default) is stored as nil, so a ValueFrom.Expression can fall back via `??`,
+// while a legitimately empty output ("") is NOT treated as absent.
+func TestSkippedOptionalExpressionResolution(t *testing.T) {
+	const ref = "tasks.producer.outputs.parameters.msg"
+	const expr = "tasks.producer.outputs.parameters.msg ?? 'fallback-from-expr'"
+
+	t.Run("skipped resolves to fallback", func(t *testing.T) {
+		scope := createScope(nil)
+		scope.addSkippedParamToScope(ref) // skipped, no producer default -> nil
+		val, _, err := scope.resolveParameter(&wfv1.ValueFrom{Expression: expr})
+		require.NoError(t, err)
+		assert.Equal(t, "fallback-from-expr", val)
+	})
+
+	t.Run("real empty value is preserved", func(t *testing.T) {
+		scope := createScope(nil)
+		scope.addParamToScope(ref, "") // produced an empty string -> NOT absent
+		val, _, err := scope.resolveParameter(&wfv1.ValueFrom{Expression: expr})
+		require.NoError(t, err)
+		assert.Empty(t, val)
+	})
+
+	t.Run("unhandled nil errors like inline expressions", func(t *testing.T) {
+		scope := createScope(nil)
+		scope.addSkippedParamToScope(ref) // skipped, no producer default -> nil
+		_, _, err := scope.resolveParameter(&wfv1.ValueFrom{Expression: ref})
+		require.ErrorContains(t, err, "failed to evaluate expression")
+	})
+}
+
+// TestAbsentOptionalRefRequiresTag verifies that absentOptionalRef only matches a real pure
+// "{{...}}" reference: a literal argument value that merely spells out a scope key is data, not a
+// reference, and must not be treated as a skipped-output ref (which would get the argument silently
+// dropped); composite and nested values are not pure references either.
+func TestAbsentOptionalRefRequiresTag(t *testing.T) {
+	const ref = "tasks.producer.outputs.parameters.msg"
+	scope := createScope(nil)
+	scope.addSkippedParamToScope(ref)
+	scope.addParamToScope("tasks.real.outputs.parameters.msg", "value")
+
+	assert.True(t, scope.absentOptionalRef("{{"+ref+"}}"), "a pure tag referencing the skipped output should match")
+	assert.True(t, scope.absentOptionalRef("{{ "+ref+" }}"), "inner whitespace is trimmed like simple-tag resolution")
+	assert.False(t, scope.absentOptionalRef(ref), "a brace-less literal equal to a scope key is data, not a reference")
+	assert.False(t, scope.absentOptionalRef("x-{{"+ref+"}}-y"), "composite values are not pure references")
+	assert.False(t, scope.absentOptionalRef("{{outer-{{"+ref+"}}}}"), "nested tags are not pure references")
+	assert.False(t, scope.absentOptionalRef("{{tasks.real.outputs.parameters.msg}}"), "a reference to a produced value is not absent")
+	assert.False(t, scope.absentOptionalRef("{{tasks.unknown.outputs.parameters.msg}}"), "an unknown key is unresolved, not absent")
+}

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -246,7 +246,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 
 	// First, resolve any references to outputs from previous steps, and perform substitution
 	var resolveErr error
-	stepGroup, resolveErr = woc.resolveReferences(ctx, stepsCtx.tmplCtx, stepGroup, stepsCtx.scope)
+	stepGroup, resolveErr = woc.resolveReferences(ctx, stepGroup, stepsCtx.scope)
 	if resolveErr != nil {
 		if errors.Is(resolveErr, ErrRequeue) {
 			return node, nil
@@ -436,27 +436,13 @@ func errorFromChannel(errCh <-chan error) error {
 // 3) dereferencing output.exitCode from previous steps
 // 4) dereferencing artifacts from previous steps
 // 5) dereferencing artifacts from inputs
-func (woc *wfOperationCtx) resolveReferences(ctx context.Context, tmplCtx *templateresolution.TemplateContext, stepGroup []wfv1.WorkflowStep, scope *wfScope) ([]wfv1.WorkflowStep, error) {
+func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wfv1.WorkflowStep, scope *wfScope) ([]wfv1.WorkflowStep, error) {
 	newStepGroup := make([]wfv1.WorkflowStep, len(stepGroup))
 
 	// Step 0: replace all parameter scope references for volumes
 	substErr := woc.substituteParamsInVolumes(ctx, scope.getParametersAny(nil))
 	if substErr != nil {
 		return nil, substErr
-	}
-
-	// Sequential pre-pass (ResolveTemplate is not safe to call concurrently): drop arguments that
-	// are pure references to a skipped/omitted step's output with no producer default when the
-	// consumed template declares its own input default, BEFORE substitution — the argument becomes
-	// unsupplied so the input default applies, while any absent-optional reference left in place
-	// fails substitution with a terminal error. Operates on shallow copies; dropping allocates a
-	// fresh Parameters slice, so the caller's step group is never mutated.
-	steps := make([]wfv1.WorkflowStep, len(stepGroup))
-	copy(steps, stepGroup)
-	for i := range steps {
-		if err := woc.dropSkippedDefaultedArgs(ctx, tmplCtx, &steps[i], &steps[i].Arguments, scope); err != nil {
-			return nil, err
-		}
 	}
 
 	// Resolve a Step's References and add it to newStepGroup
@@ -506,6 +492,13 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, tmplCtx *templ
 			}
 		}
 
+		// Replace arguments that are pure references to a skipped/omitted step's output with no
+		// producer default with a sentinel BEFORE substitution; common.ProcessArgs interprets it as
+		// "unsupplied" at consumption time so the consumed template's input default applies (or
+		// fails terminally if it has none). When-false steps returned early above and never
+		// execute. Allocates a fresh Parameters slice, so the caller's step group is never mutated.
+		scope.markAbsentOptionalArgs(&step.Arguments)
+
 		stepBytes, err := json.Marshal(step)
 		if err != nil {
 			return argoerrors.InternalWrapError(err)
@@ -552,9 +545,9 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, tmplCtx *templ
 
 	// When resolveStepReferences we can use a channel parallelStepNum to control the number of concurrencies
 	parallelStepNum := make(chan string, 500)
-	errCh := make(chan error, len(steps)) // contains the error during resolveStepReferences
+	errCh := make(chan error, len(stepGroup)) // contains the error during resolveStepReferences
 	var wg sync.WaitGroup
-	for i, step := range steps {
+	for i, step := range stepGroup {
 		parallelStepNum <- step.Name
 		wg.Go(func() {
 			if refErr := resolveStepReferences(i, step, newStepGroup); refErr != nil {

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -163,28 +163,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 				woc.buildLocalScope(stepsCtx.scope, prefix, sgNode)
 			} else {
 				woc.buildLocalScope(stepsCtx.scope, prefix, childNode)
-
-				if (childNode.Phase == wfv1.NodeSkipped || childNode.Phase == wfv1.NodeOmitted) && childNode.Outputs == nil {
-					_, stepTmpl, _, resolveErr := stepsCtx.tmplCtx.ResolveTemplate(ctx, &step)
-
-					if resolveErr != nil {
-						woc.log.WithError(resolveErr).Debug(ctx, "failed to resolve template for skipped step, outputs will not be populated in scope")
-					}
-
-					if resolveErr == nil && stepTmpl != nil {
-						for _, param := range stepTmpl.Outputs.Parameters {
-							key := fmt.Sprintf("%s.outputs.parameters.%s", prefix, param.Name)
-							stepsCtx.scope.addSkippedParamToScope(key)
-						}
-						for _, artifact := range stepTmpl.Outputs.Artifacts {
-							key := fmt.Sprintf("%s.outputs.artifacts.%s", prefix, artifact.Name)
-							stepsCtx.scope.addArtifactToScope(key, wfv1.Artifact{})
-						}
-						if stepTmpl.Outputs.Result != nil {
-							stepsCtx.scope.addSkippedParamToScope(fmt.Sprintf("%s.outputs.result", prefix))
-						}
-					}
-				}
+				woc.addSkippedNodeOutputsToScope(ctx, stepsCtx.tmplCtx, stepsCtx.scope, prefix, childNode, &step, true)
 			}
 		}
 	}
@@ -267,7 +246,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 
 	// First, resolve any references to outputs from previous steps, and perform substitution
 	var resolveErr error
-	stepGroup, resolveErr = woc.resolveReferences(ctx, stepGroup, stepsCtx.scope)
+	stepGroup, resolveErr = woc.resolveReferences(ctx, stepsCtx.tmplCtx, stepGroup, stepsCtx.scope)
 	if resolveErr != nil {
 		if errors.Is(resolveErr, ErrRequeue) {
 			return node, nil
@@ -457,13 +436,27 @@ func errorFromChannel(errCh <-chan error) error {
 // 3) dereferencing output.exitCode from previous steps
 // 4) dereferencing artifacts from previous steps
 // 5) dereferencing artifacts from inputs
-func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wfv1.WorkflowStep, scope *wfScope) ([]wfv1.WorkflowStep, error) {
+func (woc *wfOperationCtx) resolveReferences(ctx context.Context, tmplCtx *templateresolution.TemplateContext, stepGroup []wfv1.WorkflowStep, scope *wfScope) ([]wfv1.WorkflowStep, error) {
 	newStepGroup := make([]wfv1.WorkflowStep, len(stepGroup))
 
 	// Step 0: replace all parameter scope references for volumes
 	substErr := woc.substituteParamsInVolumes(ctx, scope.getParameters())
 	if substErr != nil {
 		return nil, substErr
+	}
+
+	// Sequential pre-pass (ResolveTemplate is not safe to call concurrently): drop arguments that
+	// are pure references to a skipped/omitted step's output with no producer default when the
+	// consumed template declares its own input default, BEFORE substitution — the argument becomes
+	// unsupplied so the input default applies, while any absent-optional reference left in place
+	// fails substitution with a terminal error. Operates on shallow copies; dropping allocates a
+	// fresh Parameters slice, so the caller's step group is never mutated.
+	steps := make([]wfv1.WorkflowStep, len(stepGroup))
+	copy(steps, stepGroup)
+	for i := range steps {
+		if err := woc.dropSkippedDefaultedArgs(ctx, tmplCtx, &steps[i], &steps[i].Arguments, scope); err != nil {
+			return nil, err
+		}
 	}
 
 	// Resolve a Step's References and add it to newStepGroup
@@ -473,7 +466,8 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 		originalHooks := step.Hooks
 		step.Hooks = nil
 
-		mergedParams := woc.globalParams.Merge(scope.getParameters())
+		// nil-preserving view so expression tags can apply `??` fallbacks to skipped/omitted outputs
+		mergedParams := scope.getParametersAny(woc.globalParams)
 
 		// Resolve the "when" clause first to check if this step should execute before resolving the full step.
 		// This avoids unnecessary requeues when a step won't execute but other fields have unresolved references.
@@ -482,7 +476,7 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 			if err != nil {
 				return argoerrors.InternalWrapError(err)
 			}
-			resolvedWhenStr, err := template.ReplaceStrict(ctx, string(whenBytes), mergedParams, []string{"steps", "tasks"})
+			resolvedWhenStr, err := template.ReplaceStrictAny(ctx, string(whenBytes), mergedParams, []string{"steps", "tasks"})
 			if err != nil {
 				if template.IsMissingVariableErr(err) {
 					woc.requeue()
@@ -516,7 +510,7 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 		if err != nil {
 			return argoerrors.InternalWrapError(err)
 		}
-		newStepStr, err := template.ReplaceStrict(ctx, string(stepBytes), mergedParams, []string{"steps", "tasks"})
+		newStepStr, err := template.ReplaceStrictAny(ctx, string(stepBytes), mergedParams, []string{"steps", "tasks"})
 		if err != nil {
 			if template.IsMissingVariableErr(err) {
 				woc.requeue()
@@ -558,9 +552,9 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 
 	// When resolveStepReferences we can use a channel parallelStepNum to control the number of concurrencies
 	parallelStepNum := make(chan string, 500)
-	errCh := make(chan error, len(stepGroup)) // contains the error during resolveStepReferences
+	errCh := make(chan error, len(steps)) // contains the error during resolveStepReferences
 	var wg sync.WaitGroup
-	for i, step := range stepGroup {
+	for i, step := range steps {
 		parallelStepNum <- step.Name
 		wg.Go(func() {
 			if refErr := resolveStepReferences(i, step, newStepGroup); refErr != nil {

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -440,7 +440,7 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, tmplCtx *templ
 	newStepGroup := make([]wfv1.WorkflowStep, len(stepGroup))
 
 	// Step 0: replace all parameter scope references for volumes
-	substErr := woc.substituteParamsInVolumes(ctx, scope.getParameters())
+	substErr := woc.substituteParamsInVolumes(ctx, scope.getParametersAny(nil))
 	if substErr != nil {
 		return nil, substErr
 	}
@@ -652,7 +652,7 @@ func (woc *wfOperationCtx) expandStep(ctx context.Context, step wfv1.WorkflowSte
 
 	for i, item := range items {
 		var newStep wfv1.WorkflowStep
-		newStepName, err := processItem(ctx, t, step.Name, i, item, &newStep, step.When, woc.globalParams.Merge(scope.getParameters()))
+		newStepName, err := processItem(ctx, t, step.Name, i, item, &newStep, step.When, scope.getParametersAny(woc.globalParams))
 		if err != nil {
 			return nil, err
 		}
@@ -663,11 +663,11 @@ func (woc *wfOperationCtx) expandStep(ctx context.Context, step wfv1.WorkflowSte
 	return expandedStep, nil
 }
 
-func (woc *wfOperationCtx) prepareDefaultMetricScope() (map[string]string, map[string]func() float64) {
+func (woc *wfOperationCtx) prepareDefaultMetricScope() (map[string]any, map[string]func() float64) {
 	durationCPU := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceCPU)
 	durationMem := fmt.Sprintf("%s.%s", common.LocalVarResourcesDuration, v1.ResourceMemory)
 
-	localScope := woc.globalParams.DeepCopy()
+	localScope := template.ToAnyMap(woc.globalParams)
 	localScope[common.LocalVarDuration] = "0"
 	localScope[common.LocalVarStatus] = string(wfv1.NodePending)
 	localScope[durationCPU] = "0"
@@ -680,7 +680,7 @@ func (woc *wfOperationCtx) prepareDefaultMetricScope() (map[string]string, map[s
 	return localScope, realTimeScope
 }
 
-func (woc *wfOperationCtx) prepareMetricScope(node *wfv1.NodeStatus) (map[string]string, map[string]func() float64) {
+func (woc *wfOperationCtx) prepareMetricScope(node *wfv1.NodeStatus) (map[string]any, map[string]func() float64) {
 	localScope, realTimeScope := woc.prepareDefaultMetricScope()
 	if node.Fulfilled() {
 		localScope[common.LocalVarDuration] = fmt.Sprintf("%f", node.FinishedAt.Sub(node.StartedAt.Time).Seconds())

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -946,10 +947,10 @@ spec:
 `
 
 // TestStepsSkippedRefDynamicTemplateName verifies that a step whose templateRef is itself templated
-// ("{{item.*}}", resolved only at expansion) fails terminally — not with a requeue — when an
-// argument references a skipped defaultless output: the skipped-arg default handling cannot resolve
-// the consumed template at that point, so the absent optional survives into substitution and is a
-// terminal error (add a producer valueFrom.default or a `??` expression fallback to handle it).
+// ("{{item.*}}", resolved only at expansion) is still rescued by the consumed template's input
+// default when an argument references a skipped defaultless output: the argument is marked with the
+// absent-optional sentinel before substitution and ProcessArgs interprets it at consumption time,
+// when the dynamic templateRef has been resolved.
 func TestStepsSkippedRefDynamicTemplateName(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	cancel, controller := newController(ctx, wfv1.MustUnmarshalWorkflow(stepsSkippedRefDynamicTemplateName), wfv1.MustUnmarshalWorkflowTemplate(skippedRefConsumeWorkflowTemplate))
@@ -962,15 +963,20 @@ func TestStepsSkippedRefDynamicTemplateName(t *testing.T) {
 	require.NotNil(t, producer)
 	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
 
-	var errored *wfv1.NodeStatus
+	var consumer *wfv1.NodeStatus
 	for _, node := range woc.wf.Status.Nodes {
-		if node.Phase == wfv1.NodeError {
+		assert.NotEqual(t, wfv1.NodeError, node.Phase, "node %q should not error: %s", node.DisplayName, node.Message)
+		if strings.HasPrefix(node.DisplayName, "consumer(") {
 			n := node
-			errored = &n
+			consumer = &n
 		}
 	}
-	require.NotNil(t, errored, "an unhandled absent optional must fail the step group terminally")
-	assert.Contains(t, errored.Message, "absent optional")
+	require.NotNil(t, consumer, "consumer should be scheduled even though producer was skipped")
+	require.NotNil(t, consumer.Inputs)
+	in := consumer.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	assert.Equal(t, "FALLBACK", in.Value.String())
 }
 
 var stepsWhenFalseSkippedRefDrop = `
@@ -1011,9 +1017,9 @@ spec:
 `
 
 // TestStepsWhenFalseSkipsDropPass verifies that a step whose when-clause evaluates to false does
-// not fail on an absent-optional argument: the drop pre-pass is best-effort when the template is
-// unresolvable (e.g. a dynamic "{{item.*}}" templateRef), and a when-false step never substitutes
-// its body, so the absent optional is never hit and the step group proceeds with the step Skipped.
+// not fail on an absent-optional argument: a when-false step never substitutes its body (and item
+// expansion strips nils for never-executing steps), so the absent optional is never hit and the
+// step group proceeds with the step Skipped.
 func TestStepsWhenFalseSkipsDropPass(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	cancel, controller := newController(ctx, wfv1.MustUnmarshalWorkflow(stepsWhenFalseSkippedRefDrop), wfv1.MustUnmarshalWorkflowTemplate(skippedRefConsumeWorkflowTemplate))

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -822,3 +822,213 @@ func TestStepsWhenExprWithParamFilter(t *testing.T) {
 	require.NotNil(t, node3)
 	assert.Equal(t, wfv1.NodePending, node3.Phase)
 }
+
+var stepsSkippedOutputDefault = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-skipped-output-default-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: producer
+        template: produce
+        when: "false"
+    - - name: consumer
+        template: consume
+        arguments:
+          parameters:
+          - name: in
+            value: "{{steps.producer.outputs.parameters.msg}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+          default: "default-from-producer"
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+  - name: consume
+    inputs:
+      parameters:
+      - name: in
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.in}}"]
+`
+
+// TestStepsSkippedOutputDefault verifies that when a step is skipped and its template declares an
+// output parameter with a valueFrom.default, a downstream step referencing that output in its INPUT
+// receives the producer's declared default instead of an empty string.
+func TestStepsSkippedOutputDefault(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(stepsSkippedOutputDefault)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	consumer := woc.wf.Status.Nodes.FindByDisplayName("consumer")
+	require.NotNil(t, consumer, "consumer should be scheduled even though producer was skipped")
+	require.NotNil(t, consumer.Inputs)
+	in := consumer.Inputs.GetParameterByName("in")
+	require.NotNil(t, in)
+	require.NotNil(t, in.Value)
+	assert.Equal(t, "default-from-producer", in.Value.String())
+}
+
+var skippedRefConsumeWorkflowTemplate = `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: skipped-ref-consume
+  namespace: default
+spec:
+  templates:
+  - name: consume
+    inputs:
+      parameters:
+      - name: in
+        default: "FALLBACK"
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.in}}"]
+`
+
+var stepsSkippedRefDynamicTemplateName = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: steps-skipped-ref-dynamic-template
+  namespace: default
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: producer
+        template: produce
+        when: "false"
+    - - name: consumer
+        templateRef:
+          name: "{{item.wftmpl}}"
+          template: "{{item.tmpl}}"
+        withItems:
+        - { wftmpl: "skipped-ref-consume", tmpl: "consume" }
+        arguments:
+          parameters:
+          - name: in
+            value: "{{steps.producer.outputs.parameters.msg}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+`
+
+// TestStepsSkippedRefDynamicTemplateName verifies that a step whose templateRef is itself templated
+// ("{{item.*}}", resolved only at expansion) fails terminally — not with a requeue — when an
+// argument references a skipped defaultless output: the skipped-arg default handling cannot resolve
+// the consumed template at that point, so the absent optional survives into substitution and is a
+// terminal error (add a producer valueFrom.default or a `??` expression fallback to handle it).
+func TestStepsSkippedRefDynamicTemplateName(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx, wfv1.MustUnmarshalWorkflow(stepsSkippedRefDynamicTemplateName), wfv1.MustUnmarshalWorkflowTemplate(skippedRefConsumeWorkflowTemplate))
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wfv1.MustUnmarshalWorkflow(stepsSkippedRefDynamicTemplateName), controller)
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	var errored *wfv1.NodeStatus
+	for _, node := range woc.wf.Status.Nodes {
+		if node.Phase == wfv1.NodeError {
+			n := node
+			errored = &n
+		}
+	}
+	require.NotNil(t, errored, "an unhandled absent optional must fail the step group terminally")
+	assert.Contains(t, errored.Message, "absent optional")
+}
+
+var stepsWhenFalseSkippedRefDrop = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: steps-when-false-skipped-ref-drop
+  namespace: default
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: producer
+        template: produce
+        when: "false"
+    - - name: consumer
+        templateRef:
+          name: "{{item.wftmpl}}"
+          template: "{{item.tmpl}}"
+        withItems:
+        - { wftmpl: "skipped-ref-consume", tmpl: "consume" }
+        when: "false"
+        arguments:
+          parameters:
+          - name: in
+            value: "{{steps.producer.outputs.parameters.msg}}"
+  - name: produce
+    outputs:
+      parameters:
+      - name: msg
+        valueFrom:
+          path: /tmp/out.txt
+    container:
+      image: alpine:3.23
+      command: [sh, -c]
+      args: ["echo hello > /tmp/out.txt"]
+`
+
+// TestStepsWhenFalseSkipsDropPass verifies that a step whose when-clause evaluates to false does
+// not fail on an absent-optional argument: the drop pre-pass is best-effort when the template is
+// unresolvable (e.g. a dynamic "{{item.*}}" templateRef), and a when-false step never substitutes
+// its body, so the absent optional is never hit and the step group proceeds with the step Skipped.
+func TestStepsWhenFalseSkipsDropPass(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx, wfv1.MustUnmarshalWorkflow(stepsWhenFalseSkippedRefDrop), wfv1.MustUnmarshalWorkflowTemplate(skippedRefConsumeWorkflowTemplate))
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wfv1.MustUnmarshalWorkflow(stepsWhenFalseSkippedRefDrop), controller)
+	woc.operate(ctx)
+
+	producer := woc.wf.Status.Nodes.FindByDisplayName("producer")
+	require.NotNil(t, producer)
+	require.Equal(t, wfv1.NodeSkipped, producer.Phase)
+
+	for _, node := range woc.wf.Status.Nodes {
+		assert.NotEqual(t, wfv1.NodeError, node.Phase, "node %q should not error: %s", node.DisplayName, node.Message)
+	}
+	assert.NotEqual(t, wfv1.WorkflowError, woc.wf.Status.Phase)
+	assert.NotEqual(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
+}

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -718,7 +718,7 @@ func substitutePodParams(ctx context.Context, pod *apiv1.Pod, globalParams commo
 	if err != nil {
 		return nil, err
 	}
-	newSpecBytes, err := template.Replace(ctx, string(specBytes), podParams, true)
+	newSpecBytes, err := template.Replace(ctx, string(specBytes), template.ToAnyMap(podParams), true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
  ### Motivation

  Skipped/omitted node outputs resolved to `""`, so: producer `valueFrom.default` was ignored, consumer input defaults were clobbered, and `??` never fired (value was
  present-empty, not absent).

  ### Modifications

  - Skipped/omitted outputs are `nil` in scope (absent optional); simple `{{...}}` refs still flatten to `""` (preserves #15932 no-requeue behavior).
  - Producer `valueFrom.default` applies; else consumer input default applies (`dropSkippedDefaultedArgs`); else `""`.
  - New `ReplaceStrictAny` preserves nil into expression envs, so `??` works in inline `{{=...}}` args and `when` clauses, not just
  `valueFrom.expression`/`fromExpression`.
  - Nil expression result with all identifiers present in env collapses to `""` instead of staying unresolved.
  - Refactor: unified identifier-vs-env checks on AST-based `missingVarsInEnv`; removed lexer-token `hasVariableInExpression`/`searchTokens`/`filterEOF`.
  - Behavior change: expressions doing e.g. `skippedRef + '-suffix'` now see nil (error) instead of `""`; use `??`.

  ### Verification

  New unit tests (`TestReplaceStrictAnyNilValues`, `Test_missingVarsInEnv`) and controller tests (`TestDAGSkippedOutput*`, `TestDAGSkippedInlineExpressionFallback`,
  `TestStepsSkippedOutputDefault`, `examples_skipped_defaults_test.go`). Full `workflow/controller`, `workflow/validate`, `workflow/common`, `util/template` suites pass.

  ### Documentation

  New examples in `examples/skipped-output-defaults/`.

  ### AI

  Claude Code was used for code, tests, and this description, under human review.