### PR TITLE
fix(controller): do not postpone already-Running workflows. Fixes #14123

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -967,7 +967,10 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 	// immediately. Only read from wf on this path, never mutate it.
 	shutdownStrategy := wf.Spec.Shutdown
 
-	if (!shutdownStrategy.Enabled() || shutdownStrategy != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) {
+	// A Running workflow must never be postponed, even if the throttler no longer admits
+	// it (e.g. it was removed when an archive attempt failed mid-flight): skipping
+	// reconciliation would orphan its pods (#14123).
+	if (!shutdownStrategy.Enabled() || shutdownStrategy != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) && wf.Status.Phase != wfv1.WorkflowRunning {
 		logger.WithFields(logging.Fields{"workflow": wf.Name, "namespace": wf.Namespace, "key": key}).
 			Info(ctx, "Workflow processing has been postponed due to max parallelism limit")
 		if wf.Status.Phase == wfv1.WorkflowUnknown {

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -776,6 +776,73 @@ spec:
 	}
 }
 
+// A Running workflow that has been dropped from the throttler (e.g. an archive attempt
+// failed mid-flight after throttler.Remove) must not be postponed by the parallelism
+// limit: it must still be reconciled, or its pods are orphaned. Regression test for
+// #14123; the fix from #14606 was accidentally reverted by the slog refactor (#14527).
+func TestParallelismDoesNotPostponeRunningWorkflows(t *testing.T) {
+	for tt, f := range map[string]func(controller *WorkflowController){
+		"Parallelism": func(x *WorkflowController) {
+			x.Config.Parallelism = 1
+		},
+		"NamespaceParallelism": func(x *WorkflowController) {
+			x.Config.NamespaceParallelism = 1
+		},
+	} {
+		t.Run(tt, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			cancel, controller := newController(ctx,
+				wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf-0
+  labels:
+    workflows.argoproj.io/phase: Running
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+status:
+  phase: Running
+`),
+				wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf-1
+  labels:
+    workflows.argoproj.io/phase: Running
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+status:
+  phase: Running
+`),
+				f,
+			)
+			defer cancel()
+
+			// Both workflows are admitted at startup by throttler.Init. Simulate my-wf-1
+			// being dropped mid-life, as the archived-workflow path does.
+			controller.throttler.Remove("my-wf-1")
+
+			// my-wf-0 is still admitted and occupies the only slot.
+			assert.True(t, controller.processNextItem(ctx))
+
+			// my-wf-1 is Running but no longer admitted; it must be reconciled anyway,
+			// not postponed. Reconciliation creates its entrypoint node.
+			assert.True(t, controller.processNextItem(ctx))
+			expectWorkflow(ctx, controller, "my-wf-1", func(wf *wfv1.Workflow) {
+				require.NotNil(t, wf)
+				assert.Equal(t, wfv1.WorkflowRunning, wf.Status.Phase)
+				assert.NotEmpty(t, wf.Status.Nodes)
+			})
+		})
+	}
+}
+
 func TestWorkflowController_archivedWorkflowGarbageCollector(t *testing.T) {
 	cancel, controller := newController(logging.TestContext(t.Context()))
 	defer cancel()


### PR DESCRIPTION
Fixes #14123

### Motivation

#14606 added a guard to the parallelism throttle check so that an already-`Running` workflow that is no longer admitted by the throttler (e.g. it was removed when an archive attempt failed mid-flight, then the still-`Running` object was re-delivered) is still reconciled rather than postponed indefinitely, which orphaned its pods (#14123, #14100, #12103).

The slog logging refactor (#14527) was based on an older commit and accidentally dropped the `&& woc.wf.Status.Phase != wfv1.WorkflowRunning` clause while reformatting this condition. #14606 shipped without a regression test, so nothing caught the revert — the guard has been absent since v4.0. Found during review of #16560, which rewrote the same predicate.

### Modifications

- Re-apply the guard on top of the restructured throttle check from #16560: a `Running` workflow is never postponed by the parallelism limit.
- Add the regression test #14606 lacked: `TestParallelismDoesNotPostponeRunningWorkflows` simulates the mid-life drop (`throttler.Remove` on a `Running` workflow, as the archived-workflow path does) and asserts the workflow is still reconciled, for both `Parallelism` and `NamespaceParallelism`. The test fails without the guard.

### Verification

- `go test ./workflow/controller/` passes in full (`-count=1`).
- The new test fails when the guard is removed, in both subtests.
- The `woc-misuse` awk lint from `make lint-go` passes.

Needs backporting to `release-4.0` (contains #14527). `release-3.7` still carries the original guard (cherry-pick `6e9ef1eb92`) and does not need it.

### Documentation

Not needed — restores previously-documented behaviour of #14606; no user-facing surface change.

### AI

Claude Code (Fable 5) — analysis, patch, and test authored with AI assistance under maintainer direction; verified by running the test suite locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Running workflows are no longer incorrectly postponed when parallelism limits are reached.
  - Workflows that were temporarily removed from throttling continue reconciliation and retain their Running status.
  - Prevents running workflows from becoming orphaned due to incorrect postponement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->