### PR TITLE
docs: fix Docs CI failures accumulated on release-3.7

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -80,6 +80,7 @@ Kaniko
 Katacoda
 Katib
 Kerberos
+KeyValueEditor
 Killercoda
 KubectlExec
 Kubeflow
@@ -110,6 +111,7 @@ PersistentVolumeClaims
 Ploomber
 PostgreSQL
 Postgres
+Pre-fill
 PriorityClass
 RCs
 Risc-V
@@ -140,11 +142,13 @@ apis
 architecting
 arg
 argo
+argoexec
 argoproj
 args
 async
 auth
 backend
+backoff
 backported
 boolean
 booleans
@@ -221,6 +225,7 @@ qps
 ray
 rc2
 repo
+retryStrategy
 roadmap
 rollout
 rollouts
@@ -273,6 +278,8 @@ v3.4.4
 v3.5
 v3.6
 v3.7
+v3.7.16
+v4.0.7
 validator
 vendored
 versioned

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -613,7 +613,6 @@ Counts both WorkflowTemplate and ClusterWorkflowTemplate usage.
 | `name`          | ⚠️ The name of the WorkflowTemplate/ClusterWorkflowTemplate. |
 | `namespace`     | The namespace that the WorkflowTemplate is in               |
 | `cluster_scope` | A boolean set true if this is a ClusterWorkflowTemplate     |
-| `phase`         | The phase that the Workflow has entered                     |
 <!-- Generated documentation END -->
 
 ### Metric types


### PR DESCRIPTION
## Motivation

Docs CI never ran on release branches until #16544, so backported docs accumulated problems that are now failing the `docs` job on release-3.7 pushes and PRs.

## Modifications

1. Add words unknown to the mdspell dictionary to `.spelling`: `retryStrategy`, `backoff`, `KeyValueEditor`, `Pre-fill`, `argoexec` (from `docs/new-features.md`) and `v3.7.16`, `v4.0.7` (from `docs/variables.md`), keeping the file `LC_COLLATE=C`-sorted as the Makefile does.
2. Regenerate `docs/metrics.md`: the cherry-pick of #14979 (#15031) added the `phase` attribute row to the generated `workflowtemplate_triggered_total` docs, but that attribute only exists on main (added with the OTel tracing work in #15582) and was never backported to release-3.7's `util/telemetry/builder/values.yaml`. The docs job regenerates this file and fails `git diff --exit-code` on the mismatch.

## Verification

Ran the same checks locally: `markdown-spellcheck@1.3.1` over the Makefile's full file list reports 136 files free from spelling errors, and `go run ./util/telemetry/builder --metricsDocs docs/metrics.md` produces no further diff (regenerated blob matches CI's expected output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018juwnvT4EzBAp8xohQMBbD