### PR TITLE
fix: reject stale copies of completed workflows using resourceVersion comparison (cherry-pick #16357 for 3.7)

### DIFF
--- a/util/resourceversion/resourceversion.go
+++ b/util/resourceversion/resourceversion.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package resourceversion is a copy of k8s.io/apimachinery/pkg/util/resourceversion,
+// which was introduced in apimachinery v0.35.0 and so is not available in the
+// version used by this release branch. Remove this copy and import the upstream
+// package once the k8s dependencies are bumped to v0.35.0 or later.
+package resourceversion
+
+import (
+	"fmt"
+	"strings"
+)
+
+type InvalidResourceVersion struct {
+	rv string
+}
+
+func (i InvalidResourceVersion) Error() string {
+	return fmt.Sprintf("resource version is not well formed: %s", i.rv)
+}
+
+// CompareResourceVersion runs a comparison between two ResourceVersions. This
+// only has semantic meaning when the comparison is done on two objects of the
+// same resource. The return values are:
+//
+//	-1: If RV a < RV b
+//	 0: If RV a == RV b
+//	+1: If RV a > RV b
+//
+// The function will return an error if the resource version is not a properly
+// formatted positive integer, but has no restriction on length. A properly
+// formatted integer will not contain leading zeros or non integer characters.
+// Zero is also considered an invalid value as it is used as a special value in
+// list/watch events and will never be a live resource version.
+func CompareResourceVersion(a, b string) (int, error) {
+	if !isWellFormed(a) {
+		return 0, InvalidResourceVersion{rv: a}
+	}
+	if !isWellFormed(b) {
+		return 0, InvalidResourceVersion{rv: b}
+	}
+	// both are well-formed integer strings with no leading zeros
+	aLen := len(a)
+	bLen := len(b)
+	switch {
+	case aLen < bLen:
+		// shorter is less
+		return -1, nil
+	case aLen > bLen:
+		// longer is greater
+		return 1, nil
+	default:
+		// equal-length compares lexically
+		return strings.Compare(a, b), nil
+	}
+}
+
+func isWellFormed(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] == '0' {
+		return false
+	}
+	for i := range s {
+		if !isDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}

--- a/util/resourceversion/resourceversion_test.go
+++ b/util/resourceversion/resourceversion_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceversion
+
+import (
+	"testing"
+)
+
+func TestCompareResourceVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		a        string
+		b        string
+		expected int
+		err      bool
+	}{
+		{
+			name:     "a less than b",
+			a:        "100",
+			b:        "200",
+			expected: -1,
+		},
+		{
+			name: "a is zero, invalid",
+			a:    "0",
+			b:    "1",
+			err:  true,
+		},
+		{
+			name: "both zero",
+			a:    "0",
+			b:    "0",
+			err:  true,
+		},
+		{
+			name:     "a greater than b",
+			a:        "200",
+			b:        "100",
+			expected: 1,
+		},
+		{
+			name: "b is 0, invalid",
+			a:    "1",
+			b:    "0",
+			err:  true,
+		},
+		{
+			name:     "a equal to b small",
+			a:        "1",
+			b:        "1",
+			expected: 0,
+		},
+		{
+			name:     "a equal to b",
+			a:        "100",
+			b:        "100",
+			expected: 0,
+		},
+		{
+			name:     "a shorter than b",
+			a:        "99",
+			b:        "100",
+			expected: -1,
+		},
+		{
+			name:     "a longer than b",
+			a:        "100",
+			b:        "99",
+			expected: 1,
+		},
+		{
+			name:     "a with leading zero",
+			a:        "0100",
+			b:        "100",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "b with leading zero",
+			a:        "100",
+			b:        "0100",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "a empty",
+			a:        "",
+			b:        "100",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name:     "b empty",
+			a:        "100",
+			b:        "",
+			expected: 0,
+			err:      true,
+		},
+		{
+			name: "a non-digit",
+			a:    "100a",
+			b:    "100",
+			err:  true,
+		},
+		{
+			name: "b non-digit",
+			a:    "100",
+			b:    "100a",
+			err:  true,
+		},
+		{
+			name:     "large int a less than b",
+			a:        "99999999999999999999999999999999999999999999999999",
+			b:        "100000000000000000000000000000000000000000000000000",
+			expected: -1,
+		},
+		{
+			name:     "large int a greater than b",
+			a:        "100000000000000000000000000000000000000000000000000",
+			b:        "99999999999999999999999999999999999999999999999999",
+			expected: 1,
+		},
+		{
+			name:     "large int a equal to b",
+			a:        "12345678901234567890123456789012345678901234567890",
+			b:        "12345678901234567890123456789012345678901234567890",
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := CompareResourceVersion(tc.a, tc.b)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error, but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expected {
+				t.Errorf("expected %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -53,9 +53,6 @@ const (
 	// the strategy whose artifacts are being deleted
 	AnnotationKeyArtifactGCStrategy = workflow.WorkflowFullName + "/artifact-gc-strategy"
 
-	// AnnotationKeyLastSeenVersion stores the last seen version of the workflow when it was last successfully processed by the controller
-	AnnotationKeyLastSeenVersion = workflow.WorkflowFullName + "/last-seen-version"
-
 	// LabelParallelismLimit is a label applied on namespace objects to control the per namespace parallelism.
 	LabelParallelismLimit = workflow.WorkflowFullName + "/parallelism-limit"
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/util/env"
 	"github.com/argoproj/argo-workflows/v3/util/errors"
 	rbacutil "github.com/argoproj/argo-workflows/v3/util/rbac"
+	"github.com/argoproj/argo-workflows/v3/util/resourceversion"
 	"github.com/argoproj/argo-workflows/v3/util/retry"
 	"github.com/argoproj/argo-workflows/v3/util/telemetry"
 	waitutil "github.com/argoproj/argo-workflows/v3/util/wait"
@@ -71,19 +72,21 @@ import (
 
 const maxAllowedStackDepth = 100
 
-type recentlyCompletedWorkflow struct {
-	key  string
-	when time.Time
+// lastWrittenVersion records the most recent resourceVersion of a workflow
+// that this controller has written, or has seen complete or be deleted.
+type lastWrittenVersion struct {
+	resourceVersion string
+	// completedAt is set when the workflow completed or was deleted. The
+	// record is retained for completedVersionRetention afterwards so that
+	// stale copies of the workflow re-entering the informer can still be
+	// rejected, and is then expired.
+	completedAt time.Time
 }
 
-type recentCompletions struct {
-	completions []recentlyCompletedWorkflow
+type lastWrittenVersions struct {
+	versions    map[types.UID]lastWrittenVersion
+	nextCleanup time.Time
 	mutex       gosync.RWMutex
-}
-
-type lastSeenVersions struct {
-	versions map[string]string
-	mutex    gosync.RWMutex
 }
 
 // WorkflowController is the controller for workflow resources
@@ -154,11 +157,10 @@ type WorkflowController struct {
 	progressFileTickDuration time.Duration
 	executorPlugins          map[string]map[string]*spec.Plugin // namespace -> name -> plugin
 
-	recentCompletions recentCompletions
 	// lastUnreconciledWorkflows is a map of workflows that have been recently unreconciled
 	lastUnreconciledWorkflows map[string]*wfv1.Workflow
 
-	lastSeenVersions lastSeenVersions // key: workflow UID, value: resource version
+	lastWrittenVersions lastWrittenVersions
 }
 
 const (
@@ -212,8 +214,8 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		eventRecorderManager:       events.NewEventRecorderManager(kubeclientset),
 		progressPatchTickDuration:  env.LookupEnvDurationOr(common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:   env.LookupEnvDurationOr(common.EnvVarProgressFileTickDuration, 3*time.Second),
-		lastSeenVersions: lastSeenVersions{
-			versions: make(map[string]string),
+		lastWrittenVersions: lastWrittenVersions{
+			versions: make(map[types.UID]lastWrittenVersion),
 			mutex:    gosync.RWMutex{},
 		},
 	}
@@ -735,7 +737,11 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		return true
 	}
 
-	if wfc.isOutdated(un) {
+	if outdated, completed := wfc.isOutdated(un); outdated {
+		if completed {
+			log.WithField("key", key).Warn("Rejecting stale copy of a completed workflow")
+			return true
+		}
 		log.WithField("key", key).Debug("Skipping outdated workflow event")
 		wfc.wfQueue.AddRateLimited(key)
 		return true
@@ -752,11 +758,6 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		woc := newWorkflowOperationCtx(wf, wfc)
 		woc.markWorkflowFailed(ctx, fmt.Sprintf("cannot unmarshall spec: %s", err.Error()))
 		woc.persistUpdates(ctx)
-		return true
-	}
-
-	if wf.Status.Phase != "" && wfc.checkRecentlyCompleted(wf.Name) {
-		log.WithFields(log.Fields{"name": wf.ObjectMeta.Name}).Warn("Cache: Rejecting recently deleted")
 		return true
 	}
 
@@ -888,56 +889,56 @@ func getWfPriority(obj interface{}) (int32, time.Time) {
 	return int32(priority), un.GetCreationTimestamp().Time
 }
 
-// 10 minutes in the past
-const maxCompletedStoreTime = time.Second * -600
+// how long to retain the record of a completed or deleted workflow
+const completedVersionRetention = 10 * time.Minute
 
-// This is a helper function for expiring old records of workflows
-// completed more than maxCompletedStoreTime ago
-func (wfc *WorkflowController) cleanCompletedWorkflowsRecord() {
-	cutoff := time.Now().Add(maxCompletedStoreTime)
-	removeIndex := -1
-	wfc.recentCompletions.mutex.Lock()
-	defer wfc.recentCompletions.mutex.Unlock()
+// how often, at most, to scan for expired completed workflow records
+const versionCleanupPeriod = time.Minute
 
-	for i, val := range wfc.recentCompletions.completions {
-		if val.when.After(cutoff) {
-			removeIndex = i - 1
-			break
-		}
+// expireCompletedVersions removes records of workflows that completed or were
+// deleted more than completedVersionRetention ago. Scans are throttled to at
+// most one per versionCleanupPeriod. The caller must hold the
+// lastWrittenVersions write lock.
+func (wfc *WorkflowController) expireCompletedVersions() {
+	now := time.Now()
+	if now.Before(wfc.lastWrittenVersions.nextCleanup) {
+		return
 	}
-	if removeIndex >= 0 {
-		wfc.recentCompletions.completions = wfc.recentCompletions.completions[removeIndex+1:]
+	wfc.lastWrittenVersions.nextCleanup = now.Add(versionCleanupPeriod)
+	for uid, last := range wfc.lastWrittenVersions.versions {
+		if !last.completedAt.IsZero() && now.Sub(last.completedAt) > completedVersionRetention {
+			delete(wfc.lastWrittenVersions.versions, uid)
+		}
 	}
 }
 
-// Records a workflow as recently completed in the list
-// if it isn't already in the list
-func (wfc *WorkflowController) recordCompletedWorkflow(key string) {
-	if !wfc.checkRecentlyCompleted(key) {
-		wfc.recentCompletions.mutex.Lock()
-		defer wfc.recentCompletions.mutex.Unlock()
-		wfc.recentCompletions.completions = append(wfc.recentCompletions.completions,
-			recentlyCompletedWorkflow{
-				key:  key,
-				when: time.Now(),
-			})
-	}
+// recordWorkflowWrite records the resourceVersion of a workflow just written
+// by this controller, so that older copies of it can be recognized as stale.
+func (wfc *WorkflowController) recordWorkflowWrite(wf metav1.Object) {
+	wfc.lastWrittenVersions.mutex.Lock()
+	defer wfc.lastWrittenVersions.mutex.Unlock()
+	wfc.expireCompletedVersions()
+	wfc.lastWrittenVersions.versions[wf.GetUID()] = lastWrittenVersion{resourceVersion: wf.GetResourceVersion()}
 }
 
-// Returns true if the workflow given by key is in the recently completed
-// list. Will perform expiry cleanup before checking.
-func (wfc *WorkflowController) checkRecentlyCompleted(key string) bool {
-	wfc.cleanCompletedWorkflowsRecord()
-	recent := false
-	wfc.recentCompletions.mutex.RLock()
-	defer wfc.recentCompletions.mutex.RUnlock()
-	for _, val := range wfc.recentCompletions.completions {
-		if val.key == key {
-			recent = true
-			break
+// recordWorkflowCompleted marks a workflow as completed or deleted, retaining
+// its latest known resourceVersion for completedVersionRetention so that
+// stale copies of it re-entering the informer can be rejected.
+func (wfc *WorkflowController) recordWorkflowCompleted(wf metav1.Object) {
+	wfc.lastWrittenVersions.mutex.Lock()
+	defer wfc.lastWrittenVersions.mutex.Unlock()
+	wfc.expireCompletedVersions()
+	rv := wf.GetResourceVersion()
+	if last, ok := wfc.lastWrittenVersions.versions[wf.GetUID()]; ok {
+		// never regress the recorded version: this event may itself be stale
+		if cmp, err := resourceversion.CompareResourceVersion(rv, last.resourceVersion); err != nil || cmp < 0 {
+			rv = last.resourceVersion
 		}
 	}
-	return recent
+	wfc.lastWrittenVersions.versions[wf.GetUID()] = lastWrittenVersion{
+		resourceVersion: rv,
+		completedAt:     time.Now(),
+	}
 }
 
 func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) error {
@@ -955,9 +956,7 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 				}
 				needed := reconciliationNeeded(un)
 				if !needed {
-					key, _ := cache.MetaNamespaceKeyFunc(un)
-					wfc.recordCompletedWorkflow(key)
-					wfc.deleteLastSeenVersionKey(wfc.getLastSeenVersionKey(un))
+					wfc.recordWorkflowCompleted(un)
 				}
 				return needed
 			},
@@ -1011,11 +1010,10 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 					if err == nil {
 						wfc.releaseAllWorkflowLocks(obj)
-						wfc.recordCompletedWorkflow(key)
 						// no need to add to the queue - this workflow is done
 						wfc.throttler.Remove(key)
 					}
-					wfc.deleteLastSeenVersionKey(wfc.getLastSeenVersionKey(obj.(*unstructured.Unstructured)))
+					wfc.recordWorkflowCompleted(obj.(*unstructured.Unstructured))
 				},
 			},
 		},
@@ -1357,24 +1355,22 @@ func (wfc *WorkflowController) IsLeader() bool {
 	return wfc.wfInformer != nil
 }
 
-func (wfc *WorkflowController) isOutdated(wf metav1.Object) bool {
-	wfc.lastSeenVersions.mutex.RLock()
-	defer wfc.lastSeenVersions.mutex.RUnlock()
-	lastSeenRV, ok := wfc.lastSeenVersions.versions[wfc.getLastSeenVersionKey(wf)]
+// isOutdated returns whether this copy of the workflow is older than the
+// version last written by this controller, and whether that version was the
+// completed or deleted state of the workflow.
+func (wfc *WorkflowController) isOutdated(wf metav1.Object) (outdated bool, completedWorkflow bool) {
+	wfc.lastWrittenVersions.mutex.RLock()
+	defer wfc.lastWrittenVersions.mutex.RUnlock()
+	last, ok := wfc.lastWrittenVersions.versions[wf.GetUID()]
 	// always process if not seen before
-	if !ok || lastSeenRV == "" {
-		return false
+	if !ok {
+		return false, false
 	}
-	annotations := wf.GetAnnotations()[common.AnnotationKeyLastSeenVersion]
-	return annotations != lastSeenRV
-}
-
-func (wfc *WorkflowController) getLastSeenVersionKey(wf metav1.Object) string {
-	return string(wf.GetUID())
-}
-
-func (wfc *WorkflowController) deleteLastSeenVersionKey(key string) {
-	wfc.lastSeenVersions.mutex.Lock()
-	defer wfc.lastSeenVersions.mutex.Unlock()
-	delete(wfc.lastSeenVersions.versions, key)
+	cmp, err := resourceversion.CompareResourceVersion(wf.GetResourceVersion(), last.resourceVersion)
+	if err != nil {
+		// resourceVersions on this cluster are not comparable, so process everything
+		log.WithError(err).WithField("name", wf.GetName()).Warn("Cannot compare workflow resource versions")
+		return false, false
+	}
+	return cmp < 0, !last.completedAt.IsZero()
 }

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -299,6 +300,9 @@ func newController(options ...interface{}) (context.CancelFunc, *WorkflowControl
 		progressPatchTickDuration: envutil.LookupEnvDurationOr(common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:  envutil.LookupEnvDurationOr(common.EnvVarProgressFileTickDuration, 3*time.Second),
 		maxStackDepth:             maxAllowedStackDepth,
+		lastWrittenVersions: lastWrittenVersions{
+			versions: make(map[types.UID]lastWrittenVersion),
+		},
 	}
 
 	for _, opt := range options {
@@ -1337,4 +1341,75 @@ func TestPodSpecPatchTemplateLevel(t *testing.T) {
 	}
 	require.NotNil(t, mainContainer)
 	assert.Equal(t, "25Mi", mainContainer.Resources.Requests.Memory().String())
+}
+
+func TestIsOutdated(t *testing.T) {
+	cancel, controller := newController()
+	defer cancel()
+
+	obj := func(uid types.UID, rv string) metav1.Object {
+		return &metav1.ObjectMeta{UID: uid, ResourceVersion: rv}
+	}
+	assertOutdated := func(t *testing.T, wantOutdated, wantCompleted bool, wf metav1.Object) {
+		t.Helper()
+		outdated, completed := controller.isOutdated(wf)
+		assert.Equal(t, wantOutdated, outdated, "outdated")
+		assert.Equal(t, wantCompleted, completed, "completed")
+	}
+
+	// workflows the controller has never written are always processed
+	assertOutdated(t, false, false, obj("wf-1", "99"))
+
+	controller.recordWorkflowWrite(obj("wf-1", "100"))
+	assertOutdated(t, true, false, obj("wf-1", "99"))
+	assertOutdated(t, false, false, obj("wf-1", "100"))
+	// a newer version written by another actor is not outdated
+	assertOutdated(t, false, false, obj("wf-1", "101"))
+
+	// incomparable resourceVersions must fail open and process the workflow
+	assertOutdated(t, false, false, obj("wf-1", "not-a-number"))
+
+	// stale copy of a completed workflow is rejected: regression test for
+	// https://github.com/argoproj/argo-workflows/issues/16305
+	controller.recordWorkflowCompleted(obj("wf-1", "110"))
+	assertOutdated(t, true, true, obj("wf-1", "99"))
+	// a retried workflow keeps its UID but has a newer resourceVersion
+	assertOutdated(t, false, true, obj("wf-1", "120"))
+	// a recreated workflow with the same name has a different UID
+	assertOutdated(t, false, false, obj("wf-2", "50"))
+
+	// a stale completion event must not regress the recorded version
+	controller.recordWorkflowCompleted(obj("wf-1", "105"))
+	assertOutdated(t, true, true, obj("wf-1", "109"))
+
+	// the controller's first write of a retried workflow clears the
+	// completed state, restoring requeue rather than drop for stale copies
+	controller.recordWorkflowWrite(obj("wf-1", "160"))
+	assertOutdated(t, true, false, obj("wf-1", "150"))
+}
+
+func TestExpireCompletedVersions(t *testing.T) {
+	cancel, controller := newController()
+	defer cancel()
+
+	inFlight := &metav1.ObjectMeta{UID: "wf-in-flight", ResourceVersion: "100"}
+	completed := &metav1.ObjectMeta{UID: "wf-completed", ResourceVersion: "200"}
+	controller.recordWorkflowWrite(inFlight)
+	controller.recordWorkflowCompleted(completed)
+
+	// age the completed record beyond retention and force a cleanup scan
+	controller.lastWrittenVersions.mutex.Lock()
+	last := controller.lastWrittenVersions.versions[completed.UID]
+	last.completedAt = time.Now().Add(-completedVersionRetention - time.Minute)
+	controller.lastWrittenVersions.versions[completed.UID] = last
+	controller.lastWrittenVersions.nextCleanup = time.Time{}
+	controller.lastWrittenVersions.mutex.Unlock()
+
+	controller.recordWorkflowWrite(&metav1.ObjectMeta{UID: "wf-other", ResourceVersion: "300"})
+
+	outdated, completedWf := controller.isOutdated(&metav1.ObjectMeta{UID: completed.UID, ResourceVersion: "199"})
+	assert.False(t, outdated, "expired completed record should be forgotten")
+	assert.False(t, completedWf)
+	outdated, _ = controller.isOutdated(&metav1.ObjectMeta{UID: inFlight.UID, ResourceVersion: "99"})
+	assert.True(t, outdated, "in-flight records must not expire")
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -762,10 +762,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.log.WithError(err).Warn("error updating taskset")
 	}
 
-	oldRV := woc.wf.ResourceVersion
-	woc.updateLastSeenVersionAnnotation(oldRV)
-	wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
-	if err != nil {
+	if wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{}); err != nil {
 		woc.log.Warnf("Error updating workflow: %v %s", err, apierr.ReasonForError(err))
 		if argokubeerr.IsRequestEntityTooLargeErr(err) {
 			woc.persistWorkflowSizeLimitErr(ctx, wfClient, err)
@@ -775,7 +772,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 			return
 		}
 		woc.log.Info("Re-applying updates on latest version and retrying update")
-		wf, err := woc.reapplyUpdate(ctx, wfClient, nodes)
+		wf, err = woc.reapplyUpdate(ctx, wfClient, nodes)
 		if err != nil {
 			woc.log.WithError(err).Info("Failed to re-apply update")
 			return
@@ -786,7 +783,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		woc.controller.hydrator.HydrateWithNodes(woc.wf, nodes)
 	}
 
-	woc.updateLastSeenVersion(oldRV)
+	woc.controller.recordWorkflowWrite(woc.wf)
 	// The workflow returned from wfClient.Update doesn't have a TypeMeta associated
 	// with it, so copy from the original workflow.
 	woc.wf.TypeMeta = woc.orig.TypeMeta
@@ -820,7 +817,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 		}
 	}
 	// If Finalizer exists, requeue to make sure Finalizer can be removed.
-	if woc.wf.Status.Fulfilled() && len(wf.GetFinalizers()) > 0 {
+	if woc.wf.Status.Fulfilled() && len(woc.wf.GetFinalizers()) > 0 {
 		woc.requeueAfter(5 * time.Second)
 	}
 
@@ -868,13 +865,11 @@ func (woc *wfOperationCtx) writeBackToInformer() error {
 func (woc *wfOperationCtx) persistWorkflowSizeLimitErr(ctx context.Context, wfClient v1alpha1.WorkflowInterface, err error) {
 	woc.wf = woc.orig.DeepCopy()
 	woc.markWorkflowError(ctx, err)
-	oldRV := woc.wf.ResourceVersion
-	woc.updateLastSeenVersionAnnotation(oldRV)
-	_, err = wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
+	wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
 	if err != nil {
 		woc.log.Warnf("Error updating workflow with size error: %v", err)
 	} else {
-		woc.updateLastSeenVersion(oldRV)
+		woc.controller.recordWorkflowWrite(wf)
 	}
 }
 
@@ -4503,20 +4498,4 @@ func (woc *wfOperationCtx) setNodeDisplayName(node *wfv1.NodeStatus, displayName
 	newNode := node.DeepCopy()
 	newNode.DisplayName = displayName
 	woc.wf.Status.Nodes.Set(nodeID, *newNode)
-}
-
-func (woc *wfOperationCtx) updateLastSeenVersionAnnotation(value string) {
-	if woc.wf.GetAnnotations() == nil {
-		woc.wf.SetAnnotations(make(map[string]string))
-	}
-	woc.wf.GetAnnotations()[common.AnnotationKeyLastSeenVersion] = value
-}
-
-func (woc *wfOperationCtx) updateLastSeenVersion(value string) {
-	woc.controller.lastSeenVersions.mutex.Lock()
-	defer woc.controller.lastSeenVersions.mutex.Unlock()
-	if woc.controller.lastSeenVersions.versions == nil {
-		woc.controller.lastSeenVersions.versions = make(map[string]string)
-	}
-	woc.controller.lastSeenVersions.versions[woc.controller.getLastSeenVersionKey(woc.wf)] = value
 }


### PR DESCRIPTION
Cherry-picked fix: reject stale copies of completed workflows using resourceVersion comparison (#16357)