### PR TITLE
fix: return 404 instead of panic when archived workflow is not yet persisted

### DIFF
--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -152,7 +152,10 @@ func (a *ArtifactServer) GetArtifactFile(w http.ResponseWriter, r *http.Request)
 			a.serverInternalError(ctx, err, w)
 			return
 		}
-
+		if wf == nil {
+			a.httpFromError(ctx, argoerrors.New(argoerrors.CodeNotFound, "workflow not yet archived"), w)
+			return
+		}
 		// check that the namespace passed in matches this workflow's namespace
 		if wf.GetNamespace() != namespace {
 			a.httpBadRequestError(w)
@@ -348,12 +351,11 @@ func (a *ArtifactServer) getArtifactByUID(w http.ResponseWriter, r *http.Request
 		a.httpFromError(ctx, err, w)
 		return
 	}
-
-	ctx, err = a.gateKeeping(r, types.NamespaceHolder(wf.GetNamespace()))
-	if err != nil {
-		a.unauthorizedError(w)
+	if wf == nil {
+		a.httpFromError(ctx, argoerrors.New(argoerrors.CodeNotFound, "workflow not yet archived"), w)
 		return
 	}
+	ctx, err = a.gateKeeping(r, types.NamespaceHolder(wf.GetNamespace()))
 
 	// return 401 if the client does not have permission to get wf
 	err = a.validateAccess(ctx, wf)

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -356,7 +356,10 @@ func (a *ArtifactServer) getArtifactByUID(w http.ResponseWriter, r *http.Request
 		return
 	}
 	ctx, err = a.gateKeeping(r, types.NamespaceHolder(wf.GetNamespace()))
-
+	if err != nil {
+		a.unauthorizedError(w)
+		return
+	}
 	// return 401 if the client does not have permission to get wf
 	err = a.validateAccess(ctx, wf)
 	if err != nil {

--- a/server/artifacts/artifact_server_test.go
+++ b/server/artifacts/artifact_server_test.go
@@ -790,3 +790,77 @@ func TestArtifactServer_httpFromError(t *testing.T) {
 	s.httpFromError(ctx, err, recorder)
 	assert.Equal(t, http.StatusNotFound, recorder.Result().StatusCode)
 }
+
+// TestArtifactServer_GetArtifactByUID_WorkflowNotInArchive verifies that querying an artifact
+// by UID for a workflow that is not yet in the archive returns 404 instead of panicking
+// with a nil pointer dereference. This covers the race window between workflow completion
+// and the archiver persisting the record.
+func TestArtifactServer_GetArtifactByUID_WorkflowNotInArchive(t *testing.T) {
+	gatekeeper := &authmocks.Gatekeeper{}
+	kube := kubefake.NewClientset()
+	instanceID := "my-instanceid"
+	argo := fakewfv1.NewClientset()
+	ctx := context.WithValue(context.WithValue(logging.TestContext(t.Context()), auth.KubeKey, kube), auth.WfKey, argo)
+	gatekeeper.On("ContextWithRequest", mock.Anything, mock.Anything).Return(ctx, nil)
+
+	a := &sqldbmocks.WorkflowArchive{}
+	// Simulate the race: workflow exists but is not yet archived — GetWorkflow returns (nil, nil).
+	a.On("GetWorkflow", mock.Anything, "not-yet-archived-uid", "", "").Return((*wfv1.Workflow)(nil), nil)
+
+	fakeArtifactDriverFactory := func(_ context.Context, _ *wfv1.Artifact, _ resource.Interface) (artifactscommon.ArtifactDriver, error) {
+		return &fakeArtifactDriver{data: []byte("my-data")}, nil
+	}
+	artifactRepositories := armocks.DummyArtifactRepositories(&wfv1.ArtifactRepository{
+		S3: &wfv1.S3ArtifactRepository{
+			S3Bucket: wfv1.S3Bucket{Endpoint: "my-endpoint", Bucket: "my-bucket"},
+		},
+	})
+	s := newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), fakeArtifactDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx))
+
+	t.Run("GetOutputArtifactByUID", func(t *testing.T) {
+		r := &http.Request{}
+		r.URL = mustParse("/artifacts/not-yet-archived-uid/my-node-1/my-artifact")
+		recorder := httptest.NewRecorder()
+		s.GetOutputArtifactByUID(recorder, r)
+		assert.Equal(t, http.StatusNotFound, recorder.Result().StatusCode)
+	})
+
+	t.Run("GetInputArtifactByUID", func(t *testing.T) {
+		r := &http.Request{}
+		r.URL = mustParse("/input-artifacts/not-yet-archived-uid/my-node-1/my-artifact")
+		recorder := httptest.NewRecorder()
+		s.GetInputArtifactByUID(recorder, r)
+		assert.Equal(t, http.StatusNotFound, recorder.Result().StatusCode)
+	})
+}
+
+// TestArtifactServer_GetArtifactFile_ArchivedWorkflowNotFound verifies that the
+// archived-workflows branch of GetArtifactFile returns 404 when GetWorkflow returns
+// (nil, nil) instead of panicking with a nil pointer dereference.
+func TestArtifactServer_GetArtifactFile_ArchivedWorkflowNotFound(t *testing.T) {
+	gatekeeper := &authmocks.Gatekeeper{}
+	kube := kubefake.NewClientset()
+	instanceID := "my-instanceid"
+	argo := fakewfv1.NewClientset()
+	ctx := context.WithValue(context.WithValue(logging.TestContext(t.Context()), auth.KubeKey, kube), auth.WfKey, argo)
+	gatekeeper.On("ContextWithRequest", mock.Anything, mock.Anything).Return(ctx, nil)
+
+	a := &sqldbmocks.WorkflowArchive{}
+	a.On("GetWorkflow", mock.Anything, "not-yet-archived-uid", "", "").Return((*wfv1.Workflow)(nil), nil)
+
+	fakeArtifactDriverFactory := func(_ context.Context, _ *wfv1.Artifact, _ resource.Interface) (artifactscommon.ArtifactDriver, error) {
+		return &fakeArtifactDriver{data: []byte("my-data")}, nil
+	}
+	artifactRepositories := armocks.DummyArtifactRepositories(&wfv1.ArtifactRepository{
+		S3: &wfv1.S3ArtifactRepository{
+			S3Bucket: wfv1.S3Bucket{Endpoint: "my-endpoint", Bucket: "my-bucket"},
+		},
+	})
+	s := newArtifactServer(gatekeeper, hydratorfake.Noop, a, instanceid.NewService(instanceID), fakeArtifactDriverFactory, artifactRepositories, logging.RequireLoggerFromContext(ctx))
+
+	r := &http.Request{}
+	r.URL = mustParse("/artifact-files/my-ns/archived-workflows/not-yet-archived-uid/my-node-1/outputs/my-artifact")
+	recorder := httptest.NewRecorder()
+	s.GetArtifactFile(recorder, r)
+	assert.Equal(t, http.StatusNotFound, recorder.Result().StatusCode)
+}


