### PR TITLE
fix(ui): resolve login logo paths with non-root baseHref

### DIFF
--- a/ui/src/login/login.scss
+++ b/ui/src/login/login.scss
@@ -1,7 +1,7 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
-$logoPath: '../assets/images/argologo.svg';
-$logoNegativePath: '../assets/images/argo.png';
+$logoPath: 'assets/images/argologo.svg';
+$logoNegativePath: 'assets/images/argo.png';
 
 $contentMinWidth: 560px;
 


### PR DESCRIPTION
## Summary

- Drop the `../` prefix from login page SCSS asset paths so logos resolve correctly when `server.baseHref` is set (e.g. `/wf/`).
- Matches how other UI `src=""` references already rely on baseHref prefixing.

Fixes #16256

## Test plan

- [ ] Configure `server.baseHref: /wf/` with URL rewrite
- [ ] Open the login page and confirm `argologo.svg` / `argo.png` render
- [ ] Confirm default (root) baseHref still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the login page to use more reliable asset paths for the logo, improving consistency in how the image loads across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->