### PR TITLE
test(ui): cover the workflow lifecycle in the Playwright suite

### DIFF
--- a/.tiltignore
+++ b/.tiltignore
@@ -1,6 +1,12 @@
-# Artifacts the Playwright suite writes under ui/ on every run. The image deps
-# include all of ui/, so without these ignores each test run triggers an image
-# rebuild and a rolling restart of argo-server mid-suite (seen as 503s).
-ui/e2e/.auth
+# The image deps in the Tiltfile cover all of ui/, but webpack only bundles
+# ui/src — so anything else under ui/ changing while Tilt is up rebuilds the
+# images and rolling-restarts argo-server, dropping its port-forward out from
+# under whatever is driving the UI (seen mid-suite as 503s or connection-refused).
+#
+# Artifacts the Playwright suite writes on every run:
 ui/test-results
 ui/playwright-report
+# ...and the suite's own sources, so editing a test while Tilt is up does not
+# restart the stack that test is about to run against:
+ui/e2e
+ui/playwright.config.ts

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -58,7 +58,8 @@ and point the tests at it with `ARGO_UI_BASE_URL`.
 - **Backend state** (`e2e/fixtures/api.ts`): tests seed workflows over the REST
   API and wait for a terminal phase *before* asserting on the rendered page, so
   rendering never races the controller. Created workflows are cleaned up on
-  teardown.
+  teardown; workflows the *browser* creates (submit, resubmit) are handed to
+  `api.track()` so they are cleaned up too.
 - **Page objects** (`e2e/pages/`) centralise selectors. Prefer role/text/href
   locators; add a `data-testid` only when nothing stable exists.
 

--- a/ui/e2e/fixtures/api.ts
+++ b/ui/e2e/fixtures/api.ts
@@ -27,6 +27,14 @@ export class ApiClient {
         return name;
     }
 
