### PR TITLE
fix(controller): archive each workflow once, and retry failed archives. Fixes #16575

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1391,7 +1391,7 @@ func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) 
 		if apierr.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to archive workflow: %w", err)
+		return fmt.Errorf("failed to mark the workflow archived: %w", err)
 	}
 	return nil
 }

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1034,10 +1034,7 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 		return true
 	}
 
-	if err := wfc.archiveWorkflow(ctx, obj); err != nil {
-		logger.WithField("key", key).WithError(err).Warn(ctx, "failed to archive workflow, requeuing")
-		wfc.wfArchiveQueue.AddRateLimited(key)
-	}
+	wfc.archiveWorkflow(ctx, obj)
 	return true
 }
 
@@ -1286,25 +1283,25 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 	return nil
 }
 
-func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) error {
+func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) {
 	logger := logging.RequireLoggerFromContext(ctx)
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		logger.Error(ctx, "failed to get key for object")
-		return nil // non-retryable
+		return // non-retryable
 	}
 	wfc.workflowKeyLock.Lock(key)
 	defer wfc.workflowKeyLock.Unlock(key)
 	key, err = cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		logger.Error(ctx, "failed to get key for object after locking")
-		return nil // non-retryable
+		return // non-retryable
 	}
+	// Archiving failures are non-retryable: log and swallow.
 	err = wfc.archiveWorkflowAux(ctx, obj)
 	if err != nil {
 		logger.WithField("key", key).WithError(err).Error(ctx, "failed to archive workflow")
 	}
-	return nil // non-retryable
 }
 
 func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) error {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1031,10 +1031,18 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 		return true
 	}
 	if !exists {
+		// The workflow is gone, so no further attempt will be made: drop any
+		// backoff the rate limiter is still holding for this key.
+		wfc.wfArchiveQueue.Forget(key)
 		return true
 	}
 
-	wfc.archiveWorkflow(ctx, obj)
+	if err := wfc.archiveWorkflow(ctx, obj); err != nil {
+		logger.WithField("key", key).WithError(err).Warn(ctx, "failed to archive workflow, requeuing")
+		wfc.wfArchiveQueue.AddRateLimited(key)
+		return true
+	}
+	wfc.wfArchiveQueue.Forget(key)
 	return true
 }
 
@@ -1283,25 +1291,29 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 	return nil
 }
 
-func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) {
+func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) error {
 	logger := logging.RequireLoggerFromContext(ctx)
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		logger.Error(ctx, "failed to get key for object")
-		return // non-retryable
+		return nil // non-retryable
 	}
 	wfc.workflowKeyLock.Lock(key)
 	defer wfc.workflowKeyLock.Unlock(key)
 	key, err = cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		logger.Error(ctx, "failed to get key for object after locking")
-		return // non-retryable
+		return nil // non-retryable
 	}
-	// Archiving failures are non-retryable: log and swallow.
-	err = wfc.archiveWorkflowAux(ctx, obj)
-	if err != nil {
+	// Archive once, and hand a failure back to the caller so it can requeue:
+	// a transient database error, such as a MySQL deadlock between two
+	// workflows archiving at the same time, otherwise leaves the workflow at
+	// archiving-status=Pending until the controller restarts.
+	if err := wfc.archiveWorkflowAux(ctx, obj); err != nil {
 		logger.WithField("key", key).WithError(err).Error(ctx, "failed to archive workflow")
+		return err
 	}
+	return nil
 }
 
 func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) error {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1332,10 +1332,6 @@ func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) err
 	}
 	wfc.workflowKeyLock.Lock(key)
 	defer wfc.workflowKeyLock.Unlock(key)
-	if _, err := cache.MetaNamespaceKeyFunc(obj); err != nil {
-		logger.Error(ctx, "failed to get key for object after locking")
-		return nil // non-retryable
-	}
 	// Archive once, and hand a failure back to the caller so it can requeue:
 	// a transient database error, such as a MySQL deadlock between two
 	// workflows archiving at the same time, otherwise leaves the workflow at

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -359,6 +359,9 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	}
 
 	defer wfc.wfQueue.ShutDown()
