### PR TITLE
chore: use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/hack/docs/copy-readme.sh
+++ b/hack/docs/copy-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 target="docs/README.md"

--- a/hack/k8s-versions.sh
+++ b/hack/k8s-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Centralized config to define the minimum and maximum tested Kubernetes versions.
 # This is used in the CI workflow for e2e tests, the devcontainer, and to generate docs.

--- a/hack/pull-build-images.sh
+++ b/hack/pull-build-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 grep FROM Dockerfile.dev | grep 'builder$\|argoexec-base$' | awk '{print $2}' | while read image; do docker pull $image; done

--- a/hack/recurl.sh
+++ b/hack/recurl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux -o pipefail
 
 file=$1

--- a/hack/update-image-tags.sh
+++ b/hack/update-image-tags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 dir=$1

--- a/hack/update-ssh-known-hosts.sh
+++ b/hack/update-ssh-known-hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
### Motivation

devenv.nix is now up to date but we're still reliant on a /bin/bash to run the hack scripts from the Makefile. I don't have one of those in that location on nixos.

### Modifications

Switch to `/usr/bin/env bash` for developer scripts so they run on machines with bash but without it in /bin/bash (e.g. native nixos)

### Verification

`make docs` now works.

### Documentation

None required

### AI

No