### PR TITLE
docs: add words to .spelling missed while Docs CI was skipped (release-4.0)

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -286,7 +286,9 @@ v3.6.1
 v3.6.5
 v3.7
 v3.7.0
+v3.7.16
 v4.0
+v4.0.7
 validator
 vendored
 versioned


### PR DESCRIPTION
## Motivation

Docs CI never ran on release branches until #16545, so backported docs accumulated words unknown to the mdspell dictionary. The `docs` job is now failing on release-4.0 pushes and PRs (e.g. https://github.com/argoproj/argo-workflows/actions/runs/30248075053/job/89919537826).

## Modifications

Add the missing words to `.spelling`: `v3.7.16` and `v4.0.7` (from `docs/variables.md`), keeping the file `LC_COLLATE=C`-sorted as the Makefile does.

## Verification

Ran the same check locally with `markdown-spellcheck@1.3.1` over the Makefile's full file list: 139 files are free from spelling errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018juwnvT4EzBAp8xohQMBbD