+	// The archive workers block in Get() until the queue shuts down, so
+	// cancelling their context alone does not release them.
+	defer wfc.wfArchiveQueue.ShutDown()
 
 	logger.WithFields(argo.GetVersion().Fields()).WithFields(logging.Fields{
 		"instanceID":         wfc.Config.InstanceID,
@@ -1025,6 +1028,13 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 	logger := logging.RequireLoggerFromContext(ctx)
 	defer wfc.wfArchiveQueue.Done(key)
 
+	// Same order as processNextItem: hold the key lock, then read the current
+	// object, then decide. The queue holds only namespace/name, and a
+	// rate-limited retry can fire long after the key was added, so nothing about
+	// the object may be assumed from the key alone.
+	wfc.workflowKeyLock.Lock(key)
+	defer wfc.workflowKeyLock.Unlock(key)
+
 	obj, exists, err := wfc.wfInformer.GetIndexer().GetByKey(key)
 	if err != nil {
 		logger.WithField("key", key).WithError(err).Error(ctx, "Failed to get workflow from informer")
@@ -1039,37 +1049,44 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 		wfc.wfArchiveQueue.Forget(key)
 		return true
 	}
-
-	// The queue holds only namespace/name, and a rate-limited retry can fire
-	// long after the key was added, so re-check the condition the informer
-	// filter matched on before acting on it. `argo retry` deletes this label
-	// and puts the workflow back to Unknown, and a same-named workflow may have
-	// been recreated in the meantime; archiving either would write a running
-	// workflow to the archive and then label it Archived. The GC controller
-	// re-checks the current object for the same reason, see #12636.
-	//
-	// common.IsDone is deliberately not used here: it treats a Pending
-	// archiving-status as not-done, so it is false for precisely the workflows
-	// this queue exists to archive.
-	//
-	// This reads the informer cache, so it closes the long window the rate
-	// limiter opens, not the short one where the cache has yet to catch up with
-	// a write. Archiving stays at-least-once for that reason: ArchiveWorkflow
-	// deletes and re-inserts by uid, so a repeat is wasted work rather than
-	// corruption. The GC controller's equivalent check has the same property.
 	un, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		logger.WithField("key", key).Error(ctx, "Workflow from the informer is not unstructured")
 		wfc.wfArchiveQueue.Forget(key)
 		return true
 	}
-	if un.GetLabels()[common.LabelKeyWorkflowArchivingStatus] != "Pending" {
+
+	// A stale copy still carries the labels it had when it was written, so the
+	// eligibility check below cannot tell it from a current one. Reject it the
+	// way processNextItem does (#15090): ArchiveWorkflow deletes and re-inserts
+	// by uid, so archiving an older snapshot does not merely repeat work, it
+	// replaces a newer archived record with an older one. Requeue rather than
+	// drop, so the archive still happens once the informer catches up.
+	if outdated, _ := wfc.isOutdated(ctx, un); outdated {
+		logger.WithField("key", key).Debug(ctx, "Waiting for a current copy of the workflow before archiving")
+		wfc.wfArchiveQueue.AddRateLimited(key)
+		return true
+	}
+
+	// Re-check what the informer filter matched on. `argo retry` removes both
+	// labels and puts the workflow back to Unknown, and a same-named workflow
+	// may have been recreated meanwhile; archiving either would write a running
+	// workflow to the archive and then label it Archived. The GC controller
+	// re-checks the current object for the same reason, see #12636.
+	//
+	// common.IsDone is deliberately not used: it treats a Pending
+	// archiving-status as not-done, so it is false for precisely the workflows
+	// this queue exists to archive.
+	labels := un.GetLabels()
+	if labels[common.LabelKeyCompleted] != "true" ||
+		labels[common.LabelKeyWorkflowArchivingStatus] != "Pending" {
 		logger.WithField("key", key).Info(ctx, "Workflow is no longer pending archiving, skipping")
 		wfc.wfArchiveQueue.Forget(key)
 		return true
 	}
 
-	if err := wfc.archiveWorkflow(ctx, obj); err != nil {
+	// The caller holds the key lock, so archiveWorkflowAux is entered directly.
+	if err := wfc.archiveWorkflowAux(ctx, obj); err != nil {
 		logger.WithField("key", key).WithError(err).Warn(ctx, "failed to archive workflow, requeuing")
 		wfc.wfArchiveQueue.AddRateLimited(key)
 		return true
@@ -1282,8 +1299,17 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 	_, err = wfc.wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj any) bool {
 			un, ok := obj.(*unstructured.Unstructured)
-			// no need to check the `common.LabelKeyCompleted` as we already know it must be complete
-			return ok && un.GetLabels()[common.LabelKeyWorkflowArchivingStatus] == "Pending"
+			if !ok {
+				return false
+			}
+			// Require both labels rather than assuming completion from the
+			// archiving status: nothing in this handler enforces that the two
+			// were set together, so a hand-applied Pending label would otherwise
+			// queue a running workflow for archiving. The completion path sets
+			// both in one update, so this excludes nothing legitimate.
+			labels := un.GetLabels()
+			return labels[common.LabelKeyCompleted] == "true" &&
+				labels[common.LabelKeyWorkflowArchivingStatus] == "Pending"
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
@@ -1321,23 +1347,6 @@ func (wfc *WorkflowController) addWorkflowInformerHandlers(ctx context.Context) 
 		return err
 	}
 	return nil
-}
-
-func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) error {
-	logger := logging.RequireLoggerFromContext(ctx)
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		logger.Error(ctx, "failed to get key for object")
-		return nil // non-retryable
-	}
-	wfc.workflowKeyLock.Lock(key)
-	defer wfc.workflowKeyLock.Unlock(key)
-	// Archive once, and hand a failure back to the caller so it can requeue:
-	// a transient database error, such as a MySQL deadlock between two
-	// workflows archiving at the same time, otherwise leaves the workflow at
-	// archiving-status=Pending until the controller restarts. The caller logs
-	// the failure, so it is not logged again here.
-	return wfc.archiveWorkflowAux(ctx, obj)
 }
 
 func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) error {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1163,8 +1163,20 @@ func getWfPriority(obj any) (int32, time.Time) {
 	return int32(priority), un.GetCreationTimestamp().Time
 }
 
-// how long to retain the record of a completed or deleted workflow
-const completedVersionRetention = 10 * time.Minute
+// The ceiling of the exponential backoff in
+// workqueue.DefaultTypedControllerRateLimiter, which both controller queues use.
+// Named here because the retention below has to outlast it.
+const maxQueueBackoff = 1000 * time.Second
+
+// How long to retain the record of a completed or deleted workflow.
+//
+// It has to exceed maxQueueBackoff. A rate-limited archive key can fire up to
+// 16m40s after it was enqueued, and if its record has been cleaned up by then
+// isOutdated finds nothing and reports the workflow as current -- so the
+// stale-copy guard would be missing from exactly the long-delayed retries that
+// restoring the archive retry makes possible. The cost is holding one small
+// entry per completed workflow for longer, bounded by the completion rate.
+const completedVersionRetention = maxQueueBackoff + 5*time.Minute
 
 // how often, at most, to scan for expired completed workflow records
 const versionCleanupPeriod = time.Minute

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1028,6 +1028,9 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 	obj, exists, err := wfc.wfInformer.GetIndexer().GetByKey(key)
 	if err != nil {
 		logger.WithField("key", key).WithError(err).Error(ctx, "Failed to get workflow from informer")
+		// The indexer never returns an error today, but drop the backoff rather
+		// than leave the only exit that keeps rate-limiter state behind.
+		wfc.wfArchiveQueue.Forget(key)
 		return true
 	}
 	if !exists {
@@ -1048,6 +1051,12 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 	// common.IsDone is deliberately not used here: it treats a Pending
 	// archiving-status as not-done, so it is false for precisely the workflows
 	// this queue exists to archive.
+	//
+	// This reads the informer cache, so it closes the long window the rate
+	// limiter opens, not the short one where the cache has yet to catch up with
+	// a write. Archiving stays at-least-once for that reason: ArchiveWorkflow
+	// deletes and re-inserts by uid, so a repeat is wasted work rather than
+	// corruption. The GC controller's equivalent check has the same property.
 	un, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		logger.WithField("key", key).Error(ctx, "Workflow from the informer is not unstructured")
@@ -1331,9 +1340,9 @@ func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) err
 	// Archive once, and hand a failure back to the caller so it can requeue:
 	// a transient database error, such as a MySQL deadlock between two
 	// workflows archiving at the same time, otherwise leaves the workflow at
-	// archiving-status=Pending until the controller restarts.
+	// archiving-status=Pending until the controller restarts. The caller logs
+	// the failure, so it is not logged again here.
 	if err := wfc.archiveWorkflowAux(ctx, obj); err != nil {
-		logger.WithField("key", key).WithError(err).Error(ctx, "failed to archive workflow")
 		return err
 	}
 	return nil

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1303,9 +1303,8 @@ func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) err
 	err = wfc.archiveWorkflowAux(ctx, obj)
 	if err != nil {
 		logger.WithField("key", key).WithError(err).Error(ctx, "failed to archive workflow")
-		return nil // non-retryable
 	}
