### PR TITLE
feat(sync): grant-set promotion to eliminate O(N^2) semaphore bounce

### DIFF
--- a/hack/semaphore-before-after.sh
+++ b/hack/semaphore-before-after.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Measures semaphore promotion cost before and after the grant-set change, by
+# running the same benchmark harness against two real revisions -- no emulation of
+# the old implementation.
+#
+# Usage:
+#
+#   ./hack/semaphore-before-after.sh                    # BEFORE_REF..HEAD
+#   ./hack/semaphore-before-after.sh <before> <after>   # explicit revisions
+#
+# How it works: the harness (workflow/sync/semaphore_bench_test.go) only touches
+# the semaphore's exported-to-package surface -- newInternalSemaphore, addToQueue,
+# tryAcquire, release -- which is unchanged across the revisions being compared. So
+# the same file compiles against either tree. The script creates a git worktree per
+# revision, copies today's harness in, runs it, and joins the RESULT lines into a
+# markdown table.
+#
+# Because both sides run byte-identical harness code, any difference in the numbers
+# is a difference in semaphore.go and nothing else.
+
+BEFORE_REF="${1:-}"
+AFTER_REF="${2:-HEAD}"
+
+# Default "before" is the merge-base with the upstream default branch, i.e. the
+# revision this work branched from. Overridable since that is a guess about intent.
+if [[ -z "$BEFORE_REF" ]]; then
+  BEFORE_REF="$(git merge-base HEAD origin/main 2>/dev/null || true)"
+  if [[ -z "$BEFORE_REF" ]]; then
+    echo "error: could not determine a default 'before' revision (no origin/main?)." >&2
+    echo "       pass one explicitly: $0 <before-ref> [after-ref]" >&2
+    exit 1
+  fi
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HARNESS="workflow/sync/semaphore_bench_test.go"
+TEST_NAME="TestSemaphorePromotionCost"
+
+if [[ ! -f "$REPO_ROOT/$HARNESS" ]]; then
+  echo "error: $HARNESS not found in the working tree." >&2
+  exit 1
+fi
+
+# Resolve to full SHAs so the labels are unambiguous and so a moving ref cannot
+# change meaning between the two runs.
+before_sha="$(git rev-parse --verify "$BEFORE_REF^{commit}")"
+after_sha="$(git rev-parse --verify "$AFTER_REF^{commit}")"
+
+if [[ "$before_sha" == "$after_sha" ]]; then
+  echo "error: before and after resolve to the same commit ($before_sha)." >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  # Remove worktrees before the directory holding them, or git keeps stale entries.
+  for wt in "$WORKDIR"/before "$WORKDIR"/after; do
+    [[ -d "$wt" ]] && git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || true
+  done
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# run_at <label> <sha> -> writes RESULT lines to $WORKDIR/<label>.txt
+run_at() {
+  local label="$1"
+  local sha="$2"
+  local wt="$WORKDIR/$label"
+
+  echo "==> $label: $(git -C "$REPO_ROOT" log --oneline -1 "$sha")" >&2
+
+  # A detached worktree leaves the user's checkout, index, and stash untouched.
+  git -C "$REPO_ROOT" worktree add --detach --quiet "$wt" "$sha"
+
+  # Today's harness, so both sides measure with identical instrumentation. This is
+  # the point of the script: only semaphore.go differs between the runs.
+  cp "$REPO_ROOT/$HARNESS" "$wt/$HARNESS"
+
+  if ! (cd "$wt" && go test ./workflow/sync/ -run "$TEST_NAME" -count=1 -v \
+        >"$WORKDIR/$label.log" 2>&1); then
+    echo "error: harness failed to build or run at $label ($sha). Last 40 lines:" >&2
+    tail -40 "$WORKDIR/$label.log" >&2
+    exit 1
+  fi
+
+  grep -o 'RESULT .*' "$WORKDIR/$label.log" >"$WORKDIR/$label.txt" || true
+  if [[ ! -s "$WORKDIR/$label.txt" ]]; then
+    echo "error: no RESULT lines from $label ($sha) -- harness ran but reported nothing." >&2
+    tail -40 "$WORKDIR/$label.log" >&2
+    exit 1
+  fi
+}
+
+run_at before "$before_sha"
+run_at after "$after_sha"
+
+echo >&2
+
+# Join on scenario name and format. Kept in awk rather than shell arithmetic
+# because the reduction factor needs floating point.
+awk '
+function commas(n, s, out, i, len) {
+  s = sprintf("%d", n); len = length(s); out = ""
+  for (i = 1; i <= len; i++) {
+    out = out substr(s, i, 1)
+    if ((len - i) % 3 == 0 && i < len) out = out ","
+  }
+  return out
+}
+function cell(rec, wf) {
+  return sprintf("%s (%.1f/wf)", commas(rec), rec / wf)
+}
+# RESULT scenario=X limit=N workflows=N reconciles=N rounds=N
+# Fills the global kv[]. Trailing params are awks local-variable idiom; kv is
+# deliberately NOT among them, since the caller reads it.
+function parse(line,   i, n, parts, p) {
+  delete kv
+  n = split(line, parts, " ")
+  for (i = 2; i <= n; i++) {
+    split(parts[i], p, "=")
+    kv[p[1]] = p[2]
+  }
+}
+FNR == NR {
+  parse($0)
+  order[++count] = kv["scenario"]
+  limit[kv["scenario"]]  = kv["limit"]
+  wfs[kv["scenario"]]    = kv["workflows"]
+  before[kv["scenario"]] = kv["reconciles"]
+  next
+}
+{
+  parse($0)
+  after[kv["scenario"]] = kv["reconciles"]
+}
+END {
+  print "| limit | workflows | before | after | reduction |"
+  print "|------:|----------:|-------:|------:|----------:|"
+  for (i = 1; i <= count; i++) {
+    s = order[i]
+    if (!(s in after)) {
+      printf("| %s | %s | %s | (missing) | - |\n", limit[s], wfs[s], cell(before[s], wfs[s]))
+      continue
+    }
+    printf("| %s | %s | %s | %s | %.0fx |\n",
+           limit[s], wfs[s], cell(before[s], wfs[s]), cell(after[s], wfs[s]),
+           after[s] > 0 ? before[s] / after[s] : 0)
+  }
+}
+' "$WORKDIR/before.txt" "$WORKDIR/after.txt"
+
+echo
+echo "before: $before_sha"
+echo "after:  $after_sha"
+echo "reconciles = total tryAcquire calls to drain the queue; /wf divides by the"
+echo "workflow count, where 1.0/wf is the floor (each workflow admitted first look)."

--- a/workflow/sync/mutex.go
+++ b/workflow/sync/mutex.go
@@ -16,6 +16,7 @@ func newInternalMutex(name string, nextWorkflow NextWorkflow) *prioritySemaphore
 		pending:      &priorityQueue{itemByKey: make(map[string]*item)},
 		semaphore:    sema.NewWeighted(int64(1)),
 		lockHolder:   make(map[string]bool),
+		granted:      make(map[string]bool),
 		nextWorkflow: nextWorkflow,
 		logger:       logger.get,
 	}

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -18,6 +18,7 @@ type prioritySemaphore struct {
 	pending      *priorityQueue
 	semaphore    *sema.Weighted
 	lockHolder   map[string]bool
+	granted      map[string]bool
 	nextWorkflow NextWorkflow
 	logger       loggerFn
 }
@@ -35,6 +36,7 @@ func newInternalSemaphore(ctx context.Context, name string, nextWorkflow NextWor
 		pending:      &priorityQueue{itemByKey: make(map[string]*item)},
 		semaphore:    sema.NewWeighted(int64(0)),
 		lockHolder:   make(map[string]bool),
+		granted:      make(map[string]bool),
 		nextWorkflow: nextWorkflow,
 		logger:       logger.get,
 	}
@@ -126,12 +128,29 @@ func (s *prioritySemaphore) release(ctx context.Context, key string) bool {
 	return true
 }
 
