### PR TITLE
fix: set GCS content type from file extension. Fixes #16051

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -318,8 +318,6 @@ func uploadObject(ctx context.Context, client *storage.Client, bucket, key, loca
 	ext := filepath.Ext(localPath)
 	mimeType := mime.TypeByExtension(ext)
 
-	fmt.Println("mimeType =", mimeType)
-
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}

--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"os"
 	"path/filepath"
 	"strings"
@@ -313,7 +314,18 @@ func uploadObject(ctx context.Context, client *storage.Client, bucket, key, loca
 			logger.WithField("path", localPath).WithError(closeErr).Error(ctx, "Error closing file")
 		}
 	}()
+
+	ext := filepath.Ext(localPath)
+	mimeType := mime.TypeByExtension(ext)
+
+	fmt.Println("mimeType =", mimeType)
+
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
 	wc := client.Bucket(bucket).Object(key).NewWriter(ctx)
+	wc.ContentType = mimeType
+
 	if _, err = io.Copy(wc, f); err != nil {
 		return fmt.Errorf("io copy: %w", err)
 	}


### PR DESCRIPTION
Fixes #16051

## Motivation

When uploading JSON artifacts to GCS, the resulting object was assigned the content type `text/plain` instead of `application/json`.

This occurs because the GCS writer does not automatically infer the desired content type from the artifact filename, causing JSON artifacts to be uploaded with incorrect metadata.

## Modifications

Set the GCS object's content type using the artifact file extension before upload.

The implementation derives the MIME type using `mime.TypeByExtension(filepath.Ext(localPath))` and assigns it to the GCS writer's `ContentType` field prior to copying the object contents.

A fallback of `application/octet-stream` is used when the file extension cannot be mapped to a known MIME type.

## Verification

Reproduced the issue using a workflow that uploads a JSON artifact to GCS.

Before the change:

* Uploaded object content type: `text/plain`

After the change:

* Uploaded object content type: `application/json`

Also verified that MIME type detection correctly resolves common extensions such as:

* `.json` → `application/json`
* `.csv` → `text/csv`
* `.html` → `text/html`
* `.xlsx` → `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`

## Documentation

No documentation changes were required.

## AI

Used ChatGPT for debugging discussion and PR preparation.