-	return wfc.archiveWorkflowAux(ctx, obj)
+	return nil // non-retryable
 }
 
 func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) error {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1332,8 +1332,7 @@ func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) err
 	}
 	wfc.workflowKeyLock.Lock(key)
 	defer wfc.workflowKeyLock.Unlock(key)
-	key, err = cache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
+	if _, err := cache.MetaNamespaceKeyFunc(obj); err != nil {
 		logger.Error(ctx, "failed to get key for object after locking")
 		return nil // non-retryable
 	}
@@ -1342,10 +1341,7 @@ func (wfc *WorkflowController) archiveWorkflow(ctx context.Context, obj any) err
 	// workflows archiving at the same time, otherwise leaves the workflow at
 	// archiving-status=Pending until the controller restarts. The caller logs
 	// the failure, so it is not logged again here.
-	if err := wfc.archiveWorkflowAux(ctx, obj); err != nil {
-		return err
-	}
-	return nil
+	return wfc.archiveWorkflowAux(ctx, obj)
 }
 
 func (wfc *WorkflowController) archiveWorkflowAux(ctx context.Context, obj any) error {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1163,19 +1163,27 @@ func getWfPriority(obj any) (int32, time.Time) {
 	return int32(priority), un.GetCreationTimestamp().Time
 }
 
-// The ceiling of the exponential backoff in
-// workqueue.DefaultTypedControllerRateLimiter, which both controller queues use.
-// Named here because the retention below has to outlast it.
+// The ceiling of the per-item exponential backoff in
+// workqueue.DefaultTypedControllerRateLimiter, which the archive queue uses.
+// The workflow queue is rate limited differently.
+//
+// This is not the queue's worst case. That limiter takes the maximum of the
+// exponential and a global 10 qps token bucket, whose delay grows with the
+// number of keys waiting and has no ceiling, and a key waits again for a free
+// worker after it becomes ready.
 const maxQueueBackoff = 1000 * time.Second
 
 // How long to retain the record of a completed or deleted workflow.
 //
-// It has to exceed maxQueueBackoff. A rate-limited archive key can fire up to
-// 16m40s after it was enqueued, and if its record has been cleaned up by then
+// Sized past maxQueueBackoff. A rate-limited archive key can fire up to 16m40s
+// after it was enqueued, and if its record has been cleaned up by then
 // isOutdated finds nothing and reports the workflow as current -- so the
 // stale-copy guard would be missing from exactly the long-delayed retries that
-// restoring the archive retry makes possible. The cost is holding one small
-// entry per completed workflow for longer, bounded by the completion rate.
+// restoring the archive retry makes possible. This covers the delay a retry
+// actually takes in normal operation; it is not a bound, since the terms above
+// are unbounded and a retry has no total deadline. The cost is holding one
+// small entry per completed workflow for longer, bounded by the completion
+// rate.
 const completedVersionRetention = maxQueueBackoff + 5*time.Minute
 
 // how often, at most, to scan for expired completed workflow records

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1037,6 +1037,29 @@ func (wfc *WorkflowController) processNextArchiveItem(ctx context.Context) bool 
 		return true
 	}
 