-// notifyWaiters enqueues the next N workflows who are waiting for the semaphore to the workqueue,
-// where N is the availability of the semaphore. If semaphore is out of capacity, this does nothing.
 func (s *prioritySemaphore) notifyWaiters(ctx context.Context) {
-	triggerCount := min(s.pending.Len(), s.getLimit(ctx)-len(s.lockHolder))
-	for idx := range triggerCount {
+	s.grantWaiters(ctx, "")
+}
+
+// grantWaiters grants the top-priority waiters (up to the free slots) and enqueues each
+// newly-granted key. A workflow may only acquire while granted, so this fills K freed slots
+// in one round instead of one per round. Already-granted keys are skipped, so release bursts
+// don't re-wake the same head. skipKey is granted but not enqueued (the caller is already
+// reconciling it). The weighted semaphore is still the hard limit, so an over-grant never
+// over-acquires.
+func (s *prioritySemaphore) grantWaiters(ctx context.Context, skipKey string) {
+	grantCount := s.getLimit(ctx) - len(s.lockHolder) - len(s.granted)
+	granted := 0
+	for idx := 0; idx < s.pending.Len() && granted < grantCount; idx++ {
 		item := s.pending.items[idx]
+		if s.granted[item.key] {
+			continue
+		}
+		s.granted[item.key] = true
+		granted++
+		if item.key == skipKey {
+			continue
+		}
 		wfKey := workflowKey(item.key)
 		s.logger(ctx).WithField("workflow", wfKey).Debug(ctx, "Enqueue the workflow")
 		s.nextWorkflow(wfKey)
@@ -165,6 +184,8 @@ func (s *prioritySemaphore) addToQueue(ctx context.Context, holderKey string, pr
 
 func (s *prioritySemaphore) removeFromQueue(ctx context.Context, holderKey string) error {
 	logger := s.logger(ctx)
+	// Drop any grant too, so a removed workflow leaves no stale grant behind.
+	delete(s.granted, holderKey)
 	s.pending.remove(holderKey)
 	logger.WithField("holderKey", holderKey).Debug(ctx, "Removed from queue")
 	return nil
@@ -193,6 +214,10 @@ func (s *prioritySemaphore) reacquire(_ context.Context, holderKey string, _ *sq
 	}
 	s.semaphore.TryAcquire(1) // best effort: take a slot if one is free
 	s.lockHolder[holderKey] = true
+	// A reestablished holder is no longer a waiter, so drop any grant it held.
+	// Leaving one behind would count against grantCount forever and permanently
+	// shrink the grant set.
+	delete(s.granted, holderKey)
 	return nil
 }
 
@@ -232,17 +257,12 @@ func (s *prioritySemaphore) checkAcquire(ctx context.Context, holderKey string, 
 
 	waitingMsg := fmt.Sprintf("Waiting for %s lock. Lock status: %d/%d", s.name, limit-len(s.lockHolder), limit)
 
-	// Check whether requested holdkey is in front of priority queue.
-	// If it is in front position, it will allow to acquire lock.
-	// If it is not a front key, it needs to wait for its turn.
-	if s.pending.Len() > 0 {
-		item := s.pending.peek()
-		if !isSameWorkflowNodeKeys(holderKey, item.key) {
-			// Enqueue the front workflow if lock is available
-			if len(s.lockHolder) < limit {
-				s.nextWorkflow(workflowKey(item.key))
-			}
-			logger.WithField("holderKey", holderKey).Info(ctx, "isn't at the front")
+	// A workflow may only acquire while granted. If not yet granted, try to grant now
+	// (covers a fresh arrival and the first acquire); skipKey avoids a self-enqueue.
+	if !s.granted[holderKey] {
+		s.grantWaiters(ctx, holderKey)
+		if !s.granted[holderKey] {
+			logger.WithField("holderKey", holderKey).Info(ctx, "isn't granted a slot")
 			return false, false, waitingMsg
 		}
 	}
@@ -266,7 +286,9 @@ func (s *prioritySemaphore) tryAcquire(ctx context.Context, holderKey string, tx
 	}
 	acquired, _ := s.acquire(ctx, holderKey, tx)
 	if acquired {
-		s.pending.pop()
+		// Remove by key, not pop(): the acquirer isn't necessarily the pending head.
+		delete(s.granted, holderKey)
+		s.pending.remove(holderKey)
 		limit := s.getLimit(ctx)
 		logger.WithFields(logging.Fields{
 			"name":      s.name,

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -12,6 +12,16 @@ import (
 
 // Tier 1 benchmark harness for semaphore promotion throughput.
 //
+// To reproduce the before/after comparison:
+//
+//	go test ./workflow/sync/ -run TestSemaphorePromotionCost -count=1 -v
+//
+// Both columns come from this one command. "before" emulates the pre-grant-set
+// admission gate in the harness (see reconcileSim.singleFront) rather than
+// requiring a checkout of the parent revision, so the comparison is a single
+// deterministic run with no build juggling. Everything is seedless, so two runs
+// on the same commit produce byte-identical numbers.
+//
 // This models the controller's reconcile loop against the in-memory
 // prioritySemaphore directly: no Kubernetes, no pods, no database. The 6-minute
 // workflow body is virtual time (a hold that spans a fixed number of rounds), so
@@ -25,8 +35,13 @@ import (
 //	tryAcquires - total tryAcquire calls. Divided by the number of workflows this
 //	              is admission amplification: 1.0 is perfect, higher means
 //	              workflows are bouncing off the semaphore and re-queueing.
-//	enqueues    - nextWorkflow callbacks. This is the workqueue churn that the
-//	              O(N^2) re-wake storm produces.
+//	bounces     - reconciles that attempted acquisition and failed. Divided by the
+//	              number of workflows, this is how many times the average workflow
+//	              is woken, fails, and must wait to be woken again.
+//	enqueues    - raw nextWorkflow callbacks. NOTE: this counts repeat callbacks
+//	              against the same key, which the real workqueue would dedupe, so
+//	              it overstates distinct reconciles. Use bounces for per-workflow
+//	              cost and rounds for latency.
 //
 // The reconcile loop is a model of the controller, not the controller itself;
 // Tier 2 (fake-clientset controller test) exists to corroborate these numbers.
@@ -40,6 +55,19 @@ type reconcileSim struct {
 	limit      int
 	total      int
 	holdRounds int
+	// workers is the controller's --workflow-workers: how many reconciles are in
+	// flight at once. Bounds how far reconcile order may deviate from queue order.
+	workers int
+
+	// singleFront emulates the pre-grant-set controller, so the "before" column is
+	// reproducible from this commit instead of requiring a checkout of the parent
+	// revision. Upstream had two separate widths: notifyWaiters woke the top
+	// (limit - holders) waiters, but checkAcquire admitted only pending.items[0].
+	// The gate lives here rather than in the semaphore because it is a property of
+	// the old code, not a configuration anyone should be able to select. Emulating
+	// it means both columns of the before/after comparison are reproducible with a
+	// single `go test` on this commit; see the header comment for how to run it.
+	singleFront bool
 
 	// enqueued is the controller workqueue: keys that nextWorkflow asked to be
 	// reconciled. A real controller also periodically resyncs, but the point of
@@ -51,18 +79,28 @@ type reconcileSim struct {
 	rounds      int
 	tryAcquires int
 	enqueues    int
+	// bounces is the number of reconciles that attempted acquisition and failed.
+	// Divided by total, this is the average number of times a workflow is woken,
+	// fails, and has to wait to be woken again. Bounded by the wake path: a
+	// workflow only bounces if something enqueued it.
+	bounces int
 
 	// utilization[i] is the number of held slots at the end of round i.
 	utilization []int
 }
 
-func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRounds int) *reconcileSim {
+// newReconcileSim builds a simulation. Set singleFront to measure the
+// pre-grant-set baseline (see reconcileSim.singleFront); leave it false to measure
+// the grant-set implementation in this commit.
+func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRounds, workers int, singleFront bool) *reconcileSim {
 	tb.Helper()
 	sim := &reconcileSim{
-		limit:      limit,
-		total:      total,
-		holdRounds: holdRounds,
-		enqueued:   make(map[string]bool, total),
+		limit:       limit,
+		total:       total,
+		holdRounds:  holdRounds,
+		workers:     workers,
+		singleFront: singleFront,
+		enqueued:    make(map[string]bool, total),
 	}
 	sem, err := newInternalSemaphore(ctx, "bench", func(key string) {
 		sim.enqueues++
@@ -77,17 +115,55 @@ func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRound
 
 func benchKey(i int) string { return fmt.Sprintf("default/wf-%05d", i) }
 
+// pendingHead returns the current head of the priority queue, i.e. the only key
+// upstream's checkAcquire would have admitted. Used solely by the singleFront
+// baseline.
+func (s *reconcileSim) pendingHead() (string, bool) {
+	if s.sem.pending.Len() == 0 {
+		return "", false
+	}
+	return s.sem.pending.items[0].key, true
+}
+
+func (s *reconcileSim) isPendingHead(key string) bool {
+	head, ok := s.pendingHead()
+	return ok && head == key
+}
+
 // shuffleDeterministic permutes keys using a seedless xorshift, so reconcile
 // order is decoupled from priority order without introducing run-to-run
 // variance. round is mixed into the state so successive rounds differ.
 func shuffleDeterministic(keys []string, round int) {
+	shuffleInBatches(keys, round, 0)
+}
+
+// shuffleInBatches models the controller's worker pool. The controller runs
+// --workflow-workers goroutines against a shared workqueue, so at any instant only
+// W workflows are in flight; the queue hands out keys in arrival order but the
+// workers finish in a nondeterministic order within each group of W.
+//
+// So: chop the wake set into consecutive batches of `workers` and permute within
+// each batch, leaving batch order intact. A key that entered the queue early is
+// still reconciled early -- it just races with the W-1 keys alongside it. This is
+// strictly weaker than a whole-set shuffle, which lets a key at the back of the
+// queue be reconciled first.
+//
+// workers <= 0 means unbounded (one batch, i.e. a full shuffle), which is the
+// worst case for the single-front gate and the original harness behaviour.
+func shuffleInBatches(keys []string, round, workers int) {
+	if workers <= 0 || workers > len(keys) {
+		workers = len(keys)
+	}
 	state := uint64(round)*2862933555777941757 + 3037000493
-	for i := len(keys) - 1; i > 0; i-- {
-		state ^= state << 13
-		state ^= state >> 7
-		state ^= state << 17
-		j := int(state % uint64(i+1))
-		keys[i], keys[j] = keys[j], keys[i]
+	for start := 0; start < len(keys); start += workers {
+		end := min(start+workers, len(keys))
+		for i := end - 1; i > start; i-- {
+			state ^= state << 13
+			state ^= state >> 7
+			state ^= state << 17
+			j := start + int(state%uint64(i-start+1))
+			keys[i], keys[j] = keys[j], keys[i]
+		}
 	}
 }
 
@@ -146,9 +222,28 @@ func (s *reconcileSim) run(ctx context.Context, maxRounds int) (completed int, h
 		}
 		sort.Strings(batch)
 		clear(s.enqueued)
-		shuffleDeterministic(batch, s.rounds)
+		shuffleInBatches(batch, s.rounds, s.workers)
+
+		if s.singleFront {
+			// Upstream had no grant set, so a waiter that had already been woken was
+			// woken again on the next release. Clearing the grants each round restores
+			// that repeated-wake behaviour; without this, grantWaiters would suppress
+			// the re-wakes and understate the churn being measured.
+			clear(s.sem.granted)
+		}
 
 		for _, key := range batch {
+			if s.singleFront && !s.isPendingHead(key) {
+				// Upstream checkAcquire admitted only pending.items[0]. Everyone else
+				// bounced with "isn't at the front" after enqueueing the head.
+				s.bounces++
+				s.tryAcquires++
+				if head, ok := s.pendingHead(); ok {
+					s.enqueues++
+					s.enqueued[head] = true
+				}
+				continue
+			}
 			s.tryAcquires++
 			acquired, _, err := s.sem.tryAcquire(ctx, key, nil)
 			if err != nil {
@@ -157,10 +252,15 @@ func (s *reconcileSim) run(ctx context.Context, maxRounds int) (completed int, h
 			if acquired {
 				releaseAt[key] = s.rounds + s.holdRounds
 			} else {
-				// Bounced: the controller re-queues it to try again. This is the
-				// cost the grant set removes.
-				s.enqueued[key] = true
+				s.bounces++
 			}
+			// A bounced workflow is NOT re-queued here. The controller marks it
+			// Pending and returns; it is only reconciled again when something wakes
+			// it (notifyWaiters on a release, or the not-at-front path in
+			// checkAcquire enqueueing the head). Those wakes arrive through the
+			// nextWorkflow callback, which populates s.enqueued. Re-adding every
+			// bouncer here would reconcile workflows the controller left alone and
+			// inflate tryAcquires past what the wake path can produce.
 		}
 
 		s.utilization = append(s.utilization, len(s.sem.lockHolder))
@@ -182,24 +282,40 @@ func (s *reconcileSim) meanUtilization() float64 {
 	return float64(sum) / float64(len(s.utilization)) / float64(s.limit)
 }
 
-// scenario is one workload shape. The Databricks reference case is
-// limit=400/total=1500; the smaller shapes show how the cost scales with limit,
-// which is the signature of the quadratic behaviour.
+// scenario is one workload shape. The reference case is limit=400/total=1500; the
+// smaller shapes show how the cost scales with limit, which is the signature of
+// the quadratic behaviour.
 type scenario struct {
 	name       string
 	limit      int
 	total      int
 	holdRounds int
+	// workers is the controller's --workflow-workers. Zero means unbounded, i.e.
+	// every woken workflow may be reconciled in any order within a round.
+	workers int
 }
 
 var benchScenarios = []scenario{
-	{name: "limit10_wf50", limit: 10, total: 50, holdRounds: 1},
-	{name: "limit50_wf200", limit: 50, total: 200, holdRounds: 1},
-	{name: "limit100_wf400", limit: 100, total: 400, holdRounds: 1},
+	{name: "limit10_wf50", limit: 10, total: 50, holdRounds: 1, workers: 32},
+	{name: "limit50_wf200", limit: 50, total: 200, holdRounds: 1, workers: 32},
+	{name: "limit100_wf400", limit: 100, total: 400, holdRounds: 1, workers: 32},
 	// The reference workload: 400 slots, 1500 workflows. holdRounds=1 isolates
 	// promotion cost from hold duration -- a longer hold only adds a constant per
 	// wave, whereas the promotion cost is what differs between implementations.
-	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1},
+	// workers=32 is the controller's --workflow-workers default.
+	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1, workers: 32},
+}
+
+// variants are the two implementations compared side by side. "before" emulates
+// the pre-grant-set controller (see reconcileSim.singleFront); "after" is the
+// grant-set code in this commit. Both columns are therefore reproducible from a
+// single checkout, with no need to build the parent revision.
+var variants = []struct {
+	name        string
+	singleFront bool
+}{
+	{name: "before", singleFront: true},
+	{name: "after", singleFront: false},
 }
 
 // TestSemaphorePromotionCost is the headline measurement, written as a test
@@ -212,37 +328,40 @@ var benchScenarios = []scenario{
 func TestSemaphorePromotionCost(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 
-	t.Logf("%-18s %7s %7s %9s %9s %7s %7s %6s",
-		"scenario", "limit", "wfs", "rounds", "optimum", "ratio", "ampl", "util")
+	t.Logf("%-18s %7s %7s %8s %9s %9s %7s %8s %6s",
+		"scenario", "limit", "wfs", "variant", "rounds", "optimum", "ratio", "bounce/wf", "util")
 
 	for _, sc := range benchScenarios {
-		t.Run(sc.name, func(t *testing.T) {
-			sim := newReconcileSim(ctx, t, sc.limit, sc.total, sc.holdRounds)
+		for _, v := range variants {
+			t.Run(sc.name+"/"+v.name, func(t *testing.T) {
+				sim := newReconcileSim(ctx, t, sc.limit, sc.total, sc.holdRounds, sc.workers, v.singleFront)
 
-			// Cap generously: the quadratic case needs ~limit rounds per wave, so
-			// allow that plus slack. Hitting the cap is reported, not hidden.
-			waves := (sc.total + sc.limit - 1) / sc.limit
-			maxRounds := waves * (sc.limit + sc.holdRounds) * 4
+				// Cap generously: the quadratic case needs ~limit rounds per wave, so
+				// allow that plus slack. Hitting the cap is reported, not hidden.
+				waves := (sc.total + sc.limit - 1) / sc.limit
+				maxRounds := waves * (sc.limit + sc.holdRounds) * 4
 
-			start := time.Now()
-			completed, hitCap := sim.run(ctx, maxRounds)
-			elapsed := time.Since(start)
+				start := time.Now()
+				completed, hitCap := sim.run(ctx, maxRounds)
+				elapsed := time.Since(start)
 
-			optimum := waves * sc.holdRounds
-			ratio := float64(sim.rounds) / float64(optimum)
-			ampl := float64(sim.tryAcquires) / float64(sc.total)
+				optimum := waves * sc.holdRounds
+				ratio := float64(sim.rounds) / float64(optimum)
+				bouncesPerWf := float64(sim.bounces) / float64(sc.total)
 
-			t.Logf("%-18s %7d %7d %9d %9d %6.1fx %6.1fx %5.0f%%",
-				sc.name, sc.limit, sc.total, sim.rounds, optimum, ratio, ampl,
-				sim.meanUtilization()*100)
-			t.Logf("  completed=%d/%d enqueues=%d tryAcquires=%d wall=%s hitRoundCap=%v",
-				completed, sc.total, sim.enqueues, sim.tryAcquires, elapsed.Round(time.Millisecond), hitCap)
+				t.Logf("%-18s %7d %7d %8s %9d %9d %6.1fx %8.1f %5.0f%%",
+					sc.name, sc.limit, sc.total, v.name, sim.rounds, optimum, ratio,
+					bouncesPerWf, sim.meanUtilization()*100)
+				t.Logf("  completed=%d/%d bounces=%d tryAcquires=%d enqueues=%d wall=%s hitRoundCap=%v",
+					completed, sc.total, sim.bounces, sim.tryAcquires, sim.enqueues,
+					elapsed.Round(time.Millisecond), hitCap)
 
-			if completed != sc.total {
-				t.Logf("  NOTE: only %d/%d workflows drained within %d rounds",
-					completed, sc.total, maxRounds)
-			}
-		})
+				if completed != sc.total {
+					t.Logf("  NOTE: only %d/%d workflows drained within %d rounds",
+						completed, sc.total, maxRounds)
+				}
+			})
+		}
 	}
 }
 
@@ -252,16 +371,18 @@ func TestSemaphorePromotionCost(t *testing.T) {
 func BenchmarkSemaphorePromotion(b *testing.B) {
 	ctx := logging.TestContext(b.Context())
 	for _, sc := range benchScenarios {
-		b.Run(sc.name, func(b *testing.B) {
-			waves := (sc.total + sc.limit - 1) / sc.limit
-			maxRounds := waves * (sc.limit + sc.holdRounds) * 4
-			b.ReportAllocs()
-			for b.Loop() {
-				sim := newReconcileSim(ctx, b, sc.limit, sc.total, sc.holdRounds)
-				sim.run(ctx, maxRounds)
-				b.ReportMetric(float64(sim.rounds), "rounds")
-				b.ReportMetric(float64(sim.tryAcquires)/float64(sc.total), "tryAcquire/wf")
-			}
-		})
+		for _, v := range variants {
+			b.Run(sc.name+"/"+v.name, func(b *testing.B) {
+				waves := (sc.total + sc.limit - 1) / sc.limit
+				maxRounds := waves * (sc.limit + sc.holdRounds) * 4
+				b.ReportAllocs()
+				for b.Loop() {
+					sim := newReconcileSim(ctx, b, sc.limit, sc.total, sc.holdRounds, sc.workers, v.singleFront)
+					sim.run(ctx, maxRounds)
+					b.ReportMetric(float64(sim.rounds), "rounds")
+					b.ReportMetric(float64(sim.bounces)/float64(sc.total), "bounces/wf")
+				}
+			})
+		}
 	}
 }

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -354,8 +354,12 @@ var variants = []struct {
 func TestSemaphorePromotionCost(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 
-	t.Logf("%-18s %7s %7s %8s %9s %9s %7s %8s %6s",
-		"scenario", "limit", "wfs", "variant", "rounds", "optimum", "ratio", "bounce/wf", "util")
+	// reconciles/wf is the whole result: how many times the average workflow is
+	// reconciled before it holds the semaphore. Every workflow acquires exactly
+	// once, so this is tryAcquires/total -- one successful reconcile plus every
+	// wasted one. It is the admission amplification factor: 1.0 would mean each
+	// workflow is looked at once and admitted.
+	t.Logf("%-18s %8s %14s", "scenario", "variant", "reconciles/wf")
 
 	for _, sc := range benchScenarios {
 		for _, v := range variants {
@@ -371,20 +375,14 @@ func TestSemaphorePromotionCost(t *testing.T) {
 				completed, hitCap := sim.run(ctx, maxRounds)
 				elapsed := time.Since(start)
 
-				optimum := waves * sc.holdRounds
-				ratio := float64(sim.rounds) / float64(optimum)
-				bouncesPerWf := float64(sim.bounces) / float64(sc.total)
+				t.Logf("%-18s %8s %14.1f",
+					sc.name, v.name, float64(sim.tryAcquires)/float64(sc.total))
 
-				t.Logf("%-18s %7d %7d %8s %9d %9d %6.1fx %8.1f %5.0f%%",
-					sc.name, sc.limit, sc.total, v.name, sim.rounds, optimum, ratio,
-					bouncesPerWf, sim.meanUtilization()*100)
-				t.Logf("  completed=%d/%d bounces=%d tryAcquires=%d enqueues=%d wall=%s hitRoundCap=%v",
-					completed, sc.total, sim.bounces, sim.tryAcquires, sim.enqueues,
-					elapsed.Round(time.Millisecond), hitCap)
-
-				if completed != sc.total {
-					t.Logf("  NOTE: only %d/%d workflows drained within %d rounds",
-						completed, sc.total, maxRounds)
+				// The number above is only meaningful if every workflow actually got
+				// through, so this is an assertion rather than a reported column.
+				if hitCap || completed != sc.total {
+					t.Fatalf("only %d/%d workflows drained within %d rounds (%s)",
+						completed, sc.total, maxRounds, elapsed.Round(time.Millisecond))
 				}
 			})
 		}

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,10 +13,11 @@ import (
 // Benchmark harness for semaphore promotion throughput. See
 // TestSemaphorePromotionCost below for how to run it and what it measures.
 //
-// Both columns come from a single run on this commit: "before" emulates the
-// pre-grant-set admission gate in the harness (see reconcileSim.singleFront)
-// rather than requiring a checkout of the parent revision. Everything is seedless,
-// so two runs on the same commit produce byte-identical numbers.
+// This measures whichever semaphore implementation it is compiled against, and
+// prints one RESULT line per scenario. It does not emulate the old implementation:
+// hack/semaphore-before-after.sh checks out two revisions, runs the same harness
+// at each, and joins the numbers. Everything is seedless, so a given revision
+// produces byte-identical numbers run to run.
 //
 // The simulation tracks more than it prints, for use when investigating:
 //
@@ -36,12 +35,10 @@ import (
 //	              it overstates distinct reconciles. Use bounces for per-workflow
 //	              cost and rounds for latency.
 //
-// The reconcile loop is a model of the controller, not the controller itself. It
-// is calibrated against the real thing at one point: the reference shape measured
-// 884 rounds here against 894 on the actual pre-grant-set commit. Nothing else is
-// corroborated end-to-end, so treat the absolute counts as the cost of the
-// promotion strategy under this model, and the before/after ratio -- which shares
-// the model, and so most of its error -- as the load-bearing result.
+// The reconcile loop is a model of the controller, not the controller itself: one
+// round is one reconcile pass over everything woken, where real workers have
+// staggered latency and retry backoff. Both sides of the comparison run the same
+// model, so the ratio is more trustworthy than the absolute counts.
 
 // reconcileSim drives a semaphore the way the workflow controller does: a set of
 // pending workflows, each of which is reconciled once per round, attempting to
@@ -55,16 +52,6 @@ type reconcileSim struct {
 	// workers is the controller's --workflow-workers: how many reconciles are in
 	// flight at once. Bounds how far reconcile order may deviate from queue order.
 	workers int
-
-	// singleFront emulates the pre-grant-set controller, so the "before" column is
-	// reproducible from this commit instead of requiring a checkout of the parent
-	// revision. Upstream had two separate widths: notifyWaiters woke the top
-	// (limit - holders) waiters, but checkAcquire admitted only pending.items[0].
-	// The gate lives here rather than in the semaphore because it is a property of
-	// the old code, not a configuration anyone should be able to select. Emulating
-	// it means both columns of the before/after comparison are reproducible with a
-	// single `go test` on this commit; see the header comment for how to run it.
-	singleFront bool
 
 	// enqueued is the controller workqueue: keys that nextWorkflow asked to be
 	// reconciled. A real controller also periodically resyncs, but the point of
@@ -86,18 +73,17 @@ type reconcileSim struct {
 	utilization []int
 }
 
-// newReconcileSim builds a simulation. Set singleFront to measure the
-// pre-grant-set baseline (see reconcileSim.singleFront); leave it false to measure
-// the grant-set implementation in this commit.
-func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRounds, workers int, singleFront bool) *reconcileSim {
+// newReconcileSim builds a simulation against whatever semaphore implementation
+// is compiled in. There is no before/after switch: the harness measures the tree
+// it is built from, and hack/semaphore-before-after.sh runs it at two revisions.
+func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRounds, workers int) *reconcileSim {
 	tb.Helper()
 	sim := &reconcileSim{
-		limit:       limit,
-		total:       total,
-		holdRounds:  holdRounds,
-		workers:     workers,
-		singleFront: singleFront,
-		enqueued:    make(map[string]bool, total),
+		limit:      limit,
+		total:      total,
+		holdRounds: holdRounds,
+		workers:    workers,
+		enqueued:   make(map[string]bool, total),
 	}
 	sem, err := newInternalSemaphore(ctx, "bench", func(key string) {
 		sim.enqueues++
@@ -111,21 +97,6 @@ func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRound
 }
 
 func benchKey(i int) string { return fmt.Sprintf("default/wf-%05d", i) }
-
-// pendingHead returns the current head of the priority queue, i.e. the only key
-// upstream's checkAcquire would have admitted. Used solely by the singleFront
-// baseline.
-func (s *reconcileSim) pendingHead() (string, bool) {
-	if s.sem.pending.Len() == 0 {
-		return "", false
-	}
-	return s.sem.pending.items[0].key, true
-}
-
-func (s *reconcileSim) isPendingHead(key string) bool {
-	head, ok := s.pendingHead()
-	return ok && head == key
-}
 
 // shuffleDeterministic permutes keys using a seedless xorshift, so reconcile
 // order is decoupled from priority order without introducing run-to-run
@@ -232,26 +203,7 @@ func (s *reconcileSim) run(ctx context.Context, maxRounds int) (completed int, h
 		clear(s.enqueued)
 		shuffleInBatches(batch, s.rounds, s.workers)
 
-		if s.singleFront {
-			// Upstream had no grant set, so a waiter that had already been woken was
-			// woken again on the next release. Clearing the grants each round restores
-			// that repeated-wake behaviour; without this, grantWaiters would suppress
-			// the re-wakes and understate the churn being measured.
-			clear(s.sem.granted)
-		}
-
 		for _, key := range batch {
-			if s.singleFront && !s.isPendingHead(key) {
-				// Upstream checkAcquire admitted only pending.items[0]. Everyone else
-				// bounced with "isn't at the front" after enqueueing the head.
-				s.bounces++
-				s.tryAcquires++
-				if head, ok := s.pendingHead(); ok {
-					s.enqueues++
-					s.enqueued[head] = true
-				}
-				continue
-			}
 			s.tryAcquires++
 			acquired, _, err := s.sem.tryAcquire(ctx, key, nil)
 			if err != nil {
@@ -335,31 +287,22 @@ var benchScenarios = []scenario{
 	{name: "limit500_wf5000", limit: 500, total: 5000, holdRounds: 1, workers: 16},
 }
 
-// variants are the two implementations compared side by side. "before" emulates
-// the pre-grant-set controller (see reconcileSim.singleFront); "after" is the
-// grant-set code in this commit. Both columns are therefore reproducible from a
-// single checkout, with no need to build the parent revision.
-var variants = []struct {
-	name        string
-	singleFront bool
-}{
-	{name: "before", singleFront: true},
-	{name: "after", singleFront: false},
-}
-
 // TestSemaphorePromotionCost is the headline measurement.
 //
-// Run it with:
+// For the before/after comparison, use the script -- it runs this test at the
+// pre-grant-set revision and at HEAD, and prints a markdown table:
+//
+//	./hack/semaphore-before-after.sh
+//
+// To run just this revision:
 //
 //	go test ./workflow/sync/ -run TestSemaphorePromotionCost -count=1 -v
 //
-// -v is required, since the results come out through t.Logf. Takes about 3s. Add
-// a scenario name to narrow it:
+// -v is required, since results come out through t.Logf. Takes about 3s. Append a
+// scenario name to narrow it (-run '.../limit500_wf2000').
 //
-//	go test ./workflow/sync/ -run 'TestSemaphorePromotionCost/limit500_wf2000' -count=1 -v
-//
-// Narrowing further to one variant (-run '.../before') runs but prints no table:
-// a row needs both variants to compute its reduction factor, so it is skipped.
+// It reports whichever implementation it was built from; there is no before/after
+// switch in the harness.
 //
 // What it does: queue `total` workflows against one semaphore of size `limit`,
 // then reconcile in rounds until all have run. Each round reconciles every
@@ -370,11 +313,11 @@ var variants = []struct {
 // Kubernetes, no pods, no database, and the workflow body is virtual time -- a
 // drain that takes ~25 minutes on a cluster runs here in under a second.
 //
-// What it reports: total tryAcquire calls to drain the queue, absolute and per
-// workflow. Every workflow acquires exactly once, so the per-workflow figure is
-// one useful reconcile plus every wasted one, and 1.0 is the floor. That is the
-// cost of the promotion strategy, since the work of running the workflows
-// themselves is identical in both columns.
+// What it reports: total tryAcquire calls to drain the queue. Every workflow
+// acquires exactly once, so divided by the workflow count this is one useful
+// reconcile plus every wasted one, and 1.0 is the floor. That isolates the cost of
+// the promotion strategy, since the work of running the workflows themselves is
+// identical across revisions.
 //
 // It is a test rather than a Benchmark because the quantity is a structural count
 // that is identical run to run, not a time needing repetition to stabilize.
@@ -382,80 +325,39 @@ var variants = []struct {
 func TestSemaphorePromotionCost(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 
-	// reconciles is total tryAcquire calls across the drain: the absolute load the
-	// controller and apiserver carry. Per workflow it is the admission
-	// amplification factor, since every workflow acquires exactly once -- one
-	// successful reconcile plus every wasted one, where 1.0 would mean each
-	// workflow is looked at once and admitted.
-	//
-	// One row per scenario with before and after side by side, emitted as a
-	// markdown table so the result can be pasted into a PR or issue unedited.
-	rows := make([]string, 0, len(benchScenarios))
-
+	// One RESULT line per scenario, in a fixed parseable format, because this test
+	// measures whichever revision it was compiled from and cannot know the other
+	// side. hack/semaphore-before-after.sh runs it at two revisions and joins the
+	// lines into the before/after table.
 	for _, sc := range benchScenarios {
-		perVariant := make(map[string]int, len(variants))
+		t.Run(sc.name, func(t *testing.T) {
+			sim := newReconcileSim(ctx, t, sc.limit, sc.total, sc.holdRounds, sc.workers)
 
-		for _, v := range variants {
-			t.Run(sc.name+"/"+v.name, func(t *testing.T) {
-				sim := newReconcileSim(ctx, t, sc.limit, sc.total, sc.holdRounds, sc.workers, v.singleFront)
+			// Cap generously: the quadratic case needs ~limit rounds per wave, so
+			// allow that plus slack. Hitting the cap is reported, not hidden.
+			waves := (sc.total + sc.limit - 1) / sc.limit
+			maxRounds := waves * (sc.limit + sc.holdRounds) * 4
 
-				// Cap generously: the quadratic case needs ~limit rounds per wave, so
-				// allow that plus slack. Hitting the cap is reported, not hidden.
-				waves := (sc.total + sc.limit - 1) / sc.limit
-				maxRounds := waves * (sc.limit + sc.holdRounds) * 4
+			start := time.Now()
+			completed, hitCap := sim.run(ctx, maxRounds)
+			elapsed := time.Since(start)
 
-				start := time.Now()
-				completed, hitCap := sim.run(ctx, maxRounds)
-				elapsed := time.Since(start)
+			// The counts are only meaningful if every workflow got through, so this
+			// is an assertion rather than a reported column.
+			if hitCap || completed != sc.total {
+				t.Fatalf("only %d/%d workflows drained within %d rounds (%s)",
+					completed, sc.total, maxRounds, elapsed.Round(time.Millisecond))
+			}
 
-				// The counts are only meaningful if every workflow got through, so
-				// this is an assertion rather than a reported column.
-				if hitCap || completed != sc.total {
-					t.Fatalf("only %d/%d workflows drained within %d rounds (%s)",
-						completed, sc.total, maxRounds, elapsed.Round(time.Millisecond))
-				}
-				perVariant[v.name] = sim.tryAcquires
-			})
-		}
-
-		// A subtest that failed leaves its variant unrecorded; skip the row rather
-		// than printing a ratio against a zero.
-		before, okBefore := perVariant["before"]
-		after, okAfter := perVariant["after"]
-		if !okBefore || !okAfter {
-			continue
-		}
-		rows = append(rows, fmt.Sprintf("| %d | %d | %s | %s | %.0fx |",
-			sc.limit, sc.total,
-			reconcileCell(before, sc.total), reconcileCell(after, sc.total),
-			float64(before)/float64(after)))
+			// reconciles is total tryAcquire calls across the drain: the absolute
+			// load the controller and apiserver carry. Divided by the workflow count
+			// it is the admission amplification factor, since every workflow acquires
+			// exactly once -- one useful reconcile plus every wasted one, where 1.0
+			// would mean each workflow is looked at once and admitted.
+			t.Logf("RESULT scenario=%s limit=%d workflows=%d reconciles=%d rounds=%d",
+				sc.name, sc.limit, sc.total, sim.tryAcquires, sim.rounds)
+		})
 	}
-
-	t.Logf("\n%s\n%s\n%s",
-		"| limit | workflows | before | after | reduction |",
-		"|------:|----------:|-------:|------:|----------:|",
-		strings.Join(rows, "\n"))
-}
-
-// reconcileCell renders a reconcile count as "total (N.N/wf)", the absolute load
-// alongside the same figure normalized per workflow.
-func reconcileCell(reconciles, total int) string {
-	return fmt.Sprintf("%s (%.1f/wf)", humanCount(reconciles),
-		float64(reconciles)/float64(total))
-}
-
-// humanCount groups thousands with commas: 1394953 -> "1,394,953". Six-digit
-// reconcile counts are the point of the table and are hard to compare unseparated.
-func humanCount(n int) string {
-	s := strconv.Itoa(n)
-	var b strings.Builder
-	for i, c := range s {
-		if i > 0 && (len(s)-i)%3 == 0 {
-			b.WriteByte(',')
-		}
-		b.WriteRune(c)
-	}
-	return b.String()
 }
 
 // BenchmarkSemaphorePromotion measures wall-clock cost of draining the reference
@@ -464,18 +366,16 @@ func humanCount(n int) string {
 func BenchmarkSemaphorePromotion(b *testing.B) {
 	ctx := logging.TestContext(b.Context())
 	for _, sc := range benchScenarios {
-		for _, v := range variants {
-			b.Run(sc.name+"/"+v.name, func(b *testing.B) {
-				waves := (sc.total + sc.limit - 1) / sc.limit
-				maxRounds := waves * (sc.limit + sc.holdRounds) * 4
-				b.ReportAllocs()
-				for b.Loop() {
-					sim := newReconcileSim(ctx, b, sc.limit, sc.total, sc.holdRounds, sc.workers, v.singleFront)
-					sim.run(ctx, maxRounds)
-					b.ReportMetric(float64(sim.rounds), "rounds")
-					b.ReportMetric(float64(sim.bounces)/float64(sc.total), "bounces/wf")
-				}
-			})
-		}
+		b.Run(sc.name, func(b *testing.B) {
+			waves := (sc.total + sc.limit - 1) / sc.limit
+			maxRounds := waves * (sc.limit + sc.holdRounds) * 4
+			b.ReportAllocs()
+			for b.Loop() {
+				sim := newReconcileSim(ctx, b, sc.limit, sc.total, sc.holdRounds, sc.workers)
+				sim.run(ctx, maxRounds)
+				b.ReportMetric(float64(sim.rounds), "rounds")
+				b.ReportMetric(float64(sim.bounces)/float64(sc.total), "bounces/wf")
+			}
+		})
 	}
 }

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -366,17 +368,19 @@ var variants = []struct {
 func TestSemaphorePromotionCost(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 
-	// reconciles/wf is the whole result: how many times the average workflow is
-	// reconciled before it holds the semaphore. Every workflow acquires exactly
-	// once, so this is tryAcquires/total -- one successful reconcile plus every
-	// wasted one. It is the admission amplification factor: 1.0 would mean each
+	// reconciles is total tryAcquire calls across the drain: the absolute load the
+	// controller and apiserver carry. Per workflow it is the admission
+	// amplification factor, since every workflow acquires exactly once -- one
+	// successful reconcile plus every wasted one, where 1.0 would mean each
 	// workflow is looked at once and admitted.
-	// reconciles is the same quantity unnormalized: total tryAcquire calls across
-	// the whole drain, i.e. reconciles/wf x total. It is the absolute load the
-	// controller and apiserver actually carry.
-	t.Logf("%-18s %8s %14s %12s", "scenario", "variant", "reconciles/wf", "reconciles")
+	//
+	// One row per scenario with before and after side by side, emitted as a
+	// markdown table so the result can be pasted into a PR or issue unedited.
+	rows := make([]string, 0, len(benchScenarios))
 
 	for _, sc := range benchScenarios {
+		perVariant := make(map[string]int, len(variants))
+
 		for _, v := range variants {
 			t.Run(sc.name+"/"+v.name, func(t *testing.T) {
 				sim := newReconcileSim(ctx, t, sc.limit, sc.total, sc.holdRounds, sc.workers, v.singleFront)
@@ -390,19 +394,54 @@ func TestSemaphorePromotionCost(t *testing.T) {
 				completed, hitCap := sim.run(ctx, maxRounds)
 				elapsed := time.Since(start)
 
-				t.Logf("%-18s %8s %14.1f %12d",
-					sc.name, v.name, float64(sim.tryAcquires)/float64(sc.total),
-					sim.tryAcquires)
-
-				// The number above is only meaningful if every workflow actually got
-				// through, so this is an assertion rather than a reported column.
+				// The counts are only meaningful if every workflow got through, so
+				// this is an assertion rather than a reported column.
 				if hitCap || completed != sc.total {
 					t.Fatalf("only %d/%d workflows drained within %d rounds (%s)",
 						completed, sc.total, maxRounds, elapsed.Round(time.Millisecond))
 				}
+				perVariant[v.name] = sim.tryAcquires
 			})
 		}
+
+		// A subtest that failed leaves its variant unrecorded; skip the row rather
+		// than printing a ratio against a zero.
+		before, okBefore := perVariant["before"]
+		after, okAfter := perVariant["after"]
+		if !okBefore || !okAfter {
+			continue
+		}
+		rows = append(rows, fmt.Sprintf("| %d | %d | %s | %s | %.0fx |",
+			sc.limit, sc.total,
+			reconcileCell(before, sc.total), reconcileCell(after, sc.total),
+			float64(before)/float64(after)))
 	}
+
+	t.Logf("\n%s\n%s\n%s",
+		"| limit | workflows | before | after | reduction |",
+		"|------:|----------:|-------:|------:|----------:|",
+		strings.Join(rows, "\n"))
+}
+
+// reconcileCell renders a reconcile count as "total (N.N/wf)", the absolute load
+// alongside the same figure normalized per workflow.
+func reconcileCell(reconciles, total int) string {
+	return fmt.Sprintf("%s (%.1f/wf)", humanCount(reconciles),
+		float64(reconciles)/float64(total))
+}
+
+// humanCount groups thousands with commas: 1394953 -> "1,394,953". Six-digit
+// reconcile counts are the point of the table and are hard to compare unseparated.
+func humanCount(n int) string {
+	s := strconv.Itoa(n)
+	var b strings.Builder
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteRune(c)
+	}
+	return b.String()
 }
 
 // BenchmarkSemaphorePromotion measures wall-clock cost of draining the reference

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -12,28 +12,13 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
 
-// Tier 1 benchmark harness for semaphore promotion throughput.
+// Benchmark harness for semaphore promotion throughput. See
+// TestSemaphorePromotionCost below for how to run it and what it measures.
 //
-// To reproduce the before/after comparison:
-//
-//	go test ./workflow/sync/ -run TestSemaphorePromotionCost -count=1 -v
-//
-// Both columns come from this one command. "before" emulates the pre-grant-set
-// admission gate in the harness (see reconcileSim.singleFront) rather than
-// requiring a checkout of the parent revision, so the comparison is a single
-// deterministic run with no build juggling. Everything is seedless, so two runs
-// on the same commit produce byte-identical numbers.
-//
-// This models the controller's reconcile loop against the in-memory
-// prioritySemaphore directly: no Kubernetes, no pods, no database. The 6-minute
-// workflow body is virtual time (a hold that spans a fixed number of rounds), so
-// a run that takes ~25 minutes in a real cluster completes here in milliseconds.
-//
-// What it measures is the shape of promotion, not wall-clock makespan. The test
-// reports total tryAcquire calls both per workflow and absolute. Every workflow
-// acquires exactly once, so the per-workflow figure is one successful reconcile
-// plus every wasted one -- the admission amplification factor, where 1.0 means
-// each workflow is looked at once and admitted.
+// Both columns come from a single run on this commit: "before" emulates the
+// pre-grant-set admission gate in the harness (see reconcileSim.singleFront)
+// rather than requiring a checkout of the parent revision. Everything is seedless,
+// so two runs on the same commit produce byte-identical numbers.
 //
 // The simulation tracks more than it prints, for use when investigating:
 //
@@ -51,8 +36,12 @@ import (
 //	              it overstates distinct reconciles. Use bounces for per-workflow
 //	              cost and rounds for latency.
 //
-// The reconcile loop is a model of the controller, not the controller itself;
-// Tier 2 (fake-clientset controller test) exists to corroborate these numbers.
+// The reconcile loop is a model of the controller, not the controller itself. It
+// is calibrated against the real thing at one point: the reference shape measured
+// 884 rounds here against 894 on the actual pre-grant-set commit. Nothing else is
+// corroborated end-to-end, so treat the absolute counts as the cost of the
+// promotion strategy under this model, and the before/after ratio -- which shares
+// the model, and so most of its error -- as the load-bearing result.
 
 // reconcileSim drives a semaphore the way the workflow controller does: a set of
 // pending workflows, each of which is reconciled once per round, attempting to
@@ -358,13 +347,38 @@ var variants = []struct {
 	{name: "after", singleFront: false},
 }
 
-// TestSemaphorePromotionCost is the headline measurement, written as a test
-// rather than a Benchmark because the interesting quantity is a structural count
-// (rounds, amplification) that is identical run to run, not a time that needs
-// repetition to stabilize.
+// TestSemaphorePromotionCost is the headline measurement.
 //
-// The optimum is ceil(total/limit) waves, each taking holdRounds. Any excess is
-// promotion overhead.
+// Run it with:
+//
+//	go test ./workflow/sync/ -run TestSemaphorePromotionCost -count=1 -v
+//
+// -v is required, since the results come out through t.Logf. Takes about 3s. Add
+// a scenario name to narrow it:
+//
+//	go test ./workflow/sync/ -run 'TestSemaphorePromotionCost/limit500_wf2000' -count=1 -v
+//
+// Narrowing further to one variant (-run '.../before') runs but prints no table:
+// a row needs both variants to compute its reduction factor, so it is skipped.
+//
+// What it does: queue `total` workflows against one semaphore of size `limit`,
+// then reconcile in rounds until all have run. Each round reconciles every
+// workflow the controller has been asked to look at, in an order deliberately
+// decoupled from priority order; whoever acquires holds its slot for holdRounds
+// rounds and then releases, which wakes waiters. A workflow that fails to acquire
+// is not re-reconciled until something wakes it, exactly as in the controller. No
+// Kubernetes, no pods, no database, and the workflow body is virtual time -- a
+// drain that takes ~25 minutes on a cluster runs here in under a second.
+//
+// What it reports: total tryAcquire calls to drain the queue, absolute and per
+// workflow. Every workflow acquires exactly once, so the per-workflow figure is
+// one useful reconcile plus every wasted one, and 1.0 is the floor. That is the
+// cost of the promotion strategy, since the work of running the workflows
+// themselves is identical in both columns.
+//
+// It is a test rather than a Benchmark because the quantity is a structural count
+// that is identical run to run, not a time needing repetition to stabilize.
+// BenchmarkSemaphorePromotion below covers the wall-clock and allocation side.
 func TestSemaphorePromotionCost(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -27,17 +27,23 @@ import (
 // workflow body is virtual time (a hold that spans a fixed number of rounds), so
 // a run that takes ~25 minutes in a real cluster completes here in milliseconds.
 //
-// What it measures is the shape of promotion, not wall-clock makespan:
+// What it measures is the shape of promotion, not wall-clock makespan. The test
+// reports one number, reconciles per workflow: tryAcquires divided by the number
+// of workflows. Every workflow acquires exactly once, so this is one successful
+// reconcile plus every wasted one -- the admission amplification factor, where 1.0
+// means each workflow is looked at once and admitted.
+//
+// The simulation tracks more than it prints, for use when investigating:
 //
 //	rounds      - reconcile rounds needed to drain every workflow. The controller
 //	              cannot admit faster than one round per requeue, so rounds is the
 //	              latency multiplier that turns into real time on a cluster.
-//	tryAcquires - total tryAcquire calls. Divided by the number of workflows this
-//	              is admission amplification: 1.0 is perfect, higher means
-//	              workflows are bouncing off the semaphore and re-queueing.
-//	bounces     - reconciles that attempted acquisition and failed. Divided by the
-//	              number of workflows, this is how many times the average workflow
-//	              is woken, fails, and must wait to be woken again.
+//	bounces     - reconciles that attempted acquisition and failed, i.e.
+//	              tryAcquires minus the one success per workflow.
+//	utilization - held slots per round; meanUtilization reports occupancy as a
+//	              fraction of the limit. Deep underutilization with a large backlog
+//	              is the same bug seen from the semaphore's side rather than the
+//	              workflow's.
 //	enqueues    - raw nextWorkflow callbacks. NOTE: this counts repeat callbacks
 //	              against the same key, which the real workqueue would dedupe, so
 //	              it overstates distinct reconciles. Use bounces for per-workflow
@@ -293,8 +299,8 @@ func (s *reconcileSim) meanUtilization() float64 {
 	return float64(sum) / float64(len(s.utilization)) / float64(s.limit)
 }
 
-// scenario is one workload shape. The reference case is limit=400/total=1500; the
-// smaller shapes show how the cost scales with limit, which is the signature of
+// scenario is one workload shape. The reference case is limit=500/total=2000; the
+// smaller shape shows how the cost scales with limit, which is the signature of
 // the quadratic behaviour.
 type scenario struct {
 	name       string
@@ -306,29 +312,29 @@ type scenario struct {
 	workers int
 }
 
+// Two shapes, an order of magnitude apart in both dimensions, which is enough to
+// show that the amplification tracks the limit rather than being a property of one
+// workload size.
+//
+// holdRounds=1 isolates promotion cost from hold duration -- a longer hold only
+// adds a constant per wave, whereas promotion cost is what differs between
+// implementations. workers=16 is half the --workflow-workers default of 32, so the
+// numbers describe a conservatively-sized controller rather than the most
+// favourable one; admissions per round are near-flat in W anyway (1.76 at W=4,
+// 1.66 at W=32, 1.70 at W=512), so it is not a tuned choice.
 var benchScenarios = []scenario{
-	{name: "limit10_wf50", limit: 10, total: 50, holdRounds: 1, workers: 16},
-	{name: "limit50_wf200", limit: 50, total: 200, holdRounds: 1, workers: 16},
 	{name: "limit100_wf400", limit: 100, total: 400, holdRounds: 1, workers: 16},
-	// The reference workload: 400 slots, 1500 workflows. holdRounds=1 isolates
-	// promotion cost from hold duration -- a longer hold only adds a constant per
-	// wave, whereas the promotion cost is what differs between implementations.
-	// workers=16 across all scenarios: half the --workflow-workers default of 32,
-	// so the numbers describe a conservatively-sized controller rather than the
-	// most favourable one. Rounds are near-flat in W anyway (1.76 admissions per
-	// round at W=4, 1.66 at W=32, 1.70 at W=512), so this is not a tuned choice.
-	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1, workers: 16},
-	// Same backlog, different limits. These two exist to isolate the sharpest
-	// symptom: under the single-front gate, rounds-to-drain is a function of the
-	// backlog alone and does not respond to the limit. Both report the same round
-	// count, as do limit=200 and limit=1000 at this backlog -- admissions hold at
-	// ~1.7 workflows per round no matter how many slots are free, because only the
-	// queue head may acquire and a round admits the head plus however many
-	// successors happen to be reconciled after it. Raising the limit therefore buys
-	// no throughput at all; it only enlarges the woken set, so the wasted-reconcile
-	// count grows as limit x total. The grant set is what makes the limit mean
-	// something: "after", both drain in one round per wave.
-	{name: "limit400_wf2000", limit: 400, total: 2000, holdRounds: 1, workers: 16},
+	// The larger shape. Both dimensions are 5x the smaller one, so the gap between
+	// the two "before" figures does not by itself say which dimension drives the
+	// cost. Holding the backlog at 2000 and sweeping the limit answers that: 114
+	// wasted reconciles per workflow at limit=200 rising to 451 at limit=1000, while
+	// every one of those limits takes the same 1195 rounds to drain.
+	//
+	// So under the single-front gate the limit buys no throughput at all -- only the
+	// queue head may acquire, so a round admits the head plus whichever successors
+	// happen to be reconciled after it, about 1.7 workflows per round however many
+	// slots are free. What the limit does buy is waste, since it widens the woken
+	// set. The grant set is what makes the limit mean anything.
 	{name: "limit500_wf2000", limit: 500, total: 2000, holdRounds: 1, workers: 16},
 }
 

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -150,7 +150,18 @@ func shuffleDeterministic(keys []string, round int) {
 //
 // workers <= 0 means unbounded (one batch, i.e. a full shuffle), which is the
 // worst case for the single-front gate and the original harness behaviour.
+//
+// workers == 1 is rejected rather than supported. Batches of one cannot be
+// permuted, so the wake set would be left in the caller's sorted order, which is
+// priority order -- and iterating in priority order lets each acquire unblock the
+// next key within the same round, cascading the whole backlog through and hiding
+// the head-of-line blocking this harness exists to measure. It reports 88 rounds
+// where every W >= 4 reports ~1200. Measured admissions per round are otherwise
+// flat in W (1.76 at W=4, 1.70 at W=512), so no real setting needs W=1.
 func shuffleInBatches(keys []string, round, workers int) {
+	if workers == 1 {
+		panic("shuffleInBatches: workers=1 leaves keys in priority order, which defeats the measurement; use 0 for a full shuffle")
+	}
 	if workers <= 0 || workers > len(keys) {
 		workers = len(keys)
 	}
@@ -304,6 +315,18 @@ var benchScenarios = []scenario{
 	// wave, whereas the promotion cost is what differs between implementations.
 	// workers=32 is the controller's --workflow-workers default.
 	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1, workers: 32},
+	// Same backlog, different limits. These two exist to isolate the sharpest
+	// symptom: under the single-front gate, rounds-to-drain is a function of the
+	// backlog alone and does not respond to the limit. Both report the same round
+	// count, as do limit=200 and limit=1000 at this backlog -- admissions hold at
+	// ~1.7 workflows per round no matter how many slots are free, because only the
+	// queue head may acquire and a round admits the head plus however many
+	// successors happen to be reconciled after it. Raising the limit therefore buys
+	// no throughput at all; it only enlarges the woken set, so the wasted-reconcile
+	// count grows as limit x total. The grant set is what makes the limit mean
+	// something: "after", both drain in one round per wave.
+	{name: "limit400_wf2000", limit: 400, total: 2000, holdRounds: 1, workers: 32},
+	{name: "limit500_wf2000", limit: 500, total: 2000, holdRounds: 1, workers: 32},
 }
 
 // variants are the two implementations compared side by side. "before" emulates

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -28,10 +28,10 @@ import (
 // a run that takes ~25 minutes in a real cluster completes here in milliseconds.
 //
 // What it measures is the shape of promotion, not wall-clock makespan. The test
-// reports one number, reconciles per workflow: tryAcquires divided by the number
-// of workflows. Every workflow acquires exactly once, so this is one successful
-// reconcile plus every wasted one -- the admission amplification factor, where 1.0
-// means each workflow is looked at once and admitted.
+// reports total tryAcquire calls both per workflow and absolute. Every workflow
+// acquires exactly once, so the per-workflow figure is one successful reconcile
+// plus every wasted one -- the admission amplification factor, where 1.0 means
+// each workflow is looked at once and admitted.
 //
 // The simulation tracks more than it prints, for use when investigating:
 //
@@ -336,6 +336,12 @@ var benchScenarios = []scenario{
 	// slots are free. What the limit does buy is waste, since it widens the woken
 	// set. The grant set is what makes the limit mean anything.
 	{name: "limit500_wf2000", limit: 500, total: 2000, holdRounds: 1, workers: 16},
+	// Same limit, 2.5x the backlog. This is the pair that does isolate a single
+	// dimension: holding limit at 500, reconciles/wf rises 261 -> 279 while the
+	// absolute count rises 522k -> 1.39M. Cost per workflow is roughly flat in the
+	// backlog, so the total grows with it -- superlinearly overall, since each of
+	// the extra workflows also costs ~limit/2 reconciles of its own.
+	{name: "limit500_wf5000", limit: 500, total: 5000, holdRounds: 1, workers: 16},
 }
 
 // variants are the two implementations compared side by side. "before" emulates
@@ -365,7 +371,10 @@ func TestSemaphorePromotionCost(t *testing.T) {
 	// once, so this is tryAcquires/total -- one successful reconcile plus every
 	// wasted one. It is the admission amplification factor: 1.0 would mean each
 	// workflow is looked at once and admitted.
-	t.Logf("%-18s %8s %14s", "scenario", "variant", "reconciles/wf")
+	// reconciles is the same quantity unnormalized: total tryAcquire calls across
+	// the whole drain, i.e. reconciles/wf x total. It is the absolute load the
+	// controller and apiserver actually carry.
+	t.Logf("%-18s %8s %14s %12s", "scenario", "variant", "reconciles/wf", "reconciles")
 
 	for _, sc := range benchScenarios {
 		for _, v := range variants {
@@ -381,8 +390,9 @@ func TestSemaphorePromotionCost(t *testing.T) {
 				completed, hitCap := sim.run(ctx, maxRounds)
 				elapsed := time.Since(start)
 
-				t.Logf("%-18s %8s %14.1f",
-					sc.name, v.name, float64(sim.tryAcquires)/float64(sc.total))
+				t.Logf("%-18s %8s %14.1f %12d",
+					sc.name, v.name, float64(sim.tryAcquires)/float64(sc.total),
+					sim.tryAcquires)
 
 				// The number above is only meaningful if every workflow actually got
 				// through, so this is an assertion rather than a reported column.

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -307,14 +307,17 @@ type scenario struct {
 }
 
 var benchScenarios = []scenario{
-	{name: "limit10_wf50", limit: 10, total: 50, holdRounds: 1, workers: 32},
-	{name: "limit50_wf200", limit: 50, total: 200, holdRounds: 1, workers: 32},
-	{name: "limit100_wf400", limit: 100, total: 400, holdRounds: 1, workers: 32},
+	{name: "limit10_wf50", limit: 10, total: 50, holdRounds: 1, workers: 16},
+	{name: "limit50_wf200", limit: 50, total: 200, holdRounds: 1, workers: 16},
+	{name: "limit100_wf400", limit: 100, total: 400, holdRounds: 1, workers: 16},
 	// The reference workload: 400 slots, 1500 workflows. holdRounds=1 isolates
 	// promotion cost from hold duration -- a longer hold only adds a constant per
 	// wave, whereas the promotion cost is what differs between implementations.
-	// workers=32 is the controller's --workflow-workers default.
-	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1, workers: 32},
+	// workers=16 across all scenarios: half the --workflow-workers default of 32,
+	// so the numbers describe a conservatively-sized controller rather than the
+	// most favourable one. Rounds are near-flat in W anyway (1.76 admissions per
+	// round at W=4, 1.66 at W=32, 1.70 at W=512), so this is not a tuned choice.
+	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1, workers: 16},
 	// Same backlog, different limits. These two exist to isolate the sharpest
 	// symptom: under the single-front gate, rounds-to-drain is a function of the
 	// backlog alone and does not respond to the limit. Both report the same round
@@ -325,8 +328,8 @@ var benchScenarios = []scenario{
 	// no throughput at all; it only enlarges the woken set, so the wasted-reconcile
 	// count grows as limit x total. The grant set is what makes the limit mean
 	// something: "after", both drain in one round per wave.
-	{name: "limit400_wf2000", limit: 400, total: 2000, holdRounds: 1, workers: 32},
-	{name: "limit500_wf2000", limit: 500, total: 2000, holdRounds: 1, workers: 32},
+	{name: "limit400_wf2000", limit: 400, total: 2000, holdRounds: 1, workers: 16},
+	{name: "limit500_wf2000", limit: 500, total: 2000, holdRounds: 1, workers: 16},
 }
 
 // variants are the two implementations compared side by side. "before" emulates

--- a/workflow/sync/semaphore_bench_test.go
+++ b/workflow/sync/semaphore_bench_test.go
@@ -1,0 +1,267 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+// Tier 1 benchmark harness for semaphore promotion throughput.
+//
+// This models the controller's reconcile loop against the in-memory
+// prioritySemaphore directly: no Kubernetes, no pods, no database. The 6-minute
+// workflow body is virtual time (a hold that spans a fixed number of rounds), so
+// a run that takes ~25 minutes in a real cluster completes here in milliseconds.
+//
+// What it measures is the shape of promotion, not wall-clock makespan:
+//
+//	rounds      - reconcile rounds needed to drain every workflow. The controller
+//	              cannot admit faster than one round per requeue, so rounds is the
+//	              latency multiplier that turns into real time on a cluster.
+//	tryAcquires - total tryAcquire calls. Divided by the number of workflows this
+//	              is admission amplification: 1.0 is perfect, higher means
+//	              workflows are bouncing off the semaphore and re-queueing.
+//	enqueues    - nextWorkflow callbacks. This is the workqueue churn that the
+//	              O(N^2) re-wake storm produces.
+//
+// The reconcile loop is a model of the controller, not the controller itself;
+// Tier 2 (fake-clientset controller test) exists to corroborate these numbers.
+
+// reconcileSim drives a semaphore the way the workflow controller does: a set of
+// pending workflows, each of which is reconciled once per round, attempting to
+// acquire. A holder occupies its slot for holdRounds rounds, standing in for the
+// workflow body (e.g. sleep 6m).
+type reconcileSim struct {
+	sem        *prioritySemaphore
+	limit      int
+	total      int
+	holdRounds int
+
+	// enqueued is the controller workqueue: keys that nextWorkflow asked to be
+	// reconciled. A real controller also periodically resyncs, but the point of
+	// the comparison is precisely how much this queue is churned, so the sim
+	// reconciles exactly the woken set plus any workflow not yet done.
+	enqueued map[string]bool
+
+	// instrumentation
+	rounds      int
+	tryAcquires int
+	enqueues    int
+
+	// utilization[i] is the number of held slots at the end of round i.
+	utilization []int
+}
+
+func newReconcileSim(ctx context.Context, tb testing.TB, limit, total, holdRounds int) *reconcileSim {
+	tb.Helper()
+	sim := &reconcileSim{
+		limit:      limit,
+		total:      total,
+		holdRounds: holdRounds,
+		enqueued:   make(map[string]bool, total),
+	}
+	sem, err := newInternalSemaphore(ctx, "bench", func(key string) {
+		sim.enqueues++
+		sim.enqueued[key] = true
+	}, func(context.Context, string) (int, error) { return limit, nil }, 0)
+	if err != nil {
+		tb.Fatalf("newInternalSemaphore: %v", err)
+	}
+	sim.sem = sem
+	return sim
+}
+
+func benchKey(i int) string { return fmt.Sprintf("default/wf-%05d", i) }
+
+// shuffleDeterministic permutes keys using a seedless xorshift, so reconcile
+// order is decoupled from priority order without introducing run-to-run
+// variance. round is mixed into the state so successive rounds differ.
+func shuffleDeterministic(keys []string, round int) {
+	state := uint64(round)*2862933555777941757 + 3037000493
+	for i := len(keys) - 1; i > 0; i-- {
+		state ^= state << 13
+		state ^= state >> 7
+		state ^= state << 17
+		j := int(state % uint64(i+1))
+		keys[i], keys[j] = keys[j], keys[i]
+	}
+}
+
+// run submits every workflow, then reconciles until all have acquired and
+// released. It returns once every workflow is done or maxRounds is exceeded.
+//
+// maxRounds is a safety valve: the pathological case is quadratic, so an
+// unbounded loop on a large input would appear to hang. Exceeding it is itself a
+// meaningful result and is reported rather than silently truncated.
+func (s *reconcileSim) run(ctx context.Context, maxRounds int) (completed int, hitCap bool) {
+	now := time.Now()
+	for i := range s.total {
+		// Priority ties broken by creation time, mirroring real submission order.
+		if err := s.sem.addToQueue(ctx, benchKey(i), 0, now.Add(time.Duration(i)*time.Millisecond)); err != nil {
+			panic(err)
+		}
+		s.enqueued[benchKey(i)] = true
+	}
+
+	// releaseAt[key] is the round at which a holder's virtual work finishes.
+	releaseAt := make(map[string]int, s.total)
+	done := make(map[string]bool, s.total)
+
+	for len(done) < s.total && s.rounds < maxRounds {
+		s.rounds++
+
+		// Releases land first: a holder whose work finished frees its slot before
+		// this round's admissions, as in the controller where pod completion is
+		// observed and Release runs during that workflow's reconcile.
+		for key, at := range releaseAt {
+			if at == s.rounds {
+				s.sem.release(ctx, key)
+				delete(releaseAt, key)
+				done[key] = true
+			}
+		}
+
+		// Reconcile every workflow the controller has been asked to look at.
+		//
+		// Order matters and must NOT be priority order. The controller's workqueue
+		// is keyed by workflow name and shuffled by arrival, retry backoff, and
+		// worker concurrency; it does not hand work to the reconciler in semaphore
+		// priority order. Iterating in sorted (== priority) order would let each
+		// acquire unblock the next key within a single round, which silently
+		// defeats the very head-of-line blocking being measured and makes the
+		// single-front implementation look optimal.
+		//
+		// So: collect deterministically (Go map order is randomized), then apply a
+		// fixed permutation to decouple reconcile order from priority order. The
+		// permutation is seedless and reproducible, so runs stay comparable.
+		batch := make([]string, 0, len(s.enqueued))
+		for key := range s.enqueued {
+			if !done[key] && releaseAt[key] == 0 {
+				batch = append(batch, key)
+			}
+		}
+		sort.Strings(batch)
+		clear(s.enqueued)
+		shuffleDeterministic(batch, s.rounds)
+
+		for _, key := range batch {
+			s.tryAcquires++
+			acquired, _, err := s.sem.tryAcquire(ctx, key, nil)
+			if err != nil {
+				panic(err)
+			}
+			if acquired {
+				releaseAt[key] = s.rounds + s.holdRounds
+			} else {
+				// Bounced: the controller re-queues it to try again. This is the
+				// cost the grant set removes.
+				s.enqueued[key] = true
+			}
+		}
+
+		s.utilization = append(s.utilization, len(s.sem.lockHolder))
+	}
+	return len(done), s.rounds >= maxRounds
+}
+
+// meanUtilization reports average slot occupancy as a fraction of the limit,
+// over rounds where work remained. Deep underutilization with a large backlog is
+// the clearest evidence of head-of-line blocking.
+func (s *reconcileSim) meanUtilization() float64 {
+	if len(s.utilization) == 0 {
+		return 0
+	}
+	sum := 0
+	for _, u := range s.utilization {
+		sum += u
+	}
+	return float64(sum) / float64(len(s.utilization)) / float64(s.limit)
+}
+
+// scenario is one workload shape. The Databricks reference case is
+// limit=400/total=1500; the smaller shapes show how the cost scales with limit,
+// which is the signature of the quadratic behaviour.
+type scenario struct {
+	name       string
+	limit      int
+	total      int
+	holdRounds int
+}
+
+var benchScenarios = []scenario{
+	{name: "limit10_wf50", limit: 10, total: 50, holdRounds: 1},
+	{name: "limit50_wf200", limit: 50, total: 200, holdRounds: 1},
+	{name: "limit100_wf400", limit: 100, total: 400, holdRounds: 1},
+	// The reference workload: 400 slots, 1500 workflows. holdRounds=1 isolates
+	// promotion cost from hold duration -- a longer hold only adds a constant per
+	// wave, whereas the promotion cost is what differs between implementations.
+	{name: "limit400_wf1500", limit: 400, total: 1500, holdRounds: 1},
+}
+
+// TestSemaphorePromotionCost is the headline measurement, written as a test
+// rather than a Benchmark because the interesting quantity is a structural count
+// (rounds, amplification) that is identical run to run, not a time that needs
+// repetition to stabilize.
+//
+// The optimum is ceil(total/limit) waves, each taking holdRounds. Any excess is
+// promotion overhead.
+func TestSemaphorePromotionCost(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	t.Logf("%-18s %7s %7s %9s %9s %7s %7s %6s",
+		"scenario", "limit", "wfs", "rounds", "optimum", "ratio", "ampl", "util")
+
+	for _, sc := range benchScenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			sim := newReconcileSim(ctx, t, sc.limit, sc.total, sc.holdRounds)
+
+			// Cap generously: the quadratic case needs ~limit rounds per wave, so
+			// allow that plus slack. Hitting the cap is reported, not hidden.
+			waves := (sc.total + sc.limit - 1) / sc.limit
+			maxRounds := waves * (sc.limit + sc.holdRounds) * 4
+
+			start := time.Now()
+			completed, hitCap := sim.run(ctx, maxRounds)
+			elapsed := time.Since(start)
+
+			optimum := waves * sc.holdRounds
+			ratio := float64(sim.rounds) / float64(optimum)
+			ampl := float64(sim.tryAcquires) / float64(sc.total)
+
+			t.Logf("%-18s %7d %7d %9d %9d %6.1fx %6.1fx %5.0f%%",
+				sc.name, sc.limit, sc.total, sim.rounds, optimum, ratio, ampl,
+				sim.meanUtilization()*100)
+			t.Logf("  completed=%d/%d enqueues=%d tryAcquires=%d wall=%s hitRoundCap=%v",
+				completed, sc.total, sim.enqueues, sim.tryAcquires, elapsed.Round(time.Millisecond), hitCap)
+
+			if completed != sc.total {
+				t.Logf("  NOTE: only %d/%d workflows drained within %d rounds",
+					completed, sc.total, maxRounds)
+			}
+		})
+	}
+}
+
+// BenchmarkSemaphorePromotion measures wall-clock cost of draining the reference
+// workload, for the CPU side of the comparison. A fix that trades stalling for
+// busy-looping would show up here as a regression even while rounds improve.
+func BenchmarkSemaphorePromotion(b *testing.B) {
+	ctx := logging.TestContext(b.Context())
+	for _, sc := range benchScenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			waves := (sc.total + sc.limit - 1) / sc.limit
+			maxRounds := waves * (sc.limit + sc.holdRounds) * 4
+			b.ReportAllocs()
+			for b.Loop() {
+				sim := newReconcileSim(ctx, b, sc.limit, sc.total, sc.holdRounds)
+				sim.run(ctx, maxRounds)
+				b.ReportMetric(float64(sim.rounds), "rounds")
+				b.ReportMetric(float64(sim.tryAcquires)/float64(sc.total), "tryAcquire/wf")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

More details addressed in issue #16606 

## Summary

Adds example code for grant-set promotion to in-memory semaphores, to avoid a performance cliff on semaphores with many slots and a deep queue of pending workflows. Draft for the discussion in #16606.

### Motivation

Today notifyWaiters enqueues the top K pending workflows (K = free slots), but checkAcquire admits one only if it is at the front of the queue. With multiple workers those K are not processed in priority order, so few are actually promoted and the rest bounce and requeue. Work to drain the queue grows as O(KN) instead of O(N), and capacity sits idle -- I have observed 95% of slots free but unused. Similar issues reported in #12039.

### Modifications

- `prioritySemaphore` gains a granted `map[string]bool`, and a workflow may only acquire while granted.
- `grantWaiters` walks the pending queue and grants the top `limit - holders - granted` waiters, enqueueing each newly-granted key, so K freed slots fill in one round.
- Already-granted keys are skipped, so a burst of releases does not repeatedly re-wake the same head.
- `checkAcquire` grants on demand for a workflow that arrives ungranted, passing its own key as skipKey to avoid a self-enqueue.
- Grants are dropped on acquire and on removal from the queue, so nothing stale counts against the grant count.

Priority ordering is now approximate rather than strict. Instead of guaranteeing that the highest-priority waiter always starts *first*, higher-priority waiters are granted *sooner* — they enter the grant set in priority order, but members of a grant set may acquire in any order among themselves.

While not implemented at the moment, our suggested feature in #16606 is to implement this as an opt-in alternative queueing strategy, so original behavior is preserved.

### Verification

`./hack/semaphore-before-after.sh` builds and runs the same harness at the merge-base and at HEAD in separate git worktrees, then prints the comparison. Both sides run byte-identical measurement code, so the only difference is semaphore.go. We use 16 simulated workers, and report the total number of `tryAcquire calls`, as well as the average per workflow.

limit | total (N) | before | after | reduction
-- | -- | -- | -- | --
100 | 400 | 21,545 (53.9/wf) | 700 (1.8/wf) | 31x
500 | 2000 | 521,924 (261.0/wf) | 3,500 (1.8/wf) | 149x
500 | 5000 | 1,394,953 (279.0/wf) | 9,500 (1.9/wf) | 147x

Note draft PR implemented as demonstration, so some CI tests are failing right now.

### Documentation

`docs/synchronization.md` would gain a note about new configuration

### AI

This PR was co-written by Claude to port change from downstream fork. Human-verified.