### PR TITLE
perf(controller): check the throttler before converting the workflow. Fixes #16568

### DIFF
--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -953,38 +953,45 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		return true
 	}
 
-	wf, err := util.FromUnstructured(un)
-	if err != nil {
-		logger.WithField("key", key).WithError(err).Warn(ctx, "Failed to unmarshal key to workflow object")
-		woc := newWorkflowOperationCtx(ctx, wf, wfc)
-		ctx = logging.WithLogger(ctx, woc.log)
-		woc.markWorkflowFailed(ctx, fmt.Sprintf("cannot unmarshall spec: %s", err.Error()))
-		woc.persistUpdates(ctx)
-		return true
-	}
-
 	// this will ensure we process every incomplete workflow once every 20m
 	wfc.wfQueue.AddAfter(key, workflowResyncPeriod)
 
-	// Check the parallelism limit before building the operation context: newWorkflowOperationCtx
-	// deep-copies the entire Workflow, and for a workflow that is postponed that copy is discarded
-	// immediately. Only read from wf on this path, never mutate it.
-	shutdownStrategy := wf.Spec.Shutdown
+	// Check the parallelism limit before converting the object: util.FromUnstructured
+	// allocates a whole typed Workflow, and for a workflow that is postponed that
+	// allocation is discarded immediately. Deciding only needs spec.shutdown and
+	// status.phase, both of which can be read straight from the unstructured object.
+	shutdownStrategy := wfv1.ShutdownStrategy(nestedString(un, "spec", "shutdown"))
+	phase := wfv1.WorkflowPhase(nestedString(un, "status", "phase"))
 
 	// A Running workflow must never be postponed, even if the throttler no longer admits
 	// it (e.g. it was removed when an archive attempt failed mid-flight): skipping
 	// reconciliation would orphan its pods (#14123).
-	if (!shutdownStrategy.Enabled() || shutdownStrategy != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) && wf.Status.Phase != wfv1.WorkflowRunning {
-		logger.WithFields(logging.Fields{"workflow": wf.Name, "namespace": wf.Namespace, "key": key}).
+	if (!shutdownStrategy.Enabled() || shutdownStrategy != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key) && phase != wfv1.WorkflowRunning {
+		logger.WithFields(logging.Fields{"workflow": un.GetName(), "namespace": un.GetNamespace(), "key": key}).
 			Info(ctx, "Workflow processing has been postponed due to max parallelism limit")
-		if wf.Status.Phase == wfv1.WorkflowUnknown {
-			// Only this branch mutates and persists the workflow, so only it needs the deep copy.
-			// It runs once per workflow, the first time that workflow is postponed.
+		if phase == wfv1.WorkflowUnknown {
+			// Only this branch mutates and persists the workflow, so only it needs the typed
+			// object and the deep copy newWorkflowOperationCtx makes: that copy becomes
+			// woc.orig, the pristine baseline persistUpdates diffs against to build its merge
+			// patch. It runs only until the workflow has been successfully marked Pending; if
+			// persistUpdates fails the stored phase stays Unknown and it runs again on the
+			// next requeue.
+			wf, err := util.FromUnstructured(un)
+			if err != nil {
+				wfc.markWorkflowUnmarshalFailed(ctx, wf, err, key, logger)
+				return true
+			}
 			woc := newWorkflowOperationCtx(ctx, wf, wfc)
 			ctx = logging.WithLogger(ctx, woc.log)
 			ctx = woc.markWorkflowPhase(ctx, wfv1.WorkflowPending, "Workflow processing has been postponed because too many workflows are already running")
 			woc.persistUpdates(ctx)
 		}
+		return true
+	}
+
+	wf, err := util.FromUnstructured(un)
+	if err != nil {
+		wfc.markWorkflowUnmarshalFailed(ctx, wf, err, key, logger)
 		return true
 	}
 
@@ -1108,6 +1115,26 @@ func (wfc *WorkflowController) getWorkflowByKey(ctx context.Context, key string)
 		return nil, false
 	}
 	return obj, true
+}
+
+// nestedString reads a string field from an unstructured object, returning "" when the
+// field is absent or is not a string.
+func nestedString(un *unstructured.Unstructured, fields ...string) string {
+	value, found, err := unstructured.NestedString(un.Object, fields...)
+	if err != nil || !found {
+		return ""
+	}
+	return value
+}
+
+// markWorkflowUnmarshalFailed marks a workflow that cannot be converted to a typed object
+// as failed, so it does not sit in the queue forever.
+func (wfc *WorkflowController) markWorkflowUnmarshalFailed(ctx context.Context, wf *wfv1.Workflow, err error, key string, logger logging.Logger) {
+	logger.WithField("key", key).WithError(err).Warn(ctx, "Failed to unmarshal key to workflow object")
+	woc := newWorkflowOperationCtx(ctx, wf, wfc)
+	ctx = logging.WithLogger(ctx, woc.log)
+	woc.markWorkflowFailed(ctx, fmt.Sprintf("cannot unmarshall spec: %s", err.Error()))
+	woc.persistUpdates(ctx)
 }
 
 func reconciliationNeeded(wf metav1.Object) bool {

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -780,6 +780,55 @@ spec:
 	}
 }
 
