### PR TITLE
fix: log "Max parallelism reached" at info level, not error. Fixes #16378 (cherry-pick #16379 for 4.0)

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -374,14 +374,17 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 
 	node, err := woc.executeTemplate(ctx, woc.wf.Name, &wfv1.WorkflowStep{Template: woc.execWf.Spec.Entrypoint}, tmplCtx, woc.execWf.Spec.Arguments, &executeTemplateOpts{})
 	if err != nil {
-		woc.log.WithError(err).Error(ctx, "error in entry template execution")
 		// we wrap this error up to report a clear message
 		x := fmt.Errorf("error in entry template execution: %w", err)
 		switch err {
 		case ErrDeadlineExceeded:
+			woc.log.WithError(err).Error(ctx, "error in entry template execution")
 			woc.eventRecorder.Event(woc.wf, apiv1.EventTypeWarning, "WorkflowTimedOut", x.Error())
 		case ErrParallelismReached:
+			// parallelism is a normal, transient backpressure condition, not an error: the workflow waits and is requeued
+			woc.log.WithError(err).Info(ctx, "entry template execution deferred, will requeue")
 		default:
+			woc.log.WithError(err).Error(ctx, "error in entry template execution")
 			if !errorsutil.IsTransientErr(ctx, err) && !woc.wf.Status.Phase.Completed() && os.Getenv("BUBBLE_ENTRY_TEMPLATE_ERR") != "false" {
 				woc.markWorkflowError(ctx, x)
 


### PR DESCRIPTION
Cherry-picked fix: log "Max parallelism reached" at info level, not error. Fixes #16378 (#16379)