### PR TITLE
perf(controller): avoid full Workflow DeepCopy for postponed workflows. Fixes #16559

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -962,17 +962,27 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 	// this will ensure we process every incomplete workflow once every 20m
 	wfc.wfQueue.AddAfter(key, workflowResyncPeriod)
 
-	woc := newWorkflowOperationCtx(ctx, wf, wfc)
-	ctx = logging.WithLogger(ctx, woc.log)
+	// Check the parallelism limit before building the operation context: newWorkflowOperationCtx
+	// deep-copies the entire Workflow, and for a workflow that is postponed that copy is discarded
+	// immediately. Only read from wf on this path, never mutate it.
+	shutdownStrategy := wf.Spec.Shutdown
 
-	if (!woc.GetShutdownStrategy().Enabled() || woc.GetShutdownStrategy() != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) {
-		woc.log.WithField("key", key).Info(ctx, "Workflow processing has been postponed due to max parallelism limit")
-		if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
+	if (!shutdownStrategy.Enabled() || shutdownStrategy != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) {
+		logger.WithFields(logging.Fields{"workflow": wf.Name, "namespace": wf.Namespace, "key": key}).
+			Info(ctx, "Workflow processing has been postponed due to max parallelism limit")
+		if wf.Status.Phase == wfv1.WorkflowUnknown {
+			// Only this branch mutates and persists the workflow, so only it needs the deep copy.
+			// It runs once per workflow, the first time that workflow is postponed.
+			woc := newWorkflowOperationCtx(ctx, wf, wfc)
+			ctx = logging.WithLogger(ctx, woc.log)
 			ctx = woc.markWorkflowPhase(ctx, wfv1.WorkflowPending, "Workflow processing has been postponed because too many workflows are already running")
 			woc.persistUpdates(ctx)
 		}
 		return true
 	}
+
+	woc := newWorkflowOperationCtx(ctx, wf, wfc)
+	ctx = logging.WithLogger(ctx, woc.log)
 
 	// make sure this is removed from the throttler is complete
 	defer func() {


### PR DESCRIPTION
Fixes #16559

### Motivation

`processNextItem` built the workflow operation context - which deep-copies the entire `Workflow` - before checking `throttler.Admit`. For a workflow postponed by the parallelism limit that copy is discarded immediately, so with a large backlog of pending workflows it is wasted allocation and GC churn on every requeue, including on each 20m resync of the whole pending backlog.

As noted in the issue, this is purely transient garbage rather than retained heap, so it does not change the informer cache footprint - but at tens of thousands of pending workflows it is one full `Workflow` deep copy per pending workflow per resync period, for no benefit.

### Modifications

Moved the `throttler.Admit` check ahead of `newWorkflowOperationCtx`:

- The shutdown strategy is now read from `wf.Spec.Shutdown` and the phase from `wf.Status.Phase`, instead of via `woc`. Both are reads only, so the object is never mutated on this path.
- `newWorkflowOperationCtx` (and therefore the deep copy) is constructed lazily inside the one sub-case that actually mutates and persists the workflow: the first time a workflow is postponed, when `Status.Phase` is still `Unknown` and it is marked `Pending`. That runs once per workflow.
- Otherwise the function logs and returns without ever copying.

The log message and its fields (`workflow`, `namespace`, `key`) are unchanged.

### Verification

- `go build ./workflow/controller/...` and `go vet ./workflow/controller/...` both clean.
- `gofmt` clean.
- `go test ./workflow/controller/ -run '^TestParallelism$'` passes, including both the `Parallelism` and `NamespaceParallelism` subtests. That test exercises all three branches touched here: a workflow that is admitted and reaches `Running`, one that is postponed and is marked `Pending` with the postponement message, and one with `shutdown: Terminate` that bypasses the throttle.
- Remaining failures in the package on my machine are pre-existing and unrelated - they are image entrypoint lookups failing with `no child with platform windows/amd64 in index alpine` (artifact plugin / container set / script template tests). I confirmed they fail identically on an unmodified tree.

### Documentation

Not needed - this is an internal refactor of the controller work loop with no user-visible behaviour or configuration change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved workflow processing efficiency by delaying workflow context creation until it is required.
  * Reduced unnecessary workflow copying when execution is postponed due to parallelism limits.

* **Bug Fixes**
  * Ensured shutdown strategy and workflow phase handling are evaluated consistently before execution proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->