+	// The queue holds only namespace/name, and a rate-limited retry can fire
+	// long after the key was added, so re-check the condition the informer
+	// filter matched on before acting on it. `argo retry` deletes this label
+	// and puts the workflow back to Unknown, and a same-named workflow may have
+	// been recreated in the meantime; archiving either would write a running
+	// workflow to the archive and then label it Archived. The GC controller
+	// re-checks the current object for the same reason, see #12636.
+	//
+	// common.IsDone is deliberately not used here: it treats a Pending
+	// archiving-status as not-done, so it is false for precisely the workflows
+	// this queue exists to archive.
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		logger.WithField("key", key).Error(ctx, "Workflow from the informer is not unstructured")
+		wfc.wfArchiveQueue.Forget(key)
+		return true
+	}
+	if un.GetLabels()[common.LabelKeyWorkflowArchivingStatus] != "Pending" {
+		logger.WithField("key", key).Info(ctx, "Workflow is no longer pending archiving, skipping")
+		wfc.wfArchiveQueue.Forget(key)
+		return true
+	}
+
 	if err := wfc.archiveWorkflow(ctx, obj); err != nil {
 		logger.WithField("key", key).WithError(err).Warn(ctx, "failed to archive workflow, requeuing")
 		wfc.wfArchiveQueue.AddRateLimited(key)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -874,7 +874,7 @@ func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
 	un, err := util.ToUnstructured(wf)
 	require.NoError(t, err)
 
-	err = controller.archiveWorkflow(ctx, un)
+	err = controller.archiveWorkflowAux(ctx, un)
 	require.NoError(t, err)
 	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 }
@@ -902,7 +902,7 @@ func TestWorkflowController_archiveWorkflow_ReturnsErrorOnce(t *testing.T) {
 	un, err := util.ToUnstructured(wf)
 	require.NoError(t, err)
 
-	err = controller.archiveWorkflow(ctx, un)
+	err = controller.archiveWorkflowAux(ctx, un)
 	require.ErrorIs(t, err, deadlock)
 	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 }
@@ -958,6 +958,53 @@ func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testin
 	got, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "Archived", got.Labels[common.LabelKeyWorkflowArchivingStatus])
+}
+
+// TestWorkflowController_processNextArchiveItem_RejectsStaleInformerCopy pins the
+// isOutdated guard on the archive path. The label check reads the informer, so a
+// copy that was Pending when written still looks Pending after the workflow has
+// moved on; processNextItem rejects such copies (#15090) and this worker has to
+// do the same, or an informer that regresses re-archives the workflow and
+// re-patches whatever currently holds that name.
+func TestWorkflowController_processNextArchiveItem_RejectsStaleInformerCopy(t *testing.T) {
+	wf := pendingArchiveWorkflow()
+	wf.UID = "uid-1"
+	wf.ResourceVersion = "100"
+	ctx := logging.TestContext(t.Context())
+	archive := sqldbmocks.NewWorkflowArchive(t)
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
+		wfc.wfArchive = archive
+	})
+	defer cancel()
+	defer controller.wfArchiveQueue.ShutDown()
+
+	// The controller has already written a newer version of this workflow.
+	controller.lastWrittenVersions.versions[wf.UID] = lastWrittenVersion{
+		resourceVersion: "200",
+		completedAt:     time.Now(),
+	}
+
+	key := "argo/my-wf"
+	controller.wfArchiveQueue.Add(key)
+	assert.True(t, controller.processNextArchiveItem(ctx))
+
+	// The mock has no ArchiveWorkflow expectation, so any call fails the test.
+	archive.AssertNotCalled(t, "ArchiveWorkflow")
+	// Requeued rather than dropped: the workflow still needs archiving once the
+	// informer catches up, and dropping it would wait for the next resync.
+	assert.Equal(t, 1, controller.wfArchiveQueue.NumRequeues(key))
+
+	// Once the informer holds a copy at least as new as the last write, the
+	// same key archives normally.
+	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).Return(nil).Once()
+	current := wf.DeepCopy()
+	current.ResourceVersion = "200"
+	currentUn, err := util.ToUnstructured(current)
+	require.NoError(t, err)
+	require.NoError(t, controller.wfInformer.GetIndexer().Update(currentUn))
+	assert.True(t, controller.processNextArchiveItem(ctx))
+	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
+	assert.Equal(t, 0, controller.wfArchiveQueue.NumRequeues(key))
 }
 
 // TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow pins that a

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/argoproj/pkg/sync"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v4/config"
 	"github.com/argoproj/argo-workflows/v4/persist/sqldb"
