### PR TITLE
fix(ui): show Forbidden error on workflow details delete. Fixes #16409

### DIFF
--- a/ui/src/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/workflows/components/workflow-details/workflow-details.tsx
@@ -206,15 +206,28 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                                 .then(async yes => {
                                     if (!yes) return;
 
+                                    // Use a local flag instead of React `error` state (stale closure).
+                                    // Otherwise a failed DELETE still navigates away and the ErrorNotice never shows.
+                                    let deleteFailed = false;
                                     const allPromises = [];
                                     if (isWorkflowInCluster(workflow)) {
-                                        allPromises.push(services.workflows.delete(workflow.metadata.name, workflow.metadata.namespace).catch(setError));
+                                        allPromises.push(
+                                            services.workflows.delete(workflow.metadata.name, workflow.metadata.namespace).catch(err => {
+                                                deleteFailed = true;
+                                                setError(err);
+                                            })
+                                        );
                                     }
                                     if (isArchivedWorkflow(workflow) && (globalDeleteArchived || !isWorkflowInCluster(workflow))) {
-                                        allPromises.push(services.workflows.deleteArchived(workflow.metadata.uid, workflow.metadata.namespace).catch(setError));
+                                        allPromises.push(
+                                            services.workflows.deleteArchived(workflow.metadata.uid, workflow.metadata.namespace).catch(err => {
+                                                deleteFailed = true;
+                                                setError(err);
+                                            })
+                                        );
                                     }
                                     await Promise.all(allPromises);
-                                    if (error !== null) {
+                                    if (deleteFailed) {
                                         return;
                                     }
 


### PR DESCRIPTION
Fixes #16409

### Motivation

When a readonly / RBAC-restricted user deletes a workflow from the **workflow details** page:

1. The API correctly returns `403 Forbidden` and the workflow is **not** deleted.
2. The UI shows **no error** (no toast / ErrorNotice).
3. The page often navigates back to the list, so it looks like a silent no-op.

This is confusing because:

- The **workflow list** delete path already shows an error notification on Forbidden.
- The same details page **RESUBMIT** path correctly shows an `ErrorNotice` on Forbidden.

Root cause: the details-page DELETE handler waits for the delete promises, then decides whether to navigate with:

```ts
.catch(setError)
...
if (error !== null) {
  return;
}
navigation.goto(...);
```

`error` here is captured from React state via a **stale closure**. After the details watch is established, `setError(null)` runs on open, so `error` is typically `null` at click time. Even when the delete call fails and queues `setError(err)`, the post-await check still sees the old `null`, navigates away, and the details-page `ErrorNotice` never becomes visible.

### Modifications

In `ui/src/workflows/components/workflow-details/workflow-details.tsx`:

- Track delete success/failure with a local `deleteFailed` flag inside the DELETE confirm handler.
- On failure: `setError(err)` and **do not** navigate away, so the existing details-page `ErrorNotice` can render the Forbidden message.
- On success: keep the existing navigate-back-to-list behavior.

No server / RBAC / API changes.

### Verification

Manual:

1. Log in as a user without `delete` on `workflows.argoproj.io`.
2. Open a workflow details page → DELETE → confirm.
3. Before: Network 403, no UI error, may jump to list.
4. After: stay on details page; Forbidden is shown via `ErrorNotice`.
5. Repeat with an admin / delete-capable user: successful delete still navigates to the list.

Also compared with list-page delete and details-page Resubmit Forbidden behavior.

### Documentation

Not needed: bugfix only; no new feature or config surface.

### AI

This PR was prepared with assistance from Cursor (code change and PR text). The bug analysis and intended fix were reviewed by the author.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow deletion error handling.
  * Users now remain on the workflow details page when a deletion fails, allowing the error message to be displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->