### PR TITLE
docs: fix duplicated words in stress-testing and estimated-duration

### DIFF
--- a/docs/estimated-duration.md
+++ b/docs/estimated-duration.md
@@ -8,7 +8,7 @@ This is based on the most recently successful workflow submitted from the same w
 
 To get this data, the controller queries the Kubernetes API first (as this is faster) and then [workflow archive](workflow-archive.md) (if enabled).
 
-If you've used tools like Jenkins, you'll know that that estimates can be inaccurate:
+If you've used tools like Jenkins, you'll know that estimates can be inaccurate:
 
 * A pod spent a long amount of time pending scheduling.
 * The workflow is non-deterministic, e.g. it uses `when` to execute different paths.

--- a/docs/stress-testing.md
+++ b/docs/stress-testing.md
@@ -43,7 +43,7 @@ Check Prometheus:
    on first reconciliation). Otherwise, if you see anything else, that might be a problem.
 2. How many errors were logged? `log_messages{level="error"}` What was the cause?
 
-Check PProf to see if there any any hot spots:
+Check PProf to see if there are any hot spots:
 
 ```bash
 go tool pprof -png http://localhost:6060/debug/pprof/allocs


### PR DESCRIPTION
Two small docs corrections:

- `docs/stress-testing.md`: `see if there any any hot spots` -> `see if there are any hot spots` (also restores the missing verb).
- `docs/estimated-duration.md`: `know that that estimates` -> `know that estimates`.

Hand-authored prose; no meaning change.