### PR TITLE
feat(controller): hot-reload namespaceParallelism from config

### DIFF
--- a/.features/pending/hot-reload-namespace-parallelism.md
+++ b/.features/pending/hot-reload-namespace-parallelism.md
@@ -1,7 +1,7 @@
 Description: Hot-reload namespaceParallelism from the controller ConfigMap
 Author: [shuangkun](https://github.com/shuangkun)
 Component: General
-Issues: 16486
+Issues: 16490
 
 Changes to `namespaceParallelism` in the workflow controller ConfigMap now take effect on reload without restarting the controller, matching the existing `parallelism` behavior.
 Namespaces without an explicit parallelism label override track the live default.

--- a/.features/pending/hot-reload-namespace-parallelism.md
+++ b/.features/pending/hot-reload-namespace-parallelism.md
@@ -1,0 +1,7 @@
+Description: Hot-reload namespaceParallelism from the controller ConfigMap
+Author: [shuangkun](https://github.com/shuangkun)
+Component: General
+Issues: 16486
+
+Changes to `namespaceParallelism` in the workflow controller ConfigMap now take effect on reload without restarting the controller, matching the existing `parallelism` behavior.
+Namespaces without an explicit parallelism label override track the live default.

--- a/workflow/controller/config.go
+++ b/workflow/controller/config.go
@@ -31,6 +31,7 @@ func (wfc *WorkflowController) updateConfig(ctx context.Context) error {
 	wfc.archiveLabelSelector = labels.Everything()
 	if wfc.throttler != nil {
 		wfc.throttler.UpdateParallelism(wfc.Config.Parallelism)
+		wfc.throttler.UpdateNamespaceParallelismDefault(wfc.Config.NamespaceParallelism)
 	}
 
 	persistence := wfc.Config.Persistence

--- a/workflow/sync/mocks/Throttler.go
+++ b/workflow/sync/mocks/Throttler.go
@@ -358,3 +358,43 @@ func (_c *Throttler_UpdateParallelism_Call) RunAndReturn(run func(limit int)) *T
 	_c.Run(run)
 	return _c
 }
+
+// UpdateNamespaceParallelismDefault provides a mock function for the type Throttler
+func (_mock *Throttler) UpdateNamespaceParallelismDefault(limit int) {
+	_mock.Called(limit)
+	return
+}
+
+// Throttler_UpdateNamespaceParallelismDefault_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateNamespaceParallelismDefault'
+type Throttler_UpdateNamespaceParallelismDefault_Call struct {
+	*mock.Call
+}
+
+// UpdateNamespaceParallelismDefault is a helper method to define mock.On call
+//   - limit int
+func (_e *Throttler_Expecter) UpdateNamespaceParallelismDefault(limit interface{}) *Throttler_UpdateNamespaceParallelismDefault_Call {
+	return &Throttler_UpdateNamespaceParallelismDefault_Call{Call: _e.mock.On("UpdateNamespaceParallelismDefault", limit)}
+}
+
+func (_c *Throttler_UpdateNamespaceParallelismDefault_Call) Run(run func(limit int)) *Throttler_UpdateNamespaceParallelismDefault_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Throttler_UpdateNamespaceParallelismDefault_Call) Return() *Throttler_UpdateNamespaceParallelismDefault_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Throttler_UpdateNamespaceParallelismDefault_Call) RunAndReturn(run func(limit int)) *Throttler_UpdateNamespaceParallelismDefault_Call {
+	_c.Run(run)
+	return _c
+}

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -159,7 +159,7 @@ func (m *multiThrottler) UpdateParallelism(limit int) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.totalParallelism = limit
-	m.queueThrottled()
+	m.drainThrottled()
 }
 
 // UpdateNamespaceParallelismDefault updates the default per-namespace parallelism limit
@@ -168,14 +168,14 @@ func (m *multiThrottler) UpdateNamespaceParallelismDefault(limit int) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.namespaceParallelismDefault = limit
-	m.queueThrottled()
+	m.drainThrottled()
 }
 
 func (m *multiThrottler) UpdateNamespaceParallelism(namespace string, limit int) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.namespaceParallelism[namespace] = limit
