### PR TITLE
fix: log missing optional output parameter at warn level, not error. Fixes #16395

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -703,7 +703,7 @@ func saveParameter(ctx context.Context, srcPath string) error {
 	}
 	src, err := os.Open(filepath.Clean(srcPath))
 	if os.IsNotExist(err) { // might be optional, so we ignore
-		logger.WithField("src", srcPath).WithError(err).Error(ctx, "cannot save parameter, does not exist")
+		logger.WithField("src", srcPath).WithError(err).Warn(ctx, "cannot save parameter, does not exist")
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes #16395

### Motivation

When an output parameter's source file does not exist, `saveParameter` logs the condition at `error` level and then returns `nil`, so it is already treated as non-fatal (see the existing "might be optional, so we ignore" comment on the same line). A missing file is expected when the parameter defines a `default`, or when a step only conditionally writes its output. Logging it at `error` produces noise that users have to filter out of their monitoring systems.

### Modifications

Changed the log level of the "cannot save parameter, does not exist" message in `cmd/argoexec/commands/emissary.go` from `Error` to `Warn`. Control flow is unchanged; the function still returns `nil`.

### Verification

`go build ./cmd/argoexec/commands/` and `go vet ./cmd/argoexec/commands/` pass locally. This is a log-severity-only change with identical control flow, consistent with the previously merged #16379, which lowered the level of a comparable non-error condition.

### Documentation

No documentation changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced log severity for missing optional parameter files from error to warning, preventing unnecessary error-level noise while keeping the same behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->