### PR TITLE
fix(errors): retry transient "failed calling webhook" apiserver 500s

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -46,6 +46,7 @@ func isTransientErr(err error) bool {
 		apierr.IsTooManyRequests(err) ||
 		isResourceQuotaConflictErr(err) ||
 		isResourceQuotaTimeoutErr(err) ||
+		isTransientWebhookErr(err) ||
 		isTransientNetworkErr(err) ||
 		apierr.IsServerTimeout(err) ||
 		apierr.IsTimeout(err) ||
@@ -86,6 +87,11 @@ func isResourceQuotaConflictErr(err error) bool {
 
 func isResourceQuotaTimeoutErr(err error) bool {
 	return apierr.IsInternalError(err) && strings.Contains(err.Error(), "resource quota evaluation timed out")
+}
+
+// isTransientWebhookErr reports whether the error is a transient apiserver failure to reach an admission webhook.
+func isTransientWebhookErr(err error) bool {
+	return apierr.IsInternalError(err) && strings.Contains(err.Error(), "failed calling webhook")
 }
 
 func isTransientEtcdErr(err error) bool {

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -75,6 +75,11 @@ func TestIsTransientErr(t *testing.T) {
 		assert.False(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New(""))))
 		assert.True(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New("resource quota evaluation timed out"))))
 	})
+	t.Run("TransientWebhookErr", func(t *testing.T) {
+		assert.True(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New(`failed calling webhook "x": context deadline exceeded`))))
+		assert.False(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New("some other internal error"))))
+		assert.False(t, IsTransientErr(ctx, apierr.NewInternalError(errors.New(`admission webhook "x" denied the request`))))
+	})
 	t.Run("ExceededQuotaErr", func(t *testing.T) {
 		assert.False(t, IsTransientErr(ctx, apierr.NewForbidden(schema.GroupResource{}, "", nil)))
 		assert.True(t, IsTransientErr(ctx, apierr.NewForbidden(schema.GroupResource{Group: "v1", Resource: "pods"}, "", errors.New("exceeded quota"))))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14220 

### Motivation
<!-- TODO: Say why you made your changes. -->
A webhook can be briefly unreachable during normal operation. While it is unreachable, the kube-apiserver
rejects the request with an HTTP 500 `InternalError`:
```
Internal error occurred: failed calling webhook "..."
```
An earlier attempt (PR #16038) treated *all* 500s as transient which was not that correct. Blindly retrying them would mask real failures and pile load onto an already-unhealthy apiserver.
So this task is to retry **only** this known-transient case while leaving every other 500 classified as permanent.

### Modifications
<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
Added a single targeted classifier in `util/errors/errors.go`, same style as the existing `isResourceQuotaTimeoutErr`:

```go
func isTransientWebhookErr(err error) bool {
    return apierr.IsInternalError(err) && strings.Contains(err.Error(), "failed calling webhook")
}
```
And added into isTransientErr` alongside the other transient checks. 


### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

### AI
<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->
Claude Sonnet 4.8
- Debug core logic.
- Refine comment wording
- Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for temporary webhook failures so affected operations can be retried appropriately.
  * Preserved existing behavior for unrelated internal errors and requests explicitly denied by webhooks.

* **Tests**
  * Added coverage for transient webhook timeouts, unrelated errors, and denied requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->