### PR TITLE
docs: document IAM-based database authentication for PostgreSQL

### DIFF
--- a/docs/synchronization-config.md
+++ b/docs/synchronization-config.md
@@ -34,6 +34,8 @@ Before you can manage database limits via the API, you must:
 1. Configure a PostgreSQL, MySQL, or MariaDB database for synchronization (see [workflow synchronization](synchronization.md#database-configuration))
 2. Enable the synchronization API in your workflow controller configuration
 
+For PostgreSQL, the database connection supports [IAM-based authentication](workflow-archive.md#iam-based-authentication) with Microsoft Entra ID or AWS RDS IAM tokens instead of a static password.
+
 ### Enable the API
 
 Add this configuration to your [workflow-controller-configmap.yaml](workflow-controller-configmap.yaml):

--- a/docs/workflow-archive.md
+++ b/docs/workflow-archive.md
@@ -37,9 +37,8 @@ Example:
 
     kubectl create secret generic argo-postgres-config -n argo --from-literal=password=mypassword --from-literal=username=argodbuser
 
-Note that IAM-based authentication is not currently supported. However, you can start your database proxy as a sidecar
-(e.g. via [CloudSQL Proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy) on GCP) and then specify your local
-proxy address, IAM username, and an empty string as your password in the persistence configuration to connect to it.
+Instead of a static password, you can authenticate to some managed PostgreSQL services with short-lived tokens.
+See [IAM-based Authentication](#iam-based-authentication).
 
 The following tables will be created in the database when you start the workflow controller with enabled archive:
 
@@ -47,6 +46,68 @@ The following tables will be created in the database when you start the workflow
 * `argo_archived_workflows`
 * `argo_archived_workflows_labels`
 * `schema_history`
+
+## IAM-based Authentication
+
+> v4.1 and after
+
+For PostgreSQL, the controller can authenticate to the database with short-lived cloud IAM tokens instead of a static password.
+Use this to avoid storing long-lived database passwords in Kubernetes secrets.
+When token authentication is enabled the `passwordSecret` is not used, but you must still provide a `userNameSecret` containing the database user that is mapped to your cloud identity.
+Only one token mechanism can be enabled at a time.
+
+These options are part of the shared database configuration, so they also apply to the databases used for [synchronization](synchronization.md#database-configuration) and [node status offloading](offloading-large-workflows.md).
+
+### Microsoft Entra ID on Azure
+
+To connect to an Azure Database for PostgreSQL using [Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-azure-ad-authentication), enable `azureToken`:
+
+    persistence:
+      archive: true
+      postgresql:
+        host: example.postgres.database.azure.com
+        port: 5432
+        database: postgres
+        tableName: argo_workflows
+        ssl: true
+        sslMode: require
+        userNameSecret:
+          name: argo-postgres-config
+          key: username
+        azureToken:
+          enabled: true
+
+The controller requests a token for each new database connection using the default Azure credential chain, which supports Workload Identity, Managed Identity and other standard mechanisms.
+The token scope defaults to `https://ossrdbms-aad.database.windows.net/.default` and can be overridden with `azureToken.scope`.
+
+### AWS RDS IAM
+
+To connect to an AWS RDS for PostgreSQL database using [IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.html), enable `awsRDSToken`:
+
+    persistence:
+      archive: true
+      postgresql:
+        host: example.eu-west-1.rds.amazonaws.com
+        port: 5432
+        database: postgres
+        tableName: argo_workflows
+        ssl: true
+        userNameSecret:
+          name: argo-postgres-config
+          key: username
+        awsRDSToken:
+          enabled: true
+          region: eu-west-1
+
+The controller requests an IAM authentication token for each new database connection using the default AWS credential chain, which supports IAM Roles for Service Accounts (IRSA), instance profiles and other standard mechanisms.
+The `region` field is optional and is auto-detected from the environment if omitted.
+You must enable SSL with `ssl: true` to use AWS RDS IAM authentication.
+
+### Other providers
+
+For providers without direct support, you can start your database proxy as a sidecar
+(e.g. via [CloudSQL Proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy) on GCP) and then specify your local
+proxy address, IAM username, and an empty string as your password in the persistence configuration to connect to it.
 
 ## Automatic Database Migration
 


### PR DESCRIPTION
### Motivation

As noted in https://github.com/argoproj/argo-workflows/issues/16529#issuecomment-5062069347, `workflow-archive.md` still said IAM-based authentication is not supported, but v4.1 added Microsoft Entra ID token authentication (#15511) and AWS RDS IAM token authentication (#15833) for PostgreSQL.

### Modifications

- `docs/workflow-archive.md`: replaced the outdated paragraph with a new "IAM-based Authentication" section (`> v4.1 and after`) documenting `azureToken` and `awsRDSToken` with working examples, the constraints from the implementation (`userNameSecret` still required, `passwordSecret` unused, mechanisms mutually exclusive, AWS requires `ssl: true`), and retaining the proxy sidecar guidance for other providers.
- `docs/synchronization-config.md`: noted that the synchronization database connection supports the same token authentication, linking to the new section.

### Verification

Docs-only change. `typos`, `cspell` and `markdownlint` all pass on the modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qrP84Jkb31xa434Dw4aFh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using short-lived IAM tokens to authenticate PostgreSQL connections instead of static passwords.
  - Documented Microsoft Entra ID and AWS RDS IAM configuration options, including required settings and connection requirements.
  - Clarified supported token mechanisms, required secrets, and proxy-based workarounds for other providers.
  - Updated workflow archive documentation with setup instructions and relevant cross-references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->