-	m.queueThrottled()
+	m.drainThrottled()
 }
 
 func (m *multiThrottler) ResetNamespaceParallelism(namespace string) {
@@ -184,9 +184,19 @@ func (m *multiThrottler) ResetNamespaceParallelism(namespace string) {
 	delete(m.namespaceParallelism, namespace)
 }
 
-func (m *multiThrottler) queueThrottled() {
+// drainThrottled repeatedly admits eligible queued workflows until no further
+// capacity is available. Used when a parallelism limit is raised so that all newly
+// eligible workflows are released immediately, rather than one per subsequent event.
+func (m *multiThrottler) drainThrottled() {
+	for m.queueThrottled() {
+	}
+}
+
+// queueThrottled admits at most one eligible queued workflow and returns true if it
+// admitted one, so callers can loop to drain all newly eligible workflows.
+func (m *multiThrottler) queueThrottled() bool {
 	if m.totalParallelism != 0 && len(m.running) >= m.totalParallelism {
-		return
+		return false
 	}
 
 	minPq := &priorityQueue{itemByKey: make(map[string]*item)}
@@ -199,7 +209,7 @@ func (m *multiThrottler) queueThrottled() {
 
 		namespace, _, err := cache.SplitMetaNamespaceKey(currItem.key)
 		if err != nil {
-			return
+			return false
 		}
 		if !m.namespaceAllows(namespace) {
 			continue
@@ -213,7 +223,9 @@ func (m *multiThrottler) queueThrottled() {
 		m.pending[bestNamespace].pop()
 		m.running[bestItem.key] = true
 		m.queue(bestItem.key)
+		return true
 	}
+	return false
 }
 
 type item struct {

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -162,6 +162,8 @@ func (m *multiThrottler) UpdateParallelism(limit int) {
 	m.queueThrottled()
 }
 
+// UpdateNamespaceParallelismDefault updates the default per-namespace parallelism limit
+// applied to namespaces without an explicit override, and re-queues throttled items.
 func (m *multiThrottler) UpdateNamespaceParallelismDefault(limit int) {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -23,6 +23,9 @@ type Throttler interface {
 	Remove(key Key)
 	// UpdateParallelism
 	UpdateParallelism(limit int)
+	// UpdateNamespaceParallelismDefault updates the controller-config default limit for namespaces
+	// without an explicit Namespace label override.
+	UpdateNamespaceParallelismDefault(limit int)
 	// UpdateNamespaceParallelism updates the namespace parallelism
 	UpdateNamespaceParallelism(namespace string, limit int)
 	// ResetNamespaceParallelism sets the namespace parallelism to the default value
@@ -79,9 +82,11 @@ func (m *multiThrottler) Init(wfs []wfv1.Workflow) error {
 }
 
 func (m *multiThrottler) namespaceCount(namespace string) (int, int) {
-	setLimit, has := m.namespaceParallelism[namespace]
-	if !has {
-		m.namespaceParallelism[namespace] = m.namespaceParallelismDefault
+	var setLimit int
+	if lim, has := m.namespaceParallelism[namespace]; has {
+		setLimit = lim
+	} else {
+		// Use the live default so UpdateNamespaceParallelismDefault applies without a restart.
 		setLimit = m.namespaceParallelismDefault
 	}
 	if setLimit == 0 {
@@ -154,6 +159,13 @@ func (m *multiThrottler) UpdateParallelism(limit int) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.totalParallelism = limit
+	m.queueThrottled()
+}
+
+func (m *multiThrottler) UpdateNamespaceParallelismDefault(limit int) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.namespaceParallelismDefault = limit
 	m.queueThrottled()
 }
 

--- a/workflow/sync/multi_throttler_test.go
+++ b/workflow/sync/multi_throttler_test.go
@@ -236,6 +236,8 @@ func TestNamespaceParallelismUpdate(t *testing.T) {
 	assert.False(throttler.Admit("argo/b"))
 }
 
+// TestNamespaceParallelismDefaultUpdate verifies that raising the default namespace parallelism
+// at runtime admits a previously throttled workflow in a namespace without an explicit override.
 func TestNamespaceParallelismDefaultUpdate(t *testing.T) {
 	assert := assert.New(t)
 	throttler := NewMultiThrottler(4, 1, func(Key) {})

--- a/workflow/sync/multi_throttler_test.go
+++ b/workflow/sync/multi_throttler_test.go
@@ -235,3 +235,16 @@ func TestNamespaceParallelismUpdate(t *testing.T) {
 	assert.True(throttler.Admit("argo/a"))
 	assert.False(throttler.Admit("argo/b"))
 }
+
+func TestNamespaceParallelismDefaultUpdate(t *testing.T) {
+	assert := assert.New(t)
+	throttler := NewMultiThrottler(4, 1, func(Key) {})
+	throttler.Add("default/a", 0, time.Now())
+	throttler.Add("default/b", 0, time.Now())
+	assert.True(throttler.Admit("default/a"))
+	assert.False(throttler.Admit("default/b"))
+
+	// Raising the default limit must apply to namespaces without an explicit override.
+	throttler.UpdateNamespaceParallelismDefault(2)
+	assert.True(throttler.Admit("default/b"))
+}

--- a/workflow/sync/multi_throttler_test.go
+++ b/workflow/sync/multi_throttler_test.go
@@ -243,10 +243,14 @@ func TestNamespaceParallelismDefaultUpdate(t *testing.T) {
 	throttler := NewMultiThrottler(4, 1, func(Key) {})
 	throttler.Add("default/a", 0, time.Now())
 	throttler.Add("default/b", 0, time.Now())
+	throttler.Add("default/c", 0, time.Now())
 	assert.True(throttler.Admit("default/a"))
 	assert.False(throttler.Admit("default/b"))
+	assert.False(throttler.Admit("default/c"))
 
-	// Raising the default limit must apply to namespaces without an explicit override.
-	throttler.UpdateNamespaceParallelismDefault(2)
+	// Raising the default limit must apply to namespaces without an explicit override,
+	// and must admit all newly eligible workflows at once, not just one.
+	throttler.UpdateNamespaceParallelismDefault(3)
 	assert.True(throttler.Admit("default/b"))
+	assert.True(throttler.Admit("default/c"))
 }


### PR DESCRIPTION
Fixes #16490

### Motivation

The controller applies global `parallelism` changes on ConfigMap reload, but `namespaceParallelism` was not hot-reloaded — operators had to restart the controller for it to take effect. In addition, `namespaceCount` cached the default limit into the per-namespace map on first use, so namespaces without an explicit label override did not track a later default change. This PR makes `namespaceParallelism` hot-reloadable, consistent with global `parallelism`.

### Modifications

- Add `Throttler.UpdateNamespaceParallelismDefault(limit int)` and call it from `updateConfig` on ConfigMap reload, matching the existing `UpdateParallelism` behavior.
- In `namespaceCount`, stop caching the default into the per-namespace map; namespaces without an explicit override now read the live default, so default changes apply without a restart.
- Update the generated `Throttler` mock accordingly.

### Verification

- Added `TestNamespaceParallelismDefaultUpdate`, which raises the default limit at runtime and asserts a previously throttled workflow (in a namespace without an override) is then admitted.
- Existing throttler tests continue to pass (`go test ./workflow/sync/ -run 'TestNamespaceParallelism'`).

### Documentation

No new configuration key is introduced — `namespaceParallelism` already exists and is documented in the [Workflow Controller ConfigMap](https://argo-workflows.readthedocs.io/en/latest/workflow-controller-configmap/) / [Parallelism](https://argo-workflows.readthedocs.io/en/latest/parallelism/) docs. The user-facing improvement is that changing `namespaceParallelism` now takes effect on ConfigMap reload without a controller restart, matching `parallelism`. Happy to add a note to the parallelism docs clarifying this hot-reload behavior if maintainers prefer.

### AI

Cursor was used to draft the initial change; Qoder (an AI coding assistant) was used to adapt it to the latest main, write the unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hot-reloading configuration now updates the default per-namespace parallelism without restarting the workflow controller.
  - Namespaces without an explicit parallelism override automatically follow the latest configured default.
  - When the default limit changes, previously queued work is re-evaluated and admitted as capacity becomes available.

- **Documentation**
  - Added documentation explaining the live update behavior for namespace parallelism during hot reload.

- **Tests**
  - Added coverage to verify that increasing the default limit unblocks workflows that were previously throttled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
