### PR TITLE
ci: run Docs CI on release branches and use Python 3.14 (release-4.0)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - main
+      - release-*
   pull_request:
     branches:
       - main
-      - release/*
+      - release-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: 3.9
+          python-version: "3.14"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: "1.25"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,4 +9,4 @@ python:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.14"


### PR DESCRIPTION
## Motivation

The Docs workflow's `pull_request` filter matched `release/*`, but release branches are named `release-*`, so docs CI has never run on PRs targeting release branches. This let #16534 and #16536 merge unchecked: they bump `pymdown-extensions` to v11, which requires Python >=3.10, while the docs CI job pins Python 3.9 — the same bump on `main` (#16532) is failing docs CI for exactly this reason.

## Modifications

- Fix the `pull_request` branch filter: `release/*` → `release-*`, and add `release-*` to the `push` trigger to match `ci-build.yaml`.
- Bump Python from 3.9 (EOL since October 2025) to 3.14 in both docs CI and `.readthedocs.yml`, keeping CI and the production Read the Docs build on the same interpreter. The whole docs toolchain (pymdown-extensions 11, properdocs 1.6.7, mkdocs-material 9, RTD build tools) supports 3.14.

## Verification

Read the Docs already builds these docs successfully with pymdown-extensions 11 on Python 3.12; 3.14 is within every dependency's declared support range. The docs job on this PR exercises the new Python version directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018juwnvT4EzBAp8xohQMBbD