### PR TITLE
fix: log "Max parallelism reached" at info level, not error. Fixes #16378

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -398,15 +398,17 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 
 	node, err := woc.executeTemplate(ctx, woc.wf.Name, &wfv1.WorkflowStep{Template: woc.execWf.Spec.Entrypoint}, tmplCtx, woc.execWf.Spec.Arguments, &executeTemplateOpts{})
 	if err != nil {
-		woc.log.WithError(err).Error(ctx, "error in entry template execution")
 		// we wrap this error up to report a clear message
 		x := fmt.Errorf("error in entry template execution: %w", err)
 		switch {
 		case errors.Is(err, ErrDeadlineExceeded):
+			woc.log.WithError(err).Error(ctx, "error in entry template execution")
 			woc.eventRecorder.Event(woc.wf, apiv1.EventTypeWarning, "WorkflowTimedOut", x.Error())
 		case errors.Is(err, ErrParallelismReached):
-			// do nothing
+			// parallelism is a normal, transient backpressure condition, not an error: the workflow waits and is requeued
+			woc.log.WithError(err).Info(ctx, "entry template execution deferred, will requeue")
 		default:
+			woc.log.WithError(err).Error(ctx, "error in entry template execution")
 			if !errorsutil.IsTransientErr(ctx, err) && !woc.wf.Status.Phase.Completed() && os.Getenv("BUBBLE_ENTRY_TEMPLATE_ERR") != "false" {
 				woc.markWorkflowError(ctx, x)
 


### PR DESCRIPTION
Fixes #16378

### Motivation

When a workflow with a bounded `spec.parallelism` reaches its limit under high load, the controller logs `level=error msg="error in entry template execution" error="Max parallelism reached"` on every reconciliation while it waits for capacity. This is misleading: `ErrParallelismReached` is a normal, transient backpressure condition that is explicitly handled as a no-op in `operate()` — the workflow is requeued and completes successfully once active pods drop below the limit. Logging it at `error` floods controller logs and pollutes error-based alerting during ordinary steady-state operation. This was originally reported by @alexec in #3260 ("Do not log users errors at error level"), which was closed as completed, but the entry-template instance still logs at `error` today.

### Modifications

The unconditional `woc.log.WithError(err).Error(...)` that ran before the error-discriminating `switch` was moved into the `switch` itself, so the benign `ErrParallelismReached` case now logs at `info` ("entry template execution deferred, will requeue") while `ErrDeadlineExceeded` and genuine errors in the `default` branch continue to log at `error`. This is behavior-preserving for every case except the log level of the parallelism case.

### Verification

`go build ./workflow/controller/` passes and `gofmt` reports no changes. Behavior is unchanged: `ErrDeadlineExceeded` still logs at `error` and fires the `WorkflowTimedOut` event, genuine errors still log at `error` and mark the workflow errored, and the parallelism no-op path is untouched apart from its log level.

### Documentation

No documentation change needed — this only adjusts the severity of an internal controller log line for a condition that is already documented behavior of `spec.parallelism`.

### AI

This PR was prepared with the assistance of a generative AI coding agent (opencode), which located the offending log statement, applied the change, and drafted the issue, commit message, and this description. All output was reviewed by the author before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of entry template execution failures with clearer logging and workflow events.
  * Workflows that time out now emit a timeout warning event consistently.
  * When execution is limited by parallelism, only an info level log line with appropriate message is logged, rather than an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->