### PR TITLE
fix(sync): remove the acquiring key from the pending queue, not the front. Fixes #16567

### DIFF
--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -266,7 +266,7 @@ func (s *prioritySemaphore) tryAcquire(ctx context.Context, holderKey string, tx
 	}
 	acquired, _ := s.acquire(ctx, holderKey, tx)
 	if acquired {
-		s.pending.pop()
+		s.pending.remove(holderKey)
 		limit := s.getLimit(ctx)
 		logger.WithFields(logging.Fields{
 			"name":      s.name,

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -254,6 +254,55 @@ func TestCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t *testing.T) {
 	}
 }
 
+// testTryAcquireRemovesAcquiringKeyFromQueue is a regression test: checkAcquire lets a
+// node acquire the lock while a sibling node of the same workflow is at the front of the
+// pending queue. tryAcquire used to pop the front entry rather than the acquiring one, so
+// the sibling was silently dropped from the queue - no later notifyWaiters iteration
+// included it - while the acquiring node's own entry was left behind as a stale
+// front-of-queue entry.
+func testTryAcquireRemovesAcquiringKeyFromQueue(t *testing.T, factory semaphoreFactory) {
+	t.Helper()
+	ctx := logging.TestContext(t.Context())
+	nextWorkflow := func(_ string) {}
+
+	s, sessionProxy, cleanup := factory(ctx, t, "bar", "foo", 1, nextWorkflow)
+	defer cleanup()
+
+	now := time.Now()
+	require.NoError(t, s.addToQueue(ctx, "foo/wf-01/node-aaa", 0, now))
+	require.NoError(t, s.addToQueue(ctx, "foo/wf-01/node-bbb", 0, now.Add(time.Second)))
+	require.NoError(t, s.addToQueue(ctx, "foo/wf-02/node-ccc", 0, now.Add(2*time.Second)))
+
+	tx := sessionProxy
+	// node-bbb isn't at the front, but node-aaa is and belongs to the same workflow,
+	// so node-bbb is allowed to acquire.
+	acquired, _, err := s.tryAcquire(ctx, "foo/wf-01/node-bbb", tx)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// Only node-bbb's entry may be gone: node-aaa is still waiting for its turn.
+	pending, err := s.getCurrentPending(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"foo/wf-01/node-aaa", "foo/wf-02/node-ccc"}, pending)
+
+	s.release(ctx, "foo/wf-01/node-bbb")
+	require.NoError(t, s.removeFromQueue(ctx, "foo/wf-01/node-bbb"))
+
+	// node-aaa is still the front of the queue, so it takes the released lock.
+	acquired, _, err = s.tryAcquire(ctx, "foo/wf-01/node-aaa", tx)
+	require.NoError(t, err)
+	assert.True(t, acquired, "node-aaa should still be queued and acquire the released lock")
+}
+
+// TestTryAcquireRemovesAcquiringKeyFromQueue runs the queue removal test for all implementations
+func TestTryAcquireRemovesAcquiringKeyFromQueue(t *testing.T) {
+	for name, factory := range semaphoreFactories {
+		t.Run(name, func(t *testing.T) {
+			testTryAcquireRemovesAcquiringKeyFromQueue(t, factory)
+		})
+	}
+}
+
 // TestInternalSemaphoreReleaseWithLimitFetchFailure is a regression test: a transient
 // error fetching the ConfigMap limit during release() used to make getLimit return 0,
 // which release() mistook for a downward resize — the holder was removed from the map


### PR DESCRIPTION
Fixes #16567

### Motivation
`checkAcquire()` deliberately lets a node acquire an in-memory (ConfigMap) semaphore or mutex while a *sibling node of the same workflow* is at the front of the pending queue.
`tryAcquire()` then removed the **front** entry via `pending.pop()` rather than the entry that actually acquired, so the sibling was silently dropped from the queue.

Both entries belong to the same workflow — that is exactly why `checkAcquire()` let the non-front node through — so the release notification itself still fires: `workflowKey()` truncates both keys to the same workflow key, and `release()` runs before`removeFromQueue()` in `Manager.Release`, so the stale entry is still queued when `notifyWaiters()` runs.

The damage is to the queue itself, which then lists a node that already holds the lock and omits a node that is genuinely waiting. Once the stale entry is cleaned up on release, the dropped sibling is in no queue at all, so no later `notifyWaiters()` can reach it.

This affects both `synchronization.semaphores` and `synchronization.mutex`, since both are backed by `prioritySemaphore`. The database-backed locks are unaffected: their `acquire()` updates the row for `holderKey` itself.

See the issue for logs of the wrong entry being popped and before/after hand-off latency measurements.

### Modifications
`workflow/sync/semaphore.go`: replace `s.pending.pop()` with `s.pending.remove(holderKey)`, an `O(log n)` removal via the queue's `itemByKey` map, so the entry removed is the one that acquired.

### Verification
New regression test `TestTryAcquireRemovesAcquiringKeyFromQueue`, run against all three semaphore implementations (in-memory, Postgres, MySQL). It queues `wf-01/node-aaa`, `wf-01/node-bbb` and `wf-02/node-ccc` with `limit: 1`, has the non-front `node-bbb` acquire, and asserts `node-aaa` is still queued and takes the lock once `node-bbb` releases. It fails on the pre-fix code (both the pending-queue assertion and the follow-up acquire) and passes after. `go test ./workflow/sync/` passes in full.

### Documentation
None needed — this is a bug fix with no user-facing API or behavior change beyond the lock hand-off no longer stalling.

### AI
Generative AI (Claude) was used to help the regression test.
All changes were reviewed and verified by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected semaphore queue cleanup so that only the workflow node acquiring a slot is removed from the pending queue.
  - Prevented unrelated queued nodes from being removed, ensuring they can acquire a slot when it becomes available.

- **Tests**
  - Added regression coverage confirming correct queue behavior across semaphore implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->