### PR TITLE
fix(controller): preserve NodeSucceeded on daemon pod PodFailed/PodSucceeded events after teardown. Fixes #16397

### DIFF
--- a/workflow/controller/container_set_template.go
+++ b/workflow/controller/container_set_template.go
@@ -10,7 +10,7 @@ import (
 func (woc *wfOperationCtx) executeContainerSet(ctx context.Context, nodeName string, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
-		_, node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, false)
+		_, node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, tmpl.IsDaemon())
 	}
 	includeScriptOutput, err := woc.includeScriptOutput(ctx, nodeName, opts.boundaryID)
 	if err != nil {

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -121,5 +121,13 @@ func (woc *wfOperationCtx) killDaemonedChildren(ctx context.Context, nodeID stri
 		childNode.Daemoned = nil
 		woc.wf.Status.Nodes.Set(ctx, childNode.ID, childNode)
 		woc.updated = true
+		// A daemoned containerSet also has container child nodes under the pod node. They are
+		// stopped along with the pod, so complete any that have not already finished on their
+		// own; their exit codes carry no failure meaning because the controller is killing them.
+		for _, ctrNode := range woc.wf.Status.Nodes {
+			if ctrNode.BoundaryID == childNode.ID && ctrNode.Type == wfv1.NodeTypeContainer && !ctrNode.Fulfilled() {
+				woc.markNodePhase(ctx, ctrNode.Name, wfv1.NodeSucceeded)
+			}
+		}
 	}
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1477,7 +1477,7 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	}
 	if tmpl == nil {
 		woc.log.WithFields(logging.Fields{"nodeName": old.Name, "templateName": old.TemplateName}).
-			Warn(ctx, "cannot resolve template for node; daemon teardown detection is disabled for it")
+			Debug(ctx, "no template resolved for node (expected for inline templates); daemon teardown detection is disabled for it")
 	}
 	// The only way a daemon node becomes Succeeded while its pod is still alive is
 	// killDaemonedChildren, which marks the node and then requests pod termination.
@@ -1632,7 +1632,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	// We capture the exit-code after we look for the task-result.
 	// All other outputs are set by the executor, only the exit-code is set by the controller.
 	// By waiting, we avoid breaking the race-condition check.
-	if exitCode := getExitCode(pod); exitCode != nil {
+	// A daemon we stopped ourselves reports the exit code of our own signal, which says nothing
+	// about the node: recording it would contradict the Succeeded phase we just preserved.
+	if exitCode := getExitCode(pod); !stoppedDaemon && exitCode != nil {
 		if updated.Outputs == nil {
 			updated.Outputs = &wfv1.Outputs{}
 		}
@@ -3617,7 +3619,7 @@ loop:
 func (woc *wfOperationCtx) executeScript(ctx context.Context, nodeName string, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
-		ctx, node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, false)
+		ctx, node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, tmpl.IsDaemon())
 	} else if !node.Pending() {
 		return node, nil
 	}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1449,29 +1449,6 @@ func (woc *wfOperationCtx) getAllWorkflowPods() ([]*apiv1.Pod, error) {
 	return pods, nil
 }
 
-// killedByDaemonTeardown checks if a container was killed by killDaemonedChildren rather than failing
-// on its own. The teardown sends SIGTERM then SIGKILL, so its containers are either not terminated yet,
-// exited 0, or exited 137 (128 + SIGKILL) / 143 (128 + SIGTERM). The kubelet reports 137 for OOMKilled
-// too, so the signal codes also require a reason it did not diagnose itself.
-func killedByDaemonTeardown(c apiv1.ContainerStatus) bool {
-	t := c.State.Terminated
-	if t == nil {
-		return true
-	}
-	if t.ExitCode == 0 {
-		return true
-	}
-	if t.ExitCode != 137 && t.ExitCode != 143 {
-		return false
-	}
-	switch t.Reason {
-	case "", "Error", "Completed":
-		return true
-	default:
-		return false
-	}
-}
-
 func (woc *wfOperationCtx) printPodSpecLog(ctx context.Context, pod *apiv1.Pod, wfName string) {
 	podSpecByte, err := json.Marshal(pod)
 	log := woc.log.WithField("workflow", wfName).
@@ -1498,9 +1475,12 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		woc.log.Error(ctx, err.Error())
 		return nil
 	}
-	// A daemon node only reaches NodeSucceeded via killDaemonedChildren, which marks it before
-	// signalling the pod. So the PodFailed/PodSucceeded below is just Kubernetes confirming our own kill.
-	daemonTeardown := tmpl.IsDaemon() && old.Phase == wfv1.NodeSucceeded
+	// The only way a daemon node becomes Succeeded while its pod is still alive is
+	// killDaemonedChildren, which marks the node and then requests pod termination.
+	// Any pod completion seen after that is the result of our own kill and must not
+	// overwrite the phase; a daemon that dies of its own accord is assessed normally
+	// (its node is still Running at that point) so retryStrategy still works.
+	stoppedDaemon := tmpl != nil && tmpl.IsDaemon() && old.Succeeded()
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		updated.Phase = wfv1.NodePending
@@ -1513,9 +1493,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		}
 	case apiv1.PodSucceeded:
 		// if the pod is succeeded, we need to check if it is a daemoned step or not
