### PR TITLE
fix(ci): unbreak cherry-pick automation after actions/checkout v7 bump

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+          # An explicit ref avoids checkout v7's fork-PR guard: on a merged
+          # fork PR the default checkout commit is the base branch tip, which
+          # equals merge_commit_sha and is refused under pull_request_target.
+          ref: main
 
       - name: Configure Git
         run: |
@@ -122,3 +126,6 @@ jobs:
             --body "❌ Cherry-pick failed for ${{ inputs.version_number }}. Please check the [workflow logs](https://github.com/argoproj/argo-workflows/actions/runs/${{ github.run_id }}) for details."
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          # This step must work even when the checkout failed, so don't rely
+          # on a local git repository for repo context
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
### Motivation

Since #16342 bumped actions/checkout to v7.0.0, every automated cherry-pick of a fork PR has failed at the checkout step, e.g. [this run](https://github.com/argoproj/argo-workflows/actions/runs/28647453951) for #16357.

checkout v7 ([actions/checkout#2454](https://github.com/actions/checkout/pull/2454)) refuses to check out fork PR code from `pull_request_target` workflows unless `allow-unsafe-pr-checkout: true` is set. Its guard compares the resolved checkout commit against `pull_request.head.sha` and `pull_request.merge_commit_sha`. On a just-merged fork PR the default checkout commit is the base branch tip, which *is* the merge commit SHA, so the guard fires even though only merged, reviewed code is being checked out. PRs from branches in argoproj are unaffected, which is why this wasn't caught by every cherry-pick.

The failure was invisible on the original PRs because the `Comment on failure` step relied on the (failed) checkout for repo context and errored with `not a git repository`.

### Modifications

- Pass an explicit `ref: main` to checkout so the guard's commit comparison no longer applies. This keeps the fork-PR guard active rather than opting out with `allow-unsafe-pr-checkout: true`, and is semantically identical: main's tip contains the merge commit, and the script cherry-picks by SHA.
- Set `GH_REPO` on the `Comment on failure` step so failures are reported on the original PR even when checkout fails.

### Verification

Root cause confirmed by reading the failed run logs and the guard implementation in [`src/unsafe-pr-checkout-helper.ts` @ v7.0.0](https://github.com/actions/checkout/blob/v7.0.0/src/unsafe-pr-checkout-helper.ts): with an explicit `ref`, the `commit` input is empty, so none of the guard's three match conditions (head repo, `refs/pull/*` ref, PR SHA) apply.

After merging, the missed cherry-picks (#16357, #16274, #15991, and #16223/#16302 for 3.7) can be re-triggered by removing and re-adding their `cherry-pick/*` labels.

### AI

Diagnosed and authored with Claude Code (Claude Fable 5), directed and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of an automated repository workflow so it can continue handling failed checkouts and leave the appropriate comment.
  * Made the workflow less likely to be blocked by checkout behavior in pull request-related runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->