+	sqldbmocks "github.com/argoproj/argo-workflows/v4/persist/sqldb/mocks"
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	fakewfclientset "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
@@ -848,6 +850,31 @@ func TestWorkflowController_archivedWorkflowGarbageCollector(t *testing.T) {
 	defer cancel()
 
 	controller.archivedWorkflowGarbageCollector(logging.TestContext(t.Context()))
+}
+
+// TestWorkflowController_archiveWorkflow_ArchivesOnce pins that a successfully
+// archived workflow is written to the archive exactly once. archiveWorkflow used
+// to call archiveWorkflowAux twice on the success path, double-archiving every
+// workflow and inverting its non-retryable error handling.
+func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
+	wf := &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
+		Status:     wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},
+	}
+	ctx := logging.TestContext(t.Context())
+	archive := sqldbmocks.NewWorkflowArchive(t)
+	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).Return(nil)
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
+		wfc.wfArchive = archive
+	})
+	defer cancel()
+
+	un, err := util.ToUnstructured(wf)
+	require.NoError(t, err)
+
+	err = controller.archiveWorkflow(ctx, un)
+	require.NoError(t, err)
+	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 }
 
 const wfWithTmplRef = `

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -332,6 +332,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		wfc.metrics, testExporter, _ = metrics.CreateDefaultTestMetrics(ctx)
 		wfc.entrypoint = entrypoint.New(kube, wfc.Config.Images)
 		wfc.wfQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+		wfc.wfArchiveQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 		wfc.throttler = wfc.newThrottler()
 		wfc.rateLimiter = wfc.newRateLimiter()
 	}
@@ -934,20 +935,10 @@ func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testin
 	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).
 		Return(errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")).Once()
 	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).Return(nil).Once()
-	// The workflow is seeded straight into the informer store rather than
-	// through the fake client, so the archive informer handler does not enqueue
-	// it before this test builds the queue below.
-	cancel, controller := newController(ctx, func(wfc *WorkflowController) {
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
 		wfc.wfArchive = archive
 	})
 	defer cancel()
-
-	un, err := util.ToUnstructured(wf)
-	require.NoError(t, err)
-	require.NoError(t, controller.wfInformer.GetIndexer().Add(un))
-
-	// newController does not build the archive queue, so make one here.
-	controller.wfArchiveQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	defer controller.wfArchiveQueue.ShutDown()
 
 	key := "argo/my-wf"
@@ -960,6 +951,12 @@ func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testin
 	// The requeued key archives cleanly, and its backoff is forgotten.
 	assert.True(t, controller.processNextArchiveItem(ctx))
 	assert.Equal(t, 0, controller.wfArchiveQueue.NumRequeues(key))
+
+	// The archive is only half the work: the workflow must also be labelled, or
+	// it stays Pending and is archived again on the next resync.
+	got, err := controller.wfclientset.ArgoprojV1alpha1().Workflows("argo").Get(ctx, "my-wf", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "Archived", got.Labels[common.LabelKeyWorkflowArchivingStatus])
 }
 
 // TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow pins that a
@@ -976,18 +973,10 @@ func TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow(t *testi
 	// The only archive attempt is the first one, which fails.
 	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).
 		Return(errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")).Once()
-	// Seeded straight into the informer store so the archive informer handler
-	// does not enqueue it before this test builds the queue below.
-	cancel, controller := newController(ctx, func(wfc *WorkflowController) {
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
 		wfc.wfArchive = archive
 	})
 	defer cancel()
-
-	un, err := util.ToUnstructured(wf)
-	require.NoError(t, err)
-	require.NoError(t, controller.wfInformer.GetIndexer().Add(un))
-
-	controller.wfArchiveQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	defer controller.wfArchiveQueue.ShutDown()
 
 	key := "argo/my-wf"

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -872,8 +872,7 @@ func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
 	un, err := util.ToUnstructured(wf)
 	require.NoError(t, err)
 
-	err = controller.archiveWorkflow(ctx, un)
-	require.NoError(t, err)
+	controller.archiveWorkflow(ctx, un)
 	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 }
 

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -1914,16 +1914,3 @@ func TestExpireCompletedVersions(t *testing.T) {
 	outdated, _ = controller.isOutdated(ctx, &metav1.ObjectMeta{UID: inFlight.UID, ResourceVersion: "99"})
 	assert.True(t, outdated, "in-flight records must not expire")
 }
-
-// TestCompletedVersionRetentionOutlastsTheQueueBackoff pins the relationship
-// between two constants that are easy to change independently.
-//
-// A rate-limited archive key can fire up to the queue's maximum backoff after it
-// was enqueued. If the recorded version has been cleaned up by then, isOutdated
-// finds no record and reports the workflow as current, so the stale-copy guard
-// is absent from precisely the long-delayed retries that restoring the archive
-// retry made possible.
-func TestCompletedVersionRetentionOutlastsTheQueueBackoff(t *testing.T) {
-	assert.Greater(t, completedVersionRetention, maxQueueBackoff,
-		"a retry can fire after its recorded version was cleaned up")
-}

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -854,11 +854,11 @@ func TestWorkflowController_archivedWorkflowGarbageCollector(t *testing.T) {
 	controller.archivedWorkflowGarbageCollector(logging.TestContext(t.Context()))
 }
 
-// TestWorkflowController_archiveWorkflow_ArchivesOnce pins that a successfully
+// TestWorkflowController_archiveWorkflowAux_ArchivesOnce pins that a successfully
 // archived workflow is written to the archive exactly once. archiveWorkflow used
 // to call archiveWorkflowAux a second time on the success path, archiving every
 // workflow twice.
-func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
+func TestWorkflowController_archiveWorkflowAux_ArchivesOnce(t *testing.T) {
 	wf := &wfv1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
 		Status:     wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},
@@ -879,12 +879,12 @@ func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
 	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 }
 
-// TestWorkflowController_archiveWorkflow_ReturnsErrorOnce pins that a failed
+// TestWorkflowController_archiveWorkflowAux_ReturnsArchiveError pins that a failed
 // archive is attempted exactly once and that the error reaches the caller, so
 // processNextArchiveItem can requeue it. The retry added in #15780 never fired,
 // because a first-attempt failure returned nil and only the duplicate second
 // attempt could surface an error.
-func TestWorkflowController_archiveWorkflow_ReturnsErrorOnce(t *testing.T) {
+func TestWorkflowController_archiveWorkflowAux_ReturnsArchiveError(t *testing.T) {
 	wf := &wfv1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
 		Status:     wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -979,12 +979,18 @@ func TestWorkflowController_processNextArchiveItem_RejectsStaleInformerCopy(t *t
 	defer controller.wfArchiveQueue.ShutDown()
 
 	// The controller has already written a newer version of this workflow.
-	controller.lastWrittenVersions.versions[wf.UID] = lastWrittenVersion{
-		resourceVersion: "200",
-		completedAt:     time.Now(),
-	}
+	// Recorded through the production helper rather than by writing the map:
+	// newController has started the workflow informer, whose FilterFunc calls
+	// recordWorkflowCompleted for a completed workflow, so an unguarded write
+	// here races that goroutine. Going through the helper also keeps this
+	// deterministic if the informer records resourceVersion 100 afterwards,
+	// since the helper never regresses the recorded version.
+	newer := wf.DeepCopy()
+	newer.ResourceVersion = "200"
+	controller.recordWorkflowCompleted(newer)
 
-	key := "argo/my-wf"
+	key, err := cache.MetaNamespaceKeyFunc(wf)
+	require.NoError(t, err)
 	controller.wfArchiveQueue.Add(key)
 	assert.True(t, controller.processNextArchiveItem(ctx))
 

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -1914,3 +1914,16 @@ func TestExpireCompletedVersions(t *testing.T) {
 	outdated, _ = controller.isOutdated(ctx, &metav1.ObjectMeta{UID: inFlight.UID, ResourceVersion: "99"})
 	assert.True(t, outdated, "in-flight records must not expire")
 }
+
+// TestCompletedVersionRetentionOutlastsTheQueueBackoff pins the relationship
+// between two constants that are easy to change independently.
+//
+// A rate-limited archive key can fire up to the queue's maximum backoff after it
+// was enqueued. If the recorded version has been cleaned up by then, isOutdated
+// finds no record and reports the workflow as current, so the stale-copy guard
+// is absent from precisely the long-delayed retries that restoring the archive
+// retry made possible.
+func TestCompletedVersionRetentionOutlastsTheQueueBackoff(t *testing.T) {
+	assert.Greater(t, completedVersionRetention, maxQueueBackoff,
+		"a retry can fire after its recorded version was cleaned up")
+}

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	gosync "sync"
 	"sync/atomic"
 	"testing"
@@ -854,8 +855,8 @@ func TestWorkflowController_archivedWorkflowGarbageCollector(t *testing.T) {
 
 // TestWorkflowController_archiveWorkflow_ArchivesOnce pins that a successfully
 // archived workflow is written to the archive exactly once. archiveWorkflow used
-// to call archiveWorkflowAux twice on the success path, double-archiving every
-// workflow and inverting its non-retryable error handling.
+// to call archiveWorkflowAux a second time on the success path, archiving every
+// workflow twice.
 func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
 	wf := &wfv1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
@@ -872,8 +873,76 @@ func TestWorkflowController_archiveWorkflow_ArchivesOnce(t *testing.T) {
 	un, err := util.ToUnstructured(wf)
 	require.NoError(t, err)
 
-	controller.archiveWorkflow(ctx, un)
+	err = controller.archiveWorkflow(ctx, un)
+	require.NoError(t, err)
 	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
+}
+
+// TestWorkflowController_archiveWorkflow_ReturnsErrorOnce pins that a failed
+// archive is attempted exactly once and that the error reaches the caller, so
+// processNextArchiveItem can requeue it. The retry added in #15780 never fired,
+// because a first-attempt failure returned nil and only the duplicate second
+// attempt could surface an error.
+func TestWorkflowController_archiveWorkflow_ReturnsErrorOnce(t *testing.T) {
+	wf := &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
+		Status:     wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},
+	}
+	ctx := logging.TestContext(t.Context())
+	archive := sqldbmocks.NewWorkflowArchive(t)
+	// The transient failure #15780 was written for.
+	deadlock := errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")
+	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).Return(deadlock)
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
+		wfc.wfArchive = archive
+	})
+	defer cancel()
+
+	un, err := util.ToUnstructured(wf)
+	require.NoError(t, err)
+
+	err = controller.archiveWorkflow(ctx, un)
+	require.ErrorIs(t, err, deadlock)
+	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
+}
+
+// TestWorkflowController_processNextArchiveItem_RequeuesThenForgets pins the
+// other half of that retry: a failure requeues the key rate-limited rather than
+// dropping it until the controller restarts, and a later success clears the
+// backoff the rate limiter recorded, so its per-key state does not accumulate.
+func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testing.T) {
+	wf := &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
+		Status:     wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},
+	}
+	ctx := logging.TestContext(t.Context())
+	archive := sqldbmocks.NewWorkflowArchive(t)
+	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).
+		Return(errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")).Once()
+	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).Return(nil).Once()
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
+		wfc.wfArchive = archive
+	})
+	defer cancel()
+
+	un, err := util.ToUnstructured(wf)
+	require.NoError(t, err)
+	require.NoError(t, controller.wfInformer.GetIndexer().Add(un))
+
+	// newController does not build the archive queue, so make one here.
+	controller.wfArchiveQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer controller.wfArchiveQueue.ShutDown()
+
+	key := "argo/my-wf"
+	controller.wfArchiveQueue.Add(key)
+
+	// The deadlock puts the key back on the queue instead of dropping it.
+	assert.True(t, controller.processNextArchiveItem(ctx))
+	assert.Equal(t, 1, controller.wfArchiveQueue.NumRequeues(key))
+
+	// The requeued key archives cleanly, and its backoff is forgotten.
+	assert.True(t, controller.processNextArchiveItem(ctx))
+	assert.Equal(t, 0, controller.wfArchiveQueue.NumRequeues(key))
 }
 
 const wfWithTmplRef = `

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -906,21 +906,38 @@ func TestWorkflowController_archiveWorkflow_ReturnsErrorOnce(t *testing.T) {
 	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 }
 
