### PR TITLE
feat: add preferred type to retry nodeAntiAffinity. Fixes #13969

### DIFF
--- a/.features/pending/retry-node-anti-affinity-preferred.md
+++ b/.features/pending/retry-node-anti-affinity-preferred.md
@@ -1,0 +1,19 @@
+Description: Soft (preferred) node anti-affinity for retries
+Authors: [somaz](https://github.com/somaz94)
+Component: General
+Issues: 13969
+
+`retryStrategy.affinity.nodeAntiAffinity` now accepts a `type` field controlling how strictly a retry avoids the hosts earlier attempts ran on.
+
+`Required` is the default and keeps the existing behaviour: previously used hosts are excluded outright, which means a retry stays unschedulable once every eligible host has been tried.
+
+`Preferred` only de-prioritises those hosts, so retries keep running even after every eligible host has failed at least once.
+Use it when your cluster has fewer eligible nodes than the retry limit.
+
+```yaml
+retryStrategy:
+  limit: "10"
+  affinity:
+    nodeAntiAffinity:
+      type: Preferred
+```

--- a/.features/pending/retry-node-anti-affinity-preferred.md
+++ b/.features/pending/retry-node-anti-affinity-preferred.md
@@ -4,16 +4,6 @@ Component: General
 Issues: 13969
 
 `retryStrategy.affinity.nodeAntiAffinity` now accepts a `type` field controlling how strictly a retry avoids the hosts earlier attempts ran on.
-
 `Required` is the default and keeps the existing behaviour: previously used hosts are excluded outright, which means a retry stays unschedulable once every eligible host has been tried.
-
 `Preferred` only de-prioritises those hosts, so retries keep running even after every eligible host has failed at least once.
-Use it when your cluster has fewer eligible nodes than the retry limit.
-
-```yaml
-retryStrategy:
-  limit: "10"
-  affinity:
-    nodeAntiAffinity:
-      type: Preferred
-```
+Set `nodeAntiAffinity: {type: Preferred}` when your cluster has fewer eligible nodes than the retry limit.

--- a/.features/pending/retry-node-anti-affinity-preferred.md
+++ b/.features/pending/retry-node-anti-affinity-preferred.md
@@ -5,5 +5,5 @@ Issues: 13969
 
 `retryStrategy.affinity.nodeAntiAffinity` now accepts a `type` field controlling how strictly a retry avoids the hosts earlier attempts ran on.
 `Required` is the default and keeps the existing behaviour: previously used hosts are excluded outright, which means a retry stays unschedulable once every eligible host has been tried.
-`Preferred` only de-prioritises those hosts, so retries keep running even after every eligible host has failed at least once.
+`Preferred` only de-prioritises those hosts, so a retry can still be scheduled onto a previously tried host once every eligible host has been tried, provided no other scheduling constraint blocks it.
 Set `nodeAntiAffinity: {type: Preferred}` when your cluster has fewer eligible nodes than the retry limit.

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -6733,7 +6733,13 @@
       "type": "object"
     },
     "io.argoproj.workflow.v1alpha1.RetryNodeAntiAffinity": {
-      "description": "RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed. In order to prevent running steps on the same host, it uses \"kubernetes.io/hostname\".",
+      "description": "RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on. In order to identify hosts, it uses \"kubernetes.io/hostname\".",
+      "properties": {
+        "type": {
+          "description": "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when retries must remain schedulable even after every eligible host has been tried.",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "io.argoproj.workflow.v1alpha1.RetryStrategy": {

--- a/api/jsonschema/schema.json
+++ b/api/jsonschema/schema.json
@@ -6736,7 +6736,7 @@
       "description": "RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on. In order to identify hosts, it uses \"kubernetes.io/hostname\".",
       "properties": {
         "type": {
-          "description": "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when retries must remain schedulable even after every eligible host has been tried.",
+          "description": "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when a retry should still be able to run on a previously used host once every eligible host has been tried, rather than staying pending.",
           "type": "string"
         }
       },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11028,7 +11028,7 @@
       "type": "object",
       "properties": {
         "type": {
-          "description": "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when retries must remain schedulable even after every eligible host has been tried.",
+          "description": "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when a retry should still be able to run on a previously used host once every eligible host has been tried, rather than staying pending.",
           "type": "string"
         }
       }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11024,8 +11024,14 @@
       }
     },
     "io.argoproj.workflow.v1alpha1.RetryNodeAntiAffinity": {
-      "description": "RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed. In order to prevent running steps on the same host, it uses \"kubernetes.io/hostname\".",
-      "type": "object"
+      "description": "RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on. In order to identify hosts, it uses \"kubernetes.io/hostname\".",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when retries must remain schedulable even after every eligible host has been tried.",
+          "type": "string"
+        }
+      }
     },
     "io.argoproj.workflow.v1alpha1.RetryStrategy": {
       "description": "RetryStrategy provides controls on how to retry a workflow step",

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -3382,12 +3382,35 @@ cause implementors to also use a fixed point implementation.
 ### <span id="retry-node-anti-affinity"></span> RetryNodeAntiAffinity
 
 
-> In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+> In order to identify hosts, it uses "kubernetes.io/hostname".
   
 
 
 
-`any`
+
+
+**Properties**
+
+| Name | Type | Go type | Required | Default | Description | Example |
+|------|------|---------|:--------:| ------- |-------------|---------|
+| type | [RetryNodeAntiAffinityType](#retry-node-anti-affinity-type)| `RetryNodeAntiAffinityType` |  | |  |  |
+
+
+
+### <span id="retry-node-anti-affinity-type"></span> RetryNodeAntiAffinityType
+
+
+> RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that
+previous attempts ran on.
+  
+
+
+
+| Name | Type | Go type | Default | Description | Example |
+|------|------|---------| ------- |-------------|---------|
+| RetryNodeAntiAffinityType | string| string | | RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that</br>previous attempts ran on. </br>*Allowed values: "", Required, Preferred.*|  |
+
+
 
 ### <span id="retry-policy"></span> RetryPolicy
 

--- a/docs/executor_swagger.md
+++ b/docs/executor_swagger.md
@@ -3401,14 +3401,15 @@ cause implementors to also use a fixed point implementation.
 
 
 > RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that
-previous attempts ran on.
+previous attempts ran on. An omitted or empty value is treated as "Required", which
+is the behaviour of releases before this field existed.
   
 
 
 
 | Name | Type | Go type | Default | Description | Example |
 |------|------|---------| ------- |-------------|---------|
-| RetryNodeAntiAffinityType | string| string | | RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that</br>previous attempts ran on. </br>*Allowed values: "", Required, Preferred.*|  |
+| RetryNodeAntiAffinityType | string| string | | RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that</br>previous attempts ran on. An omitted or empty value is treated as "Required", which</br>is the behaviour of releases before this field existed. </br>*Allowed values: "", Required, Preferred.*|  |
 
 
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -4584,7 +4584,7 @@ RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts
 ### Fields
 | Field Name | Field Type | Description   |
 |:----------:|:----------:|---------------|
-|`type`|`string`|Type determines whether previously used hosts are excluded outright ("Required", the default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must remain schedulable even after every eligible host has been tried.|
+|`type`|`string`|Type determines whether previously used hosts are excluded outright ("Required", the default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should still be able to run on a previously used host once every eligible host has been tried, rather than staying pending.|
 
 ## SyncDatabaseRef
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -4579,7 +4579,12 @@ MetricLabel is a single label for a prometheus metric
 
 ## RetryNodeAntiAffinity
 
-RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed. In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on. In order to identify hosts, it uses "kubernetes.io/hostname".
+
+### Fields
+| Field Name | Field Type | Description   |
+|:----------:|:----------:|---------------|
+|`type`|`string`|Type determines whether previously used hosts are excluded outright ("Required", the default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must remain schedulable even after every eligible host has been tried.|
 
 ## SyncDatabaseRef
 

--- a/docs/walk-through/retrying-failed-or-errored-steps.md
+++ b/docs/walk-through/retrying-failed-or-errored-steps.md
@@ -31,6 +31,17 @@ spec:
 * `limit` is the maximum number of times the container will be retried.
 * `retryPolicy` specifies if a container will be retried on failure, error, both, or only transient errors (e.g. i/o or TLS handshake timeout). "Always" retries on both errors and failures. Also available: `OnFailure` (default), "`OnError`", and "`OnTransientError`" (available after v3.0.0-rc2).
 * `backoff` is an exponential back-off
-* `nodeAntiAffinity` prevents running steps on the same host.  Current implementation allows only empty `nodeAntiAffinity` (i.e. `nodeAntiAffinity: {}`) and by default it uses label `kubernetes.io/hostname` as the selector.
+* `nodeAntiAffinity` prevents running steps on the same host. By default it uses label `kubernetes.io/hostname` as the selector.
+  Its `type` controls how strictly earlier hosts are avoided:
+    * `Required` (the default, and what an empty `nodeAntiAffinity: {}` gives you) excludes those hosts outright, so a retry stays unschedulable once every eligible host has been tried.
+    * `Preferred` only de-prioritises them, so retries keep running after every eligible host has been tried. Use this when the retry limit is higher than the number of eligible nodes.
+
+```yaml
+    retryStrategy:
+      limit: 10
+      affinity:
+        nodeAntiAffinity:
+          type: Preferred
+```
 
 Providing an empty `retryStrategy` (i.e. `retryStrategy: {}`) will cause a container to retry until completion.

--- a/docs/walk-through/retrying-failed-or-errored-steps.md
+++ b/docs/walk-through/retrying-failed-or-errored-steps.md
@@ -31,17 +31,22 @@ spec:
 * `limit` is the maximum number of times the container will be retried.
 * `retryPolicy` specifies if a container will be retried on failure, error, both, or only transient errors (e.g. i/o or TLS handshake timeout). "Always" retries on both errors and failures. Also available: `OnFailure` (default), "`OnError`", and "`OnTransientError`" (available after v3.0.0-rc2).
 * `backoff` is an exponential back-off
-* `nodeAntiAffinity` prevents running steps on the same host. By default it uses label `kubernetes.io/hostname` as the selector.
-  Its `type` controls how strictly earlier hosts are avoided:
-    * `Required` (the default, and what an empty `nodeAntiAffinity: {}` gives you) excludes those hosts outright, so a retry stays unschedulable once every eligible host has been tried.
-    * `Preferred` only de-prioritises them, so a retry can be scheduled onto a previously tried host once every eligible host has been tried. This is a preference rather than a guarantee — other scheduling constraints can still leave the retry pending. Use this when the retry limit is higher than the number of eligible nodes.
+* `nodeAntiAffinity` prevents running steps on the same host.
+  By default it uses label `kubernetes.io/hostname` as the selector.
+  Its `type` controls how strictly earlier hosts are avoided (available after v4.2.0).
+    * `Required` is the default, and is what an empty `nodeAntiAffinity: {}` gives you.
+      It excludes previously tried hosts outright, so a retry stays unschedulable once every eligible host has been tried.
+    * `Preferred` only de-prioritises them.
+      A retry can then still be scheduled onto a previously tried host once every eligible host has been tried.
+      This is a preference rather than a guarantee, so other scheduling constraints can still leave the retry pending.
+      Use it when the retry limit is higher than the number of eligible nodes.
 
 ```yaml
-    retryStrategy:
-      limit: 10
-      affinity:
-        nodeAntiAffinity:
-          type: Preferred
+retryStrategy:
+  limit: 10
+  affinity:
+    nodeAntiAffinity:
+      type: Preferred
 ```
 
 Providing an empty `retryStrategy` (i.e. `retryStrategy: {}`) will cause a container to retry until completion.

--- a/docs/walk-through/retrying-failed-or-errored-steps.md
+++ b/docs/walk-through/retrying-failed-or-errored-steps.md
@@ -34,7 +34,7 @@ spec:
 * `nodeAntiAffinity` prevents running steps on the same host. By default it uses label `kubernetes.io/hostname` as the selector.
   Its `type` controls how strictly earlier hosts are avoided:
     * `Required` (the default, and what an empty `nodeAntiAffinity: {}` gives you) excludes those hosts outright, so a retry stays unschedulable once every eligible host has been tried.
-    * `Preferred` only de-prioritises them, so retries keep running after every eligible host has been tried. Use this when the retry limit is higher than the number of eligible nodes.
+    * `Preferred` only de-prioritises them, so a retry can be scheduled onto a previously tried host once every eligible host has been tried. This is a preference rather than a guarantee — other scheduling constraints can still leave the retry pending. Use this when the retry limit is higher than the number of eligible nodes.
 
 ```yaml
     retryStrategy:

--- a/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
@@ -5654,8 +5654,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13495,6 +13506,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32135,8 +32153,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
@@ -5660,8 +5660,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32159,8 +32160,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
@@ -5833,8 +5833,9 @@ spec:
                               type:
                                 description: |-
                                   Type determines whether previously used hosts are excluded outright ("Required", the
-                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                  remain schedulable even after every eligible host has been tried.
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                  still be able to run on a previously used host once every eligible host has been
+                                  tried, rather than staying pending.
                                 enum:
                                 - ""
                                 - Required
@@ -32696,8 +32697,9 @@ spec:
                                     type:
                                       description: |-
                                         Type determines whether previously used hosts are excluded outright ("Required", the
-                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                        remain schedulable even after every eligible host has been tried.
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                        still be able to run on a previously used host once every eligible host has been
+                                        tried, rather than staying pending.
                                       enum:
                                       - ""
                                       - Required

--- a/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
@@ -5827,8 +5827,19 @@ spec:
                         properties:
                           nodeAntiAffinity:
                             description: |-
-                              RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                              In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                              RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                              In order to identify hosts, it uses "kubernetes.io/hostname".
+                            properties:
+                              type:
+                                description: |-
+                                  Type determines whether previously used hosts are excluded outright ("Required", the
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                  remain schedulable even after every eligible host has been tried.
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -13673,6 +13684,13 @@ spec:
                           affinity:
                             properties:
                               nodeAntiAffinity:
+                                properties:
+                                  type:
+                                    enum:
+                                    - ""
+                                    - Required
+                                    - Preferred
+                                    type: string
                                 type: object
                             type: object
                           backoff:
@@ -32672,8 +32690,19 @@ spec:
                               properties:
                                 nodeAntiAffinity:
                                   description: |-
-                                    RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                    In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                    RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                    In order to identify hosts, it uses "kubernetes.io/hostname".
+                                  properties:
+                                    type:
+                                      description: |-
+                                        Type determines whether previously used hosts are excluded outright ("Required", the
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                        remain schedulable even after every eligible host has been tried.
+                                      enum:
+                                      - ""
+                                      - Required
+                                      - Preferred
+                                      type: string
                                   type: object
                               type: object
                             backoff:

--- a/manifests/base/crds/full/argoproj.io_workflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflows.yaml
@@ -5667,8 +5667,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13508,6 +13519,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32148,8 +32166,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/base/crds/full/argoproj.io_workflows.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflows.yaml
@@ -5673,8 +5673,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32172,8 +32173,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
@@ -7425,6 +7425,13 @@ spec:
                         affinity:
                           properties:
                             nodeAntiAffinity:
+                              properties:
+                                type:
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
@@ -5658,8 +5658,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32157,8 +32158,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
+++ b/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
@@ -5652,8 +5652,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13493,6 +13504,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32133,8 +32151,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/base/crds/minimal/argoproj.io_workflowtasksets.yaml
+++ b/manifests/base/crds/minimal/argoproj.io_workflowtasksets.yaml
@@ -7425,6 +7425,13 @@ spec:
                         affinity:
                           properties:
                             nodeAntiAffinity:
+                              properties:
+                                type:
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -5654,8 +5654,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13495,6 +13506,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32135,8 +32153,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -48701,8 +48730,19 @@ spec:
                         properties:
                           nodeAntiAffinity:
                             description: |-
-                              RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                              In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                              RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                              In order to identify hosts, it uses "kubernetes.io/hostname".
+                            properties:
+                              type:
+                                description: |-
+                                  Type determines whether previously used hosts are excluded outright ("Required", the
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                  remain schedulable even after every eligible host has been tried.
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -56547,6 +56587,13 @@ spec:
                           affinity:
                             properties:
                               nodeAntiAffinity:
+                                properties:
+                                  type:
+                                    enum:
+                                    - ""
+                                    - Required
+                                    - Preferred
+                                    type: string
                                 type: object
                             type: object
                           backoff:
@@ -75546,8 +75593,19 @@ spec:
                               properties:
                                 nodeAntiAffinity:
                                   description: |-
-                                    RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                    In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                    RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                    In order to identify hosts, it uses "kubernetes.io/hostname".
+                                  properties:
+                                    type:
+                                      description: |-
+                                        Type determines whether previously used hosts are excluded outright ("Required", the
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                        remain schedulable even after every eligible host has been tried.
+                                      enum:
+                                      - ""
+                                      - Required
+                                      - Preferred
+                                      type: string
                                   type: object
                               type: object
                             backoff:
@@ -94673,8 +94731,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -102514,6 +102583,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -121154,8 +121230,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -143899,6 +143986,13 @@ spec:
                         affinity:
                           properties:
                             nodeAntiAffinity:
+                              properties:
+                                type:
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -154648,8 +154742,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -162489,6 +162594,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -181129,8 +181241,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/quick-start-minimal.yaml
+++ b/manifests/quick-start-minimal.yaml
@@ -5660,8 +5660,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32159,8 +32160,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -48736,8 +48738,9 @@ spec:
                               type:
                                 description: |-
                                   Type determines whether previously used hosts are excluded outright ("Required", the
-                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                  remain schedulable even after every eligible host has been tried.
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                  still be able to run on a previously used host once every eligible host has been
+                                  tried, rather than staying pending.
                                 enum:
                                 - ""
                                 - Required
@@ -75599,8 +75602,9 @@ spec:
                                     type:
                                       description: |-
                                         Type determines whether previously used hosts are excluded outright ("Required", the
-                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                        remain schedulable even after every eligible host has been tried.
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                        still be able to run on a previously used host once every eligible host has been
+                                        tried, rather than staying pending.
                                       enum:
                                       - ""
                                       - Required
@@ -94737,8 +94741,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -121236,8 +121241,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -154748,8 +154754,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -181247,8 +181254,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -5654,8 +5654,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13495,6 +13506,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32135,8 +32153,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -48701,8 +48730,19 @@ spec:
                         properties:
                           nodeAntiAffinity:
                             description: |-
-                              RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                              In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                              RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                              In order to identify hosts, it uses "kubernetes.io/hostname".
+                            properties:
+                              type:
+                                description: |-
+                                  Type determines whether previously used hosts are excluded outright ("Required", the
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                  remain schedulable even after every eligible host has been tried.
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -56547,6 +56587,13 @@ spec:
                           affinity:
                             properties:
                               nodeAntiAffinity:
+                                properties:
+                                  type:
+                                    enum:
+                                    - ""
+                                    - Required
+                                    - Preferred
+                                    type: string
                                 type: object
                             type: object
                           backoff:
@@ -75546,8 +75593,19 @@ spec:
                               properties:
                                 nodeAntiAffinity:
                                   description: |-
-                                    RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                    In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                    RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                    In order to identify hosts, it uses "kubernetes.io/hostname".
+                                  properties:
+                                    type:
+                                      description: |-
+                                        Type determines whether previously used hosts are excluded outright ("Required", the
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                        remain schedulable even after every eligible host has been tried.
+                                      enum:
+                                      - ""
+                                      - Required
+                                      - Preferred
+                                      type: string
                                   type: object
                               type: object
                             backoff:
@@ -94673,8 +94731,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -102514,6 +102583,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -121154,8 +121230,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -143899,6 +143986,13 @@ spec:
                         affinity:
                           properties:
                             nodeAntiAffinity:
+                              properties:
+                                type:
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -154648,8 +154742,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -162489,6 +162594,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -181129,8 +181241,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/quick-start-mysql.yaml
+++ b/manifests/quick-start-mysql.yaml
@@ -5660,8 +5660,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32159,8 +32160,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -48736,8 +48738,9 @@ spec:
                               type:
                                 description: |-
                                   Type determines whether previously used hosts are excluded outright ("Required", the
-                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                  remain schedulable even after every eligible host has been tried.
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                  still be able to run on a previously used host once every eligible host has been
+                                  tried, rather than staying pending.
                                 enum:
                                 - ""
                                 - Required
@@ -75599,8 +75602,9 @@ spec:
                                     type:
                                       description: |-
                                         Type determines whether previously used hosts are excluded outright ("Required", the
-                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                        remain schedulable even after every eligible host has been tried.
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                        still be able to run on a previously used host once every eligible host has been
+                                        tried, rather than staying pending.
                                       enum:
                                       - ""
                                       - Required
@@ -94737,8 +94741,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -121236,8 +121241,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -154748,8 +154754,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -181247,8 +181254,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -5654,8 +5654,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13495,6 +13506,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32135,8 +32153,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -48701,8 +48730,19 @@ spec:
                         properties:
                           nodeAntiAffinity:
                             description: |-
-                              RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                              In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                              RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                              In order to identify hosts, it uses "kubernetes.io/hostname".
+                            properties:
+                              type:
+                                description: |-
+                                  Type determines whether previously used hosts are excluded outright ("Required", the
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                  remain schedulable even after every eligible host has been tried.
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -56547,6 +56587,13 @@ spec:
                           affinity:
                             properties:
                               nodeAntiAffinity:
+                                properties:
+                                  type:
+                                    enum:
+                                    - ""
+                                    - Required
+                                    - Preferred
+                                    type: string
                                 type: object
                             type: object
                           backoff:
@@ -75546,8 +75593,19 @@ spec:
                               properties:
                                 nodeAntiAffinity:
                                   description: |-
-                                    RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                    In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                    RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                    In order to identify hosts, it uses "kubernetes.io/hostname".
+                                  properties:
+                                    type:
+                                      description: |-
+                                        Type determines whether previously used hosts are excluded outright ("Required", the
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                        remain schedulable even after every eligible host has been tried.
+                                      enum:
+                                      - ""
+                                      - Required
+                                      - Preferred
+                                      type: string
                                   type: object
                               type: object
                             backoff:
@@ -94673,8 +94731,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -102514,6 +102583,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -121154,8 +121230,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -143899,6 +143986,13 @@ spec:
                         affinity:
                           properties:
                             nodeAntiAffinity:
+                              properties:
+                                type:
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -154648,8 +154742,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -162489,6 +162594,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -181129,8 +181241,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/quick-start-postgres.yaml
+++ b/manifests/quick-start-postgres.yaml
@@ -5660,8 +5660,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32159,8 +32160,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -48736,8 +48738,9 @@ spec:
                               type:
                                 description: |-
                                   Type determines whether previously used hosts are excluded outright ("Required", the
-                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                  remain schedulable even after every eligible host has been tried.
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                  still be able to run on a previously used host once every eligible host has been
+                                  tried, rather than staying pending.
                                 enum:
                                 - ""
                                 - Required
@@ -75599,8 +75602,9 @@ spec:
                                     type:
                                       description: |-
                                         Type determines whether previously used hosts are excluded outright ("Required", the
-                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                        remain schedulable even after every eligible host has been tried.
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                        still be able to run on a previously used host once every eligible host has been
+                                        tried, rather than staying pending.
                                       enum:
                                       - ""
                                       - Required
@@ -94737,8 +94741,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -121236,8 +121241,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -154748,8 +154754,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -181247,8 +181254,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/manifests/quick-start-telemetry.yaml
+++ b/manifests/quick-start-telemetry.yaml
@@ -5654,8 +5654,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -13495,6 +13506,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -32135,8 +32153,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -48701,8 +48730,19 @@ spec:
                         properties:
                           nodeAntiAffinity:
                             description: |-
-                              RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                              In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                              RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                              In order to identify hosts, it uses "kubernetes.io/hostname".
+                            properties:
+                              type:
+                                description: |-
+                                  Type determines whether previously used hosts are excluded outright ("Required", the
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                  remain schedulable even after every eligible host has been tried.
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -56547,6 +56587,13 @@ spec:
                           affinity:
                             properties:
                               nodeAntiAffinity:
+                                properties:
+                                  type:
+                                    enum:
+                                    - ""
+                                    - Required
+                                    - Preferred
+                                    type: string
                                 type: object
                             type: object
                           backoff:
@@ -75546,8 +75593,19 @@ spec:
                               properties:
                                 nodeAntiAffinity:
                                   description: |-
-                                    RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                    In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                    RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                    In order to identify hosts, it uses "kubernetes.io/hostname".
+                                  properties:
+                                    type:
+                                      description: |-
+                                        Type determines whether previously used hosts are excluded outright ("Required", the
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                        remain schedulable even after every eligible host has been tried.
+                                      enum:
+                                      - ""
+                                      - Required
+                                      - Preferred
+                                      type: string
                                   type: object
                               type: object
                             backoff:
@@ -94673,8 +94731,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -102514,6 +102583,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -121154,8 +121230,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -143899,6 +143986,13 @@ spec:
                         affinity:
                           properties:
                             nodeAntiAffinity:
+                              properties:
+                                type:
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:
@@ -154648,8 +154742,19 @@ spec:
                     properties:
                       nodeAntiAffinity:
                         description: |-
-                          RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                          In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                          RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                          In order to identify hosts, it uses "kubernetes.io/hostname".
+                        properties:
+                          type:
+                            description: |-
+                              Type determines whether previously used hosts are excluded outright ("Required", the
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                              remain schedulable even after every eligible host has been tried.
+                            enum:
+                            - ""
+                            - Required
+                            - Preferred
+                            type: string
                         type: object
                     type: object
                   backoff:
@@ -162489,6 +162594,13 @@ spec:
                       affinity:
                         properties:
                           nodeAntiAffinity:
+                            properties:
+                              type:
+                                enum:
+                                - ""
+                                - Required
+                                - Preferred
+                                type: string
                             type: object
                         type: object
                       backoff:
@@ -181129,8 +181241,19 @@ spec:
                           properties:
                             nodeAntiAffinity:
                               description: |-
-                                RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-                                In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+                                RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+                                In order to identify hosts, it uses "kubernetes.io/hostname".
+                              properties:
+                                type:
+                                  description: |-
+                                    Type determines whether previously used hosts are excluded outright ("Required", the
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+                                    remain schedulable even after every eligible host has been tried.
+                                  enum:
+                                  - ""
+                                  - Required
+                                  - Preferred
+                                  type: string
                               type: object
                           type: object
                         backoff:

--- a/manifests/quick-start-telemetry.yaml
+++ b/manifests/quick-start-telemetry.yaml
@@ -5660,8 +5660,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -32159,8 +32160,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -48736,8 +48738,9 @@ spec:
                               type:
                                 description: |-
                                   Type determines whether previously used hosts are excluded outright ("Required", the
-                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                  remain schedulable even after every eligible host has been tried.
+                                  default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                  still be able to run on a previously used host once every eligible host has been
+                                  tried, rather than staying pending.
                                 enum:
                                 - ""
                                 - Required
@@ -75599,8 +75602,9 @@ spec:
                                     type:
                                       description: |-
                                         Type determines whether previously used hosts are excluded outright ("Required", the
-                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                        remain schedulable even after every eligible host has been tried.
+                                        default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                        still be able to run on a previously used host once every eligible host has been
+                                        tried, rather than staying pending.
                                       enum:
                                       - ""
                                       - Required
@@ -94737,8 +94741,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -121236,8 +121241,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required
@@ -154748,8 +154754,9 @@ spec:
                           type:
                             description: |-
                               Type determines whether previously used hosts are excluded outright ("Required", the
-                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                              remain schedulable even after every eligible host has been tried.
+                              default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                              still be able to run on a previously used host once every eligible host has been
+                              tried, rather than staying pending.
                             enum:
                             - ""
                             - Required
@@ -181247,8 +181254,9 @@ spec:
                                 type:
                                   description: |-
                                     Type determines whether previously used hosts are excluded outright ("Required", the
-                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-                                    remain schedulable even after every eligible host has been tried.
+                                    default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+                                    still be able to run on a previously used host once every eligible host has been
+                                    tried, rather than staying pending.
                                   enum:
                                   - ""
                                   - Required

--- a/pkg/apis/workflow/v1alpha1/generated.pb.go
+++ b/pkg/apis/workflow/v1alpha1/generated.pb.go
@@ -5982,6 +5982,11 @@ func (m *RetryNodeAntiAffinity) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	i -= len(m.Type)
+	copy(dAtA[i:], m.Type)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.Type)))
+	i--
+	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -11823,6 +11828,8 @@ func (m *RetryNodeAntiAffinity) Size() (n int) {
 	}
 	var l int
 	_ = l
+	l = len(m.Type)
+	n += 1 + l + sovGenerated(uint64(l))
 	return n
 }
 
@@ -14658,6 +14665,7 @@ func (this *RetryNodeAntiAffinity) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&RetryNodeAntiAffinity{`,
+		`Type:` + fmt.Sprintf("%v", this.Type) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -33214,6 +33222,38 @@ func (m *RetryNodeAntiAffinity) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: RetryNodeAntiAffinity: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Type = RetryNodeAntiAffinityType(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(dAtA[iNdEx:])

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -1482,8 +1482,9 @@ message RetryAffinity {
 // In order to identify hosts, it uses "kubernetes.io/hostname".
 message RetryNodeAntiAffinity {
   // Type determines whether previously used hosts are excluded outright ("Required", the
-  // default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-  // remain schedulable even after every eligible host has been tried.
+  // default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+  // still be able to run on a previously used host once every eligible host has been
+  // tried, rather than staying pending.
   optional string type = 1;
 }
 

--- a/pkg/apis/workflow/v1alpha1/generated.proto
+++ b/pkg/apis/workflow/v1alpha1/generated.proto
@@ -1478,9 +1478,13 @@ message RetryAffinity {
   optional RetryNodeAntiAffinity nodeAntiAffinity = 1;
 }
 
-// RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-// In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
+// RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+// In order to identify hosts, it uses "kubernetes.io/hostname".
 message RetryNodeAntiAffinity {
+  // Type determines whether previously used hosts are excluded outright ("Required", the
+  // default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+  // remain schedulable even after every eligible host has been tried.
+  optional string type = 1;
 }
 
 // RetryStrategy provides controls on how to retry a workflow step

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -5381,7 +5381,7 @@ func schema_pkg_apis_workflow_v1alpha1_RetryNodeAntiAffinity(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when retries must remain schedulable even after every eligible host has been tried.",
+							Description: "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when a retry should still be able to run on a previously used host once every eligible host has been tried, rather than staying pending.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/workflow/v1alpha1/openapi_generated.go
+++ b/pkg/apis/workflow/v1alpha1/openapi_generated.go
@@ -5376,8 +5376,17 @@ func schema_pkg_apis_workflow_v1alpha1_RetryNodeAntiAffinity(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed. In order to prevent running steps on the same host, it uses \"kubernetes.io/hostname\".",
+				Description: "RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on. In order to identify hosts, it uses \"kubernetes.io/hostname\".",
 				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type determines whether previously used hosts are excluded outright (\"Required\", the default) or merely de-prioritised (\"Preferred\"). Use \"Preferred\" when retries must remain schedulable even after every eligible host has been tried.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2360,16 +2360,20 @@ type Backoff struct {
 }
 
 // RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that
-// previous attempts ran on.
+// previous attempts ran on. An omitted or empty value is treated as "Required", which
+// is the behaviour of releases before this field existed.
 // +kubebuilder:validation:Enum="";Required;Preferred
 type RetryNodeAntiAffinityType string
 
 const (
 	// RetryNodeAntiAffinityRequired excludes previously used hosts outright. A retry stays
-	// unschedulable once every eligible host has been tried. This is the default.
+	// unschedulable once every eligible host has been tried. This is the default, and is
+	// what an omitted or empty type resolves to.
 	RetryNodeAntiAffinityRequired RetryNodeAntiAffinityType = "Required"
 	// RetryNodeAntiAffinityPreferred only de-prioritises previously used hosts, so a retry
-	// can still be scheduled after every eligible host has been tried.
+	// can still be scheduled onto a previously used host once every eligible host has been
+	// tried. It expresses a preference, not a guarantee: other scheduling constraints can
+	// still leave the retry pending.
 	RetryNodeAntiAffinityPreferred RetryNodeAntiAffinityType = "Preferred"
 )
 
@@ -2377,8 +2381,9 @@ const (
 // In order to identify hosts, it uses "kubernetes.io/hostname".
 type RetryNodeAntiAffinity struct {
 	// Type determines whether previously used hosts are excluded outright ("Required", the
-	// default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
-	// remain schedulable even after every eligible host has been tried.
+	// default) or merely de-prioritised ("Preferred"). Use "Preferred" when a retry should
+	// still be able to run on a previously used host once every eligible host has been
+	// tried, rather than staying pending.
 	Type RetryNodeAntiAffinityType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=RetryNodeAntiAffinityType"`
 }
 

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2359,9 +2359,28 @@ type Backoff struct {
 	Cap string `json:"cap,omitempty" protobuf:"varint,4,opt,name=cap"`
 }
 
-// RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
-// In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
-type RetryNodeAntiAffinity struct{}
+// RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that
+// previous attempts ran on.
+// +kubebuilder:validation:Enum="";Required;Preferred
+type RetryNodeAntiAffinityType string
+
+const (
+	// RetryNodeAntiAffinityRequired excludes previously used hosts outright. A retry stays
+	// unschedulable once every eligible host has been tried. This is the default.
+	RetryNodeAntiAffinityRequired RetryNodeAntiAffinityType = "Required"
+	// RetryNodeAntiAffinityPreferred only de-prioritises previously used hosts, so a retry
+	// can still be scheduled after every eligible host has been tried.
+	RetryNodeAntiAffinityPreferred RetryNodeAntiAffinityType = "Preferred"
+)
+
+// RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
+// In order to identify hosts, it uses "kubernetes.io/hostname".
+type RetryNodeAntiAffinity struct {
+	// Type determines whether previously used hosts are excluded outright ("Required", the
+	// default) or merely de-prioritised ("Preferred"). Use "Preferred" when retries must
+	// remain schedulable even after every eligible host has been tried.
+	Type RetryNodeAntiAffinityType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=RetryNodeAntiAffinityType"`
+}
 
 // RetryAffinity prevents running steps on the same host.
 type RetryAffinity struct {

--- a/pkg/plugins/executor/swagger.yml
+++ b/pkg/plugins/executor/swagger.yml
@@ -3934,9 +3934,18 @@ definitions:
         title: RetryAffinity prevents running steps on the same host.
         type: object
     RetryNodeAntiAffinity:
-        description: In order to prevent running steps on the same host, it uses "kubernetes.io/hostname".
-        title: RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed.
+        description: In order to identify hosts, it uses "kubernetes.io/hostname".
+        properties:
+            type:
+                $ref: '#/definitions/RetryNodeAntiAffinityType'
+        title: RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on.
         type: object
+    RetryNodeAntiAffinityType:
+        description: |-
+            RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that
+            previous attempts ran on.
+            +kubebuilder:validation:Enum="";Required;Preferred
+        type: string
     RetryPolicy:
         description: +kubebuilder:validation:Enum=Always;OnFailure;OnError;OnTransientError
         title: RetryPolicy defines the policy for retrying workflow steps.

--- a/pkg/plugins/executor/swagger.yml
+++ b/pkg/plugins/executor/swagger.yml
@@ -3943,7 +3943,8 @@ definitions:
     RetryNodeAntiAffinityType:
         description: |-
             RetryNodeAntiAffinityType determines how strictly a retry avoids the hosts that
-            previous attempts ran on.
+            previous attempts ran on. An omitted or empty value is treated as "Required", which
+            is the behaviour of releases before this field existed.
             +kubebuilder:validation:Enum="";Required;Preferred
         type: string
     RetryPolicy:

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1RetryAffinity.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1RetryAffinity.md
@@ -8,7 +8,7 @@ RetryAffinity prevents running steps on the same host.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**nodeAntiAffinity** | **Object** | RetryNodeAntiAffinity is a placeholder for future expansion, only empty nodeAntiAffinity is allowed. In order to prevent running steps on the same host, it uses \&quot;kubernetes.io/hostname\&quot;. |  [optional]
+**nodeAntiAffinity** | [**IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity**](IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity.md) |  |  [optional]
 
 
 

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity.md
@@ -8,7 +8,7 @@ RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**type** | **String** | Type determines whether previously used hosts are excluded outright (\&quot;Required\&quot;, the default) or merely de-prioritised (\&quot;Preferred\&quot;). Use \&quot;Preferred\&quot; when retries must remain schedulable even after every eligible host has been tried. |  [optional]
+**type** | **String** | Type determines whether previously used hosts are excluded outright (\&quot;Required\&quot;, the default) or merely de-prioritised (\&quot;Preferred\&quot;). Use \&quot;Preferred\&quot; when a retry should still be able to run on a previously used host once every eligible host has been tried, rather than staying pending. |  [optional]
 
 
 

--- a/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity.md
+++ b/sdks/java/client/docs/IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity.md
@@ -1,0 +1,14 @@
+
+
+# IoArgoprojWorkflowV1alpha1RetryNodeAntiAffinity
+
+RetryNodeAntiAffinity prevents running steps on the hosts that previous attempts ran on. In order to identify hosts, it uses \"kubernetes.io/hostname\".
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**type** | **String** | Type determines whether previously used hosts are excluded outright (\&quot;Required\&quot;, the default) or merely de-prioritised (\&quot;Preferred\&quot;). Use \&quot;Preferred\&quot; when retries must remain schedulable even after every eligible host has been tried. |  [optional]
+
+
+

--- a/workflow/controller/retry_tweak.go
+++ b/workflow/controller/retry_tweak.go
@@ -29,11 +29,15 @@ func RetryOnDifferentHost(retryNodeName string) RetryTweak {
 		if retryStrategy.Affinity == nil {
 			return
 		}
-		if retryStrategy.Affinity.NodeAntiAffinity != nil {
+		if nodeAntiAffinity := retryStrategy.Affinity.NodeAntiAffinity; nodeAntiAffinity != nil {
 			hostNames := wfretry.GetFailHosts(nodes, retryNodeName)
 			hostLabel := env.GetString("RETRY_HOST_NAME_LABEL_KEY", "kubernetes.io/hostname")
 			if hostLabel != "" && len(hostNames) > 0 {
-				pod.Spec.Affinity = wfretry.AddHostnamesToAffinity(hostLabel, hostNames, pod.Spec.Affinity)
+				if nodeAntiAffinity.Type == wfv1.RetryNodeAntiAffinityPreferred {
+					pod.Spec.Affinity = wfretry.AddHostnamesToPreferredAffinity(hostLabel, hostNames, pod.Spec.Affinity)
+				} else {
+					pod.Spec.Affinity = wfretry.AddHostnamesToAffinity(hostLabel, hostNames, pod.Spec.Affinity)
+				}
 			}
 		}
 	}

--- a/workflow/controller/retry_tweak_test.go
+++ b/workflow/controller/retry_tweak_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	wfretry "github.com/argoproj/argo-workflows/v4/workflow/util/retry"
 )
 
 func TestFindRetryNode(t *testing.T) {
@@ -91,5 +94,78 @@ func TestFindRetryNode(t *testing.T) {
 	t.Run("Expect to find retry node has TemplateRef", func(t *testing.T) {
 		node := allNodes["B3"]
 		assert.Equal(t, FindRetryNode(allNodes, "C2"), &node)
+	})
+}
+
+// TestRetryOnDifferentHostAntiAffinityType checks that the configured nodeAntiAffinity
+// type decides whether the failed host lands in the required or the preferred node
+// affinity term.
+func TestRetryOnDifferentHostAntiAffinityType(t *testing.T) {
+	const (
+		retryNodeName = "retry-node"
+		hostSelector  = "kubernetes.io/hostname"
+		failedHost    = "test-fail-hostname"
+	)
+
+	nodes := wfv1.Nodes{
+		retryNodeName: wfv1.NodeStatus{
+			ID:       retryNodeName,
+			Type:     wfv1.NodeTypeRetry,
+			Phase:    wfv1.NodeRunning,
+			Children: []string{"child"},
+		},
+		"child": wfv1.NodeStatus{
+			ID:           "child",
+			HostNodeName: failedHost,
+			Type:         wfv1.NodeTypePod,
+			Phase:        wfv1.NodeFailed,
+		},
+	}
+
+	expectedRequirement := apiv1.NodeSelectorRequirement{
+		Key:      hostSelector,
+		Operator: apiv1.NodeSelectorOpNotIn,
+		Values:   []string{failedHost},
+	}
+
+	tweak := func(t *testing.T, antiAffinity *wfv1.RetryNodeAntiAffinity) *apiv1.Affinity {
+		t.Helper()
+
+		pod := &apiv1.Pod{Spec: apiv1.PodSpec{Affinity: &apiv1.Affinity{}}}
+		retryStrategy := wfv1.RetryStrategy{
+			Affinity: &wfv1.RetryAffinity{NodeAntiAffinity: antiAffinity},
+		}
+		RetryOnDifferentHost(retryNodeName)(retryStrategy, nodes, pod)
+
+		return pod.Spec.Affinity
+	}
+
+	t.Run("DefaultIsRequired", func(t *testing.T) {
+		affinity := tweak(t, &wfv1.RetryNodeAntiAffinity{})
+		required := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		require.NotNil(t, required, "an unset type must keep the pre-existing required behaviour")
+		assert.Equal(t, expectedRequirement, required.NodeSelectorTerms[0].MatchExpressions[0])
+		assert.Empty(t, affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+	})
+	t.Run("ExplicitRequired", func(t *testing.T) {
+		affinity := tweak(t, &wfv1.RetryNodeAntiAffinity{Type: wfv1.RetryNodeAntiAffinityRequired})
+		required := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		require.NotNil(t, required)
+		assert.Equal(t, expectedRequirement, required.NodeSelectorTerms[0].MatchExpressions[0])
+		assert.Empty(t, affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+	})
+	t.Run("Preferred", func(t *testing.T) {
+		affinity := tweak(t, &wfv1.RetryNodeAntiAffinity{Type: wfv1.RetryNodeAntiAffinityPreferred})
+		preferred := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, preferred, 1)
+		assert.Equal(t, wfretry.PreferredHostAntiAffinityWeight, preferred[0].Weight)
+		assert.Equal(t, expectedRequirement, preferred[0].Preference.MatchExpressions[0])
+		// the required term must stay empty, otherwise the retry would still be unschedulable
+		// once every host has been tried, which is the whole point of the preferred type
+		assert.Nil(t, affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	})
+	t.Run("NoNodeAntiAffinity", func(t *testing.T) {
+		affinity := tweak(t, nil)
+		assert.Nil(t, affinity.NodeAffinity)
 	})
 }

--- a/workflow/util/retry/retry.go
+++ b/workflow/util/retry/retry.go
@@ -93,6 +93,11 @@ func AddHostnamesToPreferredAffinity(hostSelector string, hostNames []string, ta
 			matchExpression := &targetTerms[i].Preference.MatchExpressions[j]
 			if matchExpression.Key == hostSelector && matchExpression.Operator == apiv1.NodeSelectorOpNotIn {
 				matchExpression.Values = RemoveDuplicates(append(matchExpression.Values, hostNames...))
+				// the retry hostnames now ride on this term, so it has to carry the
+				// anti-affinity weight rather than whatever lower weight it was declared with
+				if targetTerms[i].Weight < PreferredHostAntiAffinityWeight {
+					targetTerms[i].Weight = PreferredHostAntiAffinityWeight
+				}
 				return targetAffinity
 			}
 		}

--- a/workflow/util/retry/retry.go
+++ b/workflow/util/retry/retry.go
@@ -42,6 +42,68 @@ func RemoveDuplicates(strSlice []string) []string {
 	return outputList
 }
 
+// PreferredHostAntiAffinityWeight is the weight given to the preferred scheduling term that
+// steers a retry away from the hosts previous attempts ran on. It is the maximum weight, so
+// the term outranks any other preference a user configured with a lower weight, while still
+// leaving the retry schedulable when no other host is available.
+const PreferredHostAntiAffinityWeight int32 = 100
+
+// AddHostnamesToPreferredAffinity will add unique hostNames to an existing preferred
+// scheduling term in targetAffinity with key hostSelector, or insert a new one with operator
+// NotIn. Unlike AddHostnamesToAffinity the resulting term is only a preference, so a retry
+// remains schedulable once every eligible host has been tried.
+func AddHostnamesToPreferredAffinity(hostSelector string, hostNames []string, targetAffinity *apiv1.Affinity) *apiv1.Affinity {
+	if len(hostNames) == 0 {
+		return targetAffinity
+	}
+
+	nodeSelectorRequirement := apiv1.NodeSelectorRequirement{
+		Key:      hostSelector,
+		Operator: apiv1.NodeSelectorOpNotIn,
+		Values:   hostNames,
+	}
+
+	preferredTerm := apiv1.PreferredSchedulingTerm{
+		Weight: PreferredHostAntiAffinityWeight,
+		Preference: apiv1.NodeSelectorTerm{
+			MatchExpressions: []apiv1.NodeSelectorRequirement{nodeSelectorRequirement},
+		},
+	}
+
+	if targetAffinity == nil {
+		return &apiv1.Affinity{
+			NodeAffinity: &apiv1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{preferredTerm},
+			},
+		}
+	}
+
+	if targetAffinity.NodeAffinity == nil {
+		targetAffinity.NodeAffinity = &apiv1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{preferredTerm},
+		}
+		return targetAffinity
+	}
+
+	targetTerms := targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+
+	// find an existing term for the same host selector and merge into it
+	for i := range targetTerms {
+		for j := range targetTerms[i].Preference.MatchExpressions {
+			matchExpression := &targetTerms[i].Preference.MatchExpressions[j]
+			if matchExpression.Key == hostSelector && matchExpression.Operator == apiv1.NodeSelectorOpNotIn {
+				matchExpression.Values = RemoveDuplicates(append(matchExpression.Values, hostNames...))
+				return targetAffinity
+			}
+		}
+	}
+
+	targetTerms = append(targetTerms, preferredTerm)
+	targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = targetTerms
+
+	return targetAffinity
+}
+
 // AddHostnamesToAffinity will add unique hostNames to existing matchExpressions in targetAffinity with
 // key hostSelector or insert new matchExpressions with operator NotIn.
 func AddHostnamesToAffinity(hostSelector string, hostNames []string, targetAffinity *apiv1.Affinity) *apiv1.Affinity {

--- a/workflow/util/retry/retry_test.go
+++ b/workflow/util/retry/retry_test.go
@@ -468,6 +468,50 @@ func TestAddHostnamesToPreferredAffinity(t *testing.T) {
 			[]string{"hostname1", "hostnameA", "hostnameB", "hostnameC"},
 			preferred[0].Preference.MatchExpressions[0].Values,
 			"hostnameA was already present and must not be duplicated")
+		assert.Equal(t, PreferredHostAntiAffinityWeight, preferred[0].Weight)
+	})
+	t.Run("RaisesWeightOfExistingLowerWeightedTerm", func(t *testing.T) {
+		existingAffinity := &apiv1.Affinity{
+			NodeAffinity: &apiv1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{
+					{
+						Weight: 1,
+						Preference: apiv1.NodeSelectorTerm{
+							MatchExpressions: []apiv1.NodeSelectorRequirement{
+								{
+									Key:      hostSelector,
+									Operator: apiv1.NodeSelectorOpNotIn,
+									Values:   []string{"hostname1"},
+								},
+							},
+						},
+					},
+					{
+						Weight: 50,
+						Preference: apiv1.NodeSelectorTerm{
+							MatchExpressions: []apiv1.NodeSelectorRequirement{
+								{
+									Key:      "topology.kubernetes.io/zone",
+									Operator: apiv1.NodeSelectorOpIn,
+									Values:   []string{"zone-a"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		targetAffinity := AddHostnamesToPreferredAffinity(hostSelector, hostNames, existingAffinity)
+		preferred := targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, preferred, 2)
+		// merging into a term declared at weight 1 must not leave the retry hostnames
+		// ranked below the user's unrelated weight-50 preference
+		assert.Equal(t, PreferredHostAntiAffinityWeight, preferred[0].Weight,
+			"the merged term must carry the anti-affinity weight, not the weight it was declared with")
+		assert.Equal(t,
+			[]string{"hostname1", "hostnameA", "hostnameB", "hostnameC"},
+			preferred[0].Preference.MatchExpressions[0].Values)
+		assert.Equal(t, int32(50), preferred[1].Weight, "an unrelated preference must keep its own weight")
 	})
 	t.Run("AppendsAlongsideUnrelatedTerm", func(t *testing.T) {
 		unrelatedTerm := apiv1.PreferredSchedulingTerm{

--- a/workflow/util/retry/retry_test.go
+++ b/workflow/util/retry/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
@@ -410,5 +411,109 @@ func TestAddHostnamesToAffinity(t *testing.T) {
 		}
 		targetNode := AddHostnamesToAffinity(hostSelector, hostNames, existingNode)
 		assert.Equal(t, targetNode, mergedNode)
+	})
+}
+
+func TestAddHostnamesToPreferredAffinity(t *testing.T) {
+	hostNames := []string{"hostnameA", "hostnameB", "hostnameC"}
+	hostSelector := "kubernetes.io/hostname"
+
+	expectedRequirement := apiv1.NodeSelectorRequirement{
+		Key:      hostSelector,
+		Operator: apiv1.NodeSelectorOpNotIn,
+		Values:   hostNames,
+	}
+
+	t.Run("NoHostNames", func(t *testing.T) {
+		assert.Nil(t, AddHostnamesToPreferredAffinity(hostSelector, nil, nil))
+	})
+	t.Run("EmptyAffinity", func(t *testing.T) {
+		targetAffinity := AddHostnamesToPreferredAffinity(hostSelector, hostNames, nil)
+		preferred := targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, preferred, 1)
+		assert.Equal(t, PreferredHostAntiAffinityWeight, preferred[0].Weight)
+		assert.Equal(t, expectedRequirement, preferred[0].Preference.MatchExpressions[0])
+		// the required term must stay empty, otherwise this would still block scheduling
+		assert.Nil(t, targetAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	})
+	t.Run("EmptyNodeAffinity", func(t *testing.T) {
+		targetAffinity := AddHostnamesToPreferredAffinity(hostSelector, hostNames, &apiv1.Affinity{})
+		preferred := targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, preferred, 1)
+		assert.Equal(t, expectedRequirement, preferred[0].Preference.MatchExpressions[0])
+	})
+	t.Run("MergesIntoExistingTermForSameSelector", func(t *testing.T) {
+		existingAffinity := &apiv1.Affinity{
+			NodeAffinity: &apiv1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{
+					{
+						Weight: PreferredHostAntiAffinityWeight,
+						Preference: apiv1.NodeSelectorTerm{
+							MatchExpressions: []apiv1.NodeSelectorRequirement{
+								{
+									Key:      hostSelector,
+									Operator: apiv1.NodeSelectorOpNotIn,
+									Values:   []string{"hostname1", "hostnameA"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		targetAffinity := AddHostnamesToPreferredAffinity(hostSelector, hostNames, existingAffinity)
+		preferred := targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, preferred, 1, "an existing term for the same selector must be reused")
+		assert.Equal(t,
+			[]string{"hostname1", "hostnameA", "hostnameB", "hostnameC"},
+			preferred[0].Preference.MatchExpressions[0].Values,
+			"hostnameA was already present and must not be duplicated")
+	})
+	t.Run("AppendsAlongsideUnrelatedTerm", func(t *testing.T) {
+		unrelatedTerm := apiv1.PreferredSchedulingTerm{
+			Weight: 1,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "topology.kubernetes.io/zone",
+						Operator: apiv1.NodeSelectorOpIn,
+						Values:   []string{"zone-a"},
+					},
+				},
+			},
+		}
+		existingAffinity := &apiv1.Affinity{
+			NodeAffinity: &apiv1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{unrelatedTerm},
+			},
+		}
+		targetAffinity := AddHostnamesToPreferredAffinity(hostSelector, hostNames, existingAffinity)
+		preferred := targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, preferred, 2)
+		assert.Equal(t, unrelatedTerm, preferred[0], "the user's own preference must be preserved")
+		assert.Equal(t, expectedRequirement, preferred[1].Preference.MatchExpressions[0])
+	})
+	t.Run("LeavesExistingRequiredTermAlone", func(t *testing.T) {
+		requiredTerm := &apiv1.NodeSelector{
+			NodeSelectorTerms: []apiv1.NodeSelectorTerm{
+				{
+					MatchExpressions: []apiv1.NodeSelectorRequirement{
+						{
+							Key:      "kubernetes.io/os",
+							Operator: apiv1.NodeSelectorOpIn,
+							Values:   []string{"linux"},
+						},
+					},
+				},
+			},
+		}
+		existingAffinity := &apiv1.Affinity{
+			NodeAffinity: &apiv1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: requiredTerm,
+			},
+		}
+		targetAffinity := AddHostnamesToPreferredAffinity(hostSelector, hostNames, existingAffinity)
+		assert.Equal(t, requiredTerm, targetAffinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+		require.Len(t, targetAffinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 1)
 	})
 }


### PR DESCRIPTION
Fixes #13969

### Motivation

`retryStrategy.affinity.nodeAntiAffinity` always excludes the hosts earlier attempts ran on with a `requiredDuringSchedulingIgnoredDuringExecution` term.
Once every eligible host has been tried, there is no host left that satisfies the term and the retry stays unschedulable, which is the case the issue describes.

This adds the soft variant so retries stay schedulable. It is the first of the two features requested in #13969; the cap on how many hosts are excluded is left for a separate PR, as suggested in the issue.

### Modifications

`RetryNodeAntiAffinity` was an empty struct documented as "a placeholder for future expansion". It now carries a `type` field:

```yaml
retryStrategy:
  limit: "10"
  affinity:
    nodeAntiAffinity:
      type: Preferred
```

* `Required` keeps the current behaviour and is the default, so an existing `nodeAntiAffinity: {}` is unaffected.
* `Preferred` emits a `preferredDuringSchedulingIgnoredDuringExecution` term instead, at weight 100.

`AddHostnamesToAffinity` is untouched. The preferred path is a sibling function, `AddHostnamesToPreferredAffinity`, which merges into an existing term for the same host selector (de-duplicating hosts) and otherwise appends, leaving any preference the user configured themselves in place.

I kept the weight fixed at 100 rather than exposing it, to keep this change small. Happy to make it configurable if you would prefer that.

### Verification

```
gmake codegen -B
gmake lint
go test ./workflow/util/retry/... ./workflow/controller/
```

New unit tests:

* `TestAddHostnamesToPreferredAffinity` covers the empty affinity, empty `NodeAffinity`, merge-into-existing-term (with de-duplication), append-alongside-an-unrelated-preference, and leave-the-required-term-alone cases.
* `TestRetryOnDifferentHostAntiAffinityType` covers the controller dispatch: unset type, explicit `Required`, `Preferred`, and no `nodeAntiAffinity` at all.

Both `Required` cases assert that the preferred list stays empty and the `Preferred` case asserts that the required term stays nil, since a leftover required term would keep the retry unschedulable and defeat the point of the feature.

I checked the tests actually exercise the new branch by temporarily forcing the dispatch to the required path: only the `Preferred` subtest fails, the others still pass.

Note for anyone reproducing this locally on macOS: the generated files only refresh with `gmake ... -B`, and the default `make` is 3.81, which cannot parse the `ifeq` blocks in the Makefile.

### Documentation

`docs/walk-through/retrying-failed-or-errored-steps.md` is where users meet this feature, and it currently states that only an empty `nodeAntiAffinity` is allowed. That sentence is replaced with a description of both types and a short example.

`docs/fields.md` and the swagger/JSON schema outputs are regenerated, so the new field also shows up in the Fields reference.

A feature note is included at `.features/pending/retry-node-anti-affinity-preferred.md` with a worked example.

### AI

Claude Code was used as a coding assistant for the implementation, tests and this description.

Everything was reviewed and verified locally before opening (`gmake codegen -B`, `gmake lint`, `gmake docs` and the unit tests all pass, and the generated files are real codegen output). I take responsibility for the contents of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retry node anti-affinity modes: **Required** avoids hosts used by earlier attempts, while **Preferred** deprioritizes them and allows reuse when necessary.
  * Added validation and schema support for the setting across workflow resources and templates.
* **Documentation**
  * Updated retry guidance with host-selection behavior and a YAML configuration example.
* **Tests**
  * Added coverage for default, required, preferred, and disabled anti-affinity behavior, including preferred host selection and affinity merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->