### PR TITLE
feat: configurable allowlist

### DIFF
--- a/.features/pending/configurable-allowlist.md
+++ b/.features/pending/configurable-allowlist.md
@@ -1,0 +1,11 @@
+Description: Allow for configuring the allow list when using workflow template refs.
+Authors: [Isitha Subasinghe](https://github.com/isubasinghe)
+Component: General
+Issues: 23
+
+When the controller runs with `templateReferencing: Strict` or `Secure`, workflows using a `workflowTemplateRef` may only set an allow-listed set of `WorkflowSpec` fields (`arguments`, `entrypoint`, `suspend`, and other benign knobs); every other field is blocked so a submitter cannot override the template's security settings.
+The `WORKFLOW_USER_OVERRIDE_ALLOWLIST` environment variable lets operators add fields to this allow-list.
+Set it on the workflow-controller to a comma-separated list of `WorkflowSpec` field names, using the YAML/JSON names as written in a workflow, for example `WORKFLOW_USER_OVERRIDE_ALLOWLIST=podSpecPatch,volumes`.
+Use this when your environment has decided a normally-blocked field is safe for submitters to override.
+An unknown field name fails the controller at startup rather than being silently ignored, surfacing typos.
+The nested `artifactGC.podSpecPatch`, `artifactGC.serviceAccountName`, and `artifactGC.podMetadata` fields remain blocked and are not relaxed by this variable.

--- a/.features/pending/configurable-allowlist.md
+++ b/.features/pending/configurable-allowlist.md
@@ -1,7 +1,7 @@
 Description: Allow for configuring the allow list when using workflow template refs.
 Authors: [Isitha Subasinghe](https://github.com/isubasinghe)
 Component: General
-Issues: 23
+Issues: 16345
 
 When the controller runs with `templateReferencing: Strict` or `Secure`, workflows using a `workflowTemplateRef` may only set an allow-listed set of `WorkflowSpec` fields (`arguments`, `entrypoint`, `suspend`, and other benign knobs); every other field is blocked so a submitter cannot override the template's security settings.
 The `WORKFLOW_USER_OVERRIDE_ALLOWLIST` environment variable lets operators add fields to this allow-list.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -58,6 +58,7 @@ This document outlines environment variables that can be used to customize behav
 | `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS` | `bool` | `true` | Whether to watch the Controller's ConfigMap and semaphore ConfigMaps for run-time changes. When disabled, the Controller will only read these ConfigMaps once and will have to be manually restarted to pick up new changes. |
 | `SKIP_WORKFLOW_DURATION_ESTIMATION` | `bool` | `false` | Whether to lookup resource usage from prior workflows to estimate usage for new workflows. |
 | `WORKFLOW_ESTIMATION_DB_QUERY_TIMEOUT_SECONDS` | `int` | `5` | Timeout in seconds for database queries when estimating workflow duration. Prevents workflow execution from being blocked when database is slow or locked. |
+| `WORKFLOW_USER_OVERRIDE_ALLOWLIST` | `string` | `""` | Comma-separated `WorkflowSpec` field names (YAML/JSON names, e.g. `podSpecPatch,volumes`) to add to the allow-list of fields a `workflowTemplateRef` submitter may set under [`templateReferencing: Strict`/`Secure`](workflow-restrictions.md). Invalid names fail the Controller at startup. The nested `artifactGC` security fields are not relaxed. |
 
 CLI parameters of the Controller can be specified as environment variables with the `ARGO_` prefix.
 For example:

--- a/docs/workflow-restrictions.md
+++ b/docs/workflow-restrictions.md
@@ -37,6 +37,16 @@ The allow-listed fields are:
 
 All other fields on the submitted `Workflow` spec must be defined on the referenced `WorkflowTemplate` instead.
 
+### Extending the Allow-List
+
+You can add fields to the allow-list with the `WORKFLOW_USER_OVERRIDE_ALLOWLIST` [environment variable](environment-variables.md) on the Controller.
+Set it to a comma-separated list of `WorkflowSpec` field names, using the YAML/JSON names you would write in a `Workflow`, for example `WORKFLOW_USER_OVERRIDE_ALLOWLIST=podSpecPatch,volumes`.
+
+Use this when you have decided that a normally-blocked field is safe for submitters to override in your environment.
+An unknown field name fails the Controller at startup rather than being silently ignored, so typos are surfaced.
+
+The nested `artifactGC.podSpecPatch`, `artifactGC.serviceAccountName`, and `artifactGC.podMetadata` fields remain blocked and are not relaxed by this variable.
+
 ## Setting Workflow Restrictions
 
 You can add `workflowRestrictions` in the [`workflow-controller-configmap`](./workflow-controller-configmap.yaml).

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -197,6 +197,10 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		return nil, err
 	}
 
+	if err = util.ConfigureUserOverrideAllowlistFromEnv(); err != nil {
+		return nil, err
+	}
+
 	wfc := WorkflowController{
 		restConfig:                 restConfig,
 		kubeclientset:              kubeclientset,

--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -3,8 +3,10 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -31,6 +33,65 @@ var allowedUserOverrideFields = map[string]bool{
 	"WorkflowTemplateRef":   true,
 	"Metrics":               true,
 	"ArtifactGC":            true,
+}
+
+// userOverrideAllowlistEnv names an env var operators may set to ADD WorkflowSpec
+// field names to allowedUserOverrideFields (comma-separated, e.g.
+// "podSpecPatch,volumes"). Field names are the YAML/JSON names operators write in
+// their workflows, not Go identifiers. This re-opens overrides that are blocked by
+// default, so it is opt-in and validated against real field names.
+// Note: the nested ArtifactGC.PodSpecPatch/ServiceAccountName/PodMetadata blocks
+// are enforced separately and are NOT relaxed by this var.
+const userOverrideAllowlistEnv = "WORKFLOW_USER_OVERRIDE_ALLOWLIST"
+
+// ConfigureUserOverrideAllowlistFromEnv adds the WorkflowSpec field names listed
+// in $WORKFLOW_USER_OVERRIDE_ALLOWLIST to allowedUserOverrideFields. It is
+// controller-only configuration and must be called once at controller startup,
+// so an invalid field name fails the controller rather than any binary (CLI,
+// argoexec) that merely imports this package.
+func ConfigureUserOverrideAllowlistFromEnv() error {
+	fields, err := parseUserOverrideAllowlist(os.Getenv(userOverrideAllowlistEnv))
+	if err != nil {
+		return err
+	}
+	for _, f := range fields {
+		allowedUserOverrideFields[f] = true
+	}
+	return nil
+}
+
+// parseUserOverrideAllowlist parses a comma-separated list of WorkflowSpec field
+// names (the YAML/JSON names operators write, e.g. "podSpecPatch"), returning the
+// corresponding Go field names that key allowedUserOverrideFields. It errors on any
+// name that is not a real WorkflowSpec field so an operator typo is surfaced rather
+// than silently leaving a field blocked.
+func parseUserOverrideAllowlist(env string) ([]string, error) {
+	if strings.TrimSpace(env) == "" {
+		return nil, nil
+	}
+	// Map YAML/JSON name -> Go field name; allowedUserOverrideFields is keyed by Go name.
+	goName := map[string]string{}
+	t := reflect.TypeFor[wfv1.WorkflowSpec]()
+	for field := range t.Fields() {
+		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		if name == "" || name == "-" {
+			name = field.Name // ponytail: fall back to Go name for any untagged field
+		}
+		goName[name] = field.Name
+	}
+	var fields []string
+	for f := range strings.SplitSeq(env, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		g, ok := goName[f]
+		if !ok {
+			return nil, fmt.Errorf("%s: %q is not a WorkflowSpec field name", userOverrideAllowlistEnv, f)
+		}
+		fields = append(fields, g)
+	}
+	return fields, nil
 }
 
 // ValidateUserOverrides checks that a user-submitted WorkflowSpec only sets

--- a/workflow/util/merge_test.go
+++ b/workflow/util/merge_test.go
@@ -45,6 +45,26 @@ spec:
     strategy: OnPodSuccess
 `
 
+func TestParseUserOverrideAllowlist(t *testing.T) {
+	for _, env := range []string{"", "  "} {
+		got, err := parseUserOverrideAllowlist(env)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	}
+
+	// Input is the YAML/JSON name; output is the Go field name that keys allowedUserOverrideFields.
+	got, err := parseUserOverrideAllowlist(" podSpecPatch , volumes ")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"PodSpecPatch", "Volumes"}, got)
+
+	// Go identifiers are not accepted — operators write YAML names.
+	_, err = parseUserOverrideAllowlist("PodSpecPatch")
+	require.EqualError(t, err, `WORKFLOW_USER_OVERRIDE_ALLOWLIST: "PodSpecPatch" is not a WorkflowSpec field name`)
+
+	_, err = parseUserOverrideAllowlist("notAField")
+	require.EqualError(t, err, `WORKFLOW_USER_OVERRIDE_ALLOWLIST: "notAField" is not a WorkflowSpec field name`)
+}
+
 func TestMergeWorkflows(t *testing.T) {
 	patchWf := wfv1.MustUnmarshalWorkflow(origWF)
 	targetWf := wfv1.MustUnmarshalWorkflow(patchWF)


### PR DESCRIPTION
Fixes #16345

## Motivation

Under `templateReferencing: Strict`/`Secure`, a `workflowTemplateRef` submitter may only set a hard-coded allow-list of `WorkflowSpec` fields; everything else is rejected so the template's security settings can't be overridden. That list was baked into the binary, so operators who wanted to permit an extra field they'd deemed safe had no choice but to fork and rebuild the controller.

## Modifications

- Added `WORKFLOW_USER_OVERRIDE_ALLOWLIST`: a comma-separated list of `WorkflowSpec` field names (the YAML/JSON names, e.g. `podSpecPatch,volumes`) that get added to the allow-list.
- Parsed and applied once at controller startup via `ConfigureUserOverrideAllowlistFromEnv`. Names are validated against the real `WorkflowSpec` fields, so a typo fails the controller at boot instead of silently leaving a field blocked.
- Nested `artifactGC` security fields (`podSpecPatch`, `serviceAccountName`, `podMetadata`) stay blocked regardless — this var doesn't touch them.

## Verification

`TestParseUserOverrideAllowlist` covers the empty/whitespace input, YAML→Go name mapping, and the two error paths (Go identifiers and unknown names both rejected). Existing `ValidateUserOverrides` tests still pass.

## Documentation

- `docs/environment-variables.md` — new Controller env-var row.
- `docs/workflow-restrictions.md` — "Extending the Allow-List" section.

## AI

Used Claude Code to help with the docs and tests.