### PR TITLE
feat(artifacts): support S3 storage classes

### DIFF
--- a/.features/pending/s3-storage-class.md
+++ b/.features/pending/s3-storage-class.md
@@ -1,0 +1,6 @@
+Description: Choose the S3 storage class for uploaded artifacts
+Author: [workeainc](https://github.com/workeainc)
+Component: General
+Issues: 13053
+
+S3 artifact outputs can now set an optional `storageClass`, such as `STANDARD_IA` or `INTELLIGENT_TIERING`. The configured value is passed through for both file and directory uploads.

--- a/docs/configure-artifact-repository.md
+++ b/docs/configure-artifact-repository.md
@@ -267,6 +267,8 @@ artifacts:
       endpoint: s3.amazonaws.com
       bucket: my-s3-bucket
       key: path/in/bucket/my-output-artifact.tgz
+      # Optional S3 storage class, for example STANDARD_IA or INTELLIGENT_TIERING.
+      # storageClass: INTELLIGENT_TIERING
       # The following fields are secret selectors.
       # They reference the k8s secret named 'my-s3-credentials'.
       # This secret is expected to have the keys 'accessKey' and 'secretKey',

--- a/pkg/apis/workflow/v1alpha1/generated.pb.go
+++ b/pkg/apis/workflow/v1alpha1/generated.pb.go
@@ -6155,6 +6155,11 @@ func (m *S3Bucket) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	i -= len(m.StorageClass)
+	copy(dAtA[i:], m.StorageClass)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.StorageClass)))
+	i--
+	dAtA[i] = 0x72
 	i -= len(m.AddressingStyle)
 	copy(dAtA[i:], m.AddressingStyle)
 	i = encodeVarintGenerated(dAtA, i, uint64(len(m.AddressingStyle)))
@@ -11923,6 +11928,8 @@ func (m *S3Bucket) Size() (n int) {
 	}
 	l = len(m.AddressingStyle)
 	n += 1 + l + sovGenerated(uint64(l))
+	l = len(m.StorageClass)
+	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
 
@@ -14717,6 +14724,7 @@ func (this *S3Bucket) String() string {
 		`CASecret:` + strings.Replace(fmt.Sprintf("%v", this.CASecret), "SecretKeySelector", "v1.SecretKeySelector", 1) + `,`,
 		`SessionTokenSecret:` + strings.Replace(fmt.Sprintf("%v", this.SessionTokenSecret), "SecretKeySelector", "v1.SecretKeySelector", 1) + `,`,
 		`AddressingStyle:` + fmt.Sprintf("%v", this.AddressingStyle) + `,`,
+		`StorageClass:` + fmt.Sprintf("%v", this.StorageClass) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -34164,6 +34172,38 @@ func (m *S3Bucket) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.AddressingStyle = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StorageClass", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.StorageClass = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -1572,6 +1572,9 @@ message S3Bucket {
   //
   // +kubebuilder:validation:Enum="";path;virtual-hosted
   optional string addressingStyle = 13;
+
+  // StorageClass specifies the storage class used when uploading objects.
+  optional string storageClass = 14;
 }
 
 // S3EncryptionOptions used to determine encryption options during s3 operations
