### PR TITLE
fix: log missing optional output parameter at warn level, not error. Fixes #16395 (cherry-pick #16402 for 3.7)

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -368,7 +368,7 @@ func saveParameter(srcPath string) error {
 	}
 	src, err := os.Open(filepath.Clean(srcPath))
 	if os.IsNotExist(err) { // might be optional, so we ignore
-		logger.WithError(err).Errorf("cannot save parameter %s", srcPath)
+		logger.WithError(err).Warnf("cannot save parameter %s", srcPath)
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
Cherry-picked fix: log missing optional output parameter at warn level, not error. Fixes #16395 (#16402)