### PR TITLE
docs(examples): [input-artifact-git] Added GitHub Apps and disableSubmodules

### DIFF
--- a/examples/input-artifact-git.yaml
+++ b/examples/input-artifact-git.yaml
@@ -37,8 +37,10 @@ spec:
           # - Create a GitHub App, with at least "contents: read" permissions for the repo
           # - Install the GH App to the repo, noting the InstallID found in the URL
           # - Use ExternalSecretsOperator to generate rolling Access Tokens via the GH App credentials:
-          #  ESO Docs: https://external-secrets.io/main/api/generator/github/
-          #  Ensure the templated Secret has `username: x-access-token`, `password: "{{ .token }}"`
+          #   ESO Docs: https://external-secrets.io/main/api/generator/github/
+          #   Ensure the templated Secret has `username: x-access-token`, `password: "{{ .token }}"`
+          # - Use `usernameSecret` and `passwordSecret` here to reference the name and keys of the 
+          #   ESO generated GitHub token secret, which will automatically refresh every `refreshInterval` 
           #
           # insecureIgnoreHostKey disables SSH strict host key checking during the git clone
           # NOTE: this is unnecessary for the well-known public SSH keys from the major git

--- a/examples/input-artifact-git.yaml
+++ b/examples/input-artifact-git.yaml
@@ -16,7 +16,7 @@ spec:
         path: /src
         git:
           repo: https://github.com/argoproj/argo-workflows.git
-          revision: "v2.1.1"
+          revision: "v2.1.1" # See singleBranch/branch alternative below
           # For private repositories, create a k8s secret containing the git credentials and
           # reference the secret keys in the secret selectors: usernameSecret, passwordSecret,
           # or sshPrivateKeySecret.
@@ -32,7 +32,14 @@ spec:
           # sshPrivateKeySecret:
           #   name: github-creds
           #   key: ssh-private-key
-          # 
+          #
+          # Recommended approach for GitHub:
+          # - Create a GitHub App, with at least "contents: read" permissions for the repo
+          # - Install the GH App to the repo, noting the InstallID found in the URL
+          # - Use ExternalSecretsOperator to generate rolling Access Tokens via the GH App credentials:
+          #  ESO Docs: https://external-secrets.io/main/api/generator/github/
+          #  Ensure the templated Secret has `username: x-access-token`, `password: "{{ .token }}"`
+          #
           # insecureIgnoreHostKey disables SSH strict host key checking during the git clone
           # NOTE: this is unnecessary for the well-known public SSH keys from the major git
           # providers (github, bitbucket, gitlab, azure) as these keys are already baked into
@@ -54,6 +61,9 @@ spec:
           # is faster than passing in a revision, as it will only fetch the references to the given branch.
           # singleBranch: true
           # branch: my-branch
+          # 
+          # If submodule cloning is not necessary/desired
+          # disableSubmodules: true
     container:
       image: golang:1.10
       command: [sh, -c]


### PR DESCRIPTION
Documents by example, a common but non-trivial case of integration with GitHub Apps for API-token based access.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Relates to #6491, providing an example of how to integrate with secrets provisioned by External Secrets Operator.

### Motivation

Use of GitHub Application short-lived API Tokens for access to private repositories is well integrated in ArgoCD, however lacks direct support in Argo-Workflows. This provides an example comment, via the `examples/input-artifact-git.yaml` example config, for how to use Argo-Workflows with secrets provisioned by External Secrets Operator, which does support GitHub Application token generation.

### Modifications

This PR makes changes only to comments.

### Verification

I'm using these example values in a local workflow, along with External Secrets Operator for GitHub App integration.

### Documentation

Reference to GitHub Apps were not found in the existing documentation. This example should greatly help, though additional documentation covering these cases should be considered.

`disableSubmodules` is documented in https://argo-workflows.readthedocs.io/en/latest/executor_swagger/#gitartifact, though I would argue that page has a discoverability problem. It could benefit from a link in https://argo-workflows.readthedocs.io/en/latest/walk-through/artifacts/.

### AI

No AI was used in producing this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring GitHub App authentication with a rolling token.
  * Documented how to reference generated token secrets using `usernameSecret` and `passwordSecret`.
  * Added instructions for disabling Git submodule cloning.
  * Clarified the single-branch alternative for Git revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->