### PR TITLE
docs: code of conduct and governance pointers

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+Argo Workflows is a [CNCF](https://www.cncf.io/) graduated project.
+All participation in the project — issues, pull requests, Slack, meetings, and events — is governed by the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+## Reporting
+To report a violation, email the CNCF Code of Conduct Committee at <conduct@cncf.io>. Reports are handled confidentially.
+
+You may also raise concerns with the Argo maintainers in the [#argo-workflows-contributors](https://cloud-native.slack.com/archives/C0510EUH90V) Slack channel, though formal incident handling is done by the CNCF committee.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,11 @@
+# Governance
+
+Argo Workflows is part of the [Argo project](https://github.com/argoproj) and is governed by the shared governance of the four Argo subprojects, maintained in the  [`argoproj/argoproj`](https://github.com/argoproj/argoproj) repository.
+
+* [Argo Governance](https://github.com/argoproj/argoproj/blob/main/community/GOVERNANCE.md) — roles, voting, and conflict resolution.
+* [Membership & roles](https://github.com/argoproj/argoproj/blob/main/community/membership.md) — the contributor ladder (member → reviewer → approver → lead) and how to advance.
+* [SIG governance](https://github.com/argoproj/argoproj/blob/main/community/SIG-GOVERNANCE.md)
+
+## Maintainers
+
+The current maintainers of this repository are listed in [MAINTAINERS.md](MAINTAINERS.md)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ An incomplete list of features Argo Workflows provides:
 We host monthly community meetings where we and the community showcase demos and discuss the current and future state of the project. Feel free to join us!
 For Community Meeting information, minutes and recordings, please [see here](https://bit.ly/argo-wf-cmty-mtng).
 
-Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 
 ## Community Blogs and Presentations
 
@@ -158,6 +158,9 @@ Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https:
 * [Argo Project GitHub organization](https://github.com/argoproj)
 * [Argo Website](https://argoproj.github.io/)
 * [Argo Slack](https://argoproj.github.io/community/join-slack)
+* [Contributing](docs/CONTRIBUTING.md)
+* [Governance](https://github.com/argoproj/argoproj/blob/main/community/GOVERNANCE.md)
+* [Code of Conduct](https://github.com/argoproj/argo-workflows/blob/main/CODE_OF_CONDUCT.md)
 
 ## Security
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please [raise an issue in Github](https://github.com/argoproj/argo-workflows/iss
 
 ## Code of Conduct
 
-See [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+See [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 ## Community Meetings (monthly)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ An incomplete list of features Argo Workflows provides:
 We host monthly community meetings where we and the community showcase demos and discuss the current and future state of the project. Feel free to join us!
 For Community Meeting information, minutes and recordings, please [see here](https://bit.ly/argo-wf-cmty-mtng).
 
-Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
 
 ## Community Blogs and Presentations
 
@@ -158,6 +158,9 @@ Participation in Argo Workflows is governed by the [CNCF Code of Conduct](https:
 * [Argo Project GitHub organization](https://github.com/argoproj)
 * [Argo Website](https://argoproj.github.io/)
 * [Argo Slack](https://argoproj.github.io/community/join-slack)
+* [Contributing](CONTRIBUTING.md)
+* [Governance](https://github.com/argoproj/argoproj/blob/main/community/GOVERNANCE.md)
+* [Code of Conduct](https://github.com/argoproj/argo-workflows/blob/main/CODE_OF_CONDUCT.md)
 
 ## Security
 


### PR DESCRIPTION
### Motivation

As part of trying to get our contributor onboarding process better I'm filling out various docs - this isn't flagged by CLOMonitor and probably will now appear in the magic places that github will link it.

### Documentation

Add a pointer to the CNCF code of conduct and argoproj governance.

### AI

AI pointed out we didn't have this. I wrote it.