### PR TITLE
fix(errors): treat gRPC client request timeout as transient (cherry-pick #16487 for 4.0)

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -146,6 +146,9 @@ func isTransientNetworkErr(err error) bool {
 		return true
 	} else if strings.Contains(errorString, "http2: server sent GOAWAY and closed the connection") {
 		return true
+	} else if strings.Contains(errorString, "request did not complete within requested timeout") {
+		// gRPC-go client deadline (often seen from apiserver Create); retry pod create on next reconcile.
+		return true
 	} else if strings.Contains(errorString, "connect: connection refused") {
 		// If err is connection refused, retry.
 		return true

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -15,6 +15,7 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	argoerrs "github.com/argoproj/argo-workflows/v4/errors"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
 
@@ -119,6 +120,14 @@ func TestIsTransientErr(t *testing.T) {
 	})
 	t.Run("ConnectionRefusedTransientErr", func(t *testing.T) {
 		assert.True(t, IsTransientErr(ctx, connectionRefusedErr))
+	})
+	t.Run("GRPCClientRequestTimeout", func(t *testing.T) {
+		err := errors.New("Timeout: request did not complete within requested timeout")
+		assert.True(t, IsTransientErr(ctx, err))
+	})
+	t.Run("GRPCClientRequestTimeoutInternalWrap", func(t *testing.T) {
+		inner := errors.New("Timeout: request did not complete within requested timeout")
+		assert.True(t, IsTransientErr(ctx, argoerrs.InternalWrapError(inner)))
 	})
 	t.Run("ClientGoRateLimiterWaitDeadline", func(t *testing.T) {
 		err := errors.New("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")


### PR DESCRIPTION
Cherry-picked fix(errors): treat gRPC client request timeout as transient (#16487)