### PR TITLE
docs: fix access-token.md namespace inconsistencies and errors

### DIFF
--- a/docs/access-token.md
+++ b/docs/access-token.md
@@ -6,29 +6,30 @@ If you want to automate tasks with the Argo Server API or CLI, you will need an 
 
 ## Prerequisites
 
-Firstly, create a role with minimal permissions. This example role for jenkins has only permission to update and list workflows:
+Firstly, create a role with minimal permissions.
+This example role for jenkins has only permission to list and update workflows in the `argo` namespace:
 
 ```bash
-kubectl create role jenkins --verb=list,update --resource=workflows.argoproj.io
+kubectl create role jenkins --verb=list,update --resource=workflows.argoproj.io -n argo
 ```
 
-Create a service account for your service:
+Create a service account for your service in the same namespace:
 
 ```bash
-kubectl create sa jenkins
+kubectl create sa jenkins -n argo
 ```
 
-### Tip for Tokens Creation
+### Tip for Token Creation
 
 Create a unique service account for each client:
 
 - (a) you'll be able to correctly secure your workflows
 - (b) [revoke the token](#token-revocation) without impacting other clients.
 
-Bind the service account to the role (in this case in the `argo` namespace):
+Bind the service account to the role:
 
 ```bash
-kubectl create rolebinding jenkins --role=jenkins --serviceaccount=argo:jenkins
+kubectl create rolebinding jenkins --role=jenkins --serviceaccount=argo:jenkins -n argo
 ```
 
 ## Token Creation
@@ -41,16 +42,17 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: jenkins.service-account-token
+  namespace: argo
   annotations:
     kubernetes.io/service-account.name: jenkins
 type: kubernetes.io/service-account-token
 EOF
 ```
 
-Wait a few seconds:
+Wait a few seconds for Kubernetes to populate the token:
 
 ```bash
-ARGO_TOKEN="Bearer $(kubectl get secret jenkins.service-account-token -o=jsonpath='{.data.token}' | base64 --decode)"
+ARGO_TOKEN="Bearer $(kubectl get secret jenkins.service-account-token -n argo -o=jsonpath='{.data.token}' | base64 --decode)"
 echo $ARGO_TOKEN
 Bearer ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNkltS...
 ```
@@ -59,14 +61,14 @@ Bearer ZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNkltS...
 
 To use that token with the CLI you need to set `ARGO_SERVER` (see `argo --help`).
 
-Use that token in your API requests, e.g. to list workflows:
+Use that token in your API requests, e.g. to list workflows in the `argo` namespace:
 
 ```bash
 curl https://localhost:2746/api/v1/workflows/argo -H "Authorization: $ARGO_TOKEN"
 # 200 OK
 ```
 
-You should check you cannot do things you're not allowed!
+You should check you cannot do things you're not allowed:
 
 ```bash
 curl https://localhost:2746/api/v1/workflow-templates/argo -H "Authorization: $ARGO_TOKEN"
@@ -80,7 +82,7 @@ curl https://localhost:2746/api/v1/workflow-templates/argo -H "Authorization: $A
 ```bash
 ARGO_SERVER="${{HOST}}:443"
 KUBECONFIG=/dev/null
-ARGO_NAMESPACE=sandbox
+ARGO_NAMESPACE=argo
 ```
 
 ### Start container with settings above
@@ -94,16 +96,16 @@ docker run --rm -it \
   -e ARGO_HTTP=false \
   -e ARGO_HTTP1=true \
   -e KUBECONFIG=/dev/null \
-  -e ARGO_NAMESPACE=$ARGO_NAMESPACE  \
+  -e ARGO_NAMESPACE=$ARGO_NAMESPACE \
   quay.io/argoproj/argocli:latest template list -v -e -k
 ```
 
 ## Token Revocation
 
-Token compromised?
+If a token is compromised, delete the secret:
 
 ```bash
-kubectl delete secret $SECRET
+kubectl delete secret jenkins.service-account-token -n argo
 ```
 
-A new one will be created.
+A new token can be created by re-creating the secret as described in [Token Creation](#token-creation).


### PR DESCRIPTION
## Summary

Fixes all 7 issues reported in #11852 with the access-token.md documentation.

**Changes:**

- Add `-n argo` to `kubectl create role jenkins` — role was created without a namespace (defaulting to `default`), but the rolebinding referenced `argo:jenkins`
- Add `-n argo` to `kubectl create sa jenkins` — SA was created in the wrong namespace relative to the rolebinding
- Add `-n argo` to `kubectl create rolebinding` and the `kubectl apply` for the secret
- Add `-n argo` to the `kubectl get secret` command used to fetch the token
- Update the `curl` test examples — they queried the `argo` namespace but the role/rolebinding only granted access to `default`; fixed by making everything consistently use `argo`
- Docker section: replace `sandbox` namespace (unrelated to the jenkins example) with `argo`
- Token Revocation: replace undefined `$SECRET` with the concrete secret name `jenkins.service-account-token`; add `-n argo`
- Token Revocation: replace "A new one will be created." (incorrect since Kubernetes v1.24 no longer auto-creates SA tokens) with a note directing the reader to re-create the secret as shown in Token Creation
- Rename "Tip for Tokens Creation" → "Tip for Token Creation"

Fixes #11852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified access-token setup with namespace-scoped permissions.
  * Updated token creation, usage, Docker, CLI, and revocation examples for the `argo` namespace.
  * Refined guidance on token testing, minimal permissions, and recreating revoked tokens.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->