### PR TITLE
fix(cron): retry and surface transient submission errors

### DIFF
--- a/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/cron_workflow_types.go
@@ -207,6 +207,8 @@ func (c *CronWorkflowStatus) HasActiveUID(uid types.UID) bool {
 }
 
 const (
-	// ConditionTypeSubmissionError signifies that there was an error when submitting the CronWorkflow as a Workflow
+	// ConditionTypeSubmissionError signifies that there was a permanent error when submitting the CronWorkflow as a Workflow
 	ConditionTypeSubmissionError ConditionType = "SubmissionError"
+	// ConditionTypeTransientSubmissionError signifies that a transient infrastructure error prevented submission.
+	ConditionTypeTransientSubmissionError ConditionType = "TransientSubmissionError"
 )

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2496,6 +2496,15 @@ func (cs *Conditions) RemoveCondition(conditionType ConditionType) {
 	}
 }
 
+func (cs *Conditions) HasCondition(conditionType ConditionType) bool {
+	for _, wfCondition := range *cs {
+		if wfCondition.Type == conditionType {
+			return true
+		}
+	}
+	return false
+}
+
 func (cs *Conditions) DisplayString(fmtStr string, iconMap map[ConditionType]string) string {
 	if len(*cs) == 0 {
 		return fmt.Sprintf(fmtStr, "Conditions:", "None")

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -871,6 +871,21 @@ func TestCronWorkflowConditions(t *testing.T) {
 	assert.Empty(t, cwfCond)
 }
 
+func TestConditionsHasCondition(t *testing.T) {
+	cwfCond := Conditions{}
+	// An empty set has no conditions.
+	assert.False(t, cwfCond.HasCondition(ConditionTypeSubmissionError))
+
+	cwfCond.UpsertCondition(Condition{
+		Type:    ConditionTypeTransientSubmissionError,
+		Message: "Failed to submit Workflow (transient, will retry)",
+		Status:  metav1.ConditionTrue,
+	})
+	// Present type matches, absent type does not.
+	assert.True(t, cwfCond.HasCondition(ConditionTypeTransientSubmissionError))
+	assert.False(t, cwfCond.HasCondition(ConditionTypeSubmissionError))
+}
+
 func TestDisplayConditions(t *testing.T) {
 	const fmtStr = "%-20s %v\n"
 	cwfCond := Conditions{}

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -182,7 +182,7 @@ func (cc *Controller) processNextCronItem(ctx context.Context) bool {
 	}
 	ctx = wfctx.InjectObjectMeta(ctx, &cronWf.ObjectMeta)
 
-	cronWorkflowOperationCtx := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults)
+	cronWorkflowOperationCtx := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults, cc.eventRecorderManager.Get(ctx, cronWf.Namespace))
 
 	err = cronWorkflowOperationCtx.validateCronWorkflow(ctx)
 	if err != nil {
@@ -300,7 +300,7 @@ func (cc *Controller) syncCronWorkflow(ctx context.Context, cronWf *v1alpha1.Cro
 	cc.keyLock.Lock(key)
 	defer cc.keyLock.Unlock(key)
 
-	cwoc := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults)
+	cwoc := newCronWfOperationCtx(ctx, cronWf, cc.wfClientset, cc.metrics, cc.wftmplInformer, cc.cwftmplInformer, cc.wfDefaults, cc.eventRecorderManager.Get(ctx, cronWf.Namespace))
 	err := cwoc.enforceHistoryLimit(ctx, workflows)
 	if err != nil {
 		return err

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 
 	argoerrs "github.com/argoproj/argo-workflows/v4/errors"
 
@@ -53,6 +54,7 @@ type cronWfOperationCtx struct {
 	cwftmplInformer wfextvv1alpha1.ClusterWorkflowTemplateInformer
 	log             logging.Logger
 	metrics         *metrics.Metrics
+	eventRecorder   record.EventRecorder
 	// scheduledTimeFunc returns the last scheduled time when it is called
 	scheduledTimeFunc ScheduledTimeFunc
 	//nolint: containedctx
@@ -62,6 +64,7 @@ type cronWfOperationCtx struct {
 func newCronWfOperationCtx(ctx context.Context, cronWorkflow *v1alpha1.CronWorkflow, wfClientset versioned.Interface,
 	metrics *metrics.Metrics, wftmplInformer wfextvv1alpha1.WorkflowTemplateInformer,
 	cwftmplInformer wfextvv1alpha1.ClusterWorkflowTemplateInformer, wfDefaults *v1alpha1.Workflow,
+	eventRecorder record.EventRecorder,
 ) *cronWfOperationCtx {
 	log := logging.RequireLoggerFromContext(ctx)
 	return &cronWfOperationCtx{
@@ -76,7 +79,8 @@ func newCronWfOperationCtx(ctx context.Context, cronWorkflow *v1alpha1.CronWorkf
 			"workflow":  cronWorkflow.Name,
 			"namespace": cronWorkflow.Namespace,
 		}),
-		metrics: metrics,
+		metrics:       metrics,
+		eventRecorder: eventRecorder,
 		// inferScheduledTime returns an inferred scheduled time based on the current time and only works if it is called
 		// within 59 seconds of the scheduled time. Here it acts as a placeholder until it is replaced by a similar
 		// function that returns the last scheduled time deterministically from the cron engine. Since we are only able
@@ -134,7 +138,15 @@ func (woc *cronWfOperationCtx) run(ctx context.Context, scheduledRuntime time.Ti
 		if apierrors.IsAlreadyExists(err) {
 			return
 		}
-		woc.reportCronWorkflowError(ctx, v1alpha1.ConditionTypeSubmissionError, fmt.Sprintf("Failed to submit Workflow: %s", err))
+		if errorsutil.IsTransientErrQuiet(ctx, err) {
+			// Transient infrastructure error (e.g. etcd leader change): mark for automatic retry on the next
+			// reconciliation without counting this as a workflow failure.
+			woc.reportCronWorkflowError(ctx, v1alpha1.ConditionTypeTransientSubmissionError,
+				fmt.Sprintf("Failed to submit Workflow (transient, will retry): %s", err))
+		} else {
+			woc.reportCronWorkflowError(ctx, v1alpha1.ConditionTypeSubmissionError,
+				fmt.Sprintf("Failed to submit Workflow: %s", err))
+		}
 		return
 	}
 
@@ -142,6 +154,7 @@ func (woc *cronWfOperationCtx) run(ctx context.Context, scheduledRuntime time.Ti
 	woc.cronWf.Status.Phase = v1alpha1.ActivePhase
 	woc.cronWf.Status.LastScheduledTime = &v1.Time{Time: scheduledRuntime}
 	woc.cronWf.Status.Conditions.RemoveCondition(v1alpha1.ConditionTypeSubmissionError)
+	woc.cronWf.Status.Conditions.RemoveCondition(v1alpha1.ConditionTypeTransientSubmissionError)
 }
 
 func (woc *cronWfOperationCtx) validateCronWorkflow(ctx context.Context) error {
@@ -348,6 +361,12 @@ func (woc *cronWfOperationCtx) shouldOutstandingWorkflowsBeRun(ctx context.Conte
 
 			// We missed the latest execution time
 			if !missedExecutionTime.IsZero() {
+				// If the previous submission failed due to a transient error retry unconditionally.
+				// LastScheduledTime was not updated so the run is safe to re-attempt.
+				if woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeTransientSubmissionError) {
+					woc.log.WithFields(logging.Fields{"name": woc.cronWf.Name, "missedExecutionTime": missedExecutionTime.Format("Mon Jan _2 15:04:05 2006")}).Info(ctx, "retrying missed execution after transient submission error")
+					return missedExecutionTime, nil
+				}
 				// if missedExecutionTime is within StartDeadlineSeconds, We are still within the deadline window, run the Workflow
 				if woc.cronWf.Spec.StartingDeadlineSeconds != nil && now.Before(missedExecutionTime.Add(time.Duration(*woc.cronWf.Spec.StartingDeadlineSeconds)*time.Second)) {
 					woc.log.WithFields(logging.Fields{"name": woc.cronWf.Name, "missedExecutionTime": missedExecutionTime.Format("Mon Jan _2 15:04:05 2006")}).Info(ctx, "missed an execution and is within StartingDeadline")
@@ -479,9 +498,13 @@ func (woc *cronWfOperationCtx) reportCronWorkflowError(ctx context.Context, cond
 		Message: errString,
 		Status:  v1.ConditionTrue,
 	})
+	if woc.eventRecorder != nil {
+		woc.eventRecorder.Event(woc.cronWf, corev1.EventTypeWarning, string(conditionType), errString)
+	}
 	if conditionType == v1alpha1.ConditionTypeSpecError {
 		woc.metrics.CronWorkflowSpecError(ctx)
 	} else {
+		// Only permanent submission errors count as a workflow failure; transient errors will be retried.
 		if conditionType == v1alpha1.ConditionTypeSubmissionError {
 			woc.cronWf.Status.Failed++
 		}

--- a/workflow/cron/operator_test.go
+++ b/workflow/cron/operator_test.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -8,6 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
@@ -814,4 +818,171 @@ func TestEvaluateWhenUnresolvedOutside(t *testing.T) {
 	result, err := evalWhen(ctx, &cronWf)
 	require.NoError(t, err)
 	assert.True(t, result)
+}
+
+// failCreateWorkflowReactor makes every "create workflows" call on the fake clientset fail with the
+// supplied error, so the submission path in run() can be exercised without a real API server.
+func failCreateWorkflowReactor(err error) ktesting.ReactionFunc {
+	return func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, err
+	}
+}
+
+// TestRunTransientSubmissionError: a transient submission error sets the transient condition, isn't counted as a failure, and emits a Warning event.
+func TestRunTransientSubmissionError(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	var cronWf v1alpha1.CronWorkflow
+	v1alpha1.MustUnmarshal([]byte(scheduledWf), &cronWf)
+
+	cs := fake.NewClientset()
+	// isTransientEtcdErr matches this substring, so the create is retried then reported as transient.
+	cs.PrependReactor("create", "workflows", failCreateWorkflowReactor(errors.New("etcdserver: leader changed")))
+	testMetrics, err := metrics.New(ctx, telemetry.TestScopeName, telemetry.TestScopeName, &telemetry.MetricsConfig{}, metrics.Callbacks{})
+	require.NoError(t, err)
+	recorder := record.NewFakeRecorder(64)
+	woc := &cronWfOperationCtx{
+		wfClientset:       cs,
+		wfClient:          cs.ArgoprojV1alpha1().Workflows(""),
+		cronWfIf:          cs.ArgoprojV1alpha1().CronWorkflows(""),
+		cronWf:            &cronWf,
+		log:               logging.RequireLoggerFromContext(ctx),
+		metrics:           testMetrics,
+		eventRecorder:     recorder,
+		scheduledTimeFunc: inferScheduledTime,
+		ctx:               ctx,
+	}
+	woc.Run()
+
+	assert.True(t, woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeTransientSubmissionError))
+	assert.False(t, woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeSubmissionError))
+	// Transient errors must not be counted as a workflow failure, otherwise they pollute Failed.
+	assert.Equal(t, int64(0), woc.cronWf.Status.Failed)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, string(v1alpha1.ConditionTypeTransientSubmissionError))
+		assert.Contains(t, event, "Warning")
+	default:
+		t.Fatal("expected a Warning event to be emitted for the transient submission error")
+	}
+}
+
+// TestRunPermanentSubmissionError: a permanent submission error sets the submission-error condition, increments Status.Failed, and emits a Warning event.
+func TestRunPermanentSubmissionError(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	var cronWf v1alpha1.CronWorkflow
+	v1alpha1.MustUnmarshal([]byte(scheduledWf), &cronWf)
+
+	cs := fake.NewClientset()
+	cs.PrependReactor("create", "workflows", failCreateWorkflowReactor(errors.New("some permanent failure")))
+	testMetrics, err := metrics.New(ctx, telemetry.TestScopeName, telemetry.TestScopeName, &telemetry.MetricsConfig{}, metrics.Callbacks{})
+	require.NoError(t, err)
+	recorder := record.NewFakeRecorder(64)
+	woc := &cronWfOperationCtx{
+		wfClientset:       cs,
+		wfClient:          cs.ArgoprojV1alpha1().Workflows(""),
+		cronWfIf:          cs.ArgoprojV1alpha1().CronWorkflows(""),
+		cronWf:            &cronWf,
+		log:               logging.RequireLoggerFromContext(ctx),
+		metrics:           testMetrics,
+		eventRecorder:     recorder,
+		scheduledTimeFunc: inferScheduledTime,
+		ctx:               ctx,
+	}
+	woc.Run()
+
+	assert.True(t, woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeSubmissionError))
+	assert.False(t, woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeTransientSubmissionError))
+	// Permanent errors are real failures and must be counted.
+	assert.Equal(t, int64(1), woc.cronWf.Status.Failed)
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, string(v1alpha1.ConditionTypeSubmissionError))
+		assert.Contains(t, event, "Warning")
+	default:
+		t.Fatal("expected a Warning event to be emitted for the permanent submission error")
+	}
+}
+
+// TestSubmissionErrorConditionsClearedOnSuccess: a successful submission clears both submission-error conditions.
+func TestSubmissionErrorConditionsClearedOnSuccess(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	var cronWf v1alpha1.CronWorkflow
+	v1alpha1.MustUnmarshal([]byte(scheduledWf), &cronWf)
+
+	// Seed both conditions as if previous submissions had failed.
+	cronWf.Status.Conditions.UpsertCondition(v1alpha1.Condition{
+		Type:    v1alpha1.ConditionTypeSubmissionError,
+		Message: "old permanent error",
+		Status:  v1.ConditionTrue,
+	})
+	cronWf.Status.Conditions.UpsertCondition(v1alpha1.Condition{
+		Type:    v1alpha1.ConditionTypeTransientSubmissionError,
+		Message: "old transient error",
+		Status:  v1.ConditionTrue,
+	})
+
+	cs := fake.NewClientset() // no reactor: the create succeeds
+	testMetrics, err := metrics.New(ctx, telemetry.TestScopeName, telemetry.TestScopeName, &telemetry.MetricsConfig{}, metrics.Callbacks{})
+	require.NoError(t, err)
+	woc := &cronWfOperationCtx{
+		wfClientset:       cs,
+		wfClient:          cs.ArgoprojV1alpha1().Workflows(""),
+		cronWfIf:          cs.ArgoprojV1alpha1().CronWorkflows(""),
+		cronWf:            &cronWf,
+		log:               logging.RequireLoggerFromContext(ctx),
+		metrics:           testMetrics,
+		eventRecorder:     record.NewFakeRecorder(64),
+		scheduledTimeFunc: inferScheduledTime,
+		ctx:               ctx,
+	}
+	woc.Run()
+
+	assert.False(t, woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeSubmissionError))
+	assert.False(t, woc.cronWf.Status.Conditions.HasCondition(v1alpha1.ConditionTypeTransientSubmissionError))
+
+	wsl, err := cs.ArgoprojV1alpha1().Workflows("").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, wsl.Items.Len())
+}
+
+// TestShouldRetryOutstandingWorkflowsOnTransientError: a transient condition forces a missed run to be retried even without StartingDeadlineSeconds.
+func TestShouldRetryOutstandingWorkflowsOnTransientError(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	newWoc := func() *cronWfOperationCtx {
+		var cronWf v1alpha1.CronWorkflow
+		v1alpha1.MustUnmarshal([]byte(scheduledWf), &cronWf)
+		// No deadline window, and a missed execution two minutes ago.
+		cronWf.Spec.StartingDeadlineSeconds = nil
+		cronWf.Status.LastScheduledTime = &v1.Time{Time: time.Now().Add(-2 * time.Minute)}
+		woc := &cronWfOperationCtx{
+			cronWf: &cronWf,
+			log:    logging.RequireLoggerFromContext(ctx),
+		}
+		woc.cronWf.SetSchedule(woc.cronWf.Spec.GetScheduleWithTimezoneString())
+		return woc
+	}
+
+	t.Run("WithoutTransientCondition", func(t *testing.T) {
+		// Without StartingDeadlineSeconds and no transient condition, the missed run is skipped.
+		woc := newWoc()
+		missedExecutionTime, err := woc.shouldOutstandingWorkflowsBeRun(ctx)
+		require.NoError(t, err)
+		assert.True(t, missedExecutionTime.IsZero())
+	})
+
+	t.Run("WithTransientCondition", func(t *testing.T) {
+		// The transient condition forces an unconditional retry of the missed run.
+		woc := newWoc()
+		woc.cronWf.Status.Conditions.UpsertCondition(v1alpha1.Condition{
+			Type:    v1alpha1.ConditionTypeTransientSubmissionError,
+			Message: "Failed to submit Workflow (transient, will retry)",
+			Status:  v1.ConditionTrue,
+		})
+		missedExecutionTime, err := woc.shouldOutstandingWorkflowsBeRun(ctx)
+		require.NoError(t, err)
+		assert.False(t, missedExecutionTime.IsZero())
+	})
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14880

### Motivation
<!-- TODO: Say why you made your changes. -->
When a CronWorkflow fires during an etcd leader election, the Kubernetes API returns "etcdserver: leader changed". `util.SubmitWorkflow()` retries this with exponential backoff, but the default retry window is only ~310 ms — far shorter than a typical etcd leader election (1–10 s). 

This leads to two combined bugs:
- **Silent failure**: The system only updates the `status.conditions`. It does not create a Kubernetes Event, so tools like kubectl get events and your alerts will not see anything wrong.
- **No automatic retry**: Missed runs are only tried again if a specific setting `StartingDeadlineSeconds` is used.
https://github.com/argoproj/argo-workflows/blob/41a1991925f36cc24d6fddea55825da127528fbc/workflow/cron/operator.go#L346-L352


### Modifications
<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
- Transient submission errors are now distinguished from permanent errors (e.g. RBAC denial, invalid spec) at the point where `util.SubmitWorkflow()` returns to the cron operator.
  - A new condition type `TransientSubmissionError` signals "submission failed but is safe to retry". The existing `SubmissionError` is reserved for permanent failures only.
  - A Kubernetes Warning event is emitted on every submission error, making failures visible to kubectl get events and compatible alerting systems.
  - A missed execution guarded by `TransientSubmissionError` is always retried on the next reconciliation, without requiring `spec.startingDeadlineSeconds`.
  - Transient errors are no longer counted in status.failed — the workflow never ran, so it is not a workflow failure


### AI
**Claude Sonnet 4.6**
- Debug core logic.
- Refine comment wording 
- Unit tests


<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cron workflow submission errors are now distinguished between transient infrastructure failures and permanent errors.
  * Transient failures automatically retry missed executions and clear after a successful submission.
  * Warning events provide visibility into cron workflow errors when event reporting is enabled.

* **Bug Fixes**
  * Transient submission failures no longer incorrectly increase failed workflow counts.
  * Permanent submission failures continue to be recorded and counted accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->