+// pendingArchiveWorkflow returns a completed workflow labelled the way the
+// operator labels one it has queued for archiving, which is what the archive
+// queue's informer filter matches on.
+func pendingArchiveWorkflow() *wfv1.Workflow {
+	return &wfv1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-wf",
+			Namespace: "argo",
+			Labels: map[string]string{
+				common.LabelKeyCompleted:               "true",
+				common.LabelKeyWorkflowArchivingStatus: "Pending",
+			},
+		},
+		Status: wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},
+	}
+}
+
 // TestWorkflowController_processNextArchiveItem_RequeuesThenForgets pins the
 // other half of that retry: a failure requeues the key rate-limited rather than
 // dropping it until the controller restarts, and a later success clears the
 // backoff the rate limiter recorded, so its per-key state does not accumulate.
 func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testing.T) {
-	wf := &wfv1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{Name: "my-wf", Namespace: "argo"},
-		Status:     wfv1.WorkflowStatus{Phase: wfv1.WorkflowSucceeded},
-	}
+	wf := pendingArchiveWorkflow()
 	ctx := logging.TestContext(t.Context())
 	archive := sqldbmocks.NewWorkflowArchive(t)
 	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).
 		Return(errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")).Once()
 	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).Return(nil).Once()
-	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
+	// The workflow is seeded straight into the informer store rather than
+	// through the fake client, so the archive informer handler does not enqueue
+	// it before this test builds the queue below.
+	cancel, controller := newController(ctx, func(wfc *WorkflowController) {
 		wfc.wfArchive = archive
 	})
 	defer cancel()
