### PR TITLE
fix: honor ?? and ?. guards in strict missing-variable check

### DIFF
--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -103,9 +103,13 @@ func expressionReplaceStrict(ctx context.Context, w io.Writer, expression string
 type identifierVisitor struct {
 	identifiers []string
 	seen        map[string]bool
+	guarded     map[ast.Node]bool
 }
 
 func (v *identifierVisitor) Visit(node *ast.Node) {
+	if v.guarded[*node] {
+		return
+	}
 	if n, ok := (*node).(*ast.IdentifierNode); ok {
 		if !v.seen[n.Value] {
 			v.identifiers = append(v.identifiers, n.Value)
@@ -127,6 +131,9 @@ func getMemberPath(node *ast.MemberNode) (string, bool) {
 	var parts []string
 	curr := node
 	for {
+		if curr.Optional {
+			return "", false
+		}
 		prop, ok := curr.Property.(*ast.StringNode)
 		if !ok {
 			return "", false
@@ -146,13 +153,49 @@ func getMemberPath(node *ast.MemberNode) (string, bool) {
 	}
 }
 
+// guardVisitor collects the member nodes whose access is guarded by the
+// nil-coalescing (??) or optional-chaining (?.) operators, so they are not
+// reported as strictly-required identifiers. Base identifiers are left
+// untouched so a genuinely-unavailable variable still triggers a requeue.
+type guardVisitor struct {
+	guarded map[ast.Node]bool
+}
+
+func (v *guardVisitor) Visit(node *ast.Node) {
+	switch n := (*node).(type) {
+	case *ast.BinaryNode:
+		if n.Operator == "??" {
+			ast.Walk(&n.Left, &memberMarker{guarded: v.guarded})
+		}
+	case *ast.MemberNode:
+		if n.Optional {
+			if _, ok := n.Node.(*ast.MemberNode); ok {
+				v.guarded[n.Node] = true
+			}
+		}
+	}
+}
+
+type memberMarker struct {
+	guarded map[ast.Node]bool
+}
+
+func (m *memberMarker) Visit(node *ast.Node) {
+	if _, ok := (*node).(*ast.MemberNode); ok {
+		m.guarded[*node] = true
+	}
+}
+
 func getIdentifiers(expression string) ([]string, error) {
 	tree, err := parser.Parse(expression)
 	if err != nil {
 		return nil, err
 	}
+	guarded := make(map[ast.Node]bool)
+	ast.Walk(&tree.Node, &guardVisitor{guarded: guarded})
 	visitor := &identifierVisitor{
-		seen: make(map[string]bool),
+		seen:    make(map[string]bool),
+		guarded: guarded,
 	}
 	ast.Walk(&tree.Node, visitor)
 	return visitor.identifiers, nil

--- a/util/template/expression_template_test.go
+++ b/util/template/expression_template_test.go
@@ -99,6 +99,57 @@ func Test_hasVarInEnv(t *testing.T) {
 	})
 }
 
+func Test_getIdentifiers(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		want       []string
+	}{
+		{
+			name:       "plain member path is required",
+			expression: "item.requiredKey",
+			want:       []string{"item", "item.requiredKey"},
+		},
+		{
+			name:       "nil-coalescing guards the member path but keeps the base variable",
+			expression: "item.optionalKey ?? 'fallback'",
+			want:       []string{"item"},
+		},
+		{
+			name:       "nil-coalescing with bracket notation is guarded",
+			expression: "item['optionalKey'] ?? ''",
+			want:       []string{"item"},
+		},
+		{
+			name:       "optional chaining is guarded",
+			expression: "item?.optionalKey",
+			want:       []string{"item"},
+		},
+		{
+			name:       "optional chaining also guards the optional receiver",
+			expression: "item.a?.b",
+			want:       []string{"item"},
+		},
+		{
+			name:       "only the guarded member path is skipped",
+			expression: "item.requiredKey + (item.optionalKey ?? 'x')",
+			want:       []string{"item", "item.requiredKey"},
+		},
+		{
+			name:       "base variable stays required so requeue still works",
+			expression: "tasks.a.outputs.result ?? 'default'",
+			want:       []string{"tasks"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getIdentifiers(tt.expression)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
 func Test_anyVarNotInEnv(t *testing.T) {
 	emptyEnv := map[string]any{}
 	missing := func(expression string) *string { return anyVarNotInEnv(expression, emptyEnv) }

--- a/util/template/replace_test.go
+++ b/util/template/replace_test.go
@@ -105,6 +105,59 @@ func Test_Replace(t *testing.T) {
 	})
 }
 
+func Test_ReplaceStrict_NilCoalescing(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	itemPresent := map[string]any{"item": map[string]any{"name": "a", "optionalKey": "value"}}
+	itemMissing := map[string]any{"item": map[string]any{"name": "b"}}
+
+	tests := []struct {
+		name        string
+		expression  string
+		wantPresent string
+		wantMissing string
+	}{
+		{
+			name:        "nil-coalescing",
+			expression:  `{{= item.optionalKey ?? 'fallback' }}`,
+			wantPresent: "value",
+			wantMissing: "fallback",
+		},
+		{
+			name:        "nil-coalescing with bracket notation",
+			expression:  `{{= item['optionalKey'] ?? 'fallback' }}`,
+			wantPresent: "value",
+			wantMissing: "fallback",
+		},
+		{
+			name:        "optional chaining with nil-coalescing",
+			expression:  `{{= item?.optionalKey ?? 'fallback' }}`,
+			wantPresent: "value",
+			wantMissing: "fallback",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := NewTemplate(tt.expression)
+			require.NoError(t, err)
+
+			out, err := tmpl.ReplaceStrict(ctx, itemPresent, []string{"item"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPresent, out)
+
+			out, err = tmpl.ReplaceStrict(ctx, itemMissing, []string{"item"})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMissing, out)
+		})
+	}
+
+	t.Run("missing base variable still fails strict check", func(t *testing.T) {
+		tmpl, err := NewTemplate(`{{= item.optionalKey ?? 'fallback' }}`)
+		require.NoError(t, err)
+		_, err = tmpl.ReplaceStrict(ctx, map[string]any{}, []string{"item"})
+		require.EqualError(t, err, "failed to evaluate expression: item is missing")
+	})
+}
+
 func TestNestedReplaceString(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	replaceMap := map[string]any{"inputs.parameters.message": "hello world"}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Fixes https://github.com/argoproj/argo-workflows/issues/16276

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

Commit 9f32c38 introduced a strict missing-variable check in `ReplaceStrict`. Before evaluating an expression template, it walks the AST, collects every referenced identifier, and requeues the workflow if any of them are not in scope yet. That is correct behavior for plain member paths like `tasks.a.outputs.result` — if the variable is not there yet, we should wait.

The problem is that the check did not account for `??` (nil-coalescing) and `?.` (optional chaining). An expression like:

```
{{= tasks.a.outputs.result ?? 'default' }}
```

is designed to handle a missing value gracefully, but the pre-check still treated `tasks.a.outputs.result` as strictly required and triggered a requeue, even though the `??` fallback would have handled it just fine at evaluation time.

### Reproduction

take any DAG where a downstream task optionally consumes the output of a sibling using `??`:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: nil-coalescing-bug-
spec:
  entrypoint: main
  templates:
    - name: main
      dag:
        tasks:
          - name: produce
            template: echo
            arguments:
              parameters:
                - name: message
                  value: "hello"
          - name: consume
            template: echo
            arguments:
              parameters:
                - name: message
                  value: "{{= tasks['produce'].outputs.result ?? 'fallback' }}"
```

Even though `tasks['produce'].outputs.result` is guarded by `??`, the workflow gets stuck requeuing and never reaches the `consume` task. The error you see in the controller logs is:

```
failed to evaluate expression: tasks.produce.outputs.result is missing
```

Note the identifier is reported in dot notation (`tasks.produce.outputs.result`) because `getMemberPath` normalizes bracket notation when building the required-identifier set.

### expr-lang 

<img width="1260" height="1384" alt="image" src="https://github.com/user-attachments/assets/c195b36e-1aee-48c0-b674-4a8f01d94a3f" />


What happens under the hood: [expr-lang](https://github.com/expr-lang/expr) parses the expression into an AST where `tasks['produce'].outputs.result` becomes a chain of `MemberNode`s and `??` becomes a `BinaryNode` with operator `??`. The strict check in `ReplaceStrict` walks that AST with `identifierVisitor`, which collected every `MemberNode` path as a required identifier without looking at what operator surrounded it. So `tasks.produce.outputs.result` was added to the required set, the check found it missing, and triggered a requeue — completely ignoring the `??` that was meant to handle exactly that case.

Worth noting: this is a different issue from #15839, which fixed runtime eval errors in the `allowUnresolved=true` path (`SubstituteParams`). This PR fixes the strict identifier pre-check path used by `resolveDependencyReferences`.

### Modifications

Added a `guardVisitor` / `memberMarker` pre-pass that walks the AST before identifier collection and marks any member node sitting under a `??` or `?.` operator as guarded. The existing `identifierVisitor` now skips those nodes so they are not counted as strictly required. `getMemberPath` also bails out early on optional-chaining members for the same reason.

The base variable of a guarded path (e.g. `tasks` in `tasks.a.outputs.result ?? 'default'`) is intentionally kept in the required set. If the whole variable does not exist yet, the requeue behavior is still correct.

### Verification

Added two new test functions:

`Test_getIdentifiers` covers plain required members, `??`-guarded paths, bracket notation (`item['key'] ?? ''`), optional chaining (`item?.key`, `item.a?.b`), and mixed expressions where some paths are required and others are guarded.

`Test_ReplaceStrict_NilCoalescing` runs `ReplaceStrict` end-to-end with a present and a missing optional key for each operator variant, plus a case confirming that a missing base variable still correctly triggers the strict check.

All existing `util/template` tests continue to pass.

### Documentation

not needed

### AI

Claude Opus helped with the investigation, implementation and tests.
