### PR TITLE
fix: don't leak semaphore slots when limit fetch fails during release (cherry-pick #16405 for 3.7)

### DIFF
--- a/workflow/sync/cached_limit_test.go
+++ b/workflow/sync/cached_limit_test.go
@@ -148,3 +148,38 @@ func TestGetLimitErrorThenSuccess(t *testing.T) {
 
 	assert.True(t, changed, "Limit should be marked as changed after successful refresh")
 }
+
+func TestGetLimitErrorReturnsCachedValue(t *testing.T) {
+	// Setup
+	mockNow = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	expectedError := errors.New("limit service unavailable")
+	shouldFail := false
+
+	mockGetter := func(key string) (int, error) {
+		if shouldFail {
+			return 0, expectedError
+		}
+		return 5, nil
+	}
+
+	cl := newCachedLimit(mockGetter, 10*time.Minute)
+
+	// First call populates the cache
+	limit, _, err := cl.get("test-key")
+	require.NoError(t, err)
+	require.Equal(t, 5, limit)
+
+	// Past TTL, the getter fails: the last known limit is returned alongside the error
+	advanceTime(15 * time.Minute)
+	shouldFail = true
+	limit, changed, err := cl.get("test-key")
+	require.ErrorIs(t, err, expectedError)
+	assert.Equal(t, 5, limit, "last known limit should be returned on error")
+	assert.False(t, changed)
+
+	// The failed fetch must not refresh the timestamp, so the next call retries the getter
+	shouldFail = false
+	limit, _, err = cl.get("test-key")
+	require.NoError(t, err)
+	assert.Equal(t, 5, limit)
+}

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -125,8 +125,10 @@ func (s *databaseSemaphore) getLimit() int {
 	}).Infof("getLimit")
 	limit, _, err := s.limitGetter.get(s.shortDBKey)
 	if err != nil {
-		s.log.WithError(err).Errorf("Failed to get limit for semaphore %s", s.name)
-		return 0
+		// Fall back to the last known limit (returned by the cache alongside
+		// the error) rather than misreporting a transient failure as limit 0.
+		s.log.WithError(err).WithField("fallbackLimit", limit).Errorf("Failed to get limit for semaphore %s, using last known limit", s.name)
+		return limit
 	}
 	return limit
 }

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -49,8 +49,11 @@ func (s *prioritySemaphore) getName() string {
 func (s *prioritySemaphore) getLimit() int {
 	limit, changed, err := s.limitGetter.get(s.name)
 	if err != nil {
-		s.log.WithError(err).Errorf("failed to get limit for semaphore %s", s.name)
-		return 0
+		// Fall back to the last known limit (returned by the cache alongside
+		// the error). Returning 0 here would make release() treat a transient
+		// fetch failure as a downward resize and permanently leak a slot.
+		s.log.WithError(err).WithField("fallbackLimit", limit).Errorf("failed to get limit for semaphore %s, using last known limit", s.name)
+		return limit
 	}
 	if changed {
 		s.resize(limit)

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -247,3 +247,43 @@ func TestCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t *testing.T) {
 		})
 	}
 }
+
+// TestInternalSemaphoreReleaseWithLimitFetchFailure is a regression test: a transient
+// error fetching the ConfigMap limit during release() used to make getLimit return 0,
+// which release() mistook for a downward resize — the holder was removed from the map
+// but the weighted-semaphore slot was never freed, permanently leaking capacity until
+// controller restart.
+func TestInternalSemaphoreReleaseWithLimitFetchFailure(t *testing.T) {
+	fail := false
+	getter := func(_ string) (int, error) {
+		if fail {
+			return 0, fmt.Errorf("transient apiserver error")
+		}
+		return 1, nil
+	}
+	nextWorkflow := func(_ string) {}
+
+	// TTL 0 forces a live limit fetch on every getLimit call
+	sem, err := newInternalSemaphore("default/ConfigMap/my-config/workflow", nextWorkflow, getter, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, sem.addToQueue("default/wf-a", 0, time.Now()))
+	acquired, _, err := sem.tryAcquire("default/wf-a", nil)
+	require.NoError(t, err)
+	require.True(t, acquired, "wf-a should acquire the only slot")
+
+	// The limit fetch fails transiently while wf-a releases.
+	fail = true
+	sem.release("default/wf-a")
+	fail = false
+
+	holders, err := sem.getCurrentHolders()
+	require.NoError(t, err)
+	assert.Empty(t, holders)
+
+	// wf-b must be able to acquire: limit is 1 and there are no holders.
+	require.NoError(t, sem.addToQueue("default/wf-b", 0, time.Now()))
+	acquired, _, err = sem.tryAcquire("default/wf-b", nil)
+	require.NoError(t, err)
+	assert.True(t, acquired, "wf-b should acquire the slot released by wf-a")
+}


### PR DESCRIPTION
Cherry-picked fix: don't leak semaphore slots when limit fetch fails during release (#16405)