### PR TITLE
feat(ui): paginate cluster workflow templates. Fixes #10845

### DIFF
--- a/.features/pending/cluster-workflow-template-pagination.md
+++ b/.features/pending/cluster-workflow-template-pagination.md
@@ -1,0 +1,6 @@
+Description: Paginate Cluster Workflow Templates in the UI
+Authors: [hyzaw](https://github.com/hyzaw)
+Component: UI
+Issues: 10845
+
+The Cluster Workflow Templates page now supports configurable page sizes and navigation through large template lists.

--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-list.test.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-list.test.tsx
@@ -1,0 +1,45 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
+import * as React from 'react';
+import {Router} from 'react-router-dom';
+
+import {Context} from '../shared/context';
+import {exampleClusterWorkflowTemplate} from '../shared/examples';
+import {services} from '../shared/services';
+import {ClusterWorkflowTemplateList} from './cluster-workflow-template-list';
+
+jest.mock('./cluster-workflow-template-creator', () => ({ClusterWorkflowTemplateCreator: (): null => null}));
+
+describe('ClusterWorkflowTemplateList', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('loads pagination from the URL and requests the next page', async () => {
+        const template = exampleClusterWorkflowTemplate();
+        template.metadata.name = 'example-template';
+        const list = jest
+            .spyOn(services.clusterWorkflowTemplate, 'list')
+            .mockResolvedValueOnce({metadata: {continue: 'next-token'}, items: [template]} as any)
+            .mockResolvedValueOnce({metadata: {}, items: [template]} as any);
+        const history = createMemoryHistory();
+        history.push('/cluster-workflow-templates?offset=current-token&limit=5');
+
+        render(
+            <Router history={history}>
+                <Context.Provider value={{navigation: {goto: jest.fn()}} as any}>
+                    <ClusterWorkflowTemplateList history={history} location={history.location} match={{} as any} />
+                </Context.Provider>
+            </Router>
+        );
+
+        await waitFor(() => expect(list).toHaveBeenCalledWith({offset: 'current-token', limit: 5}));
+        const nextPage = await screen.findByRole('button', {name: /Next page/});
+        expect(nextPage).toBeEnabled();
+
+        fireEvent.click(nextPage);
+
+        await waitFor(() => expect(list).toHaveBeenNthCalledWith(2, {offset: 'next-token', limit: 5}));
+    });
+});

--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-list.test.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-list.test.tsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {createMemoryHistory} from 'history';
 import * as React from 'react';
 import {Router} from 'react-router-dom';
@@ -10,6 +10,30 @@ import {ClusterWorkflowTemplateList} from './cluster-workflow-template-list';
 
 jest.mock('./cluster-workflow-template-creator', () => ({ClusterWorkflowTemplateCreator: (): null => null}));
 
