### PR TITLE
fix: select service account token secret by type. Fixes #16109

### DIFF
--- a/server/auth/gatekeeper.go
+++ b/server/auth/gatekeeper.go
@@ -319,7 +319,12 @@ func (s *gatekeeper) rbacAuthorization(ctx context.Context, claims *authTypes.Cl
 }
 
 func (s *gatekeeper) authorizationForServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount) (string, error) {
-	secretName := secrets.TokenNameForServiceAccount(serviceAccount)
+	secretName, err := secrets.TokenNameForServiceAccountWithSecretGetter(ctx, serviceAccount, func(ctx context.Context, name string) (*corev1.Secret, error) {
+		return s.cache.GetSecret(ctx, serviceAccount.GetNamespace(), name)
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to select service account token secret: %w", err)
+	}
 	secret, err := s.cache.GetSecret(ctx, serviceAccount.GetNamespace(), secretName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get service account secret: %w", err)

--- a/server/auth/gatekeeper_test.go
+++ b/server/auth/gatekeeper_test.go
@@ -90,24 +90,28 @@ func TestServer_GetWFClient(t *testing.T) {
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "my-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data: map[string][]byte{
 				"token": {},
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "user-secret", Namespace: "user1-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data: map[string][]byte{
 				"token": {},
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "user-secret", Namespace: "user2-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data: map[string][]byte{
 				"token": {},
 			},
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "user-secret", Namespace: "user3-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data: map[string][]byte{
 				"token": {},
 			},

--- a/server/auth/webhook/interceptor.go
+++ b/server/auth/webhook/interceptor.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/secrets"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
@@ -102,9 +104,15 @@ func (i *Interceptor) addWebhookAuthorization(r *http.Request, kube kubernetes.I
 			if err != nil {
 				return fmt.Errorf("failed to get service account \"%s\": %w", serviceAccountName, err)
 			}
-			tokenSecret, err := secretsInterface.Get(ctx, secrets.TokenNameForServiceAccount(serviceAccount), metav1.GetOptions{})
+			tokenSecretName, err := secrets.TokenNameForServiceAccountWithSecretGetter(ctx, serviceAccount, func(ctx context.Context, name string) (*corev1.Secret, error) {
+				return secretsInterface.Get(ctx, name, metav1.GetOptions{})
+			})
 			if err != nil {
-				return fmt.Errorf("failed to get token secret \"%s\": %w", tokenSecret, err)
+				return fmt.Errorf("failed to select token secret for service account \"%s\": %w", serviceAccountName, err)
+			}
+			tokenSecret, err := secretsInterface.Get(ctx, tokenSecretName, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get token secret \"%s\": %w", tokenSecretName, err)
 			}
 			r.Header["Authorization"] = []string{"Bearer " + string(tokenSecret.Data["token"])}
 			return nil

--- a/server/auth/webhook/interceptor_test.go
+++ b/server/auth/webhook/interceptor_test.go
@@ -116,6 +116,7 @@ func intercept(ctx context.Context, method string, target string, headers map[st
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "bitbucket-token", Namespace: "my-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data:       map[string][]byte{"token": []byte("my-bitbucket-token")},
 		},
 		// bitbucketserver
@@ -125,6 +126,7 @@ func intercept(ctx context.Context, method string, target string, headers map[st
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "bitbucketserver-token", Namespace: "my-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data:       map[string][]byte{"token": []byte("my-bitbucketserver-token")},
 		},
 		// github
@@ -134,6 +136,7 @@ func intercept(ctx context.Context, method string, target string, headers map[st
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "github-token", Namespace: "my-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data:       map[string][]byte{"token": []byte("my-github-token")},
 		},
 		// gitlab
@@ -143,6 +146,7 @@ func intercept(ctx context.Context, method string, target string, headers map[st
 		},
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "gitlab-token", Namespace: "my-ns"},
+			Type:       corev1.SecretTypeServiceAccountToken,
 			Data:       map[string][]byte{"token": []byte("my-gitlab-token")},
 		},
 	)

--- a/util/secrets/secret_name.go
+++ b/util/secrets/secret_name.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
@@ -13,6 +14,30 @@ func TokenNameForServiceAccount(sa *corev1.ServiceAccount) string {
 	if len(sa.Secrets) > 0 {
 		return sa.Secrets[0].Name
 	}
+	return fallbackTokenNameForServiceAccount(sa)
+}
+
+// TokenNameForServiceAccountWithSecretGetter returns the first referenced service account token secret name.
+func TokenNameForServiceAccountWithSecretGetter(ctx context.Context, sa *corev1.ServiceAccount, getSecret func(context.Context, string) (*corev1.Secret, error)) (string, error) {
+	if getSecret == nil {
+		return TokenNameForServiceAccount(sa), nil
+	}
+	for _, ref := range sa.Secrets {
+		if ref.Name == "" {
+			continue
+		}
+		secret, err := getSecret(ctx, ref.Name)
+		if err != nil {
+			return "", fmt.Errorf("failed to get secret %q referenced by service account %q: %w", ref.Name, sa.Name, err)
+		}
+		if secret.Type == corev1.SecretTypeServiceAccountToken {
+			return ref.Name, nil
+		}
+	}
+	return fallbackTokenNameForServiceAccount(sa), nil
+}
+
+func fallbackTokenNameForServiceAccount(sa *corev1.ServiceAccount) string {
 	if v, ok := sa.Annotations[common.AnnotationKeyServiceAccountTokenName]; ok {
 		return v
 	}

--- a/util/secrets/secret_name_test.go
+++ b/util/secrets/secret_name_test.go
@@ -1,8 +1,12 @@
 package secrets
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -43,4 +47,81 @@ func TestServiceAccountTokenName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTokenNameForServiceAccountWithSecretGetter(t *testing.T) {
+	ctx := context.Background()
+	secrets := map[string]*corev1.Secret{
+		"image-pull-secret": {
+			ObjectMeta: metav1.ObjectMeta{Name: "image-pull-secret"},
+			Type:       corev1.SecretTypeDockerConfigJson,
+		},
+		"my-token": {
+			ObjectMeta: metav1.ObjectMeta{Name: "my-token"},
+			Type:       corev1.SecretTypeServiceAccountToken,
+		},
+	}
+	getSecret := func(_ context.Context, name string) (*corev1.Secret, error) {
+		secret, ok := secrets[name]
+		if !ok {
+			return nil, errors.New("not found")
+		}
+		return secret, nil
+	}
+
+	t.Run("selects first service account token secret", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-sa"},
+			Secrets: []corev1.ObjectReference{
+				{Name: "image-pull-secret"},
+				{Name: "my-token"},
+			},
+		}
+		got, err := TokenNameForServiceAccountWithSecretGetter(ctx, sa, getSecret)
+		require.NoError(t, err)
+		assert.Equal(t, "my-token", got)
+	})
+
+	t.Run("falls back to annotation when no token secret is referenced", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "my-sa",
+				Annotations: map[string]string{"workflows.argoproj.io/service-account-token.name": "annotated-token"},
+			},
+			Secrets: []corev1.ObjectReference{{Name: "image-pull-secret"}},
+		}
+		got, err := TokenNameForServiceAccountWithSecretGetter(ctx, sa, getSecret)
+		require.NoError(t, err)
+		assert.Equal(t, "annotated-token", got)
+	})
+
+	t.Run("falls back to generated name when no token secret is referenced", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-sa"},
+			Secrets:    []corev1.ObjectReference{{Name: "image-pull-secret"}},
+		}
+		got, err := TokenNameForServiceAccountWithSecretGetter(ctx, sa, getSecret)
+		require.NoError(t, err)
+		assert.Equal(t, "my-sa.service-account-token", got)
+	})
+
+	t.Run("ignores empty secret references", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-sa"},
+			Secrets:    []corev1.ObjectReference{{}},
+		}
+		got, err := TokenNameForServiceAccountWithSecretGetter(ctx, sa, getSecret)
+		require.NoError(t, err)
+		assert.Equal(t, "my-sa.service-account-token", got)
+	})
+
+	t.Run("returns get errors", func(t *testing.T) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-sa"},
+			Secrets:    []corev1.ObjectReference{{Name: "missing-secret"}},
+		}
+		_, err := TokenNameForServiceAccountWithSecretGetter(ctx, sa, getSecret)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing-secret")
+	})
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4553,7 +4553,9 @@ func (woc *wfOperationCtx) getServiceAccountTokenName(ctx context.Context, name 
 	if err != nil {
 		return "", err
 	}
-	return secrets.TokenNameForServiceAccount(account), nil
+	return secrets.TokenNameForServiceAccountWithSecretGetter(ctx, account, func(ctx context.Context, name string) (*apiv1.Secret, error) {
+		return woc.controller.kubeclientset.CoreV1().Secrets(woc.wf.Namespace).Get(ctx, name, metav1.GetOptions{})
+	})
 }
 
 // setWfPodNamesAnnotation sets an annotation on a workflow with the pod naming

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -23,6 +23,7 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/test/util"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
+	"github.com/argoproj/argo-workflows/v4/util/secrets"
 	armocks "github.com/argoproj/argo-workflows/v4/workflow/artifactrepositories/mocks"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	wfutil "github.com/argoproj/argo-workflows/v4/workflow/util"
