### PR TITLE
fix(errors): treat client-go response body read failures as transient (cherry-pick #16484 for 4.0)

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -98,13 +99,21 @@ func isTransientEtcdErr(err error) bool {
 }
 
 func isTransientNetworkErr(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
 	switch err.(type) {
 	case *net.DNSError, *net.OpError, net.UnknownNetworkError:
 		return true
 	}
 
 	errorString := generateErrorString(err)
-	if strings.Contains(errorString, "Connection closed by foreign host") {
+	if strings.Contains(errorString, "unexpected error when reading response body") ||
+		strings.Contains(errorString, "stream error when reading response body") {
+		// client-go rest.Request: body read failed mid-response; the message asks to retry.
+		return true
+	} else if strings.Contains(errorString, "Connection closed by foreign host") {
 		// For a URL error, where it replies back "connection closed"
 		// retry again.
 		return true

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -3,6 +3,8 @@ package errors
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -146,5 +148,17 @@ func TestIsTransientUErr(t *testing.T) {
 	})
 	t.Run("EOFUErr", func(t *testing.T) {
 		assert.True(t, IsTransientErr(ctx, EOFUErr))
+	})
+	t.Run("ClientGoResponseBodyReadErr", func(t *testing.T) {
+		err := fmt.Errorf("unexpected error when reading response body. Please retry. Original error: %w", io.ErrUnexpectedEOF)
+		assert.True(t, IsTransientErr(ctx, err))
+	})
+	t.Run("ClientGoUnexpectedResponseBodyReadErr", func(t *testing.T) {
+		err := errors.New("unexpected error when reading response body")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
+	t.Run("ClientGoStreamResponseBodyReadErr", func(t *testing.T) {
+		err := errors.New("stream error when reading response body")
+		assert.True(t, IsTransientErr(ctx, err))
 	})
 }


### PR DESCRIPTION
Cherry-picked fix(errors): treat client-go response body read failures as transient (#16484)