### PR TITLE
fix(errors): treat gRPC client request timeout as transient

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -124,6 +124,9 @@ func isTransientNetworkErr(err error) bool {
 		return true
 	case strings.Contains(errorString, "http2: server sent GOAWAY and closed the connection"):
 		return true
+	case strings.Contains(errorString, "request did not complete within requested timeout"):
+		// gRPC-go client deadline (often seen from apiserver Create); retry pod create on next reconcile.
+		return true
 	case strings.Contains(errorString, "connect: connection refused"):
 		// If err is connection refused, retry.
 		return true

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -13,6 +13,7 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	argoerrs "github.com/argoproj/argo-workflows/v4/errors"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
 
@@ -117,6 +118,14 @@ func TestIsTransientErr(t *testing.T) {
 	})
 	t.Run("ConnectionRefusedTransientErr", func(t *testing.T) {
 		assert.True(t, IsTransientErr(ctx, connectionRefusedErr))
+	})
+	t.Run("GRPCClientRequestTimeout", func(t *testing.T) {
+		err := errors.New("Timeout: request did not complete within requested timeout")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
+	t.Run("GRPCClientRequestTimeoutInternalWrap", func(t *testing.T) {
+		inner := errors.New("Timeout: request did not complete within requested timeout")
+		assert.True(t, IsTransientErr(ctx, argoerrs.InternalWrapError(inner)))
 	})
 }
 


### PR DESCRIPTION
### Motivation

When the apiserver `Create` (or another client-go request) exceeds the client deadline, gRPC-go / apiserver returns `Timeout: request did not complete within requested timeout`. This is transient and retryable, but `IsTransientErr` did not recognize it, so pod creation failures were wrapped as non-retryable errors and the node was marked `Error` instead of being requeued.

### Modifications

- In `isTransientNetworkErr`, treat the `request did not complete within requested timeout` message as transient so the controller requeues the node.

### Verification

- Added `TestIsTransientErr` subtests for the raw message and for the message wrapped via `errors.InternalWrapError`.
- Existing transient-error tests continue to pass (`go test ./util/errors/ -run 'TestIsTransient'`).

### Documentation

No documentation changes needed — this refines internal transient-error classification with no user-facing behavior or API change.

### AI

Cursor was used to draft the initial change; Qoder (an AI coding assistant) was used to adapt it to the latest main, write the unit tests, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of specific network timeout errors by recognizing them as temporary failures.
  * Enables affected operations to be retried instead of failing immediately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->