### PR TITLE
fix: prevent panic in ParseProgress on input without a slash

### DIFF
--- a/pkg/apis/workflow/v1alpha1/progress.go
+++ b/pkg/apis/workflow/v1alpha1/progress.go
@@ -21,7 +21,14 @@ func ParseProgress(s string) (Progress, bool) {
 }
 
 func (in Progress) parts() []string {
-	return strings.SplitN(string(in), "/", 2)
+	parts := strings.SplitN(string(in), "/", 2)
+	if len(parts) < 2 {
+		// Input without a "/" separator is malformed. Pad the missing
+		// denominator so N()/M() never index out of range; IsValid() then
+		// rejects it because M() is 0.
+		return []string{parts[0], ""}
+	}
+	return parts
 }
 
 func (in Progress) N() int64 {

--- a/pkg/apis/workflow/v1alpha1/progress.go
+++ b/pkg/apis/workflow/v1alpha1/progress.go
@@ -20,23 +20,21 @@ func ParseProgress(s string) (Progress, bool) {
 	return v, v.IsValid()
 }
 
-func (in Progress) parts() []string {
-	parts := strings.SplitN(string(in), "/", 2)
-	if len(parts) < 2 {
-		// Input without a "/" separator is malformed. Pad the missing
-		// denominator so N()/M() never index out of range; IsValid() then
-		// rejects it because M() is 0.
-		return []string{parts[0], ""}
-	}
-	return parts
+func (in Progress) parts() (string, string) {
+	// Input without a "/" separator is malformed: m stays empty, so M()
+	// returns 0 and IsValid() rejects it.
+	n, m, _ := strings.Cut(string(in), "/")
+	return n, m
 }
 
 func (in Progress) N() int64 {
-	return parseInt64(in.parts()[0])
+	n, _ := in.parts()
+	return parseInt64(n)
 }
 
 func (in Progress) M() int64 {
-	return parseInt64(in.parts()[1])
+	_, m := in.parts()
+	return parseInt64(m)
 }
 
 func (in Progress) Add(x Progress) Progress {

--- a/pkg/apis/workflow/v1alpha1/progress_test.go
+++ b/pkg/apis/workflow/v1alpha1/progress_test.go
@@ -10,12 +10,15 @@ func TestProgress(t *testing.T) {
 	t.Run("ParseProgress", func(t *testing.T) {
 		_, ok := ParseProgress("")
 		assert.False(t, ok)
+		_, ok = ParseProgress("5")
+		assert.False(t, ok)
 		progress, ok := ParseProgress("0/1")
 		assert.True(t, ok)
 		assert.Equal(t, Progress("0/1"), progress)
 	})
 	t.Run("IsValid", func(t *testing.T) {
 		assert.False(t, Progress("").IsValid())
+		assert.False(t, Progress("5").IsValid())
 		assert.False(t, Progress("/0").IsValid())
 		assert.False(t, Progress("0/").IsValid())
 		assert.False(t, Progress("0/0").IsValid())


### PR DESCRIPTION
## Motivation

`ParseProgress` panics with `runtime error: index out of range [1] with length 1` when given a string that contains no `/`, e.g. `ParseProgress("5")`. It is meant to return `(_, false)` for invalid input, and it is called on untrusted data:

- `workflow/executor/executor.go` parses the last line of a user-written progress file.
- `workflow/controller/workflowpod.go` parses a pod annotation value.

So a workflow that writes a progress line without a `/` (`5`, `done`, …) crashes the progress-watching goroutine.

The cause: `parts()` uses `strings.SplitN(s, "/", 2)`, which returns a length-1 slice when there is no separator. `IsValid()` then calls `M()` → `parts()[1]`, indexing out of range. The existing tests only cover invalid inputs that *contain* a slash (`/0`, `0/`, `0/0`, `1/0`), so the no-slash path was never exercised.

## Modifications

`parts()` now pads a missing denominator to `""` so `N()`/`M()` never index out of range. `IsValid()` then rejects such input because `M()` is `0` (`in.M() > 0` is false), keeping the intended "invalid → false" contract with no panic.

## Verification

`ParseProgress("5")` now returns `ok == false`. Added `"5"` cases to both `ParseProgress` and `IsValid` sub-tests in `progress_test.go`. `go test ./pkg/apis/workflow/v1alpha1/` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed progress values that omit the `/` separator.
  * Progress parsing and validation now safely reject incomplete values, such as `"5"`.

* **Tests**
  * Expanded coverage to verify incomplete progress strings fail parsing and are not considered valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->