### PR TITLE
fix: make workflow retry reset deterministic. Fixes #16450

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -847,7 +847,12 @@ func newWorkflowsDag(wf *wfv1.Workflow) ([]*dagNode, error) {
 
 	// create mapping from node to parent
 	// as well as creating temp mappings from nodeID to node
-	for _, wfNode := range wf.Status.Nodes {
+	// A node may appear as a child of more than one node (e.g. a task that
+	// `depends` on several others). Only one parent is recorded, so iterate in a
+	// deterministic order to keep the resulting parent chain, and therefore the
+	// reset set computed by resetPath, stable across invocations.
+	for _, nodeID := range slices.Sorted(maps.Keys(wf.Status.Nodes)) {
+		wfNode := wf.Status.Nodes[nodeID]
 		n := dagNode{}
 		n.n = &wfNode
 		nodes[wfNode.ID] = &n

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -4881,3 +4881,127 @@ status:
 	assert.Contains(t, podsToDelete, "workflow-retry-passfail-3976347509",
 		"Stale succeeded pod should also be in deletion list")
 }
+
+// retryMultiParentTaskGroup is a diamond where the failed leaf X has two ancestry
+// branches: one through a plain pod (P) and one through a fan-out TaskGroup (G,
+// expanded into G0/G1). X therefore has more than one parent, and whether a retry
+// resets G depends on which branch resetPath walks up from X.
+const retryMultiParentTaskGroup = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    workflows.argoproj.io/pod-name-format: v2
+  name: retry-multiparent
+  namespace: argo
+  labels:
+    workflows.argoproj.io/completed: "true"
+    workflows.argoproj.io/phase: Failed
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: P
+        template: echo
+      - name: G
+        template: echo
+        withItems: [a, b]
+      - name: X
+        template: echo
+        depends: P && G
+  - name: echo
+    container:
+      image: alpine:3.7
+      command: [echo]
+status:
+  phase: Failed
+  nodes:
+    retry-multiparent:
+      id: retry-multiparent
+      name: retry-multiparent
+      displayName: retry-multiparent
+      type: DAG
+      phase: Failed
+      templateName: main
+      children:
+      - retry-multiparent-P
+      - retry-multiparent-G
+    retry-multiparent-P:
+      id: retry-multiparent-P
+      name: retry-multiparent.P
+      displayName: P
+      type: Pod
+      phase: Succeeded
+      boundaryID: retry-multiparent
+      templateName: echo
+      children:
+      - retry-multiparent-X
+    retry-multiparent-G:
+      id: retry-multiparent-G
+      name: retry-multiparent.G
+      displayName: G
+      type: TaskGroup
+      phase: Succeeded
+      boundaryID: retry-multiparent
+      templateName: echo
+      nodeFlag: {}
+      children:
+      - retry-multiparent-G0
+      - retry-multiparent-G1
+    retry-multiparent-G0:
+      id: retry-multiparent-G0
+      name: retry-multiparent.G(0:a)
+      displayName: G(0:a)
+      type: Pod
+      phase: Succeeded
+      boundaryID: retry-multiparent
+      templateName: echo
+      children:
+      - retry-multiparent-X
+    retry-multiparent-G1:
+      id: retry-multiparent-G1
+      name: retry-multiparent.G(1:b)
+      displayName: G(1:b)
+      type: Pod
+      phase: Succeeded
+      boundaryID: retry-multiparent
+      templateName: echo
+      children:
+      - retry-multiparent-X
+    retry-multiparent-X:
+      id: retry-multiparent-X
+      name: retry-multiparent.X
+      displayName: X
+      type: Pod
+      phase: Failed
+      boundaryID: retry-multiparent
+      templateName: echo
+`
+
+// TestFormulateRetryWorkflowDeterministicReset guards against map-order dependence
+// in FormulateRetryWorkflow. A node with more than one parent is assigned a single
+// parent by newWorkflowsDag, and resetPath walks that one chain. If the parent is
+// chosen by Go map iteration order, retrying the same workflow can reset different
+// nodes from one call to the next. The set of nodes a retry resets must be stable.
+func TestFormulateRetryWorkflowDeterministicReset(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	resetNodeIDs := func() map[string]bool {
+		wf := wfv1.MustUnmarshalWorkflow(retryMultiParentTaskGroup)
+		newWf, _, err := FormulateRetryWorkflow(ctx, wf, false, "", nil)
+		require.NoError(t, err)
+		reset := make(map[string]bool)
+		for _, node := range newWf.Status.Nodes {
+			if node.Phase == wfv1.NodeRunning {
+				reset[node.ID] = true
+			}
+		}
+		return reset
+	}
+
+	want := resetNodeIDs()
+	for i := range 50 {
+		require.Equal(t, want, resetNodeIDs(), "reset set differed between retry invocations on iteration %d", i)
+	}
+}


### PR DESCRIPTION
Fixes #16450

### Motivation

Retrying a DAG workflow can be non-deterministic. `newWorkflowsDag` records a
single parent per node while ranging over the `status.nodes` map, so a node with
more than one parent (for example a task that `depends` on several others) keeps
whichever parent Go's map iteration happens to visit last. `resetPath` then walks
that one parent chain, which means retrying the same workflow twice can reset a
different set of nodes each time.

In the worst case the branch that gets walked skips a fan-out `TaskGroup`, so the
group is left `Running` after the retry while nothing downstream ever completes
it, and the workflow hangs in `Running` with every pod finished. This is the
first of the two defects described in #16450 (a follow-up will address the
controller side so it can recover such a group).

### Modifications

- `newWorkflowsDag` now iterates the nodes in sorted ID order, so the recorded
  parent — and the reset set derived from it — is stable across invocations. This
  does not change which chain is chosen when a node has several parents, only that
  the choice is deterministic.
- Added `TestFormulateRetryWorkflowDeterministicReset`, which retries a diamond
  (a failed leaf reachable through both a plain pod and a fan-out `TaskGroup`)
  many times and asserts the set of reset nodes is identical every time.

### Verification

- The new test fails on `main` (the reset set flips depending on map iteration
  order) and passes with this change, including under `-count` to exercise Go's
  per-range map-order randomisation.
- `go test ./workflow/util/` and `go vet ./workflow/util/` pass.

### Documentation

Not needed — this is an internal bug fix with no user-facing or API change.

### AI

This PR was prepared with assistance from Claude (Anthropic's Claude Code): the
diagnosis, the code change, the test, and this description were drafted by the
model and then reviewed and verified by me before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow retry behavior to produce consistent reset results when tasks have multiple parent paths.
  * Ensured repeated retry attempts handle affected tasks deterministically.

* **Tests**
  * Added regression coverage for workflows with tasks that have multiple ancestry paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->