### PR TITLE
fix(errors): treat client-go response body read failures as transient

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -94,6 +95,10 @@ func isTransientEtcdErr(err error) bool {
 }
 
 func isTransientNetworkErr(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
 	var dnsErr *net.DNSError
 	var opErr *net.OpError
 	var unknownNetErr net.UnknownNetworkError
@@ -103,6 +108,10 @@ func isTransientNetworkErr(err error) bool {
 
 	errorString := generateErrorString(err)
 	switch {
+	case strings.Contains(errorString, "unexpected error when reading response body") ||
+		strings.Contains(errorString, "stream error when reading response body"):
+		// client-go rest.Request: body read failed mid-response; the message asks to retry.
+		return true
 	case strings.Contains(errorString, "Connection closed by foreign host"):
 		// For a URL error, where it replies back "connection closed"
 		// retry again.

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -154,7 +154,7 @@ func TestIsTransientUErr(t *testing.T) {
 		assert.True(t, IsTransientErr(ctx, err))
 	})
 	t.Run("ClientGoUnexpectedResponseBodyReadErr", func(t *testing.T) {
-		err := errors.New("unexpected error when reading response body. Please retry.")
+		err := errors.New("unexpected error when reading response body")
 		assert.True(t, IsTransientErr(ctx, err))
 	})
 	t.Run("ClientGoStreamResponseBodyReadErr", func(t *testing.T) {

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -153,4 +153,12 @@ func TestIsTransientUErr(t *testing.T) {
 		err := fmt.Errorf("unexpected error when reading response body. Please retry. Original error: %w", io.ErrUnexpectedEOF)
 		assert.True(t, IsTransientErr(ctx, err))
 	})
+	t.Run("ClientGoUnexpectedResponseBodyReadErr", func(t *testing.T) {
+		err := errors.New("unexpected error when reading response body. Please retry.")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
+	t.Run("ClientGoStreamResponseBodyReadErr", func(t *testing.T) {
+		err := errors.New("stream error when reading response body")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
 }

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -3,6 +3,8 @@ package errors
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -146,5 +148,9 @@ func TestIsTransientUErr(t *testing.T) {
 	})
 	t.Run("EOFUErr", func(t *testing.T) {
 		assert.True(t, IsTransientErr(ctx, EOFUErr))
+	})
+	t.Run("ClientGoResponseBodyReadErr", func(t *testing.T) {
+		err := fmt.Errorf("unexpected error when reading response body. Please retry. Original error: %w", io.ErrUnexpectedEOF)
+		assert.True(t, IsTransientErr(ctx, err))
 	})
 }


### PR DESCRIPTION
### Motivation

When client-go reads a response body that is truncated or interrupted mid-stream, it returns errors such as `io.ErrUnexpectedEOF` or messages like `unexpected error when reading response body. Please retry.`. These are transient and retryable, but `IsTransientErr` did not recognize them, so `createWorkflowPod` returned a non-transient error and the node was marked `Error` instead of being retried.

### Modifications

- In `isTransientNetworkErr`, treat `io.ErrUnexpectedEOF` as transient.
- Recognize client-go `rest.Request` body-read messages (`unexpected error when reading response body` / `stream error when reading response body`) as transient.

### Verification

- Added a `TestIsTransientUErr` subtest asserting a wrapped `io.ErrUnexpectedEOF` "reading response body" error is transient.
- Existing transient-error tests continue to pass (`go test ./util/errors/ -run 'TestIsTransient'`).

### Documentation

No documentation changes needed — this refines internal transient-error classification with no user-facing behavior or API change.

### AI

Cursor was used to draft the initial change; Qoder (an AI coding assistant) was used to adapt it to the latest main, write the unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted network responses by recognizing additional unexpected-end-of-file and response body/stream read failures as temporary/transient.
  * These failures can now be retried instead of being treated as permanent errors.
* **Tests**
  * Added/expanded coverage for transient error classification, including wrapped unexpected-end-of-file scenarios and additional body/stream read failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->