-		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely,
-		// unless we are the ones who stopped it.
-		if tmpl.IsDaemon() && !daemonTeardown {
+		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely
+		// (unless the controller stopped it itself, in which case it stays Succeeded)
+		if tmpl.IsDaemon() && !stoppedDaemon {
 			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod succeeded. Marking it as failed")
 			updated.Phase = wfv1.NodeFailed
 		} else {
@@ -1525,14 +1505,10 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		updated.Daemoned = nil
 		updated.RestartingPodUID = ""
 	case apiv1.PodFailed:
-		// The failure is our own teardown, not the step failing.
-		if daemonTeardown {
-			woc.log.WithFields(logging.Fields{"displayName": old.DisplayName, "pod": pod.Name}).Info(ctx, "Daemon pod already marked Succeeded by teardown; ignoring PodFailed event")
-			updated.Phase = wfv1.NodeSucceeded
-			updated.Daemoned = nil
+		if stoppedDaemon {
+			woc.log.WithFields(logging.Fields{"displayName": old.DisplayName, "pod": pod.Name}).Info(ctx, "Ignoring pod failure of daemon stopped by the controller")
 			break
 		}
-		// ignore pod failure for daemoned steps
 		updated.Phase, updated.Message = woc.inferFailedReason(ctx, pod, tmpl)
 		woc.log.WithFields(logging.Fields{"message": updated.Message, "displayName": old.DisplayName, "templateName": wfutil.GetTemplateFromNode(*old), "pod": pod.Name}).Info(ctx, "Pod failed")
 		updated.Daemoned = nil
@@ -1603,13 +1579,19 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	// in this case need to update nodes according to container status
 	for _, c := range pod.Status.ContainerStatuses {
 		ctrNodeName := fmt.Sprintf("%s.%s", old.Name, c.Name)
-		if _, err := woc.wf.GetNodeByName(ctrNodeName); err != nil {
+		ctrNode, err := woc.wf.GetNodeByName(ctrNodeName)
+		if err != nil {
+			continue
+		}
+		if stoppedDaemon {
+			// The containers were killed by the controller, so their exit codes carry no
+			// failure meaning; complete any unfinished container nodes along with the pod node.
+			if !ctrNode.Fulfilled() {
+				woc.markNodePhase(ctx, ctrNodeName, wfv1.NodeSucceeded)
+			}
 			continue
 		}
 		switch {
-		case daemonTeardown && killedByDaemonTeardown(c):
-			// Killed by our teardown, so keep the Succeeded phase the node already has.
-			woc.markNodePhase(ctx, ctrNodeName, wfv1.NodeSucceeded)
 		case c.State.Terminated != nil:
 			exitCode := int(c.State.Terminated.ExitCode)
 			message := fmt.Sprintf("%s: %s (exit code %d): %s", c.Name, c.State.Terminated.Reason, exitCode, c.State.Terminated.Message)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1449,6 +1449,29 @@ func (woc *wfOperationCtx) getAllWorkflowPods() ([]*apiv1.Pod, error) {
 	return pods, nil
 }
 
+// killedByDaemonTeardown checks if a container was killed by killDaemonedChildren rather than failing
+// on its own. The teardown sends SIGTERM then SIGKILL, so its containers are either not terminated yet,
+// exited 0, or exited 137 (128 + SIGKILL) / 143 (128 + SIGTERM). The kubelet reports 137 for OOMKilled
+// too, so the signal codes also require a reason it did not diagnose itself.
+func killedByDaemonTeardown(c apiv1.ContainerStatus) bool {
+	t := c.State.Terminated
+	if t == nil {
+		return true
+	}
+	if t.ExitCode == 0 {
+		return true
+	}
+	if t.ExitCode != 137 && t.ExitCode != 143 {
+		return false
+	}
+	switch t.Reason {
+	case "", "Error", "Completed":
+		return true
+	default:
+		return false
+	}
+}
+
 func (woc *wfOperationCtx) printPodSpecLog(ctx context.Context, pod *apiv1.Pod, wfName string) {
 	podSpecByte, err := json.Marshal(pod)
 	log := woc.log.WithField("workflow", wfName).
@@ -1475,6 +1498,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		woc.log.Error(ctx, err.Error())
 		return nil
 	}
+	// A daemon node only reaches NodeSucceeded via killDaemonedChildren, which marks it before
+	// signalling the pod. So the PodFailed/PodSucceeded below is just Kubernetes confirming our own kill.
+	daemonTeardown := tmpl.IsDaemon() && old.Phase == wfv1.NodeSucceeded
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		updated.Phase = wfv1.NodePending
@@ -1487,8 +1513,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		}
 	case apiv1.PodSucceeded:
 		// if the pod is succeeded, we need to check if it is a daemoned step or not
-		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely
-		if tmpl.IsDaemon() {
+		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely,
+		// unless we are the ones who stopped it.
+		if tmpl.IsDaemon() && !daemonTeardown {
 			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod succeeded. Marking it as failed")
 			updated.Phase = wfv1.NodeFailed
 		} else {
@@ -1498,6 +1525,13 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		updated.Daemoned = nil
 		updated.RestartingPodUID = ""
 	case apiv1.PodFailed:
+		// The failure is our own teardown, not the step failing.
+		if daemonTeardown {
+			woc.log.WithFields(logging.Fields{"displayName": old.DisplayName, "pod": pod.Name}).Info(ctx, "Daemon pod already marked Succeeded by teardown; ignoring PodFailed event")
+			updated.Phase = wfv1.NodeSucceeded
+			updated.Daemoned = nil
+			break
+		}
 		// ignore pod failure for daemoned steps
 		updated.Phase, updated.Message = woc.inferFailedReason(ctx, pod, tmpl)
 		woc.log.WithFields(logging.Fields{"message": updated.Message, "displayName": old.DisplayName, "templateName": wfutil.GetTemplateFromNode(*old), "pod": pod.Name}).Info(ctx, "Pod failed")
@@ -1573,6 +1607,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			continue
 		}
 		switch {
+		case daemonTeardown && killedByDaemonTeardown(c):
+			// Killed by our teardown, so keep the Succeeded phase the node already has.
+			woc.markNodePhase(ctx, ctrNodeName, wfv1.NodeSucceeded)
 		case c.State.Terminated != nil:
 			exitCode := int(c.State.Terminated.ExitCode)
 			message := fmt.Sprintf("%s: %s (exit code %d): %s", c.Name, c.State.Terminated.Reason, exitCode, c.State.Terminated.Message)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1475,12 +1475,16 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		woc.log.Error(ctx, err.Error())
 		return nil
 	}
+	if tmpl == nil {
+		woc.log.WithFields(logging.Fields{"nodeName": old.Name, "templateName": old.TemplateName}).
+			Warn(ctx, "cannot resolve template for node; daemon teardown detection is disabled for it")
+	}
 	// The only way a daemon node becomes Succeeded while its pod is still alive is
 	// killDaemonedChildren, which marks the node and then requests pod termination.
 	// Any pod completion seen after that is the result of our own kill and must not
 	// overwrite the phase; a daemon that dies of its own accord is assessed normally
 	// (its node is still Running at that point) so retryStrategy still works.
-	stoppedDaemon := tmpl != nil && tmpl.IsDaemon() && old.Succeeded()
+	stoppedDaemon := tmpl.IsDaemon() && old.Succeeded()
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		updated.Phase = wfv1.NodePending
@@ -1507,6 +1511,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	case apiv1.PodFailed:
 		if stoppedDaemon {
 			woc.log.WithFields(logging.Fields{"displayName": old.DisplayName, "pod": pod.Name}).Info(ctx, "Ignoring pod failure of daemon stopped by the controller")
+			// killDaemonedChildren already cleared Daemoned when it marked the node Succeeded,
+			// but clear it here too so a stuck flag can never block workflow completion.
+			updated.Daemoned = nil
 			break
 		}
 		updated.Phase, updated.Message = woc.inferFailedReason(ctx, pod, tmpl)
@@ -1579,16 +1586,13 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	// in this case need to update nodes according to container status
 	for _, c := range pod.Status.ContainerStatuses {
 		ctrNodeName := fmt.Sprintf("%s.%s", old.Name, c.Name)
-		ctrNode, err := woc.wf.GetNodeByName(ctrNodeName)
-		if err != nil {
+		if _, err := woc.wf.GetNodeByName(ctrNodeName); err != nil {
 			continue
 		}
 		if stoppedDaemon {
-			// The containers were killed by the controller, so their exit codes carry no
-			// failure meaning; complete any unfinished container nodes along with the pod node.
-			if !ctrNode.Fulfilled() {
-				woc.markNodePhase(ctx, ctrNodeName, wfv1.NodeSucceeded)
-			}
+			// killDaemonedChildren already completed the container child nodes when it stopped
+			// this daemon; the exit codes of our own kill carry no failure meaning, so leave
+			// the children untouched.
 			continue
 		}
 		switch {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1410,6 +1410,29 @@ func (woc *wfOperationCtx) getAllWorkflowPods() ([]*apiv1.Pod, error) {
 	return pods, nil
 }
 
+// killedByDaemonTeardown checks if a container was killed by killDaemonedChildren rather than failing
+// on its own. The teardown sends SIGTERM then SIGKILL, so its containers are either not terminated yet,
+// exited 0, or exited 137 (128 + SIGKILL) / 143 (128 + SIGTERM). The kubelet reports 137 for OOMKilled
+// too, so the signal codes also require a reason it did not diagnose itself.
+func killedByDaemonTeardown(c apiv1.ContainerStatus) bool {
+	t := c.State.Terminated
+	if t == nil {
+		return true
+	}
+	if t.ExitCode == 0 {
+		return true
+	}
+	if t.ExitCode != 137 && t.ExitCode != 143 {
+		return false
+	}
+	switch t.Reason {
+	case "", "Error", "Completed":
+		return true
+	default:
+		return false
+	}
+}
+
 func (woc *wfOperationCtx) printPodSpecLog(ctx context.Context, pod *apiv1.Pod, wfName string) {
 	podSpecByte, err := json.Marshal(pod)
 	log := woc.log.WithField("workflow", wfName).
@@ -1436,6 +1459,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		woc.log.Error(ctx, err.Error())
 		return nil
 	}
+	// A daemon node only reaches NodeSucceeded via killDaemonedChildren, which marks it before
+	// signalling the pod. So the PodFailed/PodSucceeded below is just Kubernetes confirming our own kill.
+	daemonTeardown := tmpl.IsDaemon() && old.Phase == wfv1.NodeSucceeded
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		updated.Phase = wfv1.NodePending
@@ -1448,8 +1474,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		}
 	case apiv1.PodSucceeded:
 		// if the pod is succeeded, we need to check if it is a daemoned step or not
-		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely
-		if tmpl.IsDaemon() {
+		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely,
+		// unless we are the ones who stopped it.
+		if tmpl.IsDaemon() && !daemonTeardown {
 			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod succeeded. Marking it as failed")
 			updated.Phase = wfv1.NodeFailed
 		} else {
@@ -1459,6 +1486,13 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		updated.Daemoned = nil
 		updated.RestartingPodUID = ""
 	case apiv1.PodFailed:
+		// The failure is our own teardown, not the step failing.
+		if daemonTeardown {
+			woc.log.WithFields(logging.Fields{"displayName": old.DisplayName, "pod": pod.Name}).Info(ctx, "Daemon pod already marked Succeeded by teardown; ignoring PodFailed event")
+			updated.Phase = wfv1.NodeSucceeded
+			updated.Daemoned = nil
+			break
+		}
 		// ignore pod failure for daemoned steps
 		updated.Phase, updated.Message = woc.inferFailedReason(ctx, pod, tmpl)
 		woc.log.WithFields(logging.Fields{"message": updated.Message, "displayName": old.DisplayName, "templateName": wfutil.GetTemplateFromNode(*old), "pod": pod.Name}).Info(ctx, "Pod failed")
@@ -1534,6 +1568,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 			continue
 		}
 		switch {
+		case daemonTeardown && killedByDaemonTeardown(c):
+			// Killed by our teardown, so keep the Succeeded phase the node already has.
+			woc.markNodePhase(ctx, ctrNodeName, wfv1.NodeSucceeded)
 		case c.State.Terminated != nil:
 			exitCode := int(c.State.Terminated.ExitCode)
 			message := fmt.Sprintf("%s: %s (exit code %d): %s", c.Name, c.State.Terminated.Reason, exitCode, c.State.Terminated.Message)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1988,6 +1988,9 @@ func TestAssessNodeStatus(t *testing.T) {
 			defer cancel()
 			woc := newWorkflowOperationCtx(ctx, wf, controller)
 			got := woc.assessNodeStatus(ctx, tt.pod, tt.node)
+			if got == nil {
+				got = tt.node // nil means the node is unchanged
+			}
 			assert.Equal(t, tt.wantPhase, got.Phase)
 			assert.Equal(t, tt.wantMessage, got.Message)
 		})
@@ -2015,9 +2018,10 @@ spec:
 `
 
 // TestAssessNodeStatusDaemonContainerSetTeardown verifies that when killDaemonedChildren has
-// stopped a daemon container set pod (marking its node Succeeded before terminating the pod),
-// the resulting PodFailed event neither fails the pod node nor the container child nodes,
-// while a container that genuinely failed beforehand keeps its Failed phase.
+// stopped a daemon container set pod (marking its node and unfinished container children
+// Succeeded before terminating the pod), the resulting PodFailed event and the containers'
+// kill exit codes neither fail the pod node nor the container child nodes, while a container
+// that genuinely failed beforehand keeps its Failed phase.
 // See https://github.com/argoproj/argo-workflows/issues/16397.
 func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
@@ -2037,8 +2041,8 @@ func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
 	}
 	woc.wf.Status.Nodes.Set(ctx, podNode.ID, *podNode)
 	for name, phase := range map[string]wfv1.NodePhase{
-		"step-1": wfv1.NodeRunning, // killed by the controller's teardown
-		"step-2": wfv1.NodeFailed,  // genuinely failed before the teardown
+		"step-1": wfv1.NodeSucceeded, // completed by killDaemonedChildren during the teardown
+		"step-2": wfv1.NodeFailed,    // genuinely failed before the teardown
 	} {
 		childName := podNodeName + "." + name
 		woc.wf.Status.Nodes.Set(ctx, woc.wf.NodeID(childName), wfv1.NodeStatus{
@@ -2066,7 +2070,7 @@ func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
 
 	step1, err := woc.wf.GetNodeByName(podNodeName + ".step-1")
 	require.NoError(t, err)
-	assert.Equal(t, wfv1.NodeSucceeded, step1.Phase, "container killed by the teardown completes with the pod node")
+	assert.Equal(t, wfv1.NodeSucceeded, step1.Phase, "container completed by the teardown must not be failed by its kill exit code")
 
 	step2, err := woc.wf.GetNodeByName(podNodeName + ".step-2")
 	require.NoError(t, err)
@@ -2109,10 +2113,9 @@ spec:
 // that Kubernetes reports because the containers were SIGKILLed.
 //
 // This is the container-set-run-as-daemon case raised in review on
-// https://github.com/argoproj/argo-workflows/pull/16396: killDaemonedChildren only ever marks the
-// pod node (it filters on IsDaemoned, and only the pod node is Daemoned), so the container child
-// nodes are still Running when the event arrives and the ContainerStatuses loop in assessNodeStatus
-// would otherwise mark them Failed from their exit codes.
+// https://github.com/argoproj/argo-workflows/pull/16396: killDaemonedChildren completes the
+// container child nodes together with the pod node, and the ContainerStatuses loop in
+// assessNodeStatus must not then mark any of them Failed from the kill's exit codes.
 func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetStepsWf)
@@ -2139,8 +2142,11 @@ func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
 				State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
 			})
 		}
-		_, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+		updatedPod, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
 		require.NoError(t, updateErr)
+		// operate reads pods from the informer cache, which the fake clientset feeds
+		// asynchronously; update the store directly so the next operate sees the new status.
+		require.NoError(t, controller.PodController.TestingPodInformer().GetStore().Update(updatedPod))
 	}
 	woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
 	woc.operate(ctx)
@@ -2149,8 +2155,8 @@ func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, daemonNode.IsDaemoned(), "daemon pod node should be Daemoned before teardown")
 
-	// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded and
-	// signals the pod, but deliberately leaves the container children as they are.
+	// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded,
+	// completes the unfinished container children, and signals the pod.
 	woc.killDaemonedChildren(ctx, daemonNode.BoundaryID)
 
 	daemonNode, err = woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
@@ -2159,8 +2165,8 @@ func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
 	for _, ctr := range []string{"step-1", "step-2"} {
 		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
 		require.NoError(t, childErr)
-		require.Equal(t, wfv1.NodeRunning, child.Phase,
-			"precondition: killDaemonedChildren leaves container node %s Running", ctr)
+		require.Equal(t, wfv1.NodeSucceeded, child.Phase,
+			"killDaemonedChildren should complete container node %s with the pod node", ctr)
 	}
 
 	// Kubernetes now reports the pod Failed, its containers SIGKILLed by the teardown.
@@ -2180,11 +2186,14 @@ func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
 		}
 	}
 
-	// assessNodeStatus returns nil when it made no change to the pod node, which is the intent here:
-	// the node was already Succeeded and must stay that way.
+	// Mirror podReconciliation's contract: store whatever assessNodeStatus returns (nil means no
+	// change), then assert on the stored node so the check runs regardless of the return value.
 	if updated := woc.assessNodeStatus(ctx, daemonPod, daemonNode); updated != nil {
-		assert.Equal(t, wfv1.NodeSucceeded, updated.Phase, "daemon pod node should stay Succeeded")
+		woc.wf.Status.Nodes.Set(ctx, updated.ID, *updated)
 	}
+	storedNode, err := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeSucceeded, storedNode.Phase, "daemon pod node should stay Succeeded")
 
 	// The container children must not be dragged to Failed by the teardown.
 	for _, ctr := range []string{"step-1", "step-2"} {

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1711,6 +1712,43 @@ func TestAssessNodeStatus(t *testing.T) {
 		wantPhase:   wfv1.NodeFailed,
 		wantMessage: "can't find failed message for pod  namespace ", // daemoned nodes currently don't have a fail message
 	}, {
+		// node already marked Succeeded by killDaemonedChildren; PodFailed event must be ignored.
+		name: "pod failed - daemoned, already marked succeeded by teardown",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodFailed,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeSucceeded,
+		wantMessage: "",
+	}, {
+		// non-daemon node that previously Succeeded must still go through inferFailedReason.
+		name: "pod failed - not daemoned, previously succeeded",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Message: "failed for some reason",
+				Phase:   apiv1.PodFailed,
+			},
+		},
+		daemon:      false,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeFailed,
+		wantMessage: "failed for some reason",
+	}, {
+		// node already marked Succeeded by killDaemonedChildren; PodSucceeded must not overwrite to NodeFailed.
+		name: "pod succeeded - daemoned, already marked succeeded by teardown",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodSucceeded,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeSucceeded,
+		wantMessage: "",
+	}, {
 		name: "daemon, pod running, node failed",
 		pod: &apiv1.Pod{
 			Status: apiv1.PodStatus{
@@ -1928,6 +1966,289 @@ func TestAssessNodeStatus(t *testing.T) {
 			got := woc.assessNodeStatus(ctx, tt.pod, tt.node)
 			assert.Equal(t, tt.wantPhase, got.Phase)
 			assert.Equal(t, tt.wantMessage, got.Message)
+		})
+	}
+}
+
+var daemonContainerSetWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-container-set
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    daemon: true
+    containerSet:
+      containers:
+      - name: step-1
+        image: alpine
+        command: [sh, -c, sleep 999999]
+      - name: step-2
+        image: alpine
+        command: [sh, -c, sleep 999999]
+`
+
+// TestAssessNodeStatusDaemonContainerSetTeardown verifies that when killDaemonedChildren has already
+// marked a daemon container-set pod node Succeeded, the subsequent PodFailed event (the Kubernetes
+// confirmation of the intentional teardown) does not flip the pod node or its container-set child nodes
+// to Failed. See https://github.com/argoproj/argo-workflows/issues/16397.
+func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
+	const podNodeName = "daemon-container-set"
+
+	// setup builds a woc whose daemon container-set pod node was already marked Succeeded by
+	// killDaemonedChildren, then assesses the given container statuses against it.
+	setup := func(t *testing.T) (*wfOperationCtx, *wfv1.NodeStatus, context.Context) {
+		t.Helper()
+		ctx := logging.TestContext(t.Context())
+		wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetWf)
+		cancel, controller := newController(ctx, wf)
+		t.Cleanup(cancel)
+		woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+		// Parent pod node, already marked Succeeded by killDaemonedChildren before the pod was signalled.
+		podNode := &wfv1.NodeStatus{
+			ID:           woc.wf.NodeID(podNodeName),
+			Name:         podNodeName,
+			DisplayName:  podNodeName,
+			Type:         wfv1.NodeTypePod,
+			TemplateName: "main",
+			Phase:        wfv1.NodeSucceeded,
+		}
+		woc.wf.Status.Nodes.Set(ctx, podNode.ID, *podNode)
+		// Container-set child nodes. killDaemonedChildren only marks the pod node, since only it is
+		// ever Daemoned, so the children are still Running when the PodFailed event arrives.
+		for _, ctr := range []string{"step-1", "step-2"} {
+			childName := podNodeName + "." + ctr
+			child := wfv1.NodeStatus{
+				ID:           woc.wf.NodeID(childName),
+				Name:         childName,
+				DisplayName:  ctr,
+				Type:         wfv1.NodeTypeContainer,
+				TemplateName: "main",
+				BoundaryID:   podNode.ID,
+				Phase:        wfv1.NodeRunning,
+			}
+			woc.wf.Status.Nodes.Set(ctx, child.ID, child)
+		}
+		return woc, podNode, ctx
+	}
+
+	// terminated states that killDaemonedChildren's SIGTERM/SIGKILL can plausibly produce.
+	for _, tc := range []struct {
+		name     string
+		state    apiv1.ContainerState
+		expected wfv1.NodePhase
+	}{{
+		name:     "SIGKILLed by teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		name:     "SIGTERMed by teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143, Reason: "Error"}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		name:     "exited cleanly on SIGTERM",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		name:     "kill still in flight, container running",
+		state:    apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		// A genuine failure racing with the teardown must NOT be masked as Succeeded.
+		name:     "genuine failure racing with teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}},
+		expected: wfv1.NodeFailed,
+	}, {
+		// Emissary error exit code must still surface as NodeError.
+		name:     "emissary error racing with teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 64, Reason: "Error"}},
+		expected: wfv1.NodeError,
+	}, {
+		// The kubelet also reports 137 for OOMKilled. That is a genuine failure and must not be
+		// laundered into Succeeded just because a teardown was in progress.
+		name:     "OOMKilled racing with teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}},
+		expected: wfv1.NodeFailed,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			woc, podNode, ctx := setup(t)
+			// step-1 takes the state under test; step-2 is always a plain teardown kill.
+			pod := &apiv1.Pod{
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodFailed,
+					ContainerStatuses: []apiv1.ContainerStatus{
+						{Name: "step-1", State: tc.state},
+						{Name: "step-2", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}}},
+					},
+				},
+			}
+
+			got := woc.assessNodeStatus(ctx, pod, podNode)
+			require.NotNil(t, got)
+			// The parent pod node stays Succeeded: the teardown was intentional.
+			assert.Equal(t, wfv1.NodeSucceeded, got.Phase)
+
+			step1, err := woc.wf.GetNodeByName(podNodeName + ".step-1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, step1.Phase, "container node step-1")
+
+			// The container killed by teardown always stays Succeeded.
+			step2, err := woc.wf.GetNodeByName(podNodeName + ".step-2")
+			require.NoError(t, err)
+			assert.Equal(t, wfv1.NodeSucceeded, step2.Phase, "container node step-2 should stay Succeeded after teardown")
+		})
+	}
+}
+
+var daemonContainerSetStepsWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-cs-steps
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: daemon
+        template: cs
+    - - name: after
+        template: noop
+  - name: cs
+    daemon: true
+    containerSet:
+      containers:
+      - name: step-1
+        image: alpine
+        command: [sh, -c, sleep 999999]
+      - name: step-2
+        image: alpine
+        command: [sh, -c, sleep 999999]
+  - name: noop
+    container:
+      image: alpine
+      command: [sh, -c, "true"]
+`
+
+// TestDaemonContainerSetTeardownEndToEnd drives the whole teardown sequence through the real code
+// path, rather than hand-building node status: operate, bring the daemon pod up Running and Ready,
+// let killDaemonedChildren stop it when the step group completes, then deliver the PodFailed event
+// that Kubernetes reports because the containers were SIGKILLed.
+//
+// This is the container-set-run-as-daemon case raised in review on
+// https://github.com/argoproj/argo-workflows/pull/16396: killDaemonedChildren only ever marks the
+// pod node (it filters on IsDaemoned, and only the pod node is Daemoned), so the container child
+// nodes are still Running when the event arrives and the ContainerStatuses loop in assessNodeStatus
+// would otherwise mark them Failed from their exit codes.
+func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetStepsWf)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	// Bring the daemon container-set pod up: Running with every container Ready, which is what makes
+	// assessNodeStatus mark the node Daemoned.
+	pods, err := listPods(ctx, woc)
+	require.NoError(t, err)
+	require.NotEmpty(t, pods.Items)
+	for _, p := range pods.Items {
+		pod := p
+		pod.Status.Phase = apiv1.PodRunning
+		// The fake client does not populate ContainerStatuses, so synthesize what a kubelet reports.
+		pod.Status.ContainerStatuses = nil
+		for _, c := range pod.Spec.Containers {
+			pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, apiv1.ContainerStatus{
+				Name:  c.Name,
+				Ready: true,
+				State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+			})
+		}
+		_, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+		require.NoError(t, updateErr)
+	}
+	woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
+	woc.operate(ctx)
+
+	daemonNode, err := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
+	require.NoError(t, err)
+	require.True(t, daemonNode.IsDaemoned(), "daemon pod node should be Daemoned before teardown")
+
+	// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded and
+	// signals the pod, but deliberately leaves the container children as they are.
+	woc.killDaemonedChildren(ctx, daemonNode.BoundaryID)
+
+	daemonNode, err = woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
+	require.NoError(t, err)
+	require.Equal(t, wfv1.NodeSucceeded, daemonNode.Phase, "killDaemonedChildren should mark the pod node Succeeded")
+	for _, ctr := range []string{"step-1", "step-2"} {
+		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
+		require.NoError(t, childErr)
+		require.Equal(t, wfv1.NodeRunning, child.Phase,
+			"precondition: killDaemonedChildren leaves container node %s Running", ctr)
+	}
+
+	// Kubernetes now reports the pod Failed, its containers SIGKILLed by the teardown.
+	pods, err = listPods(ctx, woc)
+	require.NoError(t, err)
+	var daemonPod *apiv1.Pod
+	for i := range pods.Items {
+		if pods.Items[i].Annotations[common.AnnotationKeyNodeID] == daemonNode.ID {
+			daemonPod = &pods.Items[i]
+		}
+	}
+	require.NotNil(t, daemonPod, "daemon pod")
+	daemonPod.Status.Phase = apiv1.PodFailed
+	for i := range daemonPod.Status.ContainerStatuses {
+		daemonPod.Status.ContainerStatuses[i].State = apiv1.ContainerState{
+			Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"},
+		}
+	}
+
+	// assessNodeStatus returns nil when it made no change to the pod node, which is the intent here:
+	// the node was already Succeeded and must stay that way.
+	if updated := woc.assessNodeStatus(ctx, daemonPod, daemonNode); updated != nil {
+		assert.Equal(t, wfv1.NodeSucceeded, updated.Phase, "daemon pod node should stay Succeeded")
+	}
+
+	// The container children must not be dragged to Failed by the teardown.
+	for _, ctr := range []string{"step-1", "step-2"} {
+		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
+		require.NoError(t, childErr)
+		assert.Equal(t, wfv1.NodeSucceeded, child.Phase,
+			"container node %s must not be Failed by the intentional teardown", ctr)
+	}
+}
+
+func TestKilledByDaemonTeardown(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state apiv1.ContainerState
+		want  bool
+	}{
+		{"not terminated - running", apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}}, true},
+		{"not terminated - waiting", apiv1.ContainerState{Waiting: &apiv1.ContainerStateWaiting{}}, true},
+		{"exit 0", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}}, true},
+		{"exit 137 SIGKILL", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}, true},
+		{"exit 143 SIGTERM", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143}}, true},
+		{"exit 1 genuine failure", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}}, false},
+		{"exit 64 emissary error", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 64}}, false},
+		{"exit 2 genuine failure", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 2}}, false},
+		// 137 is also what the kubelet reports for OOMKilled, which is a real failure and must not
+		// be mistaken for our own SIGKILL.
+		{"exit 137 OOMKilled", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}}, false},
+		{"exit 137 Evicted", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Evicted"}}, false},
+		{"exit 137 DeadlineExceeded", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "DeadlineExceeded"}}, false},
+		{"exit 143 OOMKilled", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143, Reason: "OOMKilled"}}, false},
+		{"exit 137 empty reason", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, killedByDaemonTeardown(apiv1.ContainerStatus{Name: "c", State: tc.state}))
 		})
 	}
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1736,6 +1737,43 @@ func TestAssessNodeStatus(t *testing.T) {
 		wantPhase:   wfv1.NodeFailed,
 		wantMessage: "can't find failed message for pod  namespace ", // daemoned nodes currently don't have a fail message
 	}, {
+		// node already marked Succeeded by killDaemonedChildren; PodFailed event must be ignored.
+		name: "pod failed - daemoned, already marked succeeded by teardown",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodFailed,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeSucceeded,
+		wantMessage: "",
+	}, {
+		// non-daemon node that previously Succeeded must still go through inferFailedReason.
+		name: "pod failed - not daemoned, previously succeeded",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Message: "failed for some reason",
+				Phase:   apiv1.PodFailed,
+			},
+		},
+		daemon:      false,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeFailed,
+		wantMessage: "failed for some reason",
+	}, {
+		// node already marked Succeeded by killDaemonedChildren; PodSucceeded must not overwrite to NodeFailed.
+		name: "pod succeeded - daemoned, already marked succeeded by teardown",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodSucceeded,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeSucceeded,
+		wantMessage: "",
+	}, {
 		name: "daemon, pod running, node failed",
 		pod: &apiv1.Pod{
 			Status: apiv1.PodStatus{
@@ -1953,6 +1991,289 @@ func TestAssessNodeStatus(t *testing.T) {
 			got := woc.assessNodeStatus(ctx, tt.pod, tt.node)
 			assert.Equal(t, tt.wantPhase, got.Phase)
 			assert.Equal(t, tt.wantMessage, got.Message)
+		})
+	}
+}
+
+var daemonContainerSetWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-container-set
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    daemon: true
+    containerSet:
+      containers:
+      - name: step-1
+        image: alpine
+        command: [sh, -c, sleep 999999]
+      - name: step-2
+        image: alpine
+        command: [sh, -c, sleep 999999]
+`
+
+// TestAssessNodeStatusDaemonContainerSetTeardown verifies that when killDaemonedChildren has already
+// marked a daemon container-set pod node Succeeded, the subsequent PodFailed event (the Kubernetes
+// confirmation of the intentional teardown) does not flip the pod node or its container-set child nodes
+// to Failed. See https://github.com/argoproj/argo-workflows/issues/16397.
+func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
+	const podNodeName = "daemon-container-set"
+
+	// setup builds a woc whose daemon container-set pod node was already marked Succeeded by
+	// killDaemonedChildren, then assesses the given container statuses against it.
+	setup := func(t *testing.T) (*wfOperationCtx, *wfv1.NodeStatus, context.Context) {
+		t.Helper()
+		ctx := logging.TestContext(t.Context())
+		wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetWf)
+		cancel, controller := newController(ctx, wf)
+		t.Cleanup(cancel)
+		woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+		// Parent pod node, already marked Succeeded by killDaemonedChildren before the pod was signalled.
+		podNode := &wfv1.NodeStatus{
+			ID:           woc.wf.NodeID(podNodeName),
+			Name:         podNodeName,
+			DisplayName:  podNodeName,
+			Type:         wfv1.NodeTypePod,
+			TemplateName: "main",
+			Phase:        wfv1.NodeSucceeded,
+		}
+		woc.wf.Status.Nodes.Set(ctx, podNode.ID, *podNode)
+		// Container-set child nodes. killDaemonedChildren only marks the pod node, since only it is
+		// ever Daemoned, so the children are still Running when the PodFailed event arrives.
+		for _, ctr := range []string{"step-1", "step-2"} {
+			childName := podNodeName + "." + ctr
+			child := wfv1.NodeStatus{
+				ID:           woc.wf.NodeID(childName),
+				Name:         childName,
+				DisplayName:  ctr,
+				Type:         wfv1.NodeTypeContainer,
+				TemplateName: "main",
+				BoundaryID:   podNode.ID,
+				Phase:        wfv1.NodeRunning,
+			}
+			woc.wf.Status.Nodes.Set(ctx, child.ID, child)
+		}
+		return woc, podNode, ctx
+	}
+
+	// terminated states that killDaemonedChildren's SIGTERM/SIGKILL can plausibly produce.
+	for _, tc := range []struct {
+		name     string
+		state    apiv1.ContainerState
+		expected wfv1.NodePhase
+	}{{
+		name:     "SIGKILLed by teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		name:     "SIGTERMed by teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143, Reason: "Error"}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		name:     "exited cleanly on SIGTERM",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		name:     "kill still in flight, container running",
+		state:    apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+		expected: wfv1.NodeSucceeded,
+	}, {
+		// A genuine failure racing with the teardown must NOT be masked as Succeeded.
+		name:     "genuine failure racing with teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}},
+		expected: wfv1.NodeFailed,
+	}, {
+		// Emissary error exit code must still surface as NodeError.
+		name:     "emissary error racing with teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 64, Reason: "Error"}},
+		expected: wfv1.NodeError,
+	}, {
+		// The kubelet also reports 137 for OOMKilled. That is a genuine failure and must not be
+		// laundered into Succeeded just because a teardown was in progress.
+		name:     "OOMKilled racing with teardown",
+		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}},
+		expected: wfv1.NodeFailed,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			woc, podNode, ctx := setup(t)
+			// step-1 takes the state under test; step-2 is always a plain teardown kill.
+			pod := &apiv1.Pod{
+				Status: apiv1.PodStatus{
+					Phase: apiv1.PodFailed,
+					ContainerStatuses: []apiv1.ContainerStatus{
+						{Name: "step-1", State: tc.state},
+						{Name: "step-2", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}}},
+					},
+				},
+			}
+
+			got := woc.assessNodeStatus(ctx, pod, podNode)
+			require.NotNil(t, got)
+			// The parent pod node stays Succeeded: the teardown was intentional.
+			assert.Equal(t, wfv1.NodeSucceeded, got.Phase)
+
+			step1, err := woc.wf.GetNodeByName(podNodeName + ".step-1")
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, step1.Phase, "container node step-1")
+
+			// The container killed by teardown always stays Succeeded.
+			step2, err := woc.wf.GetNodeByName(podNodeName + ".step-2")
+			require.NoError(t, err)
+			assert.Equal(t, wfv1.NodeSucceeded, step2.Phase, "container node step-2 should stay Succeeded after teardown")
+		})
+	}
+}
+
+var daemonContainerSetStepsWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-cs-steps
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: daemon
+        template: cs
+    - - name: after
+        template: noop
+  - name: cs
+    daemon: true
+    containerSet:
+      containers:
+      - name: step-1
+        image: alpine
+        command: [sh, -c, sleep 999999]
+      - name: step-2
+        image: alpine
+        command: [sh, -c, sleep 999999]
+  - name: noop
+    container:
+      image: alpine
+      command: [sh, -c, "true"]
+`
+
+// TestDaemonContainerSetTeardownEndToEnd drives the whole teardown sequence through the real code
+// path, rather than hand-building node status: operate, bring the daemon pod up Running and Ready,
+// let killDaemonedChildren stop it when the step group completes, then deliver the PodFailed event
+// that Kubernetes reports because the containers were SIGKILLed.
+//
+// This is the container-set-run-as-daemon case raised in review on
+// https://github.com/argoproj/argo-workflows/pull/16396: killDaemonedChildren only ever marks the
+// pod node (it filters on IsDaemoned, and only the pod node is Daemoned), so the container child
+// nodes are still Running when the event arrives and the ContainerStatuses loop in assessNodeStatus
+// would otherwise mark them Failed from their exit codes.
+func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetStepsWf)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	// Bring the daemon container-set pod up: Running with every container Ready, which is what makes
+	// assessNodeStatus mark the node Daemoned.
+	pods, err := listPods(ctx, woc)
+	require.NoError(t, err)
+	require.NotEmpty(t, pods.Items)
+	for _, p := range pods.Items {
+		pod := p
+		pod.Status.Phase = apiv1.PodRunning
+		// The fake client does not populate ContainerStatuses, so synthesize what a kubelet reports.
+		pod.Status.ContainerStatuses = nil
+		for _, c := range pod.Spec.Containers {
+			pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, apiv1.ContainerStatus{
+				Name:  c.Name,
+				Ready: true,
+				State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+			})
+		}
+		_, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+		require.NoError(t, updateErr)
+	}
+	woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
+	woc.operate(ctx)
+
+	daemonNode, err := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
+	require.NoError(t, err)
+	require.True(t, daemonNode.IsDaemoned(), "daemon pod node should be Daemoned before teardown")
+
+	// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded and
+	// signals the pod, but deliberately leaves the container children as they are.
+	woc.killDaemonedChildren(ctx, daemonNode.BoundaryID)
+
+	daemonNode, err = woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
+	require.NoError(t, err)
+	require.Equal(t, wfv1.NodeSucceeded, daemonNode.Phase, "killDaemonedChildren should mark the pod node Succeeded")
+	for _, ctr := range []string{"step-1", "step-2"} {
+		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
+		require.NoError(t, childErr)
+		require.Equal(t, wfv1.NodeRunning, child.Phase,
+			"precondition: killDaemonedChildren leaves container node %s Running", ctr)
+	}
+
+	// Kubernetes now reports the pod Failed, its containers SIGKILLed by the teardown.
+	pods, err = listPods(ctx, woc)
+	require.NoError(t, err)
+	var daemonPod *apiv1.Pod
+	for i := range pods.Items {
+		if pods.Items[i].Annotations[common.AnnotationKeyNodeID] == daemonNode.ID {
+			daemonPod = &pods.Items[i]
+		}
+	}
+	require.NotNil(t, daemonPod, "daemon pod")
+	daemonPod.Status.Phase = apiv1.PodFailed
+	for i := range daemonPod.Status.ContainerStatuses {
+		daemonPod.Status.ContainerStatuses[i].State = apiv1.ContainerState{
+			Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"},
+		}
+	}
+
+	// assessNodeStatus returns nil when it made no change to the pod node, which is the intent here:
+	// the node was already Succeeded and must stay that way.
+	if updated := woc.assessNodeStatus(ctx, daemonPod, daemonNode); updated != nil {
+		assert.Equal(t, wfv1.NodeSucceeded, updated.Phase, "daemon pod node should stay Succeeded")
+	}
+
+	// The container children must not be dragged to Failed by the teardown.
+	for _, ctr := range []string{"step-1", "step-2"} {
+		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
+		require.NoError(t, childErr)
+		assert.Equal(t, wfv1.NodeSucceeded, child.Phase,
+			"container node %s must not be Failed by the intentional teardown", ctr)
+	}
+}
+
+func TestKilledByDaemonTeardown(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state apiv1.ContainerState
+		want  bool
+	}{
+		{"not terminated - running", apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}}, true},
+		{"not terminated - waiting", apiv1.ContainerState{Waiting: &apiv1.ContainerStateWaiting{}}, true},
+		{"exit 0", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}}, true},
+		{"exit 137 SIGKILL", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}, true},
+		{"exit 143 SIGTERM", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143}}, true},
+		{"exit 1 genuine failure", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}}, false},
+		{"exit 64 emissary error", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 64}}, false},
+		{"exit 2 genuine failure", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 2}}, false},
+		// 137 is also what the kubelet reports for OOMKilled, which is a real failure and must not
+		// be mistaken for our own SIGKILL.
+		{"exit 137 OOMKilled", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}}, false},
+		{"exit 137 Evicted", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Evicted"}}, false},
+		{"exit 137 DeadlineExceeded", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "DeadlineExceeded"}}, false},
+		{"exit 143 OOMKilled", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143, Reason: "OOMKilled"}}, false},
+		{"exit 137 empty reason", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, killedByDaemonTeardown(apiv1.ContainerStatus{Name: "c", State: tc.state}))
 		})
 	}
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1748,6 +1749,21 @@ func TestAssessNodeStatus(t *testing.T) {
 		wantPhase:   wfv1.NodeSucceeded,
 		wantMessage: "",
 	}, {
+		// A live daemon that dies on its own must still be assessed normally: its node is Running
+		// and Daemoned, not Succeeded, so the teardown predicate must not swallow the failure --
+		// otherwise retryStrategy never sees the attempt fail.
+		name: "pod failed - daemoned, died on its own",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Message: "died on its own",
+				Phase:   apiv1.PodFailed,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeRunning, Daemoned: new(true)},
+		wantPhase:   wfv1.NodeFailed,
+		wantMessage: "died on its own",
+	}, {
 		// non-daemon node that previously Succeeded must still go through inferFailedReason.
 		name: "pod failed - not daemoned, previously succeeded",
 		pod: &apiv1.Pod{
@@ -2107,100 +2123,204 @@ spec:
       command: [sh, -c, "true"]
 `
 
