### PR TITLE
docs: prepare for v4.1.0-rc1

### DIFF
--- a/.features/pending/15636-improve-s3-upload-speed-thread-partsize.md
+++ b/.features/pending/15636-improve-s3-upload-speed-thread-partsize.md
@@ -3,6 +3,6 @@ Authors: [Antoine Tran](https://github.com/antoinetran)
 Component: General
 Issues: 15636
 
-By default, the S3 upload code is configured with 4 threads and no fix part size. The part size is dynamically set by MinIO depending on the max number of chunks and file size, but generally it is 16MiB (for file size <= 156GiB).
+By default, the S3 upload code is configured with 4 threads and no fixed part size. The part size is dynamically set by MinIO depending on the max number of chunks and file size, but generally it is 16MiB (for file size <= 156GiB).
 
 The feature will allow setting the number of threads and part size with env var ARTIFACT_S3_UPLOAD_THREADS and ARTIFACT_S3_UPLOAD_PART_SIZE_MIB.

--- a/.features/pending/archive-cli.md
+++ b/.features/pending/archive-cli.md
@@ -4,5 +4,5 @@ Component: CLI
 Issues: 15199 
 
 This change allows for `archive` related cli commands to use the workflow name
-instead of relying upon the uid. This is explicitly a user experience related improvement.
+instead of relying upon the uid. This is explicitly a user-experience-related improvement.
 Note that if your name itself is a uid, you will have to manually force to fetch via uid or name, see the documentation for more detail.

--- a/.features/pending/azure-postgres-entra-auth.md
+++ b/.features/pending/azure-postgres-entra-auth.md
@@ -1,7 +1,7 @@
 Description: Support for Azure PostgreSQL/Entra ID authentication
 Authors: [isubasinghe](https://github.com/isubasinghe)
 Component: General
-Issues: 123456
+Issues: 15530
 
 Add support for authenticating to Azure Database for PostgreSQL using Azure AD (Entra ID) tokens.
 This allows Argo Workflows to use Azure Workload Identity or Managed Identity to connect to its persistence database, removing the need for long-lived database passwords.

--- a/.features/pending/disable-agent-pod.md
+++ b/.features/pending/disable-agent-pod.md
@@ -3,4 +3,4 @@ Authors: [Gaurang Mishra](https://github.com/gaurang9991)
 Component: General
 Issues: 7891
 
-Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by exeternal controllers or agents. User should be careful using this, when enabled it stop creating default agent pods for HTTP templates.
+Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by external controllers or agents. User should be careful using this, when enabled it stop creating default agent pods for HTTP templates.

--- a/.features/pending/disable-agent-pod.md
+++ b/.features/pending/disable-agent-pod.md
@@ -3,4 +3,4 @@ Authors: [Gaurang Mishra](https://github.com/gaurang9991)
 Component: General
 Issues: 7891
 
-Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by external controllers or agents. User should be careful using this, when enabled it stop creating default agent pods for HTTP templates.
+Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by external controllers or agents. Users should be careful when using this: when enabled, it stops creating default agent pods for HTTP templates.

--- a/.features/pending/input-artifact-upload.md
+++ b/.features/pending/input-artifact-upload.md
@@ -15,7 +15,7 @@ This feature works with all supported artifact repositories (S3, GCS, Azure Blob
 Uploaded files are written under the `uploads/{namespace}/{uuid}/{filename}` key in the artifact
 repository before the workflow is submitted. The maximum accepted upload size is controlled by the
 `ARGO_SERVER_MAX_ARTIFACT_UPLOAD_BYTES` environment variable on the Argo Server (default `1073741824`,
-i.e. 1GiB); requests over this size receive `413 Request Entity Too Large`.
+i.e., 1 GiB); requests over this size receive `413 Request Entity Too Large`.
 
 Abandoned uploads (never submitted) rely on operator-configured bucket lifecycle under
 `uploads/{namespace}/`; see [Configuring Your Artifact Repository](configure-artifact-repository.md#abandoned-upload-cleanup).

--- a/.features/pending/wf-label-workflowTemplateRef.md
+++ b/.features/pending/wf-label-workflowTemplateRef.md
@@ -3,4 +3,4 @@ Authors: [Eduardo Rodrigues](https://github.com/eduardodbr)
 Component: General
 Issues: 12670
 
-When a `Workflow` or a `CronWorkflow` is submitted from a `WorkflowTemplate` or `ClusterWorkflowTemplate` ( i.e. using the `workflowTemplateRef`) it stores the the `WorkflowTemplate` name as a label.
+When a `Workflow` or a `CronWorkflow` is submitted from a `WorkflowTemplate` or `ClusterWorkflowTemplate` ( i.e. using the `workflowTemplateRef`) it stores the `WorkflowTemplate` name as a label.

--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -1,171 +1,179 @@
-# New features in v4.0.0 (2026-02-04)
+# New features in v4.1.0 (2026-07-22)
 
 This is a concise list of new features.
 
 ## General
 
-- Name filter parameter for prefix/contains/exact search in `/archived-workflows` by [Armin Friedl](https://github.com/arminfriedl) ([#14069](https://github.com/argoproj/argo-workflows/issues/14069))
-  A new `nameFilter` parameter was added to the `GET
-  /archived-workflows` endpoint. The filter works analogous to the one
-  in `GET /workflows`. It allows to specify how a search for
-  `?listOptions.fieldSelector=metadata.name=<search-string>` in these
-  endpoints should be interpreted. Possible values are `Prefix`,
-  `Contains` and `Exact`. The `metadata.name` field is matched
-  accordingly against the value for `<search-string>`.
+- Add Optional Argo Workflow–Level Configuration for Executor Plugins by [ntny](https://github.com/ntny) ([#15234](https://github.com/argoproj/argo-workflows/issues/15234))
+  This PR allows configuring the Argo Workflow Executor Plugin for a specific Argo Workflow directly within the Workflow spec.
+  Enable this with the `ARGO_WORKFLOW_LEVEL_EXECUTOR_PLUGINS=true` controller environment variable.
+  Workflow-level executor plugin settings take precedence over globally configured executor plugins.
+  See `docs/executor_plugins.md` for configuration details and examples.
 
-- Artifact Drivers as plugins by [Alan Clucas](https://github.com/Joibel), [JP Zivalich](https://github.com/JPZ13), [Elliot Gunton](https://github.com/elliotgunton) ([#5862](https://github.com/argoproj/argo-workflows/issues/5862))
-  Artifact Drivers can now be added via a plugin mechanism.
-  You can write a GRPC server which acts as an artifact driver to upload and download artifacts to a repository, and supply that as a container image.
-  Argo workflows can then use that as a driver.
+- improve S3 upload speed with customization of S3 upload threads / partsize by [Antoine Tran](https://github.com/antoinetran) ([#15636](https://github.com/argoproj/argo-workflows/issues/15636))
+  By default, the S3 upload code is configured with 4 threads and no fix part size. The part size is dynamically set by MinIO depending on the max number of chunks and file size, but generally it is 16MiB (for file size <= 156GiB).
+  The feature will allow setting the number of threads and part size with env var ARTIFACT_S3_UPLOAD_THREADS and ARTIFACT_S3_UPLOAD_PART_SIZE_MIB.
 
-- Support update total parallelism without restart controller. by [Shuangkun Tian](https://github.com/shuangkun) ([#14689](https://github.com/argoproj/argo-workflows/issues/14689))
-  When modify the global parallelism in workflow-controller-configmap, the change takes effect directly without restarting the controller.
+- add a streaming save path to artifact drivers, including gRPC streaming for plugins by [panicboat](https://github.com/panicboat) ([#12656](https://github.com/argoproj/argo-workflows/issues/12656))
+  Artifact drivers can now save an output artifact from an `io.Reader` via a new `SaveStream` method, in addition to saving from a local file path.
+  Azure and HTTP/Artifactory stream the reader directly to the destination.
+  S3, GCS, OSS, and HDFS buffer the reader to a temp file and reuse their existing save path, so bucket creation, key handling, and retries are unchanged.
+  Streaming an HTTP artifact directly cannot follow a 307/308 redirect (e.g. webHDFS), because a one-shot reader cannot be replayed for the redirected request. Set `saveStreamViaFile: true` on the HTTP artifact to buffer the stream to a temp file first, which restores redirect support at the cost of the extra buffering.
+  Artifact plugins gain an optional client-streaming `SaveStream` gRPC method plus a `GetCapabilities` method.
+  A plugin that advertises support receives the artifact content chunk by chunk with no intermediate temp file.
+  A plugin that does not implement these methods keeps working unchanged: Argo buffers the content to a temp file and calls the existing `Save`, so this is backward compatible.
 
-- Added CRD validation rules by [Alan Clucas](https://github.com/Joibel ([#13503](https://github.com/argoproj/argo-workflows/issues/13503))
-  Added some validation rules to the full CRDs which allow some simpler validation to happen as the object is added to the kubernetes cluster.
-  This is useful if you're using a mechanism which bypasses the validator such as kubectl apply.
-  It will inform you of
-  **Note:** Some validations cannot be implemented as CEL rules due to Kubernetes limitations.
-  Fields marked with `+kubebuilder:validation:Schemaless` (like `withItems`) or `+kubebuilder:pruning:PreserveUnknownFields` (like `inline`) are not visible to CEL validation expressions.
-  **CEL Budget Management:** Kubernetes limits the total cost of CEL validation rules per CRD. To stay within these limits:
-      - All `status` blocks have CEL validations automatically stripped during CRD generation
-      - Controller-managed CRDs (WorkflowTaskSet, WorkflowTaskResult, WorkflowArtifactGCTask) have all CEL validations removed from both spec and status
-      - Server-side validations in `workflow/validate/validate.go` supplement CEL for fields that cannot be validated with CEL (e.g., schemaless fields)
-  **Array and String Size Limits:** To manage CEL validation costs, the following maximum sizes are enforced:
-      - Templates per workflow: 200
-      - DAG tasks per DAG template: 200
-      - Parameters: 500
-      - Prometheus metrics per template: 100
-      - Gauge metric value string: 256 characters
-  **Mutual Exclusivity Rules:**
-      - only one template type per template
-      - only one of sequence count/end
-      - only one of manifest/manifestFrom
-      - cannot use both depends and dependencies in DAG tasks.
-  **DAG Task Constraints:**
-      - task names cannot start with digit when using depends/dependencies
-      - cannot use continueOn with depends.
-  **Timeout on Non-Leaf Templates:**
-      - Timeout cannot be set on steps or dag templates (only on leaf templates).
-  **Cron Schedule Format:**
-      - CronWorkflow schedules must be valid 5-field cron expressions, specialdescriptors (@yearly, @hourly, etc.), or interval format (@every).
-  **Metric Validation:**
-      - metric and label names validation
-      - help and value fields required
-      - real-time gauges cannot use resourcesDuration metrics
-  **Artifact:**
-      - At most one artifact location may be specified
-      - Artifact.Mode must be between 0 and 511 (0777 octal) for file permissions.
-  **Enum Validations:**
-      - PodGC strategy
-      - ConcurrencyPolicy
-      - RetryPolicy
-      - GaugeOperation
-      - Resource action
-      - MergeStrategy
-        all have restricted allowed values.
-  **Name Pattern Constraints:**
-      - Template/Step/Task names: max 128 chars, pattern `^[a-zA-Z0-9][-a-zA-Z0-9]*$;`
-      - Parameter/Artifact names: pattern `^[a-zA-Z0-9_][-a-zA-Z0-9_]*$.`
-  **Minimum Array Sizes:**
-      - Template.Steps requires at least one step group
-      - Parameter.Enum requires at least one value
-      - CronWorkflow.Schedules requires at least one schedule
-      - DAG.Tasks requires at least one task.
-  **Numeric Constraints:**
-      - Parallelism minimum 1
-      - StartingDeadlineSeconds minimum 0.
+- Support for AWS RDS PostgreSQL IAM authentication by [isubasinghe](https://github.com/isubasinghe) ([#15834](https://github.com/argoproj/argo-workflows/issues/15834))
+  Add support for authenticating to AWS RDS PostgreSQL using IAM authentication tokens.
+  This allows Argo Workflows to use IAM roles to connect to its persistence database, removing the need for long-lived database passwords.
+    - Uses the default AWS credential chain for seamless authentication in AWS environments.
+    - Supports optional region override (auto-detected if omitted).
+    - Integrates with both persistence and synchronization database configurations.
 
-- Allow custom CA certificate configuration for SSO OIDC provider connections by [bradfordwagner](https://github.com/bradfordwagner) ([#7198](https://github.com/argoproj/argo-workflows/issues/7198))
-  This feature adds support for custom TLS configuration when connecting to OIDC providers for SSO authentication.
-  This is particularly useful when your OIDC provider uses self-signed certificates or custom Certificate Authorities (CAs).
-      - Use this feature when your OIDC provider uses custom self-signed CA certificates
-      - Configure custom CA certificates either inline or by file path
-  **Configuration Examples**
-  **Inline PEM content**
-      sso:
-        # Custom PEM encoded CA certificate file contents
-        rootCA: |-
-          -----BEGIN CERTIFICATE-----
-          MIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-          ...
-          -----END CERTIFICATE-----
-  The system will automatically use certificates configured with SSL_CERT_DIR, and SSL_CERT_FILE for non macOS environments.
-  For production environments, always use proper CA certificates instead of skipping TLS verification.
+- Support for Azure PostgreSQL/Entra ID authentication by [isubasinghe](https://github.com/isubasinghe) ([#15530](https://github.com/argoproj/argo-workflows/issues/15530))
+  Add support for authenticating to Azure Database for PostgreSQL using Azure AD (Entra ID) tokens.
+  This allows Argo Workflows to use Azure Workload Identity or Managed Identity to connect to its persistence database, removing the need for long-lived database passwords.
+    - Uses `DefaultAzureCredential` for seamless authentication in Azure environments.
+    - Supports configurable token scopes.
+    - Integrates with both persistence and synchronization database configurations.
 
-- Deprecate singular in favour of plural items by [Alan Clucas](https://github.com/Joibel) ([#14977](https://github.com/argoproj/argo-workflows/issues/14977))
-  Deprecation: remove singular `mutex`, `semaphore` and `schedule` from the specs, all were replaced by the plural version in 3.6
+- Allow for configuring the allow list when using workflow template refs. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#16345](https://github.com/argoproj/argo-workflows/issues/16345))
+  When the controller runs with `templateReferencing: Strict` or `Secure`, workflows using a `workflowTemplateRef` may only set an allow-listed set of `WorkflowSpec` fields (`arguments`, `entrypoint`, `suspend`, and other benign knobs); every other field is blocked so a submitter cannot override the template's security settings.
+  The `WORKFLOW_USER_OVERRIDE_ALLOWLIST` environment variable lets operators add fields to this allow-list.
+  Set it on the workflow-controller to a comma-separated list of `WorkflowSpec` field names, using the YAML/JSON names as written in a workflow, for example `WORKFLOW_USER_OVERRIDE_ALLOWLIST=podSpecPatch,volumes`.
+  Use this when your environment has decided a normally-blocked field is safe for submitters to override.
+  An unknown field name fails the controller at startup rather than being silently ignored, surfacing typos.
+  The nested `artifactGC.podSpecPatch`, `artifactGC.serviceAccountName`, and `artifactGC.podMetadata` fields remain blocked and are not relaxed by this variable.
 
-- Disable write back informer by default by [Eduardo Rodrigues](https://github.com/eduardodbr) ([#12352](https://github.com/argoproj/argo-workflows/issues/12352))
-  Update the controller’s default behavior to disable the write-back informer. We’ve seen several cases of unexpected behavior that appear to be caused by the write-back mechanism, and Kubernetes docs recommend avoiding writes to the informer store. Although turning it off may increase the frequency of 409 Conflict errors, it should help reduce unpredictable controller behavior.
+- Configurable node status compression algorithm (gzip, zstd, or brotli) and level by [Isitha Subasinghe](https://github.com/isubasinghe) ([#16262](https://github.com/argoproj/argo-workflows/issues/16262))
+  Large workflow node statuses can now be compressed with `zstd` or `brotli` instead of gzip via the `WORKFLOW_COMPRESSION_ALGORITHM` environment variable, with `WORKFLOW_COMPRESSION_LEVEL` tuning the level.
+  Decompression auto-detects the algorithm.
+  See [node status compression](offloading-large-workflows.md#node-status-compression).
 
-- This migrates most of the logging off logrus and onto a custom logger. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120))
-  Currently it is quite hard to identify log lines with it's corresponding
-  workflow. This change propagates a context object down the call hierarchy
-  containing an annotated logging object. This allows context aware logging from
-  deep within the codebase.
+- Disable agent pod creation for plugins by [Gaurang Mishra](https://github.com/gaurang9991) ([#7891](https://github.com/argoproj/argo-workflows/issues/7891))
+  Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by external controllers or agents. User should be careful using this, when enabled it stop creating default agent pods for HTTP templates.
 
-- Support metadata.name= and metadata.name!= in field selectors by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
-  Field selectors for `metadata.name` now support the `==` and `!=` operators, giving you more flexible control over resource filtering.
-  Use the `==` operator to match resources with an exact name, or use `!=` to exclude resources by name.
-  This brings field selector behavior in line with native Kubernetes functionality and enables more precise resource queries.
+- Reconnect and retry queries by [Isitha Subasinghe](https://github.com/isubasinghe) ([#15011](https://github.com/argoproj/argo-workflows/issues/15011))
+  Queries against the database are now retried where a network connection issue was the cause of failure, this
+  is done through reconnecting first.
 
-- Restart pods that fail before starting by [Alan Clucas](https://github.com/Joibel) ([#12572](https://github.com/argoproj/argo-workflows/issues/12572))
-  Automatically restart pods that fail before starting for reasons like node eviction.
-  This is safe to do even for non-idempotent workloads.
-  You need to configure this in your workflow controller configmap for it to take effect.
+- Hot-reload namespaceParallelism from the controller ConfigMap by [shuangkun](https://github.com/shuangkun) ([#16490](https://github.com/argoproj/argo-workflows/issues/16490))
+  Changes to `namespaceParallelism` in the workflow controller ConfigMap now take effect on reload without restarting the controller, matching the existing `parallelism` behavior.
+  Namespaces without an explicit parallelism label override track the live default.
 
-- Removal of logrus and more structured logging by [Alan Clucas](https://github.com/Joibel) ([#11120](https://github.com/argoproj/argo-workflows/issues/11120), [#2308](https://github.com/argoproj/argo-workflows/issues/2308))
-  Complete context passing so all logs should have correct context and enable remaining logs to be fully structured logs.
+- Opt-in pod layout that removes the `argoexec init` container by [Alan Clucas](https://github.com/Joibel) ([#16154](https://github.com/argoproj/argo-workflows/issues/16154))
+  New controller-wide `initlessPod` mode (workflow controller ConfigMap) that eliminates the `argoexec init` container. Beta: off by default and may change in incompatible ways in future minor releases before being promoted to stable.
+  The `argoexec` binary is mounted into `main` via a Kubernetes image volume (KEP-4639 — Beta in K8s 1.33 behind a feature gate, GA in 1.36), and a new `supervisor` container handles template write, script staging, input artifact download, readiness signaling, and the post-main responsibilities previously held by `wait`.
+  Artifact plugins run as regular sidecars invoked by `supervisor` for both Load and Save instead of as init containers, so pods run with zero init containers.
+  Off by default; `wait` and the legacy pod layout remain unchanged.
+  Enable by setting `initlessPod.enabled: true` in the workflow controller ConfigMap — every subsequently scheduled workflow pod uses the init-less layout.
+  Rollback by setting it back to `false`; in-flight pods keep their original layout.
+
+- Add `!=` and `==` operators for namespace field selector by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
+  You can now use the `!=` and `==` operators when filtering workflows by namespace field.
+  This provides more flexible query capabilities, allowing you to easily exclude specific namespaces or match exact namespace values in your workflow queries.
+  For example, you can filter with `namespace!=kube-system` to exclude system namespaces or `namespace==production` to target only production environments.
+
+- Add pendingTimeout field to templates for setting maximum time in pending status. by [Dennis Lawler](https://github.com/drawlerr) ([#10341](https://github.com/argoproj/argo-workflows/issues/10341))
+  Adds a new `pendingTimeout` field to workflow templates that allows setting a maximum duration a pod can spend in Pending status.
+  This is useful when pods may be stuck pending due to resource constraints, scheduling issues, or node availability.
+  Unlike the existing `timeout` field which covers the entire node lifecycle, `pendingTimeout` specifically targets the pending phase.
+  Enforcement is performed by the controller based on its most recently observed pod state, so it is approximate: a pod that
+  starts running at almost exactly the moment the pending deadline expires may still be failed and deleted. When the timeout
+  fires, the node is marked Failed and the pending pod is deleted to free the resources it was waiting on.
+
+- Pod-level resource requests and limits for workflow pods by [Isitha Subasinghe](https://github.com/isubasinghe) ([#16399](https://github.com/argoproj/argo-workflows/issues/16399))
+  Workflow pods can now set [pod-level resource requests and limits](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/) via the new `podResources` field, available at the workflow spec level and the template level.
+  Template-level `podResources` overrides the workflow-level value.
+  This lets you set a single resource budget shared by all containers in a pod (main, init, wait and sidecars) instead of sizing each container individually.
+  Requires the `PodLevelResources` feature gate to be enabled on the cluster (beta and on by default since Kubernetes v1.34).
+  If the feature gate is disabled, the API server strips the field and the controller emits a `PodLevelResourcesDropped` warning event on the workflow.
+
+- S3 virtual-hosted-style bucket addressing by [Himesh Panchal](https://github.com/himeshp) ([#10851](https://github.com/argoproj/argo-workflows/issues/10851))
+  S3 artifact storage now supports configuring the bucket addressing style via the `addressingStyle` field.
+  Valid values are `""` (auto-detect, default), `"path"` (force path-style), and `"virtual-hosted"` (force virtual-hosted-style).
+  This fixes broken log streaming and artifact browsing for S3-compatible providers that only support virtual-hosted-style addressing.
+
+- Workflow Tracing by [Alan Clucas](https://github.com/Joibel) ([#12077](https://github.com/argoproj/argo-workflows/issues/12077))
+  Argo Workflows can now emit OpenTelemetry traces, letting you see exactly what's happening inside a workflow run -- from controller reconciliation down to individual artifact uploads and log saves. Traces follow execution across the controller and executor processes, so you get a single span tree covering DAG node scheduling, pod creation, synchronization locks, script capture, and everything in between. If your workloads also emit OTel traces, they'll show up nested in the right place. Configure the tracing section in your workflow-controller-configmap with a collector URL and point your Jaeger or Tempo instance at it.
+
+- Add WorkflowTemplate name as label when using workflowTemplateRef by [Eduardo Rodrigues](https://github.com/eduardodbr) ([#12670](https://github.com/argoproj/argo-workflows/issues/12670))
+  When a `Workflow` or a `CronWorkflow` is submitted from a `WorkflowTemplate` or `ClusterWorkflowTemplate` ( i.e. using the `workflowTemplateRef`) it stores the `WorkflowTemplate` name as a label.
 
 ## UI
 
-- Add an informational message to the CronWorkflow delete confirmation modal indicating that Workflows created by the CronSchedule will also be deleted. by [minsun yun](https://github.com/miinsun) ([#14679](https://github.com/argoproj/argo-workflows/issues/14679))
-  UI/UX only; **no functional logic** is changed
-  Verified manually by deleting a CronWorkflow in the Workflows UI and confirming the message renders correctly
+- Allow setting the namespace when submitting a `ClusterWorkflowTemplate` by [Mason Malone](https://github.com/MasonM) ([#10398](https://github.com/argoproj/argo-workflows/issues/10398))
+  You can now specify the namespace when submitting a workflow from a `ClusterWorkflowTemplate` using an input field on the "Submit Workflow" panel.
 
-- Add label query parameter sync with URL in WorkflowTemplates UI to match Workflows list behavior for consistent filtering. by [puretension](https://github.com/puretension) ([#14807](https://github.com/argoproj/argo-workflows/issues/14807))
-  WorkflowTemplates UI now properly handles label query parameters (e.g., ?label=key%3Dvalue)
-  Combined URL updates and localStorage persistence in single useEffect
-  Enables custom UI links for filtered template views
-  Verified that URL updates when changing filters and filters persist on page refresh
+- Upload input artifacts when submitting workflows from the UI by [panicboat](https://github.com/panicboat) ([#12656](https://github.com/argoproj/argo-workflows/issues/12656))
+  When a WorkflowTemplate defines input artifacts in `spec.arguments.artifacts`, users can now upload files directly from the UI when submitting the workflow.
+  Previously, users had to manually upload files to the artifact repository, know the exact key path, and hard-code the key in the WorkflowTemplate.
+  Now, users can simply select a file in the submit dialog.
+  The system will upload the file to the artifact repository via the Argo Server, automatically override the artifact key with the uploaded file's location, and submit the workflow with the correct artifact configuration.
+  This feature works with all supported artifact repositories (S3, GCS, Azure Blob Storage, OSS, HDFS).
+  Uploaded files are written under the `uploads/{namespace}/{uuid}/{filename}` key in the artifact
+  repository before the workflow is submitted. The maximum accepted upload size is controlled by the
+  `ARGO_SERVER_MAX_ARTIFACT_UPLOAD_BYTES` environment variable on the Argo Server (default `1073741824`,
+  i.e. 1GiB); requests over this size receive `413 Request Entity Too Large`.
+  Abandoned uploads (never submitted) rely on operator-configured bucket lifecycle under
+  `uploads/{namespace}/`; see [Configuring Your Artifact Repository](configure-artifact-repository.md#abandoned-upload-cleanup).
 
-- Name Not Equals filter now available in the UI for filtering workflows by [Miltiadis Alexis](https://github.com/miltalex) ([#13468](https://github.com/argoproj/argo-workflows/issues/13468))
-  You can now use the "Name Not Equals" filter in the workflow list to exclude workflows by name.
-  This complements the existing "Name Exact" filter and provides more flexible filtering options.
-  Use this filter when you want to view all workflows except those matching a specific name pattern.
+- Add markdown rendering support to Tooltip component. by [panicboat](https://github.com/panicboat) ([#13936](https://github.com/argoproj/argo-workflows/issues/13936))
+  Tooltip now renders markdown content, supporting links, formatting, and line breaks.
 
-- Support open custom links in new tab automatically. by [Shuangkun Tian](https://github.com/shuangkun) ([#13114](https://github.com/argoproj/argo-workflows/issues/13114))
-  Support configuring a custom link to open in a new tab by default.
-  If `target == _blank`, open in new tab, if target is null or `_self`, open in this tab. For example:
-      - name: Pod Link
-        scope: pod
-        target: _blank
-        url: http://logging-facility?namespace=${metadata.namespace}&podName=${metadata.name}&startedAt=${status.startedAt}&finishedAt=${status.finishedAt}
+- Autocomplete the Namespace filter from the namespaces of resources currently visible on the page by [Morgan Allen](https://github.com/callmemorgan) ([#7405](https://github.com/argoproj/argo-workflows/issues/7405))
+  The Namespace filter on the workflows, workflow templates, cron workflows, sensors, event sources, event bindings, and event flow pages now autocompletes from the namespaces of resources already loaded for that page, in addition to the existing localStorage history.
+  When the user is viewing resources across multiple namespaces (cluster-wide mode), the namespace filter dropdown now lists the namespaces present on the current page and narrows as you type. No new server endpoint or RBAC is involved — suggestions are derived from data the user already has permission to see.
+  The managed-namespace short-circuit (where the filter renders as plain text) is unchanged.
 
-- Optimize pagination performance when counting workflows in archive. by [Shuangkun Tian](https://github.com/shuangkun) ([#13948](https://github.com/argoproj/argo-workflows/issues/13948))
-  When querying archived workflows with pagination, the system now uses more efficient methods to check if there are more items available. Instead of performing expensive full table scans, the new implementation uses LIMIT queries to check if there are items beyond the current offset+limit, significantly improving performance for large datasets.
+- Show full tag value on hover in TagsInput by [nakatani-yo](https://github.com/nakatani-yo) ([#16096](https://github.com/argoproj/argo-workflows/issues/16096))
+  Hovering over truncated tags now shows the full value.
 
 ## CLI
 
-- Add support for creating a configmap semaphore config using CLI by [Darko Janjic](https://github.com/djanjic) ([#14671](https://github.com/argoproj/argo-workflows/issues/14671))
-  Allow user to create a configmap semaphore configuration using CLI
+- Extend client TLS certificate support in server mode by [Miltiadis Alexis](https://github.com/miltalex) ([#13437](https://github.com/argoproj/argo-workflows/issues/13437))
+  Use `--client-certificate` and `--client-key` when an Argo Server or its proxy requires mutual TLS authentication.
+  Both flags must be provided together.
+  Use `--certificate-authority` to trust the certificate authority that signed the server certificate.
+  The certificates are used by the gRPC and HTTP/1 clients, including artifact downloads with `argo cp`.
+  For example, run `argo --argo-server argo.example.com:443 --secure --certificate-authority ca.crt --client-certificate client.crt --client-key client.key list`.
+  In server mode, client certificates and certificate authorities embedded in a kubeconfig context are not used automatically.
+  Pass the three flags explicitly when connecting through Argo Server.
+  The flags do not have `ARGO_*` environment variable equivalents.
 
-- `convert` CLI command to convert to new workflow format by [Alan Clucas](https://github.com/Joibel) ([#14977](https://github.com/argoproj/argo-workflows/issues/14977))
-  A new CLI command `convert` which will convert Workflows, CronWorkflows, and (Cluster)WorkflowTemplates to the new format.
-  It will remove `schedule` from CronWorkflows, moving that into `schedules`
-  It will remove `mutex` and `semaphore` from `synchronization` blocks and move them to the plural version.
-  Otherwise this command works much the same as linting.
+- Allow archive cli commands to use workflow name instead of uid. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#15199](https://github.com/argoproj/argo-workflows/issues/15199))
+  This change allows for `archive` related cli commands to use the workflow name
+  instead of relying upon the uid. This is explicitly a user experience related improvement.
+  Note that if your name itself is a uid, you will have to manually force to fetch via uid or name, see the documentation for more detail.
 
-- Add support for creating a database semaphore config using CLI by [Darko Janjic](https://github.com/djanjic) ([#14783](https://github.com/argoproj/argo-workflows/issues/14783))
-  Allow user to create a database semaphore configuration using CLI
+- Add HTTP proxy support to Argo CLI by [Shimako55](https://github.com/shimako55) ([#10794](https://github.com/argoproj/argo-workflows/issues/10794))
+  Add `--proxy-url` flag to Argo CLI commands to support HTTP proxy connections.
+  This allows users to connect to Argo Server or Kubernetes API through a corporate proxy or network gateway.
+  Works with both Argo Server mode and Kubernetes API mode.
+  If `--proxy-url` is not specified, the CLI will respect the standard `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
+
+## Telemetry
+
+- Metrics to observe mutex and semaphore locks, so users can detect unreleased locks that are blocking workflows by [Jason Meridth](https://github.com/jmeridth) [Alan Clucas](https://github.com/Joibel) ([#14888](https://github.com/argoproj/argo-workflows/issues/14888))
+  The controller now emits telemetry for synchronization locks (mutexes and semaphores), letting you detect unreleased locks that are causing workflow blocks or timeouts.
+  Three metrics are exposed, each labelled by `type` (`mutex` or `semaphore`), `storage` (`configmap` or `database`), `lock_name` and `namespace`:
+    - `locks_taken_total` — a counter of how many locks have been acquired, for throughput and churn (`rate()`).
+    - `locks_held` — a gauge of how many holders currently hold each lock right now.
+    - `locks_pending` — a gauge of how many workflows are currently waiting to acquire each lock.
+  For database-backed locks (which are shared across controllers and clusters) each controller reports only its own contribution, using a single per-controller aggregate query per scrape.
+
+- Add metrics for the rate limiter by [Alan Clucas](https://github.com/Joibel) ([#15245](https://github.com/argoproj/argo-workflows/issues/15245))
+  Add two rate limiter metrics to help us understand the effects:
+    - the k8s API client rate limiter (enabled by default and set quite low, configurable via --qps)
+    - and the resource rate limiter configured in the configmap and disabled by default.
+  These produce histogram metrics
 
 ## Build and Development
 
-- Document features as they are created by [Alan Clucas](https://github.com/Joibel) ([#14155](https://github.com/argoproj/argo-workflows/issues/14155))
-  To assist with creating release documentation and blog postings, all features now require a document in .features/pending explaining what they do for users.
-
-- Support plural "Authors:" field in feature notes by " field in feature notes ([#14155](https://github.com/argoproj/argo-workflows/issues/14155))
-  The featuregen tool now uses the plural "Authors:" field instead of "Author:" for new feature notes.
-  This better reflects that features can have multiple authors.
-  The change maintains full backwards compatibility with existing feature files that use the singular "Author:" field.
+- PR readiness helper bot guides contributors through fixing CI failures by [Alan Clucas](https://github.com/Joibel) ([#16231](https://github.com/argoproj/argo-workflows/issues/16231))
+  A bot now helps contributors get their PRs ready for review.
+  When CI completes on a PR it maintains a single comment listing the contributor-fixable problems — lint, codegen, UI, build, docs, PR title format, missing feature files, DCO sign-off and an unfilled PR description — each with the command to fix it.
+  PRs with blocking problems are moved to draft; mark the PR ready for review again once they are fixed.
+  The comment updates as checks change and shows all-clear when everything contributor-fixable is resolved.
+  Unit and E2E test results are not covered by the bot.
+  Maintainers can tune the covered checks and guidance in `.github/pr-readiness/checks.config.json`.

--- a/docs/new-features.md
+++ b/docs/new-features.md
@@ -11,7 +11,7 @@ This is a concise list of new features.
   See `docs/executor_plugins.md` for configuration details and examples.
 
 - improve S3 upload speed with customization of S3 upload threads / partsize by [Antoine Tran](https://github.com/antoinetran) ([#15636](https://github.com/argoproj/argo-workflows/issues/15636))
-  By default, the S3 upload code is configured with 4 threads and no fix part size. The part size is dynamically set by MinIO depending on the max number of chunks and file size, but generally it is 16MiB (for file size <= 156GiB).
+  By default, the S3 upload code is configured with 4 threads and no fixed part size. The part size is dynamically set by MinIO depending on the max number of chunks and file size, but generally it is 16MiB (for file size <= 156GiB).
   The feature will allow setting the number of threads and part size with env var ARTIFACT_S3_UPLOAD_THREADS and ARTIFACT_S3_UPLOAD_PART_SIZE_MIB.
 
 - add a streaming save path to artifact drivers, including gRPC streaming for plugins by [panicboat](https://github.com/panicboat) ([#12656](https://github.com/argoproj/argo-workflows/issues/12656))
@@ -51,7 +51,7 @@ This is a concise list of new features.
   See [node status compression](offloading-large-workflows.md#node-status-compression).
 
 - Disable agent pod creation for plugins by [Gaurang Mishra](https://github.com/gaurang9991) ([#7891](https://github.com/argoproj/argo-workflows/issues/7891))
-  Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by external controllers or agents. User should be careful using this, when enabled it stop creating default agent pods for HTTP templates.
+  Allow users to disable agent pod creation for plugins. Workflow Controller watches the task sets updated by external controllers or agents. Users should be careful when using this: when enabled, it stops creating default agent pods for HTTP templates.
 
 - Reconnect and retry queries by [Isitha Subasinghe](https://github.com/isubasinghe) ([#15011](https://github.com/argoproj/argo-workflows/issues/15011))
   Queries against the database are now retried where a network connection issue was the cause of failure, this
@@ -114,7 +114,7 @@ This is a concise list of new features.
   Uploaded files are written under the `uploads/{namespace}/{uuid}/{filename}` key in the artifact
   repository before the workflow is submitted. The maximum accepted upload size is controlled by the
   `ARGO_SERVER_MAX_ARTIFACT_UPLOAD_BYTES` environment variable on the Argo Server (default `1073741824`,
-  i.e. 1GiB); requests over this size receive `413 Request Entity Too Large`.
+  i.e., 1 GiB); requests over this size receive `413 Request Entity Too Large`.
   Abandoned uploads (never submitted) rely on operator-configured bucket lifecycle under
   `uploads/{namespace}/`; see [Configuring Your Artifact Repository](configure-artifact-repository.md#abandoned-upload-cleanup).
 
@@ -143,7 +143,7 @@ This is a concise list of new features.
 
 - Allow archive cli commands to use workflow name instead of uid. by [Isitha Subasinghe](https://github.com/isubasinghe) ([#15199](https://github.com/argoproj/argo-workflows/issues/15199))
   This change allows for `archive` related cli commands to use the workflow name
-  instead of relying upon the uid. This is explicitly a user experience related improvement.
+  instead of relying upon the uid. This is explicitly a user-experience-related improvement.
   Note that if your name itself is a uid, you will have to manually force to fetch via uid or name, see the documentation for more detail.
 
 - Add HTTP proxy support to Argo CLI by [Shimako55](https://github.com/shimako55) ([#10794](https://github.com/argoproj/argo-workflows/issues/10794))

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,15 @@ the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summar
 
 ## Upgrading to v4.1
 
+### `argo archive` commands accept a workflow name as well as a UID
+
+The `argo archive get`, `delete`, `resubmit` and `retry` commands previously took a workflow UID as their argument.
+They now accept either a workflow name or a UID ([#15198](https://github.com/argoproj/argo-workflows/pull/15198)).
+An argument that matches the UUID format is treated as a UID; anything else is treated as a name, resolved within the selected namespace.
+If multiple archived workflows share the name, the command fails and lists the matching UIDs.
+You can force the interpretation with the new `--uid` or `--name` flags, for example if a workflow's name is itself formatted as a UUID.
+Existing scripts that pass UIDs continue to work unchanged.
+
 ### INFORMER_WRITE_BACK environment variable removed
 
 The `INFORMER_WRITE_BACK` environment variable has been removed.

--- a/ui/src/modals/new-version-modal.tsx
+++ b/ui/src/modals/new-version-modal.tsx
@@ -23,7 +23,7 @@ export function NewVersionModal({version, dismiss}: {version: string; dismiss: (
                 <li>Faster pod startup with an opt-in initless pod layout</li>
                 <li>Workflow-level executor plugin configuration</li>
                 <li>Artifact uploads, faster S3 uploads, and S3 virtual-hosted-style addressing</li>
-                <li>Database IAM authentication for AWS RDS and Azure Entra ID</li>
+                <li>Database authentication via AWS RDS IAM and Azure PostgreSQL Entra ID</li>
                 <li>
                     Pod-level{' '}
                     <a href='https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/' target='_blank' rel='noreferrer'>

--- a/ui/src/modals/new-version-modal.tsx
+++ b/ui/src/modals/new-version-modal.tsx
@@ -17,6 +17,25 @@ export function NewVersionModal({version, dismiss}: {version: string; dismiss: (
             <h4 className='new-version-modal-title'>
                 It looks like <b>{version}</b> has just been installed!
             </h4>
+            <h5>v4.1</h5>
+            <ul className='new-version-modal-bullets'>
+                <li>Workflow tracing with OpenTelemetry spans</li>
+                <li>Faster pod startup with an opt-in initless pod layout</li>
+                <li>Artifact uploads, faster S3 uploads, and S3 virtual-hosted-style addressing</li>
+                <li>Database IAM authentication for AWS RDS and Azure Entra ID</li>
+                <li>
+                    Pod-level{' '}
+                    <a href='https://kubernetes.io/docs/tasks/configure-pod-container/assign-pod-level-resources/' target='_blank' rel='noreferrer'>
+                        resource requests and limits
+                    </a>{' '}
+                    via <code>podResources</code>
+                </li>
+            </ul>
+            <p>
+                <a href='https://argo-workflows.readthedocs.io/en/release-4.1/new-features/?utm_source=argo-ui' target='_blank' rel='noreferrer'>
+                    See the list of changes
+                </a>
+            </p>
             <h5>v4.0</h5>
             <ul className='new-version-modal-bullets'>
                 <li>Artifact drivers as plugins</li>

--- a/ui/src/modals/new-version-modal.tsx
+++ b/ui/src/modals/new-version-modal.tsx
@@ -21,6 +21,7 @@ export function NewVersionModal({version, dismiss}: {version: string; dismiss: (
             <ul className='new-version-modal-bullets'>
                 <li>Workflow tracing with OpenTelemetry spans</li>
                 <li>Faster pod startup with an opt-in initless pod layout</li>
+                <li>Workflow-level executor plugin configuration</li>
                 <li>Artifact uploads, faster S3 uploads, and S3 virtual-hosted-style addressing</li>
                 <li>Database IAM authentication for AWS RDS and Azure Entra ID</li>
                 <li>


### PR DESCRIPTION
### Motivation

Release preparation for v4.1.0-rc1, per [the release instructions](https://argo-workflows.readthedocs.io/en/latest/releasing/).

### Modifications

- Ran `featuregen update --version v4.1.0` (`make features-update`) to regenerate `docs/new-features.md` from the 28 pending feature files. Features stay in `.features/pending/` until the final 4.1.0 release.
- Documented the `argo archive` name/UID breaking change (#15198) in the v4.1 section of `docs/upgrading.md`.
- Added a v4.1 section to the UI new-version modal.
- Fixed a placeholder issue number (`#123456` → #15530) in the Azure Entra feature file, and two typos in other pending feature files.

### Verification

- `markdownlint` passes on `docs/new-features.md` and `docs/upgrading.md`.
- `eslint`/prettier pass on `ui/src/modals/new-version-modal.tsx`.
- `go test ./hack/featuregen` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6wZnuGGYdsWCyCK5vYEbo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated v4.1 release notes with expanded coverage across workflow management, artifact handling & streaming, authentication, UI/CLI improvements, telemetry, and build/development.
  * Expanded “Upgrading to v4.1” for `argo archive` to accept workflow name or UID, with `--name`/`--uid` for clarity.
  * Refined pending feature notes (S3 upload speed defaults/env overrides, archive CLI name support, input upload size wording, and several documentation wording fixes).
* **New Features**
  * Updated the in-app version modal to add a “v4.1” highlights section with a link to the full change list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->