### PR TITLE
fix: addressed a typo in devenv config

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -17,7 +17,7 @@ let
     "${mkEnv envAttrs}${execName} ${execArgs}"
   );
   controllerCmd = mkExec "./dist/workflow-controller" argoConfig.controller.env argoConfig.controller.args;
-  argoServerCmd = mkExec "./argo" argoConfig.argoServer.env argoConfig.argoServer.args;
+  argoServerCmd = mkExec "./dist/argo" argoConfig.argoServer.env argoConfig.argoServer.args;
   uiCmd = mkExec "yarn" argoConfig.ui.env argoConfig.ui.args;
 in
 {


### PR DESCRIPTION
Really silly typo, I think this changed after I tested out the new `devenv up`. When running it again, it couldn't find the binary that was under `dist`.

## Verification
<img width="1911" height="927" alt="image" src="https://github.com/user-attachments/assets/d5b61beb-bd3b-4629-8de1-439625f3227a" />