-// TestDaemonContainerSetTeardownEndToEnd drives the whole teardown sequence through the real code
-// path, rather than hand-building node status: operate, bring the daemon pod up Running and Ready,
-// let killDaemonedChildren stop it when the step group completes, then deliver the PodFailed event
-// that Kubernetes reports because the containers were SIGKILLed.
+var daemonScriptStepsWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-script-steps
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: daemon
+        template: script
+    - - name: after
+        template: noop
+  - name: script
+    daemon: true
+    script:
+      image: alpine
+      command: [sh]
+      source: |
+        sleep 999999
+  - name: noop
+    container:
+      image: alpine
+      command: [sh, -c, "true"]
+`
+
+// injectPlaceholderTaskResult mirrors what the executor writes at pod start: a WorkflowTaskResult
+// labelled report-outputs-completed=false, before any output has been reported. Every pod with an
+// aux container has one from the moment it starts, and it is what flips a node's TaskResultSynced
+// to false. Without it a teardown test cannot tell whether a daemon node was initialized with
+// omitTaskResultSynced, because MarkTaskResultIncomplete leaves a nil TaskResultSynced alone.
+func injectPlaceholderTaskResult(ctx context.Context, t *testing.T, woc *wfOperationCtx, nodeID string) {
+	t.Helper()
+	result := &wfv1.WorkflowTaskResult{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: workflow.APIVersion,
+			Kind:       workflow.WorkflowTaskResultKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeID,
+			Namespace: woc.wf.Namespace,
+			Labels: map[string]string{
+				common.LabelKeyWorkflow:               woc.wf.Name,
+				common.LabelKeyReportOutputsCompleted: "false",
+			},
+		},
+	}
+	_, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskResults(woc.wf.Namespace).
+		Create(ctx, result, metav1.CreateOptions{})
+	require.NoError(t, err)
+	// The informer is fed asynchronously from the fake clientset; seed the indexer directly so the
+	// next operate's taskResultReconciliation sees the placeholder.
+	require.NoError(t, woc.controller.taskResultInformer.GetIndexer().Add(result))
+}
+
+// TestDaemonTeardownEndToEnd drives the whole teardown sequence through the real code path, rather
+// than hand-building node status: operate, bring the daemon pod up Running and Ready, let
+// killDaemonedChildren stop it when the step group completes, deliver the PodRunning event that is
+// still in flight at that moment, then the PodFailed event that Kubernetes reports because the
+// containers were SIGKILLed.
 //
-// This is the container-set-run-as-daemon case raised in review on
-// https://github.com/argoproj/argo-workflows/pull/16396: killDaemonedChildren completes the
-// container child nodes together with the pod node, and the ContainerStatuses loop in
-// assessNodeStatus must not then mark any of them Failed from the kill's exit codes.
-func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
-	ctx := logging.TestContext(t.Context())
-	wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetStepsWf)
-	cancel, controller := newController(ctx, wf)
-	defer cancel()
+// This is the daemon case raised in review on
+// https://github.com/argoproj/argo-workflows/pull/16396. Three things must hold at the end:
+// the pod node stays Succeeded, killDaemonedChildren's completed container children are not
+// dragged to Failed by the kill's exit codes, and no exit code from our own kill is recorded.
+//
+// The placeholder WorkflowTaskResult is what makes this test able to fail. Without it
+// TaskResultSynced never becomes false, the node stays Fulfilled through teardown, and the
+// PodRunning branch below never resurrects it -- so initializing the node without
+// omitTaskResultSynced would go unnoticed.
+func TestDaemonTeardownEndToEnd(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		wf         string
+		daemonNode string
+		ctrNodes   []string
+	}{{
+		// a container set pod has no container called "main", so getExitCode never matches it
+		name:       "container set",
+		wf:         daemonContainerSetStepsWf,
+		daemonNode: "daemon-cs-steps[0].daemon",
+		ctrNodes:   []string{"step-1", "step-2"},
+	}, {
+		// a script pod does have a "main" container, so it is the case that can record an exit code
+		name:       "script",
+		wf:         daemonScriptStepsWf,
+		daemonNode: "daemon-script-steps[0].daemon",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			wf := wfv1.MustUnmarshalWorkflow(tt.wf)
+			cancel, controller := newController(ctx, wf)
+			defer cancel()
 
-	woc := newWorkflowOperationCtx(ctx, wf, controller)
-	woc.operate(ctx)
+			woc := newWorkflowOperationCtx(ctx, wf, controller)
+			woc.operate(ctx)
 
-	// Bring the daemon container-set pod up: Running with every container Ready, which is what makes
-	// assessNodeStatus mark the node Daemoned.
-	pods, err := listPods(ctx, woc)
-	require.NoError(t, err)
-	require.NotEmpty(t, pods.Items)
-	for _, p := range pods.Items {
-		pod := p
-		pod.Status.Phase = apiv1.PodRunning
-		// The fake client does not populate ContainerStatuses, so synthesize what a kubelet reports.
-		pod.Status.ContainerStatuses = nil
-		for _, c := range pod.Spec.Containers {
-			pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, apiv1.ContainerStatus{
-				Name:  c.Name,
-				Ready: true,
-				State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
-			})
-		}
-		updatedPod, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
-		require.NoError(t, updateErr)
-		// operate reads pods from the informer cache, which the fake clientset feeds
-		// asynchronously; update the store directly so the next operate sees the new status.
-		require.NoError(t, controller.PodController.TestingPodInformer().GetStore().Update(updatedPod))
-	}
-	woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
-	woc.operate(ctx)
+			daemonNode, err := woc.wf.GetNodeByName(tt.daemonNode)
+			require.NoError(t, err)
+			injectPlaceholderTaskResult(ctx, t, woc, daemonNode.ID)
 
-	daemonNode, err := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
-	require.NoError(t, err)
-	require.True(t, daemonNode.IsDaemoned(), "daemon pod node should be Daemoned before teardown")
+			// Bring the daemon pod up: Running with every container Ready, which is what makes
+			// assessNodeStatus mark the node Daemoned.
+			pods, err := listPods(ctx, woc)
+			require.NoError(t, err)
+			require.NotEmpty(t, pods.Items)
+			for _, p := range pods.Items {
+				pod := p
+				pod.Status.Phase = apiv1.PodRunning
+				// The fake client does not populate ContainerStatuses, so synthesize what a kubelet reports.
+				pod.Status.ContainerStatuses = nil
+				for _, c := range pod.Spec.Containers {
+					pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, apiv1.ContainerStatus{
+						Name:  c.Name,
+						Ready: true,
+						State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+					})
+				}
+				updatedPod, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+				require.NoError(t, updateErr)
+				// operate reads pods from the informer cache, which the fake clientset feeds
+				// asynchronously; update the store directly so the next operate sees the new status.
+				require.NoError(t, controller.PodController.TestingPodInformer().GetStore().Update(updatedPod))
+			}
+			woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
+			woc.operate(ctx)
 
-	// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded,
-	// completes the unfinished container children, and signals the pod.
-	woc.killDaemonedChildren(ctx, daemonNode.BoundaryID)
+			daemonNode, err = woc.wf.GetNodeByName(tt.daemonNode)
+			require.NoError(t, err)
+			require.True(t, daemonNode.IsDaemoned(), "daemon pod node should be Daemoned before teardown")
 
-	daemonNode, err = woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
-	require.NoError(t, err)
-	require.Equal(t, wfv1.NodeSucceeded, daemonNode.Phase, "killDaemonedChildren should mark the pod node Succeeded")
-	for _, ctr := range []string{"step-1", "step-2"} {
-		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
-		require.NoError(t, childErr)
-		require.Equal(t, wfv1.NodeSucceeded, child.Phase,
-			"killDaemonedChildren should complete container node %s with the pod node", ctr)
-	}
+			// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded,
+			// completes the unfinished container children, and signals the pod.
+			woc.killDaemonedChildren(ctx, daemonNode.BoundaryID)
 
-	// Kubernetes now reports the pod Failed, its containers SIGKILLed by the teardown.
-	pods, err = listPods(ctx, woc)
-	require.NoError(t, err)
-	var daemonPod *apiv1.Pod
-	for i := range pods.Items {
-		if pods.Items[i].Annotations[common.AnnotationKeyNodeID] == daemonNode.ID {
-			daemonPod = &pods.Items[i]
-		}
-	}
-	require.NotNil(t, daemonPod, "daemon pod")
-	daemonPod.Status.Phase = apiv1.PodFailed
-	for i := range daemonPod.Status.ContainerStatuses {
-		daemonPod.Status.ContainerStatuses[i].State = apiv1.ContainerState{
-			Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"},
-		}
-	}
+			daemonNode, err = woc.wf.GetNodeByName(tt.daemonNode)
+			require.NoError(t, err)
+			require.Equal(t, wfv1.NodeSucceeded, daemonNode.Phase, "killDaemonedChildren should mark the pod node Succeeded")
+			for _, ctr := range tt.ctrNodes {
+				child, childErr := woc.wf.GetNodeByName(tt.daemonNode + "." + ctr)
+				require.NoError(t, childErr)
+				require.Equal(t, wfv1.NodeSucceeded, child.Phase,
+					"killDaemonedChildren should complete container node %s with the pod node", ctr)
+			}
 
-	// Mirror podReconciliation's contract: store whatever assessNodeStatus returns (nil means no
-	// change), then assert on the stored node so the check runs regardless of the return value.
-	if updated := woc.assessNodeStatus(ctx, daemonPod, daemonNode); updated != nil {
-		woc.wf.Status.Nodes.Set(ctx, updated.ID, *updated)
-	}
-	storedNode, err := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon")
-	require.NoError(t, err)
-	assert.Equal(t, wfv1.NodeSucceeded, storedNode.Phase, "daemon pod node should stay Succeeded")
+			pods, err = listPods(ctx, woc)
+			require.NoError(t, err)
+			var daemonPod *apiv1.Pod
+			for i := range pods.Items {
+				if pods.Items[i].Annotations[common.AnnotationKeyNodeID] == daemonNode.ID {
+					daemonPod = &pods.Items[i]
+				}
+			}
+			require.NotNil(t, daemonPod, "daemon pod")
 
-	// The container children must not be dragged to Failed by the teardown.
-	for _, ctr := range []string{"step-1", "step-2"} {
-		child, childErr := woc.wf.GetNodeByName("daemon-cs-steps[0].daemon." + ctr)
-		require.NoError(t, childErr)
-		assert.Equal(t, wfv1.NodeSucceeded, child.Phase,
-			"container node %s must not be Failed by the intentional teardown", ctr)
+			// assessNodeStatus returns nil when nothing changed; mirror podReconciliation's contract
+			// and store whatever comes back, so every assertion below reads the stored node.
+			assess := func() *wfv1.NodeStatus {
+				old, getErr := woc.wf.GetNodeByName(tt.daemonNode)
+				require.NoError(t, getErr)
+				if updated := woc.assessNodeStatus(ctx, daemonPod, old); updated != nil {
+					woc.wf.Status.Nodes.Set(ctx, updated.ID, *updated)
+				}
+				stored, getErr := woc.wf.GetNodeByName(tt.daemonNode)
+				require.NoError(t, getErr)
+				return stored
+			}
+
+			// The kill is queued, not yet delivered: the pod is still Running when the next reconcile
+			// lands. This is where a node whose TaskResultSynced is false gets resurrected to
+			// Running+Daemoned, which makes the following PodFailed look like a spontaneous death.
+			require.Equal(t, wfv1.NodeSucceeded, assess().Phase, "a stopped daemon must not be resurrected to Running")
+
+			// Kubernetes now reports the pod Failed, its containers SIGKILLed by the teardown.
+			daemonPod.Status.Phase = apiv1.PodFailed
+			for i := range daemonPod.Status.ContainerStatuses {
+				daemonPod.Status.ContainerStatuses[i].State = apiv1.ContainerState{
+					Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"},
+				}
+			}
+
+			storedNode := assess()
+			assert.Equal(t, wfv1.NodeSucceeded, storedNode.Phase, "daemon pod node should stay Succeeded")
+			var exitCode *string
+			if storedNode.Outputs != nil {
+				exitCode = storedNode.Outputs.ExitCode
+			}
+			assert.Nil(t, exitCode, "a daemon stopped by the controller must not record our own kill's exit code")
+
+			// The container children must not be dragged to Failed by the teardown.
+			for _, ctr := range tt.ctrNodes {
+				child, childErr := woc.wf.GetNodeByName(tt.daemonNode + "." + ctr)
+				require.NoError(t, childErr)
+				assert.Equal(t, wfv1.NodeSucceeded, child.Phase,
+					"container node %s must not be Failed by the intentional teardown", ctr)
+			}
+		})
 	}
 }
 

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2015,117 +2014,63 @@ spec:
         command: [sh, -c, sleep 999999]
 `
 
