### PR TITLE
fix(ui): trim login token and hint when missing Bearer/Basic prefix

### DIFF
--- a/ui/src/login/login.scss
+++ b/ui/src/login/login.scss
@@ -56,6 +56,11 @@ $contentMinWidth: 560px;
         }
     }
 
+    &__token-hint {
+        color: $argo-color-red;
+        font-size: 0.85em;
+    }
+
     &__logo {
         display: block;
         background-repeat: no-repeat;

--- a/ui/src/login/login.test.tsx
+++ b/ui/src/login/login.test.tsx
@@ -50,11 +50,11 @@ describe('Login', () => {
             const {getAllByText, getByRole} = render(LoginWithHistory(createMemoryHistory()));
 
             const button = getAllByText('Login')[1];
-            fireEvent.change(getByRole('textbox'), {target: {value: 'test-token'}});
+            fireEvent.change(getByRole('textbox'), {target: {value: 'Bearer test-token'}});
             fireEvent.click(button);
 
             expect(button.getAttribute('href')).toBe('/');
-            expect(setCookie).toHaveBeenCalledWith('authorization', 'test-token');
+            expect(setCookie).toHaveBeenCalledWith('authorization', 'Bearer test-token');
         });
 
         it('responds to click with custom <base>', () => {
@@ -62,11 +62,43 @@ describe('Login', () => {
             const {getAllByText, getByRole} = render(LoginWithHistory(createMemoryHistory()));
 
             const button = getAllByText('Login')[1];
-            fireEvent.change(getByRole('textbox'), {target: {value: 'test123'}});
+            fireEvent.change(getByRole('textbox'), {target: {value: 'Bearer test123'}});
             fireEvent.click(button);
 
             expect(button.getAttribute('href')).toBe('/test/argo');
-            expect(setCookie).toHaveBeenCalledWith('authorization', 'test123');
+            expect(setCookie).toHaveBeenCalledWith('authorization', 'Bearer test123');
+        });
+
+        it('trims leading/trailing whitespace and newlines before setting the cookie', () => {
+            const {getAllByText, getByRole} = render(LoginWithHistory(createMemoryHistory()));
+
+            const button = getAllByText('Login')[1];
+            fireEvent.change(getByRole('textbox'), {target: {value: '\n Bearer test-token \n'}});
+            fireEvent.click(button);
+
+            expect(setCookie).toHaveBeenCalledWith('authorization', 'Bearer test-token');
+        });
+
+        it('shows a hint when the token does not start with "Bearer " or "Basic "', () => {
+            const {getByRole, queryByText} = render(LoginWithHistory(createMemoryHistory()));
+
+            fireEvent.change(getByRole('textbox'), {target: {value: 'test-token'}});
+
+            expect(queryByText(/should usually start with/)).not.toBeNull();
+        });
+
+        it('does not show a hint when the token starts with "Bearer "', () => {
+            const {getByRole, queryByText} = render(LoginWithHistory(createMemoryHistory()));
+
+            fireEvent.change(getByRole('textbox'), {target: {value: 'Bearer test-token'}});
+
+            expect(queryByText(/should usually start with/)).toBeNull();
+        });
+
+        it('does not show a hint when the token is empty', () => {
+            const {queryByText} = render(LoginWithHistory(createMemoryHistory()));
+
+            expect(queryByText(/should usually start with/)).toBeNull();
         });
     });
 

--- a/ui/src/login/login.tsx
+++ b/ui/src/login/login.tsx
@@ -61,8 +61,11 @@ export function Login({location, history}: RouteComponentProps<any>) {
                         <div>
                             <textarea id='token' className='token-input' rows={4} value={token} onChange={e => setToken(e.target.value)} />
                         </div>
+                        {token.trim() !== '' && !token.trim().startsWith('Bearer ') && !token.trim().startsWith('Basic ') && (
+                            <p className='login__token-hint'>Token should usually start with &quot;Bearer &quot; or &quot;Basic &quot;, including the prefix.</p>
+                        )}
                         <div>
-                            <a className='argo-button argo-button--base-o' href={uiUrl('')} onClick={() => setCookie('authorization', token)}>
+                            <a className='argo-button argo-button--base-o' href={uiUrl('')} onClick={() => setCookie('authorization', token.trim())}>
                                 <i className='fa fa-sign-in-alt' /> Login
                             </a>
                         </div>


### PR DESCRIPTION
Motivation:
Users following the client-authentication login instructions
sometimes paste only the raw token (without the required "Bearer "
prefix) or include stray leading/trailing whitespace/newlines, e.g.
when copying from a terminal. The login page writes the pasted value
into the `authorization` cookie verbatim, and the server forwards it
into gRPC metadata unchanged, so a malformed value fails gRPC's
printable-ASCII header check with an opaque `Internal Server Error`
before authentication is even attempted. Reported in #14455.

This does not change that server-side behavior (still tracked more
generally in #12721) or the underlying gRPC header validation - a
well-formed but invalid token still shows the intended "token not
valid" error. It only reduces how often users end up with a malformed
cookie value in the first place, and gives them a clearer signal
before clicking Login.

Approach:
In ui/src/login/login.tsx, trim the token before writing it to the
`authorization` cookie via setCookie, and show a hint below the
textarea when the (trimmed) token is non-empty and does not start
with "Bearer " or "Basic ", the two schemes the server expects.

Validation:
ran `yarn --cwd ui jest src/login/login.test.tsx` (10/10 passed,
including new cases for trimming and the hint's presence/absence),
`npx eslint src/login/login.tsx src/login/login.test.tsx` (clean),
and `npx tsc --noEmit` (clean) from ui/.

Fixes #14455

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a login hint when a token is missing the required `Bearer` or `Basic` prefix.

* **Bug Fixes**
  * Tokens are now trimmed before being saved, preventing accidental whitespace from affecting authentication.
  * Improved token-login validation while preserving redirect and custom-base behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->