### PR TITLE
fix: don't leak semaphore slots when limit fetch fails during release

### DIFF
--- a/workflow/sync/cached_limit_test.go
+++ b/workflow/sync/cached_limit_test.go
@@ -155,3 +155,39 @@ func TestGetLimitErrorThenSuccess(t *testing.T) {
 
 	assert.True(t, changed, "Limit should be marked as changed after successful refresh")
 }
+
+func TestGetLimitErrorReturnsCachedValue(t *testing.T) {
+	ctx := context.Background()
+	// Setup
+	mockNow = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	expectedError := errors.New("limit service unavailable")
+	shouldFail := false
+
+	mockGetter := func(ctx context.Context, key string) (int, error) {
+		if shouldFail {
+			return 0, expectedError
+		}
+		return 5, nil
+	}
+
+	cl := newCachedLimit(mockGetter, 10*time.Minute)
+
+	// First call populates the cache
+	limit, _, err := cl.get(ctx, "test-key")
+	require.NoError(t, err)
+	require.Equal(t, 5, limit)
+
+	// Past TTL, the getter fails: the last known limit is returned alongside the error
+	advanceTime(15 * time.Minute)
+	shouldFail = true
+	limit, changed, err := cl.get(ctx, "test-key")
+	require.ErrorIs(t, err, expectedError)
+	assert.Equal(t, 5, limit, "last known limit should be returned on error")
+	assert.False(t, changed)
+
+	// The failed fetch must not refresh the timestamp, so the next call retries the getter
+	shouldFail = false
+	limit, _, err = cl.get(ctx, "test-key")
+	require.NoError(t, err)
+	assert.Equal(t, 5, limit)
+}

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -77,8 +77,13 @@ func (s *databaseSemaphore) getLimit(ctx context.Context) int {
 	logger.WithField("dbKey", s.shortDBKey).Info(ctx, "getLimit")
 	limit, _, err := s.limitGetter.get(ctx, s.shortDBKey)
 	if err != nil {
-		logger.WithField("name", s.name).WithError(err).Error(ctx, "Failed to get limit")
-		return 0
+		// Fall back to the last known limit (returned by the cache alongside
+		// the error) rather than misreporting a transient failure as limit 0.
+		logger.WithFields(logging.Fields{
+			"name":          s.name,
+			"fallbackLimit": limit,
+		}).WithError(err).Error(ctx, "Failed to get limit, using last known limit")
+		return limit
 	}
 	return limit
 }

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -49,8 +49,14 @@ func newInternalSemaphore(ctx context.Context, name string, nextWorkflow NextWor
 func (s *prioritySemaphore) getLimit(ctx context.Context) int {
 	limit, changed, err := s.limitGetter.get(ctx, s.name)
 	if err != nil {
-		s.logger(ctx).WithError(err).WithField("name", s.name).Error(ctx, "failed to get limit for semaphore")
-		return 0
+		// Fall back to the last known limit (returned by the cache alongside
+		// the error). Returning 0 here would make release() treat a transient
+		// fetch failure as a downward resize and permanently leak a slot.
+		s.logger(ctx).WithError(err).WithFields(logging.Fields{
+			"name":          s.name,
+			"fallbackLimit": limit,
+		}).Error(ctx, "failed to get limit for semaphore, using last known limit")
+		return limit
 	}
 	if changed {
 		s.resize(ctx, limit)

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -253,3 +253,44 @@ func TestCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t *testing.T) {
 		})
 	}
 }