-// TestAssessNodeStatusDaemonContainerSetTeardown verifies that when killDaemonedChildren has already
-// marked a daemon container-set pod node Succeeded, the subsequent PodFailed event (the Kubernetes
-// confirmation of the intentional teardown) does not flip the pod node or its container-set child nodes
-// to Failed. See https://github.com/argoproj/argo-workflows/issues/16397.
+// TestAssessNodeStatusDaemonContainerSetTeardown verifies that when killDaemonedChildren has
+// stopped a daemon container set pod (marking its node Succeeded before terminating the pod),
+// the resulting PodFailed event neither fails the pod node nor the container child nodes,
+// while a container that genuinely failed beforehand keeps its Failed phase.
+// See https://github.com/argoproj/argo-workflows/issues/16397.
 func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetWf)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
 	const podNodeName = "daemon-container-set"
-
-	// setup builds a woc whose daemon container-set pod node was already marked Succeeded by
-	// killDaemonedChildren, then assesses the given container statuses against it.
-	setup := func(t *testing.T) (*wfOperationCtx, *wfv1.NodeStatus, context.Context) {
-		t.Helper()
-		ctx := logging.TestContext(t.Context())
-		wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetWf)
-		cancel, controller := newController(ctx, wf)
-		t.Cleanup(cancel)
-		woc := newWorkflowOperationCtx(ctx, wf, controller)
-
-		// Parent pod node, already marked Succeeded by killDaemonedChildren before the pod was signalled.
-		podNode := &wfv1.NodeStatus{
-			ID:           woc.wf.NodeID(podNodeName),
-			Name:         podNodeName,
-			DisplayName:  podNodeName,
-			Type:         wfv1.NodeTypePod,
-			TemplateName: "main",
-			Phase:        wfv1.NodeSucceeded,
-		}
-		woc.wf.Status.Nodes.Set(ctx, podNode.ID, *podNode)
-		// Container-set child nodes. killDaemonedChildren only marks the pod node, since only it is
-		// ever Daemoned, so the children are still Running when the PodFailed event arrives.
-		for _, ctr := range []string{"step-1", "step-2"} {
-			childName := podNodeName + "." + ctr
-			child := wfv1.NodeStatus{
-				ID:           woc.wf.NodeID(childName),
-				Name:         childName,
-				DisplayName:  ctr,
-				Type:         wfv1.NodeTypeContainer,
-				TemplateName: "main",
-				BoundaryID:   podNode.ID,
-				Phase:        wfv1.NodeRunning,
-			}
-			woc.wf.Status.Nodes.Set(ctx, child.ID, child)
-		}
-		return woc, podNode, ctx
+	podNode := &wfv1.NodeStatus{
+		ID:           woc.wf.NodeID(podNodeName),
+		Name:         podNodeName,
+		Type:         wfv1.NodeTypePod,
+		TemplateName: "main",
+		// set by killDaemonedChildren before the pod was terminated
+		Phase: wfv1.NodeSucceeded,
 	}
