### PR TITLE
feat: archive sidecar container logs in SaveLogs

### DIFF
--- a/.features/pending/archive-sidecar-container-logs.md
+++ b/.features/pending/archive-sidecar-container-logs.md
@@ -1,7 +1,7 @@
 Description: Archive sidecar container logs when archiveLogs is enabled
 Author: [shuangkun](https://github.com/shuangkun)
 Component: General
-Issues: 16483
+Issues: 16489
 
 When `archiveLogs` is enabled, sidecar container logs are now archived alongside the main container(s).
 Each sidecar produces its own `<container>-logs` artifact, so sidecar output can be retrieved after the pod is gone.

--- a/.features/pending/archive-sidecar-container-logs.md
+++ b/.features/pending/archive-sidecar-container-logs.md
@@ -1,0 +1,7 @@
+Description: Archive sidecar container logs when archiveLogs is enabled
+Author: [shuangkun](https://github.com/shuangkun)
+Component: General
+Issues: 16483
+
+When `archiveLogs` is enabled, sidecar container logs are now archived alongside the main container(s).
+Each sidecar produces its own `<container>-logs` artifact, so sidecar output can be retrieved after the pod is gone.

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -753,6 +753,8 @@ func (we *WorkflowExecutor) SaveLogs(ctx context.Context) []wfv1.Artifact {
 		}
 
 		containerNames := we.Template.GetMainContainerNames()
+		// also archive sidecar container logs so they are not lost
+		containerNames = append(containerNames, we.Template.GetSidecarNames()...)
 		logArtifacts = make([]wfv1.Artifact, 0)
 
 		for _, containerName := range containerNames {

--- a/workflow/executor/executor_test.go
+++ b/workflow/executor/executor_test.go
@@ -698,6 +698,32 @@ func TestSaveLogs(t *testing.T) {
 		assert.Empty(t, logArtifacts)
 		assert.NoError(t, we.HasError(), "a missing combined log must not be a fatal error")
 	})
+
+	t.Run("sidecar container logs are also saved", func(t *testing.T) {
+		// SaveLogs must archive sidecar container logs in addition to the main container(s).
+		ctx := logging.TestContext(t.Context())
+		tr, err := tracing.New(ctx, `argoexec`)
+		require.NoError(t, err)
+		we := WorkflowExecutor{
+			Template: wfv1.Template{
+				ArchiveLocation: &wfv1.ArtifactLocation{ArchiveLogs: new(true)},
+				Sidecars: []wfv1.UserContainer{
+					{Container: corev1.Container{Name: "sidecar-0"}},
+				},
+			},
+			RuntimeExecutor: &mockRuntimeExecutor,
+			Tracing:         tr,
+		}
+
+		we.SaveLogs(ctx)
+
+		// One artifact-storage error per processed container (main + sidecar) proves the
+		// sidecar container was included alongside the main container.
+		require.Len(t, we.errors, 2)
+		for _, e := range we.errors {
+			assert.EqualError(t, e, artStorageError)
+		}
+	})
 }
 
 func TestReportOutputs(t *testing.T) {


### PR DESCRIPTION
Fixes #14802

### Motivation

When `archiveLogs` (or a template's `archiveLocation.archiveLogs`) is enabled, the executor archived only the **main** container log(s). Logs from **sidecar** containers were not saved, so users could not retrieve sidecar output as archived log artifacts (e.g. for debugging a proxy/agent sidecar after the pod is gone).

### Modifications

- In `WorkflowExecutor.SaveLogs`, append the template's sidecar container names (`Template.GetSidecarNames()`) to the set of containers whose logs are archived. Each sidecar now produces its own `<container>-logs` artifact alongside the main container(s).

### Verification

- Added a `TestSaveLogs` subtest ("sidecar container logs are also saved") that configures a template with a sidecar and asserts `SaveLogs` processes both the main and sidecar containers.
- Existing executor tests continue to pass (`go test ./workflow/executor/ -run 'TestSaveLogs'`).

### Documentation

No new configuration is introduced — the feature is driven by the existing `archiveLogs` setting, so users discover it through the existing [Configuring Archive Logs](https://argo-workflows.readthedocs.io/en/latest/configure-archive-logs/) documentation. Behavior change to note: enabling `archiveLogs` now also archives sidecar logs, producing one `<container>-logs` artifact per sidecar in addition to the main container. Happy to add an explicit sentence to `docs/configure-archive-logs.md` if maintainers prefer.

### AI

Qoder (an AI coding assistant) was used to help draft the code, unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidecar container logs are now archived alongside main container logs when log archiving is enabled.
  * Each sidecar’s logs are saved as a separate `<container>-logs` artifact for retrieval after pod removal.

* **Tests**
  * Added coverage verifying that both main and sidecar log artifacts are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