+    /**
+     * Registers a workflow this client did not submit — one the browser created,
+     * whose name the server generated — so teardown cleans it up too.
+     */
+    track(name: string): void {
+        this.created.push(name);
+    }
+
     async getWorkflow(name: string): Promise<any> {
         const res = await this.request.get(`api/v1/workflows/${this.namespace}/${name}`, {headers: this.headers});
         expect(res.ok(), `get ${name} failed: ${res.status()}`).toBeTruthy();

--- a/ui/e2e/fixtures/test.ts
+++ b/ui/e2e/fixtures/test.ts
@@ -1,12 +1,16 @@
 import {test as base} from '@playwright/test';
 
+import {ConfirmDialog} from '../pages/confirm-dialog';
 import {LoginPage} from '../pages/login-page';
+import {WorkflowDetailsPage} from '../pages/workflow-details-page';
 import {WorkflowListPage} from '../pages/workflow-list-page';
 import {ApiClient} from './api';
 
 interface Fixtures {
     api: ApiClient;
+    confirmDialog: ConfirmDialog;
     loginPage: LoginPage;
+    workflowDetailsPage: WorkflowDetailsPage;
     workflowListPage: WorkflowListPage;
 }
 
@@ -28,8 +32,14 @@ export const test = base.extend<Fixtures>({
         await use(api);
         await api.cleanup();
     },
+    confirmDialog: async ({page}, use) => {
+        await use(new ConfirmDialog(page));
+    },
     loginPage: async ({page}, use) => {
         await use(new LoginPage(page));
+    },
+    workflowDetailsPage: async ({page}, use) => {
+        await use(new WorkflowDetailsPage(page));
     },
     workflowListPage: async ({page}, use) => {
         await use(new WorkflowListPage(page));

--- a/ui/e2e/fixtures/workflows.ts
+++ b/ui/e2e/fixtures/workflows.ts
@@ -15,13 +15,53 @@ function base(generateName: string): Pick<TestWorkflow, 'metadata'> {
     return {metadata: {generateName, namespace: NAMESPACE, labels: {[TEST_LABEL]: 'true'}}};
 }
 
-/** A workflow that echoes `message` and succeeds within a few seconds. */
-export function echoWorkflow(message = 'hello e2e', generateName = 'e2e-smoke-'): TestWorkflow {
+const ARGOSAY = 'argoproj/argosay:v2';
+
+/** A single-container workflow running `argosay <args>`. */
+function oneStep(generateName: string, args: string[]): TestWorkflow {
     return {
         ...base(generateName),
         spec: {
             entrypoint: 'main',
-            templates: [{name: 'main', container: {image: 'argoproj/argosay:v2', args: ['echo', message]}}]
+            templates: [{name: 'main', container: {image: ARGOSAY, args}}]
+        }
+    };
+}
+
+/** A workflow that echoes `message` and succeeds within a few seconds. */
+export function echoWorkflow(message = 'hello e2e', generateName = 'e2e-smoke-'): TestWorkflow {
+    return oneStep(generateName, ['echo', message]);
+}
+
+/** A workflow whose only step exits non-zero, so it settles in `Failed`. */
+export function failingWorkflow(generateName = 'e2e-fail-'): TestWorkflow {
+    return oneStep(generateName, ['exit', '1']);
+}
+
+/** A workflow that stays `Running` for `seconds`, for tests that act on a live workflow. */
+export function sleepWorkflow(seconds = 60, generateName = 'e2e-sleep-'): TestWorkflow {
+    return oneStep(generateName, ['sleep', String(seconds)]);
+}
+
+/** The task names in `dagWorkflow`, which double as its graph node labels. */
+export const DAG_TASKS = ['generate', 'process-a', 'process-b'];
+
+/** A DAG that fans `generate` out into two parallel tasks and succeeds. */
+export function dagWorkflow(generateName = 'e2e-dag-'): TestWorkflow {
+    const [generate, ...processors] = DAG_TASKS;
+    return {
+        ...base(generateName),
+        spec: {
+            entrypoint: 'main',
+            templates: [
+                {
+                    name: 'main',
+                    dag: {
+                        tasks: [{name: generate, template: 'echo'}, ...processors.map(name => ({name, template: 'echo', dependencies: [generate]}))]
+                    }
+                },
+                {name: 'echo', container: {image: ARGOSAY, args: ['echo', 'hello e2e']}}
+            ]
         }
     };
 }

--- a/ui/e2e/pages/confirm-dialog.ts
+++ b/ui/e2e/pages/confirm-dialog.ts
@@ -1,0 +1,16 @@
+import {Locator, Page} from '@playwright/test';
+
+// The app-wide confirmation popup (argo-ui's PopupManager.confirm), which gates
+// both the workflow list's bulk actions and the details page's toolbar
+// operations. The buttons carry no accessible id beyond their text.
+export class ConfirmDialog {
+    readonly container: Locator;
+    readonly ok: Locator;
+    readonly cancel: Locator;
+
+    constructor(page: Page) {
+        this.container = page.locator('.popup-container');
+        this.ok = this.container.getByRole('button', {name: 'OK'});
+        this.cancel = this.container.getByRole('button', {name: 'Cancel'});
+    }
+}

--- a/ui/e2e/pages/workflow-details-page.ts
+++ b/ui/e2e/pages/workflow-details-page.ts
@@ -1,0 +1,100 @@
+import {expect, Locator, Page} from '@playwright/test';
+
+import {NAMESPACE} from '../fixtures/auth';
+
+/** Escapes `value` for embedding in a RegExp; workflow names contain `.` and `-`. */
+function quote(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Page object for the workflow details page (ui/src/workflows/components/workflow-details):
+// its operation toolbar, the DAG graph and the node-info side panel.
+export class WorkflowDetailsPage {
+    readonly toolbar: Locator;
+    readonly graph: Locator;
+    readonly nodeInfo: Locator;
+    readonly panel: Locator;
+
+    constructor(private readonly page: Page) {
+        // argo-ui's TopBar renders the breadcrumb bar as `top-bar` and the action
+        // menu below it as `top-bar row`, so both classes are needed to pick out
+        // the operation buttons.
+        this.toolbar = page.locator('.top-bar.row');
+        this.graph = page.locator('.graph');
+        this.nodeInfo = page.locator('.workflow-node-info');
+        this.panel = page.locator('.sliding-panel--opened .sliding-panel__body');
+    }
+
+    async goto(name: string): Promise<void> {
+        await this.page.goto(`workflows/${NAMESPACE}/${name}`);
+    }
+
+    /** The name of the workflow currently shown — the only place a UI-created name surfaces. */
+    async currentWorkflowName(): Promise<string> {
+        const pattern = new RegExp(`/workflows/${NAMESPACE}/([^/?#]+)`);
+        await expect(this.page).toHaveURL(pattern);
+        const match = pattern.exec(this.page.url());
+        if (!match) {
+            throw new Error(`not on a workflow details page: ${this.page.url()}`);
+        }
+        return match[1];
+    }
+
+    /**
+     * Waits for an operation that creates a *new* workflow (resubmit, submit) to
+     * redirect away from `name`, then returns the new workflow's name.
+     */
+    async waitForRedirectFrom(name: string): Promise<string> {
+        await expect(this.page).not.toHaveURL(new RegExp(`/workflows/${NAMESPACE}/${quote(name)}(?:[?#]|$)`));
+        return this.currentWorkflowName();
+    }
+
+    /**
+     * A toolbar operation button (Retry, Resubmit, Terminate, Delete, ...).
+     * WorkflowOperationsMap only offers the operations that are legal for the
+     * current phase, so these appear and disappear as a workflow progresses.
+     */
+    operation(title: string): Locator {
+        return this.toolbar.getByRole('button', {name: title});
+    }
+
+    async openTab(title: 'Summary' | 'Events' | 'Timeline' | 'Workflow'): Promise<void> {
+        await this.page.locator(`.workflow-details__topbar-buttons a[title="${title}"]`).click();
+    }
+
+    /** The value cell of a row in the Summary tab's attribute table, e.g. `Status`. */
+    summaryAttribute(title: string): Locator {
+        return this.page
+            .locator('.white-box__details-row')
+            .filter({has: this.page.getByText(title, {exact: true})})
+            .locator('.columns.small-9');
+    }
+
+    /**
+     * A node in the DAG. Each node is an SVG group holding a `<title>` of
+     * `"<nodeId> (<label>)"` alongside the clickable inner `g.node`. Anchoring on
+     * the bracketed label keeps this independent of the generated node id and of
+     * the line-wrapping graph-panel applies to the visible label.
+     */
+    node(label: string): Locator {
+        return this.graph
+            .locator('svg > g > g')
+            .filter({has: this.page.locator('title', {hasText: new RegExp(`\\(${quote(label)}\\)$`)})})
+            .locator('g.node');
+    }
+
+    async openNode(label: string): Promise<void> {
+        await this.node(label).click();
+        await expect(this.nodeInfo).toBeVisible();
+    }
+
+    /**
+     * The value cell for `title` in the node-info summary grid. AttributeRows
+     * renders each pair as two sibling `<div>`s with nothing to tell them apart,
+     * so the value is addressed as the label's next sibling. Only the selected
+     * tab's content is mounted, so titles shared with other tabs stay unambiguous.
+     */
+    nodeAttribute(title: string): Locator {
+        return this.nodeInfo.locator(`xpath=.//div[normalize-space()="${title}"]/following-sibling::div[1]`);
+    }
+}

--- a/ui/e2e/pages/workflow-list-page.ts
+++ b/ui/e2e/pages/workflow-list-page.ts
@@ -5,11 +5,13 @@ import {NAMESPACE} from '../fixtures/auth';
 // Page object for the workflows list (ui/src/workflows/components/workflows-list).
 export class WorkflowListPage {
     readonly nameFilter: Locator;
+    readonly submitButton: Locator;
 
     constructor(private readonly page: Page) {
         // The name filter is an unlabelled InputFilter; workflow-filters.tsx tags
         // its container with data-testid="workflow-name-filter".
         this.nameFilter = page.getByTestId('workflow-name-filter').locator('input');
+        this.submitButton = page.getByRole('button', {name: 'Submit New Workflow'});
     }
 
     async goto(): Promise<void> {
@@ -46,5 +48,31 @@ export class WorkflowListPage {
     async openWorkflow(name: string): Promise<void> {
         await this.row(name).click();
         await expect(this.page).toHaveURL(new RegExp(`/workflows/${NAMESPACE}/${name}`));
+    }
+
+    /**
+     * Creates a workflow through the submit panel, taking the pre-filled example
+     * manifest (ui/src/shared/examples.ts) exactly as offered: the editor is
+     * Monaco, so tests must not type into it.
+     */
+    async submitExampleWorkflow(): Promise<void> {
+        await this.submitButton.click();
+        // The panel opens on a workflow-template picker; this link switches it to
+        // the full editor, which seeds itself with the example manifest.
+        await this.page.getByText('Edit using full workflow options').click();
+        await this.page.getByRole('button', {name: 'Create'}).click();
+    }
+
+    /** The selection checkbox in a given workflow's row, which arms the bulk toolbar. */
+    rowCheckbox(name: string): Locator {
+        return this.page
+            .locator('.workflows-list__row-container')
+            .filter({has: this.row(name)})
+            .locator('input[type=checkbox]');
+    }
+
+    /** A bulk action button, enabled only while at least one row is selected. */
+    bulkAction(title: string): Locator {
+        return this.page.locator('.workflows-toolbar__actions').getByRole('button', {name: title});
     }
 }

--- a/ui/e2e/tests/workflow-details-dag.spec.ts
+++ b/ui/e2e/tests/workflow-details-dag.spec.ts
@@ -1,0 +1,19 @@
+import {expect, test} from '../fixtures/test';
+import {DAG_TASKS, dagWorkflow} from '../fixtures/workflows';
+
+test('renders every DAG node and opens the node-info panel', async ({api, workflowDetailsPage}) => {
+    const name = await api.submitWorkflow(dagWorkflow());
+    await api.waitForPhase(name, 'Succeeded');
+
+    await workflowDetailsPage.goto(name);
+
+    for (const task of DAG_TASKS) {
+        await expect(workflowDetailsPage.node(task)).toBeVisible();
+    }
+
+    // Clicking a node opens the side panel on its summary. A DAG task's node name
+    // is `<workflow>.<task>`, which is what distinguishes it from its siblings.
+    await workflowDetailsPage.openNode('process-a');
+    await expect(workflowDetailsPage.nodeAttribute('NAME')).toContainText(`${name}.process-a`);
+    await expect(workflowDetailsPage.nodeAttribute('PHASE')).toContainText('Succeeded');
+});

--- a/ui/e2e/tests/workflow-operations.spec.ts
+++ b/ui/e2e/tests/workflow-operations.spec.ts
@@ -1,0 +1,38 @@
+import {ENV_FACTOR} from '../fixtures/auth';
+import {expect, test} from '../fixtures/test';
+import {failingWorkflow, sleepWorkflow} from '../fixtures/workflows';
+
+test('terminates a running workflow from the details page', async ({api, confirmDialog, workflowDetailsPage}) => {
+    const name = await api.submitWorkflow(sleepWorkflow(60));
+    await api.waitForPhase(name, 'Running');
+
+    await workflowDetailsPage.goto(name);
+    // Terminate is only offered while the workflow is running, so finding the
+    // button is itself an assertion that the page reflects the live phase.
+    await workflowDetailsPage.operation('Terminate').click();
+    await confirmDialog.ok.click();
+
+    await workflowDetailsPage.openTab('Summary');
+    // Terminating means killing a pod, so give it more than the default expect
+    // timeout — but stay well inside the per-test timeout, which scales too.
+    await expect(workflowDetailsPage.summaryAttribute('Status')).toContainText('Failed', {timeout: 30_000 * ENV_FACTOR});
+});
+
+test('retries a failed workflow from the details page', async ({api, workflowDetailsPage}) => {
+    const name = await api.submitWorkflow(failingWorkflow());
+    await api.waitForPhase(name, 'Failed');
+    const failedAt = (await api.getWorkflow(name)).status.finishedAt;
+
+    await workflowDetailsPage.goto(name);
+    await workflowDetailsPage.operation('Retry').click();
+
+    // Retry opens a panel of retry options rather than a confirm dialog.
+    await expect(workflowDetailsPage.panel.getByRole('heading', {name: 'Retry Workflow'})).toBeVisible();
+    await workflowDetailsPage.panel.getByRole('button', {name: 'Retry'}).click();
+    await expect(workflowDetailsPage.panel).toBeHidden();
+
+    // A retry reuses the workflow's name, so the observable effect is that the
+    // previous run's finish time is replaced. Watching for a `Running` phase in
+    // the UI instead would race this workflow's (immediate) second failure.
+    await expect.poll(async () => (await api.getWorkflow(name)).status.finishedAt, {timeout: 20_000 * ENV_FACTOR}).not.toBe(failedAt);
+});

--- a/ui/e2e/tests/workflow-resubmit-delete.spec.ts
+++ b/ui/e2e/tests/workflow-resubmit-delete.spec.ts
@@ -1,0 +1,35 @@
+import {expect, test} from '../fixtures/test';
+import {echoWorkflow} from '../fixtures/workflows';
+
+test('resubmits a workflow from the details page', async ({api, workflowDetailsPage}) => {
+    const name = await api.submitWorkflow(echoWorkflow());
+    await api.waitForPhase(name, 'Succeeded');
+
+    await workflowDetailsPage.goto(name);
+    await workflowDetailsPage.operation('Resubmit').click();
+
+    // Resubmit opens a panel of resubmit options rather than a confirm dialog.
+    await expect(workflowDetailsPage.panel.getByRole('heading', {name: 'Resubmit Workflow'})).toBeVisible();
+    await workflowDetailsPage.panel.getByRole('button', {name: 'Resubmit'}).click();
+
+    // The resubmit creates a separate workflow and redirects to it.
+    const resubmitted = await workflowDetailsPage.waitForRedirectFrom(name);
+    api.track(resubmitted);
+    await expect(workflowDetailsPage.operation('Resubmit')).toBeVisible();
+});
+
+test('deletes a workflow from the list', async ({api, confirmDialog, workflowListPage}) => {
+    const name = await api.submitWorkflow(echoWorkflow());
+    await api.waitForPhase(name, 'Succeeded');
+
+    await workflowListPage.goto();
+    await workflowListPage.filterByName(name);
+    await expect(workflowListPage.row(name)).toBeVisible();
+
+    // Selecting a row reveals the bulk toolbar; its Delete acts on the selection.
+    await workflowListPage.rowCheckbox(name).check();
+    await workflowListPage.bulkAction('Delete').click();
+    await confirmDialog.ok.click();
+
+    await expect(workflowListPage.row(name)).toBeHidden();
+});

--- a/ui/e2e/tests/workflow-submit.spec.ts
+++ b/ui/e2e/tests/workflow-submit.spec.ts
@@ -1,0 +1,19 @@
+import {ENV_FACTOR} from '../fixtures/auth';
+import {expect, test} from '../fixtures/test';
+
+test('submits the example workflow from the UI and it runs to completion', async ({api, workflowListPage, workflowDetailsPage}) => {
+    await workflowListPage.goto();
+    await workflowListPage.submitExampleWorkflow();
+
+    // The example manifest names itself, so the name is only knowable once the UI
+    // has redirected to the new workflow's details page.
+    const name = await workflowDetailsPage.currentWorkflowName();
+    api.track(name);
+
+    // Unlike the seeded tests, this one necessarily starts from a workflow that
+    // has not run yet, so allow a full pull-and-run before it reports Succeeded.
+    // Keep this comfortably under playwright.config.ts's per-test timeout (also
+    // scaled by E2E_ENV_FACTOR), or the test dies before the assertion reports.
+    await workflowDetailsPage.openTab('Summary');
+    await expect(workflowDetailsPage.summaryAttribute('Status')).toContainText('Succeeded', {timeout: 45_000 * ENV_FACTOR});
+});


### PR DESCRIPTION
## Motivation

Follow-up to #16398, which landed the Playwright harness plus the login and workflow-list journeys. This adds the highest-traffic UI surfaces that still had no browser coverage — the workflow lifecycle.

## Modifications

New specs:

- **`workflow-submit`** — "Submit New Workflow" with the pre-filled example manifest, through to `Succeeded` on the details page. (Nothing is typed into Monaco; the default manifest is used as offered.)
- **`workflow-details-dag`** — a completed DAG renders every node, and clicking one opens the node-info panel showing that node's name and phase. `workflow-dag` was the most complex untested component.
- **`workflow-operations`** — terminate a running workflow (confirm dialog → `Failed`); retry a failed one.
- **`workflow-resubmit-delete`** — resubmit from the details page; delete from the list via the row checkbox and the bulk toolbar.

Supporting changes:

- New page objects for the details page (operation toolbar, graph nodes, node-info panel, summary attributes) and for the shared confirm dialog; the list page gains the submit panel and bulk actions.
- New workflow builders: `failingWorkflow`, `sleepWorkflow`, `dagWorkflow`.
- `api.track()`, so workflows the *browser* creates (submit, resubmit) are cleaned up on teardown alongside the API-seeded ones.

**No new `data-testid`s were needed.** Graph nodes are addressable through the SVG `<title>` the graph panel already emits, and both attribute grids through their label cells. No production code changes at all in this PR.

Tests continue to seed workflows over the REST API and wait for a terminal phase before rendering, so assertions don't race the controller. The two exceptions are inherent to what they cover: a UI submit necessarily starts from a workflow that hasn't run, and a terminate watches its own effect land. Per-assertion timeouts are kept inside the per-test timeout, since both scale by `E2E_ENV_FACTOR` (`2` in CI) — otherwise a generous assertion timeout can never actually fire.

A separate commit extends `.tiltignore`: the Tiltfile's image deps cover all of `ui/`, but webpack only bundles `ui/src`, so editing a Playwright test while Tilt is up rebuilt the images and rolling-restarted argo-server out from under the browser driving the test. That surfaced mid-suite as 503s / `ERR_CONNECTION_REFUSED`, looking nothing like a test bug.

## Verification

Run against the CI-equivalent stack (k3d + `tilt up --mode=ci --profile=minimal --auth-mode=client`, production UI bundle at `:2746`), at CI's settings (`E2E_ENV_FACTOR=2`, 2 workers), `--repeat-each=2`: **18/18 passing**, ~1.2 min for the whole suite.

The new `e2e-ui` CI job picks these up automatically — no workflow changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for workflow submission, DAG visualization, termination, retry, resubmission, and deletion.
  * Added reusable test support for workflow details, confirmation dialogs, and workflow list actions.
  * Improved cleanup of workflows created through browser interactions.

* **Documentation**
  * Clarified end-to-end test cleanup behavior.

* **Chores**
  * Updated development tooling exclusions to prevent Playwright files and artifacts from triggering unnecessary rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->