### PR TITLE
fix(ui): handle exceptions when retrieving user info

### DIFF
--- a/ui/src/app-router.tsx
+++ b/ui/src/app-router.tsx
@@ -65,10 +65,13 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
         return () => sub.unsubscribe();
     }, [popupManager]);
     useEffect(() => {
-        services.info.getUserInfo().then(userInfo => {
-            nsUtils.setUserNamespace(userInfo.serviceAccountNamespace);
-            setNamespace(nsUtils.getCurrentNamespace());
-        });
+        services.info
+            .getUserInfo()
+            .then(userInfo => {
+                nsUtils.setUserNamespace(userInfo.serviceAccountNamespace);
+                setNamespace(nsUtils.getCurrentNamespace());
+            })
+            .catch(setError);
         services.info
             .getInfo()
             .then(info => {


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->


### Motivation

When logged out, a user's first visit will trigger an 401 error when calling `/api/v1/userinfo`, which redirects them to the login page. However, the 401 causes an uncaught exception to be thrown. In the dev environment, this causes Webpack Dev Server to show a giant "Uncaught runtime errors" overlay, which is causing the tests added in #16398 to fail.
<img width="1286" height="1037" alt="image" src="https://github.com/user-attachments/assets/01c2aaab-4c70-41b6-a51a-ced7cb7fb8c1" />


### Modifications
Add `.catch(setError)`, identical to the `services.info.getInfo()` call below
### Verification

Ran `make start AUTH_MODE=client ` locally and visited http://localhost:8080/ to verify I didn't see the overlay
### Documentation
N/A
### AI

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted user information loading logic without changing behavior or user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->