### PR TITLE
fix(controller): treat client-go rate limiter wait deadline as transient

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -51,9 +51,18 @@ func isTransientErr(err error) bool {
 		apierr.IsTimeout(err) ||
 		apierr.IsServiceUnavailable(err) ||
 		isTransientEtcdErr(err) ||
+		isClientGoRateLimiterWaitErr(err) ||
 		matchTransientErrPattern(err) ||
 		errors.Is(err, NewErrTransient("")) ||
 		isTransientSqbErr(err)
+}
+
+// isClientGoRateLimiterWaitErr matches client-go's rest.Request error when the
+// client-side QPS limiter blocks until the request context would expire
+// ("rate: Wait(n=1) would exceed context deadline"). This is backpressure, not
+// a terminal failure; the controller should requeue (see createWorkflowPod).
+func isClientGoRateLimiterWaitErr(err error) bool {
+	return strings.Contains(generateErrorString(err), "client rate limiter Wait returned an error")
 }
 
 func matchTransientErrPattern(err error) bool {

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -129,6 +129,10 @@ func TestIsTransientErr(t *testing.T) {
 		inner := errors.New("Timeout: request did not complete within requested timeout")
 		assert.True(t, IsTransientErr(ctx, argoerrs.InternalWrapError(inner)))
 	})
+	t.Run("ClientGoRateLimiterWaitDeadline", func(t *testing.T) {
+		err := errors.New("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
 }
 
 func TestIsTransientUErr(t *testing.T) {


### PR DESCRIPTION
### Motivation

When the Kubernetes client-side QPS rate limiter blocks until the request context expires, `Pod` Create fails with `client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline`. This is backpressure, not a terminal failure, but `IsTransientErr` did not recognize it, so `createWorkflowPod` wrapped it as a non-retryable internal error and the node was marked `Error` instead of being requeued.

### Modifications

- Add `isClientGoRateLimiterWaitErr` and include it in `isTransientErr`, so the "client rate limiter Wait returned an error" message is classified as transient and the controller requeues the node.

### Verification

- Added a `TestIsTransientErr` subtest asserting the client-go rate limiter wait deadline error is transient.
- Existing transient-error tests continue to pass (`go test ./util/errors/ -run 'TestIsTransient'`).

### Documentation

No documentation changes needed — this refines internal transient-error classification with no user-facing behavior or API change.

### AI

Cursor was used to draft the initial change; Qoder (an AI coding assistant) was used to adapt it to the latest main, write the unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client rate-limiting delays by recognizing specific “rate limiter wait” failures (including those tied to context deadline overruns) as transient so they can be retried.
* **Tests**
  * Added a new test case covering transient detection for client-go rate limiter wait errors that would exceed the context deadline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->