### PR TITLE
feat: add argo-workflows-crdinstaller image. Fixes #16621

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -51,7 +51,6 @@
     "artifactgc",
     "clientset",
     "clusterworkflowtemplate",
-    "crds",
     "Creds",
     "cronworkflow",
     "cronworkflows",

--- a/.cspell.json
+++ b/.cspell.json
@@ -51,6 +51,7 @@
     "artifactgc",
     "clientset",
     "clusterworkflowtemplate",
+    "crds",
     "Creds",
     "cronworkflow",
     "cronworkflows",

--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,5 @@ vendor
 !dist/workflow-controller
 !dist/argo
 !dist/argoexec
+# Re-include the full CRDs bundled into the argo-workflows-crdinstaller image
+!manifests/base/crds/full/argoproj.io_*.yaml

--- a/.features/pending/crd-installer-image.md
+++ b/.features/pending/crd-installer-image.md
@@ -1,0 +1,9 @@
+Description: New `argo-workflows-crdinstaller` image for installing the full CRDs
+Authors: [Alan Clucas](https://github.com/Joibel)
+Component: General
+Issues: 16621
+
+A new image, `quay.io/argoproj/argo-workflows-crdinstaller`, is published with each release.
+It bundles `kubectl` and the [full CRDs](https://argo-workflows.readthedocs.io/en/latest/installation/#full-crds) matching the release, and by default applies them using server-side apply.
+It is intended to run as a Kubernetes Job by installation tooling that cannot server-side apply the full CRDs itself, such as the community Helm chart, and works without network access to GitHub — including in air-gapped clusters.
+See [the CRD installer documentation](https://argo-workflows.readthedocs.io/en/latest/crd-installer/) for usage and the required RBAC.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         platform: [ linux/amd64, linux/arm64 ]
-        target: [ workflow-controller, argocli, argoexec, argoexec-nonroot ]
+        target: [ workflow-controller, argocli, argoexec, argoexec-nonroot, argo-workflows-crdinstaller ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -200,7 +200,7 @@ jobs:
             tag="latest"
           fi
 
-          targets="workflow-controller argoexec argoexec-nonroot argocli"
+          targets="workflow-controller argoexec argoexec-nonroot argocli argo-workflows-crdinstaller"
           for target in $targets; do
             if [ "$target" = "argoexec-nonroot" ]; then
               # Special handling for argoexec-nonroot: create argoexec:tag-nonroot manifest
@@ -228,7 +228,7 @@ jobs:
     strategy:
       matrix:
         platform: [ linux/amd64 ]
-        target: [ workflow-controller, argocli, argoexec, argoexec-nonroot ]
+        target: [ workflow-controller, argocli, argoexec, argoexec-nonroot, argo-workflows-crdinstaller ]
     steps:
       - name: Docker Login
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -421,6 +421,7 @@ jobs:
       - run: bom generate --image quay.io/argoproj/argocli:$VERSION -o dist/argocli.spdx
       - run: bom generate --image quay.io/argoproj/argoexec:$VERSION -o dist/argoexec.spdx
       - run: bom generate --image quay.io/argoproj/argoexec:$VERSION-nonroot -o dist/argoexec-nonroot.spdx
+      - run: bom generate --image quay.io/argoproj/argo-workflows-crdinstaller:$VERSION -o dist/argo-workflows-crdinstaller.spdx
       # pack the boms into one file to make it easy to download
       - run: tar -zcf dist/sbom.tar.gz dist/*.spdx
       - run: make release-notes VERSION=$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,9 +141,13 @@ ENTRYPOINT [ "argo" ]
 
 ####################################################################################################
 
-FROM registry.k8s.io/kubectl:v1.36.3 AS argo-workflows-crdinstaller
+FROM registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789 AS argo-workflows-crdinstaller
 
 USER 8737
+
+# The base image sets no HOME, so kubectl would put its discovery cache in
+# /.kube/cache, which UID 8737 cannot write. /tmp is world-writable (1777).
+ENV HOME=/tmp
 
 COPY manifests/base/crds/full/argoproj.io_*.yaml /crds/full/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,16 @@ COPY --from=argocli-build /go/src/github.com/argoproj/argo-workflows/dist/argo /
 ENTRYPOINT [ "argo" ]
 
 ####################################################################################################
+
+FROM registry.k8s.io/kubectl:v1.36.3 AS argo-workflows-crdinstaller
+
+USER 8737
+
+COPY manifests/base/crds/full/argoproj.io_*.yaml /crds/full/
+
+CMD [ "apply", "--server-side", "--force-conflicts", "-f", "/crds/full/" ]
+
+####################################################################################################
 # Dev-only stages for Tilt. Small alpine base; NOT shipped to users. The
 # binaries are compiled on the host (by Tilt local_resources) and COPYed from
 # the build context, so each binary is built exactly once. On change Tilt

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ USER 8737
 
 COPY manifests/base/crds/full/argoproj.io_*.yaml /crds/full/
 
-CMD [ "apply", "--server-side", "--force-conflicts", "-f", "/crds/full/" ]
+CMD [ "apply", "--server-side", "--force-conflicts", "-v=6", "-f", "/crds/full/" ]
 
 ####################################################################################################
 # Dev-only stages for Tilt. Small alpine base; NOT shipped to users. The

--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,7 @@ endif
 
 argoexec-image: ## Build the executor image
 argoexec-nonroot-image:
+argo-workflows-crdinstaller-image: ## Build the CRD installer image
 
 %-image:
 	[ ! -e dist/$* ] || mv dist/$* .
@@ -406,7 +407,11 @@ argoexec-nonroot-image:
 		--load \
 		.; \
 	[ ! -e $* ] || mv $* dist/; \
-	docker run --rm -t $$image_name version; \
+	if [ "$*" = "argo-workflows-crdinstaller" ]; then \
+		docker run --rm -t $$image_name version --client; \
+	else \
+		docker run --rm -t $$image_name version; \
+	fi; \
 	if [ $(K3D) = true ]; then \
 		k3d image import -c $(K3D_CLUSTER_NAME) $$image_name; \
 	fi; \

--- a/docs/crd-installer.md
+++ b/docs/crd-installer.md
@@ -1,6 +1,6 @@
 # CRD Installer Image
 
-> v4.0 and after
+> v4.0.9 and 4.1.0 and after
 
 The `argo-workflows-crdinstaller` image installs the [full CRDs](installation.md#full-crds) into a cluster.
 It bundles `kubectl` together with the full CRD manifests for exactly the Argo Workflows version the image is tagged with, so it can install them without any network access to GitHub — including in air-gapped clusters.
@@ -19,10 +19,11 @@ The [community Helm chart](https://github.com/argoproj/argo-helm) runs it as a p
 The default command is:
 
 ```bash
-kubectl apply --server-side --force-conflicts -f /crds/full/
+kubectl apply --server-side --force-conflicts -v=6 -f /crds/full/
 ```
 
 [Server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) is required because the full CRDs exceed the size limit of the `last-applied-configuration` annotation used by client-side apply.
+`-v=6` logs each API request `kubectl` makes, so the Job's logs record which CRDs it applied.
 
 You can override the arguments, for example to preview changes with `apply --server-side --dry-run=server -f /crds/full/`.
 

--- a/docs/crd-installer.md
+++ b/docs/crd-installer.md
@@ -1,0 +1,81 @@
+# CRD Installer Image
+
+> v4.0 and after
+
+The `argo-workflows-crdinstaller` image installs the [full CRDs](installation.md#full-crds) into a cluster.
+It bundles `kubectl` together with the full CRD manifests for exactly the Argo Workflows version the image is tagged with, so it can install them without any network access to GitHub — including in air-gapped clusters.
+
+It is published to `quay.io/argoproj/argo-workflows-crdinstaller` with the same tags as the other Argo Workflows images: one tag per release (for example `v4.1.0`), plus `latest` tracking the tip of `main`.
+
+The image is not used by the official release manifests, which include the CRDs directly.
+It exists for installation tooling that cannot apply the full CRDs itself — most notably Helm, which cannot server-side apply CRDs of this size from within a chart.
+The [community Helm chart](https://github.com/argoproj/argo-helm) runs it as a pre-install/pre-upgrade hook Job.
+
+## Contents
+
+- `/bin/kubectl` — the image is based on the official [`registry.k8s.io/kubectl`](https://registry.k8s.io/) image, and `kubectl` is the entrypoint.
+- `/crds/full/` — the [full CRDs](https://github.com/argoproj/argo-workflows/tree/main/manifests/base/crds/full) matching the image's version.
+
+The default command is:
+
+```bash
+kubectl apply --server-side --force-conflicts -f /crds/full/
+```
+
+[Server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) is required because the full CRDs exceed the size limit of the `last-applied-configuration` annotation used by client-side apply.
+
+You can override the arguments, for example to preview changes with `apply --server-side --dry-run=server -f /crds/full/`.
+
+The container runs as a non-root user (UID 8737), like the other Argo Workflows images.
+
+## Usage
+
+The image expects the credentials it runs with to be permitted to manage CRDs; it does not create any RBAC itself.
+Run it as a Kubernetes Job with a ServiceAccount bound to a ClusterRole such as the one below:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflows-crd-installer
+  namespace: argo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-workflows-crd-installer
+rules:
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [create, get, list, patch, update]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-workflows-crd-installer
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflows-crd-installer
+    namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflows-crd-installer
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: argo-workflows-crd-installer
+  namespace: argo
+spec:
+  template:
+    spec:
+      serviceAccountName: argo-workflows-crd-installer
+      containers:
+        - name: install
+          image: quay.io/argoproj/argo-workflows-crdinstaller:v4.1.0
+      restartPolicy: Never
+  backoffLimit: 3
+```
+
+Use the image tag matching the Argo Workflows version you are installing, so the CRDs stay in sync with the controller and server.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,6 +28,8 @@ They must be applied using [server-side apply](https://kubernetes.io/docs/refere
 
 Previous versions used [minimal CRDs](https://github.com/argoproj/argo-workflows/tree/main/manifests/base/crds/minimal) that stripped out validation information to avoid the size limits.
 
+If your installation tooling cannot perform server-side apply, you can install the full CRDs with the [CRD installer image](crd-installer.md).
+
 #### Argo Workflows Helm Chart
 
 You can install Argo Workflows using the community maintained [Helm charts](https://github.com/argoproj/argo-helm).

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -253,6 +253,7 @@ nav:
           - argo watch: cli/argo_watch.md
   - Operator Manual:
       - installation.md
+      - crd-installer.md
       - releases.md
       - upgrading.md
       - new-features.md


### PR DESCRIPTION
Fixes #16621

### Motivation

Since 4.0 the release manifests ship the full CRDs, which are too big for client-side `kubectl apply` and have to be applied server-side. Tooling that can't do that needs a workaround: the [argo-helm chart](https://github.com/argoproj/argo-helm) currently runs a Job which downloads the full CRDs from raw.githubusercontent.com at install time. That fails in air-gapped clusters and ties the CRD contents to the chart version rather than the workflows version.

This publishes a `quay.io/argoproj/argo-workflows-crdinstaller` image bundling `kubectl` and the full CRDs matching the release, defaulting to server-side applying them. It is documented but not consumed by anything in this repo; the helm chart (and anything else in the same position) can run it as a Job with suitable RBAC and no network access to GitHub.

### Modifications

- `Dockerfile`: new `argo-workflows-crdinstaller` stage based on the official `registry.k8s.io/kubectl` image, running as non-root (UID 8737), with the full CRDs at `/crds/full/` and a default command of `apply --server-side --force-conflicts -f /crds/full/`. The Dockerfile target name matches the image name, so no name mapping is needed in the Makefile or CI.
- `.dockerignore`: re-include `manifests/base/crds/full/argoproj.io_*.yaml` (only the CRDs; `kustomization.yaml` and `README.md` stay out so `kubectl apply -f` on the directory works).
- `Makefile`: `argo-workflows-crdinstaller-image` target; the image smoke test runs `version --client` for this image since bare `kubectl version` fails without a cluster.
- `.github/workflows/release.yaml`: added to the linux build matrix, multiarch manifest push (signed with cosign like the others), pull test, and SBOM generation.
- `docs/crd-installer.md`: new page with the image contents, tag scheme, and a usage example including the required RBAC; linked from the Full CRDs section of `installation.md` and added to the docs nav.
- `.features/pending/crd-installer-image.md` feature note.

### Verification

- `make argo-workflows-crdinstaller-image` builds and the `version --client` smoke test passes.
- End-to-end on a k3d cluster (k3s v1.31): applied the RBAC + Job example from the new doc, the Job completed, and all 8 CRDs were server-side applied with their full validation schemas present.
- Extracted `/crds/full/` from the built image to confirm it contains exactly the 8 CRD files.
- Docs: strict mkdocs build, markdownlint, cspell and typos all pass; `featuregen validate` passes.
- The release.yaml changes follow the same pattern as the existing images and are verified by inspection; they only run on a tag.

### Documentation

New `docs/crd-installer.md`, linked from `docs/installation.md`.

### AI

🤖 Generated with [Claude Code](https://claude.com/claude-code) according to my spec


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a CRD installer image containing version-matched full Argo Workflows CRDs and `kubectl`.
  - Supports offline and air-gapped installations through server-side CRD application.
  - Added a build and release process, including image testing and SBOM generation.

- **Documentation**
  - Added installation guidance, configuration details, RBAC requirements, and Kubernetes Job examples.
  - Added the CRD installer guide to the Operator Manual navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->