### PR TITLE
fix: reject stale copies of completed workflows using resourceVersion comparison

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -57,9 +57,6 @@ const (
 	// the strategy whose artifacts are being deleted
 	AnnotationKeyArtifactGCStrategy = workflow.WorkflowFullName + "/artifact-gc-strategy"
 
-	// AnnotationKeyLastSeenVersion stores the last seen version of the workflow when it was last successfully processed by the controller
-	AnnotationKeyLastSeenVersion = workflow.WorkflowFullName + "/last-seen-version"
-
 	// LabelParallelismLimit is a label applied on namespace objects to control the per namespace parallelism.
 	LabelParallelismLimit = workflow.WorkflowFullName + "/parallelism-limit"
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -72,19 +73,21 @@ import (
 
 const maxAllowedStackDepth = 100
 
-type recentlyCompletedWorkflow struct {
-	key  string
-	when time.Time
+// lastWrittenVersion records the most recent resourceVersion of a workflow
+// that this controller has written, or has seen complete or be deleted.
+type lastWrittenVersion struct {
+	resourceVersion string
+	// completedAt is set when the workflow completed or was deleted. The
+	// record is retained for completedVersionRetention afterwards so that
+	// stale copies of the workflow re-entering the informer can still be
+	// rejected, and is then expired.
+	completedAt time.Time
 }
 
-type recentCompletions struct {
-	completions []recentlyCompletedWorkflow
+type lastWrittenVersions struct {
+	versions    map[types.UID]lastWrittenVersion
+	nextCleanup time.Time
 	mutex       gosync.RWMutex
-}
-
-type lastSeenVersions struct {
-	versions map[string]string
-	mutex    gosync.RWMutex
 }
 
 // WorkflowController is the controller for workflow resources
@@ -156,11 +159,10 @@ type WorkflowController struct {
 	progressFileTickDuration time.Duration
 	executorPlugins          map[string]map[string]*spec.Plugin // namespace -> name -> plugin
 
-	recentCompletions recentCompletions
 	// lastUnreconciledWorkflows is a map of workflows that have been recently unreconciled
 	lastUnreconciledWorkflows map[string]*wfv1.Workflow
 
-	lastSeenVersions lastSeenVersions // key: workflow UID, value: resource version
+	lastWrittenVersions lastWrittenVersions
 }
 
 const (
@@ -213,8 +215,8 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		eventRecorderManager:       events.NewEventRecorderManager(kubeclientset),
 		progressPatchTickDuration:  env.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:   env.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
-		lastSeenVersions: lastSeenVersions{
-			versions: make(map[string]string),
+		lastWrittenVersions: lastWrittenVersions{
+			versions: make(map[types.UID]lastWrittenVersion),
 			mutex:    gosync.RWMutex{},
 		},
 	}
@@ -777,7 +779,11 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		return true
 	}
 
-	if wfc.isOutdated(un) {
+	if outdated, completed := wfc.isOutdated(ctx, un); outdated {
+		if completed {
+			logger.WithField("key", key).Warn(ctx, "Rejecting stale copy of a completed workflow")
+			return true
+		}
 		logger.WithField("key", key).Debug(ctx, "Skipping outdated workflow event")
 		wfc.wfQueue.AddRateLimited(key)
 		return true
@@ -795,11 +801,6 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		ctx = logging.WithLogger(ctx, woc.log)
 		woc.markWorkflowFailed(ctx, fmt.Sprintf("cannot unmarshall spec: %s", err.Error()))
 		woc.persistUpdates(ctx)
-		return true
-	}
-
-	if wf.Status.Phase != "" && wfc.checkRecentlyCompleted(wf.Name) {
-		logger.WithField("name", wf.ObjectMeta.Name).Warn(ctx, "Cache: Rejecting recently deleted")
 		return true
 	}
 
@@ -941,56 +942,56 @@ func getWfPriority(obj any) (int32, time.Time) {
 	return int32(priority), un.GetCreationTimestamp().Time
 }
 
-// 10 minutes in the past
-const maxCompletedStoreTime = time.Second * -600
+// how long to retain the record of a completed or deleted workflow
+const completedVersionRetention = 10 * time.Minute
 
-// This is a helper function for expiring old records of workflows
-// completed more than maxCompletedStoreTime ago
-func (wfc *WorkflowController) cleanCompletedWorkflowsRecord() {
-	cutoff := time.Now().Add(maxCompletedStoreTime)
-	removeIndex := -1
-	wfc.recentCompletions.mutex.Lock()
-	defer wfc.recentCompletions.mutex.Unlock()
+// how often, at most, to scan for expired completed workflow records
+const versionCleanupPeriod = time.Minute
 
-	for i, val := range wfc.recentCompletions.completions {
-		if val.when.After(cutoff) {
-			removeIndex = i - 1
-			break
-		}
+// expireCompletedVersions removes records of workflows that completed or were
+// deleted more than completedVersionRetention ago. Scans are throttled to at
+// most one per versionCleanupPeriod. The caller must hold the
+// lastWrittenVersions write lock.
+func (wfc *WorkflowController) expireCompletedVersions() {
+	now := time.Now()
+	if now.Before(wfc.lastWrittenVersions.nextCleanup) {
+		return
 	}
-	if removeIndex >= 0 {
-		wfc.recentCompletions.completions = wfc.recentCompletions.completions[removeIndex+1:]
+	wfc.lastWrittenVersions.nextCleanup = now.Add(versionCleanupPeriod)
+	for uid, last := range wfc.lastWrittenVersions.versions {
+		if !last.completedAt.IsZero() && now.Sub(last.completedAt) > completedVersionRetention {
+			delete(wfc.lastWrittenVersions.versions, uid)
+		}
 	}
 }
 
-// Records a workflow as recently completed in the list
-// if it isn't already in the list
-func (wfc *WorkflowController) recordCompletedWorkflow(key string) {
-	if !wfc.checkRecentlyCompleted(key) {
-		wfc.recentCompletions.mutex.Lock()
-		defer wfc.recentCompletions.mutex.Unlock()
-		wfc.recentCompletions.completions = append(wfc.recentCompletions.completions,
-			recentlyCompletedWorkflow{
-				key:  key,
-				when: time.Now(),
-			})
-	}
+// recordWorkflowWrite records the resourceVersion of a workflow just written
+// by this controller, so that older copies of it can be recognized as stale.
+func (wfc *WorkflowController) recordWorkflowWrite(wf metav1.Object) {
+	wfc.lastWrittenVersions.mutex.Lock()
+	defer wfc.lastWrittenVersions.mutex.Unlock()
+	wfc.expireCompletedVersions()
+	wfc.lastWrittenVersions.versions[wf.GetUID()] = lastWrittenVersion{resourceVersion: wf.GetResourceVersion()}
 }
 
-// Returns true if the workflow given by key is in the recently completed
-// list. Will perform expiry cleanup before checking.
-func (wfc *WorkflowController) checkRecentlyCompleted(key string) bool {
-	wfc.cleanCompletedWorkflowsRecord()
-	recent := false
-	wfc.recentCompletions.mutex.RLock()
-	defer wfc.recentCompletions.mutex.RUnlock()
-	for _, val := range wfc.recentCompletions.completions {
-		if val.key == key {
-			recent = true
-			break
+// recordWorkflowCompleted marks a workflow as completed or deleted, retaining
+// its latest known resourceVersion for completedVersionRetention so that
+// stale copies of it re-entering the informer can be rejected.
+func (wfc *WorkflowController) recordWorkflowCompleted(wf metav1.Object) {
+	wfc.lastWrittenVersions.mutex.Lock()
+	defer wfc.lastWrittenVersions.mutex.Unlock()
+	wfc.expireCompletedVersions()
+	rv := wf.GetResourceVersion()
+	if last, ok := wfc.lastWrittenVersions.versions[wf.GetUID()]; ok {
+		// never regress the recorded version: this event may itself be stale
+		if cmp, err := resourceversion.CompareResourceVersion(rv, last.resourceVersion); err != nil || cmp < 0 {
+			rv = last.resourceVersion
 		}
 	}
-	return recent
+	wfc.lastWrittenVersions.versions[wf.GetUID()] = lastWrittenVersion{
+		resourceVersion: rv,
+		completedAt:     time.Now(),
+	}
 }
 
 func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) error {
@@ -1009,9 +1010,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 				}
 				needed := reconciliationNeeded(un)
 				if !needed {
-					key, _ := cache.MetaNamespaceKeyFunc(un)
-					wfc.recordCompletedWorkflow(key)
-					wfc.deleteLastSeenVersionKey(wfc.getLastSeenVersionKey(un))
+					wfc.recordWorkflowCompleted(un)
 				}
 				return needed
 			},
@@ -1065,11 +1064,10 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 					if err == nil {
 						wfc.releaseAllWorkflowLocks(ctx, obj)
-						wfc.recordCompletedWorkflow(key)
 						// no need to add to the queue - this workflow is done
 						wfc.throttler.Remove(key)
 					}
-					wfc.deleteLastSeenVersionKey(wfc.getLastSeenVersionKey(obj.(*unstructured.Unstructured)))
+					wfc.recordWorkflowCompleted(obj.(*unstructured.Unstructured))
 				},
 			},
 		},
@@ -1422,24 +1420,22 @@ func (wfc *WorkflowController) IsLeader() bool {
 	return wfc.wfInformer != nil
 }
 
-func (wfc *WorkflowController) isOutdated(wf metav1.Object) bool {
-	wfc.lastSeenVersions.mutex.RLock()
-	defer wfc.lastSeenVersions.mutex.RUnlock()
-	lastSeenRV, ok := wfc.lastSeenVersions.versions[wfc.getLastSeenVersionKey(wf)]
+// isOutdated returns whether this copy of the workflow is older than the
+// version last written by this controller, and whether that version was the
+// completed or deleted state of the workflow.
+func (wfc *WorkflowController) isOutdated(ctx context.Context, wf metav1.Object) (outdated bool, completedWorkflow bool) {
+	wfc.lastWrittenVersions.mutex.RLock()
+	defer wfc.lastWrittenVersions.mutex.RUnlock()
+	last, ok := wfc.lastWrittenVersions.versions[wf.GetUID()]
 	// always process if not seen before
-	if !ok || lastSeenRV == "" {
-		return false
+	if !ok {
+		return false, false
 	}
-	annotations := wf.GetAnnotations()[common.AnnotationKeyLastSeenVersion]
-	return annotations != lastSeenRV
-}
-
-func (wfc *WorkflowController) getLastSeenVersionKey(wf metav1.Object) string {
-	return string(wf.GetUID())
-}
-
-func (wfc *WorkflowController) deleteLastSeenVersionKey(key string) {
-	wfc.lastSeenVersions.mutex.Lock()
-	defer wfc.lastSeenVersions.mutex.Unlock()
-	delete(wfc.lastSeenVersions.versions, key)
+	cmp, err := resourceversion.CompareResourceVersion(wf.GetResourceVersion(), last.resourceVersion)
+	if err != nil {
+		// resourceVersions on this cluster are not comparable, so process everything
+		logging.RequireLoggerFromContext(ctx).WithError(err).WithField("name", wf.GetName()).Warn(ctx, "Cannot compare workflow resource versions")
+		return false, false
+	}
+	return cmp < 0, !last.completedAt.IsZero()
 }

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -300,6 +301,9 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		progressPatchTickDuration: envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:  envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
 		maxStackDepth:             maxAllowedStackDepth,
+		lastWrittenVersions: lastWrittenVersions{
+			versions: make(map[types.UID]lastWrittenVersion),
+		},
 	}
 
 	for _, opt := range options {
@@ -1355,4 +1359,77 @@ func TestPodSpecPatchTemplateLevel(t *testing.T) {
 	}
 	require.NotNil(t, mainContainer)
 	assert.Equal(t, "25Mi", mainContainer.Resources.Requests.Memory().String())
+}
+
+func TestIsOutdated(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+
+	obj := func(uid types.UID, rv string) metav1.Object {
+		return &metav1.ObjectMeta{UID: uid, ResourceVersion: rv}
+	}
+	assertOutdated := func(t *testing.T, wantOutdated, wantCompleted bool, wf metav1.Object) {
+		t.Helper()
+		outdated, completed := controller.isOutdated(ctx, wf)
+		assert.Equal(t, wantOutdated, outdated, "outdated")
+		assert.Equal(t, wantCompleted, completed, "completed")
+	}
+
+	// workflows the controller has never written are always processed
+	assertOutdated(t, false, false, obj("wf-1", "99"))
+
+	controller.recordWorkflowWrite(obj("wf-1", "100"))
+	assertOutdated(t, true, false, obj("wf-1", "99"))
+	assertOutdated(t, false, false, obj("wf-1", "100"))
+	// a newer version written by another actor is not outdated
+	assertOutdated(t, false, false, obj("wf-1", "101"))
+
+	// incomparable resourceVersions must fail open and process the workflow
+	assertOutdated(t, false, false, obj("wf-1", "not-a-number"))
+
+	// stale copy of a completed workflow is rejected: regression test for
+	// https://github.com/argoproj/argo-workflows/issues/16305
+	controller.recordWorkflowCompleted(obj("wf-1", "110"))
+	assertOutdated(t, true, true, obj("wf-1", "99"))
+	// a retried workflow keeps its UID but has a newer resourceVersion
+	assertOutdated(t, false, true, obj("wf-1", "120"))
+	// a recreated workflow with the same name has a different UID
+	assertOutdated(t, false, false, obj("wf-2", "50"))
+
+	// a stale completion event must not regress the recorded version
+	controller.recordWorkflowCompleted(obj("wf-1", "105"))
+	assertOutdated(t, true, true, obj("wf-1", "109"))
+
+	// the controller's first write of a retried workflow clears the
+	// completed state, restoring requeue rather than drop for stale copies
+	controller.recordWorkflowWrite(obj("wf-1", "160"))
+	assertOutdated(t, true, false, obj("wf-1", "150"))
+}
+
+func TestExpireCompletedVersions(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+
+	inFlight := &metav1.ObjectMeta{UID: "wf-in-flight", ResourceVersion: "100"}
+	completed := &metav1.ObjectMeta{UID: "wf-completed", ResourceVersion: "200"}
+	controller.recordWorkflowWrite(inFlight)
+	controller.recordWorkflowCompleted(completed)
+
+	// age the completed record beyond retention and force a cleanup scan
+	controller.lastWrittenVersions.mutex.Lock()
+	last := controller.lastWrittenVersions.versions[completed.UID]
+	last.completedAt = time.Now().Add(-completedVersionRetention - time.Minute)
+	controller.lastWrittenVersions.versions[completed.UID] = last
+	controller.lastWrittenVersions.nextCleanup = time.Time{}
+	controller.lastWrittenVersions.mutex.Unlock()
+
+	controller.recordWorkflowWrite(&metav1.ObjectMeta{UID: "wf-other", ResourceVersion: "300"})
+
+	outdated, completedWf := controller.isOutdated(ctx, &metav1.ObjectMeta{UID: completed.UID, ResourceVersion: "199"})
+	assert.False(t, outdated, "expired completed record should be forgotten")
+	assert.False(t, completedWf)
+	outdated, _ = controller.isOutdated(ctx, &metav1.ObjectMeta{UID: inFlight.UID, ResourceVersion: "99"})
+	assert.True(t, outdated, "in-flight records must not expire")
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -210,7 +210,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		}
 	}()
 
-	woc.log.WithFields(logging.Fields{"phase": woc.wf.Status.Phase, "resourceVersion": woc.wf.ObjectMeta.ResourceVersion, "lastSeenVersion": woc.wf.GetAnnotations()[common.AnnotationKeyLastSeenVersion]}).Info(ctx, "Processing workflow")
+	woc.log.WithFields(logging.Fields{"phase": woc.wf.Status.Phase, "resourceVersion": woc.wf.ObjectMeta.ResourceVersion}).Info(ctx, "Processing workflow")
 
 	// Set the Execute workflow spec for execution
 	// ExecWF is a runtime execution spec which merged from Wf, WFT and Wfdefault
@@ -783,8 +783,6 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.log.WithError(err).Warn(ctx, "error updating taskset")
 	}
 
-	oldRV := woc.wf.ResourceVersion
-	woc.updateLastSeenVersionAnnotation(oldRV)
 	if wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{}); err != nil {
 		woc.log.WithField("error", err).WithField("reason", apierr.ReasonForError(err)).Warn(ctx, "Error updating workflow")
 		if argokubeerr.IsRequestEntityTooLargeErr(err) {
@@ -807,7 +805,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.controller.hydrator.HydrateWithNodes(woc.wf, nodes)
 	}
 
-	woc.updateLastSeenVersion(oldRV)
+	woc.controller.recordWorkflowWrite(woc.wf)
 	// The workflow returned from wfClient.Update doesn't have a TypeMeta associated
 	// with it, so copy from the original workflow.
 	woc.wf.TypeMeta = woc.orig.TypeMeta
@@ -819,7 +817,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		panic("workflow should be hydrated")
 	}
 
-	woc.log.WithFields(logging.Fields{"resourceVersion": woc.wf.ResourceVersion, "phase": woc.wf.Status.Phase, "lastSeenVersion": woc.wf.GetAnnotations()[common.AnnotationKeyLastSeenVersion]}).Info(ctx, "Workflow update successful")
+	woc.log.WithFields(logging.Fields{"resourceVersion": woc.wf.ResourceVersion, "phase": woc.wf.Status.Phase}).Info(ctx, "Workflow update successful")
 
 	// Make sure the workflow completed.
 	if woc.wf.Status.Fulfilled() {
@@ -865,14 +863,12 @@ func (woc *wfOperationCtx) deleteTaskResults(ctx context.Context) error {
 func (woc *wfOperationCtx) persistWorkflowSizeLimitErr(ctx context.Context, wfClient v1alpha1.WorkflowInterface, err error) {
 	woc.wf = woc.orig.DeepCopy()
 	ctx = woc.markWorkflowError(ctx, err)
-	oldRV := woc.wf.ResourceVersion
-	woc.updateLastSeenVersionAnnotation(oldRV)
 
-	_, err = wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
+	wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
 	if err != nil {
 		woc.log.WithError(err).Warn(ctx, "Error updating workflow with size error")
 	} else {
-		woc.updateLastSeenVersion(oldRV)
+		woc.controller.recordWorkflowWrite(wf)
 	}
 }
 
@@ -4645,20 +4641,4 @@ func (woc *wfOperationCtx) setNodeDisplayName(ctx context.Context, node *wfv1.No
 	newNode := node.DeepCopy()
 	newNode.DisplayName = displayName
 	woc.wf.Status.Nodes.Set(ctx, nodeID, *newNode)
-}
-
-func (woc *wfOperationCtx) updateLastSeenVersionAnnotation(value string) {
-	if woc.wf.GetAnnotations() == nil {
-		woc.wf.SetAnnotations(make(map[string]string))
-	}
-	woc.wf.GetAnnotations()[common.AnnotationKeyLastSeenVersion] = value
-}
-
-func (woc *wfOperationCtx) updateLastSeenVersion(value string) {
-	woc.controller.lastSeenVersions.mutex.Lock()
-	defer woc.controller.lastSeenVersions.mutex.Unlock()
-	if woc.controller.lastSeenVersions.versions == nil {
-		woc.controller.lastSeenVersions.versions = make(map[string]string)
-	}
-	woc.controller.lastSeenVersions.versions[woc.controller.getLastSeenVersionKey(woc.wf)] = value
 }


### PR DESCRIPTION
Fixes #16305

### Motivation

  The recently-completed workflow cache added in #12198 records informer keys
  (`namespace/name`) but `processNextItem` checked it with `name` only. A
  Kubernetes name can never contain `/`, so the check never matched and the
  "Cache: Rejecting recently deleted" guard was dead code: a stale, still-running
  copy of a recently completed or deleted workflow re-entering the informer
  (e.g. via a relist after watch interruption) could be reprocessed,
  potentially recreating pods.

  Fixing just the key would introduce a new problem: a name-keyed membership
  check would wrongly reject a retried workflow, or a recreated workflow
  reusing a name, for up to 10 minutes after completion.

  Since #15090 the controller also tracks staleness for in-flight workflows via
  the `workflows.argoproj.io/last-seen-version` annotation plus an in-memory
  UID→resourceVersion map, using equality comparison because resourceVersions
  could not officially be ordered. `k8s.io/apimachinery/pkg/util/resourceversion`
  now provides sanctioned ordered comparison of resourceVersions of the same
  object, which lets both mechanisms be replaced by one simpler, UID-keyed one.

### Modifications

  - Replace `recentCompletions` and `lastSeenVersions` with a single
    `lastWrittenVersions` map, keyed by workflow UID, recording the last
    resourceVersion this controller wrote (or saw complete/be deleted) and
    when the workflow completed.
  - `isOutdated` now compares resourceVersions with
    `resourceversion.CompareResourceVersion` and reports whether the recorded
    version was the workflow's completed/deleted state: stale copies of
    in-flight workflows are requeued (as before), stale copies of completed
    workflows are dropped. Incomparable resourceVersions fail open (the
    workflow is processed) with a warning.
  - Retry is unaffected because this is an ordering check, not a membership
    check: the recorded completion resourceVersion acts as a floor, so only
    copies strictly older than it are rejected. A retry mutates the same
    object (same UID) and therefore always carries a newer resourceVersion;
    the controller's first write of the retried workflow then clears the
    completed state, restoring requeue semantics for in-flight staleness.
    A recreated workflow reusing a name has a new UID and is untracked.
  - `persistUpdates`/`persistWorkflowSizeLimitErr` record the Update response
    resourceVersion; the controller no longer writes the
    `workflows.argoproj.io/last-seen-version` annotation, and the constant is
    removed. Existing annotations on workflows are ignored and harmless.
  - Records of completed workflows expire after 10 minutes (matching the old
    cache's retention); expiry scans are throttled to once per minute.
    A stale completion event cannot regress the recorded version.

### Verification

  - New unit tests (`TestIsOutdated`, `TestExpireCompletedVersions`) cover the
    #16305 regression scenario, the full retry cycle (newer copy passes while
    the completed record stands; the first controller write after retry clears
    the completed state so stale copies requeue rather than drop), name reuse,
    fail-open on incomparable resourceVersions, no-regress on stale completion
    events, and record expiry. Neither previous mechanism had unit coverage.
  - `go test ./workflow/controller/... ./workflow/common/...` passes.
  - `golangci-lint run` on the changed packages reports only pre-existing
    issues on untouched lines.

  ### Documentation

  Not needed: this is internal controller bookkeeping. The removed
  `last-seen-version` annotation was never documented.

  ### AI

The idea to swtich to resourceVersion was mine.
This PR was developed with Claude Code (Claude Fable 5): analysis of the issue, the code changes, tests, and this PR text, reviewed and directed by me.