### PR TITLE
feat(ui): add copy button to workflow logs viewer. Fixes #636, #6384

### DIFF
--- a/.features/pending/logs-copy-button.md
+++ b/.features/pending/logs-copy-button.md
@@ -1,0 +1,8 @@
+Description: Add copy button to workflow logs viewer
+Authors: [nakatani-yo](https://github.com/nakatani-yo)
+Component: UI
+Issues: 636, 6384
+
+The workflow logs viewer now includes a "Copy" button in the toolbar that copies the entire log content to the clipboard.
+The button provides visual feedback by briefly showing a checkmark icon and "Copied" text after a successful copy.
+This resolves a long-standing UX pain point where manually selecting log text was error-prone, especially for running pods where the selection gets cleared as new logs stream in.

--- a/ui/src/shared/components/icon.ts
+++ b/ui/src/shared/components/icon.ts
@@ -15,6 +15,7 @@ export type Icon =
     | 'chevron-right'
     | 'circle'
     | 'circle-notch'
+    | 'clipboard'
     | 'clock'
     | 'code'
     | 'cog'

--- a/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -1,6 +1,6 @@
 import {Autocomplete} from 'argo-ui/src/components/autocomplete/autocomplete';
 import * as React from 'react';
-import {useContext, useEffect, useState} from 'react';
+import {useContext, useEffect, useRef, useState} from 'react';
 import {Observable} from 'rxjs';
 import {map, publishReplay, refCount} from 'rxjs/operators';
 
@@ -145,8 +145,12 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
         //   publishReplay(),
         //   refCount()
         // );
+        logsRef.current = [];
         const subscription = source.subscribe(
-            () => setLoaded(true),
+            (log: string) => {
+                logsRef.current.push(log);
+                setLoaded(true);
+            },
             setError,
             () => setLoaded(true)
         );
@@ -214,6 +218,8 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
         )
     ];
     const [candidateContainer, setCandidateContainer] = useState(container);
+    const [logsCopied, setLogsCopied] = useState(false);
+    const logsRef = useRef<string[]>([]);
     const filteredTimezones = timezones.filter(tz => tz.startsWith(uiTimezone) || uiTimezone === '');
 
     async function popupJsonFieldSelector() {
@@ -272,6 +278,16 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
                 />
                 <Button onClick={popupJsonFieldSelector} icon={'exchange-alt'}>
                     Log Fields
+                </Button>
+                <Button
+                    onClick={() => {
+                        const text = logsRef.current.join('');
+                        navigator.clipboard.writeText(text);
+                        setLogsCopied(true);
+                        setTimeout(() => setLogsCopied(false), 2000);
+                    }}
+                    icon={logsCopied ? 'check' : 'clipboard'}>
+                    {logsCopied ? 'Copied' : 'Copy'}
                 </Button>
                 <span className='fa-pull-right'>
                     <div className='log-menu'>


### PR DESCRIPTION
Fixes #636
Fixes #6384

### Motivation

When viewing workflow logs in the UI, copying log content is unnecessarily difficult. Users must manually select text in the log viewer, which is error-prone — especially for running pods where the selection gets immediately cleared as new logs stream in (#6384). This has been a long-standing UX pain point since 2018 (#636).

### Modifications

- Added a "Copy" button to the workflow logs viewer toolbar that copies the entire log content to the clipboard.
- The button provides visual feedback by briefly showing a checkmark icon and "Copied" text after a successful copy.
- Internally, log lines are accumulated in a `useRef` so clipboard copy can access the full log content without triggering re-renders.
- Added `'clipboard'` to the shared icon type definitions.

### Verification

- Opened the workflow logs viewer in the browser and confirmed the Copy button appears in the toolbar.
- Clicked the button and verified log content is copied to clipboard correctly.
- Confirmed the button shows "Copied" feedback for 2 seconds before reverting.
- Verified existing log viewer functionality (streaming, filtering, download) is unaffected.

<img width="1563" height="404" alt="image" src="https://github.com/user-attachments/assets/0491064f-d0fb-43cf-a743-095a8ebeeabc" />

### Documentation

No documentation update needed. The copy button is self-discoverable in the UI toolbar alongside existing buttons (Download, Log Fields).

### AI

Codex