### PR TITLE
fix: prevent NaN display in cron workflow number input fields

### DIFF
--- a/ui/src/cron-workflows/cron-workflow-spec-editor.test.tsx
+++ b/ui/src/cron-workflows/cron-workflow-spec-editor.test.tsx
@@ -1,0 +1,78 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {CronWorkflowSpec} from '../shared/models';
+import {CronWorkflowSpecEditor} from './cron-workflow-spec-editor';
+
+const baseSpec: CronWorkflowSpec = {
+    schedules: ['* * * * *'],
+    workflowSpec: {
+        entrypoint: 'main',
+        templates: [{name: 'main', container: {name: 'main', image: 'argoproj/argosay:v2', command: ['cowsay']}}]
+    }
+};
+
+describe('CronWorkflowSpecEditor', () => {
+    it('does not display NaN when startingDeadlineSeconds is undefined', () => {
+        render(<CronWorkflowSpecEditor spec={baseSpec} onChange={() => undefined} />);
+        const inputs = screen.getAllByRole('textbox');
+        inputs.forEach(input => {
+            expect(input).not.toHaveValue('NaN');
+        });
+    });
+
+    it('does not display NaN when numeric fields are explicitly undefined', () => {
+        const spec: CronWorkflowSpec = {
+            ...baseSpec,
+            startingDeadlineSeconds: undefined,
+            successfulJobsHistoryLimit: undefined,
+            failedJobsHistoryLimit: undefined
+        };
+        render(<CronWorkflowSpecEditor spec={spec} onChange={() => undefined} />);
+        const inputs = screen.getAllByRole('textbox');
+        inputs.forEach(input => {
+            expect(input).not.toHaveValue('NaN');
+        });
+    });
+
+    it('displays numeric values correctly when set', () => {
+        const spec: CronWorkflowSpec = {
+            ...baseSpec,
+            startingDeadlineSeconds: 60,
+            successfulJobsHistoryLimit: 3,
+            failedJobsHistoryLimit: 1
+        };
+        render(<CronWorkflowSpecEditor spec={spec} onChange={() => undefined} />);
+        expect(screen.getByDisplayValue('60')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+    });
+
+    it('calls onChange with undefined when a numeric field is cleared', () => {
+        const handleChange = jest.fn();
+        const spec: CronWorkflowSpec = {
+            ...baseSpec,
+            startingDeadlineSeconds: 60
+        };
+        render(<CronWorkflowSpecEditor spec={spec} onChange={handleChange} />);
+        const input = screen.getByDisplayValue('60');
+        fireEvent.change(input, {target: {value: ''}});
+        expect(handleChange).toHaveBeenCalledWith(
+            expect.objectContaining({startingDeadlineSeconds: undefined})
+        );
+    });
+
+    it('calls onChange with parsed number when a valid value is entered', () => {
+        const handleChange = jest.fn();
+        const spec: CronWorkflowSpec = {
+            ...baseSpec,
+            successfulJobsHistoryLimit: 3
+        };
+        render(<CronWorkflowSpecEditor spec={spec} onChange={handleChange} />);
+        const input = screen.getByDisplayValue('3');
+        fireEvent.change(input, {target: {value: '5'}});
+        expect(handleChange).toHaveBeenCalledWith(
+            expect.objectContaining({successfulJobsHistoryLimit: 5})
+        );
+    });
+});

--- a/ui/src/cron-workflows/cron-workflow-spec-editor.test.tsx
+++ b/ui/src/cron-workflows/cron-workflow-spec-editor.test.tsx
@@ -57,9 +57,7 @@ describe('CronWorkflowSpecEditor', () => {
         render(<CronWorkflowSpecEditor spec={spec} onChange={handleChange} />);
         const input = screen.getByDisplayValue('60');
         fireEvent.change(input, {target: {value: ''}});
-        expect(handleChange).toHaveBeenCalledWith(
-            expect.objectContaining({startingDeadlineSeconds: undefined})
-        );
+        expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({startingDeadlineSeconds: undefined}));
     });
 
     it('calls onChange with parsed number when a valid value is entered', () => {
@@ -71,8 +69,6 @@ describe('CronWorkflowSpecEditor', () => {
         render(<CronWorkflowSpecEditor spec={spec} onChange={handleChange} />);
         const input = screen.getByDisplayValue('3');
         fireEvent.change(input, {target: {value: '5'}});
-        expect(handleChange).toHaveBeenCalledWith(
-            expect.objectContaining({successfulJobsHistoryLimit: 5})
-        );
+        expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({successfulJobsHistoryLimit: 5}));
     });
 });

