### PR TITLE
chore(artifacts): set argo-workflows User-Agent on S3 requests

### DIFF
--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -26,6 +26,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/argoproj/argo-workflows/v4"
 	argoerrs "github.com/argoproj/argo-workflows/v4/errors"
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/file"
@@ -517,6 +518,8 @@ func NewClient(ctx context.Context, opts ClientOpts) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// appended to minio-go's own User-Agent, matching the tag we set on Kubernetes API requests
+	minioClient.SetAppInfo("argo-workflows", argo.GetVersion().Version)
 	if opts.Trace {
 		minioClient.TraceOn(os.Stderr)
 	}


### PR DESCRIPTION
### Motivation

`workflow/artifacts/s3` builds its minio-go client from the artifact repository's configured `endpoint`, so Argo's artifact traffic can target Amazon S3 or any S3-compatible endpoint. Those requests currently carry only minio-go's default `User-Agent` (`MinIO (linux; amd64) minio-go/v7.0.98`), so in a bucket's access log there is no way to tell Argo Workflows apart from any other minio-go caller. Every other client we build already identifies itself: the controller, executor, server, CLI, and API client all wrap their Kubernetes client with `restclient.AddUserAgent(config, "argo-workflows/<version> ...")`. This makes the S3 client consistent with that, which helps when attributing artifact request volume, throttling, or errors to Argo in a storage access log.

### Modifications

One `SetAppInfo` call after the client is constructed, using `argo.GetVersion().Version`, the same version source the existing `AddUserAgent` call sites use. `SetAppInfo` appends rather than replaces (minio-go `api.go:1031`), so requests now send `MinIO (linux; amd64) minio-go/v7.0.98 argo-workflows/v3.7.2`. `GetVersion()` already falls back to `v0.0.0+unknown` outside a Makefile build, so nothing new can fail at client construction. No new dependency, no new config key, no change to request behavior.

### Verification

Locally on this branch: `go build ./workflow/...`, `go vet ./workflow/artifacts/s3/`, and `go test ./workflow/artifacts/s3/` all pass, plus `gofmt -l` and `goimports -local github.com/argoproj/argo-workflows/ -l` on the changed file are both clean. I did not run the full `make pre-commit` or the e2e suite; this change touches no codegen, manifests, or API types.

### Documentation

No doc change: the tag is not user-configurable, and the existing Kubernetes `User-Agent` tags are likewise undocumented.

### AI

Claude Code was used to draft this change and this description. I reviewed the diff, ran the builds and tests listed above myself, and confirmed minio-go's append behavior in the pinned v7.2.1 source.