### PR TITLE
fix(server): return InvalidArgument for nil request bodies instead of panicking. Fixes #13190

### DIFF
--- a/server/clusterworkflowtemplate/cluster_workflow_template_server.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server.go
@@ -111,6 +111,9 @@ func (cwts *Server) DeleteClusterWorkflowTemplate(ctx context.Context, req *clus
 }
 
 func (cwts *Server) LintClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateLintRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
+	if req.Template == nil {
+		return nil, serverutils.ToStatusError(fmt.Errorf("cluster workflow template was not found in the request body"), codes.InvalidArgument)
+	}
 	cwts.instanceIDService.Label(req.Template)
 	creator.LabelCreator(ctx, req.Template)
 	cwftmplGetter := cwts.cwftmplStore.Getter(ctx)

--- a/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -287,6 +289,12 @@ func TestWorkflowTemplateServer_LintClusterWorkflowTemplate(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "message", resp.Spec.Arguments.Parameters[0].Name)
 		assert.Nil(t, resp.Spec.Arguments.Parameters[0].Value)
+	})
+
+	t.Run("Nil template", func(t *testing.T) {
+		_, err := server.LintClusterWorkflowTemplate(ctx, &clusterwftmplpkg.ClusterWorkflowTemplateLintRequest{})
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 }
 

--- a/server/cronworkflow/cron_workflow_server.go
+++ b/server/cronworkflow/cron_workflow_server.go
@@ -33,6 +33,9 @@ func NewCronWorkflowServer(instanceIDService instanceid.Service, wftmplStore ser
 }
 
 func (c *cronWorkflowServiceServer) LintCronWorkflow(ctx context.Context, req *cronworkflowpkg.LintCronWorkflowRequest) (*v1alpha1.CronWorkflow, error) {
+	if req.CronWorkflow == nil {
+		return nil, sutils.ToStatusError(fmt.Errorf("cron workflow was not found in the request body"), codes.InvalidArgument)
+	}
 	wftmplGetter := c.wftmplStore.Getter(ctx, req.Namespace)
 	cwftmplGetter := c.cwftmplStore.Getter(ctx)
 	c.instanceIDService.Label(req.CronWorkflow)
@@ -86,6 +89,9 @@ func (c *cronWorkflowServiceServer) GetCronWorkflow(ctx context.Context, req *cr
 }
 
 func (c *cronWorkflowServiceServer) UpdateCronWorkflow(ctx context.Context, req *cronworkflowpkg.UpdateCronWorkflowRequest) (*v1alpha1.CronWorkflow, error) {
+	if req.CronWorkflow == nil {
+		return nil, sutils.ToStatusError(fmt.Errorf("cron workflow was not found in the request body"), codes.InvalidArgument)
+	}
 	_, err := c.getCronWorkflowAndValidate(ctx, req.Namespace, req.CronWorkflow.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)

--- a/server/cronworkflow/cron_workflow_server_test.go
+++ b/server/cronworkflow/cron_workflow_server_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	cronworkflowpkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/cronworkflow"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
@@ -85,6 +87,11 @@ metadata:
 		assert.Contains(t, wf.Labels, common.LabelKeyCreator)
 		assert.Equal(t, userEmailLabel, wf.Labels[common.LabelKeyCreatorEmail])
 	})
+	t.Run("LintWorkflowWithNilBody", func(t *testing.T) {
+		_, err := server.LintCronWorkflow(ctx, &cronworkflowpkg.LintCronWorkflowRequest{Namespace: "my-ns"})
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
 	t.Run("ListCronWorkflows", func(t *testing.T) {
 		cronWfs, err := server.ListCronWorkflows(ctx, &cronworkflowpkg.ListCronWorkflowsRequest{Namespace: "my-ns"})
 		require.NoError(t, err)
@@ -102,6 +109,11 @@ metadata:
 		})
 	})
 	t.Run("UpdateCronWorkflow", func(t *testing.T) {
+		t.Run("NilBody", func(t *testing.T) {
+			_, err := server.UpdateCronWorkflow(ctx, &cronworkflowpkg.UpdateCronWorkflowRequest{Namespace: "my-ns"})
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
 		t.Run("Invalid", func(t *testing.T) {
 			x := cronWf.DeepCopy()
 			x.Spec.Schedules = []string{"invalid"}

--- a/server/workflowtemplate/workflow_template_server.go
+++ b/server/workflowtemplate/workflow_template_server.go
@@ -184,6 +184,9 @@ func (wts *Server) DeleteWorkflowTemplate(ctx context.Context, req *workflowtemp
 }
 
 func (wts *Server) LintWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateLintRequest) (*v1alpha1.WorkflowTemplate, error) {
+	if req.Template == nil {
+		return nil, sutils.ToStatusError(fmt.Errorf("workflow template was not found in the request body"), codes.InvalidArgument)
+	}
 	wts.instanceIDService.Label(req.Template)
 	creator.LabelCreator(ctx, req.Template)
 	wftmplGetter := wts.wftmplStore.Getter(ctx, req.Namespace)

--- a/server/workflowtemplate/workflow_template_server_test.go
+++ b/server/workflowtemplate/workflow_template_server_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -287,11 +289,18 @@ func TestWorkflowTemplateServer_DeleteWorkflowTemplate(t *testing.T) {
 
 func TestWorkflowTemplateServer_LintWorkflowTemplate(t *testing.T) {
 	server, ctx := getWorkflowTemplateServer(t)
-	tmpl, err := server.LintWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateLintRequest{
-		Template: &v1alpha1.WorkflowTemplate{},
+	t.Run("Labelled", func(t *testing.T) {
+		tmpl, err := server.LintWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateLintRequest{
+			Template: &v1alpha1.WorkflowTemplate{},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, tmpl.Labels, common.LabelKeyControllerInstanceID)
 	})
-	require.NoError(t, err)
-	assert.Contains(t, tmpl.Labels, common.LabelKeyControllerInstanceID)
+	t.Run("Nil template", func(t *testing.T) {
+		_, err := server.LintWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateLintRequest{Namespace: "default"})
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
 }
 
 func TestWorkflowTemplateServer_UpdateWorkflowTemplate(t *testing.T) {


### PR DESCRIPTION
Fixes #13190

### Motivation

A `POST` to `/api/v1/workflow-templates/{namespace}/lint` whose JSON body omits the `{"template": ...}` wrapper (e.g. posting a bare `WorkflowTemplate` manifest) leaves `req.Template` as `nil`. `LintWorkflowTemplate` then calls `instanceIDService.Label(req.Template)`, which dereferences the nil pointer and the server responds with:

```json
{
  "code": 13,
  "message": "runtime error: invalid memory address or nil pointer dereference"
}
```

As diagnosed in #13190, this malformed request should get a 400 (`InvalidArgument`) error rather than a recovered panic / code 13 (`Internal`). The `Create`/`Update` handlers for workflow templates already guard against a nil body; the lint handlers (and one cron workflow handler) were missed.

### Modifications

Added the same nil-body guard that `CreateWorkflowTemplate`, `UpdateWorkflowTemplate`, `CreateCronWorkflow`, `CreateWorkflow` and `LintWorkflow` already use to the remaining handlers that dereference the request body without checking it:

- `server/workflowtemplate/workflow_template_server.go`: `LintWorkflowTemplate` (the endpoint reported in #13190)
- `server/clusterworkflowtemplate/cluster_workflow_template_server.go`: `LintClusterWorkflowTemplate`
- `server/cronworkflow/cron_workflow_server.go`: `LintCronWorkflow`, and `UpdateCronWorkflow` (which dereferenced `req.CronWorkflow.Name` before any nil check)

Each guard returns `sutils.ToStatusError(..., codes.InvalidArgument)`, matching the existing guards' error message style, so the HTTP API returns a 400 instead of crashing.

Added unit tests for all four handlers; each test panics without the fix.

This supersedes the stale #13868 (inactive since November 2024, per the [PR takeover process](https://github.com/argoproj/argo-workflows/blob/main/docs/CONTRIBUTING.md#pr-author-timeliness)), which covered only the `LintWorkflowTemplate` endpoint and had no tests. Credit to @tooptoop4 for the original PR and to @agilgur5 for the in-issue diagnosis.

An alternative suggested in the issue was annotating the protobufs with `[(google.api.field_behavior) = REQUIRED]`. grpc-gateway only uses that annotation to mark fields as required in the generated OpenAPI spec; it does not generate runtime enforcement, so explicit nil checks (the codebase's existing convention) are still needed.

### Verification

Unit tests (the new subtests fail with a nil pointer panic without the fix):

```
go test ./server/workflowtemplate/ ./server/clusterworkflowtemplate/ ./server/cronworkflow/ -count=1
ok  	github.com/argoproj/argo-workflows/v4/server/workflowtemplate
ok  	github.com/argoproj/argo-workflows/v4/server/clusterworkflowtemplate
ok  	github.com/argoproj/argo-workflows/v4/server/cronworkflow
```

Also passes with `-race`, and `golangci-lint run` on the three changed packages reports 0 issues.

### Documentation

No documentation changes needed: this fixes the error code returned for malformed requests; the API schema already documents the required `template`/`cronWorkflow` wrapper fields.

### AI

Claude Code was used to help prepare this PR (locating the affected code paths, writing the fix, tests, and this description). All changes were reviewed, tested, and verified by the author.

### AI

This PR (code, tests, and description) was prepared with AI assistance (Claude Code). I have reviewed, tested, and take responsibility for all changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear `InvalidArgument` errors when lint or update requests are missing their workflow payload.
  * Prevented invalid requests from causing unexpected behavior during workflow validation.
  * Preserved successful linting and labeling for valid workflow templates.

* **Tests**
  * Added coverage for missing request bodies across workflow, template, cluster template, and cron workflow operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->