### PR TITLE
feat(controller): strip managedFields from informer caches. Fixes #16564

### DIFF
--- a/.features/pending/strip-managed-fields.md
+++ b/.features/pending/strip-managed-fields.md
@@ -1,0 +1,8 @@
+Description: Strip managedFields from controller informer caches to reduce memory usage
+Authors: [Alan Clucas](https://github.com/Joibel)
+Component: General
+Issues: 16564
+
+The workflow-controller now removes `metadata.managedFields` from objects before storing them in its informer caches.
+`managedFields` can be 20% or more of a cached object and nothing reads it, so this reduces controller memory usage at scale with no functional change.
+Objects stored in the cluster are unaffected.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -15,6 +15,9 @@ You can scale the controller vertically in these ways:
 
 If you observe the Controller using its total CPU or memory requests, you should increase those.
 
+At scale the Controller's memory usage is dominated by its informer caches, which hold every live Workflow, Pod and related object it watches.
+Since v4.1 the Controller strips `metadata.managedFields` from objects before caching them, which reduces the memory needed per cached object; keep this in mind when comparing heap profiles across versions.
+
 ### Adding Goroutines to Increase Concurrency
 
 If you have sufficient CPU cores, you can take advantage of them with more goroutines:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,12 @@ the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summar
 
 ## Upgrading to v4.1
 
+### Controller caches no longer store `managedFields`
+
+The workflow-controller (and the parts of the argo-server that share its informers) now strips `metadata.managedFields` from objects before storing them in its informer caches ([#TBD](https://github.com/argoproj/argo-workflows/pull/TBD)).
+This reduces controller memory usage — As a rough guide `managedFields` might be about 20% of the memory usage of objects, and at scale informer objects use most of the controllers memory footprint.
+This is internal to the controller's caches; objects stored in the cluster are unaffected.
+
 ### `argo archive` commands accept a workflow name as well as a UID
 
 The `argo archive get`, `delete`, `resubmit` and `retry` commands previously took a workflow UID as their argument.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -9,7 +9,7 @@ the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summar
 
 ### Controller caches no longer store `managedFields`
 
-The workflow-controller (and the parts of the argo-server that share its informers) now strips `metadata.managedFields` from objects before storing them in its informer caches ([#TBD](https://github.com/argoproj/argo-workflows/pull/TBD)).
+The workflow-controller (and the parts of the argo-server that share its informers) now strips `metadata.managedFields` from objects before storing them in its informer caches ([#16563](https://github.com/argoproj/argo-workflows/pull/16563)).
 This reduces controller memory usage — As a rough guide `managedFields` might be about 20% of the memory usage of objects, and at scale informer objects use most of the controllers memory footprint.
 This is internal to the controller's caches; objects stored in the cluster are unaffected.
 

--- a/util/informer/transform.go
+++ b/util/informer/transform.go
@@ -1,0 +1,23 @@
+// Package informer provides helpers shared by the informers used in the
+// workflow-controller and argo-server.
+package informer
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// StripManagedFields is a cache.TransformFunc that removes
+// metadata.managedFields before objects enter an informer cache.
+// Nothing reads managedFields from the cache, and the API server ignores
+// a nil managedFields on non-apply updates, so this is loss-free. It can
+// be 20% or more of the object size.
+func StripManagedFields(i any) (any, error) {
+	obj, err := meta.Accessor(i)
+	// err != nil: tombstones (DeletedFinalStateUnknown) etc — pass through.
+	// The nil-check avoids mutating objects that already lack managedFields
+	// (kubernetes/kubernetes#124337).
+	if err == nil && obj.GetManagedFields() != nil {
+		obj.SetManagedFields(nil)
+	}
+	return i, nil
+}

--- a/util/informer/transform_test.go
+++ b/util/informer/transform_test.go
@@ -1,0 +1,62 @@
+package informer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestStripManagedFields(t *testing.T) {
+	t.Run("typed object", func(t *testing.T) {
+		pod := &apiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:          "my-pod",
+				ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubelet"}},
+			},
+		}
+		out, err := StripManagedFields(pod)
+		require.NoError(t, err)
+		assert.Same(t, pod, out)
+		assert.Nil(t, pod.ManagedFields)
+		assert.Equal(t, "my-pod", pod.Name)
+	})
+	t.Run("unstructured object", func(t *testing.T) {
+		un := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Workflow",
+			"metadata": map[string]any{
+				"name":          "my-wf",
+				"managedFields": []any{map[string]any{"manager": "workflow-controller"}},
+			},
+		}}
+		out, err := StripManagedFields(un)
+		require.NoError(t, err)
+		assert.Same(t, un, out)
+		assert.Nil(t, un.GetManagedFields())
+		assert.NotContains(t, un.Object["metadata"], "managedFields")
+		assert.Equal(t, "my-wf", un.GetName())
+	})
+	t.Run("nil managedFields is not mutated", func(t *testing.T) {
+		un := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Workflow",
+			"metadata":   map[string]any{"name": "my-wf"},
+		}}
+		want := un.DeepCopy()
+		out, err := StripManagedFields(un)
+		require.NoError(t, err)
+		assert.Same(t, un, out)
+		assert.Equal(t, want, un)
+	})
+	t.Run("non-object input passes through", func(t *testing.T) {
+		tombstone := cache.DeletedFinalStateUnknown{Key: "my-ns/my-pod"}
+		out, err := StripManagedFields(tombstone)
+		require.NoError(t, err)
+		assert.Equal(t, tombstone, out)
+	})
+}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/deprecation"
 	"github.com/argoproj/argo-workflows/v4/util/env"
 	"github.com/argoproj/argo-workflows/v4/util/errors"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 	rbacutil "github.com/argoproj/argo-workflows/v4/util/rbac"
 	"github.com/argoproj/argo-workflows/v4/util/retry"
 	utilsqldb "github.com/argoproj/argo-workflows/v4/util/sqldb"
@@ -1351,6 +1352,8 @@ func (wfc *WorkflowController) newTypedConfigMapInformer(ctx context.Context) ca
 	}, func(opts *metav1.ListOptions) {
 		opts.LabelSelector = common.LabelKeyConfigMapType
 	})
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	indexInformer.SetTransform(informerutil.StripManagedFields)
 	ctx, logger := logging.RequireLoggerFromContext(ctx).WithField("component", "config_map_informer").InContext(ctx)
 	logger.WithField("executorPlugins", wfc.executorPlugins != nil).Info(ctx, "Plugins")
 	if wfc.executorPlugins != nil {
@@ -1532,7 +1535,8 @@ func (wfc *WorkflowController) newWorkflowTaskSetInformer() wfextvv1alpha1.Workf
 		externalversions.WithTweakListOptions(func(x *metav1.ListOptions) {
 			r := util.InstanceIDRequirement(wfc.Config.InstanceID)
 			x.LabelSelector = r.String()
-		})).Argoproj().V1alpha1().WorkflowTaskSets()
+		}),
+		externalversions.WithTransform(informerutil.StripManagedFields)).Argoproj().V1alpha1().WorkflowTaskSets()
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	informer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -1554,7 +1558,8 @@ func (wfc *WorkflowController) newArtGCTaskInformer() wfextvv1alpha1.WorkflowArt
 		externalversions.WithTweakListOptions(func(x *metav1.ListOptions) {
 			r := util.InstanceIDRequirement(wfc.Config.InstanceID)
 			x.LabelSelector = r.String()
-		})).Argoproj().V1alpha1().WorkflowArtifactGCTasks()
+		}),
+		externalversions.WithTransform(informerutil.StripManagedFields)).Argoproj().V1alpha1().WorkflowArtifactGCTasks()
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	informer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/workflow/controller/informer/tolerant_cluster_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_cluster_workflow_template_informer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
 	extwfv1 "github.com/argoproj/argo-workflows/v4/pkg/client/informers/externalversions/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/pkg/client/listers/workflow/v1alpha1"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 )
 
 type tolerantClusterWorkflowTemplateInformer struct {
@@ -21,14 +22,17 @@ type tolerantClusterWorkflowTemplateInformer struct {
 
 // NewTolerantClusterWorkflowTemplateInformer is a drop-in replacement for `extwfv1.ClusterWorkflowTemplateInformer` that ignores malformed resources.
 func NewTolerantClusterWorkflowTemplateInformer(dynamicInterface dynamic.Interface, defaultResync time.Duration) extwfv1.ClusterWorkflowTemplateInformer {
-	return &tolerantClusterWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, "", func(options *metav1.ListOptions) {
+	delegate := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, "", func(options *metav1.ListOptions) {
 		// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
 		// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
 		// Check if ResourceVersion is "0" and reset it to empty string to ensure proper pagination behavior
 		if options.ResourceVersion == "0" {
 			options.ResourceVersion = ""
 		}
-	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.ClusterWorkflowTemplatePlural})}
+	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.ClusterWorkflowTemplatePlural})
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	delegate.Informer().SetTransform(informerutil.StripManagedFields)
+	return &tolerantClusterWorkflowTemplateInformer{delegate: delegate}
 }
 
 func (t *tolerantClusterWorkflowTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/workflow/controller/informer/tolerant_workflow_template_informer.go
+++ b/workflow/controller/informer/tolerant_workflow_template_informer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
 	extwfv1 "github.com/argoproj/argo-workflows/v4/pkg/client/informers/externalversions/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/pkg/client/listers/workflow/v1alpha1"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 )
 
 type tolerantWorkflowTemplateInformer struct {
@@ -21,14 +22,17 @@ type tolerantWorkflowTemplateInformer struct {
 
 // NewTolerantWorkflowTemplateInformer is a drop-in replacement for `extwfv1.WorkflowTemplateInformer` that ignores malformed resources.
 func NewTolerantWorkflowTemplateInformer(dynamicInterface dynamic.Interface, defaultResync time.Duration, namespace string) extwfv1.WorkflowTemplateInformer {
-	return &tolerantWorkflowTemplateInformer{delegate: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, namespace, func(options *metav1.ListOptions) {
+	delegate := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicInterface, defaultResync, namespace, func(options *metav1.ListOptions) {
 		// `ResourceVersion=0` does not honor the `limit` in API calls, which results in making significant List calls
 		// without `limit`. For details, see https://github.com/argoproj/argo-workflows/pull/11343
 		// Check if ResourceVersion is "0" and reset it to empty string to ensure proper pagination behavior
 		if options.ResourceVersion == "0" {
 			options.ResourceVersion = ""
 		}
-	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural})}
+	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.WorkflowTemplatePlural})
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	delegate.Informer().SetTransform(informerutil.StripManagedFields)
+	return &tolerantWorkflowTemplateInformer{delegate: delegate}
 }
 
 func (t *tolerantWorkflowTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/workflow/controller/ns_watcher.go
+++ b/workflow/controller/ns_watcher.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	authutil "github.com/argoproj/argo-workflows/v4/util/auth"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 )
@@ -56,6 +57,8 @@ func (wfc *WorkflowController) newNamespaceInformer(ctx context.Context, kubecli
 
 	source := &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 	informer := cache.NewSharedIndexInformer(cache.ToListWatcherWithWatchListSemantics(source, kubeclientset), &apiv1.Namespace{}, nsResyncPeriod, cache.Indexers{})
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	informer.SetTransform(informerutil.StripManagedFields)
 
 	_, err := informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/diff"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	"github.com/argoproj/argo-workflows/v4/workflow/controller/indexes"
@@ -328,6 +329,8 @@ func newInformer(ctx context.Context, clientSet kubernetes.Interface, instanceID
 		indexes.NodeIDIndex:   indexes.MetaNodeIDIndexFunc,
 		indexes.PodPhaseIndex: indexes.PodPhaseIndexFunc,
 	})
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	informer.SetTransform(informerutil.StripManagedFields)
 	return informer
 }
 

