### PR TITLE
fix(controller): guard nil ValueFrom in addRawOutputFields. Fixes #13929

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3910,7 +3910,7 @@ func addRawOutputFields(node *wfv1.NodeStatus, tmpl *wfv1.Template) *wfv1.NodeSt
 		panic("addRawOutputFields should only be used for nodes and templates of type suspend")
 	}
 	for _, param := range tmpl.Outputs.Parameters {
-		if param.ValueFrom.Supplied != nil {
+		if param.ValueFrom != nil && param.ValueFrom.Supplied != nil {
 			if node.Outputs == nil {
 				node.Outputs = &wfv1.Outputs{Parameters: []wfv1.Parameter{}}
 			}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -2564,6 +2564,44 @@ func TestSuspendInputsResolution(t *testing.T) {
 	assert.Equal(t, "value2", node.Inputs.Parameters[1].Value.String())
 }
 
+var suspendTemplateOutputWithoutValueFrom = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: suspend-template
+spec:
+  entrypoint: suspend
+  templates:
+  - name: suspend
+    outputs:
+      parameters:
+        - name: consumerConfig
+          value: "{}"
+    suspend: {}
+`
+
+// TestSuspendOutputWithoutValueFrom ensures that a suspend template whose output
+// parameter has a literal value but no valueFrom does not panic the controller.
+// Regression test for https://github.com/argoproj/argo-workflows/issues/13929
+func TestSuspendOutputWithoutValueFrom(t *testing.T) {
+	cancel, controller := newController(logging.TestContext(t.Context()))
+	defer cancel()
+
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(suspendTemplateOutputWithoutValueFrom)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	// Before the fix, addRawOutputFields dereferenced a nil ValueFrom and panicked
+	// in initializeExecutableNode, so the suspend node never reached Running (and
+	// the recovered panic marked the workflow Error). It should suspend instead.
+	node := woc.wf.Status.Nodes.FindByDisplayName("suspend-template")
+	require.NotNil(t, node)
+	assert.Equal(t, wfv1.NodeTypeSuspend, node.Type)
+	assert.Equal(t, wfv1.NodeRunning, node.Phase)
+	assert.NotEqual(t, wfv1.WorkflowError, woc.wf.Status.Phase)
+}
+
 var sequence = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
Fixes #13929

### Motivation

A `suspend` template whose output parameter has a literal `value:` but no
`valueFrom:` panics the workflow-controller. `addRawOutputFields` dereferences
`param.ValueFrom.Supplied`, but `Parameter.ValueFrom` is a nullable
`*ValueFrom`, so it is `nil` in this case. The recovered panic flips the entire
workflow to `Error` (see the controller log and stack trace in the issue).

Minimal reproducer (from the issue):

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  name: placeholder
spec:
  entrypoint: main
  templates:
    - name: main
      outputs:
        parameters:
          - name: consumerConfig
            value: "{}"
      suspend: {}
```

### Modifications

- `workflow/controller/operator.go`: guard the nil pointer in
  `addRawOutputFields` — `if param.ValueFrom != nil && param.ValueFrom.Supplied != nil`.
  An output parameter without a `valueFrom` source is simply skipped (it has no
  supplied source to add), so the suspend node initializes normally.

### Verification

- Added `TestSuspendOutputWithoutValueFrom` in
  `workflow/controller/operator_test.go`, a regression test that operates a
  suspend template with a `value:`-only output parameter.
  - Without the fix it **fails**: the recovered panic sets the workflow phase to
    `Error` and the node is stuck `Pending`.
  - With the fix it **passes**: the node suspends as `Running`.
- `go test ./workflow/controller/ -run TestSuspendOutputWithoutValueFrom` passes;
  `go vet ./workflow/controller/` is clean.

### Documentation

Not needed — this is a panic-guard bug fix with no user-facing behavior or API
change.

### AI

This PR was prepared with the assistance of a generative AI coding tool
(Claude Code). The author reviewed and verified all changes, including the
root-cause analysis and the regression test (confirmed failing before the fix
and passing after). Per the Argo project's Generative AI policy:
https://github.com/argoproj/argoproj/blob/main/community/genai.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause workflows with suspended steps and literal output values to fail unexpectedly.
  * Suspended workflows now continue running correctly when an output does not specify a value source.

* **Tests**
  * Added coverage to verify the workflow remains active and avoids entering an error state in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->