### PR TITLE
fix(sso): fix "asymmetric encryption algorithms not supported for JWT". Fixes #16232

### DIFF
--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -59,6 +59,7 @@ type sso struct {
 	baseHRef          string
 	secure            bool
 	privateKey        crypto.PrivateKey
+	signer            jose.Signer
 	encrypter         jose.Encrypter
 	rbacConfig        *config.RBACConfig
 	expiry            time.Duration
@@ -190,7 +191,12 @@ func newSso(
 		Scopes:       append(c.Scopes, oidc.ScopeOpenID),
 	}
 	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: config.ClientID})
-	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: privateKey.Public()}, &jose.EncrypterOptions{Compression: jose.DEFLATE})
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT signer: %w", err)
+	}
+	encrypterOptions := (&jose.EncrypterOptions{Compression: jose.DEFLATE}).WithContentType("JWT")
+	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: privateKey.Public()}, encrypterOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create JWT encrpytor: %w", err)
 	}
@@ -220,6 +226,7 @@ func newSso(
 		httpClient:        httpClient,
 		secure:            secure,
 		privateKey:        privateKey,
+		signer:            signer,
 		encrypter:         encrypter,
 		rbacConfig:        c.RBAC,
 		expiry:            c.GetSessionExpiry(),
@@ -340,7 +347,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		PreferredUsername:       c.PreferredUsername,
 		ServiceAccountNamespace: c.ServiceAccountNamespace,
 	}
-	raw, err := jwt.Encrypted(s.encrypter).Claims(argoClaims).Serialize()
+	raw, err := jwt.SignedAndEncrypted(s.signer, s.encrypter).Claims(argoClaims).Serialize()
 	if err != nil {
 		s.logger.WithError(err).Error(r.Context(), "failed to encrypt and serialize the jwt token")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -387,19 +394,29 @@ func isValidFinalRedirectURL(redirect string) bool {
 
 // authorize verifies a bearer token and pulls user information form the claims.
 func (s *sso) Authorize(authorization string) (*types.Claims, error) {
-	tok, err := jwt.ParseEncrypted(strings.TrimPrefix(authorization, Prefix), []jose.KeyAlgorithm{jose.RSA_OAEP_256}, []jose.ContentEncryption{jose.A256GCM})
+	enc, err := jose.ParseEncrypted(strings.TrimPrefix(authorization, Prefix), []jose.KeyAlgorithm{jose.RSA_OAEP_256}, []jose.ContentEncryption{jose.A256GCM})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse encrypted token: %w", err)
 	}
+
+	payload, err := enc.Decrypt(s.privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt token: %w", err)
+	}
+
+	tok, err := jwt.ParseSigned(string(payload), []jose.SignatureAlgorithm{jose.RS256})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse signed token: %w", err)
+	}
+
 	c := &types.Claims{}
-	if err := tok.Claims(s.privateKey, c); err != nil {
-		return nil, fmt.Errorf("failed to parse claims: %w", err)
+	if err := tok.Claims(s.privateKey.(*rsa.PrivateKey).Public(), c); err != nil {
+		return nil, fmt.Errorf("failed to verify signed token: %w", err)
 	}
 
 	if err := c.Validate(jwt.Expected{Issuer: issuer}); err != nil {
 		return nil, fmt.Errorf("failed to validate claims: %w", err)
 	}
-
 	return c, nil
 }
 

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -2,10 +2,14 @@ package sso
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"testing"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -13,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/argoproj/argo-workflows/v4/server/auth/types"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
 
@@ -91,6 +96,54 @@ func TestNewSsoWithIssuerAlias(t *testing.T) {
 	_, err := newSso(logging.TestContext(t.Context()), fakeOidcFactory, config, fakeClient, "/", false)
 	require.NoError(t, err)
 }
+
+func TestAuthorizeSignedEncryptedToken(t *testing.T) {
+	ssoObject := newTestSso(t)
+	raw, err := jwt.SignedAndEncrypted(ssoObject.signer, ssoObject.encrypter).Claims(newTestClaims()).Serialize()
+	require.NoError(t, err)
+
+	claims, err := ssoObject.Authorize(Prefix + raw)
+	require.NoError(t, err)
+	assert.Equal(t, "test-subject", claims.Subject)
+	assert.Equal(t, []string{"test-group"}, claims.Groups)
+}
+
+func TestAuthorizeLegacyEncryptedTokenFails(t *testing.T) {
+	ssoObject := newTestSso(t)
+	legacyEncrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: ssoObject.privateKey.(*rsa.PrivateKey).Public()}, &jose.EncrypterOptions{Compression: jose.DEFLATE})
+	require.NoError(t, err)
+	raw, err := jwt.Encrypted(legacyEncrypter).Claims(newTestClaims()).Serialize()
+	require.NoError(t, err)
+
+	claims, err := ssoObject.Authorize(Prefix + raw)
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.ErrorContains(t, err, "failed to parse signed token")
+}
+
+func newTestSso(t *testing.T) *sso {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}, nil)
+	require.NoError(t, err)
+	encrypterOptions := (&jose.EncrypterOptions{Compression: jose.DEFLATE}).WithContentType("JWT")
+	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: privateKey.Public()}, encrypterOptions)
+	require.NoError(t, err)
+	return &sso{privateKey: privateKey, signer: signer, encrypter: encrypter}
+}
+
+func newTestClaims() *types.Claims {
+	return &types.Claims{
+		Claims: jwt.Claims{
+			Issuer:  issuer,
+			Subject: "test-subject",
+			Expiry:  jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		Groups: []string{"test-group"},
+	}
+}
+
 func TestLoadSsoClientIdFromDifferentSecret(t *testing.T) {
 	clientIDSecret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #16232

### Motivation

https://github.com/argoproj/argo-workflows/pull/16213 introduced a bug when SSO is enabled: after logging in, the JWT stored in the `authorization` cookie is unusable. Any attempt to access an API with it results in the following error:
```
{"code":16,"message":"failed to parse encrypted token: asymmetric encryption algorithms not supported for JWT: invalid key encryption algorithm: RSA-OAEP-256"}
```
<img width="1706" height="600" alt="image" src="https://github.com/user-attachments/assets/f2a0b806-48d9-4dca-851f-a8dc4bdc1357" />


### Modifications
This is happening because go-jose v4 dropped support for encrypting JWTs with a public key, specifically in https://github.com/go-jose/go-jose/pull/78. 

The fix is to use a nested JWT inside a JWE, since go-jose still supports decrypting a JWE with a public key. Note that this does mean user sessions will be effectively invalidated and they'll be forced to login again, but that seems minor enough it's not worth calling out in the release notes.
 
### Verification

Tested locally using `make start PROFILE=sso UI=true`
<img width="1512" height="1026" alt="Screenshot_20260621_211236" src="https://github.com/user-attachments/assets/c59eab65-9991-487c-99fb-c5bdf228aebb" />


### Documentation

N/A

### AI

Used GPT 5.5 for initial code and tests.