### PR TITLE
chore: enable CodeRabbit auto-reviews on main, excluding dependency PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,7 +37,14 @@ reviews:
     - "!**/sdks/python/client/**"
 
   auto_review:
-    enabled: false
+    # Automatically review PRs targeting the default branch (main).
+    # base_branches is intentionally left empty so only main is covered.
+    enabled: true
+
+    # Skip PRs labelled as dependency updates (dependabot/renovate use
+    # the "type/dependencies" label). The "!" prefix is a negative match.
+    labels:
+      - "!type/dependencies"
 
   # Tools configuration
   tools:


### PR DESCRIPTION
Enable automatic CodeRabbit reviews for PRs targeting the default branch (main). Skip PRs labelled 'type/dependencies' (used by dependabot and renovate) via a negative label match.

## AI

Claude drafted this for me