### PR TITLE
fix: sync global artifacts into scope before global onExit handler.

### DIFF
--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/workflow/common"
 )
 
 var stepsOnExitTmpl = `apiVersion: argoproj.io/v1alpha1
@@ -1067,4 +1068,95 @@ spec:
 	require.Len(t, hookNode.Inputs.Parameters, 1)
 	assert.NotNil(t, hookNode.Inputs.Parameters[0].Value)
 	assert.Equal(t, hookNode.Inputs.Parameters[0].Value.String(), string(apiv1.PodFailed))
+}
+
+var globalArtifactOnExit = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: global-artifact-on-exit
+spec:
+  entrypoint: main
+  onExit: exit-handler
+  templates:
+  - name: main
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["hello world"]
+    outputs:
+      artifacts:
+      - name: result
+        path: /tmp/hello_world.txt
+        globalName: global-result
+  - name: exit-handler
+    container:
+      image: docker/whalesay
+      command: [cowsay]
+      args: ["goodbye world"]
+`
+
+// TestTaskResultReconciliationSyncsGlobalArtifact reproduces the runtime side of
+// #11610: when a leaf pod's outputs (including a global artifact) are reported
+// asynchronously via a WorkflowTaskResult, taskResultReconciliation() must sync
+// them into the workflow-level global scope so that the global onExit handler can
+// later resolve {{workflow.outputs.artifacts.global-result}}.
+func TestTaskResultReconciliationSyncsGlobalArtifact(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(globalArtifactOnExit)
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	// Locate the entrypoint pod node.
+	var nodeID string
+	for id, node := range woc.wf.Status.Nodes {
+		if node.Type == wfv1.NodeTypePod {
+			nodeID = id
+			break
+		}
+	}
+	require.NotEmpty(t, nodeID)
+
+	// Simulate the executor reporting the outputs (with a global artifact)
+	// asynchronously via a WorkflowTaskResult in the informer.
+	taskResult := &wfv1.WorkflowTaskResult{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      nodeID,
+			Namespace: woc.wf.Namespace,
+			Labels: map[string]string{
+				common.LabelKeyWorkflow:               woc.wf.Name,
+				common.LabelKeyReportOutputsCompleted: "true",
+			},
+		},
+		NodeResult: wfv1.NodeResult{
+			Phase: wfv1.NodeSucceeded,
+			Outputs: &wfv1.Outputs{
+				Artifacts: wfv1.Artifacts{
+					{
+						Name:       "result",
+						GlobalName: "global-result",
+						ArtifactLocation: wfv1.ArtifactLocation{
+							S3: &wfv1.S3Artifact{Key: "test"},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, controller.taskResultInformer.GetIndexer().Add(taskResult))
+
+	woc.taskResultReconciliation(ctx)
+
+	// The global artifact must have been synced into the workflow-level global scope.
+	require.NotNil(t, woc.wf.Status.Outputs)
+	var globalArtifactPresent bool
+	for _, art := range woc.wf.Status.Outputs.Artifacts {
+		if art.Name == "global-result" {
+			globalArtifactPresent = true
+			break
+		}
+	}
+	assert.True(t, globalArtifactPresent, "global artifact should be synced into the global scope during task-result reconciliation")
 }

--- a/workflow/controller/exit_handler_test.go
+++ b/workflow/controller/exit_handler_test.go
@@ -1076,7 +1076,13 @@ metadata:
   name: global-artifact-on-exit
 spec:
   entrypoint: main
-  onExit: exit-handler
+  hooks:
+    exit:
+      template: exit-handler
+      arguments:
+        artifacts:
+        - name: message
+          from: "{{workflow.outputs.artifacts.global-result}}"
   templates:
   - name: main
     container:
@@ -1089,6 +1095,10 @@ spec:
         path: /tmp/hello_world.txt
         globalName: global-result
   - name: exit-handler
+    inputs:
+      artifacts:
+      - name: message
+        path: /tmp/message
     container:
       image: docker/whalesay
       command: [cowsay]
@@ -1108,8 +1118,11 @@ func TestTaskResultReconciliationSyncsGlobalArtifact(t *testing.T) {
 
 	woc := newWorkflowOperationCtx(ctx, wf, controller)
 	woc.operate(ctx)
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
 
-	// Locate the entrypoint pod node.
+	// Locate the entrypoint pod node. Its outputs (the global artifact) are not set
+	// here on purpose: they arrive asynchronously via a WorkflowTaskResult below, which
+	// is exactly the #11610 race this test reproduces.
 	var nodeID string
 	for id, node := range woc.wf.Status.Nodes {
 		if node.Type == wfv1.NodeTypePod {
@@ -1119,14 +1132,24 @@ func TestTaskResultReconciliationSyncsGlobalArtifact(t *testing.T) {
 	}
 	require.NotEmpty(t, nodeID)
 
-	// Simulate the executor reporting the outputs (with a global artifact)
-	// asynchronously via a WorkflowTaskResult in the informer.
+	// Guard (operator.go): while the leaf's task result is still in progress, the
+	// global onExit handler must not start, otherwise it could resolve
+	// {{workflow.outputs.artifacts.global-result}} against a not-yet-synced scope.
+	woc.wf.Status.MarkTaskResultIncomplete(ctx, nodeID)
+	wocGuard := newWorkflowOperationCtx(ctx, woc.wf, controller)
+	wocGuard.operate(ctx)
+	for _, node := range wocGuard.wf.Status.Nodes {
+		require.NotContains(t, node.Name, "onExit", "onExit handler must not start while task results are in progress")
+	}
+
+	// The executor reports the outputs (with the global artifact) asynchronously
+	// via a completed WorkflowTaskResult in the informer.
 	taskResult := &wfv1.WorkflowTaskResult{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      nodeID,
-			Namespace: woc.wf.Namespace,
+			Namespace: wocGuard.wf.Namespace,
 			Labels: map[string]string{
-				common.LabelKeyWorkflow:               woc.wf.Name,
+				common.LabelKeyWorkflow:               wocGuard.wf.Name,
 				common.LabelKeyReportOutputsCompleted: "true",
 			},
 		},
@@ -1146,17 +1169,37 @@ func TestTaskResultReconciliationSyncsGlobalArtifact(t *testing.T) {
 		},
 	}
 	require.NoError(t, controller.taskResultInformer.GetIndexer().Add(taskResult))
-
-	woc.taskResultReconciliation(ctx)
+	wocGuard.wf.Status.MarkTaskResultComplete(ctx, nodeID)
+	wocGuard.taskResultReconciliation(ctx)
 
 	// The global artifact must have been synced into the workflow-level global scope.
-	require.NotNil(t, woc.wf.Status.Outputs)
+	require.NotNil(t, wocGuard.wf.Status.Outputs)
 	var globalArtifactPresent bool
-	for _, art := range woc.wf.Status.Outputs.Artifacts {
+	for _, art := range wocGuard.wf.Status.Outputs.Artifacts {
 		if art.Name == "global-result" {
 			globalArtifactPresent = true
 			break
 		}
 	}
-	assert.True(t, globalArtifactPresent, "global artifact should be synced into the global scope during task-result reconciliation")
+	require.True(t, globalArtifactPresent, "global artifact should be synced into the global scope during task-result reconciliation")
+
+	// Now that the task result is complete and the global artifact is in scope, the
+	// onExit handler runs and must resolve {{workflow.outputs.artifacts.global-result}}.
+	woc2 := newWorkflowOperationCtx(ctx, wocGuard.wf, controller)
+	woc2.operate(ctx)
+	var onExitNode *wfv1.NodeStatus
+	for id := range woc2.wf.Status.Nodes {
+		if strings.Contains(woc2.wf.Status.Nodes[id].Name, "onExit") {
+			node := woc2.wf.Status.Nodes[id]
+			onExitNode = &node
+			break
+		}
+	}
+	require.NotNil(t, onExitNode, "onExit handler should run once task results are complete")
+	// The handler's argument {{workflow.outputs.artifacts.global-result}} must have resolved
+	// against the freshly-synced global scope. We only assert it resolved (not an
+	// unresolved-variable failure); a bare S3 key has no repository location in a unit test,
+	// which is an unrelated concern also not asserted by the sibling *OnExitTmplWithArt tests.
+	assert.NotContains(t, onExitNode.Message, "failed to resolve")
+	assert.NotContains(t, onExitNode.Message, "global-result}}")
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -481,6 +481,12 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 
 	var onExitNode *wfv1.NodeStatus
 	if woc.execWf.Spec.HasExitHook() {
+		// wait for task results so global artifacts are in scope before the onExit handler runs
+		if woc.checkTaskResultsInProgress(ctx) {
+			woc.log.Info(ctx, "Waiting for task results to complete before executing global onExit handler")
+			woc.requeueAfter(GetRequeueTime())
+			return
+		}
 		woc.log.WithField("onExit", woc.execWf.Spec.OnExit).Info(ctx, "Running OnExit handler")
 		onExitNodeName := common.GenerateOnExitNodeName(woc.wf.Name)
 		onExitNode, _ = woc.execWf.GetNodeByName(onExitNodeName)

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -481,15 +481,18 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 
 	var onExitNode *wfv1.NodeStatus
 	if woc.execWf.Spec.HasExitHook() {
-		// wait for task results so global artifacts are in scope before the onExit handler runs
-		if woc.checkTaskResultsInProgress(ctx) {
-			woc.log.Info(ctx, "Waiting for task results to complete before executing global onExit handler")
+		onExitNodeName := common.GenerateOnExitNodeName(woc.wf.Name)
+		onExitNode, _ = woc.execWf.GetNodeByName(onExitNodeName)
+		// On the first entry (before the handler starts), wait for in-flight task results so
+		// upstream global artifacts are synced into scope before the onExit handler resolves
+		// them. Once the handler has started, skip this so it isn't blocked by its own subtree's
+		// task results (e.g. a daemon in the handler whose result never completes).
+		if onExitNode == nil && woc.checkTaskResultsInProgress(ctx) {
+			woc.log.Debug(ctx, "Waiting for task results to complete before executing global onExit handler")
 			woc.requeueAfter(GetRequeueTime())
 			return
 		}
 		woc.log.WithField("onExit", woc.execWf.Spec.OnExit).Info(ctx, "Running OnExit handler")
-		onExitNodeName := common.GenerateOnExitNodeName(woc.wf.Name)
-		onExitNode, _ = woc.execWf.GetNodeByName(onExitNodeName)
 		if onExitNode != nil || woc.GetShutdownStrategy().ShouldExecute(true) {
 			exitHook := woc.execWf.Spec.GetExitHook(woc.execWf.Spec.Arguments)
 			onExitNode, err = woc.executeTemplate(ctx, onExitNodeName, &wfv1.WorkflowStep{Template: exitHook.Template, TemplateRef: exitHook.TemplateRef}, tmplCtx, exitHook.Arguments, &executeTemplateOpts{

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -139,8 +139,10 @@ func (woc *wfOperationCtx) taskResultReconciliation(ctx context.Context) {
 				WithField("nodeID", nodeID).
 				Debug(ctx, "task-result changed")
 			woc.wf.Status.Nodes.Set(ctx, nodeID, *newNode)
-			// task results may carry global artifacts/parameters; add them to the global scope
-			if newNode.Outputs != nil && newNode.Outputs.HasOutputs() {
+			// task results may carry global artifacts/parameters; add them to the global scope,
+			// but only once the task result is complete so we don't publish not-yet-final outputs
+			// (mirrors the gate in podReconciliation/assessNodeStatus, see #12537).
+			if newNode.Outputs != nil && newNode.Outputs.HasOutputs() && !woc.wf.Status.IsTaskResultIncomplete(nodeID) {
 				woc.addOutputsToGlobalScope(ctx, newNode.Outputs)
 			}
 			woc.updated = true

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -139,6 +139,10 @@ func (woc *wfOperationCtx) taskResultReconciliation(ctx context.Context) {
 				WithField("nodeID", nodeID).
 				Debug(ctx, "task-result changed")
 			woc.wf.Status.Nodes.Set(ctx, nodeID, *newNode)
+			// task results may carry global artifacts/parameters; add them to the global scope
+			if newNode.Outputs != nil && newNode.Outputs.HasOutputs() {
+				woc.addOutputsToGlobalScope(ctx, newNode.Outputs)
+			}
 			woc.updated = true
 		}
 		span.End()


### PR DESCRIPTION
Fixes #11610

### Motivation

The global `onExit` handler resolves `{{workflow.outputs.artifacts.*}}` (and global output parameters) from the workflow-level global scope. For a leaf pod whose outputs are only reported **asynchronously** via a `WorkflowTaskResult`, the outputs land in `Status.Nodes` during `taskResultReconciliation()` but were never added to the global scope. As a result the global onExit handler can run before those global artifacts are in scope and fail to resolve them (e.g. `failed to resolve {{workflow.outputs.artifacts.output-result-car}}`).

This is a **runtime timing** bug, distinct from the **validation-only** fix in #14991.

### Modifications

- `taskResultReconciliation()`: when a node's outputs are (re)populated from its task result, also push them into the global scope via `addOutputsToGlobalScope`.
- `operate()`: before running the global onExit handler, if any task result is still in progress, `requeue` and return so we retry once all outputs are reported. `taskResultReconciliation()` already runs at the start of every `operate()` cycle, so no extra reconciliation call is needed.

### Verification

- Added `TestTaskResultReconciliationSyncsGlobalArtifact`, which reports a global artifact via a `WorkflowTaskResult` and asserts it is synced into the workflow-level global scope.
- Existing onExit / exit-handler / task-result tests continue to pass (`go test ./workflow/controller/ -run 'OnExit|ExitHandler|TaskResult'`).

### Documentation

No documentation changes needed — this restores expected runtime behavior for existing functionality and does not add any user-facing feature or API.

### AI

Qoder (an AI coding assistant) was used to help draft the code, unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow `onExit` handling by waiting for task results to finish before triggering the global exit handler.
  * Completed task outputs are now propagated into global workflow artifacts when the task result is not marked incomplete.
  * Exit handlers no longer fail due to unresolved artifact references from in-progress task results.
* **Tests**
  * Added/extended coverage to verify global artifact synchronization and that the global `onExit` waits for completed task results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->