### PR TITLE
fix: normalize GCS artifact keys to forward slashes on Windows. Fixes #16470 (cherry-pick #16476 for 3.7)

### DIFF
--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -119,8 +119,18 @@ func (h *ArtifactDriver) Load(inputArtifact *wfv1.Artifact, path string) error {
 	return err
 }
 
+// normalizeGCSKey converts Windows path separators to forward slashes, since GCS object
+// names always use "/" regardless of host OS.
+func normalizeGCSKey(key string) string {
+	if os.PathSeparator == '\\' {
+		return strings.ReplaceAll(key, "\\", "/")
+	}
+	return key
+}
+
 // download all the objects of a key from the bucket
 func downloadObjects(client *storage.Client, bucket, key, path string) error {
+	key = normalizeGCSKey(key)
 	objNames, err := listByPrefix(client, bucket, key, "")
 	if err != nil {
 		return err
@@ -140,11 +150,7 @@ func downloadObjects(client *storage.Client, bucket, key, path string) error {
 
 // download an object from the bucket
 func downloadObject(client *storage.Client, bucket, key, objName, path string) error {
-	objPrefix := filepath.Clean(key)
-	if os.PathSeparator == '\\' {
-		objPrefix = strings.ReplaceAll(objPrefix, "\\", "/")
-	}
-
+	objPrefix := normalizeGCSKey(filepath.Clean(key))
 	relObjPath := strings.TrimPrefix(objName, objPrefix)
 	localPath := filepath.Join(path, relObjPath)
 	objectDir, _ := filepath.Split(localPath)
@@ -274,21 +280,14 @@ func uploadObjects(client *storage.Client, bucket, key, path string) error {
 			return err
 		}
 		for _, relPath := range fileRelPaths {
-			fullKey := keyPrefix + relPath
-			if os.PathSeparator == '\\' {
-				fullKey = strings.ReplaceAll(fullKey, "\\", "/")
-			}
-
+			fullKey := normalizeGCSKey(keyPrefix + relPath)
 			err = uploadObject(client, bucket, fullKey, dirName+relPath)
 			if err != nil {
 				return fmt.Errorf("upload %s: %w", dirName+relPath, err)
 			}
 		}
 	} else {
-		objectKey := filepath.Clean(key)
-		if os.PathSeparator == '\\' {
-			objectKey = strings.ReplaceAll(objectKey, "\\", "/")
-		}
+		objectKey := normalizeGCSKey(filepath.Clean(key))
 		err = uploadObject(client, bucket, objectKey, path)
 		if err != nil {
 			return fmt.Errorf("upload %s: %w", path, err)

--- a/workflow/artifacts/gcs/gcs_test.go
+++ b/workflow/artifacts/gcs/gcs_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"runtime"
 	"testing"
 
 	"google.golang.org/api/googleapi"
@@ -41,6 +42,29 @@ func TestIsTransientGCSErr(t *testing.T) {
 		got := isTransientGCSErr(test.err)
 		if got != test.shouldretry {
 			t.Errorf("%+v: got %v, want %v", test, got, test.shouldretry)
+		}
+	}
+}
+
+func TestNormalizeGCSKey(t *testing.T) {
+	// GCS object names always use "/"; normalizeGCSKey only converts "\" to "/" on
+	// Windows, since "\" is a valid filename character on other OSes.
+	for _, test := range []struct {
+		key      string
+		expected string
+	}{
+		{"utils\\p4", "utils/p4"},
+		{"some\\prefix\\some-file.exe", "some/prefix/some-file.exe"},
+		{"some/prefix/some-file.exe", "some/prefix/some-file.exe"},
+		{"no-separators", "no-separators"},
+	} {
+		expected := test.expected
+		if runtime.GOOS != "windows" {
+			expected = test.key
+		}
+		got := normalizeGCSKey(test.key)
+		if got != expected {
+			t.Errorf("normalizeGCSKey(%q): got %q, want %q", test.key, got, expected)
 		}
 	}
 }

--- a/workflow/sync/sync_manager_multiple_test.go
+++ b/workflow/sync/sync_manager_multiple_test.go
@@ -57,8 +57,10 @@ func setupMultipleLockManagers(t *testing.T, dbType sqldb.DBType, semaphoreSize 
 	// Create a database session for the semaphore
 	info, deferfn, cfg, err := createTestDBSession(t, dbType)
 	deferfn2 := func() {
-		deferfn()
+		// Cancel the context before closing the database session so the
+		// managers' background goroutines stop first.
 		cancel()
+		deferfn()
 	}
 	require.NoError(t, err)
 

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -2064,6 +2064,12 @@ func TestUnconfiguredSemaphores(t *testing.T) {
 				require.NoError(t, err)
 				defer cleanup()
 
+				// Cancel the context before cleanup closes the database session
+				// so the manager's background goroutines stop first (upstream
+				// these tests rely on t.Context() being canceled at test end).
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
 				// Configure sync manager
 				syncManager := createLockManager(ctx, info.session, &syncConfig, nil, func(key string) {
 				}, WorkflowExistenceFunc)


### PR DESCRIPTION
Cherry-picked fix: normalize GCS artifact keys to forward slashes on Windows. Fixes #16470 (#16476)