@@ -285,6 +286,19 @@ func TestWFLevelExecutorServiceAccountName(t *testing.T) {
 	woc := newWoc(ctx)
 	_, err := util.CreateServiceAccountWithToken(ctx, woc.controller.kubeclientset, "", "foo")
 	require.NoError(t, err)
+	_, err = woc.controller.kubeclientset.CoreV1().Secrets("").Create(ctx, &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo-image-pull-secret"},
+		Type:       apiv1.SecretTypeDockerConfigJson,
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	sa, err := woc.controller.kubeclientset.CoreV1().ServiceAccounts("").Get(ctx, "foo", metav1.GetOptions{})
+	require.NoError(t, err)
+	sa.Secrets = []apiv1.ObjectReference{
+		{Name: "foo-image-pull-secret"},
+		{Name: secrets.TokenName("foo")},
+	}
+	_, err = woc.controller.kubeclientset.CoreV1().ServiceAccounts("").Update(ctx, sa, metav1.UpdateOptions{})
+	require.NoError(t, err)
 
 	woc.execWf.Spec.Executor = &wfv1.ExecutorConfig{ServiceAccountName: "foo"}
 	tmplCtx, err := woc.createTemplateContext(ctx, wfv1.ResourceScopeLocal, "")
@@ -297,6 +311,7 @@ func TestWFLevelExecutorServiceAccountName(t *testing.T) {
 	assert.Len(t, pods.Items, 1)
 	pod := pods.Items[0]
 	assert.Equal(t, "exec-sa-token", pod.Spec.Volumes[2].Name)
+	assert.Equal(t, secrets.TokenName("foo"), pod.Spec.Volumes[2].Secret.SecretName)
 
 	waitCtr := pod.Spec.Containers[0]
 	verifyServiceAccountTokenVolumeMount(t, waitCtr, "exec-sa-token", "/var/run/secrets/kubernetes.io/serviceaccount")


### PR DESCRIPTION
  Fixes #16109

  ### Motivation

  `TokenNameForServiceAccount` previously returned the first secret referenced by a ServiceAccount without checking whether that secret was actually a
  Kubernetes service account token. If a ServiceAccount references another secret first, such as an image pull secret, Argo may use the wrong secret name.

  ### Modifications

  Added `TokenNameForServiceAccountWithSecretGetter`, which checks referenced secrets and selects the first one with type `kubernetes.io/service-account-
  token`.

  Updated the controller, SSO gatekeeper, and webhook authorization paths to use the new selection logic where a Kubernetes Secret getter is available.

  Kept the existing fallback behavior for annotation-based and generated token secret names.

  Added tests for:
  - selecting the service account token secret when another secret appears first
  - falling back to annotation or generated token secret names
  - ignoring empty secret references
  - preserving auth/webhook fake ServiceAccount token secret behavior

  ### Verification

  ```bash
  GOCACHE=/tmp/argo-go-build-cache GOMODCACHE=/tmp/argo-go-mod-cache go test ./util/secrets ./server/auth ./server/auth/webhook

  GOCACHE=/tmp/argo-go-build-cache GOMODCACHE=/tmp/argo-go-mod-cache go test ./workflow/controller -run 'TestExecuteTaskSet|
  TestWFLevelExecutorServiceAccountName'

  I also attempted make pre-commit -B, but it failed in the existing proto-vendor Makefile path after executing ARGOEXEC_PKG_FILES := as a shell command.
  This appears unrelated to this change.

  ### Documentation

  No user-facing documentation change is needed. This fixes internal service account token secret selection behavior.

  ### AI

  Used ChatGPT/Codex to inspect the issue, update code/tests, run verification commands, and prepare the commit.
