### PR TITLE
feat: Retry initial DB connection with backoff to avoid startup flapping. Fixes #8797

### DIFF
--- a/.features/pending/db-startup-connection-retry.md
+++ b/.features/pending/db-startup-connection-retry.md
@@ -1,0 +1,8 @@
+Description: Retry the initial database connection with backoff instead of crash-looping while the database starts up
+Author: [Jojin](https://github.com/jojinkb)
+Component: General
+Issues: 8797
+
+The workflow controller and argo-server previously exited immediately when the persistence database was not yet reachable at startup, causing them to "flap" (restart repeatedly) while waiting for PostgreSQL or MySQL to come up.
+The initial database connection is now retried with backoff using the same policy as reconnections, configurable via `persistence.reconnectionConfig`.
+Non-transient errors, such as invalid configuration or credentials, still fail fast.

--- a/util/sqldb/session.go
+++ b/util/sqldb/session.go
@@ -117,7 +117,11 @@ func NewSessionProxy(ctx context.Context, config SessionProxyConfig) (*SessionPr
 		proxy.retryMultiple = 1.0
 	}
 
-	if err := proxy.connect(ctx); err != nil {
+	// Establish the initial connection with the same retry and backoff policy
+	// as reconnections, so that components don't crash-loop ("flap") while the
+	// database is still starting up. Non-transient errors (e.g. bad
+	// configuration or credentials) still fail fast.
+	if err := proxy.Reconnect(ctx); err != nil {
 		return nil, fmt.Errorf("failed to create initial database session: %w", err)
 	}
 
@@ -190,6 +194,8 @@ func (sp *SessionProxy) connect(ctx context.Context) error {
 
 	err = sess.Ping()
 	if err != nil {
+		// Close the unusable session so retries don't leak connection pools.
+		sess.Close()
 		return err
 	}
 	sp.closed = false

--- a/util/sqldb/session_test.go
+++ b/util/sqldb/session_test.go
@@ -2,6 +2,7 @@ package sqldb
 
 import (
 	"context"
+	"net"
 	"net/netip"
 	"runtime"
 	"testing"
@@ -129,4 +130,72 @@ func TestSessionReconnect(t *testing.T) {
 	assert.Equal(t, cfg.PostgreSQL.Port, newDBConfig.PostgreSQL.Port)
 	<-doneChan
 	cancel()
+}
+
+// TestNewSessionProxyInitialConnection verifies that the initial connection is
+// retried with backoff when the database is not yet reachable, so components
+// don't crash-loop while waiting for the database to start.
+// https://github.com/argoproj/argo-workflows/issues/8797
+func TestNewSessionProxyInitialConnection(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	t.Run("retries transient connection errors with backoff", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows reports refused connections with a different error (\"connectex: ...actively refused it\") that isNetworkError does not classify as transient")
+		}
+
+		// Reserve a port with no listener so connection attempts are refused.
+		listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := listener.Addr().(*net.TCPAddr).Port
+		require.NoError(t, listener.Close())
+
+		start := time.Now()
+		_, err = NewSessionProxy(ctx, SessionProxyConfig{
+			DBConfig: config.DBConfig{
+				DBReconnectConfig: &config.DBReconnectConfig{
+					MaxRetries:    2,
+					RetryMultiple: 2.0,
+				},
+				PostgreSQL: &config.PostgreSQLConfig{
+					DatabaseConfig: config.DatabaseConfig{
+						Database: dbName,
+						Host:     "127.0.0.1",
+						Port:     port,
+					},
+				},
+			},
+			Username: userName,
+			Password: password,
+		})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "connection refused")
+		// With the default 100ms base delay, maxRetries=2 and retryMultiple=2.0,
+		// the proxy waits 200ms and then 400ms between the three attempts.
+		assert.GreaterOrEqual(t, elapsed, 500*time.Millisecond)
+	})
+
+	t.Run("does not retry non-transient errors", func(t *testing.T) {
+		start := time.Now()
+		_, err := NewSessionProxy(ctx, SessionProxyConfig{
+			// No database is configured, which is not a network error.
+			DBConfig: config.DBConfig{
+				DBReconnectConfig: &config.DBReconnectConfig{
+					MaxRetries:       3,
+					BaseDelaySeconds: 5,
+				},
+			},
+			Username: userName,
+			Password: password,
+		})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no databases are configured")
+		// The first retry would only happen after a multi-second delay, so a
+		// fast failure proves the error was not retried.
+		assert.Less(t, elapsed, 5*time.Second)
+	})
 }


### PR DESCRIPTION
Fixes #8797

### Motivation

When persistence (workflow archive / node status offload / DB-backed sync) is configured, the workflow controller and argo-server exit immediately if the database is not yet reachable at startup. In environments where the components start alongside PostgreSQL/MySQL (e.g. the quickstart manifests), both components "flap" — restarting several times under CrashLoopBackOff — until the database comes up, which slows down the startup of the system as a whole.

#15006 added `SessionProxy` with retry-and-backoff for connections that drop *at runtime*, but the *initial* connection in `NewSessionProxy` was still a single attempt that failed fast, so the startup flapping described in #8797 remained.

### Modifications

- `NewSessionProxy` now establishes the initial connection via the existing `Reconnect` retry loop instead of a single `connect` call. This reuses the exact same backoff policy, transient-error detection, and context cancellation handling as runtime reconnections, and is tunable through the existing `persistence.reconnectionConfig` settings (`maxRetries`, `baseDelaySeconds`, `maxDelaySeconds`, `retryMultiple`) — no new configuration is introduced. Non-transient errors (e.g. missing secrets, invalid configuration, bad credentials) are not retried and still fail fast, exactly as in the runtime reconnect path.
- `SessionProxy.connect` now closes the freshly created session when the initial `Ping` fails, so repeated connection attempts don't leak connection pools (previously each failed attempt leaked an open `*sql.DB`).
- Added a `.features` description file.

With the defaults (5 retries, 100ms base delay, 2.0 multiple) a component now retries internally for ~3s before exiting; if the database takes longer, Kubernetes restarts remain the outer retry loop, but the number of restarts is reduced and operators can extend the window via `reconnectionConfig` without any code change.

### Verification

- New unit test `TestNewSessionProxyInitialConnection` in `util/sqldb`:
  - `retries transient connection errors with backoff`: points the proxy at a port with no listener ("connection refused") with `maxRetries: 2` and asserts the elapsed time covers the expected backoff sleeps (200ms + 400ms). This test fails on `main` (fails after a single attempt in <1ms) and passes with this change. It is skipped on Windows (same pattern as `TestSessionReconnect`) because Windows reports refused connections with a different error (`connectex: ... actively refused it`) that `isNetworkError` does not classify as transient.
  - `does not retry non-transient errors`: asserts a configuration error ("no databases are configured") fails fast without retries.
- Existing `TestSessionReconnect` (testcontainers, PostgreSQL) passes: `go test ./util/sqldb/ -run TestSessionReconnect -count=1` → PASS (40s).
- `go test ./util/sqldb/ -count=1` passes locally in ~43s (Docker required for the testcontainers-based tests).
- `go vet ./util/sqldb/` clean for both the host platform and `GOOS=windows`.
- `golangci-lint run ./util/sqldb/...` → 0 issues.

### Documentation

Added `.features/pending/db-startup-connection-retry.md` describing the behavior change. No new configuration options were added; the behavior is governed by the already-documented `persistence.reconnectionConfig` settings.

### AI

This PR was prepared with the assistance of Claude Code (Anthropic Claude). All changes and tests were reviewed, verified, and are understood by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup database connections now retry temporary connectivity failures with configurable backoff.
  * Services no longer exit immediately when the persistence database is briefly unavailable.
  * Invalid configuration and credential errors continue to fail fast.
  * Improved cleanup prevents unusable database connections from being retained during retries.

* **Documentation**
  * Documented startup connection retry behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->