### PR TITLE
ci: run Docs CI on release branches and use Python 3.14

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
     branches:
       - main
-      - release/*
+      - release-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: 3.9
+          python-version: "3.14"
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ formats: all
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.14"
   commands:
     - pip install -r docs/requirements.txt
     - properdocs build -d $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## Motivation

The Docs workflow's `pull_request` filter matched `release/*`, but release branches are named `release-*`, so docs CI has never run on PRs targeting release branches. This let #16534 and #16536 merge unchecked: they bump `pymdown-extensions` to v11, which requires Python >=3.10, while the docs CI job pins Python 3.9 — the same bump on `main` (#16532) is failing docs CI for exactly this reason.

## Modifications

- Fix the `pull_request` branch filter: `release/*` → `release-*`, and add `release-*` to the `push` trigger to match `ci-build.yaml`.
- Bump Python from 3.9 (EOL since October 2025) to 3.14 in both docs CI and `.readthedocs.yml`, keeping CI and the production Read the Docs build on the same interpreter. The whole docs toolchain (pymdown-extensions 11, properdocs 1.6.7, mkdocs-material 9, RTD build tools) supports 3.14.

## Verification

Read the Docs already builds these docs successfully with pymdown-extensions 11 on Python 3.12; 3.14 is within every dependency's declared support range. The docs job on this PR exercises the new Python version directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018juwnvT4EzBAp8xohQMBbD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation builds to use Python 3.14.
  * Documentation workflows now run for the main branch and release branches using the updated branch pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->