### PR TITLE
fix: eval ternary expression

### DIFF
--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -168,6 +168,9 @@ func (v *guardVisitor) Visit(node *ast.Node) {
 		if n.Operator == "??" {
 			ast.Walk(&n.Left, &memberMarker{guarded: v.guarded})
 		}
+	case *ast.ConditionalNode:
+		ast.Walk(&n.Exp1, &memberMarker{guarded: v.guarded})
+		ast.Walk(&n.Exp2, &memberMarker{guarded: v.guarded})
 	case *ast.MemberNode:
 		if n.Optional {
 			if _, ok := n.Node.(*ast.MemberNode); ok {

--- a/util/template/expression_template_test.go
+++ b/util/template/expression_template_test.go
@@ -140,6 +140,11 @@ func Test_getIdentifiers(t *testing.T) {
 			expression: "tasks.a.outputs.result ?? 'default'",
 			want:       []string{"tasks"},
 		},
+		{
+			name:       "ternary guards both branches independently",
+			expression: "cond ? x.y : z.w",
+			want:       []string{"cond", "x", "z"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -737,6 +737,63 @@ func TestStepsWhenSkipNoRequeue(t *testing.T) {
 	assert.Equal(t, wfv1.NodeSkipped, nodeB.Phase)
 }
 
+var stepsWhenSkipWithExpression = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: steps-when-skip-with-expression-
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: A
+        template: script-echo
+        when: "false"
+    - - name: B
+        template: echo-with-param
+        arguments:
+          parameters:
+          - name: msg
+            value: "{{= steps.A.status == 'Skipped' ? 'skipped' : steps.A.outputs.result}}"
+  - name: script-echo
+    script:
+      image: alpine:3.23
+      command: [sh]
+      source: |
+        echo hello
+  - name: echo-with-param
+    inputs:
+      parameters:
+      - name: msg
+    container:
+      image: alpine:3.23
+      command: [echo, "{{inputs.parameters.msg}}"]
+`
+
+func TestStepsWhenSkipExpression(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+
+	wf := wfv1.MustUnmarshalWorkflow(stepsWhenSkipWithExpression)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+
+	// Verify the resolved value of steps.B.msg
+	nodeB := woc.wf.Status.Nodes.FindByDisplayName("B")
+	require.NotNil(t, nodeB)
+
+	require.NotNil(t, nodeB.Inputs)
+	require.Len(t, nodeB.Inputs.Parameters, 1)
+	assert.Equal(t, "skipped", nodeB.Inputs.Parameters[0].Value.String())
+	assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+}
+
 var stepsWhenExprWithParamFilter = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

Fixes #16123

### Motivation

strict check for ternary expression

### Modifications

for `ConditionalNode`, walk down both sides

### Verification

extended test with `ternary` expression and regression test for steps using this for skipped steps

### AI

(local) AI used for investigation, why test is failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional expression handling so member values in both branches are evaluated correctly.
  * Fixed workflow step expressions that depend on skipped steps, ensuring downstream values resolve as expected.

* **Tests**
  * Added coverage for ternary expressions and conditional workflow skipping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->