### PR TITLE
fix(controller): treat client-go rate limiter wait deadline as transient (cherry-pick #16485 for 4.0)

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -57,9 +57,18 @@ func isTransientErr(err error) bool {
 		apierr.IsTimeout(err) ||
 		apierr.IsServiceUnavailable(err) ||
 		isTransientEtcdErr(err) ||
+		isClientGoRateLimiterWaitErr(err) ||
 		matchTransientErrPattern(err) ||
 		errors.Is(err, NewErrTransient("")) ||
 		isTransientSqbErr(err)
+}
+
+// isClientGoRateLimiterWaitErr matches client-go's rest.Request error when the
+// client-side QPS limiter blocks until the request context would expire
+// ("rate: Wait(n=1) would exceed context deadline"). This is backpressure, not
+// a terminal failure; the controller should requeue (see createWorkflowPod).
+func isClientGoRateLimiterWaitErr(err error) bool {
+	return strings.Contains(generateErrorString(err), "client rate limiter Wait returned an error")
 }
 
 func matchTransientErrPattern(err error) bool {

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -118,6 +118,10 @@ func TestIsTransientErr(t *testing.T) {
 	t.Run("ConnectionRefusedTransientErr", func(t *testing.T) {
 		assert.True(t, IsTransientErr(ctx, connectionRefusedErr))
 	})
+	t.Run("ClientGoRateLimiterWaitDeadline", func(t *testing.T) {
+		err := errors.New("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
 }
 
 func TestIsTransientUErr(t *testing.T) {


### PR DESCRIPTION
Cherry-picked fix(controller): treat client-go rate limiter wait deadline as transient (#16485)