### PR TITLE
chore: add .spelling to docs code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,4 @@
 /README.md            @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
 /CONTRIBUTING.md      @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
 /USERS.md             @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers
+/.spelling            @argoproj/argo-workflows-approvers-docs @argoproj/argo-workflows-approvers


### PR DESCRIPTION
### Motivation

`.spelling` is the custom dictionary for the docs spell check (`make docs-serve` and the docs CI check). It currently falls under the default `*` ownership in CODEOWNERS, so the docs approvers who actually maintain it aren't requested for review when it changes.

### Modifications

Added `/.spelling` to the Documentation section of CODEOWNERS, owned by `@argoproj/argo-workflows-approvers-docs` and `@argoproj/argo-workflows-approvers` (same as `/README.md`, `/CONTRIBUTING.md`, and `/USERS.md`).

### Verification

CODEOWNERS-only change, no code. GitHub validates the file syntax and recomputes ownership automatically.

### Documentation

Not needed. This is repository tooling config, not user-facing docs.

### AI

This PR was prepared with Claude Code (commit message, PR description, and the one-line CODEOWNERS edit).