### PR TITLE
docs: fix duplicated word in doc-changes

### DIFF
--- a/docs/doc-changes.md
+++ b/docs/doc-changes.md
@@ -31,7 +31,7 @@ See [the pull request template](https://github.com/argoproj/argo-workflows/blob/
 On entering a PR, our CI will run the same checks as `make docs-serve`, and fail the build if any issues are found.
 
 Additionally, your PR will be published to a temporary URL, which you can access by clicking on the "Details" link next to the `docs/readthedocs.org:argo-workflows` check.
-This can can be used to preview your changes and do a [visual diff](https://docs.readthedocs.com/platform/stable/visual-diff.html).
+This can be used to preview your changes and do a [visual diff](https://docs.readthedocs.com/platform/stable/visual-diff.html).
 
 ## Tips
 


### PR DESCRIPTION
The contributor docs guide read "This can can be used to preview your changes" — removed the duplicated "can".
