### PR TITLE
chore: label no-test for non-deterministic example

### DIFF
--- a/examples/retry-container-to-completion.yaml
+++ b/examples/retry-container-to-completion.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: retry-to-completion-
+  labels:
+    workflows.argoproj.io/no-test: "duration"
 spec:
   entrypoint: retry-to-completion
   templates:


### PR DESCRIPTION
Add label to workflow to skip during examples testing as it may take too long to complete - non-deterministic duration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow example metadata to exclude duration-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->