### PR TITLE
fix(ui): show CronWorkflow errors in list. Fixes #10264

### DIFF
--- a/ui/src/cron-workflows/cron-workflow-row.test.tsx
+++ b/ui/src/cron-workflows/cron-workflow-row.test.tsx
@@ -1,0 +1,67 @@
+import {render, screen} from '@testing-library/react';
+import * as React from 'react';
+import {MemoryRouter} from 'react-router-dom';
+
+import {Condition, CronWorkflow} from '../shared/models';
+import {CronWorkflowRow} from './cron-workflow-row';
+
+function workflow(conditions?: Condition[], suspend = false): CronWorkflow {
+    return {
+        metadata: {
+            name: 'my-cron-workflow',
+            namespace: 'default'
+        },
+        spec: {
+            schedules: ['0 * * * *'],
+            suspend,
+            workflowSpec: {}
+        },
+        status: conditions
+            ? {
+                  active: [],
+                  conditions,
+                  lastScheduledTime: null
+              }
+            : undefined
+    };
+}
+
+function renderRow(cronWorkflow: CronWorkflow) {
+    return render(
+        <MemoryRouter>
+            <CronWorkflowRow workflow={cronWorkflow} displayISOFormatCreation={false} displayISOFormatNextScheduled={false} />
+        </MemoryRouter>
+    );
+}
+
+describe('CronWorkflowRow', () => {
+    it('shows an error icon and condition message for an error condition', () => {
+        const {container} = renderRow(
+            workflow([
+                {
+                    type: 'SpecError',
+                    status: 'True',
+                    message: "template name 'missing' undefined"
+                }
+            ])
+        );
+
+        const error = screen.getByTitle("template name 'missing' undefined");
+        expect(error.querySelector('.status-icon--error')).toBeInTheDocument();
+        expect(container.querySelector('.fa-clock')).not.toBeInTheDocument();
+    });
+
+    it('shows the clock icon when there are no error conditions', () => {
+        const {container} = renderRow(workflow());
+
+        expect(container.querySelector('.fa-clock')).toBeInTheDocument();
+        expect(container.querySelector('.status-icon--error')).not.toBeInTheDocument();
+    });
+
+    it('keeps the pause icon for a suspended workflow without errors', () => {
+        const {container} = renderRow(workflow(undefined, true));
+
+        expect(container.querySelector('.fa-pause')).toBeInTheDocument();
+        expect(container.querySelector('.status-icon--error')).not.toBeInTheDocument();
+    });
+});

--- a/ui/src/cron-workflows/cron-workflow-row.tsx
+++ b/ui/src/cron-workflows/cron-workflow-row.tsx
@@ -4,8 +4,10 @@ import {Link} from 'react-router-dom';
 
 import {ANNOTATION_DESCRIPTION, ANNOTATION_TITLE} from '../shared/annotations';
 import {uiUrl} from '../shared/base';
+import {ErrorIcon} from '../shared/components/fa-icons';
 import {SuspenseReactMarkdownGfm} from '../shared/components/suspense-react-markdown-gfm';
 import {Timestamp} from '../shared/components/timestamp';
+import {getErrorCondition} from '../shared/conditions-panel';
 import {getNextScheduledTime} from '../shared/cron';
 import {CronWorkflow, CronWorkflowSpec} from '../shared/models';
 import {escapeInvalidMarkdown} from '../workflows/utils';
