### PR TITLE
fix: Add extra guard preventing `when:` expansion on `withParam` template steps. Fixes #16270

### DIFF
--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -455,9 +455,11 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 		// nil-preserving view so expression tags can apply `??` fallbacks to skipped/omitted outputs
 		mergedParams := scope.getParametersAny(woc.globalParams())
 
-		// Resolve the "when" clause first to check if this step should execute before resolving the full step.
-		// This avoids unnecessary requeues when a step won't execute but other fields have unresolved references.
-		if step.When != "" {
+		// Resolve the "when" clause first for non-expanding steps (requiring further resolution) to check if this step
+		// should execute before resolving the full step. This avoids unnecessary requeues when a step won't execute but
+		// other fields have unresolved references.
+		// The `!step.ShouldExpand()` guard was added to fix bug #16270
+		if step.When != "" && !step.ShouldExpand() {
 			whenBytes, err := json.Marshal(step.When)
 			if err != nil {
 				return argoerrors.InternalWrapError(err)

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -455,9 +455,11 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 		// nil-preserving view so expression tags can apply `??` fallbacks to skipped/omitted outputs
 		mergedParams := scope.getParametersAny(woc.globalParams)
 
-		// Resolve the "when" clause first to check if this step should execute before resolving the full step.
-		// This avoids unnecessary requeues when a step won't execute but other fields have unresolved references.
-		if step.When != "" {
+		// Resolve the "when" clause first for non-expanding steps (requiring further resolution) to check if this step
+		// should execute before resolving the full step. This avoids unnecessary requeues when a step won't execute but
+		// other fields have unresolved references.
+		// The `!step.ShouldExpand()` guard was added to fix bug #16270
+		if step.When != "" && !step.ShouldExpand() {
 			whenBytes, err := json.Marshal(step.When)
 			if err != nil {
 				return argoerrors.InternalWrapError(err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #16270

### Motivation

To re-enable using `when` and `withParam` clauses in workflows

### Modifications

- Add minimal changes to the resolveStepReferences inner function in resolveReferences (steps.go module)
- Add a regression test validating future code changes

### Verification

`go test ./workflow/controller/ -run TestStepsWhenItemRefWithParam -v -count=1`

All other tests pass as they previously did.


### Documentation

No extra documentation is required as this (re-)enables documented behaviour.

### AI

Claude Opus 4.7 was used to guide me through this PR and issue #16270 as this code base is very complex, layered and hard to navigate. I did, however, read and reviewed every single line of code and text it generated and operated on a test-first basis. First, to ascertain the bug was really in this code base (failing test first) and second, by reviewing, and hand-documenting the minimal production code change introduced to fix the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed conditional step evaluation for dynamically expanded steps.
  - Prevented premature retries when expanded steps contain references that are resolved later.
  - Improved workflow execution for steps using item-, parameter-, or sequence-based expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->