### PR TITLE
fix(controller): requeue on hydration failure instead of marking workflow Error

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1004,8 +1004,9 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 	err = wfc.hydrator.Hydrate(ctx, woc.wf)
 	if err != nil {
 		woc.log.WithError(err).Error(ctx, "hydration failed")
-		ctx = woc.markWorkflowError(ctx, err)
-		woc.persistUpdates(ctx)
+		// We could not read this workflow's node status, so we do not know its state.
+		// Never make a terminal decision from ignorance — try again later.
+		wfc.wfQueue.AddRateLimited(key)
 		return true
 	}
 	ctx = wfctx.InjectObjectMeta(ctx, &woc.wf.ObjectMeta)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/workflow/controller/estimation"
 	"github.com/argoproj/argo-workflows/v4/workflow/controller/pod"
 	"github.com/argoproj/argo-workflows/v4/workflow/events"
+	"github.com/argoproj/argo-workflows/v4/workflow/hydrator"
 	hydratorfake "github.com/argoproj/argo-workflows/v4/workflow/hydrator/fake"
 	"github.com/argoproj/argo-workflows/v4/workflow/metrics"
 	"github.com/argoproj/argo-workflows/v4/workflow/tracing"
@@ -1663,6 +1664,60 @@ spec:
 	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
 	podCleanupKey := "test/my-wf/labelPodCompleted"
 	assert.Equal(t, 0, controller.PodController.TestingQueueNumRequeues(podCleanupKey))
+}
+
+// TestHydrationFailureRequeuesWithoutMarkingError is the regression test for #14907: a
+// workflow whose node status is offloaded to SQL and fails to hydrate (e.g. because the
+// DB connection was dropped) must be requeued, not marked Error — and its live progress/
+// resourcesDuration aggregates must not be clobbered by recomputing them from an empty
+// (not-yet-hydrated) node map.
+func TestHydrationFailureRequeuesWithoutMarkingError(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf
+  namespace: test
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: step
+        template: work
+  - name: work
+    container:
+      image: my-image
+status:
+  phase: Running
+  progress: 1031/1033
+  resourcesDuration:
+    cpu: 100
+    memory: 200
+  offloadNodeStatusVersion: "abc123"
+  nodes: {}
+`)
+	cancel, controller := newController(logging.TestContext(t.Context()), wf)
+	defer cancel()
+
+	repo := &sqldbmocks.OffloadNodeStatusRepo{}
+	repo.On("IsEnabled").Return(true)
+	repo.On("Get", mock.Anything, mock.Anything).Return(wfv1.Nodes(nil), errors.New("FATAL: terminating connection due to administrator command (SQLSTATE 57P01)"))
+	repo.On("Save", mock.Anything, mock.Anything, mock.Anything).Return("should-not-be-called", nil)
+	controller.offloadNodeStatusRepo = repo
+	controller.hydrator = hydrator.New(repo)
+
+	ctx := logging.TestContext(t.Context())
+	assert.True(t, controller.processNextItem(ctx))
+
+	persisted, err := controller.wfclientset.ArgoprojV1alpha1().Workflows("test").Get(ctx, "my-wf", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, wfv1.WorkflowRunning, persisted.Status.Phase, "hydration failure must not mark the workflow Error")
+	assert.True(t, persisted.Status.FinishedAt.IsZero(), "workflow must not be marked completed")
+	assert.NotEqual(t, wfv1.ProgressZero, persisted.Status.Progress, "progress must not be clobbered from the empty node map")
+	assert.NotEmpty(t, persisted.Status.ResourcesDuration, "resourcesDuration must not be wiped")
+	assert.NotContains(t, persisted.Labels, common.LabelKeyWorkflowArchivingStatus, "workflow must not be queued for archiving")
+
+	repo.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPodCleanupDeletePendingPodWhenTerminate(t *testing.T) {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -779,8 +779,12 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 
 	diff.LogChanges(ctx, woc.orig, woc.wf)
 
-	resource.UpdateResourceDurations(ctx, woc.wf)
-	progress.UpdateProgress(ctx, woc.wf)
+	// Aggregates are recomputed from Status.Nodes; if node status was never loaded they
+	// would be computed from an empty map and clobber the real values.
+	if woc.controller.hydrator.IsHydrated(woc.wf) {
+		resource.UpdateResourceDurations(ctx, woc.wf)
+		progress.UpdateProgress(ctx, woc.wf)
+	}
 	// You MUST not call `persistUpdates` twice.
 	// * Fails the `reapplyUpdate` cannot work unless resource versions are different.
 	// * It will double the number of Kubernetes API requests.

--- a/workflow/controller/operator_persist_test.go
+++ b/workflow/controller/operator_persist_test.go
@@ -183,3 +183,47 @@ func TestPersistUpdatesMarksReapplyFailedOnNonConflictError(t *testing.T) {
 
 	assert.True(t, woc.reapplyFailed, "non-conflict persist error should mark reapply-failed to keep the throttler slot")
 }
+
+func TestPersistUpdatesPreservesAggregatesWhenWorkflowIsNotHydrated(t *testing.T) {
+	cancel, controller := newController(logging.TestContext(t.Context()))
+	defer cancel()
+
+	ctx := logging.TestContext(t.Context())
+	wfcset := controller.wfclientset.ArgoprojV1alpha1().Workflows("")
+	wf := wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: hello-world
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+status:
+  phase: Running
+  progress: 1031/1033
+  resourcesDuration:
+    cpu: 100
+    memory: 200
+  offloadNodeStatusVersion: abc123
+  nodes: {}
+`)
+	wf, err := wfcset.Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	expectedProgress := wf.Status.Progress
+	expectedResourcesDuration := wf.Status.ResourcesDuration.DeepCopy()
+
+	controller.offloadNodeStatusRepo, controller.hydrator = getMockDBCtx(nil, true)
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.updated = true
+	woc.persistUpdates(ctx)
+
+	wf, err = wfcset.Get(ctx, wf.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, expectedProgress, wf.Status.Progress)
+	assert.Equal(t, expectedResourcesDuration, wf.Status.ResourcesDuration)
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #14907 

### Motivation

When node-status hydration fails, the controller cannot safely determine the workflow state. Marking the workflow `Error` from a partially loaded object can leave the workflow phase inconsistent with its offloaded nodes and overwrite aggregate status fields derived from an empty node map.

This also causes data loss. `persistUpdates` recomputes workflow-level aggregates from `Status.Nodes` before persisting. When hydration fails, the node map is empty, causing values such as `status.progress` and `status.resourcesDuration` to be written back as zeroes and overwrite the correct status. The original report shows this clearly: workflow-level `progress: 0/0` is stored while the offloaded node snapshot still reports `progress: 1031/1033`.
<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
- Requeue the workflow after any hydration failure instead of marking it terminally failed.
- Recompute progress and resource-duration aggregates only after the workflow is hydrated.

This intentionally keeps a workflow whose node status remains unreadable in its current phase and retries it at the configured queue interval, rather than making an irreversible terminal decision from incomplete state.

### Verification

<!-- TODO: Say how you tested your changes. -->
- Added `TestHydrationFailureRequeuesWithoutMarkingError`, which verifies an offloaded workflow remains `Running` and preserves its aggregate status when hydration fails.
- Ran `go test ./workflow/controller -count=1`.
### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

### AI
Used generative AI assistance for issue analysis, code review, and drafting this PR description.

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows that encounter hydration failures are now requeued for retry instead of being marked as failed.
  * Existing progress and resource-duration metrics are preserved when workflow status data is unavailable.
  * Offload status is no longer saved after a hydration failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->