@@ -25,11 +27,22 @@ export function CronWorkflowRow(props: CronWorkflowRowProps) {
     const title = (wf.metadata.annotations?.[ANNOTATION_TITLE] && `${escapeInvalidMarkdown(wf.metadata.annotations[ANNOTATION_TITLE])}`) ?? wf.metadata.name;
     const description = (wf.metadata.annotations?.[ANNOTATION_DESCRIPTION] && `\n${escapeInvalidMarkdown(wf.metadata.annotations[ANNOTATION_DESCRIPTION])}`) || '';
     const markdown = `${title}${description}`;
+    const errorCondition = getErrorCondition(wf.status?.conditions || []);
 
     return (
         <div className='cron-workflows-list__row-container'>
             <div className='row argo-table-list__row'>
-                <div className='columns small-1'>{wf.spec.suspend ? <i className='fa fa-pause' /> : <i className='fa fa-clock' />}</div>
+                <div className='columns small-1'>
+                    {errorCondition ? (
+                        <span title={errorCondition.message}>
+                            <ErrorIcon />
+                        </span>
+                    ) : wf.spec.suspend ? (
+                        <i className='fa fa-pause' />
+                    ) : (
+                        <i className='fa fa-clock' />
+                    )}
+                </div>
                 <Link to={{pathname: uiUrl(`cron-workflows/${wf.metadata.namespace}/${wf.metadata.name}`)}} className='columns small-2'>
                     <div className={description.length ? 'wf-rows-name' : ''} aria-valuetext={markdown}>
                         <SuspenseReactMarkdownGfm markdown={markdown} />

--- a/ui/src/shared/conditions-panel.tsx
+++ b/ui/src/shared/conditions-panel.tsx
@@ -10,6 +10,10 @@ interface Props {
 const WarningConditions: ConditionType[] = ['SpecWarning'];
 const ErrorConditions: ConditionType[] = ['MetricsError', 'SubmissionError', 'SpecError', 'ArtifactGCError'];
 
+export function getErrorCondition(conditions: Condition[]): Condition | undefined {
+    return conditions.find(condition => ErrorConditions.includes(condition.type));
+}
+
 export function hasWarningConditionBadge(conditions: Condition[]): boolean {
     for (const condition of conditions) {
         if (WarningConditions.includes(condition.type)) {


### PR DESCRIPTION
Fixes #10264

### Motivation

CronWorkflows with an error condition such as `SpecError` currently show the same clock or pause icon as healthy workflows in the list. This makes configuration errors easy to miss without opening the workflow details.

### Modifications

- Reuse the shared error-condition classification to identify CronWorkflow errors.
- Show the existing red error icon in the CronWorkflow list when an error condition is present.
- Expose the condition message as the icon's tooltip.
- Preserve the clock and pause icons for workflows without errors.
- Add focused row tests for error, healthy, and suspended states.

### Verification

- `corepack yarn --cwd ui test --runInBand` (28 suites, 134 tests)
- `corepack yarn --cwd ui eslint src/cron-workflows/cron-workflow-row.tsx src/cron-workflows/cron-workflow-row.test.tsx src/shared/conditions-panel.tsx`
- `corepack yarn --cwd ui tsc --noEmit`
- `corepack yarn --cwd ui e2e:typecheck`
- `corepack yarn --cwd ui prettier --check src/cron-workflows/cron-workflow-row.tsx src/cron-workflows/cron-workflow-row.test.tsx src/shared/conditions-panel.tsx`
- Production Webpack build via `corepack yarn --cwd ui webpack --mode production` with `NODE_ENV=production`
- `git diff --check`

The full `make pre-commit -B` target could not run on this native Windows environment because it depends on Unix commands and paths. The relevant UI checks above pass, and the direct production Webpack build passes with only the existing asset-size warnings.

### Documentation

No documentation changes are needed. This fixes the existing CronWorkflow list status presentation and does not add a new user-facing workflow or configuration option.

### AI

OpenAI Codex was used to help identify the issue, implement the code and tests, run validation, and draft the commit and PR text. I reviewed the diff and test coverage and verified the behavior with the checks listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cron workflows now display an error icon when an error condition is present, with a tooltip showing the error message.
  * Suspended workflows continue to display a pause icon, while active workflows display a clock icon when no errors exist.

* **Tests**
  * Added coverage for error, suspended, and active workflow indicator states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->