--- a/workflow/controller/taskresult.go
+++ b/workflow/controller/taskresult.go
@@ -14,6 +14,7 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	wfextvv1alpha1 "github.com/argoproj/argo-workflows/v4/pkg/client/informers/externalversions/workflow/v1alpha1"
 	envutil "github.com/argoproj/argo-workflows/v4/util/env"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	"github.com/argoproj/argo-workflows/v4/workflow/controller/indexes"
@@ -51,6 +52,8 @@ func (wfc *WorkflowController) newWorkflowTaskResultInformer(ctx context.Context
 			}
 		},
 	)
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	informer.SetTransform(informerutil.StripManagedFields)
 	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
 	informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -2032,6 +2032,9 @@ func TestPodExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, existingPod)
 	assert.True(t, doesExist)
+	// the informer cache strips managedFields from the pod returned by the API
+	assert.Nil(t, existingPod.ManagedFields)
+	pod.ManagedFields = nil
 	assert.Equal(t, pod, existingPod)
 }
 

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -29,6 +29,7 @@ import (
 	wfextvv1alpha1 "github.com/argoproj/argo-workflows/v4/pkg/client/informers/externalversions/workflow/v1alpha1"
 	wfctx "github.com/argoproj/argo-workflows/v4/util/context"
 	"github.com/argoproj/argo-workflows/v4/util/env"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	"github.com/argoproj/argo-workflows/v4/workflow/events"
@@ -107,6 +108,8 @@ func (cc *Controller) Run(ctx context.Context) {
 	cc.cronWfInformer = dynamicinformer.NewFilteredDynamicSharedInformerFactory(cc.dynamicInterface, cronWorkflowResyncPeriod, cc.managedNamespace, func(options *v1.ListOptions) {
 		cronWfInformerListOptionsFunc(options, cc.instanceID)
 	}).ForResource(schema.GroupVersionResource{Group: workflow.Group, Version: workflow.Version, Resource: workflow.CronWorkflowPlural})
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	cc.cronWfInformer.Informer().SetTransform(informerutil.StripManagedFields)
 	err := cc.addCronWorkflowInformerHandler(ctx)
 	if err != nil {
 		cc.logger.WithFatal().Error(ctx, err.Error())

--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -45,6 +45,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/typed/workflow/v1alpha1"
 	cmdutil "github.com/argoproj/argo-workflows/v4/util/cmd"
 	errorsutil "github.com/argoproj/argo-workflows/v4/util/errors"
+	informerutil "github.com/argoproj/argo-workflows/v4/util/informer"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/retry"
 	unstructutil "github.com/argoproj/argo-workflows/v4/util/unstructured"
@@ -78,6 +79,8 @@ func NewWorkflowInformer(ctx context.Context, dclient dynamic.Interface, ns stri
 		tweakListRequestListOptions,
 		tweakWatchRequestListOptions,
 	)
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	informer.SetTransform(informerutil.StripManagedFields)
 	return informer
 }
 


### PR DESCRIPTION
Fixes #16564

### Motivation

`metadata.managedFields` is a meaningful share of every object the workflow-controller caches, and nothing ever reads it. Measured with `--show-managed-fields=true` on a k3s v1.35.6 cluster running real workloads:

| Object | Total size | managedFields | Share |
|---|---|---|---|
| Workflow (large CI run, many nodes) | 438 KB | 101.8 KB | 23% |
| Workflow (small backup job) | 17.9 KB | 3.9 KB | 21% |
| CronWorkflow | 2.3 KB | 706 B | 30% |
| WorkflowTemplate (GitOps-applied) | 8.3 KB | 372 B | 4% |

The dominant entry on Workflows is the controller's own: `status.nodes` is a granular map on a CRD, so the controller's `fieldsV1` set enumerates every node ID and every field beneath it — the overhead grows with node count and is worst exactly on the workflows that already stress the controller. Pods accumulate entries from kubelet, the scheduler and the controller (typically 2–4 KB each; at 10k running pods, tens of MB).

Stripping it before caching is the standard ecosystem mitigation — controller-runtime ships it as [`cache.TransformStripManagedFields`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#TransformStripManagedFields), and upstream measured managedFields handling as one of the two largest contributors to control-plane cache memory (kubernetes/kubernetes#137109). Related: #13684.

### Modifications

- New `util/informer.StripManagedFields`, a `cache.TransformFunc` identical in behaviour to controller-runtime's: `meta.Accessor` so it handles typed and `unstructured` objects, tombstones pass through, and a nil-check avoids mutating objects that already lack managedFields (kubernetes/kubernetes#124337). Mutating in place is safe: transforms run on the reflector's freshly-decoded object before it is stored or handed to handlers.
- Wired into every controller informer: workflow (`NewWorkflowInformer`, also used by the cron controller), pod, task result, task set, artifact GC task (via `externalversions.WithTransform`), tolerant WorkflowTemplate/ClusterWorkflowTemplate (also used by the argo-server's template stores), cron workflow, namespace, and typed configmap informers. The semaphore configmap informer already strips everything but identifying metadata.
- This is loss-free: the controller mutates deep copies and issues ordinary (non-apply) updates, on which the API server treats absent managedFields as "no change to field management". Audited: no non-generated code reads managedFields (only a test fixture), and there are no SSA `.Apply(` call sites outside SQL migrations.

Not covered, as possible follow-ups:

- The argo-server's workflow store (`cache.NewReflector` into a SQLite store, `server/workflow/workflow_server.go`) has no transform hook; stripping there would need doing in the store itself.
- Stripping the `kubectl.kubernetes.io/last-applied-configuration` annotation (44% of a measured GitOps-applied WorkflowTemplate) is user-visible data and needs its own discussion.

### Verification

- New unit tests for the transform: typed Pod, `unstructured` Workflow, no mutation when managedFields absent, tombstone pass-through.
- `TestPodExists` now asserts the pod in the informer store has nil managedFields (the fake clientset tracks field management on create, so this exercises the strip end-to-end through the informer).
- Existing unit tests for all touched packages pass; `golangci-lint` clean.
- [ ] Before/after heap profile from the stress profile (`ARGO_PPROF=true`, `docs/stress-testing.md`) to record the actual saving — pending, will attach numbers.

### Documentation

- `docs/scaling.md`: note that informer caches dominate controller memory and that managedFields are stripped since v4.1 (relevant when comparing heap profiles across versions).
- `docs/upgrading.md`: entry under v4.1.

### AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced controller memory usage by removing Kubernetes `managedFields` from objects held in informer caches.
  * Reduced unnecessary processing caused by updates that only change managed-field metadata.
  * Cluster-stored objects remain unchanged.

* **Documentation**
  * Added scaling guidance and upgrade notes describing the cache behavior and memory implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->