+// A workflow that is still postponed on a later requeue is decided entirely from the
+// unstructured object: it is already Pending, so it is neither converted nor persisted
+// again. Refs #16568.
+func TestParallelismPostponedWorkflowIsStableAcrossRequeues(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx,
+		wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf-0
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+`),
+		wfv1.MustUnmarshalWorkflow(`
+metadata:
+  name: my-wf-1
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      container:
+        image: my-image
+`),
+		func(x *WorkflowController) { x.Config.Parallelism = 1 },
+	)
+	defer cancel()
+
+	assert.True(t, controller.processNextItem(ctx))
+	assert.True(t, controller.processNextItem(ctx))
+
+	expectWorkflow(ctx, controller, "my-wf-1", func(wf *wfv1.Workflow) {
+		require.NotNil(t, wf)
+		assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+	})
+
+	// Requeue the postponed workflow: it stays Pending and is still not reconciled.
+	controller.wfQueue.Add("my-wf-1")
+	assert.True(t, controller.processNextItem(ctx))
+
+	expectWorkflow(ctx, controller, "my-wf-1", func(wf *wfv1.Workflow) {
+		require.NotNil(t, wf)
+		assert.Equal(t, wfv1.WorkflowPending, wf.Status.Phase)
+		assert.Empty(t, wf.Status.Nodes)
+	})
+}
+
 // A Running workflow that has been dropped from the throttler (e.g. an archive attempt
 // failed mid-flight after throttler.Remove) must not be postponed by the parallelism
 // limit: it must still be reconciled, or its pods are orphaned. Regression test for


### PR DESCRIPTION
Fixes #16568

### Motivation

`processNextItem` called `util.FromUnstructured` unconditionally, before the throttle check that discards the result. For a postponed workflow the whole typed `Workflow` was materialised and thrown away, on every requeue, including each 20m resync of the pending backlog. Per the benchmark in the issue, on a workflow with 1000 status nodes that is ~2.74ms, 1.2MB and 16k allocations per call, roughly 13x the CPU of the DeepCopy that #16560 removed.

### Modifications

The throttle decision only needs `key`, `spec.shutdown` and `status.phase`, and the latter two are plain strings on the unstructured object. This reads them with `unstructured.NestedString` (via a small `nestedString` helper, since both call sites want the absent case to be `""`) and moves the shutdown/throttle check above the conversion.

`util.FromUnstructured` is now called only where the typed object is actually used:

- the postponed branch with `status.phase == ""`, which builds a `woc` to mark the workflow `Pending` and persist it, and
- the admitted path.

`status.phase` being absent maps to `WorkflowUnknown`, which is `""`, so the Unknown branch keeps working unchanged. The unmarshal-failure handling moved into a `markWorkflowUnmarshalFailed` helper because it now has two call sites.

**Behaviour change, as flagged in the issue:** a workflow whose spec cannot be unmarshalled is no longer marked `Failed` while it is throttled, since the conversion happens after admission. The marking is delayed until the workflow is admitted, not lost.

Also folds in the two comment corrections requested in the issue: `wf` is not a shared informer object (the store holds `unstructured.Unstructured`), so the deep copy matters because it becomes `woc.orig`, the baseline `persistUpdates` diffs against; and the Pending branch is not guaranteed to run exactly once, since a failed `persistUpdates` leaves the stored phase Unknown.

### Verification

- `TestParallelism` and `TestNamespaceParallelism*` pass unchanged. `TestParallelism` is meaningful coverage for this change: its `my-wf-2` case has `shutdown: Terminate` and still reaches `Failed`, which exercises the new `spec.shutdown` read from the unstructured object, and `my-wf-1` covers the postponed to `Pending` path.
- `TestParallelismDoesNotPostponeRunningWorkflows` passes, so the #14123 guard still holds with `status.phase` read from the unstructured object.
- Added `TestParallelismPostponedWorkflowIsStableAcrossRequeues`, which requeues an already-postponed workflow and asserts it stays `Pending` with no nodes created. That is the path this change makes allocation-free.
- `go build ./workflow/...` and `go vet ./workflow/controller/` are clean.

Note on the full package run: `TestArtifactGCPodWithPlugins`, `TestBuildPluginSidecarsDedup`, `TestAddArtifactPluginsInitless_*` and `TestArtifactPluginSidecar` fail for me, but they fail identically on a clean checkout of `main`, so they are unrelated to this change.

### Documentation

No documentation change is needed. This is an internal controller change to `processNextItem`: it moves the throttle decision above `util.FromUnstructured` so the typed conversion is skipped for postponed workflows. There is no new user-facing behaviour, no API, CLI or manifest surface, and no configuration to discover, so there is nothing for a user to read about.

The one behaviour change is the one called out under Modifications above -- a workflow whose spec cannot be unmarshalled is marked `Failed` on admission rather than while throttled. That is a change in timing of an existing error path, not a documented guarantee, so I did not add a doc note for it. Happy to add one if you would rather it were written down.

### AI

Yes -- this PR was prepared with AI assistance (Claude), covering the code, the tests and this description.

Per the Argo generative AI policy, the specifics of what that means here: I established the root cause by reading `processNextItem` and confirming which fields the throttle decision actually needs, not by taking a suggestion at face value. Two things I checked rather than assumed:

- that `status.phase` being absent maps to `WorkflowUnknown`, which is `""`, so reading it via `unstructured.NestedString` preserves the existing Unknown branch, and
- that the existing `TestParallelism` `my-wf-2` case has `shutdown: Terminate`, which is what makes it real coverage for the new `spec.shutdown` read rather than incidental.

I also verified the four failing tests I noted under Verification fail identically on a clean `main` checkout before attributing them to something other than this change. I have reviewed and understand every line of the diff and take responsibility for it.