### PR DESCRIPTION
Fixes #16296

## Motivation

`wfArchive.GetWorkflow` returns `(nil, nil)` during the race window between workflow completion and the archiver persisting the record. Two call sites in `server/artifacts/artifact_server.go` dereference `wf` without a nil check, causing a runtime panic (`500`) instead of a `404`:

- `getArtifactByUID` - via `wf.GetNamespace()` (~line 347)
- `GetArtifactFile`, `archived-workflows` branch (~line 152)

## Modifications

Nil guard at both call sites, routed through the existing `httpFromError` helper for consistent error handling and logging:

```go
if wf == nil {
    a.httpFromError(ctx, argoerrors.New(argoerrors.CodeNotFound, "workflow not yet archived"), w)
    return
}
```

No new imports, helpers, or signature changes. `argoerrors` is already imported.

- `server/artifacts/artifact_server.go` — nil guard at both `GetWorkflow` call sites
- `server/artifacts/artifact_server_test.go` - `TestArtifactServer_GetArtifactByUID_WorkflowNotInArchive`, `TestArtifactServer_GetArtifactFile_ArchivedWorkflowNotFound`

## Verification

```
go test ./server/artifacts/... -v
```

Two new unit tests mock `GetWorkflow` returning `(*wfv1.Workflow)(nil), nil` and assert `http.StatusNotFound` at each call site. Full suite passes.

## Documentation

Not required - this is a bug fix with no user-facing API or behaviour change beyond replacing the panic with a `404`.

## AI

Claude 