### PR TITLE
fix(ui): show calculated average value in duration chart label

### DIFF
--- a/ui/src/reports/workflows-to-chart-data.ts
+++ b/ui/src/reports/workflows-to-chart-data.ts
@@ -83,7 +83,8 @@ export function workflowsToChartData(workflows: Workflow[], limit: number) {
                             label: {
                                 enabled: true,
                                 position: 'left',
-                                content: 'Average'
+                                // Display calculated average duration with 1 decimal place, or show 0.0s if no data
+                                content: durationData.length > 0 ? `Average: ${(durationData.reduce((a, b) => a + b, 0) / durationData.length).toFixed(1)}s` : 'Average: 0.0s'
                             }
                         }
                     ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation

The workflow duration chart in the Reports page displays an average line, but the label only showed the static text "Average" without the actual calculated value. This made it difficult for users to quickly understand what the average duration was without visually estimating from the chart.

### Modifications

- Updated the duration chart's average line label to display the calculated average value with one decimal place (e.g., "Average: 7.3s")
- Added fallback handling to display "Average: 0.0s" when no workflow data is available
- The average value is calculated from the duration data of workflows displayed in the chart

**Changed file:**
- \`ui/src/reports/workflows-to-chart-data.ts\`: Modified the annotation label content to include the calculated average duration value

### Verification

- Manually tested the Reports page with workflows that have various durations
- Confirmed that the average line label displays the correct calculated value
- Verified the fallback behavior when no workflow data exists

<img width="2548" height="1132" alt="image" src="https://github.com/user-attachments/assets/51639158-f13c-4e75-87d1-6d29c57b48ed" />

<img width="127" height="71" alt="image" src="https://github.com/user-attachments/assets/868f63ce-296d-4c93-9b2d-76f26fa285ac" />

### Documentation

Documentation update is not required for this change as it's a UI enhancement that improves the existing feature without changing its behavior or requiring user action. The feature remains discoverable through the existing Reports page navigation.

### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

Codex
