### PR TITLE
ci: raise unit test timeout to 15m (release-4.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ endif
 E2E_WAIT_TIMEOUT      ?= 90s # timeout for wait conditions
 E2E_PARALLEL          ?= 20
 E2E_SUITE_TIMEOUT     ?= 30m
+UNIT_TEST_TIMEOUT     ?= 15m # per-package timeout for unit tests
 TEST_RETRIES          ?= 2
 JSON_TEST_OUTPUT      := test/reports/json
 # gotest function: gotest(packages, name, parameters)
@@ -589,7 +590,7 @@ lint-ui: ui/dist/app/index.html
 .PHONY: test
 test: ui/dist/app/index.html util/telemetry/metrics_list.go util/telemetry/attributes.go $(TOOL_GOTESTSUM) $(JSON_TEST_OUTPUT) ## Run tests
 	go build ./...
-	env KUBECONFIG=/dev/null $(call gotest,./...,unit,-p 20)
+	env KUBECONFIG=/dev/null $(call gotest,./...,unit,-p 20 -timeout $(UNIT_TEST_TIMEOUT))
 	# marker file, based on it's modification time, we know how long ago this target was run
 	@mkdir -p dist
 	touch dist/test


### PR DESCRIPTION
## Motivation

The `workflow/controller` unit-test package runs at **~9m50s** on `release-4.0` (vs ~1m on `main`), sitting right on Go's default **10m per-package** timeout. Recent history:

| release-4.0 run | `workflow/controller` |
|---|---|
| 2026-06-10 | 9m44s |
| 2026-06-30 | 9m49s |
| 2026-07-01 | 9m47s |
| 2026-07-01 | **10m0s → TIMEOUT** |
| `main` (contrast) | ~1m13s |

Because it's a hard ~9m50s rather than random flakiness, whether it passes is decided by runner speed, so **reruns don't help**. This has been surfacing as `panic: test timed out after 10m0s` on unrelated PRs branched off release-4.0 (e.g. #16316, #16318).

## Root cause (context, not fixed here)

The slowness comes from the v4.0 default `persistUpdates` path in `workflow/controller/operator.go`, which sleeps `1 * time.Second` after every workflow update when `INFORMER_WRITE_BACK` is unset. Every controller unit test pays ~1s per operate cycle; across ~640 tests that's the ~9m50s. `main` removed that block entirely, which is why it runs in ~1m.

Properly fixing that is a larger, behavioural change to a release branch. **This PR is just headroom** so the branch isn't wedged in the meantime.

## Change

- Add a `UNIT_TEST_TIMEOUT` Makefile variable (default `15m`), mirroring the existing `E2E_SUITE_TIMEOUT` knob.
- Pass `-timeout $(UNIT_TEST_TIMEOUT)` to `go test` in the `test` target.

`-timeout` is per-package, and 15m stays under the Unit Tests job's `timeout-minutes: 20` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)