### PR TITLE
fix: classify bare 5xx S3 responses as transient. Fixes #15565 (cherry-pick #16016 for 3.7)

### DIFF
--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -1,10 +1,10 @@
 package s3
 
 import (
-	log "github.com/sirupsen/logrus"
 	stderrors "errors"
 
 	"github.com/minio/minio-go/v7"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-workflows/v3/util/errors"
 )
@@ -41,7 +41,7 @@ func isTransientS3Err(err error) bool {
 	// 5xx responses are still treated as transient per S3 retry semantics.
 	var minioErr minio.ErrorResponse
 	if stderrors.As(err, &minioErr) && minioErr.StatusCode >= 500 && minioErr.StatusCode < 600 {
-		log.WithError(err).Error(ctx, "Transient S3 error")
+		log.Errorf("Transient S3 error: %v", err)
 		return true
 	}
 	return errors.IsTransientErr(err)

--- a/workflow/artifacts/s3/errors.go
+++ b/workflow/artifacts/s3/errors.go
@@ -2,6 +2,9 @@ package s3
 
 import (
 	log "github.com/sirupsen/logrus"
+	stderrors "errors"
+
+	"github.com/minio/minio-go/v7"
 
 	"github.com/argoproj/argo-workflows/v3/util/errors"
 )
@@ -30,6 +33,16 @@ func isTransientS3Err(err error) bool {
 			log.Errorf("Transient S3 error: %v", err)
 			return true
 		}
+	}
+	// When the response body is not a parsable S3 XML document (e.g. a proxy
+	// or load balancer returned a bare 5xx response), minio-go sets Code to
+	// the raw HTTP status string ("503 Service Unavailable"), which does not
+	// match any entry in s3TransientErrorCodes. Fall back to StatusCode so
+	// 5xx responses are still treated as transient per S3 retry semantics.
+	var minioErr minio.ErrorResponse
+	if stderrors.As(err, &minioErr) && minioErr.StatusCode >= 500 && minioErr.StatusCode < 600 {
+		log.WithError(err).Error(ctx, "Transient S3 error")
+		return true
 	}
 	return errors.IsTransientErr(err)
 }

--- a/workflow/artifacts/s3/errors_test.go
+++ b/workflow/artifacts/s3/errors_test.go
@@ -23,3 +23,18 @@ func TestIsTransientOSSErr(t *testing.T) {
 	requestErr := minio.ErrorResponse{Code: "RequestError"}
 	assert.True(t, isTransientS3Err(requestErr))
 }
+
+func TestIsTransientS3Err_BareHTTPStatus(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	// minio-go falls back to resp.Status as Code when the error body is not
+	// parsable S3 XML (e.g. a load balancer returned a plain 5xx response).
+	bare503 := minio.ErrorResponse{Code: "503 Service Unavailable", StatusCode: 503}
+	assert.True(t, isTransientS3Err(ctx, bare503))
+
+	bare500 := minio.ErrorResponse{Code: "500 Internal Server Error", StatusCode: 500}
+	assert.True(t, isTransientS3Err(ctx, bare500))
+
+	bare404 := minio.ErrorResponse{Code: "404 Not Found", StatusCode: 404}
+	assert.False(t, isTransientS3Err(ctx, bare404))
+}

--- a/workflow/artifacts/s3/errors_test.go
+++ b/workflow/artifacts/s3/errors_test.go
@@ -25,16 +25,14 @@ func TestIsTransientOSSErr(t *testing.T) {
 }
 
 func TestIsTransientS3Err_BareHTTPStatus(t *testing.T) {
-	ctx := logging.TestContext(t.Context())
-
 	// minio-go falls back to resp.Status as Code when the error body is not
 	// parsable S3 XML (e.g. a load balancer returned a plain 5xx response).
 	bare503 := minio.ErrorResponse{Code: "503 Service Unavailable", StatusCode: 503}
-	assert.True(t, isTransientS3Err(ctx, bare503))
+	assert.True(t, isTransientS3Err(bare503))
 
 	bare500 := minio.ErrorResponse{Code: "500 Internal Server Error", StatusCode: 500}
-	assert.True(t, isTransientS3Err(ctx, bare500))
+	assert.True(t, isTransientS3Err(bare500))
 
 	bare404 := minio.ErrorResponse{Code: "404 Not Found", StatusCode: 404}
-	assert.False(t, isTransientS3Err(ctx, bare404))
+	assert.False(t, isTransientS3Err(bare404))
 }


### PR DESCRIPTION
Cherry-picked fix: classify bare 5xx S3 responses as transient. Fixes #15565 (#16016)