### PR TITLE
fix: scope offloaded node status query to the page. Fixes #16611

### DIFF
--- a/persist/sqldb/explosive_offload_node_status_repo.go
+++ b/persist/sqldb/explosive_offload_node_status_repo.go
@@ -26,7 +26,7 @@ func (n *explosiveOffloadNodeStatusRepo) Get(context.Context, string, string) (w
 	return nil, ErrOffloadNotSupported
 }
 
-func (n *explosiveOffloadNodeStatusRepo) List(context.Context, string) (map[UUIDVersion]wfv1.Nodes, error) {
+func (n *explosiveOffloadNodeStatusRepo) List(context.Context, string, []UUIDVersion) (map[UUIDVersion]wfv1.Nodes, error) {
 	return nil, ErrOffloadNotSupported
 }
 

--- a/persist/sqldb/mocks/OffloadNodeStatusRepo.go
+++ b/persist/sqldb/mocks/OffloadNodeStatusRepo.go
@@ -67,13 +67,13 @@ func (_m *OffloadNodeStatusRepo) IsEnabled() bool {
 	return r0
 }
 
-// List provides a mock function with given fields: namespace
-func (_m *OffloadNodeStatusRepo) List(ctx context.Context, namespace string) (map[sqldb.UUIDVersion]v1alpha1.Nodes, error) {
-	ret := _m.Called(namespace)
+// List provides a mock function with given fields: namespace, keys
+func (_m *OffloadNodeStatusRepo) List(ctx context.Context, namespace string, keys []sqldb.UUIDVersion) (map[sqldb.UUIDVersion]v1alpha1.Nodes, error) {
+	ret := _m.Called(namespace, keys)
 
 	var r0 map[sqldb.UUIDVersion]v1alpha1.Nodes
-	if rf, ok := ret.Get(0).(func(string) map[sqldb.UUIDVersion]v1alpha1.Nodes); ok {
-		r0 = rf(namespace)
+	if rf, ok := ret.Get(0).(func(string, []sqldb.UUIDVersion) map[sqldb.UUIDVersion]v1alpha1.Nodes); ok {
+		r0 = rf(namespace, keys)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[sqldb.UUIDVersion]v1alpha1.Nodes)
@@ -81,8 +81,8 @@ func (_m *OffloadNodeStatusRepo) List(ctx context.Context, namespace string) (ma
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(namespace)
+	if rf, ok := ret.Get(1).(func(string, []sqldb.UUIDVersion) error); ok {
+		r1 = rf(namespace, keys)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/persist/sqldb/offload_node_status_repo.go
+++ b/persist/sqldb/offload_node_status_repo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,8 +16,6 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/sqldb"
 )
-
-const OffloadNodeStatusDisabled = "Workflow has offloaded nodes, but offloading has been disabled"
 
 type UUIDVersion struct {
 	UID     string `db:"uid"`
@@ -149,12 +148,15 @@ func (wdc *nodeOffloadRepo) Get(ctx context.Context, uid, version string) (wfv1.
 	return nodes, nil
 }
 
+// offloadListBatchSize caps how many keys go into a single query. MySQL and Postgres allow
+// 65535 placeholders per prepared statement and each pair costs two, so this leaves plenty of
+// headroom. A ceiling is needed because the caller decides the key count: ListWorkflows treats
+// an unset limit as "the whole namespace", and `argo list` defaults --chunk-size to 0.
+const offloadListBatchSize = 1000
+
 // uuidVersionIn matches exactly the given (uid, version) pairs. Written as OR-of-ANDs rather
 // than a row value `(uid, version) IN ((?,?),...)` so that it behaves the same on MySQL,
-// MariaDB, Postgres and SQLite.
-//
-// Each pair costs two placeholders, so this tops out at roughly 32k pairs on MySQL. A page
-// that large is not a real scenario; batch the keys here if that ever changes.
+// MariaDB and Postgres.
 func uuidVersionIn(keys []UUIDVersion) db.LogicalExpr {
 	conds := make([]db.LogicalExpr, len(keys))
 	for i, key := range keys {
@@ -171,33 +173,34 @@ func (wdc *nodeOffloadRepo) List(ctx context.Context, namespace string, keys []U
 		return map[UUIDVersion]wfv1.Nodes{}, nil
 	}
 	wdc.log.WithFields(logging.Fields{"namespace": namespace, "keys": len(keys)}).Debug(ctx, "Listing offloaded nodes")
-	var res map[UUIDVersion]wfv1.Nodes
-	err := wdc.sessionProxy.With(ctx, func(s db.Session) error {
-		var records []nodesRecord
-		err := s.SQL().
-			Select("uid", "version", "nodes").
-			From(wdc.tableName).
-			Where(db.Cond{"clustername": wdc.clusterName}).
-			And(namespaceEqual(namespace)).
-			And(uuidVersionIn(keys)).
-			All(&records)
-		if err != nil {
-			return err
-		}
-
-		res = make(map[UUIDVersion]wfv1.Nodes)
-		for _, r := range records {
-			nodes := &wfv1.Nodes{}
-			err = json.Unmarshal([]byte(r.Nodes), nodes)
+	res := make(map[UUIDVersion]wfv1.Nodes)
+	for batch := range slices.Chunk(keys, offloadListBatchSize) {
+		err := wdc.sessionProxy.With(ctx, func(s db.Session) error {
+			var records []nodesRecord
+			err := s.SQL().
+				Select("uid", "version", "nodes").
+				From(wdc.tableName).
+				Where(db.Cond{"clustername": wdc.clusterName}).
+				And(namespaceEqual(namespace)).
+				And(uuidVersionIn(batch)).
+				All(&records)
 			if err != nil {
 				return err
 			}
-			res[UUIDVersion{UID: r.UID, Version: r.Version}] = *nodes
+
+			for _, r := range records {
+				nodes := &wfv1.Nodes{}
+				err = json.Unmarshal([]byte(r.Nodes), nodes)
+				if err != nil {
+					return err
+				}
+				res[UUIDVersion{UID: r.UID, Version: r.Version}] = *nodes
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 	return res, nil
 }

--- a/persist/sqldb/offload_node_status_repo.go
+++ b/persist/sqldb/offload_node_status_repo.go
@@ -26,7 +26,7 @@ type UUIDVersion struct {
 type OffloadNodeStatusRepo interface {
 	Save(ctx context.Context, uid, namespace string, nodes wfv1.Nodes) (string, error)
 	Get(ctx context.Context, uid, version string) (wfv1.Nodes, error)
-	List(ctx context.Context, namespace string) (map[UUIDVersion]wfv1.Nodes, error)
+	List(ctx context.Context, namespace string, keys []UUIDVersion) (map[UUIDVersion]wfv1.Nodes, error)
 	ListOldOffloads(ctx context.Context, namespace string) (map[string][]string, error)
 	Delete(ctx context.Context, uid, version string) error
 	IsEnabled() bool
@@ -149,8 +149,28 @@ func (wdc *nodeOffloadRepo) Get(ctx context.Context, uid, version string) (wfv1.
 	return nodes, nil
 }
 
-func (wdc *nodeOffloadRepo) List(ctx context.Context, namespace string) (map[UUIDVersion]wfv1.Nodes, error) {
-	wdc.log.WithFields(logging.Fields{"namespace": namespace}).Debug(ctx, "Listing offloaded nodes")
+// uuidVersionIn matches exactly the given (uid, version) pairs. Written as OR-of-ANDs rather
+// than a row value `(uid, version) IN ((?,?),...)` so that it behaves the same on MySQL,
+// MariaDB, Postgres and SQLite.
+//
+// Each pair costs two placeholders, so this tops out at roughly 32k pairs on MySQL. A page
+// that large is not a real scenario; batch the keys here if that ever changes.
+func uuidVersionIn(keys []UUIDVersion) db.LogicalExpr {
+	conds := make([]db.LogicalExpr, len(keys))
+	for i, key := range keys {
+		conds[i] = db.And(db.Cond{"uid": key.UID}, db.Cond{"version": key.Version})
+	}
+	return db.Or(conds...)
+}
+
+// List returns the offloaded nodes for the given keys only.
+func (wdc *nodeOffloadRepo) List(ctx context.Context, namespace string, keys []UUIDVersion) (map[UUIDVersion]wfv1.Nodes, error) {
+	// This is not merely an optimisation: db.Or() with no arguments is an empty condition,
+	// so the query would silently widen back to every nodes blob in the namespace.
+	if len(keys) == 0 {
+		return map[UUIDVersion]wfv1.Nodes{}, nil
+	}
+	wdc.log.WithFields(logging.Fields{"namespace": namespace, "keys": len(keys)}).Debug(ctx, "Listing offloaded nodes")
 	var res map[UUIDVersion]wfv1.Nodes
 	err := wdc.sessionProxy.With(ctx, func(s db.Session) error {
 		var records []nodesRecord
@@ -159,6 +179,7 @@ func (wdc *nodeOffloadRepo) List(ctx context.Context, namespace string) (map[UUI
 			From(wdc.tableName).
 			Where(db.Cond{"clustername": wdc.clusterName}).
 			And(namespaceEqual(namespace)).
+			And(uuidVersionIn(keys)).
 			All(&records)
 		if err != nil {
 			return err

--- a/persist/sqldb/offload_node_status_repo_mysql_test.go
+++ b/persist/sqldb/offload_node_status_repo_mysql_test.go
@@ -1,0 +1,76 @@
+//go:build !windows
+
+package sqldb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+	usqldb "github.com/argoproj/argo-workflows/v4/util/sqldb"
+)
+
+// setupMySQLOffloadTest starts a MySQL or MariaDB container and returns an offload repository.
+func setupMySQLOffloadTest(ctx context.Context, t *testing.T, v usqldb.MySQLVariant) OffloadNodeStatusRepo {
+	t.Helper()
+	repo, err := NewOffloadNodeStatusRepo(ctx, logging.RequireLoggerFromContext(ctx), setupMySQLTest(ctx, t, v), "test", "argo_workflows")
+	require.NoError(t, err)
+	return repo
+}
+
+// saveOffload writes a node status and returns the version it was stored under.
+func saveOffload(ctx context.Context, t *testing.T, repo OffloadNodeStatusRepo, uid, nodeName string) string {
+	t.Helper()
+	version, err := repo.Save(ctx, uid, "argo", wfv1.Nodes{nodeName: wfv1.NodeStatus{ID: nodeName}})
+	require.NoError(t, err)
+	return version
+}
+
+// TestMySQLListOnlyReturnsRequestedKeys covers the behaviour the list path depends on: the
+// query is scoped to the keys it is given, so a caller that needs one page of workflows does
+// not pull every offloaded blob in the namespace.
+func TestMySQLListOnlyReturnsRequestedKeys(t *testing.T) {
+	for name, variant := range usqldb.MySQLVariants {
+		t.Run(name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			repo := setupMySQLOffloadTest(ctx, t, variant)
+
+			wantedA := UUIDVersion{UID: "uid-a", Version: saveOffload(ctx, t, repo, "uid-a", "node-a")}
+			wantedB := UUIDVersion{UID: "uid-b", Version: saveOffload(ctx, t, repo, "uid-b", "node-b")}
+			unwanted := UUIDVersion{UID: "uid-c", Version: saveOffload(ctx, t, repo, "uid-c", "node-c")}
+
+			got, err := repo.List(ctx, "argo", []UUIDVersion{wantedA, wantedB})
+			require.NoError(t, err)
+
+			assert.Len(t, got, 2)
+			assert.Contains(t, got, wantedA)
+			assert.Contains(t, got, wantedB)
+			assert.NotContains(t, got, unwanted, "a key that was not asked for must not come back")
+		})
+	}
+}
+
+// TestMySQLListExcludesSupersededVersions pins down why the version has to be part of the
+// condition. Older offloads of the same workflow stay in the table until they are garbage
+// collected, so filtering on the uid alone would drag those blobs back too.
+// Dialect portability is already covered on both engines by TestMySQLListOnlyReturnsRequestedKeys,
+// so one engine is enough here.
+func TestMySQLListExcludesSupersededVersions(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	repo := setupMySQLOffloadTest(ctx, t, usqldb.MySQLVariants["MySQL"])
+
+	oldVersion := saveOffload(ctx, t, repo, "uid-a", "node-old")
+	newVersion := saveOffload(ctx, t, repo, "uid-a", "node-new")
+	require.NotEqual(t, oldVersion, newVersion, "the two writes must produce different versions")
+
+	got, err := repo.List(ctx, "argo", []UUIDVersion{{UID: "uid-a", Version: newVersion}})
+	require.NoError(t, err)
+
+	assert.Len(t, got, 1)
+	assert.Contains(t, got, UUIDVersion{UID: "uid-a", Version: newVersion})
+	assert.NotContains(t, got, UUIDVersion{UID: "uid-a", Version: oldVersion})
+}

--- a/persist/sqldb/offload_node_status_repo_mysql_test.go
+++ b/persist/sqldb/offload_node_status_repo_mysql_test.go
@@ -31,17 +31,32 @@ func saveOffload(ctx context.Context, t *testing.T, repo OffloadNodeStatusRepo, 
 }
 
 // TestMySQLListOnlyReturnsRequestedKeys covers the behaviour the list path depends on: the
-// query is scoped to the keys it is given, so a caller that needs one page of workflows does
+// query matches whole (uid, version) pairs, so a caller that needs one page of workflows does
 // not pull every offloaded blob in the namespace.
+//
+// Save deliberately leaves superseded rows behind for the garbage collector, so uid-a and uid-b
+// each have two versions here and only one version of each is requested.
+//
+// The version is a hash of the node contents, so two workflows only share a version value when
+// they store identical nodes. That is arranged deliberately: without it every version value is
+// unique to one uid, and a `uid IN (...) AND version IN (...)` cross-product happens to return
+// the right rows anyway. With shared version values the cross-product matches all four rows,
+// while matching whole pairs returns two.
 func TestMySQLListOnlyReturnsRequestedKeys(t *testing.T) {
 	for name, variant := range usqldb.MySQLVariants {
 		t.Run(name, func(t *testing.T) {
 			ctx := logging.TestContext(t.Context())
 			repo := setupMySQLOffloadTest(ctx, t, variant)
 
-			wantedA := UUIDVersion{UID: "uid-a", Version: saveOffload(ctx, t, repo, "uid-a", "node-a")}
-			wantedB := UUIDVersion{UID: "uid-b", Version: saveOffload(ctx, t, repo, "uid-b", "node-b")}
+			versionX := saveOffload(ctx, t, repo, "uid-a", "node-x")
+			versionY := saveOffload(ctx, t, repo, "uid-a", "node-y")
+			require.NotEqual(t, versionX, versionY, "different nodes must produce different versions")
+			require.Equal(t, versionX, saveOffload(ctx, t, repo, "uid-b", "node-x"), "identical nodes must share a version")
+			require.Equal(t, versionY, saveOffload(ctx, t, repo, "uid-b", "node-y"), "identical nodes must share a version")
 			unwanted := UUIDVersion{UID: "uid-c", Version: saveOffload(ctx, t, repo, "uid-c", "node-c")}
+
+			wantedA := UUIDVersion{UID: "uid-a", Version: versionX}
+			wantedB := UUIDVersion{UID: "uid-b", Version: versionY}
 
 			got, err := repo.List(ctx, "argo", []UUIDVersion{wantedA, wantedB})
 			require.NoError(t, err)
@@ -49,28 +64,9 @@ func TestMySQLListOnlyReturnsRequestedKeys(t *testing.T) {
 			assert.Len(t, got, 2)
 			assert.Contains(t, got, wantedA)
 			assert.Contains(t, got, wantedB)
-			assert.NotContains(t, got, unwanted, "a key that was not asked for must not come back")
+			assert.NotContains(t, got, UUIDVersion{UID: "uid-a", Version: versionY}, "a version that was not asked for must not come back")
+			assert.NotContains(t, got, UUIDVersion{UID: "uid-b", Version: versionX}, "a version that was not asked for must not come back")
+			assert.NotContains(t, got, unwanted, "a uid that was not asked for must not come back")
 		})
 	}
-}
-
-// TestMySQLListExcludesSupersededVersions pins down why the version has to be part of the
-// condition. Older offloads of the same workflow stay in the table until they are garbage
-// collected, so filtering on the uid alone would drag those blobs back too.
-// Dialect portability is already covered on both engines by TestMySQLListOnlyReturnsRequestedKeys,
-// so one engine is enough here.
-func TestMySQLListExcludesSupersededVersions(t *testing.T) {
-	ctx := logging.TestContext(t.Context())
-	repo := setupMySQLOffloadTest(ctx, t, usqldb.MySQLVariants["MySQL"])
-
-	oldVersion := saveOffload(ctx, t, repo, "uid-a", "node-old")
-	newVersion := saveOffload(ctx, t, repo, "uid-a", "node-new")
-	require.NotEqual(t, oldVersion, newVersion, "the two writes must produce different versions")
-
-	got, err := repo.List(ctx, "argo", []UUIDVersion{{UID: "uid-a", Version: newVersion}})
-	require.NoError(t, err)
-
-	assert.Len(t, got, 1)
-	assert.Contains(t, got, UUIDVersion{UID: "uid-a", Version: newVersion})
-	assert.NotContains(t, got, UUIDVersion{UID: "uid-a", Version: oldVersion})
 }

--- a/persist/sqldb/offload_node_status_repo_test.go
+++ b/persist/sqldb/offload_node_status_repo_test.go
@@ -7,7 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
+
+// Test_ListWithoutKeys guards the empty-keys early return. Without it the generated condition
+// is empty, which would widen the query back to the whole namespace. A zero-value repo has no
+// session, so anything past the guard panics rather than quietly querying.
+func Test_ListWithoutKeys(t *testing.T) {
+	got, err := (&nodeOffloadRepo{}).List(logging.TestContext(t.Context()), "argo", nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
 
 func Test_nodeStatusVersion(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {

--- a/persist/sqldb/workflow_archive_mysql_test.go
+++ b/persist/sqldb/workflow_archive_mysql_test.go
@@ -27,6 +27,13 @@ import (
 // setupMySQLArchiveTest starts a MySQL or MariaDB container, runs migrations, and returns a WorkflowArchive.
 func setupMySQLArchiveTest(ctx context.Context, t *testing.T, v usqldb.MySQLVariant) WorkflowArchive {
 	t.Helper()
+	return NewWorkflowArchive(setupMySQLTest(ctx, t, v), "test", "", instanceid.NewService(""))
+}
+
+// setupMySQLTest starts a MySQL or MariaDB container, runs migrations, and returns a session
+// proxy the caller can build any repository on.
+func setupMySQLTest(ctx context.Context, t *testing.T, v usqldb.MySQLVariant) *usqldb.SessionProxy {
+	t.Helper()
 
 	c, err := testmysql.Run(ctx,
 		v.Image,
@@ -73,7 +80,7 @@ func setupMySQLArchiveTest(ctx context.Context, t *testing.T, v usqldb.MySQLVari
 
 	t.Cleanup(func() { proxy.Close() })
 
-	return NewWorkflowArchive(proxy, "test", "", instanceid.NewService(""))
+	return proxy
 }
 
 // TestMySQLListWorkflows verifies that JSON_EXTRACT/JSON_UNQUOTE queries in

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -285,19 +287,22 @@ func (s *workflowServer) ListWorkflows(ctx context.Context, req *workflowpkg.Wor
 	}
 
 	cleaner := fields.NewCleaner(req.Fields)
-	logger := logging.RequireLoggerFromContext(ctx)
 	if s.offloadNodeStatusRepo.IsEnabled() && !cleaner.WillExclude("items.status.nodes") {
-		offloadedNodes, err := s.offloadNodeStatusRepo.List(ctx, req.Namespace)
-		if err != nil {
-			return nil, sutils.ToStatusError(err, codes.Internal)
-		}
+		// This page is already resolved, so we know exactly which offloaded rows we need.
+		offloaded := map[int]sqldb.UUIDVersion{}
 		for i, wf := range wfs {
 			if wf.Status.IsOffloadNodeStatus() {
-				if s.offloadNodeStatusRepo.IsEnabled() {
-					wfs[i].Status.Nodes = offloadedNodes[sqldb.UUIDVersion{UID: string(wf.UID), Version: wf.GetOffloadNodeStatusVersion()}]
-				} else {
-					logger.WithFields(logging.Fields{"namespace": wf.Namespace, "name": wf.Name}).Warn(ctx, sqldb.OffloadNodeStatusDisabled)
-				}
+				offloaded[i] = sqldb.UUIDVersion{UID: string(wf.UID), Version: wf.GetOffloadNodeStatusVersion()}
+			}
+		}
+		// Nothing on this page is offloaded, so there is nothing to fetch.
+		if len(offloaded) > 0 {
+			offloadedNodes, err := s.offloadNodeStatusRepo.List(ctx, req.Namespace, slices.Collect(maps.Values(offloaded)))
+			if err != nil {
+				return nil, sutils.ToStatusError(err, codes.Internal)
+			}
+			for i, key := range offloaded {
+				wfs[i].Status.Nodes = offloadedNodes[key]
 			}
 		}
 	}

--- a/server/workflow/workflow_server_offload_test.go
+++ b/server/workflow/workflow_server_offload_test.go
@@ -3,43 +3,45 @@ package workflow
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/fake"
-	ktesting "k8s.io/client-go/testing"
 
 	"github.com/argoproj/argo-workflows/v4/persist/sqldb"
 	"github.com/argoproj/argo-workflows/v4/persist/sqldb/mocks"
 	workflowpkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflow"
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	v1alpha "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
-	"github.com/argoproj/argo-workflows/v4/server/auth"
 	authtypes "github.com/argoproj/argo-workflows/v4/server/auth/types"
-	"github.com/argoproj/argo-workflows/v4/server/clusterworkflowtemplate"
 	"github.com/argoproj/argo-workflows/v4/server/workflow/store"
-	"github.com/argoproj/argo-workflows/v4/server/workflowtemplate"
 	"github.com/argoproj/argo-workflows/v4/util/instanceid"
-	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
 
-// offloadedWorkflow builds a workflow whose node status lives in the offload table.
-func offloadedWorkflow(name, uid, version string) v1alpha1.Workflow {
+// offloadedWorkflow builds a workflow whose node status lives in the offload table. Pages are
+// ordered by startedat descending, so startedAt decides which page a fixture lands on.
+func offloadedWorkflow(name, uid, version string, startedAt time.Time) v1alpha1.Workflow {
 	return v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argo", UID: types.UID(uid)},
-		Status:     v1alpha1.WorkflowStatus{OffloadNodeStatusVersion: version},
+		Status: v1alpha1.WorkflowStatus{
+			OffloadNodeStatusVersion: version,
+			StartedAt:                metav1.NewTime(startedAt),
+		},
 	}
 }
 
+// inlineWorkflow builds a workflow that keeps its node status on the object itself, so the
+// offload table has nothing for it.
+func inlineWorkflow(name, uid string) v1alpha1.Workflow {
+	return offloadedWorkflow(name, uid, "", time.Time{})
+}
+
 // offloadTestServer builds the smallest server that can serve ListWorkflows, and hands back
-// the offload mock so tests can assert on how it was called. It deliberately does not reuse
-// getWorkflowServer, which is shared by many other tests and does not expose the mock.
+// the offload mock so tests can assert on how it was called.
 func offloadTestServer(t *testing.T, wfs ...v1alpha1.Workflow) (Server, context.Context, *mocks.OffloadNodeStatusRepo) {
 	t.Helper()
 
@@ -51,17 +53,6 @@ func offloadTestServer(t *testing.T, wfs ...v1alpha1.Workflow) (Server, context.
 	archivedRepo.On("ListWorkflows", mock.Anything, mock.Anything).Return(v1alpha1.Workflows{}, nil)
 	archivedRepo.On("HasMoreWorkflows", mock.Anything, mock.Anything).Return(false, nil)
 
-	kubeClientSet := fake.NewClientset()
-	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &authorizationv1.SelfSubjectAccessReview{
-			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
-		}, nil
-	})
-
-	wfClientset := v1alpha.NewClientset()
-	ctx := logging.TestContext(t.Context())
-	ctx = context.WithValue(context.WithValue(context.WithValue(ctx, auth.WfKey, wfClientset), auth.KubeKey, kubeClientSet), auth.ClaimsKey, &authtypes.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
-
 	// An empty instance ID keeps the store from requiring an instance-id label on the fixtures.
 	instanceIDSvc := instanceid.NewService("")
 	wfStore, err := store.NewSQLiteStore(instanceIDSvc)
@@ -70,40 +61,66 @@ func offloadTestServer(t *testing.T, wfs ...v1alpha1.Workflow) (Server, context.
 		require.NoError(t, wfStore.Add(&wfs[i]))
 	}
 
-	namespace := "argo"
-	server := NewServer(ctx, instanceIDSvc, offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, nil, workflowtemplate.NewClientStore(), clusterworkflowtemplate.NewClientStore(), nil, &namespace, nil)
+	server, ctx := newTestServer(t, testServerOpts{
+		instanceIDSvc: instanceIDSvc,
+		offloadRepo:   offloadNodeStatusRepo,
+		archivedRepo:  archivedRepo,
+		wfClientset:   v1alpha.NewClientset(),
+		wfLister:      wfStore,
+		namespace:     "argo",
+		claims:        &authtypes.Claims{Claims: jwt.Claims{Subject: "my-sub"}},
+	})
 	return server, ctx, offloadNodeStatusRepo
 }
 
 // TestListWorkflows_PassesOnlyPageKeys asserts that the offload query is scoped to the
-// workflows on this page, rather than to the whole namespace.
+// workflows on this page, and that what comes back is attached to the right workflow.
 func TestListWorkflows_PassesOnlyPageKeys(t *testing.T) {
-	wantedA := offloadedWorkflow("offloaded-a", "uid-a", "v1")
-	wantedB := offloadedWorkflow("offloaded-b", "uid-b", "v2")
-	server, ctx, offloadNodeStatusRepo := offloadTestServer(t, wantedA, wantedB, offloadedWorkflow("inline", "uid-c", ""))
+	now := time.Now()
+	first := offloadedWorkflow("offloaded-first", "uid-first", "v1", now)
+	second := offloadedWorkflow("offloaded-second", "uid-second", "v2", now.Add(-time.Minute))
+	// Offloaded as well, but a Limit of 2 puts it on the next page.
+	nextPage := offloadedWorkflow("offloaded-next-page", "uid-next-page", "v3", now.Add(-2*time.Minute))
+	server, ctx, offloadNodeStatusRepo := offloadTestServer(t, first, second, nextPage)
 
-	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
+	secondNodes := v1alpha1.Nodes{"n": v1alpha1.NodeStatus{ID: "n", Name: "belongs-to-second"}}
+	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).
+		Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{{UID: "uid-second", Version: "v2"}: secondNodes}, nil)
 
-	_, err := server.ListWorkflows(ctx, &workflowpkg.WorkflowListRequest{Namespace: "argo"})
+	list, err := server.ListWorkflows(ctx, &workflowpkg.WorkflowListRequest{
+		Namespace:   "argo",
+		ListOptions: &metav1.ListOptions{Limit: 2},
+	})
 	require.NoError(t, err)
 
 	offloadNodeStatusRepo.AssertNumberOfCalls(t, "List", 1)
 	call := offloadNodeStatusRepo.Calls[len(offloadNodeStatusRepo.Calls)-1]
-	require.Equal(t, "List", call.Method)
 	assert.Equal(t, "argo", call.Arguments[0])
 	assert.ElementsMatch(t, []sqldb.UUIDVersion{
-		{UID: "uid-a", Version: "v1"},
-		{UID: "uid-b", Version: "v2"},
+		{UID: "uid-first", Version: "v1"},
+		{UID: "uid-second", Version: "v2"},
 	}, call.Arguments[1], "List must be given exactly the offloaded keys on this page")
+
+	// The page is sorted before it is returned, so look the fixtures up by name rather than
+	// by position.
+	require.Len(t, list.Items, 2)
+	nodesByName := map[string]v1alpha1.Nodes{}
+	for _, wf := range list.Items {
+		nodesByName[wf.Name] = wf.Status.Nodes
+	}
+	assert.Equal(t, secondNodes, nodesByName["offloaded-second"], "nodes must land on the workflow they were keyed by")
+	assert.Empty(t, nodesByName["offloaded-first"], "a workflow with no offloaded row must not pick up another one's nodes")
 }
 
 // TestListWorkflows_SkipsQueryWhenPageHasNoOffload asserts that a page with nothing offloaded
 // issues no offload query at all. This is the common case for most users.
 func TestListWorkflows_SkipsQueryWhenPageHasNoOffload(t *testing.T) {
-	server, ctx, offloadNodeStatusRepo := offloadTestServer(t, offloadedWorkflow("inline-a", "uid-a", ""), offloadedWorkflow("inline-b", "uid-b", ""))
+	server, ctx, offloadNodeStatusRepo := offloadTestServer(t, inlineWorkflow("inline-a", "uid-a"), inlineWorkflow("inline-b", "uid-b"))
 
 	_, err := server.ListWorkflows(ctx, &workflowpkg.WorkflowListRequest{Namespace: "argo"})
 	require.NoError(t, err)
 
-	offloadNodeStatusRepo.AssertNotCalled(t, "List")
+	// AssertNotCalled without argument matchers can never fail: it looks for a recorded call
+	// matching the (empty) argument list it was given, which no real two-argument call does.
+	offloadNodeStatusRepo.AssertNumberOfCalls(t, "List", 0)
 }

--- a/server/workflow/workflow_server_offload_test.go
+++ b/server/workflow/workflow_server_offload_test.go
@@ -1,0 +1,109 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/argoproj/argo-workflows/v4/persist/sqldb"
+	"github.com/argoproj/argo-workflows/v4/persist/sqldb/mocks"
+	workflowpkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflow"
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	v1alpha "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned/fake"
+	"github.com/argoproj/argo-workflows/v4/server/auth"
+	authtypes "github.com/argoproj/argo-workflows/v4/server/auth/types"
+	"github.com/argoproj/argo-workflows/v4/server/clusterworkflowtemplate"
+	"github.com/argoproj/argo-workflows/v4/server/workflow/store"
+	"github.com/argoproj/argo-workflows/v4/server/workflowtemplate"
+	"github.com/argoproj/argo-workflows/v4/util/instanceid"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+// offloadedWorkflow builds a workflow whose node status lives in the offload table.
+func offloadedWorkflow(name, uid, version string) v1alpha1.Workflow {
+	return v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "argo", UID: types.UID(uid)},
+		Status:     v1alpha1.WorkflowStatus{OffloadNodeStatusVersion: version},
+	}
+}
+
+// offloadTestServer builds the smallest server that can serve ListWorkflows, and hands back
+// the offload mock so tests can assert on how it was called. It deliberately does not reuse
+// getWorkflowServer, which is shared by many other tests and does not expose the mock.
+func offloadTestServer(t *testing.T, wfs ...v1alpha1.Workflow) (Server, context.Context, *mocks.OffloadNodeStatusRepo) {
+	t.Helper()
+
+	offloadNodeStatusRepo := &mocks.OffloadNodeStatusRepo{}
+	offloadNodeStatusRepo.On("IsEnabled", mock.Anything).Return(true)
+
+	archivedRepo := &mocks.WorkflowArchive{}
+	archivedRepo.On("CountWorkflows", mock.Anything, mock.Anything).Return(int64(0), nil)
+	archivedRepo.On("ListWorkflows", mock.Anything, mock.Anything).Return(v1alpha1.Workflows{}, nil)
+	archivedRepo.On("HasMoreWorkflows", mock.Anything, mock.Anything).Return(false, nil)
+
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+		}, nil
+	})
+
+	wfClientset := v1alpha.NewClientset()
+	ctx := logging.TestContext(t.Context())
+	ctx = context.WithValue(context.WithValue(context.WithValue(ctx, auth.WfKey, wfClientset), auth.KubeKey, kubeClientSet), auth.ClaimsKey, &authtypes.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
+
+	// An empty instance ID keeps the store from requiring an instance-id label on the fixtures.
+	instanceIDSvc := instanceid.NewService("")
+	wfStore, err := store.NewSQLiteStore(instanceIDSvc)
+	require.NoError(t, err)
+	for i := range wfs {
+		require.NoError(t, wfStore.Add(&wfs[i]))
+	}
+
+	namespace := "argo"
+	server := NewServer(ctx, instanceIDSvc, offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, nil, workflowtemplate.NewClientStore(), clusterworkflowtemplate.NewClientStore(), nil, &namespace, nil)
+	return server, ctx, offloadNodeStatusRepo
+}
+
+// TestListWorkflows_PassesOnlyPageKeys asserts that the offload query is scoped to the
+// workflows on this page, rather than to the whole namespace.
+func TestListWorkflows_PassesOnlyPageKeys(t *testing.T) {
+	wantedA := offloadedWorkflow("offloaded-a", "uid-a", "v1")
+	wantedB := offloadedWorkflow("offloaded-b", "uid-b", "v2")
+	server, ctx, offloadNodeStatusRepo := offloadTestServer(t, wantedA, wantedB, offloadedWorkflow("inline", "uid-c", ""))
+
+	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
+
+	_, err := server.ListWorkflows(ctx, &workflowpkg.WorkflowListRequest{Namespace: "argo"})
+	require.NoError(t, err)
+
+	offloadNodeStatusRepo.AssertNumberOfCalls(t, "List", 1)
+	call := offloadNodeStatusRepo.Calls[len(offloadNodeStatusRepo.Calls)-1]
+	require.Equal(t, "List", call.Method)
+	assert.Equal(t, "argo", call.Arguments[0])
+	assert.ElementsMatch(t, []sqldb.UUIDVersion{
+		{UID: "uid-a", Version: "v1"},
+		{UID: "uid-b", Version: "v2"},
+	}, call.Arguments[1], "List must be given exactly the offloaded keys on this page")
+}
+
+// TestListWorkflows_SkipsQueryWhenPageHasNoOffload asserts that a page with nothing offloaded
+// issues no offload query at all. This is the common case for most users.
+func TestListWorkflows_SkipsQueryWhenPageHasNoOffload(t *testing.T) {
+	server, ctx, offloadNodeStatusRepo := offloadTestServer(t, offloadedWorkflow("inline-a", "uid-a", ""), offloadedWorkflow("inline-b", "uid-b", ""))
+
+	_, err := server.ListWorkflows(ctx, &workflowpkg.WorkflowListRequest{Namespace: "argo"})
+	require.NoError(t, err)
+
+	offloadNodeStatusRepo.AssertNotCalled(t, "List")
+}

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -578,6 +578,43 @@ const clusterworkflowtmpl = `
 
 const userEmailLabel = "my-sub.at.your.org"
 
+// testServerOpts collects the parts the harnesses in this package actually vary. Everything
+// they share — the selfsubjectaccessreviews reactor, the auth context chain, the template
+// stores and the 12-argument NewServer call — lives in newTestServer.
+type testServerOpts struct {
+	instanceIDSvc instanceid.Service
+	offloadRepo   sqldb.OffloadNodeStatusRepo
+	archivedRepo  sqldb.WorkflowArchive
+	wfClientset   versioned.Interface
+	wfLister      store.WorkflowLister
+	wfStore       store.WorkflowStore
+	namespace     string
+	claims        *types.Claims
+	artifactRepos artifactrepositories.Interface
+}
+
+// newTestServer builds a workflow server backed by fakes. Callers own the mocks they pass in,
+// so a test that needs to assert on one keeps its own reference.
+func newTestServer(t *testing.T, o testServerOpts) (Server, context.Context) {
+	t.Helper()
+
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+		}, nil
+	})
+
+	ctx := logging.TestContext(t.Context())
+	ctx = context.WithValue(ctx, auth.WfKey, o.wfClientset)
+	ctx = context.WithValue(ctx, auth.KubeKey, kubeClientSet)
+	ctx = context.WithValue(ctx, auth.ClaimsKey, o.claims)
+
+	server := NewServer(ctx, o.instanceIDSvc, o.offloadRepo, o.archivedRepo, o.wfClientset, o.wfLister, o.wfStore,
+		workflowtemplate.NewClientStore(), clusterworkflowtemplate.NewClientStore(), nil, &o.namespace, o.artifactRepos)
+	return server, ctx
+}
+
 func getWorkflowServer(t *testing.T) (workflowpkg.WorkflowServiceServer, context.Context) {
 	t.Helper()
 	var unlabelledObj, wfObj1, wfObj2, wfObj3, wfObj4, wfObj5, failedWfObj v1alpha1.Workflow
@@ -637,16 +674,8 @@ func getWorkflowServer(t *testing.T) (workflowpkg.WorkflowServiceServer, context
 	archivedRepo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "test", Limit: -1, LabelRequirements: r}).Return(v1alpha1.Workflows{wfObj4}, nil)
 	archivedRepo.On("HasMoreWorkflows", mock.Anything, sutils.ListOptions{Namespace: "test", LabelRequirements: r}).Return(false, nil)
 
-	kubeClientSet := fake.NewClientset()
-	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &authorizationv1.SelfSubjectAccessReview{
-			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
-		}, nil
-	})
 	wfClientset := v1alpha.NewClientset(&unlabelledObj, &wfObj1, &wfObj2, &wfObj3, &wfObj4, &wfObj5, &failedWfObj, &wftmpl, &cronwfObj, &cwfTmpl)
 	wfClientset.PrependReactor("create", "workflows", generateNameReactor)
-	ctx := logging.TestContext(t.Context())
-	ctx = context.WithValue(context.WithValue(context.WithValue(ctx, auth.WfKey, wfClientset), auth.KubeKey, kubeClientSet), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}, Email: "my-sub@your.org"})
 	listOptions := &metav1.ListOptions{}
 	instanceIDSvc := instanceid.NewService("my-instanceid")
 	instanceIDSvc.With(listOptions)
@@ -663,11 +692,16 @@ func getWorkflowServer(t *testing.T) (workflowpkg.WorkflowServiceServer, context
 	if err = wfStore.Add(&wfObj5); err != nil {
 		panic(err)
 	}
-	namespaceAll := metav1.NamespaceAll
-	wftmplStore := workflowtemplate.NewClientStore()
-	cwftmplStore := clusterworkflowtemplate.NewClientStore()
-	server := NewServer(ctx, instanceIDSvc, offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll, nil)
-	return server, ctx
+	return newTestServer(t, testServerOpts{
+		instanceIDSvc: instanceIDSvc,
+		offloadRepo:   offloadNodeStatusRepo,
+		archivedRepo:  archivedRepo,
+		wfClientset:   wfClientset,
+		wfLister:      wfStore,
+		wfStore:       wfStore,
+		namespace:     metav1.NamespaceAll,
+		claims:        &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}, Email: "my-sub@your.org"},
+	})
 }
 
 // generateNameReactor implements the logic required for the GenerateName field to work when using
@@ -1505,34 +1539,27 @@ func getWorkflowServerWithArtifacts(t *testing.T, template runtime.Object, defau
 
 	archivedRepo := &mocks.WorkflowArchive{}
 
-	kubeClientSet := fake.NewSimpleClientset()
-	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &authorizationv1.SelfSubjectAccessReview{
-			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
-		}, nil
-	})
-
 	wfClientset := v1alpha.NewClientset(template)
 	wfClientset.PrependReactor("create", "workflows", generateNameReactor)
 
-	ctx := logging.TestContext(t.Context())
-	ctx = context.WithValue(ctx, auth.WfKey, wfClientset)
-	ctx = context.WithValue(ctx, auth.KubeKey, kubeClientSet)
-	ctx = context.WithValue(ctx, auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
-
-	wfStore, err := store.NewSQLiteStore(instanceid.NewService("my-instanceid"))
+	instanceIDSvc := instanceid.NewService("my-instanceid")
+	wfStore, err := store.NewSQLiteStore(instanceIDSvc)
 	require.NoError(t, err)
-
-	wftmplStore := workflowtemplate.NewClientStore()
-	cwftmplStore := clusterworkflowtemplate.NewClientStore()
 
 	var artifactRepos artifactrepositories.Interface
 	if defaultRepo != nil {
 		artifactRepos = armocks.DummyArtifactRepositories(defaultRepo)
 	}
 
-	namespaceAll := metav1.NamespaceAll
-	server := NewServer(ctx, instanceid.NewService("my-instanceid"), offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll, artifactRepos)
-
-	return server, ctx
+	return newTestServer(t, testServerOpts{
+		instanceIDSvc: instanceIDSvc,
+		offloadRepo:   offloadNodeStatusRepo,
+		archivedRepo:  archivedRepo,
+		wfClientset:   wfClientset,
+		wfLister:      wfStore,
+		wfStore:       wfStore,
+		namespace:     metav1.NamespaceAll,
+		claims:        &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}},
+		artifactRepos: artifactRepos,
+	})
 }

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -598,7 +598,7 @@ func getWorkflowServer(t *testing.T) (workflowpkg.WorkflowServiceServer, context
 
 	offloadNodeStatusRepo := &mocks.OffloadNodeStatusRepo{}
 	offloadNodeStatusRepo.On("IsEnabled", mock.Anything).Return(true)
-	offloadNodeStatusRepo.On("List", mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
+	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
 
 	archivedRepo := &mocks.WorkflowArchive{}
 
@@ -1501,7 +1501,7 @@ func getWorkflowServerWithArtifacts(t *testing.T, template runtime.Object, defau
 
 	offloadNodeStatusRepo := &mocks.OffloadNodeStatusRepo{}
 	offloadNodeStatusRepo.On("IsEnabled", mock.Anything).Return(true)
-	offloadNodeStatusRepo.On("List", mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
+	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
 
 	archivedRepo := &mocks.WorkflowArchive{}
 

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -35,7 +35,7 @@ func Test_archivedWorkflowServer(t *testing.T) {
 	wfClient := &argofake.Clientset{}
 	offloadNodeStatusRepo := &mocks.OffloadNodeStatusRepo{}
 	offloadNodeStatusRepo.On("IsEnabled", mock.Anything).Return(true)
-	offloadNodeStatusRepo.On("List", mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
+	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
 	w := NewWorkflowArchiveServer(repo, offloadNodeStatusRepo, nil)
 	allowed := true
 	kubeClient.AddReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -19,7 +19,6 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	"github.com/argoproj/argo-workflows/v4/persist/sqldb"
 	"github.com/argoproj/argo-workflows/v4/persist/sqldb/mocks"
 	workflowarchivepkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflowarchive"
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
@@ -35,7 +34,6 @@ func Test_archivedWorkflowServer(t *testing.T) {
 	wfClient := &argofake.Clientset{}
 	offloadNodeStatusRepo := &mocks.OffloadNodeStatusRepo{}
 	offloadNodeStatusRepo.On("IsEnabled", mock.Anything).Return(true)
-	offloadNodeStatusRepo.On("List", mock.Anything, mock.Anything).Return(map[sqldb.UUIDVersion]v1alpha1.Nodes{}, nil)
 	w := NewWorkflowArchiveServer(repo, offloadNodeStatusRepo, nil)
 	allowed := true
 	kubeClient.AddReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #16611

### Motivation
<!-- TODO: Say why you made your changes. -->
`ListWorkflows` resolves a page of workflows and then calls `OffloadNodeStatusRepo`.List with only the namespace. As a result, the repository loads all offloaded node-status blobs in that namespace, even though the page usually needs only a small subset.

The required rows can already be identified by the existing primary key (clustername, uid, version). This PR reuses that key and introduces no schema or index changes.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->
- `OffloadNodeStatusRepo.List` now accepts the required `(uid, version)` pairs.
- `ListWorkflows` collects these keys from the resolved page and passes them to the repository.
- Added an early return for empty key sets to avoid accidental full-namespace queries.
- Skip offload lookups entirely when no workflows on the page use offloaded node status.

```mermaid
%%{init: {'theme':'base','themeVariables':{'actorBkg':'#ffffff','actorBorder':'#d1d5db','actorTextColor':'#374151','primaryTextColor':'#374151','lineColor':'#9ca3af','noteBkgColor':'#fffbeb','noteTextColor':'#4b5563','noteBorderColor':'#e5e7eb','messageTextColor':'#374151','sequenceNumberColor':'#ffffff'}}}%%
sequenceDiagram
    participant CLI as argo CLI / UI
    participant SRV as argo-server ListWorkflows
    participant SRC as live lister + archive
    participant DB as argo_workflows table

    CLI->>SRV: argo list — one page of 10
    SRV->>SRC: fetch this page (limit / offset applied)
    SRC-->>SRV: 10 items with UID + version — 2 are offloaded

    alt before — page keys are known, but not passed down
        rect rgb(255, 235, 238)
            SRV->>DB: ✗ SELECT nodes — namespace only, no uid, no LIMIT
            Note over DB: 20 offloaded rows here — all of them match
            DB-->>SRV: ✗ 20 blobs — 20.1 MB
            Note over SRV: 18 discarded, 2 used
        end
    else after — page keys go with the query
        rect rgb(232, 245, 233)
            SRV->>SRV: ✓ collect (uid, version) of the offloaded rows
            opt nothing on this page is offloaded
                Note over SRV: ✓ no query is issued at all
            end
            SRV->>DB: ✓ SELECT nodes — same query AND the 2 keys
            Note over DB: primary key is (clustername, uid, version)
            Note over DB: so each key is a point lookup, not a scan
            DB-->>SRV: ✓ exactly the 2 blobs this page needs
        end
    end

    SRV-->>CLI: one page of 10 workflows — identical response
```

### Verification

<!-- TODO: Say how you tested your changes. -->
Added tests covering:
- `ListWorkflows` passes only the required offloaded keys and skips the repository call when none are needed.
- Repository queries return only the requested `(uid, version)` pairs, including correct handling of multiple versions of the same workflow.
- Empty key sets return immediately without querying the database.

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

### AI
Claude Code (Opus 5) assisted with the analysis, implementation and tests. All changes were reviewed by the me.
<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Workflow listings now retrieve offloaded node status only for workflows shown on the current page.
  * Avoids unnecessary offload storage queries when no relevant workflows are present.

* **Bug Fixes**
  * Offloaded status results are now restricted to the requested workflow versions.
  * Empty requests return no results without querying storage.

* **Tests**
  * Added coverage for filtering, version handling, empty requests, and workflow listing behavior across supported database configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->