### PR TITLE
chore: flaky label to retry-container example

### DIFF
--- a/examples/retry-container.yaml
+++ b/examples/retry-container.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: retry-container-
+  labels:
+    workflows.argoproj.io/no-test: "flaky"
 spec:
   entrypoint: retry-container
   templates:


### PR DESCRIPTION
Add label to mark workflow as flaky. Mostly retries mean this will succeed, but it can fail, so lets not test it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the retry workflow example with metadata identifying it as flaky for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->