### PR TITLE
fix(auth): mask sensitive token in sso callback logs

### DIFF
--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -347,7 +347,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	value := Prefix + raw
-	s.logger.WithField("value", value).Debug(r.Context(), "handing oauth2 callback")
+	s.logger.Debug(r.Context(), "handing oauth2 callback")
 	http.SetCookie(w, &http.Cookie{
 		Value:    value,
 		Name:     "authorization",


### PR DESCRIPTION
Fixes #TODO

### Motivation

Debug logs in the SSO callback handler currently include the full JWT token value. While this is logged at the debug level, it still poses a security risk by exposing sensitive session tokens in system logs that might be collected by centralized logging systems.

### Modifications

Removed the `value` field from the debug log in `argo-workflows/server/auth/sso/sso.go`. The log now only indicates that the OAuth2 callback is being processed without leaking the actual token content.

### Verification

Verified the change locally. The logic for setting the cookie remains unaffected as the `value` variable is still correctly used for the cookie payload.

### Documentation

None required as this is a minor security improvement to internal logging.

### AI

None. Preparation of this PR and code changes were done without the use of generative AI tools.