### PR TITLE
ci: enable the PR readiness helper

### DIFF
--- a/.github/pr-readiness/README.md
+++ b/.github/pr-readiness/README.md
@@ -46,9 +46,9 @@ A deterministic check ([`template.ts`](template.ts)) compares the description ag
 - PR title/body/branch are attacker-controlled: they are only ever handled as data, never interpolated into shell or scripts. The comment never echoes contributor-supplied text — only the bot's own guidance, check titles/URLs, and template section names.
 - All actions are pinned to full commit SHAs (enforced by repo lint).
 
-## Dry run & rollout
+## Dry run
 
-`DRY_RUN: "true"` in the workflow renders the would-be comment and decisions to the job's **step summary** instead of commenting or drafting. Roll out: merge with dry-run on → watch summaries on real PRs (correct PR resolution, author gating, sensible text) → flip to `"false"`.
+Setting `DRY_RUN: "true"` in the workflow renders the would-be comment and decisions to the job's **step summary** instead of commenting or drafting. Use it to test changes to the bot against real PRs (correct PR resolution, author gating, sensible text) without posting.
 
 ## Maintenance notes
 

--- a/.github/workflows/pr-readiness.yaml
+++ b/.github/workflows/pr-readiness.yaml
@@ -26,9 +26,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Dry-run: render to the job summary instead of commenting/drafting.
-  # Flip to "false" to go live.
-  DRY_RUN: "true"
+  # Dry-run: set to "true" to render to the job summary instead of
+  # commenting/drafting.
+  DRY_RUN: "false"
 
 jobs:
   assess:


### PR DESCRIPTION
The helper was merged with DRY_RUN on so its decisions could be verified from job summaries on real PRs. Flip DRY_RUN off so it now posts its sticky comment and drafts not-ready PRs for real.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request readiness checks now perform live commenting and draft conversion by default.
  * Added clearer guidance for enabling dry-run mode.

* **Documentation**
  * Updated dry-run documentation to explain that results appear in the job summary without posting comments or converting drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->