--- a/ui/src/shared/components/number-input.tsx
+++ b/ui/src/shared/components/number-input.tsx
@@ -4,7 +4,7 @@ import {TextInput} from './text-input';
 
 export const NumberInput = ({onChange, value, placeholder, readOnly}: {value: number; onChange: (value: number | undefined) => void; readOnly?: boolean; placeholder?: string}) => {
     if (readOnly) {
-        return <>{value}</>;
+        return <>{value != null && !isNaN(value) ? value : ''}</>;
     }
     return (
         <TextInput

--- a/ui/src/shared/components/number-input.tsx
+++ b/ui/src/shared/components/number-input.tsx
@@ -2,5 +2,18 @@ import * as React from 'react';
 
 import {TextInput} from './text-input';
 
-export const NumberInput = ({onChange, value, placeholder, readOnly}: {value: number; onChange: (value: number) => void; readOnly?: boolean; placeholder?: string}) =>
-    readOnly ? <>{value}</> : <TextInput value={value != null ? '' + value : ''} onChange={x => onChange(parseInt(x, 10))} placeholder={placeholder} />;
+export const NumberInput = ({onChange, value, placeholder, readOnly}: {value: number; onChange: (value: number | undefined) => void; readOnly?: boolean; placeholder?: string}) => {
+    if (readOnly) {
+        return <>{value}</>;
+    }
+    return (
+        <TextInput
+            value={value != null && !isNaN(value) ? '' + value : ''}
+            onChange={x => {
+                const parsed = parseInt(x, 10);
+                onChange(isNaN(parsed) ? undefined : parsed);
+            }}
+            placeholder={placeholder}
+        />
+    );
+};


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

When creating or editing a CronWorkflow in the UI, the number input fields (startingDeadlineSeconds, successfulJobsHistoryLimit, failedJobsHistoryLimit) display "NaN" when their values are undefined (specifically, when a non-numeric key is pressed in the input field). This occurs because `parseInt(undefined, 10)` returns `NaN`, which is then rendered as a string in the input field.

Additionally, once "NaN" is displayed in the input field, it cannot be removed using the Backspace key (Windows) or Delete key (Mac), which is inconvenient for users.

<img width="1044" height="631" alt="image" src="https://github.com/user-attachments/assets/c5695bcd-0a73-466d-bcd4-38d45953b6b5" />

### Modifications

- Updated `NumberInput` component (`ui/src/shared/components/number-input.tsx`) to guard against `NaN` values:
  - Added an `isNaN()` check when converting the value to a string for display, so undefined/NaN values render as an empty string instead of "NaN".
  - Changed the `onChange` callback to return `undefined` instead of `NaN` when the input is cleared or contains an invalid number.
- Added unit tests for `CronWorkflowSpecEditor` (`ui/src/cron-workflows/cron-workflow-spec-editor.test.tsx`) to verify:
  - No NaN is displayed when numeric fields are undefined.
  - Numeric values are displayed correctly when set.
  - Clearing a numeric field calls onChange with `undefined`.
  - Entering a valid number calls onChange with the parsed number.

### Verification

- Added unit tests covering the NaN display bug and correct numeric input behavior.
- Manually verified in the UI that CronWorkflow number input fields no longer show "NaN" when values are not set.

### Documentation

No documentation changes needed. This is a bug fix for existing UI behavior.

### AI

Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric input parsing and display so invalid or cleared values no longer show `NaN`.
  * The editor now treats cleared/invalid numeric entries as `undefined`, sending `undefined` to change handlers and rendering an empty field.
  * Valid numeric values still display and edit correctly.
* **Tests**
  * Added React Testing Library coverage for the cron workflow spec editor to verify `NaN` never renders when numeric fields (including `startingDeadlineSeconds`) are omitted or cleared.
  * Verified that entering, clearing, and `undefined` numeric states behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->