+
+// TestInternalSemaphoreReleaseWithLimitFetchFailure is a regression test: a transient
+// error fetching the ConfigMap limit during release() used to make getLimit return 0,
+// which release() mistook for a downward resize — the holder was removed from the map
+// but the weighted-semaphore slot was never freed, permanently leaking capacity until
+// controller restart.
+func TestInternalSemaphoreReleaseWithLimitFetchFailure(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	fail := false
+	getter := func(_ context.Context, _ string) (int, error) {
+		if fail {
+			return 0, fmt.Errorf("transient apiserver error")
+		}
+		return 1, nil
+	}
+	nextWorkflow := func(_ string) {}
+
+	// TTL 0 forces a live limit fetch on every getLimit call
+	sem, err := newInternalSemaphore(ctx, "default/ConfigMap/my-config/workflow", nextWorkflow, getter, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, sem.addToQueue(ctx, "default/wf-a", 0, time.Now()))
+	acquired, _, err := sem.tryAcquire(ctx, "default/wf-a", nil)
+	require.NoError(t, err)
+	require.True(t, acquired, "wf-a should acquire the only slot")
+
+	// The limit fetch fails transiently while wf-a releases.
+	fail = true
+	sem.release(ctx, "default/wf-a")
+	fail = false
+
+	holders, err := sem.getCurrentHolders(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, holders)
+
+	// wf-b must be able to acquire: limit is 1 and there are no holders.
+	require.NoError(t, sem.addToQueue(ctx, "default/wf-b", 0, time.Now()))
+	acquired, _, err = sem.tryAcquire(ctx, "default/wf-b", nil)
+	require.NoError(t, err)
+	assert.True(t, acquired, "wf-b should acquire the slot released by wf-a")
+}


### PR DESCRIPTION
### Motivation

A transient failure reading the semaphore limit ConfigMap during `release()` permanently leaks a semaphore slot until controller restart.

`prioritySemaphore.release()` fetches the limit live. On any fetch error (API server blip, throttling, ConfigMap key momentarily absent), `getLimit()` returned 0, which triggered the "semaphore resized downward" early-return: the holder was removed from `lockHolder`, but the underlying `sema.Weighted` slot was never released and waiters were never notified. Each such failure shrinks the semaphore's effective capacity by one; a limit-N semaphore fully seizes after N failures. Waiting workflows then sit in a paradoxical state: the waiting message (computed from `lockHolder`) reports free slots, e.g. `Waiting for ... lock. Lock status: 1/1`, while `TryAcquire` fails forever, and the periodic resync makes no progress.

Exposure is high with default configuration: `semaphoreLimitCacheSeconds` unset means TTL 0, so every release performs live ConfigMap GETs (twice, counting `notifyWaiters`).

Introduced by #14309 (3.7.0); mutexes are unaffected. Field incidents can be confirmed by a `failed to get limit for semaphore` error at the same timestamp as a release for that lock, with no subsequent `Lock has been released` line.

### Modifications

- `prioritySemaphore.getLimit()`: on a fetch error, fall back to the last known limit — `cachedLimit.get` already returns it alongside the error; it was being discarded in favour of 0. This keeps `release()` comparing the holder count against the limit the weighted semaphore was actually sized to, so "limit unknown" is no longer conflated with "resized downward". An in-service semaphore has always completed at least one successful fetch (construction fails otherwise), so the fallback is always meaningful.
- `databaseSemaphore.getLimit()`: same fallback. The impact there was milder — a fetch error made `notifyWaiters` compute a negative trigger count and skip notification (self-healing, but needlessly delayed).
- Deliberately **not** added: a `limit > 0` guard on the early-return in `release()`. After a genuine resize to 0, the weighted semaphore has capacity 0 and skipping the early-return would `Release(1)` on it, which panics. The cached fallback alone restores the invariant.
- Regression test `TestInternalSemaphoreReleaseWithLimitFetchFailure`: acquire with limit 1 and TTL 0, fail the limit getter during release, verify a second workflow can still acquire. Fails on main, passes with this fix.
- `TestGetLimitErrorReturnsCachedValue`: pins the `cachedLimit` contract the fix depends on (error returns last good value; failed fetch does not refresh the TTL timestamp, so the next call retries).

### Verification

- New regression test fails before the fix and passes after.
- `go test ./workflow/sync/` passes in full, including the database-backed (testcontainers) suites.
- `go test ./workflow/controller/ -run 'Concurrency|Synchronization|Semaphore'` passes.
- `golangci-lint run workflow/sync/` reports 0 issues.

### Documentation

No user-facing behaviour change beyond removing the leak; no docs changes needed. The error log line gains a `fallbackLimit` field and now reads `failed to get limit for semaphore, using last known limit`.

### AI

This PR was co-diagnose and fixed with Claude Code [Fable 5]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the last known concurrency limit when temporary limit retrieval errors occur.
  * Prevented transient errors from being interpreted as zero capacity.
  * Ensured released capacity remains available even when limit updates fail.
  * Added coverage for cached-limit fallback and semaphore release behavior during fetch failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->