@@ -942,6 +959,57 @@ func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testin
 
 	// The requeued key archives cleanly, and its backoff is forgotten.
 	assert.True(t, controller.processNextArchiveItem(ctx))
+	assert.Equal(t, 0, controller.wfArchiveQueue.NumRequeues(key))
+}
+
+// TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow pins that a
+// rate-limited key is re-checked against the current object before it is
+// archived. The queue holds only namespace/name, so between the failed attempt
+// and the retry the workflow can be retried, which removes the archiving-status
+// label and puts it back to Unknown. Archiving it then would write a running
+// workflow to the archive and label it Archived. The same applies to a
+// same-named workflow recreated after the original was deleted.
+func TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow(t *testing.T) {
+	wf := pendingArchiveWorkflow()
+	ctx := logging.TestContext(t.Context())
+	archive := sqldbmocks.NewWorkflowArchive(t)
+	// The only archive attempt is the first one, which fails.
+	archive.EXPECT().ArchiveWorkflow(mock.Anything, mock.Anything).
+		Return(errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")).Once()
+	// Seeded straight into the informer store so the archive informer handler
+	// does not enqueue it before this test builds the queue below.
+	cancel, controller := newController(ctx, func(wfc *WorkflowController) {
+		wfc.wfArchive = archive
+	})
+	defer cancel()
+
+	un, err := util.ToUnstructured(wf)
+	require.NoError(t, err)
+	require.NoError(t, controller.wfInformer.GetIndexer().Add(un))
+
+	controller.wfArchiveQueue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	defer controller.wfArchiveQueue.ShutDown()
+
+	key := "argo/my-wf"
+	controller.wfArchiveQueue.Add(key)
+	assert.True(t, controller.processNextArchiveItem(ctx))
+	assert.Equal(t, 1, controller.wfArchiveQueue.NumRequeues(key))
+
+	// `argo retry` on the same object: createNewRetryWorkflow drops both labels
+	// and resets the phase, so the informer now holds a running workflow under
+	// the key the archive queue is still holding.
+	retried := wf.DeepCopy()
+	delete(retried.Labels, common.LabelKeyCompleted)
+	delete(retried.Labels, common.LabelKeyWorkflowArchivingStatus)
+	retried.Status.Phase = wfv1.WorkflowUnknown
+	retriedUn, err := util.ToUnstructured(retried)
+	require.NoError(t, err)
+	require.NoError(t, controller.wfInformer.GetIndexer().Update(retriedUn))
+
+	// The delayed retry must drop the key instead of archiving the running
+	// workflow, and must clear the backoff rather than requeue forever.
+	assert.True(t, controller.processNextArchiveItem(ctx))
+	archive.AssertNumberOfCalls(t, "ArchiveWorkflow", 1)
 	assert.Equal(t, 0, controller.wfArchiveQueue.NumRequeues(key))
 }
 

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -941,7 +941,8 @@ func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testin
 	defer cancel()
 	defer controller.wfArchiveQueue.ShutDown()
 
-	key := "argo/my-wf"
+	key, err := cache.MetaNamespaceKeyFunc(wf)
+	require.NoError(t, err)
 	controller.wfArchiveQueue.Add(key)
 
 	// The deadlock puts the key back on the queue instead of dropping it.
@@ -954,7 +955,7 @@ func TestWorkflowController_processNextArchiveItem_RequeuesThenForgets(t *testin
 
 	// The archive is only half the work: the workflow must also be labelled, or
 	// it stays Pending and is archived again on the next resync.
-	got, err := controller.wfclientset.ArgoprojV1alpha1().Workflows("argo").Get(ctx, "my-wf", metav1.GetOptions{})
+	got, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, "Archived", got.Labels[common.LabelKeyWorkflowArchivingStatus])
 }
