### PR TITLE
perf(executor): read the resource once for all output parameters

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -13,6 +13,19 @@ The workflow-controller (and the parts of the argo-server that share its informe
 This reduces controller memory usage — As a rough guide `managedFields` might be about 20% of the memory usage of objects, and at scale informer objects use most of the controllers memory footprint.
 This is internal to the controller's caches; objects stored in the cluster are unaffected.
 
+### Resource template output parameters no longer log the resource body at info level
+
+A resource template with output parameters previously ran `kubectl get` once per parameter, and logged each response body in the executor log at info level.
+It now reads the resource once for all of its output parameters, and logs only the arguments and the response size at info level ([#16602](https://github.com/argoproj/argo-workflows/pull/16602)).
+
+The body is still logged, at debug level, which matches how the resource JSON in `checkResourceState` has been logged since [#6100](https://github.com/argoproj/argo-workflows/pull/6100).
+If you relied on reading that body in executor logs at info level, raise the executor's log level to debug.
+
+Note that on earlier versions those info-level logs contained the whole resource, including the `data` or `stringData` of any `Secret` or `ConfigMap` a resource template read.
+If your log retention covers those versions, that content is in your stored executor logs.
+
+Output parameter values are unchanged: `jsonPath` expressions still see `managedFields` and `jqFilter` still does not.
+
 ### `argo archive` commands accept a workflow name as well as a UID
 
 The `argo archive get`, `delete`, `resubmit` and `retry` commands previously took a workflow UID as their argument.

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -310,13 +310,18 @@ func matchConditions(ctx context.Context, jsonBytes []byte, successReqs labels.R
 // substitute runKubectl, which needs a cluster.
 type kubectlRunner func(ctx context.Context, args ...string) ([]byte, error)
 
+// kubectlRunnerFn is the runner used in production. It is a variable rather than a parameter of
+// SaveResourceParameters so that tests can reach that function's own wiring - it is the only
+// caller of ReportOutputs.
+var kubectlRunnerFn kubectlRunner = runKubectl
+
 // SaveResourceParameters will save any resource output parameters
 func (we *WorkflowExecutor) SaveResourceParameters(ctx context.Context, resourceNamespace string, resourceName string) error {
 	if len(we.Template.Outputs.Parameters) == 0 {
 		logging.RequireLoggerFromContext(ctx).Info(ctx, "No output parameters")
 		return nil
 	}
-	if err := we.saveResourceParameters(ctx, resourceNamespace, resourceName, runKubectl); err != nil {
+	if err := we.saveResourceParameters(ctx, resourceNamespace, resourceName, kubectlRunnerFn); err != nil {
 		return err
 	}
 	return we.ReportOutputs(ctx, nil)
@@ -331,28 +336,49 @@ func (we *WorkflowExecutor) saveResourceParameters(ctx context.Context, resource
 
 	// obj is the resource as `kubectl get -o jsonpath=` used to see it; jsonBytes is the same
 	// resource as `kubectl get -o json` used to print it for jqFilter, i.e. without managedFields.
+	// Each is built only if some output parameter is actually resolved that way.
 	var obj *unstructured.Unstructured
 	var jsonBytes []byte
-	if (resourceNamespace != "" || resourceName != "") && slices.ContainsFunc(we.Template.Outputs.Parameters, needsResourceRead) {
-		// --show-managed-fields so that jsonPath expressions still see the whole object: unlike
-		// `-o json`, `-o jsonpath=` never stripped managedFields.
-		args := []string{"kubectl", "-n", resourceNamespace, "get", resourceName, "-o", "json", "--show-managed-fields=true"}
+	needsJSONPath := slices.ContainsFunc(we.Template.Outputs.Parameters, needsJSONPathRead)
+	needsJQ := slices.ContainsFunc(we.Template.Outputs.Parameters, needsJQRead)
+	if (resourceNamespace != "" || resourceName != "") && (needsJSONPath || needsJQ) {
+		args := []string{"kubectl", "-n", resourceNamespace, "get", resourceName, "-o", "json"}
+		if needsJSONPath {
+			// Ask for managedFields only when a jsonPath expression might read them: unlike
+			// `-o json`, `-o jsonpath=` never stripped them, so dropping them here would change
+			// what those expressions see. A jqFilter never sees them, so for a template whose
+			// parameters are all jqFilter this would only inflate the response for nothing.
+			args = append(args, "--show-managed-fields=true")
+		}
 		out, err := kubectl(ctx, args...)
-		// Deliberately not logging `out`: this reads the whole resource, including managedFields and
-		// any Secret/ConfigMap data, so the body must not reach the executor log at Info.
+		// The body goes to Debug, never to Info: it is the whole resource, including managedFields
+		// and any Secret or ConfigMap data. Same treatment as the resource JSON in
+		// checkResourceState, which #6100 moved to Debug for the same reason.
 		logger.WithError(err).WithField("args", args).WithField("bytes", len(out)).Info(ctx, "kubectl")
+		logger.WithField("out", string(out)).Debug(ctx, "kubectl output")
 		if err != nil {
 			return err
 		}
-		obj = &unstructured.Unstructured{}
-		if err = json.Unmarshal(out, obj); err != nil {
-			return err
+		if needsJSONPath {
+			obj = &unstructured.Unstructured{}
+			if err = json.Unmarshal(out, obj); err != nil {
+				return err
+			}
 		}
-		withoutManagedFields := obj.DeepCopy()
-		withoutManagedFields.SetManagedFields(nil)
-		jsonBytes, err = withoutManagedFields.MarshalJSON()
-		if err != nil {
-			return err
+		if needsJQ {
+			if needsJSONPath {
+				// The response carries managedFields because a jsonPath parameter asked for them.
+				// Strip them so that jqFilter still sees exactly what plain `-o json` gave it.
+				withoutManagedFields := obj.DeepCopy()
+				withoutManagedFields.SetManagedFields(nil)
+				jsonBytes, err = withoutManagedFields.MarshalJSON()
+				if err != nil {
+					return err
+				}
+			} else {
+				// `-o json` without --show-managed-fields already omits them.
+				jsonBytes = out
+			}
 		}
 	}
 
@@ -390,9 +416,15 @@ func (we *WorkflowExecutor) saveResourceParameters(ctx context.Context, resource
 	return nil
 }
 
-// needsResourceRead reports whether resolving this output parameter requires reading the resource.
-func needsResourceRead(param wfv1.Parameter) bool {
-	return param.ValueFrom != nil && (param.ValueFrom.JSONPath != "" || param.ValueFrom.JQFilter != "")
+// needsJSONPathRead and needsJQRead report which form of the resource resolving this output
+// parameter requires. They mirror the switch below, where JSONPath wins if a parameter sets both,
+// so that a parameter is only counted against the form that actually resolves it.
+func needsJSONPathRead(param wfv1.Parameter) bool {
+	return param.ValueFrom != nil && param.ValueFrom.JSONPath != ""
+}
+
+func needsJQRead(param wfv1.Parameter) bool {
+	return param.ValueFrom != nil && param.ValueFrom.JSONPath == "" && param.ValueFrom.JQFilter != ""
 }
 
 // jsonPathFilter evaluates a JSONPath expression against obj exactly as

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/itchyny/gojq"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/gengo/namer"
 	gengotypes "k8s.io/gengo/types"
@@ -304,14 +306,54 @@ func matchConditions(ctx context.Context, jsonBytes []byte, successReqs labels.R
 	return true, argoerrors.Errorf(argoerrors.CodeNotFound, "Neither success condition nor the failure condition has been matched. Retrying...")
 }
 
+// kubectlRunner runs kubectl and returns its standard output. It exists so that tests can
+// substitute runKubectl, which needs a cluster.
+type kubectlRunner func(ctx context.Context, args ...string) ([]byte, error)
+
 // SaveResourceParameters will save any resource output parameters
 func (we *WorkflowExecutor) SaveResourceParameters(ctx context.Context, resourceNamespace string, resourceName string) error {
-	logger := logging.RequireLoggerFromContext(ctx)
 	if len(we.Template.Outputs.Parameters) == 0 {
-		logger.Info(ctx, "No output parameters")
+		logging.RequireLoggerFromContext(ctx).Info(ctx, "No output parameters")
 		return nil
 	}
+	if err := we.saveResourceParameters(ctx, resourceNamespace, resourceName, runKubectl); err != nil {
+		return err
+	}
+	return we.ReportOutputs(ctx, nil)
+}
+
+// saveResourceParameters resolves the resource template's output parameters. The resource is read
+// at most once, however many output parameters there are, so that they are all resolved against the
+// same version of it.
+func (we *WorkflowExecutor) saveResourceParameters(ctx context.Context, resourceNamespace string, resourceName string, kubectl kubectlRunner) error {
+	logger := logging.RequireLoggerFromContext(ctx)
 	logger.Info(ctx, "Saving resource output parameters")
+
+	// obj is the resource as `kubectl get -o jsonpath=` used to see it; jsonBytes is the same
+	// resource as `kubectl get -o json` used to print it for jqFilter, i.e. without managedFields.
+	var obj *unstructured.Unstructured
+	var jsonBytes []byte
+	if (resourceNamespace != "" || resourceName != "") && slices.ContainsFunc(we.Template.Outputs.Parameters, needsResourceRead) {
+		// --show-managed-fields so that jsonPath expressions still see the whole object: unlike
+		// `-o json`, `-o jsonpath=` never stripped managedFields.
+		args := []string{"kubectl", "-n", resourceNamespace, "get", resourceName, "-o", "json", "--show-managed-fields=true"}
+		out, err := kubectl(ctx, args...)
+		logger.WithError(err).WithField("out", string(out)).WithField("args", args).Info(ctx, "kubectl")
+		if err != nil {
+			return err
+		}
+		obj = &unstructured.Unstructured{}
+		if err = json.Unmarshal(out, obj); err != nil {
+			return err
+		}
+		withoutManagedFields := obj.DeepCopy()
+		withoutManagedFields.SetManagedFields(nil)
+		jsonBytes, err = withoutManagedFields.MarshalJSON()
+		if err != nil {
+			return err
+		}
+	}
+
 	for i, param := range we.Template.Outputs.Parameters {
 		if param.ValueFrom == nil {
 			continue
@@ -324,35 +366,47 @@ func (we *WorkflowExecutor) SaveResourceParameters(ctx context.Context, resource
 			we.Template.Outputs.Parameters[i].Value = wfv1.AnyStringPtr(output)
 			continue
 		}
-		var outputFormat string
+		var output string
+		var err error
 		switch {
 		case param.ValueFrom.JSONPath != "":
-			outputFormat = fmt.Sprintf("jsonpath=%s", param.ValueFrom.JSONPath)
+			output, err = jsonPathFilter(obj, param.ValueFrom.JSONPath)
+			logger.WithError(err).WithField("jsonPath", param.ValueFrom.JSONPath).Info(ctx, "jsonpath")
 		case param.ValueFrom.JQFilter != "":
-			outputFormat = "json"
+			output, err = jqFilter(ctx, jsonBytes, param.ValueFrom.JQFilter)
+			logger.WithError(err).WithField("filter", param.ValueFrom.JQFilter).Info(ctx, "gojq")
 		default:
 			continue
 		}
-		args := []string{"kubectl", "-n", resourceNamespace, "get", resourceName, "-o", outputFormat}
-		out, err := runKubectl(ctx, args...)
-		logger.WithError(err).WithField("out", string(out)).WithField("args", args).Info(ctx, "kubectl")
 		if err != nil {
 			return err
-		}
-		output := string(out)
-		if param.ValueFrom.JQFilter != "" {
-			output, err = jqFilter(ctx, out, param.ValueFrom.JQFilter)
-			logger.WithError(err).WithField("out", string(out)).WithField("filter", param.ValueFrom.JQFilter).Info(ctx, "gojq")
-			if err != nil {
-				return err
-			}
 		}
 
 		we.Template.Outputs.Parameters[i].Value = wfv1.AnyStringPtr(output)
 		logger.WithFields(logging.Fields{"name": param.Name, "value": output}).Info(ctx, "Saved output parameter")
 	}
-	err := we.ReportOutputs(ctx, nil)
-	return err
+	return nil
+}
+
+// needsResourceRead reports whether resolving this output parameter requires reading the resource.
+func needsResourceRead(param wfv1.Parameter) bool {
+	return param.ValueFrom != nil && (param.ValueFrom.JSONPath != "" || param.ValueFrom.JQFilter != "")
+}
+
+// jsonPathFilter evaluates a JSONPath expression against obj exactly as
+// `kubectl get -o jsonpath=<expression>` does: the same printer, and the same
+// --allow-missing-template-keys default.
+func jsonPathFilter(obj *unstructured.Unstructured, expression string) (string, error) {
+	printer, err := printers.NewJSONPathPrinter(expression)
+	if err != nil {
+		return "", argoerrors.Errorf(argoerrors.CodeBadRequest, "error parsing jsonpath %s, %v", expression, err)
+	}
+	printer.AllowMissingKeys(true)
+	var buf bytes.Buffer
+	if err := printer.PrintObj(obj, &buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 func jqFilter(ctx context.Context, input []byte, filter string) (string, error) {

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -338,7 +338,9 @@ func (we *WorkflowExecutor) saveResourceParameters(ctx context.Context, resource
 		// `-o json`, `-o jsonpath=` never stripped managedFields.
 		args := []string{"kubectl", "-n", resourceNamespace, "get", resourceName, "-o", "json", "--show-managed-fields=true"}
 		out, err := kubectl(ctx, args...)
-		logger.WithError(err).WithField("out", string(out)).WithField("args", args).Info(ctx, "kubectl")
+		// Deliberately not logging `out`: this reads the whole resource, including managedFields and
+		// any Secret/ConfigMap data, so the body must not reach the executor log at Info.
+		logger.WithError(err).WithField("args", args).WithField("bytes", len(out)).Info(ctx, "kubectl")
 		if err != nil {
 			return err
 		}

--- a/workflow/executor/resource_test.go
+++ b/workflow/executor/resource_test.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"context"
+	"encoding/json"
 	"os"
 	"path"
 	"runtime"
@@ -15,8 +17,10 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	argofake "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/executor/mocks"
+	"github.com/argoproj/argo-workflows/v4/workflow/executor/tracing"
 )
 
 // TestResourceFlags tests whether Resource Flags
@@ -238,6 +242,137 @@ func Test_jqFilter(t *testing.T) {
 			assert.Equal(t, testCase.want, got)
 		})
 	}
+}
+
+const resourceJSON = `{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "my-pod",
+    "namespace": "my-ns",
+    "labels": {"app": "my-app"},
+    "managedFields": [{"manager": "kubectl"}]
+  },
+  "spec": {"containers": [{"name": "a"}, {"name": "b"}]}
+}`
+
+func Test_jsonPathFilter(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	require.NoError(t, json.Unmarshal([]byte(resourceJSON), obj))
+
+	for _, tc := range []struct {
+		expression string
+		want       string
+		wantErr    bool
+	}{
+		{expression: "{.metadata.name}", want: "my-pod"},
+		{expression: "{.metadata.labels.app}", want: "my-app"},
+		{expression: "{.spec.containers[*].name}", want: "a b"},
+		// kubectl passes `-o jsonpath=` templates to the JSONPath printer verbatim: text outside
+		// braces is literal, it is not relaxed into `{.metadata.name}`.
+		{expression: "metadata.name", want: "metadata.name"},
+		// kubectl defaults to --allow-missing-template-keys=true.
+		{expression: "{.metadata.nope}", want: ""},
+		// managedFields are still visible, as they were with `-o jsonpath=`.
+		{expression: "{.metadata.managedFields[0].manager}", want: "kubectl"},
+		{expression: "{unparseable", wantErr: true},
+	} {
+		t.Run(tc.expression, func(t *testing.T) {
+			got, err := jsonPathFilter(obj, tc.expression)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_saveResourceParameters(t *testing.T) {
+	tracingObj, err := tracing.New(logging.TestContext(t.Context()), `argoexec`)
+	require.NoError(t, err)
+	newExecutor := func(params ...wfv1.Parameter) *WorkflowExecutor {
+		return &WorkflowExecutor{
+			PodName:         fakePodName,
+			Namespace:       fakeNamespace,
+			nodeID:          fakeNodeID,
+			ClientSet:       fake.NewClientset(),
+			RuntimeExecutor: &mocks.ContainerRuntimeExecutor{},
+			Tracing:         tracingObj,
+			Template:        wfv1.Template{Outputs: wfv1.Outputs{Parameters: params}},
+		}
+	}
+	param := func(name string, valueFrom *wfv1.ValueFrom) wfv1.Parameter {
+		return wfv1.Parameter{Name: name, ValueFrom: valueFrom}
+	}
+
+	t.Run("reads the resource once for all parameters", func(t *testing.T) {
+		we := newExecutor(
+			param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}"}),
+			param("app", &wfv1.ValueFrom{JSONPath: "{.metadata.labels.app}"}),
+			param("jq", &wfv1.ValueFrom{JQFilter: ".spec.containers[].name"}),
+		)
+		var calls [][]string
+		kubectl := func(_ context.Context, args ...string) ([]byte, error) {
+			calls = append(calls, args)
+			return []byte(resourceJSON), nil
+		}
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl))
+
+		require.Len(t, calls, 1, "the resource must be read exactly once, not once per parameter")
+		assert.Equal(t, []string{"kubectl", "-n", "my-ns", "get", "pod./my-pod", "-o", "json", "--show-managed-fields=true"}, calls[0])
+
+		out := we.Template.Outputs.Parameters
+		assert.Equal(t, "my-pod", out[0].Value.String())
+		assert.Equal(t, "my-app", out[1].Value.String())
+		assert.Equal(t, "a\nb", out[2].Value.String())
+	})
+
+	t.Run("jqFilter does not see managedFields", func(t *testing.T) {
+		we := newExecutor(param("keys", &wfv1.ValueFrom{JQFilter: ".metadata | keys | join(\",\")"}))
+		kubectl := func(_ context.Context, _ ...string) ([]byte, error) { return []byte(resourceJSON), nil }
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl))
+		assert.Equal(t, "labels,name,namespace", we.Template.Outputs.Parameters[0].Value.String())
+	})
+
+	t.Run("no read when no parameter needs the resource", func(t *testing.T) {
+		we := newExecutor(param("supplied", &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}}))
+		calls := 0
+		kubectl := func(_ context.Context, _ ...string) ([]byte, error) {
+			calls++
+			return []byte(resourceJSON), nil
+		}
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl))
+		assert.Equal(t, 0, calls)
+	})
+
+	// SaveResourceParameters must keep short-circuiting before ReportOutputs when the template has
+	// no output parameters, otherwise every resource template would start writing a task result.
+	t.Run("no output parameters reports nothing", func(t *testing.T) {
+		we := newExecutor()
+		argoClientset := argofake.NewClientset()
+		we.taskResultClient = argoClientset.ArgoprojV1alpha1().WorkflowTaskResults(fakeNamespace)
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.SaveResourceParameters(ctx, "my-ns", "pod./my-pod"))
+		assert.Empty(t, argoClientset.Actions(), "no task result should be written when there are no output parameters")
+	})
+
+	t.Run("no resource falls back to the default", func(t *testing.T) {
+		we := newExecutor(param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}", Default: wfv1.AnyStringPtr("fallback")}))
+		calls := 0
+		kubectl := func(_ context.Context, _ ...string) ([]byte, error) {
+			calls++
+			return []byte(resourceJSON), nil
+		}
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.saveResourceParameters(ctx, "", "", kubectl))
+		assert.Equal(t, 0, calls)
+		assert.Equal(t, "fallback", we.Template.Outputs.Parameters[0].Value.String())
+	})
 }
 
 func Test_runKubectl(t *testing.T) {

--- a/workflow/executor/resource_test.go
+++ b/workflow/executor/resource_test.go
@@ -3,9 +3,11 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -256,6 +258,24 @@ const resourceJSON = `{
   "spec": {"containers": [{"name": "a"}, {"name": "b"}]}
 }`
 
+// fakeKubectl simulates `kubectl get -o json`, which omits managedFields unless
+// --show-managed-fields=true is passed. The read gating depends on that behaviour, so the fake has
+// to honour the flag rather than always returning the same body. Every call is recorded in calls.
+func fakeKubectl(calls *[][]string) kubectlRunner {
+	return func(_ context.Context, args ...string) ([]byte, error) {
+		*calls = append(*calls, args)
+		if slices.Contains(args, "--show-managed-fields=true") {
+			return []byte(resourceJSON), nil
+		}
+		obj := &unstructured.Unstructured{}
+		if err := json.Unmarshal([]byte(resourceJSON), obj); err != nil {
+			return nil, err
+		}
+		obj.SetManagedFields(nil)
+		return obj.MarshalJSON()
+	}
+}
+
 func Test_jsonPathFilter(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	require.NoError(t, json.Unmarshal([]byte(resourceJSON), obj))
@@ -275,7 +295,15 @@ func Test_jsonPathFilter(t *testing.T) {
 		{expression: "{.metadata.nope}", want: ""},
 		// managedFields are still visible, as they were with `-o jsonpath=`.
 		{expression: "{.metadata.managedFields[0].manager}", want: "kubectl"},
+		// Whitespace in the template is part of the output. `-o jsonpath=` emits it verbatim, and
+		// jqFilter's TrimSpace must not be copied here: `{range}`-style expressions rely on the
+		// trailing newline surviving. Without these two cases, adding strings.TrimSpace to
+		// jsonPathFilter leaves the whole table green.
+		{expression: "{.metadata.name}{\"\\n\"}", want: "my-pod\n"},
+		{expression: "{range .spec.containers[*]}{.name}{\"\\n\"}{end}", want: "a\nb\n"},
 		{expression: "{unparseable", wantErr: true},
+		// A valid template that cannot be executed against this object.
+		{expression: "{.spec.containers[9].name}", wantErr: true},
 	} {
 		t.Run(tc.expression, func(t *testing.T) {
 			got, err := jsonPathFilter(obj, tc.expression)
@@ -314,12 +342,8 @@ func Test_saveResourceParameters(t *testing.T) {
 			param("jq", &wfv1.ValueFrom{JQFilter: ".spec.containers[].name"}),
 		)
 		var calls [][]string
-		kubectl := func(_ context.Context, args ...string) ([]byte, error) {
-			calls = append(calls, args)
-			return []byte(resourceJSON), nil
-		}
 		ctx := logging.TestContext(t.Context())
-		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl))
+		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", fakeKubectl(&calls)))
 
 		require.Len(t, calls, 1, "the resource must be read exactly once, not once per parameter")
 		assert.Equal(t, []string{"kubectl", "-n", "my-ns", "get", "pod./my-pod", "-o", "json", "--show-managed-fields=true"}, calls[0])
@@ -330,48 +354,212 @@ func Test_saveResourceParameters(t *testing.T) {
 		assert.Equal(t, "a\nb", out[2].Value.String())
 	})
 
-	t.Run("jqFilter does not see managedFields", func(t *testing.T) {
-		we := newExecutor(param("keys", &wfv1.ValueFrom{JQFilter: ".metadata | keys | join(\",\")"}))
-		kubectl := func(_ context.Context, _ ...string) ([]byte, error) { return []byte(resourceJSON), nil }
-		ctx := logging.TestContext(t.Context())
-		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl))
-		assert.Equal(t, "labels,name,namespace", we.Template.Outputs.Parameters[0].Value.String())
-	})
-
-	t.Run("no read when no parameter needs the resource", func(t *testing.T) {
-		we := newExecutor(param("supplied", &wfv1.ValueFrom{Supplied: &wfv1.SuppliedValueFrom{}}))
-		calls := 0
-		kubectl := func(_ context.Context, _ ...string) ([]byte, error) {
-			calls++
-			return []byte(resourceJSON), nil
+	// managedFields are asked for only when a jsonPath expression could read them. A jqFilter never
+	// sees them, so requesting them for a jqFilter-only template would inflate the response and then
+	// throw the extra away - the opposite of what this change is for.
+	t.Run("managedFields are requested only when a jsonPath parameter needs them", func(t *testing.T) {
+		for _, tc := range []struct {
+			name      string
+			valueFrom *wfv1.ValueFrom
+			want      bool
+		}{
+			{"jsonPath only", &wfv1.ValueFrom{JSONPath: "{.metadata.name}"}, true},
+			{"jqFilter only", &wfv1.ValueFrom{JQFilter: ".metadata.name"}, false},
+			{"jsonPath wins when a parameter sets both", &wfv1.ValueFrom{JSONPath: "{.metadata.name}", JQFilter: ".metadata.name"}, true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				we := newExecutor(param("p", tc.valueFrom))
+				var calls [][]string
+				ctx := logging.TestContext(t.Context())
+				require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", fakeKubectl(&calls)))
+				require.Len(t, calls, 1)
+				assert.Equal(t, tc.want, slices.Contains(calls[0], "--show-managed-fields=true"))
+			})
 		}
-		ctx := logging.TestContext(t.Context())
-		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl))
-		assert.Equal(t, 0, calls)
 	})
 
-	// SaveResourceParameters must keep short-circuiting before ReportOutputs when the template has
-	// no output parameters, otherwise every resource template would start writing a task result.
-	t.Run("no output parameters reports nothing", func(t *testing.T) {
-		we := newExecutor()
-		argoClientset := argofake.NewClientset()
-		we.taskResultClient = argoClientset.ArgoprojV1alpha1().WorkflowTaskResults(fakeNamespace)
+	// Whichever way the resource was fetched, a jqFilter must see it without managedFields, exactly
+	// as it did when it was fed plain `kubectl get -o json`.
+	t.Run("jqFilter does not see managedFields", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			params []wfv1.Parameter
+			at     int
+		}{
+			{"jqFilter alone", []wfv1.Parameter{
+				param("keys", &wfv1.ValueFrom{JQFilter: ".metadata | keys | join(\",\")"}),
+			}, 0},
+			// Here the response does carry managedFields, because the jsonPath parameter asked for
+			// them; they have to be stripped back out before the jqFilter runs.
+			{"jqFilter alongside a jsonPath parameter", []wfv1.Parameter{
+				param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}"}),
+				param("keys", &wfv1.ValueFrom{JQFilter: ".metadata | keys | join(\",\")"}),
+			}, 1},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				we := newExecutor(tc.params...)
+				var calls [][]string
+				ctx := logging.TestContext(t.Context())
+				require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", fakeKubectl(&calls)))
+				assert.Equal(t, "labels,name,namespace", we.Template.Outputs.Parameters[tc.at].Value.String())
+			})
+		}
+	})
+
+	// A valueFrom that names neither jsonPath nor jqFilter resolves to nothing, so it neither
+	// triggers a read nor overwrites the value the parameter already has.
+	t.Run("parameter with neither jsonPath nor jqFilter is left alone", func(t *testing.T) {
+		we := newExecutor(wfv1.Parameter{
+			Name:      "untouched",
+			Value:     wfv1.AnyStringPtr("keep me"),
+			ValueFrom: &wfv1.ValueFrom{Default: wfv1.AnyStringPtr("unused")},
+		})
+		var calls [][]string
 		ctx := logging.TestContext(t.Context())
-		require.NoError(t, we.SaveResourceParameters(ctx, "my-ns", "pod./my-pod"))
-		assert.Empty(t, argoClientset.Actions(), "no task result should be written when there are no output parameters")
+		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", fakeKubectl(&calls)))
+		assert.Empty(t, calls)
+		assert.Equal(t, "keep me", we.Template.Outputs.Parameters[0].Value.String())
+	})
+
+	// A parameter with a literal value and no valueFrom is the honest fixture for "nothing to read":
+	// validateOutputParameter rejects Supplied for resource templates, so it never reaches here.
+	t.Run("no read when no parameter needs the resource", func(t *testing.T) {
+		we := newExecutor(wfv1.Parameter{Name: "literal", Value: wfv1.AnyStringPtr("hello")})
+		var calls [][]string
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", fakeKubectl(&calls)))
+		assert.Empty(t, calls)
+		assert.Equal(t, "hello", we.Template.Outputs.Parameters[0].Value.String())
 	})
 
 	t.Run("no resource falls back to the default", func(t *testing.T) {
 		we := newExecutor(param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}", Default: wfv1.AnyStringPtr("fallback")}))
-		calls := 0
-		kubectl := func(_ context.Context, _ ...string) ([]byte, error) {
-			calls++
-			return []byte(resourceJSON), nil
-		}
+		var calls [][]string
 		ctx := logging.TestContext(t.Context())
-		require.NoError(t, we.saveResourceParameters(ctx, "", "", kubectl))
-		assert.Equal(t, 0, calls)
+		require.NoError(t, we.saveResourceParameters(ctx, "", "", fakeKubectl(&calls)))
+		assert.Empty(t, calls)
 		assert.Equal(t, "fallback", we.Template.Outputs.Parameters[0].Value.String())
+	})
+
+	t.Run("errors are returned, not swallowed", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			param   wfv1.Parameter
+			kubectl kubectlRunner
+			wantErr string
+		}{
+			{
+				name:    "kubectl fails",
+				param:   param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}"}),
+				kubectl: func(context.Context, ...string) ([]byte, error) { return nil, errors.New("boom") },
+				wantErr: "boom",
+			},
+			{
+				// New failure mode: a jsonPath-only template never JSON-decoded kubectl's output
+				// before this change, because raw stdout was the value. #3037 exists because
+				// `kubectl get` can exit 0 with empty stdout.
+				name:    "kubectl exits 0 with empty stdout",
+				param:   param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}"}),
+				kubectl: func(context.Context, ...string) ([]byte, error) { return nil, nil },
+				wantErr: "unexpected end of JSON input",
+			},
+			{
+				name:    "kubectl exits 0 with output that is not JSON",
+				param:   param("name", &wfv1.ValueFrom{JSONPath: "{.metadata.name}"}),
+				kubectl: func(context.Context, ...string) ([]byte, error) { return []byte("No resources found"), nil },
+				wantErr: "invalid character",
+			},
+			{
+				name:    "jsonPath cannot be parsed",
+				param:   param("name", &wfv1.ValueFrom{JSONPath: "{unparseable"}),
+				wantErr: "error parsing jsonpath",
+			},
+			{
+				name:    "jqFilter cannot be parsed",
+				param:   param("name", &wfv1.ValueFrom{JQFilter: "{{"}),
+				wantErr: "unexpected token",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				we := newExecutor(tc.param)
+				kubectl := tc.kubectl
+				if kubectl == nil {
+					var calls [][]string
+					kubectl = fakeKubectl(&calls)
+				}
+				ctx := logging.TestContext(t.Context())
+				err := we.saveResourceParameters(ctx, "my-ns", "pod./my-pod", kubectl)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+			})
+		}
+	})
+}
+
+// SaveResourceParameters owns the wiring that saveResourceParameters does not: the short-circuit on
+// a template with no output parameters, and the ReportOutputs call. Neither is reachable from
+// saveResourceParameters, so both are pinned here - without this, deleting the ReportOutputs call
+// passes the whole unit suite.
+func TestSaveResourceParameters(t *testing.T) {
+	tracingObj, err := tracing.New(logging.TestContext(t.Context()), `argoexec`)
+	require.NoError(t, err)
+	newExecutor := func(params ...wfv1.Parameter) (*WorkflowExecutor, *argofake.Clientset) {
+		argoClientset := argofake.NewClientset()
+		we := &WorkflowExecutor{
+			PodName:          fakePodName,
+			Namespace:        fakeNamespace,
+			nodeID:           fakeNodeID,
+			ClientSet:        fake.NewClientset(),
+			RuntimeExecutor:  &mocks.ContainerRuntimeExecutor{},
+			Tracing:          tracingObj,
+			Template:         wfv1.Template{Outputs: wfv1.Outputs{Parameters: params}},
+			taskResultClient: argoClientset.ArgoprojV1alpha1().WorkflowTaskResults(fakeNamespace),
+		}
+		return we, argoClientset
+	}
+
+	t.Run("reports the resolved output parameters", func(t *testing.T) {
+		we, argoClientset := newExecutor(wfv1.Parameter{
+			Name:      "name",
+			ValueFrom: &wfv1.ValueFrom{JSONPath: "{.metadata.name}"},
+		})
+		var calls [][]string
+		original := kubectlRunnerFn
+		kubectlRunnerFn = fakeKubectl(&calls)
+		t.Cleanup(func() { kubectlRunnerFn = original })
+
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.SaveResourceParameters(ctx, "my-ns", "pod./my-pod"))
+
+		require.Len(t, calls, 1)
+		assert.Equal(t, "my-pod", we.Template.Outputs.Parameters[0].Value.String())
+		assert.NotEmpty(t, argoClientset.Actions(), "the resolved parameters must be reported")
+	})
+
+	// A failure to resolve the parameters must propagate and must not report a partial result.
+	t.Run("resolution failure propagates and reports nothing", func(t *testing.T) {
+		we, argoClientset := newExecutor(wfv1.Parameter{
+			Name:      "name",
+			ValueFrom: &wfv1.ValueFrom{JSONPath: "{.metadata.name}"},
+		})
+		original := kubectlRunnerFn
+		kubectlRunnerFn = func(context.Context, ...string) ([]byte, error) { return nil, errors.New("boom") }
+		t.Cleanup(func() { kubectlRunnerFn = original })
+
+		ctx := logging.TestContext(t.Context())
+		err := we.SaveResourceParameters(ctx, "my-ns", "pod./my-pod")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+		assert.Empty(t, argoClientset.Actions(), "nothing should be reported when resolution failed")
+	})
+
+	// Must keep short-circuiting before ReportOutputs when the template has no output parameters,
+	// otherwise every resource template would start writing a task result.
+	t.Run("no output parameters reports nothing", func(t *testing.T) {
+		we, argoClientset := newExecutor()
+		ctx := logging.TestContext(t.Context())
+		require.NoError(t, we.SaveResourceParameters(ctx, "my-ns", "pod./my-pod"))
+		assert.Empty(t, argoClientset.Actions(), "no task result should be written when there are no output parameters")
 	})
 }
 


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B` — ran `make lint` and the docs checks (markdownlint, cspell). `make lint` reports 10 pre-existing issues, all in files this PR does not touch (`util/unstructured`, `workflow/controller`, `workflow/sync`, `test/e2e`) and none in `workflow/executor`; CI's own lint job is green. Did not run `codegen`, as this touches no generated-code inputs.
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — n/a, this is a performance fix
- [ ] Opened as draft; will mark "Ready for review" once builds are green — builds are green

Fixes #5658

### Motivation

A resource template issued one `kubectl get` per output parameter. N parameters meant N reads of the same object, and because the reads were separate each parameter could observe a different generation of it — so a template reading `.status.phase` and `.metadata.resourceVersion` could return an inconsistent pair.

### Modifications

Read the resource once before the loop and resolve every output parameter from that one snapshot.

- `jsonPath` goes through the same cli-runtime JSONPath printer, with the same `--allow-missing-template-keys=true` default, that `kubectl get -o jsonpath=` uses.
- `jqFilter` goes through the existing `jqFilter`.

Both kinds of parameter see byte-for-byte what they saw before. `kubectl -o jsonpath=` never stripped `managedFields`, while `-o json` does, so what is fetched depends on which kinds of parameter the template actually has:

| template has | `--show-managed-fields` | unmarshal to `obj` | build `jsonBytes` |
|---|---|---|---|
| `jqFilter` only | no | no | no — `-o json` already omits `managedFields`, so its bytes are used as-is |
| `jsonPath` only | yes | yes | no |
| both | yes | yes | yes — copy and strip, so `jqFilter` sees what plain `-o json` gave it |

The read is skipped entirely when no parameter needs it.

The response body is no longer logged at info level. It is logged at debug instead, matching how the resource JSON in `checkResourceState` has been logged since #6100.

### Verification

- `go test ./workflow/executor/...` passes. `SaveResourceParameters` is at 100% statement coverage and `saveResourceParameters` at 98%; the only uncovered line is a `MarshalJSON` failure on an object that was just unmarshalled successfully.
- New unit tests cover: one read for many parameters, the three fetch shapes in the table above, `jqFilter` never seeing `managedFields` by either route, the default-value fallback, and the error paths — `kubectl` failing, and `kubectl` exiting 0 with empty or non-JSON stdout. That last one is a failure mode this change introduces, since a `jsonPath`-only template never JSON-decoded kubectl's output before; #3037 exists because `kubectl get` can exit 0 with empty stdout.
- The kubectl fake honours `--show-managed-fields`, as kubectl does, so the fetch-shape table above is actually asserted rather than assumed.
- The tests were mutation-tested — each fails when the behaviour it pins is broken. Deleting the `ReportOutputs` call, adding `strings.TrimSpace` to `jsonPathFilter`, and making `--show-managed-fields=true` unconditional each turn a test red.
- The three kubectl semantics this rests on were checked against cli-runtime source rather than assumed: `OmitManagedFieldsPrinter` is only wired into `JSONYamlPrintFlags`; `AllowMissingKeys(true)` is kubectl's default; `-o jsonpath` adds no trailing newline and gets no expression relaxation.

### Documentation

`docs/upgrading.md` gains an entry under v4.1 for the logging change, since dropping the response body from the executor log at info level is user-visible. It also notes that on earlier versions those info-level logs contained the whole resource, including any `Secret` or `ConfigMap` data a resource template read, which operators on older versions may want to know about.

### AI

AI-assisted. I used Claude Code while writing the code, tests and docs, and reviewed and verified everything before pushing: the kubectl semantics this relies on were checked against cli-runtime source, and the new tests were mutation-tested (each fails when the behaviour it pins is broken). I am responsible for the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resource templates now consistently resolve multiple output parameters from a single resource read.
  - JSONPath and jq-based outputs provide more predictable filtering, including handling of managed fields, missing values, and arrays.
  - Templates without output parameters avoid unnecessary resource reads or output reporting.
  - Resource data is no longer fully exposed in informational logs; detailed content is available only at debug level.

- **Documentation**
  - Added upgrade guidance describing resource reads, output behavior, and logging changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->