### PR TITLE
fix(controller): mark reapply-failed on persist errors to keep throttler slot

### DIFF
--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -97,8 +97,6 @@ const (
 	// * `Persisted` - has been archived and retrieved from db
 	// See also `LabelKeyCompleted`.
 	LabelKeyWorkflowArchivingStatus = workflow.WorkflowFullName + "/workflow-archiving-status"
-	// LabelKeyReApplyFailed is the pod metadata label to indicate if the pod re-apply failed
-	LabelKeyReApplyFailed = workflow.WorkflowFullName + "/reapply"
 	// LabelKeyWorkflow is the pod metadata label to indicate the associated workflow name
 	LabelKeyWorkflow = workflow.WorkflowFullName + "/workflow"
 	// LabelKeyComponent determines what component within a workflow, intentionally similar to app.kubernetes.io/component.

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -829,9 +829,9 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 	// make sure this is removed from the throttler is complete
 	defer func() {
 		// must be done with woc
-		// reapplyFailed (set in memory when Update failed) also blocks Remove so we do not free
+		// woc.reapplyFailed (set in memory when Update failed) also blocks Remove so we do not free
 		// parallelism while woc.wf may not match the API object (e.g. connection reset before persist).
-		if !reconciliationNeeded(woc.wf) && !reapplyFailed(woc.wf) {
+		if !reconciliationNeeded(woc.wf) && !woc.reapplyFailed {
 			wfc.throttler.Remove(key)
 		}
 	}()
@@ -896,10 +896,6 @@ func (wfc *WorkflowController) getWorkflowByKey(ctx context.Context, key string)
 
 func reconciliationNeeded(wf metav1.Object) bool {
 	return wf.GetLabels()[common.LabelKeyCompleted] != "true" || slices.Contains(wf.GetFinalizers(), common.FinalizerArtifactGC)
-}
-
-func reapplyFailed(wf metav1.Object) bool {
-	return wf.GetLabels()[common.LabelKeyReApplyFailed] == "true"
 }
 
 // enqueueWfFromPodLabel will extract the workflow name from pod label and

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -829,6 +829,8 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 	// make sure this is removed from the throttler is complete
 	defer func() {
 		// must be done with woc
+		// reapplyFailed (set in memory when Update failed) also blocks Remove so we do not free
+		// parallelism while woc.wf may not match the API object (e.g. connection reset before persist).
 		if !reconciliationNeeded(woc.wf) && !reapplyFailed(woc.wf) {
 			wfc.throttler.Remove(key)
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -78,6 +78,11 @@ type wfOperationCtx struct {
 	// updated indicates whether or not the workflow object itself was updated
 	// and needs to be persisted back to kubernetes
 	updated bool
+	// reapplyFailed indicates that persisting the workflow failed in a way that may
+	// leave woc.wf out of sync with the API object (e.g. a non-conflict Update error).
+	// It is transient, in-memory only, and never persisted; the throttler uses it to
+	// keep the parallelism slot until a later successful reconciliation.
+	reapplyFailed bool
 	// log is a logging interfacg to correlate logs with a workflow
 	log logging.Logger
 	// controller reference to workflow controller
@@ -753,14 +758,11 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 	return nil
 }
 
-// markInMemoryReapplyFailed sets LabelKeyReApplyFailed on woc.wf without persisting it.
+// markInMemoryReapplyFailed records, in memory only, that persisting the workflow failed.
 // persistUpdates uses this when Update fails so the throttler slot is not released while the
 // in-memory workflow may not match the API object (e.g. connection reset before persist).
 func (woc *wfOperationCtx) markInMemoryReapplyFailed() {
-	if woc.wf.Labels == nil {
-		woc.wf.Labels = make(map[string]string)
-	}
-	woc.wf.Labels[common.LabelKeyReApplyFailed] = "true"
+	woc.reapplyFailed = true
 }
 
 // persistUpdates will update a workflow with any updates made during workflow operation.

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -753,6 +753,16 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 	return nil
 }
 
+// markInMemoryReapplyFailed sets LabelKeyReApplyFailed on woc.wf without persisting it.
+// persistUpdates uses this when Update fails so the throttler slot is not released while the
+// in-memory workflow may not match the API object (e.g. connection reset before persist).
+func (woc *wfOperationCtx) markInMemoryReapplyFailed() {
+	if woc.wf.Labels == nil {
+		woc.wf.Labels = make(map[string]string)
+	}
+	woc.wf.Labels[common.LabelKeyReApplyFailed] = "true"
+}
+
 // persistUpdates will update a workflow with any updates made during workflow operation.
 // It also labels any pods as completed if we have extracted everything we need from it.
 // NOTE: a previous implementation used Patch instead of Update, but Patch does not work with
@@ -806,12 +816,15 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 			return
 		}
 		if !apierr.IsConflict(err) {
+			// Non-conflict errors (e.g. connection reset) may leave woc.wf out of sync with the API,
+			// so keep the throttler slot until a later successful reconciliation.
+			woc.markInMemoryReapplyFailed()
 			return
 		}
 		woc.log.Info(ctx, "Re-applying updates on latest version and retrying update")
 		wf, err = woc.reapplyUpdate(ctx, wfClient, nodes)
 		if err != nil {
-			woc.wf.Labels[common.LabelKeyReApplyFailed] = "true"
+			woc.markInMemoryReapplyFailed()
 			woc.log.WithError(err).Info(ctx, "Failed to re-apply update")
 			return
 		}
@@ -882,6 +895,7 @@ func (woc *wfOperationCtx) persistWorkflowSizeLimitErr(ctx context.Context, wfCl
 
 	wf, err := wfClient.Update(ctx, woc.wf, metav1.UpdateOptions{})
 	if err != nil {
+		woc.markInMemoryReapplyFailed()
 		woc.log.WithError(err).Warn(ctx, "Error updating workflow with size error")
 	} else {
 		woc.controller.recordWorkflowWrite(wf)

--- a/workflow/controller/operator_persist_test.go
+++ b/workflow/controller/operator_persist_test.go
@@ -7,11 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/argoproj/argo-workflows/v4/errors"
 	"github.com/argoproj/argo-workflows/v4/persist/sqldb/mocks"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	fakewfclientset "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/hydrator"
 	"github.com/argoproj/argo-workflows/v4/workflow/packer"
@@ -150,4 +154,32 @@ func TestPersistErrorWithLargeWfSupport(t *testing.T) {
 
 func makeMax() func() {
 	return packer.SetMaxWorkflowSize(50)
+}
+
+// TestPersistUpdatesMarksReapplyFailedOnNonConflictError verifies that a non-conflict
+// Update error (e.g. connection reset) marks the workflow reapply-failed in memory, so the
+// controller's throttler defer keeps the parallelism slot instead of releasing it while the
+// in-memory workflow may not match the API object.
+func TestPersistUpdatesMarksReapplyFailedOnNonConflictError(t *testing.T) {
+	cancel, controller := newController(logging.TestContext(t.Context()))
+	defer cancel()
+
+	ctx := logging.TestContext(t.Context())
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+	wf := wfv1.MustUnmarshalWorkflow(helloWorldWfPersist)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	controller.offloadNodeStatusRepo, controller.hydrator = getMockDBCtx(nil, false)
+
+	// Make the workflow Update fail with a non-conflict error.
+	controller.wfclientset.(*fakewfclientset.Clientset).PrependReactor("update", "workflows", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierr.NewInternalError(fmt.Errorf("connection reset by peer"))
+	})
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.updated = true // force persistUpdates to attempt the Update
+	woc.persistUpdates(ctx)
+
+	assert.True(t, reapplyFailed(woc.wf), "non-conflict persist error should mark reapply-failed to keep the throttler slot")
 }

--- a/workflow/controller/operator_persist_test.go
+++ b/workflow/controller/operator_persist_test.go
@@ -181,5 +181,5 @@ func TestPersistUpdatesMarksReapplyFailedOnNonConflictError(t *testing.T) {
 	woc.updated = true // force persistUpdates to attempt the Update
 	woc.persistUpdates(ctx)
 
-	assert.True(t, reapplyFailed(woc.wf), "non-conflict persist error should mark reapply-failed to keep the throttler slot")
+	assert.True(t, woc.reapplyFailed, "non-conflict persist error should mark reapply-failed to keep the throttler slot")
 }


### PR DESCRIPTION
### Motivation

When `wfClient.Update` fails with a **non-conflict** error (e.g. a connection reset before the write reaches the API server), the in-memory workflow may not match the API object. If the parallelism throttler slot is released in that state, the controller can over-admit workflows beyond the configured parallelism limit.

### Modifications

- Added helper `markInMemoryReapplyFailed()` that sets `LabelKeyReApplyFailed` on the in-memory workflow (without persisting).
- Call it on persist failures so the `processNextWorkflowQueueItem` defer keeps the throttler slot until a later successful reconciliation:
  - `Update` fails with a non-conflict error
  - `reapplyUpdate` fails
  - the size-limit recovery `Update` fails
- Documented in `controller.go` why `reapplyFailed` blocks `throttler.Remove`.

### Verification

- Added `TestPersistUpdatesMarksReapplyFailedOnNonConflictError`, which injects a non-conflict `Update` error and asserts the workflow is marked reapply-failed.
- Existing persist / reapply tests continue to pass (`go test ./workflow/controller/ -run 'Persist|Reapply'`).

### Documentation

No documentation changes needed — this is an internal controller correctness fix with no user-facing behavior or API change.

### AI

Cursor was used to draft the initial change; Qoder (an AI coding assistant) was used to adapt it to the latest main, write the unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow recovery after non-conflict update failures (for example, connection interruptions) by holding processing capacity until a later successful reconciliation.
  * Ensured failed updates are retried during a later reconciliation instead of incorrectly releasing processing capacity.
  * Improved handling of workflow size-limit update failures to trigger reapplication when needed.
* **Tests**
  * Added coverage verifying that non-conflict failed workflow updates are marked for reapplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->