### PR TITLE
feat(ui): keep Workflows on CronWorkflow deletion. Fixes #14679

### DIFF
--- a/.features/pending/cronworkflow-keep-workflows.md
+++ b/.features/pending/cronworkflow-keep-workflows.md
@@ -3,5 +3,7 @@ Authors: [JerryNee](https://github.com/JerryNee)
 Component: UI
 Issues: 14679
 
-The CronWorkflow deletion confirmation now includes an option to keep its non-archived Workflows.
-Selecting the option deletes the CronWorkflow with Kubernetes orphan propagation so the created Workflows remain available.
+The CronWorkflow deletion confirmation in the UI now includes a **Keep Workflows created by this CronWorkflow** checkbox.
+Select it when you want to stop future scheduled runs while retaining existing non-archived Workflows for inspection or history.
+The UI uses Kubernetes orphan propagation so the created Workflows remain available after the CronWorkflow is deleted.
+This option is currently available only in the UI; `argo cron delete` continues to delete the created Workflows.

--- a/.features/pending/cronworkflow-keep-workflows.md
+++ b/.features/pending/cronworkflow-keep-workflows.md
@@ -6,4 +6,4 @@ Issues: 14679
 The CronWorkflow deletion confirmation in the UI now includes a **Keep Workflows created by this CronWorkflow** checkbox.
 Select it when you want to stop future scheduled runs while retaining existing non-archived Workflows for inspection or history.
 The UI uses Kubernetes orphan propagation so the created Workflows remain available after the CronWorkflow is deleted.
-This option is currently available only in the UI; `argo cron delete` continues to delete the created Workflows.
+This option is available only in the UI; `argo cron delete` continues to delete the created Workflows.

--- a/.features/pending/cronworkflow-keep-workflows.md
+++ b/.features/pending/cronworkflow-keep-workflows.md
@@ -1,0 +1,7 @@
+Description: Keep created Workflows when deleting a CronWorkflow in the UI
+Authors: [JerryNee](https://github.com/JerryNee)
+Component: UI
+Issues: 14679
+
+The CronWorkflow deletion confirmation now includes an option to keep its non-archived Workflows.
+Selecting the option deletes the CronWorkflow with Kubernetes orphan propagation so the created Workflows remain available.

--- a/ui/src/cron-workflows/cron-workflow-delete-confirmation.test.tsx
+++ b/ui/src/cron-workflows/cron-workflow-delete-confirmation.test.tsx
@@ -1,0 +1,29 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import * as React from 'react';
+
+import {CronWorkflowDeleteConfirmation} from './cron-workflow-delete-confirmation';
+
+describe('CronWorkflowDeleteConfirmation', () => {
+    it('does not keep created Workflows by default', () => {
+        render(<CronWorkflowDeleteConfirmation onKeepWorkflowsChange={jest.fn()} />);
+
+        expect(screen.getByText('Deleting it also deletes all non-archived Workflows it created.')).toBeInTheDocument();
+        expect(screen.getByLabelText('Keep Workflows created by this CronWorkflow')).not.toBeChecked();
+    });
+
+    it('reports changes to the keep Workflows option', () => {
+        const onKeepWorkflowsChange = jest.fn();
+        render(<CronWorkflowDeleteConfirmation onKeepWorkflowsChange={onKeepWorkflowsChange} />);
+
+        const checkbox = screen.getByLabelText('Keep Workflows created by this CronWorkflow');
+        fireEvent.click(checkbox);
+
+        expect(checkbox).toBeChecked();
+        expect(onKeepWorkflowsChange).toHaveBeenCalledWith(true);
+
+        fireEvent.click(checkbox);
+
+        expect(checkbox).not.toBeChecked();
+        expect(onKeepWorkflowsChange).toHaveBeenLastCalledWith(false);
+    });
+});

--- a/ui/src/cron-workflows/cron-workflow-delete-confirmation.tsx
+++ b/ui/src/cron-workflows/cron-workflow-delete-confirmation.tsx
@@ -1,0 +1,27 @@
+import {Checkbox} from 'argo-ui/src/components/checkbox';
+import * as React from 'react';
+import {useState} from 'react';
+
+interface Props {
+    onKeepWorkflowsChange: (keepWorkflows: boolean) => void;
+}
+
+export function CronWorkflowDeleteConfirmation({onKeepWorkflowsChange}: Props) {
+    const [keepWorkflows, setKeepWorkflows] = useState(false);
+
+    const updateKeepWorkflows = (value: boolean) => {
+        setKeepWorkflows(value);
+        onKeepWorkflowsChange(value);
+    };
+
+    return (
+        <>
+            <p>Are you sure you want to delete this CronWorkflow?</p>
+            <p>Deleting it also deletes all non-archived Workflows it created.</p>
+            <div>
+                <Checkbox id='keep-cron-workflow-workflows' checked={keepWorkflows} onChange={updateKeepWorkflows} />
+                <label htmlFor='keep-cron-workflow-workflows'>Keep Workflows created by this CronWorkflow</label>
+            </div>
+        </>
+    );
+}

--- a/ui/src/cron-workflows/cron-workflow-details.test.tsx
+++ b/ui/src/cron-workflows/cron-workflow-details.test.tsx
@@ -1,0 +1,105 @@
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
+import * as React from 'react';
+
+import {Context} from '../shared/context';
+import {exampleCronWorkflow} from '../shared/examples';
+import {services} from '../shared/services';
+import {CronWorkflowDetails} from './cron-workflow-details';
+
+jest.mock('argo-ui/src/components/page/page', () => ({
+    Page: ({children, toolbar}: any) => (
+        <>
+            <button onClick={toolbar.actionMenu.items.find((item: {title: string}) => item.title === 'Delete').action}>Delete</button>
+            {children}
+        </>
+    )
+}));
+jest.mock('argo-ui/src/components/sliding-panel/sliding-panel', () => ({
+    SlidingPanel: ({children}: any) => <>{children}</>
+}));
+jest.mock('../shared/use-collect-event', () => ({
+    useCollectEvent: jest.fn()
+}));
+jest.mock('../widgets/widget-gallery', () => ({
+    WidgetGallery: (): React.ReactElement => <></>
+}));
+jest.mock('../workflows/components/workflow-details-list/workflow-details-list', () => ({
+    WorkflowDetailsList: (): React.ReactElement => <></>
+}));
+jest.mock('./cron-workflow-editor', () => ({
+    CronWorkflowEditor: () => <div data-testid='cron-workflow-editor' />
+}));
+
+describe('CronWorkflowDetails deletion', () => {
+    beforeEach(() => {
+        const base = document.createElement('base');
+        base.setAttribute('href', '/');
+        document.head.appendChild(base);
+    });
+
+    afterEach(() => {
+        document.querySelector('base')?.remove();
+        jest.restoreAllMocks();
+    });
+
+    async function renderDetails() {
+        const cronWorkflow = exampleCronWorkflow('ns');
+        cronWorkflow.metadata.name = 'cron-workflow';
+
+        jest.spyOn(services.cronWorkflows, 'get').mockResolvedValue(cronWorkflow);
+        jest.spyOn(services.cronWorkflows, 'delete').mockResolvedValue({} as any);
+        jest.spyOn(services.workflows, 'list').mockResolvedValue({items: []} as any);
+        jest.spyOn(services.info, 'getInfo').mockResolvedValue({columns: []} as any);
+
+        let resolveConfirmation: (confirmed: boolean) => void;
+        const confirm = jest.fn<Promise<boolean>, [string, React.ComponentType]>(
+            () =>
+                new Promise<boolean>(resolve => {
+                    resolveConfirmation = resolve;
+                })
+        );
+        const popup = {
+            confirm
+        };
+        const navigation = {goto: jest.fn()};
+        const history = createMemoryHistory();
+
+        render(
+            <Context.Provider value={{popup, navigation, notifications: {show: jest.fn()}, history} as any}>
+                <CronWorkflowDetails history={history} location={history.location} match={{params: {name: 'cron-workflow', namespace: 'ns'}} as any} />
+            </Context.Provider>
+        );
+
+        await screen.findByTestId('cron-workflow-editor');
+        return {navigation, popup, resolveConfirmation: (confirmed: boolean) => resolveConfirmation(confirmed)};
+    }
+
+    it('uses cascading deletion when keep Workflows is not selected', async () => {
+        const {navigation, popup, resolveConfirmation} = await renderDetails();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
+        await act(async () => resolveConfirmation(true));
+
+        await waitFor(() => {
+            expect(services.cronWorkflows.delete).toHaveBeenCalledWith('cron-workflow', 'ns', false);
+            expect(navigation.goto).toHaveBeenCalledWith('/cron-workflows/ns');
+        });
+        expect(popup.confirm).toHaveBeenCalledWith('Confirm', expect.any(Function));
+    });
+
+    it('uses orphan deletion when keep Workflows is selected', async () => {
+        const {navigation, popup, resolveConfirmation} = await renderDetails();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Delete'}));
+        const Confirmation = popup.confirm.mock.calls[0][1] as React.ComponentType;
+        render(<Confirmation />);
+        fireEvent.click(screen.getByLabelText('Keep Workflows created by this CronWorkflow'));
+        await act(async () => resolveConfirmation(true));
+
+        await waitFor(() => {
+            expect(services.cronWorkflows.delete).toHaveBeenCalledWith('cron-workflow', 'ns', true);
+            expect(navigation.goto).toHaveBeenCalledWith('/cron-workflows/ns');
+        });
+    });
+});

--- a/ui/src/cron-workflows/cron-workflow-details.test.tsx
+++ b/ui/src/cron-workflows/cron-workflow-details.test.tsx
@@ -32,14 +32,16 @@ jest.mock('./cron-workflow-editor', () => ({
 }));
 
 describe('CronWorkflowDetails deletion', () => {
+    let testBase: HTMLBaseElement;
+
     beforeEach(() => {
-        const base = document.createElement('base');
-        base.setAttribute('href', '/');
-        document.head.appendChild(base);
+        testBase = document.createElement('base');
+        testBase.setAttribute('href', '/');
+        document.head.appendChild(testBase);
     });
 
     afterEach(() => {
-        document.querySelector('base')?.remove();
+        testBase.remove();
         jest.restoreAllMocks();
     });
 

--- a/ui/src/cron-workflows/cron-workflow-details.tsx
+++ b/ui/src/cron-workflows/cron-workflow-details.tsx
@@ -20,6 +20,7 @@ import {useEditableObject} from '../shared/use-editable-object';
 import {useQueryParams} from '../shared/use-query-params';
 import {WidgetGallery} from '../widgets/widget-gallery';
 import {WorkflowDetailsList} from '../workflows/components/workflow-details-list/workflow-details-list';
+import {CronWorkflowDeleteConfirmation} from './cron-workflow-delete-confirmation';
 import {CronWorkflowEditor} from './cron-workflow-editor';
 
 import '../workflows/components/workflow-details/workflow-details.scss';
@@ -152,15 +153,18 @@ export function CronWorkflowDetails({match, location, history}: RouteComponentPr
                 iconClassName: 'fa fa-trash',
                 disabled: edited,
                 action: () => {
-                    popup.confirm('confirm', 'Are you sure you want to delete this cron workflow? (This also deletes all Workflows it spawned)').then(yes => {
-                        if (yes) {
-                            services.cronWorkflows
-                                .delete(name, namespace)
-                                .then(() => navigation.goto(uiUrl('cron-workflows/' + namespace)))
-                                .then(() => setError(null))
-                                .catch(setError);
-                        }
-                    });
+                    let keepWorkflows = false;
+                    popup
+                        .confirm('Confirm', () => <CronWorkflowDeleteConfirmation onKeepWorkflowsChange={value => (keepWorkflows = value)} />)
+                        .then(yes => {
+                            if (yes) {
+                                services.cronWorkflows
+                                    .delete(name, namespace, keepWorkflows)
+                                    .then(() => navigation.goto(uiUrl('cron-workflows/' + namespace)))
+                                    .then(() => setError(null))
+                                    .catch(setError);
+                            }
+                        });
                 }
             },
             {

--- a/ui/src/shared/services/cron-workflow-service.test.ts
+++ b/ui/src/shared/services/cron-workflow-service.test.ts
@@ -75,6 +75,24 @@ describe('cron workflow service', () => {
         });
     });
 
+    describe('delete', () => {
+        test('deletes created Workflows by default', async () => {
+            jest.spyOn(requests, 'delete').mockResolvedValue({} as any);
+
+            await CronWorkflowService.delete('cron-workflow', 'ns');
+
+            expect(requests.delete).toHaveBeenCalledWith('api/v1/cron-workflows/ns/cron-workflow');
+        });
+
+        test('keeps created Workflows when requested', async () => {
+            jest.spyOn(requests, 'delete').mockResolvedValue({} as any);
+
+            await CronWorkflowService.delete('cron-workflow', 'ns', true);
+
+            expect(requests.delete).toHaveBeenCalledWith('api/v1/cron-workflows/ns/cron-workflow?deleteOptions.propagationPolicy=Orphan');
+        });
+    });
+
     describe('suspend', () => {
         test('with valid CronWorkflow', async () => {
             const cronWf = exampleCronWorkflow('ns');

--- a/ui/src/shared/services/cron-workflow-service.ts
+++ b/ui/src/shared/services/cron-workflow-service.ts
@@ -35,8 +35,9 @@ export const CronWorkflowService = {
             .then(res => normalizeSchedules(res.body));
     },
 
-    delete(name: string, namespace: string) {
-        return requests.delete(`api/v1/cron-workflows/${namespace}/${name}`);
+    delete(name: string, namespace: string, keepWorkflows = false) {
+        const deleteOptions = keepWorkflows ? '?deleteOptions.propagationPolicy=Orphan' : '';
+        return requests.delete(`api/v1/cron-workflows/${namespace}/${name}${deleteOptions}`);
     },
 
     suspend(name: string, namespace: string) {


### PR DESCRIPTION
Fixes #14679

### Motivation

Deleting a CronWorkflow from the UI currently also garbage-collects its non-archived Workflows. The confirmation warns about that behavior, but users cannot preserve those Workflows when they no longer need the schedule.

### Modifications

- Replace the warning-only confirmation content with a focused component that includes a "Keep Workflows created by this CronWorkflow" checkbox.
- Keep the existing cascading deletion behavior as the unchecked default.
- Send `deleteOptions.propagationPolicy=Orphan` only when the option is selected, using the server API's existing `deleteOptions` support.
- Add component coverage for the warning, default state, and checkbox changes.
- Add service coverage for both the default and orphan-propagation DELETE requests.
- Add details-page integration coverage for both deletion policies and the post-delete navigation.
- Add the required feature description for release notes.

### Verification

- `corepack yarn --cwd ui test --runInBand` (29 suites, 136 tests)
- `corepack yarn --cwd ui tsc --noEmit`
- `corepack yarn --cwd ui e2e:typecheck`
- ESLint on all changed TypeScript files
- `corepack yarn --cwd ui build`
- `go test -mod=mod ./hack/featuregen`
- Feature document validation and generated-output MarkdownLint using the project-pinned `markdownlint-cli@0.33.0`

### Documentation

Added `.features/pending/cronworkflow-keep-workflows.md`. No separate user guide change is needed because the option is presented at the point of deletion and its behavior is described in the confirmation.

### AI

OpenAI Codex was used to inspect the relevant UI, service, API, and contribution-policy code; assist with the implementation and tests; and prepare the commit and PR text. I reviewed the resulting changes and validated them with the commands listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Keep Workflows created by this CronWorkflow” option to the deletion confirmation.
  * Users can preserve non-archived Workflows created by a CronWorkflow when deleting it.
* **Tests**
  * Added coverage for default deletion and preserving created Workflows.
* **Documentation**
  * Documented the new CronWorkflow deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->