### PR TITLE
fix(ci): trigger Codegen when its source inputs change

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -81,6 +81,10 @@ jobs:
               - cmd/**
               - examples/** # examples are used within the fields lists
               - manifests/** # a few of these are generated and committed
+              - config/** # docs/workflow-controller-configmap.md is generated from config/*.go
+              - persist/** # docs/database-migrations.md is generated from persist/sqldb/migrate.go
+              - util/sync/db/** # docs/database-migrations.md is generated from util/sync/db/migrate.go
+              - util/telemetry/builder/** # docs/metrics.md and docs/tracing.md are generated from util/telemetry/builder/values.yaml
               # generation scripts
               - hack/api/**
               - hack/docs/**


### PR DESCRIPTION
## Motivation

The `Codegen` job is gated on the `codegen` paths-filter — a hand-maintained list of generation inputs that has drifted from the actual Makefile prerequisites. Several generated docs are built from source trees the filter doesn't watch, so a PR touching only those trees skips `Codegen` (and its "fail if codegen made changes not present in the PR" check), letting a stale generated doc merge.

Discovered via #16291, which changed only `config/*.go`: `Codegen` was skipped, and the regenerated `docs/workflow-controller-configmap.md` (two new rows, under `PersistConfig` and `SyncConfig`) was never produced or checked.

## Modifications

Adds the missing generation inputs to the filter:

- `config/**` → `docs/workflow-controller-configmap.md` (Makefile: `config/*.go`)
- `persist/**`, `util/sync/db/**` → `docs/database-migrations.md` (`persist/sqldb/migrate.go`, `util/sync/db/migrate.go`)
- `util/telemetry/builder/**` → `docs/metrics.md`, `docs/tracing.md` (`util/telemetry/builder/values.yaml`)

## Verification

This is CI only, really only hand checked

## Documentation

Non required

## AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)