### PR TITLE
fix(ui): sync cron workflow list filters to URL query params

### DIFF
--- a/ui/src/cron-workflows/cron-workflow-list.tsx
+++ b/ui/src/cron-workflows/cron-workflow-list.tsx
@@ -40,8 +40,14 @@ export function CronWorkflowList({match, location, history}: RouteComponentProps
     const isFirstRender = useRef(true);
     const [namespace, setNamespace] = useState<string>(nsUtils.getNamespace(match.params.namespace) || '');
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel') === 'true');
-    const [labels, setLabels] = useState<string[]>([]);
-    const [states, setStates] = useState(['Running', 'Suspended']); // check all by default
+    const [labels, setLabels] = useState<string[]>(() => {
+        const labelQueryParam = queryParams.getAll('label');
+        return labelQueryParam.length > 0 ? labelQueryParam : [];
+    });
+    const [states, setStates] = useState<string[]>(() => {
+        const stateQueryParam = queryParams.getAll('state');
+        return stateQueryParam.length > 0 ? stateQueryParam : ['Running', 'Suspended'];
+    });
 
     const [storedDisplayISOFormatCreation, setStoredDisplayISOFormatCreation] = useTimestamp(TIMESTAMP_KEYS.CRON_WORKFLOW_LIST_CREATION);
     const [storedDisplayISOFormatNextScheduled, setStoredDisplayISOFormatNextScheduled] = useTimestamp(TIMESTAMP_KEYS.CRON_WORKFLOW_LIST_NEXT_SCHEDULED);
@@ -55,14 +61,20 @@ export function CronWorkflowList({match, location, history}: RouteComponentProps
 
     // save history
     useEffect(() => {
+        const params = new URLSearchParams();
+        labels?.forEach(label => params.append('label', label));
+        states?.forEach(state => params.append('state', state));
+        if (sidePanel) {
+            params.append('sidePanel', 'true');
+        }
         (isFirstRender.current ? history.replace : history.push)(
             historyUrl('cron-workflows' + (nsUtils.getManagedNamespace() ? '' : '/{namespace}'), {
                 namespace,
-                sidePanel
+                extraSearchParams: params
             })
         );
         isFirstRender.current = false;
-    }, [namespace, sidePanel]);
+    }, [namespace, sidePanel, labels.toString(), states.toString()]);
 
     // internal state
     const [error, setError] = useState<Error>();

--- a/ui/src/cron-workflows/cron-workflow-list.tsx
+++ b/ui/src/cron-workflows/cron-workflow-list.tsx
@@ -18,7 +18,6 @@ import {CronWorkflow} from '../shared/models';
 import * as nsUtils from '../shared/namespaces';
 import {services} from '../shared/services';
 import {useCollectEvent} from '../shared/use-collect-event';
-import {useQueryParams} from '../shared/use-query-params';
 import useTimestamp, {TIMESTAMP_KEYS} from '../shared/use-timestamp';
 import {CronWorkflowCreator} from './cron-workflow-creator';
 import {CronWorkflowFilters} from './cron-workflow-filters';
@@ -52,12 +51,18 @@ export function CronWorkflowList({match, location, history}: RouteComponentProps
     const [storedDisplayISOFormatCreation, setStoredDisplayISOFormatCreation] = useTimestamp(TIMESTAMP_KEYS.CRON_WORKFLOW_LIST_CREATION);
     const [storedDisplayISOFormatNextScheduled, setStoredDisplayISOFormatNextScheduled] = useTimestamp(TIMESTAMP_KEYS.CRON_WORKFLOW_LIST_NEXT_SCHEDULED);
 
-    useEffect(
-        useQueryParams(history, p => {
+    useEffect(() => {
+        return history.listen((newLocation, action) => {
+            const p = new URLSearchParams(newLocation.search);
             setSidePanel(p.get('sidePanel') === 'true');
-        }),
-        [history]
-    );
+            // Only restore filters on Back/Forward so our own history.push does not loop.
+            if (action === 'POP') {
+                setLabels(p.getAll('label'));
+                const stateQueryParam = p.getAll('state');
+                setStates(stateQueryParam.length > 0 ? stateQueryParam : ['Running', 'Suspended']);
+            }
+        });
+    }, [history]);
 
     // save history
     useEffect(() => {


### PR DESCRIPTION
See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [ ] Opened as draft; will mark "Ready for review" once builds are green

Fixes #13168

### Motivation

CronWorkflow list label and state filters were not reflected in the URL, so filtered views could not be shared or restored after refresh.

### Modifications

Sync label and state filters to URL query params on the cron workflow list page, and restore them on load and browser back/forward navigation.

### Verification

Manual UI check: set filters, copy URL, open in new tab, confirm filters restored. Back/forward keeps label and state in sync with the URL.

### Documentation

Not needed. UI-only behavior change.