@@ -979,7 +980,8 @@ func TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow(t *testi
 	defer cancel()
 	defer controller.wfArchiveQueue.ShutDown()
 
-	key := "argo/my-wf"
+	key, err := cache.MetaNamespaceKeyFunc(wf)
+	require.NoError(t, err)
 	controller.wfArchiveQueue.Add(key)
 	assert.True(t, controller.processNextArchiveItem(ctx))
 	assert.Equal(t, 1, controller.wfArchiveQueue.NumRequeues(key))


### PR DESCRIPTION
Fixes #16575

### Motivation

`archiveWorkflow` calls `archiveWorkflowAux` twice on the success path, so every successfully archived workflow is hydrated, written to the archive database, and label-patched twice. At high throughput the archive database takes double the write load for no benefit.

The duplicate also inverts the error handling that #15780 added. That PR gave `archiveWorkflow` an `error` return and had `processNextArchiveItem` requeue rate-limited, so a transient database error, such as a MySQL deadlock between two workflows archiving at the same time, would not leave a workflow at `archiving-status=Pending` until the controller restarted. As written, a first-attempt failure returns `nil` and is swallowed, and only the duplicate second attempt can reach the caller, which happens solely after the archive has already succeeded. The retry has therefore never fired for the deadlock it was written for, and when it does fire it re-archives a workflow that already archived.

### Modifications

Drop the trailing duplicate call, so each attempt archives once, and restore the retry to the shape #15780 intended: return the error and let `processNextArchiveItem` requeue rate-limited. The DB write and the label patch are not atomic, so a patch failure re-runs the transaction; the archive is at-least-once overall, which is safe because `ArchiveWorkflow` deletes and re-inserts by `uid`.

Returning every archive error rather than filtering matches #15780. `IsTransientErr` has no case for MySQL 1213 or Postgres 40001 today, so a filter would miss the deadlock the retry exists for. Retrying is safe at the database layer, since `ArchiveWorkflow` deletes and re-inserts by `uid` inside a single transaction.

One addition beyond the straight restore: the queue now forgets a key once the workflow archives, and when the workflow has gone. `wfArchiveQueue` uses the exponential failure rate limiter, whose per-key failure count is only cleared by `Forget`, so switching the retry back on would otherwise leave an entry behind for every workflow that ever failed to archive. `wfQueue` needs no such call, because `fixedItemIntervalRateLimiter` holds no per-item state.

Restoring the retry also makes a stale-key case reachable, so `processNextArchiveItem` re-checks the current object before archiving it. The queue holds only `namespace/name`, and the backoff runs to 1000s, so a workflow can be retried while its key waits: `createNewRetryWorkflow` deletes both the completed and archiving-status labels and resets the phase, and the delayed item would then archive a running workflow and patch it as `Archived`. A workflow deleted and recreated under the same name lands in the same place. The worker now re-reads the `workflow-archiving-status=Pending` label the informer filter matched on and forgets the key when it no longer holds, the way the GC controller re-checks the current object before deleting (#12636).

`common.IsDone` is deliberately not used for that check: it treats a `Pending` archiving-status as not-done, so it is false for precisely the workflows this queue exists to archive. The worker also rejects an outdated informer copy via `isOutdated`, the guard `processNextItem` already applies (#15090): a stale copy carries the labels it had when written, and `ArchiveWorkflow` deletes and re-inserts by `uid`, so archiving one would replace a newer archived record with an older one. What this re-check cannot close is wider than I first wrote, and is tracked in #16588. The informer is eventually consistent, so a workflow that argo-server has already retried can still read here as completed and `Pending` until the watch event arrives; `isOutdated` does not catch that, because the newer version was written by another component and never entered `lastWrittenVersions`. The final label patch is then an unconditional merge patch by namespace/name, so it applies to whatever holds that name at that moment. The exposure per attempt is bounded by informer delivery latency rather than by how long the key waited, but restoring the retry does add attempts, so it is worth being precise about. Closing it means making the patch itself conditional -- testing the uid and both labels atomically and treating a failed test as terminal -- which is a change at the API-write boundary with its own error-classification questions, so it belongs in #16588 rather than here. This PR narrows that window and does not claim to close it.

`processNextArchiveItem` takes the key lock before reading the object, matching `processNextItem`, so the read and the decision happen under it. `archiveWorkflow` existed only to take that lock afterwards and is removed; the worker calls `archiveWorkflowAux` directly. Eligibility requires the completed label alongside the archiving status, in the informer filter and in the worker, since nothing enforced that the two were set together and the completion path sets both in one update. `Run` also shuts down `wfArchiveQueue`, because cancelling the workers' context does not release a worker blocked in `Get()`.

There is no `maxRetries` cap here. #15780 had none, and adding one changes when the controller gives up on a workflow, which seemed worth deciding separately.

### Verification

Two tests cover the halves of the retry:

- `TestWorkflowController_archiveWorkflowAux_ArchivesOnce` asserts `ArchiveWorkflow` runs once per attempt and the call returns `nil`. Once per attempt is the whole claim: the archive stays at-least-once overall, since a failed label patch re-runs the transaction and a workflow marked dirty while it is being processed is re-queued when the attempt finishes.
- `TestWorkflowController_archiveWorkflowAux_ReturnsArchiveError` injects a MySQL 1213 deadlock and asserts one attempt with the error reaching the caller.
- `TestWorkflowController_processNextArchiveItem_RequeuesThenForgets` asserts the key is requeued after the deadlock and its backoff is cleared once the retry succeeds.
- `TestWorkflowController_processNextArchiveItem_SkipsRetriedWorkflow` fails the first archive, retries the workflow in the informer, and asserts the delayed item neither archives it again nor stays requeued.
- `TestWorkflowController_processNextArchiveItem_RejectsStaleInformerCopy` puts a newer version in `lastWrittenVersions` and an older Pending copy in the informer, and asserts nothing is archived and the key stays queued, then that it archives once the informer holds a current copy.

The queue tests build the workflow the way the operator labels one queued for archiving, rather than a bare `Succeeded` phase the informer filter would never have matched.

Each assertion was checked against a mutated build to confirm it fails without the corresponding change.

```
go test ./workflow/controller/ -race -count=3 \
  -run 'TestWorkflowController_(archiveWorkflowAux|processNextArchiveItem)'
```

runs clean. The whole package under `-race` still reports races in `TestWorkflowDefinedExecutorPluginsUsage` and `TestCreateTaskSet`; both reproduce on `main` without this branch.

### Documentation

Not needed. This is an internal controller behaviour fix with no user-facing surface.

### AI

This PR was prepared with the help of an AI coding agent (Claude). The author reviewed the change, and the fix and the tests were built and run locally against the repository before submitting.



