### PR TITLE
fix: normalize GCS artifact keys to forward slashes on Windows. Fixes #16470

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -124,8 +124,18 @@ func (h *ArtifactDriver) Load(ctx context.Context, inputArtifact *wfv1.Artifact,
 	return err
 }
 
+// normalizeGCSKey converts Windows path separators to forward slashes, since GCS object
+// names always use "/" regardless of host OS.
+func normalizeGCSKey(key string) string {
+	if os.PathSeparator == '\\' {
+		return strings.ReplaceAll(key, "\\", "/")
+	}
+	return key
+}
+
 // download all the objects of a key from the bucket
 func downloadObjects(ctx context.Context, client *storage.Client, bucket, key, path string) error {
+	key = normalizeGCSKey(key)
 	objNames, err := listByPrefix(ctx, client, bucket, key, "")
 	if err != nil {
 		return err
@@ -145,11 +155,7 @@ func downloadObjects(ctx context.Context, client *storage.Client, bucket, key, p
 
 // download an object from the bucket
 func downloadObject(ctx context.Context, client *storage.Client, bucket, key, objName, path string) error {
-	objPrefix := filepath.Clean(key)
-	if os.PathSeparator == '\\' {
-		objPrefix = strings.ReplaceAll(objPrefix, "\\", "/")
-	}
-
+	objPrefix := normalizeGCSKey(filepath.Clean(key))
 	relObjPath := strings.TrimPrefix(objName, objPrefix)
 	localPath := filepath.Join(path, relObjPath)
 	objectDir, _ := filepath.Split(localPath)
@@ -285,21 +291,14 @@ func uploadObjects(ctx context.Context, client *storage.Client, bucket, key, pat
 			return listErr
 		}
 		for _, relPath := range fileRelPaths {
-			fullKey := keyPrefix + relPath
-			if os.PathSeparator == '\\' {
-				fullKey = strings.ReplaceAll(fullKey, "\\", "/")
-			}
-
+			fullKey := normalizeGCSKey(keyPrefix + relPath)
 			err = uploadObject(ctx, client, bucket, fullKey, dirName+relPath)
 			if err != nil {
 				return fmt.Errorf("upload %s: %w", dirName+relPath, err)
 			}
 		}
 	} else {
-		objectKey := filepath.Clean(key)
-		if os.PathSeparator == '\\' {
-			objectKey = strings.ReplaceAll(objectKey, "\\", "/")
-		}
+		objectKey := normalizeGCSKey(filepath.Clean(key))
 		err = uploadObject(ctx, client, bucket, objectKey, path)
 		if err != nil {
 			return fmt.Errorf("upload %s: %w", path, err)

--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
-	"strings"
+	"runtime"
 	"testing"
 
 	"google.golang.org/api/googleapi"
@@ -51,24 +50,24 @@ func TestIsTransientGCSErr(t *testing.T) {
 }
 
 func TestNormalizeGCSKey(t *testing.T) {
-	// GCS object names always use "/"; normalizeGCSKey only rewrites "\" on hosts where
-	// it's the path separator (Windows), so the expected value is host-OS dependent, same
-	// as the production code being tested.
-	windowsBackslashesAreSeparators := os.PathSeparator == '\\'
-
-	for _, key := range []string{
-		"utils\\p4",
-		"some\\prefix\\some-file.exe",
-		"some/prefix/some-file.exe",
-		"no-separators",
+	// GCS object names always use "/"; normalizeGCSKey only converts "\" to "/" on
+	// Windows, since "\" is a valid filename character on other OSes.
+	for _, test := range []struct {
+		key      string
+		expected string
+	}{
+		{"utils\\p4", "utils/p4"},
+		{"some\\prefix\\some-file.exe", "some/prefix/some-file.exe"},
+		{"some/prefix/some-file.exe", "some/prefix/some-file.exe"},
+		{"no-separators", "no-separators"},
 	} {
-		expected := key
-		if windowsBackslashesAreSeparators {
-			expected = strings.ReplaceAll(key, "\\", "/")
+		expected := test.expected
+		if runtime.GOOS != "windows" {
+			expected = test.key
 		}
-		got := normalizeGCSKey(key)
+		got := normalizeGCSKey(test.key)
 		if got != expected {
-			t.Errorf("normalizeGCSKey(%q): got %q, want %q", key, got, expected)
+			t.Errorf("normalizeGCSKey(%q): got %q, want %q", test.key, got, expected)
 		}
 	}
 }

--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/googleapi"
@@ -44,6 +46,32 @@ func TestIsTransientGCSErr(t *testing.T) {
 		got := isTransientGCSErr(ctx, test.err)
 		if got != test.shouldretry {
 			t.Errorf("%+v: got %v, want %v", test, got, test.shouldretry)
+		}
+	}
+}
+
+func TestNormalizeGCSKey(t *testing.T) {
+	// GCS object names always use "/"; normalizeGCSKey only rewrites "\" on hosts where
+	// it's the path separator (Windows), so the expected value is host-OS dependent, same
+	// as the production code being tested.
+	windowsBackslashesAreSeparators := os.PathSeparator == '\\'
+
+	for _, test := range []struct {
+		key      string
+		expected string
+	}{
+		{"utils\\p4", "utils\\p4"},
+		{"some\\prefix\\some-file.exe", "some\\prefix\\some-file.exe"},
+		{"some/prefix/some-file.exe", "some/prefix/some-file.exe"},
+		{"no-separators", "no-separators"},
+	} {
+		expected := test.expected
+		if windowsBackslashesAreSeparators {
+			expected = strings.ReplaceAll(test.key, "\\", "/")
+		}
+		got := normalizeGCSKey(test.key)
+		if got != expected {
+			t.Errorf("normalizeGCSKey(%q): got %q, want %q", test.key, got, expected)
 		}
 	}
 }

--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -56,22 +56,19 @@ func TestNormalizeGCSKey(t *testing.T) {
 	// as the production code being tested.
 	windowsBackslashesAreSeparators := os.PathSeparator == '\\'
 
-	for _, test := range []struct {
-		key      string
-		expected string
-	}{
-		{"utils\\p4", "utils\\p4"},
-		{"some\\prefix\\some-file.exe", "some\\prefix\\some-file.exe"},
-		{"some/prefix/some-file.exe", "some/prefix/some-file.exe"},
-		{"no-separators", "no-separators"},
+	for _, key := range []string{
+		"utils\\p4",
+		"some\\prefix\\some-file.exe",
+		"some/prefix/some-file.exe",
+		"no-separators",
 	} {
-		expected := test.expected
+		expected := key
 		if windowsBackslashesAreSeparators {
-			expected = strings.ReplaceAll(test.key, "\\", "/")
+			expected = strings.ReplaceAll(key, "\\", "/")
 		}
-		got := normalizeGCSKey(test.key)
+		got := normalizeGCSKey(key)
 		if got != expected {
-			t.Errorf("normalizeGCSKey(%q): got %q, want %q", test.key, got, expected)
+			t.Errorf("normalizeGCSKey(%q): got %q, want %q", key, got, expected)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #16470

### Motivation

On Windows nodes, `filepath.Clean` produces backslash-separated paths. GCS object names always use `/`, so when an input artifact's key was passed straight into the GCS prefix query, it matched zero objects and failed with `no results for key: ...` even though the object exists in the bucket.

### Modifications

- Extracted the existing inline backslash-to-slash normalization (already applied in `downloadObject` and `uploadObjects`) into a single `normalizeGCSKey` helper in `workflow/artifacts/gcs/gcs.go`.
- Applied it in `downloadObjects` too, closing the one code path that was missing it (the actual cause of the bug).
- Added `TestNormalizeGCSKey` in `workflow/artifacts/gcs/gcs_test.go`, covering backslash keys, forward-slash keys, and keys with no separators. The test computes its expected value the same way the production code branches (on `os.PathSeparator`), following the existing convention for OS-conditional tests in this package (see `workflow/artifacts/common/load_to_stream_test.go`).

### Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- `golangci-lint run --build-tags=... ./workflow/artifacts/gcs/...` — 0 issues.
- `go test ./workflow/artifacts/gcs/... -v` — `TestIsTransientGCSErr` and the new `TestNormalizeGCSKey` both pass.
- `make pre-commit -B` could not be run in full in this environment: the `sdks/java` codegen step requires Maven via `apt` (root access unavailable), and the UI build / `lint-ui` / markdownlint-based `features-validate` require `registry.npmjs.org`, which is unreachable from this network. All Go-side checks above were run as a substitute.

### Documentation

Not needed — this is a bug fix with no user-facing behavior or API change; the input artifact key now resolves as originally intended.

### AI

This PR (implementation, test, commit message, and this description) was prepared with AI assistance (Claude Code), reviewed by a human before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Cloud Storage object key path handling for cross-platform correctness.
  * Upload, download, and relative path computations now consistently normalize Windows-style separators to ensure consistent behavior across Windows and non-Windows environments.
* **Tests**
  * Added a platform-aware test to verify separator normalization only applies on Windows and remains unchanged on other platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->