### PR TITLE
fix(controller): do not fail daemon nodes when main is SIGTERM'd on teardown. Fixes #16397

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1816,6 +1816,14 @@ func (woc *wfOperationCtx) inferFailedReason(ctx context.Context, pod *apiv1.Pod
 		case ctr.Name == common.InitContainerName:
 			return wfv1.NodeError, msg
 		case tmpl.IsMainContainerName(ctr.Name):
+			// A daemon's main container is deliberately SIGTERM'd/SIGKILL'd (143/137)
+			// by argoexec once downstream steps complete, so those exit codes are the
+			// expected teardown, not a failure. Any other non-zero code still fails.
+			if tmpl.IsDaemon() && (t.ExitCode == 137 || t.ExitCode == 143) {
+				woc.log.WithFields(logging.Fields{"exitCode": t.ExitCode, "containerName": ctr.Name}).Info(ctx, "ignoring daemon main container exit code")
+				mainContainerSucceeded = true
+				continue
+			}
 			return wfv1.NodeFailed, msg
 		case ctr.Name == common.WaitContainerName:
 			return wfv1.NodeError, msg

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -7686,6 +7686,85 @@ func TestPodFailureWithSidecarSigkill(t *testing.T) {
 	assert.Empty(t, msg)
 }
 
+// A daemon's main container is deliberately SIGTERM'd (143) by argoexec once
+// downstream steps complete, so that is the expected teardown rather than a
+// failure. Regression test for #16397.
+var daemonTemplate = `
+name: daemon-tmpl
+daemon: true
+container:
+  name: main
+  image: argoproj/argosay:v2
+`
+
+var podDaemonMainSigterm = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+status:
+  phase: Failed
+  containerStatuses:
+  - name: main
+    ready: false
+    state:
+      terminated:
+        exitCode: 143
+        reason: Error
+  - name: wait
+    ready: false
+    state:
+      terminated:
+        exitCode: 0
+        reason: Completed
+`
+
+func TestPodFailureWithDaemonMainSigterm(t *testing.T) {
+	var pod apiv1.Pod
+	wfv1.MustUnmarshal(podDaemonMainSigterm, &pod)
+	var tmpl wfv1.Template
+	wfv1.MustUnmarshal(daemonTemplate, &tmpl)
+	require.True(t, tmpl.IsDaemon(), "check the test case is valid")
+	ctx := logging.TestContext(t.Context())
+	nodeStatus, msg := newWoc(ctx).inferFailedReason(ctx, &pod, &tmpl)
+	// Daemon main was SIGTERM'd (143) and wait succeeded, so the node succeeds.
+	assert.Equal(t, wfv1.NodeSucceeded, nodeStatus)
+	assert.Empty(t, msg)
+}
+
+var podDaemonMainCrash = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+status:
+  phase: Failed
+  containerStatuses:
+  - name: main
+    ready: false
+    state:
+      terminated:
+        exitCode: 1
+        reason: Error
+  - name: wait
+    ready: false
+    state:
+      terminated:
+        exitCode: 0
+        reason: Completed
+`
+
+func TestPodFailureWithDaemonMainCrash(t *testing.T) {
+	var pod apiv1.Pod
+	wfv1.MustUnmarshal(podDaemonMainCrash, &pod)
+	var tmpl wfv1.Template
+	wfv1.MustUnmarshal(daemonTemplate, &tmpl)
+	ctx := logging.TestContext(t.Context())
+	nodeStatus, _ := newWoc(ctx).inferFailedReason(ctx, &pod, &tmpl)
+	// A genuine non-signal crash of a daemon's main container still fails.
+	assert.Equal(t, wfv1.NodeFailed, nodeStatus)
+}
+
 var podWithWaitContainerOOM = `
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Fixes #16397

### Motivation

argoexec deliberately terminates a daemon pod's main container (by killing argoexec) once downstream steps complete, so the main container exits 143 (SIGTERM) or 137 (SIGKILL). In v3, `assessNodeStatus` unconditionally marked daemon pods `NodeSucceeded` on `PodFailed`. v4 (commit 9b73126) removed that guard to add daemon retry support, so `PodFailed` now runs the main container through `inferFailedReason`, whose main-container case marks any non-zero exit `NodeFailed`. The result is that a succeeding workflow with a daemon reports the daemon node as failed.

### Modifications

In `inferFailedReason`, the `IsMainContainerName` case now treats exit codes 137 and 143 on a daemon template's main container the same way sidecar force-kills are already handled: it logs the code and marks the main container succeeded (so the node resolves via the existing main/wait success logic) instead of returning `NodeFailed`. Any other non-zero exit code on a daemon's main container still fails, preserving detection of real daemon crashes.

### Verification

Added `TestPodFailureWithDaemonMainSigterm` (daemon main exits 143, wait exits 0, node resolves to Succeeded) and `TestPodFailureWithDaemonMainCrash` (daemon main exits 1, node still Failed). Both pass, along with the existing `inferFailedReason` tests. `go build ./workflow/controller/` passes.

### Documentation

No documentation changes needed.