@@ -2513,4 +2516,3 @@ message WorkflowTemplateRef {
 // ZipStrategy will unzip zipped input artifacts
 message ZipStrategy {
 }
-

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -5521,6 +5521,13 @@ func schema_pkg_apis_workflow_v1alpha1_S3Artifact(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"storageClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StorageClass specifies the storage class used when uploading objects.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Key is the key in the bucket where the artifact resides",

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2892,6 +2892,9 @@ type S3Bucket struct {
 	//
 	// +kubebuilder:validation:Enum="";path;virtual-hosted
 	AddressingStyle string `json:"addressingStyle,omitempty" protobuf:"bytes,13,opt,name=addressingStyle"`
+
+	// StorageClass specifies the storage class used when uploading objects.
+	StorageClass string `json:"storageClass,omitempty" protobuf:"bytes,14,opt,name=storageClass"`
 }
 
 // S3EncryptionOptions used to determine encryption options during s3 operations

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -41,11 +41,11 @@ const nullIAMEndpoint = ""
 
 type Client interface {
 	// PutFile puts a single file to a bucket at the specified key
-	PutFile(bucket, key, path string) error
+	PutFile(bucket, key, path, storageClass string) error
 
 	// PutDirectory puts a complete directory into a bucket key prefix, with each file in the directory
 	// a separate key in the bucket.
-	PutDirectory(bucket, key, path string) error
+	PutDirectory(bucket, key, path, storageClass string) error
 
 	// GetFile downloads a file to a local file path
 	GetFile(bucket, key, path string) error
@@ -350,11 +350,11 @@ func saveS3Artifact(ctx context.Context, s3cli Client, path string, outputArtifa
 	}
 
 	if isDir {
-		if err = s3cli.PutDirectory(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
+		if err = s3cli.PutDirectory(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path, outputArtifact.S3.StorageClass); err != nil {
 			return !isTransientS3Err(ctx, err), fmt.Errorf("failed to put directory: %w", err)
 		}
 	} else {
-		if err = s3cli.PutFile(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path); err != nil {
+		if err = s3cli.PutFile(outputArtifact.S3.Bucket, outputArtifact.S3.Key, path, outputArtifact.S3.StorageClass); err != nil {
 			return !isTransientS3Err(ctx, err), fmt.Errorf("failed to put file: %w", err)
 		}
 	}
@@ -628,7 +628,7 @@ func (s *s3client) getCheckedPartSize(path string, configuredPartSizeMiB int64) 
 }
 
 // PutFile puts a single file to a bucket at the specified key
-func (s *s3client) PutFile(bucket, key, path string) error {
+func (s *s3client) PutFile(bucket, key, path, storageClass string) error {
 	logging.RequireLoggerFromContext(s.ctx).WithFields(logging.Fields{"endpoint": s.Endpoint, "bucket": bucket, "key": key, "path": path}).Info(s.ctx, "Saving file to s3")
 	// NOTE: minio will detect proper mime-type based on file extension
 
@@ -636,7 +636,11 @@ func (s *s3client) PutFile(bucket, key, path string) error {
 	if err != nil {
 		return err
 	}
-	opts := minio.PutObjectOptions{SendContentMd5: s.SendContentMd5, ServerSideEncryption: encOpts}
+	opts := minio.PutObjectOptions{
+		SendContentMd5:       s.SendContentMd5,
+		ServerSideEncryption: encOpts,
+		StorageClass:         storageClass,
+	}
 
 	// Enables better performance for parallel uploads (3 times faster in a benchmark of 4 threads 16MiB part size).
 	opts.ConcurrentStreamParts = true
@@ -718,9 +722,9 @@ func generatePutTasks(ctx context.Context, keyPrefix, rootPath string) chan uplo
 
 // PutDirectory puts a complete directory into a bucket key prefix, with each file in the directory
 // a separate key in the bucket.
-func (s *s3client) PutDirectory(bucket, key, path string) error {
+func (s *s3client) PutDirectory(bucket, key, path, storageClass string) error {
 	for putTask := range generatePutTasks(s.ctx, key, path) {
-		err := s.PutFile(bucket, putTask.key, putTask.path)
+		err := s.PutFile(bucket, putTask.key, putTask.path, storageClass)
 		if err != nil {
 			return err
 		}

--- a/workflow/artifacts/s3/s3_test.go
+++ b/workflow/artifacts/s3/s3_test.go
@@ -23,7 +23,8 @@ type mockClient struct {
 	// files is a map where key is bucket name and value consists of file keys
 	files map[string][]string
 	// mockedErrs is a map where key is the function name and value is the mocked error of that function
-	mockedErrs map[string]error
+	mockedErrs     map[string]error
+	storageClasses []string
 }
 
 func newMockClient(files map[string][]string, mockedErrs map[string]error) Client {
@@ -42,13 +43,15 @@ func (s *mockClient) getMockedErr(funcName string) error {
 }
 
 // PutFile puts a single file to a bucket at the specified key
-func (s *mockClient) PutFile(bucket, key, path string) error {
+func (s *mockClient) PutFile(bucket, key, path, storageClass string) error {
+	s.storageClasses = append(s.storageClasses, storageClass)
 	return s.getMockedErr("PutFile")
 }
 
 // PutDirectory puts a complete directory into a bucket key prefix, with each file in the directory
 // a separate key in the bucket.
-func (s *mockClient) PutDirectory(bucket, key, path string) error {
+func (s *mockClient) PutDirectory(bucket, key, path, storageClass string) error {
+	s.storageClasses = append(s.storageClasses, storageClass)
 	return s.getMockedErr("PutDirectory")
 }
 
@@ -131,11 +134,12 @@ func TestOpenStreamS3Artifact(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 
 	tests := map[string]struct {
-		s3client  Client
-		bucket    string
-		key       string
-		localPath string
-		errMsg    string
+		s3client     Client
+		bucket       string
+		key          string
+		localPath    string
+		storageClass string
+		errMsg       string
 	}{
 		"Success": {
 			s3client: newMockClient(
@@ -418,10 +422,11 @@ func TestSaveS3Artifact(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		s3client  Client
-		bucket    string
-		key       string
-		localPath string
+		s3client     Client
+		bucket       string
+		key          string
+		localPath    string
+		storageClass string
 		// skipBucketCreation leaves CreateBucketIfNotPresent nil, covering the
 		// path where MakeBucket must not be called at all.
 		skipBucketCreation bool
@@ -452,11 +457,12 @@ func TestSaveS3Artifact(t *testing.T) {
 					"my-bucket": {},
 				},
 				map[string]error{}),
-			bucket:    "my-bucket",
-			key:       "/folder/hello-art.tar.gz",
-			localPath: tempFile,
-			done:      true,
-			errMsg:    "",
+			bucket:       "my-bucket",
+			key:          "/folder/hello-art.tar.gz",
+			localPath:    tempFile,
+			storageClass: "INTELLIGENT_TIERING",
+			done:         true,
+			errMsg:       "",
 		},
 		"Success as Directory": {
 			s3client: newMockClient(
@@ -549,6 +555,7 @@ func TestSaveS3Artifact(t *testing.T) {
 						S3: &wfv1.S3Artifact{
 							S3Bucket: wfv1.S3Bucket{
 								Bucket:                   tc.bucket,
+								StorageClass:             tc.storageClass,
 								CreateBucketIfNotPresent: createBucketIfNotPresent,
 								EncryptionOptions: &wfv1.S3EncryptionOptions{
 									EnableEncryption: true,
@@ -563,6 +570,9 @@ func TestSaveS3Artifact(t *testing.T) {
 				assert.Equal(t, tc.errMsg, err.Error())
 			} else {
 				assert.Empty(t, tc.errMsg)
+			}
+			if mock, ok := tc.s3client.(*mockClient); ok && tc.storageClass != "" {
+				assert.Equal(t, []string{tc.storageClass}, mock.storageClasses)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add optional `storageClass` to S3 artifact configuration
- pass the configured value through file and directory uploads to MinIO
- update protobuf/OpenAPI metadata, documentation, and regression coverage

Closes #13053

## Validation
- `GOFLAGS=-mod=mod go test ./workflow/artifacts/s3 ./pkg/apis/workflow/v1alpha1` (passed)
- `gofmt` on changed Go files
- `git diff --check`

## AI
AI assistance was used to inspect the issue, propose the focused change, and review the patch. The final implementation and validation were performed in this checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional S3 storage class support for artifact uploads, including individual files and directories.
  * Supports storage classes such as `STANDARD_IA` and `INTELLIGENT_TIERING`.
* **Documentation**
  * Updated artifact repository configuration examples to show how to specify a storage class.
* **Tests**
  * Added coverage confirming storage class settings are passed through and applied to uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->