+function response(name: string, nextOffset?: string) {
+    const template = exampleClusterWorkflowTemplate();
+    template.metadata.name = name;
+    return {metadata: {continue: nextOffset}, items: [template]};
+}
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(r => (resolve = r));
+    return {promise, resolve};
+}
+
+function renderList(search = '') {
+    const history = createMemoryHistory();
+    history.push(`/cluster-workflow-templates${search}`);
+    render(
+        <Router history={history}>
+            <Context.Provider value={{navigation: {goto: jest.fn()}} as any}>
+                <ClusterWorkflowTemplateList history={history} location={history.location} match={{} as any} />
+            </Context.Provider>
+        </Router>
+    );
+}
+
 describe('ClusterWorkflowTemplateList', () => {
     afterEach(() => {
         jest.restoreAllMocks();
@@ -17,22 +41,11 @@ describe('ClusterWorkflowTemplateList', () => {
     });
 
     it('loads pagination from the URL and requests the next page', async () => {
-        const template = exampleClusterWorkflowTemplate();
-        template.metadata.name = 'example-template';
         const list = jest
             .spyOn(services.clusterWorkflowTemplate, 'list')
-            .mockResolvedValueOnce({metadata: {continue: 'next-token'}, items: [template]} as any)
-            .mockResolvedValueOnce({metadata: {}, items: [template]} as any);
-        const history = createMemoryHistory();
-        history.push('/cluster-workflow-templates?offset=current-token&limit=5');
-
-        render(
-            <Router history={history}>
-                <Context.Provider value={{navigation: {goto: jest.fn()}} as any}>
-                    <ClusterWorkflowTemplateList history={history} location={history.location} match={{} as any} />
-                </Context.Provider>
-            </Router>
-        );
+            .mockResolvedValueOnce(response('example-template', 'next-token') as any)
+            .mockResolvedValueOnce(response('example-template') as any);
+        renderList('?offset=current-token&limit=5');
 
         await waitFor(() => expect(list).toHaveBeenCalledWith({offset: 'current-token', limit: 5}));
         const nextPage = await screen.findByRole('button', {name: /Next page/});
@@ -41,5 +54,48 @@ describe('ClusterWorkflowTemplateList', () => {
         fireEvent.click(nextPage);
 
         await waitFor(() => expect(list).toHaveBeenNthCalledWith(2, {offset: 'next-token', limit: 5}));
+    });
+
+    it('preserves an explicit all-results limit from the URL', async () => {
+        const list = jest.spyOn(services.clusterWorkflowTemplate, 'list').mockResolvedValue(response('example-template') as any);
+
+        renderList('?limit=0');
+
+        await waitFor(() => expect(list).toHaveBeenCalledWith({offset: null, limit: 0}));
+    });
+
+    it('loads and updates the stored page size', async () => {
+        localStorage.setItem('ClusterWorkflowTemplateListOptions/paginationLimit', '10');
+        const list = jest.spyOn(services.clusterWorkflowTemplate, 'list').mockResolvedValue(response('example-template') as any);
+        renderList();
+
+        await waitFor(() => expect(list).toHaveBeenCalledWith({offset: null, limit: 10}));
+        fireEvent.change(await screen.findByRole('combobox'), {target: {value: '20'}});
+
+        await waitFor(() => expect(list).toHaveBeenLastCalledWith({limit: 20, offset: undefined}));
+        expect(localStorage.getItem('ClusterWorkflowTemplateListOptions/paginationLimit')).toBe('20');
+    });
+
+    it('ignores a stale response after the page size changes', async () => {
+        const stale = deferred<any>();
+        const latest = deferred<any>();
+        const list = jest
+            .spyOn(services.clusterWorkflowTemplate, 'list')
+            .mockResolvedValueOnce(response('first-page', 'next-token') as any)
+            .mockReturnValueOnce(stale.promise)
+            .mockReturnValueOnce(latest.promise);
+        renderList('?limit=5');
+
+        fireEvent.click(await screen.findByRole('button', {name: /Next page/}));
+        await waitFor(() => expect(list).toHaveBeenNthCalledWith(2, {offset: 'next-token', limit: 5}));
+        fireEvent.change(screen.getByRole('combobox'), {target: {value: '20'}});
+        await waitFor(() => expect(list).toHaveBeenNthCalledWith(3, {limit: 20, offset: undefined}));
+
+        await act(async () => latest.resolve(response('latest-page')));
+        expect(await screen.findByText('latest-page')).toBeInTheDocument();
+        await act(async () => stale.resolve(response('stale-page')));
+
+        expect(screen.getByText('latest-page')).toBeInTheDocument();
+        expect(screen.queryByText('stale-page')).not.toBeInTheDocument();
     });
 });

--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-list.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-list.tsx
@@ -34,21 +34,11 @@ export function ClusterWorkflowTemplateList({history, location}: RouteComponentP
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel'));
     const storage = new ScopedLocalStorage('ClusterWorkflowTemplateListOptions');
     const savedPaginationLimit = storage.getItem('paginationLimit', 0);
+    const urlLimit = parseLimit(queryParams.get('limit'));
     const [pagination, setPagination] = useState<Pagination>({
         offset: queryParams.get('offset'),
-        limit: parseLimit(queryParams.get('limit')) || savedPaginationLimit || 500
+        limit: urlLimit !== null && urlLimit >= 0 ? urlLimit : savedPaginationLimit || 500
     });
-
-    async function fetchClusterWorkflowTemplates() {
-        try {
-            const retrievedTemplates = await services.clusterWorkflowTemplate.list(pagination);
-            setPagination({...pagination, nextOffset: retrievedTemplates.metadata.continue});
-            setTemplates(retrievedTemplates.items || []);
-            setError(null);
-        } catch (err) {
-            setError(err);
-        }
-    }
 
     useEffect(
         useQueryParams(history, p => {
@@ -58,7 +48,25 @@ export function ClusterWorkflowTemplateList({history, location}: RouteComponentP
     );
 
     useEffect(() => {
-        fetchClusterWorkflowTemplates();
+        let cancelled = false;
+        services.clusterWorkflowTemplate
+            .list(pagination)
+            .then(retrievedTemplates => {
+                if (cancelled) {
+                    return;
+                }
+                setPagination(current => ({...current, nextOffset: retrievedTemplates.metadata.continue}));
+                setTemplates(retrievedTemplates.items || []);
+                setError(null);
+            })
+            .catch(err => {
+                if (!cancelled) {
+                    setError(err);
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
     }, [pagination.offset, pagination.limit]);
 
     useEffect(() => {

--- a/ui/src/cluster-workflow-templates/cluster-workflow-template-list.tsx
+++ b/ui/src/cluster-workflow-templates/cluster-workflow-template-list.tsx
@@ -9,11 +9,14 @@ import {ErrorNotice} from '../shared/components/error-notice';
 import {ExampleManifests} from '../shared/components/example-manifests';
 import {InfoIcon} from '../shared/components/fa-icons';
 import {Loading} from '../shared/components/loading';
+import {PaginationPanel} from '../shared/components/pagination-panel';
 import {Timestamp, TimestampSwitch} from '../shared/components/timestamp';
 import {ZeroState} from '../shared/components/zero-state';
 import {Context} from '../shared/context';
 import {Footnote} from '../shared/footnote';
 import * as models from '../shared/models';
+import {Pagination, parseLimit} from '../shared/pagination';
+import {ScopedLocalStorage} from '../shared/scoped-local-storage';
 import {services} from '../shared/services';
 import {useCollectEvent} from '../shared/use-collect-event';
 import {useQueryParams} from '../shared/use-query-params';
@@ -29,11 +32,18 @@ export function ClusterWorkflowTemplateList({history, location}: RouteComponentP
     const [templates, setTemplates] = useState<models.ClusterWorkflowTemplate[]>();
     const [error, setError] = useState<Error>();
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel'));
+    const storage = new ScopedLocalStorage('ClusterWorkflowTemplateListOptions');
+    const savedPaginationLimit = storage.getItem('paginationLimit', 0);
+    const [pagination, setPagination] = useState<Pagination>({
+        offset: queryParams.get('offset'),
+        limit: parseLimit(queryParams.get('limit')) || savedPaginationLimit || 500
+    });
 
     async function fetchClusterWorkflowTemplates() {
         try {
-            const retrievedTemplates = await services.clusterWorkflowTemplate.list();
-            setTemplates(retrievedTemplates);
+            const retrievedTemplates = await services.clusterWorkflowTemplate.list(pagination);
+            setPagination({...pagination, nextOffset: retrievedTemplates.metadata.continue});
+            setTemplates(retrievedTemplates.items || []);
             setError(null);
         } catch (err) {
             setError(err);
@@ -49,7 +59,11 @@ export function ClusterWorkflowTemplateList({history, location}: RouteComponentP
 
     useEffect(() => {
         fetchClusterWorkflowTemplates();
-    }, []);
+    }, [pagination.offset, pagination.limit]);
+
+    useEffect(() => {
+        storage.setItem('paginationLimit', pagination.limit, 0);
+    }, [pagination.limit]);
 
     useCollectEvent('openedClusterWorkflowTemplateList');
 
@@ -106,6 +120,7 @@ export function ClusterWorkflowTemplateList({history, location}: RouteComponentP
                 <Footnote>
                     <InfoIcon /> Cluster scoped Workflow templates are reusable templates you can create new workflows from. <ExampleManifests />. {learnMore}.
                 </Footnote>
+                <PaginationPanel onChange={setPagination} pagination={pagination} numRecords={null} />
             </>
         );
     }

--- a/ui/src/shared/services/cluster-workflow-template-service.test.ts
+++ b/ui/src/shared/services/cluster-workflow-template-service.test.ts
@@ -1,0 +1,22 @@
+import {exampleClusterWorkflowTemplate} from '../examples';
+import {ClusterWorkflowTemplateService} from './cluster-workflow-template-service';
+import requests from './requests';
+
+jest.mock('./requests');
+
+describe('cluster workflow template service', () => {
+    describe('list', () => {
+        it('passes pagination options and returns the complete list response', async () => {
+            const list = {
+                metadata: {continue: 'next-token'},
+                items: [exampleClusterWorkflowTemplate()]
+            };
+            jest.spyOn(requests, 'get').mockResolvedValue({body: list} as any);
+
+            const result = await (ClusterWorkflowTemplateService.list as any)({offset: 'current-token', limit: 20});
+
+            expect(result).toStrictEqual(list);
+            expect(requests.get).toHaveBeenCalledWith('api/v1/cluster-workflow-templates?listOptions.continue=current-token&listOptions.limit=20');
+        });
+    });
+});

--- a/ui/src/shared/services/cluster-workflow-template-service.ts
+++ b/ui/src/shared/services/cluster-workflow-template-service.ts
@@ -1,5 +1,7 @@
 import * as models from '../models';
+import {Pagination} from '../pagination';
 import requests from './requests';
+import {queryParams} from './utils';
 
 export const ClusterWorkflowTemplateService = {
     create(template: models.ClusterWorkflowTemplate) {
@@ -9,11 +11,8 @@ export const ClusterWorkflowTemplateService = {
             .then(res => res.body as models.ClusterWorkflowTemplate);
     },
 
-    list() {
-        return requests
-            .get(`api/v1/cluster-workflow-templates`)
-            .then(res => res.body as models.ClusterWorkflowTemplateList)
-            .then(list => list.items || []);
+    list(pagination?: Pagination) {
+        return requests.get(`api/v1/cluster-workflow-templates?${queryParams({pagination}).join('&')}`).then(res => res.body as models.ClusterWorkflowTemplateList);
     },
 
     get(name: string) {


### PR DESCRIPTION
Fixes #10845

### Motivation

The Cluster Workflow Templates page currently loads every template in a single request. Unlike the namespaced Workflow Templates page, it cannot request or navigate through Kubernetes list pages, which becomes expensive for clusters with many templates.

### Modifications

- Add pagination options to `ClusterWorkflowTemplateService.list()` and retain the full list response so `metadata.continue` is available.
- Initialize the list pagination from `offset` and `limit` query parameters.
- Remember the selected page size in scoped local storage.
- Refetch when the page offset or limit changes and render the shared pagination controls.
- Add service and component tests covering query serialization, response metadata, URL initialization, and next-page navigation.

### Verification

- `corepack yarn --cwd ui test --runInBand` (29 suites, 133 tests)
- `corepack yarn --cwd ui eslint src/cluster-workflow-templates/cluster-workflow-template-list.tsx src/cluster-workflow-templates/cluster-workflow-template-list.test.tsx src/shared/services/cluster-workflow-template-service.ts src/shared/services/cluster-workflow-template-service.test.ts`
- `corepack yarn --cwd ui tsc --noEmit`
- `corepack yarn --cwd ui e2e:typecheck`
- Production Webpack build via `corepack yarn --cwd ui webpack --mode production` with `NODE_ENV=production`
- `go run ./hack/featuregen validate`
- `git diff --check`

The full `make pre-commit -B` target cannot run in this native Windows environment because it depends on Unix commands and paths. The relevant UI checks above pass, and the direct production Webpack build passes with only the existing asset-size warnings.

### Documentation

Added `.features/pending/cluster-workflow-template-pagination.md` for the generated feature release notes. The UI uses the existing pagination controls and does not require separate usage documentation.

### AI

OpenAI Codex was used to help identify the issue, implement the code and tests, run validation, and draft the commit and PR text. I reviewed the diff and test coverage and verified the behavior with the checks listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL-driven pagination for Cluster Workflow Templates (offset/limit) with “Next page” navigation.
  * Added configurable page sizes, persisted across visits.
* **Bug Fixes**
  * Improved pagination reliability by ignoring stale/out-of-order list responses during page-size and page changes.
* **Documentation**
  * Documented the Cluster Workflow Template pagination update, including page sizing and navigation for large lists.
* **Tests**
  * Expanded coverage for URL limits, persisted page size behavior, pagination fetching, and stale-response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->