### PR TITLE
fix(errors): treat gRPC client request timeout as transient (cherry-pick #16487 for 3.7)

### DIFF
--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -144,6 +144,9 @@ func isTransientNetworkErr(err error) bool {
 		return true
 	} else if strings.Contains(errorString, "http2: server sent GOAWAY and closed the connection") {
 		return true
+	} else if strings.Contains(errorString, "request did not complete within requested timeout") {
+		// gRPC-go client deadline (often seen from apiserver Create); retry pod create on next reconcile.
+		return true
 	} else if strings.Contains(errorString, "connect: connection refused") {
 		// If err is connection refused, retry.
 		return true

--- a/util/errors/errors_test.go
+++ b/util/errors/errors_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	argoerrs "github.com/argoproj/argo-workflows/v3/errors"
 )
 
 type netError string
@@ -121,6 +123,14 @@ func TestIsTransientErr(t *testing.T) {
 	t.Run("ClientGoRateLimiterWaitDeadline", func(t *testing.T) {
 		err := errors.New("client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline")
 		assert.True(t, IsTransientErr(err))
+	})
+	t.Run("GRPCClientRequestTimeout", func(t *testing.T) {
+		err := errors.New("Timeout: request did not complete within requested timeout")
+		assert.True(t, IsTransientErr(err))
+	})
+	t.Run("GRPCClientRequestTimeoutInternalWrap", func(t *testing.T) {
+		inner := errors.New("Timeout: request did not complete within requested timeout")
+		assert.True(t, IsTransientErr(argoerrs.InternalWrapError(inner)))
 	})
 }
 


### PR DESCRIPTION
Cherry-picked fix(errors): treat gRPC client request timeout as transient (#16487)