### PR TITLE
fix(ui): populate URL filter parameters on first load. Fixes #15794 (cherry-pick #15796 for 3.7)

### DIFF
--- a/ui/src/cron-workflows/cron-workflow-list.tsx
+++ b/ui/src/cron-workflows/cron-workflow-list.tsx
@@ -51,16 +51,13 @@ export function CronWorkflowList({match, location, history}: RouteComponentProps
 
     // save history
     useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
-            return;
-        }
-        history.push(
+        (isFirstRender.current ? history.replace : history.push)(
             historyUrl('cron-workflows' + (nsUtils.getManagedNamespace() ? '' : '/{namespace}'), {
                 namespace,
                 sidePanel
             })
         );
+        isFirstRender.current = false;
     }, [namespace, sidePanel]);
 
     // internal state

--- a/ui/src/workflow-templates/workflow-template-list.tsx
+++ b/ui/src/workflow-templates/workflow-template-list.tsx
@@ -58,16 +58,13 @@ export function WorkflowTemplateList({match, location, history}: RouteComponentP
     );
 
     useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
-            return;
-        }
-        history.push(
+        (isFirstRender.current ? history.replace : history.push)(
             historyUrl('workflow-templates' + (nsUtils.getManagedNamespace() ? '' : '/{namespace}'), {
                 namespace,
                 sidePanel
             })
         );
+        isFirstRender.current = false;
     }, [namespace, sidePanel]);
 
     // internal state

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -126,10 +126,6 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
 
     // save history and localStorage
     useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false;
-            return;
-        }
         // add empty selectedPhases + selectedLabels for forward-compat w/ old version: previous code relies on them existing, so if you move up a version and back down, it breaks
         const options = {selectedPhases: [], selectedLabels: []} as unknown as WorkflowListRenderOptions;
         options.phases = phases;
@@ -157,7 +153,10 @@ export function WorkflowsList({match, location, history}: RouteComponentProps<an
         if (finishedBefore) {
             params.append('finishedBefore', finishedBefore.toISOString());
         }
-        history.push(historyUrl('workflows' + (nsUtils.getManagedNamespace() ? '' : '/{namespace}'), {namespace, extraSearchParams: params}));
+        (isFirstRender.current ? history.replace : history.push)(
+            historyUrl('workflows' + (nsUtils.getManagedNamespace() ? '' : '/{namespace}'), {namespace, extraSearchParams: params})
+        );
+        isFirstRender.current = false;
     }, [namespace, phases.toString(), labels.toString(), pagination.limit, pagination.offset, nameValue, nameFilter, createdAfter, finishedBefore]); // referential equality, so use values, not refs
 
     useEffect(() => {


### PR DESCRIPTION
Cherry-picked fix(ui): populate URL filter parameters on first load. Fixes #15794 (#15796)