### PR TITLE
fix(test): de-flake TestParallelismUpdate on coarse-resolution clocks

### DIFF
--- a/workflow/sync/multi_throttler_test.go
+++ b/workflow/sync/multi_throttler_test.go
@@ -207,12 +207,18 @@ func TestPriorityAcrossNamespaces(t *testing.T) {
 func TestParallelismUpdate(t *testing.T) {
 	assert := assert.New(t)
 	throttler := NewMultiThrottler(4, 0, func(Key) {})
-	throttler.Add("a/0", 0, time.Now())
-	throttler.Add("b/0", 0, time.Now())
-	throttler.Add("c/0", 0, time.Now())
-	throttler.Add("d/0", 0, time.Now())
-	throttler.Add("e/0", 0, time.Now())
-	throttler.Add("f/0", 0, time.Now())
+	// Each item is in its own namespace, so admission order is decided across
+	// namespaces by creationTime. Use strictly increasing times rather than
+	// time.Now() for every Add: on coarse-resolution clocks (e.g. Windows) the
+	// calls can return identical instants, and the resulting ties are broken by
+	// map-iteration order, making this test flaky.
+	now := time.Now()
+	throttler.Add("a/0", 0, now)
+	throttler.Add("b/0", 0, now.Add(1*time.Millisecond))
+	throttler.Add("c/0", 0, now.Add(2*time.Millisecond))
+	throttler.Add("d/0", 0, now.Add(3*time.Millisecond))
+	throttler.Add("e/0", 0, now.Add(4*time.Millisecond))
+	throttler.Add("f/0", 0, now.Add(5*time.Millisecond))
 
 	assert.True(throttler.Admit("a/0"))
 	assert.True(throttler.Admit("b/0"))


### PR DESCRIPTION
## Motivation

`workflow/sync.TestParallelismUpdate` fails intermittently on Windows CI:

```
--- FAIL: TestParallelismUpdate (0.00s)
    multi_throttler_test.go:225: Error: Should be true   // Admit("e/0")
    multi_throttler_test.go:226: Error: Should be false  // Admit("f/0")
```

The test adds six items — `a/0`…`f/0` — **each in its own namespace**, all
with `priority 0` and `creationTime = time.Now()`, then raises parallelism
and expects admission to follow insertion order (`e` before `f`).

Because each item is in a distinct namespace, `queueThrottled` ranks the
candidates **across** namespaces by `(priority, creationTime)`, iterating the
`pending` map. The items only differ by `creationTime`, so ordering depends
entirely on those timestamps being distinct.

On clocks with coarse resolution (notably Windows, ~1–15 ms), consecutive
`time.Now()` calls can return the **same instant**. The resulting
`creationTime` ties are then broken by Go's randomized map-iteration order,
so `f/0` can win the freed slot instead of `e/0`, and the test fails. Linux's
nanosecond-resolution clock hides the bug, which is why it only shows up on
the Windows runner.

This was reproduced deterministically on Linux by forcing identical
timestamps: with ties, the test fails with exactly the CI symptom
(`e admitted=false, f admitted=true`) on a fraction of runs.

## Modifications

Give the six items strictly increasing `creationTime`s (`now`, `now+1ms`, …
`now+5ms`) so the ordering is unambiguous on every platform, regardless of
clock resolution. Added a comment explaining why bare `time.Now()` is unsafe
here.

This is a **test-only** change — no production code is touched.

## Verification

- `go test -run TestParallelismUpdate -count=200 ./workflow/sync/` — passes
  (was non-deterministic under tied timestamps).
- The other tests in `multi_throttler_test.go` are unaffected: their tied
  items sit within a single namespace (stable heap insertion order) or are
  separated by distinct priorities / time offsets.
- `golangci-lint` clean, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)