### PR TITLE
fix(controller): allow onExit DAG handler to complete under Stop shutdown

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -355,7 +355,7 @@ func (woc *wfOperationCtx) executeDAG(ctx context.Context, nodeName string, tmpl
 
 	// Check if we are still running any tasks in this dag and return early if we do
 	// We should wait for onExit nodes even if ShutdownStrategy is enabled.
-	dagPhase, err := dagCtx.assessDAGPhase(ctx, targetTasks, woc.wf.Status.Nodes, woc.GetShutdownStrategy().Enabled() && onExitCompleted)
+	dagPhase, err := dagCtx.assessDAGPhase(ctx, targetTasks, woc.wf.Status.Nodes, woc.GetShutdownStrategy().Enabled() && onExitCompleted && !dagCtx.onExitTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/workflow/controller/dag_test.go
+++ b/workflow/controller/dag_test.go
@@ -4647,3 +4647,90 @@ spec:
 	assert.Equal(t, wfv1.NodeSucceeded, woc.wf.Status.Nodes[id(fanout)].Phase, "orphaned TaskGroup should be completed from its children")
 	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase, "workflow should complete")
 }
+
+var testOnExitDAGWithShutdownStop = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: dag-onexit-shutdown
+spec:
+  entrypoint: main-dag
+  onExit: exit-dag
+  shutdown: Stop
+  templates:
+  - name: main-dag
+    dag:
+      tasks:
+      - name: main-task
+        template: echo
+  - name: exit-dag
+    dag:
+      tasks:
+      - name: on-exit-handler
+        template: echo
+  - name: echo
+    container:
+      image: alpine:latest
+      command: [echo, hello]
+status:
+  phase: Running
+  startedAt: "2020-05-29T18:11:55Z"
+  nodes:
+    dag-onexit-shutdown:
+      id: dag-onexit-shutdown
+      name: dag-onexit-shutdown
+      displayName: dag-onexit-shutdown
+      type: DAG
+      templateName: main-dag
+      templateScope: local/dag-onexit-shutdown
+      phase: Running
+      startedAt: "2020-05-29T18:11:55Z"
+      children:
+      - dag-onexit-shutdown-1234567890
+      outboundNodes:
+      - dag-onexit-shutdown-1234567890
+    dag-onexit-shutdown-1234567890:
+      id: dag-onexit-shutdown-1234567890
+      name: dag-onexit-shutdown.main-task
+      displayName: main-task
+      type: Pod
+      templateName: echo
+      templateScope: local/dag-onexit-shutdown
+      phase: Succeeded
+      boundaryID: dag-onexit-shutdown
+      startedAt: "2020-05-29T18:11:55Z"
+      finishedAt: "2020-05-29T18:11:58Z"
+      outputs:
+        exitCode: "0"
+`
+
+// TestOnExitDAGNotFailedOnShutdownStop verifies that when a workflow is stopped with
+// shutdownStrategy: Stop, an onExit handler that uses a DAG template is still allowed to
+// run to completion instead of being immediately failed by the shutdown fast-fail path.
+func TestOnExitDAGNotFailedOnShutdownStop(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(testOnExitDAGWithShutdownStop)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	// The onExit DAG should be running, not immediately failed.
+	onExitNode := woc.wf.Status.Nodes.FindByDisplayName("dag-onexit-shutdown.onExit")
+	if assert.NotNil(t, onExitNode, "onExit DAG node should exist") {
+		assert.Equal(t, wfv1.NodeRunning, onExitNode.Phase, "onExit DAG node should be Running, not Failed")
+	}
+
+	// The on-exit-handler pod should have been created (Pending).
+	exitHandlerNode := woc.wf.Status.Nodes.FindByDisplayName("on-exit-handler")
+	if assert.NotNil(t, exitHandlerNode, "on-exit-handler node should exist") {
+		assert.Equal(t, wfv1.NodePending, exitHandlerNode.Phase, "on-exit-handler should be Pending")
+	}
+
+	// Workflow should NOT be completed yet — it should still be Running waiting for the exit handler.
+	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase, "workflow should still be Running while onExit handler is executing")
+}


### PR DESCRIPTION
### Motivation

When a workflow is shut down with `shutdownStrategy: Stop`, its `onExit` handler is expected to still run to completion. However, when the `onExit` handler uses a **DAG** template, `assessDAGPhase` observed the global shutdown flag and immediately returned `NodeFailed`, so the handler was failed before it could run — its pod was never created and cleanup/notification logic in the exit handler was skipped.

### Modifications

- In `executeDAG`, exclude the onExit template DAG from the shutdown fast-fail by adding `!dagCtx.onExitTemplate` to the `isShutdown` argument passed to `assessDAGPhase`.

### Verification

- Added `TestOnExitDAGNotFailedOnShutdownStop`: a workflow with `shutdown: Stop` and a DAG-based `onExit` handler; asserts the onExit DAG node is `Running` (not `Failed`), the handler pod is created (`Pending`), and the workflow stays `Running` while the handler executes.
- Existing DAG tests continue to pass (`go test ./workflow/controller/ -run 'DAG|OnExit'`).

### Documentation

No documentation changes needed — this restores the documented onExit-handler guarantee under `Stop` shutdown for DAG templates, with no new user-facing feature or API.

### AI

Claude was used to draft the initial change; Qoder (an AI coding assistant) was used to adapt it to the latest main, write the unit test, and this description. All changes were reviewed and verified by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow exit handlers using DAGs with a shutdown-stop strategy.
  * Exit-handler DAG nodes now remain active while their handler is executing instead of being marked failed immediately.
  * Workflows correctly remain in a running state until exit handling completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->