-
-	// terminated states that killDaemonedChildren's SIGTERM/SIGKILL can plausibly produce.
-	for _, tc := range []struct {
-		name     string
-		state    apiv1.ContainerState
-		expected wfv1.NodePhase
-	}{{
-		name:     "SIGKILLed by teardown",
-		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}},
-		expected: wfv1.NodeSucceeded,
-	}, {
-		name:     "SIGTERMed by teardown",
-		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143, Reason: "Error"}},
-		expected: wfv1.NodeSucceeded,
-	}, {
-		name:     "exited cleanly on SIGTERM",
-		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}},
-		expected: wfv1.NodeSucceeded,
-	}, {
-		name:     "kill still in flight, container running",
-		state:    apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
-		expected: wfv1.NodeSucceeded,
-	}, {
-		// A genuine failure racing with the teardown must NOT be masked as Succeeded.
-		name:     "genuine failure racing with teardown",
-		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}},
-		expected: wfv1.NodeFailed,
-	}, {
-		// Emissary error exit code must still surface as NodeError.
-		name:     "emissary error racing with teardown",
-		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 64, Reason: "Error"}},
-		expected: wfv1.NodeError,
-	}, {
-		// The kubelet also reports 137 for OOMKilled. That is a genuine failure and must not be
-		// laundered into Succeeded just because a teardown was in progress.
-		name:     "OOMKilled racing with teardown",
-		state:    apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}},
-		expected: wfv1.NodeFailed,
-	}} {
-		t.Run(tc.name, func(t *testing.T) {
-			woc, podNode, ctx := setup(t)
-			// step-1 takes the state under test; step-2 is always a plain teardown kill.
-			pod := &apiv1.Pod{
-				Status: apiv1.PodStatus{
-					Phase: apiv1.PodFailed,
-					ContainerStatuses: []apiv1.ContainerStatus{
-						{Name: "step-1", State: tc.state},
-						{Name: "step-2", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}}},
-					},
-				},
-			}
-
-			got := woc.assessNodeStatus(ctx, pod, podNode)
-			require.NotNil(t, got)
-			// The parent pod node stays Succeeded: the teardown was intentional.
-			assert.Equal(t, wfv1.NodeSucceeded, got.Phase)
-
-			step1, err := woc.wf.GetNodeByName(podNodeName + ".step-1")
-			require.NoError(t, err)
-			assert.Equal(t, tc.expected, step1.Phase, "container node step-1")
-
-			// The container killed by teardown always stays Succeeded.
-			step2, err := woc.wf.GetNodeByName(podNodeName + ".step-2")
-			require.NoError(t, err)
-			assert.Equal(t, wfv1.NodeSucceeded, step2.Phase, "container node step-2 should stay Succeeded after teardown")
+	woc.wf.Status.Nodes.Set(ctx, podNode.ID, *podNode)
+	for name, phase := range map[string]wfv1.NodePhase{
+		"step-1": wfv1.NodeRunning, // killed by the controller's teardown
+		"step-2": wfv1.NodeFailed,  // genuinely failed before the teardown
+	} {
+		childName := podNodeName + "." + name
+		woc.wf.Status.Nodes.Set(ctx, woc.wf.NodeID(childName), wfv1.NodeStatus{
+			ID:           woc.wf.NodeID(childName),
+			Name:         childName,
+			Type:         wfv1.NodeTypeContainer,
+			TemplateName: "main",
+			BoundaryID:   podNode.ID,
+			Phase:        phase,
 		})
 	}
+	pod := &apiv1.Pod{
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodFailed,
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{Name: "step-1", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}}},
+				{Name: "step-2", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
+			},
+		},
+	}
+
+	got := woc.assessNodeStatus(ctx, pod, podNode)
+	require.NotNil(t, got)
+	assert.Equal(t, wfv1.NodeSucceeded, got.Phase, "pod node stays Succeeded")
+
+	step1, err := woc.wf.GetNodeByName(podNodeName + ".step-1")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeSucceeded, step1.Phase, "container killed by the teardown completes with the pod node")
+
+	step2, err := woc.wf.GetNodeByName(podNodeName + ".step-2")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeFailed, step2.Phase, "container that failed before the teardown stays Failed")
 }
 
 var daemonContainerSetStepsWf = `
@@ -2247,34 +2192,6 @@ func TestDaemonContainerSetTeardownEndToEnd(t *testing.T) {
 		require.NoError(t, childErr)
 		assert.Equal(t, wfv1.NodeSucceeded, child.Phase,
 			"container node %s must not be Failed by the intentional teardown", ctr)
-	}
-}
-
-func TestKilledByDaemonTeardown(t *testing.T) {
-	for _, tc := range []struct {
-		name  string
-		state apiv1.ContainerState
-		want  bool
-	}{
-		{"not terminated - running", apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}}, true},
-		{"not terminated - waiting", apiv1.ContainerState{Waiting: &apiv1.ContainerStateWaiting{}}, true},
-		{"exit 0", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 0}}, true},
-		{"exit 137 SIGKILL", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}, true},
-		{"exit 143 SIGTERM", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143}}, true},
-		{"exit 1 genuine failure", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1}}, false},
-		{"exit 64 emissary error", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 64}}, false},
-		{"exit 2 genuine failure", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 2}}, false},
-		// 137 is also what the kubelet reports for OOMKilled, which is a real failure and must not
-		// be mistaken for our own SIGKILL.
-		{"exit 137 OOMKilled", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "OOMKilled"}}, false},
-		{"exit 137 Evicted", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Evicted"}}, false},
-		{"exit 137 DeadlineExceeded", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "DeadlineExceeded"}}, false},
-		{"exit 143 OOMKilled", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 143, Reason: "OOMKilled"}}, false},
-		{"exit 137 empty reason", apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137}}, true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, killedByDaemonTeardown(apiv1.ContainerStatus{Name: "c", State: tc.state}))
-		})
 	}
 }
 


### PR DESCRIPTION
When upgrading from Argo Workflows v3 to v4, daemon pods started being marked
NodeFailed even when the overall workflow succeeded.

In v3, assessNodeStatus unconditionally marked daemon pods as NodeSucceeded
when their Kubernetes phase was PodFailed:

    if tmpl != nil && tmpl.IsDaemon() {
        new.Phase = wfv1.NodeSucceeded // daemon failure silently ignored
    }

In v4 (commit https://github.com/argoproj/argo-workflows/commit/9b73126010eef059ba881d30da1b56153e3dd65e), this guard was removed as part of adding retry
strategy support for daemon containers. The stale comment "ignore pod failure
for daemoned steps" remains but no longer matches the behaviour.

Root cause: killDaemonedChildren sets old.Phase = NodeSucceeded synchronously
before dispatching SIGTERM to the pod. By the time the PodFailed event arrives
in the next reconciliation, the node is already marked Succeeded — the event
is just the Kubernetes confirmation of the intentional teardown. The correct
fix is to check old.Phase at the assessNodeStatus level rather than
heuristically inspecting exit codes in inferFailedReason.

We confirmed this by:
- Running dind (Docker-in-Docker) as a daemon pod in a real workflow
- Trying dockerd-entrypoint.sh, preStop lifecycle hooks, --shutdown-timeout=0,
  and wrapping dockerd with || true — none resolved the issue because the
  problem was at the controller level, not the dind container
- Tracing killDaemonedChildren and confirming it sets NodeSucceeded before
  the async signal is dispatched

Fix: in the PodFailed case of assessNodeStatus, check if old.Phase is already
NodeSucceeded. If so, the pod was intentionally killed by Argo — preserve the
Succeeded status and skip inferFailedReason entirely. This is correct for any
exit code, not just 137/143, and avoids fragile signal heuristics.

Also fix the symmetric PodSucceeded + daemon case: if a daemon pod exits 0
after Argo has already marked it NodeSucceeded, preserve that status rather
than overwriting it with NodeFailed.

Fixes #16397

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of daemon-based workflow nodes so a completed node keeps its successful status during cleanup.
  * Prevented later pod status updates from incorrectly changing an already successful node to failed.
  * Preserved the existing success state and message when teardown has already finalized the node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->