### PR TITLE
fix(controller): stop a cycle in the node graph from overflowing the stack. Fixes #16376

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3236,15 +3236,19 @@ func (woc *wfOperationCtx) markNodeWaitingForLock(ctx context.Context, nodeName 
 	return node, nil
 }
 
-func (woc *wfOperationCtx) findLeafNodeWithType(ctx context.Context, boundaryID string, nodeType wfv1.NodeType) *wfv1.NodeStatus {
+func (woc *wfOperationCtx) findLeafStepGroupNode(ctx context.Context, boundaryID string) *wfv1.NodeStatus {
 	var leafNode *wfv1.NodeStatus
 	// A node ID collision can leave a node reachable from itself. Track the
 	// current path rather than every node seen, so that a node shared by two
 	// branches is still walked once per branch, as it is today.
 	onPath := make(map[string]bool)
+	cyclic := false
 	var dfs func(nodeID string)
 	dfs = func(nodeID string) {
 		if onPath[nodeID] {
+			cyclic = true
+			woc.log.WithFields(logging.Fields{"boundaryID": boundaryID, "nodeID": nodeID}).
+				Error(ctx, "Cycle in the workflow node graph, cannot tell which step group is the leaf")
 			return
 		}
 		onPath[nodeID] = true
@@ -3254,7 +3258,7 @@ func (woc *wfOperationCtx) findLeafNodeWithType(ctx context.Context, boundaryID 
 			woc.log.WithField("nodeID", nodeID).Error(ctx, "was unable to obtain node for nodeID")
 			return
 		}
-		if node.Type == nodeType {
+		if node.Type == wfv1.NodeTypeStepGroup {
 			leafNode = node
 		}
 		for _, childID := range node.Children {
@@ -3262,6 +3266,11 @@ func (woc *wfOperationCtx) findLeafNodeWithType(ctx context.Context, boundaryID 
 		}
 	}
 	dfs(boundaryID)
+	// Whatever we reached after cutting a loop short is not an answer, and the
+	// caller would fail that node.
+	if cyclic {
+		return nil
+	}
 	return leafNode
 }
 
@@ -3278,7 +3287,7 @@ func (woc *wfOperationCtx) checkParallelism(ctx context.Context, tmpl *wfv1.Temp
 		if tmpl.IsFailFast() && woc.getUnsuccessfulChildren(node.ID) > 0 {
 			if woc.getActivePods(node.ID) == 0 {
 				if tmpl.GetType() == wfv1.TemplateTypeSteps {
-					if leafStepGroupNode := woc.findLeafNodeWithType(ctx, node.ID, wfv1.NodeTypeStepGroup); leafStepGroupNode != nil {
+					if leafStepGroupNode := woc.findLeafStepGroupNode(ctx, node.ID); leafStepGroupNode != nil {
 						woc.markNodePhase(ctx, leafStepGroupNode.Name, wfv1.NodeFailed, "template has failed or errored children and failFast enabled")
 					}
 				}
@@ -3314,7 +3323,7 @@ func (woc *wfOperationCtx) checkParallelism(ctx context.Context, tmpl *wfv1.Temp
 		if boundaryTemplate != nil && boundaryTemplate.IsFailFast() && woc.getUnsuccessfulChildren(boundaryID) > 0 {
 			if woc.getActivePods(boundaryID) == 0 {
 				if boundaryTemplate.GetType() == wfv1.TemplateTypeSteps {
-					if leafStepGroupNode := woc.findLeafNodeWithType(ctx, boundaryID, wfv1.NodeTypeStepGroup); leafStepGroupNode != nil {
+					if leafStepGroupNode := woc.findLeafStepGroupNode(ctx, boundaryID); leafStepGroupNode != nil {
 						woc.markNodePhase(ctx, leafStepGroupNode.Name, wfv1.NodeFailed, "template has failed or errored children and failFast enabled")
 					}
 				}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1375,7 +1375,7 @@ func (woc *wfOperationCtx) failNodesWithoutCreatedPodsAfterDeadlineOrShutdown(ct
 			// itself was left Running because processNodeRetries returned early while a
 			// child pod was still running at the moment of shutdown
 			if node.Type == wfv1.NodeTypeRetry {
-				if woc.childrenFulfilled(&node) {
+				if woc.childrenFulfilled(ctx, &node) {
 					message := fmt.Sprintf("Stopped with strategy '%s'", woc.GetShutdownStrategy())
 					woc.markNodePhase(ctx, node.Name, wfv1.NodeFailed, message)
 					continue
@@ -2417,7 +2417,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 		childNodeIDs, lastChildNode := getChildNodeIdsAndLastRetriedNode(retryParentNode, woc.wf.Status.Nodes)
 
 		// The retry node might have completed by now.
-		if retryParentNode.Fulfilled() && (woc.childrenFulfilled(retryParentNode) || (retryParentNode.IsDaemoned() && retryParentNode.FailedOrError())) { // if retry node is daemoned we want to check those explicitly
+		if retryParentNode.Fulfilled() && (woc.childrenFulfilled(ctx, retryParentNode) || (retryParentNode.IsDaemoned() && retryParentNode.FailedOrError())) { // if retry node is daemoned we want to check those explicitly
 			// If retry node has completed, set the output of the last child node to its output.
 			// Runtime parameters (e.g., `status`, `resourceDuration`) in the output will be used to emit metrics.
 			if lastChildNode != nil {
@@ -2829,10 +2829,18 @@ func (woc *wfOperationCtx) hasDaemonNodes() bool {
 	return false
 }
 
-func (woc *wfOperationCtx) childrenFulfilledHelper(node *wfv1.NodeStatus, cache map[string]bool) bool {
+// visiting holds the nodes on the current walk. cache is only written once a node's
+// whole subtree is done, so it never closes a loop, and a node that reaches itself
+// through its own children would otherwise recurse until the stack runs out.
+func (woc *wfOperationCtx) childrenFulfilledHelper(ctx context.Context, node *wfv1.NodeStatus, cache map[string]bool, visiting map[string]bool) bool {
 	res, has := cache[node.ID]
 	if has {
 		return res
+	}
+
+	if visiting[node.ID] {
+		woc.log.WithField("nodeID", node.ID).Error(ctx, "Cycle in the workflow node graph, cannot tell whether children are fulfilled")
+		return false
 	}
 
 	if len(node.Children) == 0 {
@@ -2840,12 +2848,15 @@ func (woc *wfOperationCtx) childrenFulfilledHelper(node *wfv1.NodeStatus, cache 
 		return node.Fulfilled()
 	}
 
+	visiting[node.ID] = true
+	defer delete(visiting, node.ID)
+
 	for _, childID := range node.Children {
 		childNode, err := woc.wf.Status.Nodes.Get(childID)
 		if err != nil {
 			continue
 		}
-		isChildrenFulfilled := woc.childrenFulfilledHelper(childNode, cache)
+		isChildrenFulfilled := woc.childrenFulfilledHelper(ctx, childNode, cache, visiting)
 		if !isChildrenFulfilled {
 			cache[node.ID] = false
 			return false
@@ -2856,10 +2867,9 @@ func (woc *wfOperationCtx) childrenFulfilledHelper(node *wfv1.NodeStatus, cache 
 	return true
 }
 
-// check if all of the nodes children are fulffilled
-func (woc *wfOperationCtx) childrenFulfilled(node *wfv1.NodeStatus) bool {
-	m := make(map[string]bool)
-	return woc.childrenFulfilledHelper(node, m)
+// check if all of the nodes children are fulfilled
+func (woc *wfOperationCtx) childrenFulfilled(ctx context.Context, node *wfv1.NodeStatus) bool {
+	return woc.childrenFulfilledHelper(ctx, node, make(map[string]bool), make(map[string]bool))
 }
 
 func (woc *wfOperationCtx) GetNodeTemplate(ctx context.Context, node *wfv1.NodeStatus) (*wfv1.Template, error) {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3238,8 +3238,17 @@ func (woc *wfOperationCtx) markNodeWaitingForLock(ctx context.Context, nodeName 
 
 func (woc *wfOperationCtx) findLeafNodeWithType(ctx context.Context, boundaryID string, nodeType wfv1.NodeType) *wfv1.NodeStatus {
 	var leafNode *wfv1.NodeStatus
+	// A node ID collision can leave a node reachable from itself. Track the
+	// current path rather than every node seen, so that a node shared by two
+	// branches is still walked once per branch, as it is today.
+	onPath := make(map[string]bool)
 	var dfs func(nodeID string)
 	dfs = func(nodeID string) {
+		if onPath[nodeID] {
+			return
+		}
+		onPath[nodeID] = true
+		defer delete(onPath, nodeID)
 		node, err := woc.wf.Status.Nodes.Get(nodeID)
 		if err != nil {
 			woc.log.WithField("nodeID", nodeID).Error(ctx, "was unable to obtain node for nodeID")

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -13250,3 +13250,125 @@ func TestCheckTemplateTimeouts(t *testing.T) {
 	assert.Nil(t, pendingDeadline)
 	require.NoError(t, err)
 }
+
+// The workflow in #16376 is named custom-job-thbh7 and its step, the template it
+// references and that template's own step are all named alike. Two of the node
+// names that produces hash to one ID, which is how a node becomes its own child.
+func TestChildrenFulfilledNodeIDCollision(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
+	wf.Name = "custom-job-thbh7"
+	woc := newWoc(ctx, *wf)
+
+	outer := woc.wf.NodeID("custom-job-thbh7[0]")
+	inner := woc.wf.NodeID("custom-job-thbh7[0].custom-job[0].custom-job-main")
+	require.Equal(t, outer, inner, "these names no longer collide, so this test no longer covers the issue")
+
+	stepGroup := woc.wf.NodeID("custom-job-thbh7[0].custom-job")
+	woc.wf.Status.Nodes = wfv1.Nodes{}
+	for _, n := range []wfv1.NodeStatus{
+		{ID: outer, Name: "custom-job-thbh7[0]", Phase: wfv1.NodeSucceeded, Children: []string{stepGroup}},
+		{ID: stepGroup, Name: "custom-job-thbh7[0].custom-job", Phase: wfv1.NodeSucceeded, Children: []string{outer}},
+	} {
+		woc.wf.Status.Nodes.Set(ctx, n.ID, n)
+	}
+
+	root, err := woc.wf.Status.Nodes.Get(outer)
+	require.NoError(t, err)
+	assert.False(t, woc.childrenFulfilled(ctx, root))
+}
+
+func TestChildrenFulfilled(t *testing.T) {
+	node := func(id string, phase wfv1.NodePhase, children ...string) wfv1.NodeStatus {
+		return wfv1.NodeStatus{ID: id, Name: id, Phase: phase, Children: children}
+	}
+
+	for _, tc := range []struct {
+		name  string
+		nodes []wfv1.NodeStatus
+		want  bool
+		// wantLoopNode is the node the walk should name when it reports a loop,
+		// empty when it should not report one at all.
+		wantLoopNode string
+	}{
+		{
+			name:  "fulfilled leaf",
+			nodes: []wfv1.NodeStatus{node("a", wfv1.NodeSucceeded)},
+			want:  true,
+		},
+		{
+			name: "child still running",
+			nodes: []wfv1.NodeStatus{
+				node("a", wfv1.NodeSucceeded, "b"),
+				node("b", wfv1.NodeRunning),
+			},
+			want: false,
+		},
+		{
+			// Both branches reach d. That is a shared child, not a loop, so it must
+			// not be mistaken for one.
+			name: "diamond reaches the same child twice",
+			nodes: []wfv1.NodeStatus{
+				node("a", wfv1.NodeSucceeded, "b", "c"),
+				node("b", wfv1.NodeSucceeded, "d"),
+				node("c", wfv1.NodeSucceeded, "d"),
+				node("d", wfv1.NodeSucceeded),
+			},
+			want: true,
+		},
+		{
+			// Regression for https://github.com/argoproj/argo-workflows/issues/16376.
+			// A node ID collision can leave a node as its own descendant, which used
+			// to recurse until the controller ran out of stack.
+			name:         "self loop",
+			nodes:        []wfv1.NodeStatus{node("a", wfv1.NodeSucceeded, "a")},
+			want:         false,
+			wantLoopNode: "a",
+		},
+		{
+			name: "two node loop",
+			nodes: []wfv1.NodeStatus{
+				node("a", wfv1.NodeSucceeded, "b"),
+				node("b", wfv1.NodeSucceeded, "a"),
+			},
+			want:         false,
+			wantLoopNode: "a",
+		},
+		{
+			name: "loop below the root",
+			nodes: []wfv1.NodeStatus{
+				node("a", wfv1.NodeSucceeded, "b"),
+				node("b", wfv1.NodeSucceeded, "c"),
+				node("c", wfv1.NodeSucceeded, "b"),
+			},
+			want:         false,
+			wantLoopNode: "b",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := logging.NewTestHook()
+			ctx := logging.WithLogger(t.Context(), logging.NewTestLogger(logging.Info, logging.Text, hook))
+			woc := newWoc(ctx)
+			woc.wf.Status.Nodes = wfv1.Nodes{}
+			for _, n := range tc.nodes {
+				woc.wf.Status.Nodes.Set(ctx, n.ID, n)
+			}
+
+			root, err := woc.wf.Status.Nodes.Get(tc.nodes[0].ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, woc.childrenFulfilled(ctx, root))
+
+			var loopNode any
+			for _, e := range hook.AllEntries() {
+				if e.Level == logging.Error && strings.Contains(e.Msg, "Cycle in the workflow node graph") {
+					loopNode = e.Fields["nodeID"]
+				}
+			}
+			if tc.wantLoopNode == "" {
+				assert.Nil(t, loopNode, "no loop should have been reported")
+			} else {
+				assert.Equal(t, tc.wantLoopNode, loopNode)
+			}
+		})
+	}
+}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -13278,27 +13278,30 @@ func TestChildrenFulfilledNodeIDCollision(t *testing.T) {
 	assert.False(t, woc.childrenFulfilled(ctx, root))
 }
 
-func TestFindLeafNodeWithTypeCycle(t *testing.T) {
+func TestFindLeafStepGroupNodeCycle(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
 	woc := newWoc(ctx, *wf)
 
 	// The same shape a node ID collision leaves behind: a node reachable from
-	// itself through its own children.
+	// itself through its own children. The healthy step group is there because
+	// the walk carries on past the loop, and the caller fails whatever comes
+	// back, so coming back with it would fail a node that is doing nothing
+	// wrong.
 	woc.wf.Status.Nodes = wfv1.Nodes{}
 	for _, n := range []wfv1.NodeStatus{
+		{ID: "root", Name: "root", Type: wfv1.NodeTypeSteps, Children: []string{"a", "healthy"}},
 		{ID: "a", Name: "a", Type: wfv1.NodeTypeSteps, Children: []string{"b"}},
 		{ID: "b", Name: "b", Type: wfv1.NodeTypeStepGroup, Children: []string{"a"}},
+		{ID: "healthy", Name: "healthy", Type: wfv1.NodeTypeStepGroup},
 	} {
 		woc.wf.Status.Nodes.Set(ctx, n.ID, n)
 	}
 
-	got := woc.findLeafNodeWithType(ctx, "a", wfv1.NodeTypeStepGroup)
-	require.NotNil(t, got)
-	assert.Equal(t, "b", got.ID)
+	assert.Nil(t, woc.findLeafStepGroupNode(ctx, "root"))
 }
 
-func TestFindLeafNodeWithTypeSharedChild(t *testing.T) {
+func TestFindLeafStepGroupNodeSharedChild(t *testing.T) {
 	ctx := logging.TestContext(t.Context())
 	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
 	woc := newWoc(ctx, *wf)
@@ -13317,7 +13320,7 @@ func TestFindLeafNodeWithTypeSharedChild(t *testing.T) {
 		woc.wf.Status.Nodes.Set(ctx, n.ID, n)
 	}
 
-	got := woc.findLeafNodeWithType(ctx, "root", wfv1.NodeTypeStepGroup)
+	got := woc.findLeafStepGroupNode(ctx, "root")
 	require.NotNil(t, got)
 	assert.Equal(t, "n", got.ID)
 }

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -13278,6 +13278,50 @@ func TestChildrenFulfilledNodeIDCollision(t *testing.T) {
 	assert.False(t, woc.childrenFulfilled(ctx, root))
 }
 
+func TestFindLeafNodeWithTypeCycle(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
+	woc := newWoc(ctx, *wf)
+
+	// The same shape a node ID collision leaves behind: a node reachable from
+	// itself through its own children.
+	woc.wf.Status.Nodes = wfv1.Nodes{}
+	for _, n := range []wfv1.NodeStatus{
+		{ID: "a", Name: "a", Type: wfv1.NodeTypeSteps, Children: []string{"b"}},
+		{ID: "b", Name: "b", Type: wfv1.NodeTypeStepGroup, Children: []string{"a"}},
+	} {
+		woc.wf.Status.Nodes.Set(ctx, n.ID, n)
+	}
+
+	got := woc.findLeafNodeWithType(ctx, "a", wfv1.NodeTypeStepGroup)
+	require.NotNil(t, got)
+	assert.Equal(t, "b", got.ID)
+}
+
+func TestFindLeafNodeWithTypeSharedChild(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
+	woc := newWoc(ctx, *wf)
+
+	// A DAG task with two dependencies is a child of both, so the walk reaches
+	// n twice. It is the last step group it reaches that wins, and skipping the
+	// second visit would hand back m instead.
+	woc.wf.Status.Nodes = wfv1.Nodes{}
+	for _, n := range []wfv1.NodeStatus{
+		{ID: "root", Name: "root", Type: wfv1.NodeTypeDAG, Children: []string{"b", "c"}},
+		{ID: "b", Name: "b", Type: wfv1.NodeTypeDAG, Children: []string{"n"}},
+		{ID: "c", Name: "c", Type: wfv1.NodeTypeDAG, Children: []string{"m", "n"}},
+		{ID: "m", Name: "m", Type: wfv1.NodeTypeStepGroup},
+		{ID: "n", Name: "n", Type: wfv1.NodeTypeStepGroup},
+	} {
+		woc.wf.Status.Nodes.Set(ctx, n.ID, n)
+	}
+
+	got := woc.findLeafNodeWithType(ctx, "root", wfv1.NodeTypeStepGroup)
+	require.NotNil(t, got)
+	assert.Equal(t, "n", got.ID)
+}
+
 func TestChildrenFulfilled(t *testing.T) {
 	node := func(id string, phase wfv1.NodePhase, children ...string) wfv1.NodeStatus {
 		return wfv1.NodeStatus{ID: id, Name: id, Phase: phase, Children: children}

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -239,7 +239,7 @@ func (woc *wfOperationCtx) executeStepGroup(ctx context.Context, stepGroup []wfv
 	if err != nil {
 		return nil, err
 	}
-	if node.Fulfilled() && woc.childrenFulfilled(node) {
+	if node.Fulfilled() && woc.childrenFulfilled(ctx, node) {
 		woc.log.WithField("node", node).Debug(ctx, "Step group node already marked completed")
 		return node, nil
 	}


### PR DESCRIPTION
Fixes #16376

`childrenFulfilledHelper` memoises each node, but only once that node's whole subtree has been walked. A node that is reachable from itself therefore never finds its own entry on the way back round, so the walk recurses until the process dies with `fatal error: stack overflow`. That takes the whole workflow-controller down, not just the workflow holding the graph, and it comes straight back up into the same reconcile.

@okzw999 traced how a graph like that appears, and their write-up in the issue is worth reading in full: `NodeID` hashes the node name with FNV-32a, two names in the same workflow can land on the same value, `GetNodeByName` then returns an unrelated node, and `addChildNode` records an ancestor as a child. I reproduced the collision they reported before starting:

```
custom-job-thbh7[0]                                  1277661780
custom-job-thbh7[0].custom-job[0].custom-job-main    1277661780
```

This PR is the containment half. The walk now carries the nodes on the current path and stops when it reaches one of them again, so this traversal no longer takes the controller down with it. Preventing the graph from being built that way in the first place is a separate change.

#### Why a loop reports "not fulfilled" rather than "fulfilled"

The obvious shortcut is to return `true` and let the walk unwind, but every caller reads a `true` here as "this subtree is done, move on":

- `executeStepGroup` returns the group as already complete and skips executing it
- `executeTemplate` treats a retry node as finished, copies the last child's outputs onto it and emits its metrics
- `failNodesWithoutCreatedPodsAfterDeadlineOrShutdown` marks the node failed

None of that should run off a graph we have just found to be broken, so the walk reports what it actually knows. The affected workflow stalls instead of advancing on bad data, and the node that closed the loop is logged at error level so it can be found.

#### `findLeafNodeWithType` had it too

`checkParallelism` walks the same graph looking for the last step group under a boundary, and its `dfs` recurses through `Children` with nothing to stop it returning to where it started. Removing the guard and running the cycle test gives `fatal error: stack overflow`, so the graph in #16376 takes the controller down through this path as well. It is the same file and the same failure, so it is in this PR rather than a follow-up.

It uses a path set rather than a visited set, which is worth a word. The function returns the *last* node of the matching type in DFS order, and a DAG task with two dependencies is a child of both, so the walk can legitimately reach a node twice. Skipping repeat visits outright would quietly hand back a different node, which is not something a crash fix should do. `TestFindLeafNodeWithTypeSharedChild` covers that: switching to a global visited set makes it fail.

#### What is still unguarded

`Nodes.NestedChildrenStatus` walks descendants with a queue and no visited set, so a cycle re-enqueues forever rather than overflowing anything. `getOutboundNodes` is also recursive without loop protection, though I want to be careful there: it only follows `Children` for `Container` and `TaskGroup` nodes and otherwise follows `OutboundNodes`, so the specific step group cycle in #16376 does not by itself prove that walker recurses indefinitely. Both are in #16626 rather than here, because one is in a different package and the other needs a decision about how to signal "I could not tell" through a plain `[]string`.

#### Testing

`TestChildrenFulfilled` covers a self loop, a two node loop, a loop below the root, and, importantly, a diamond, where two branches legitimately reach the same child. The diamond is what pins the path set being unwound correctly; a naive "seen" set would report it as a loop.

Two mutations to show the tests are load-bearing: dropping the loop check reproduces `runtime: goroutine stack exceeds 1000000000-byte limit / fatal error: stack overflow`, and flipping the loop verdict to `true` fails all three loop cases. The log assertion pins the node ID, since finding the offending node is most of the value when this fires in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow completion checks to safely handle circular dependencies.
  * Prevented workflows from incorrectly remaining unresolved when cycles are detected.
  * Added clearer error logging to identify the workflow node involved in a cycle.
  * Preserved correct handling of shared child steps and nested workflow structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Documentation

Not needed. This is an internal controller safety fix with no user facing API or configuration change.

### AI

An agent was used to enumerate the interleavings this change guards against, and to draft parts of the code and tests. Every claim in the description was checked against the source and the pinned dependencies rather than taken from the agent, each test was written to fail before the fix and then mutated to confirm it still fails when the fix is removed, and the tests and linter were run locally. Earlier revisions of this PR had mistakes that were found and corrected here. I am accountable for what is in it.
