### PR TITLE
chore: replace gojsonschema with santhosh-tekuri/jsonschema in the example validator

### DIFF
--- a/examples/validator.go
+++ b/examples/validator.go
@@ -1,13 +1,18 @@
 package validation
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 
-	"github.com/xeipuuv/gojsonschema"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 	"sigs.k8s.io/yaml"
 )
 
@@ -17,8 +22,21 @@ func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[s
 		return nil, err
 	}
 
-	schemaLoader := gojsonschema.NewStringLoader(string(schemaBytes))
+	// Load and compile the schema once, then reuse it for every file.
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaBytes))
+	if err != nil {
+		return nil, err
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", schemaDoc); err != nil {
+		return nil, err
+	}
+	schema, err := compiler.Compile("schema.json")
+	if err != nil {
+		return nil, err
+	}
 
+	printer := message.NewPrinter(language.English)
 	failed := map[string][]string{}
 
 	err = filepath.Walk(fromPath, func(path string, info os.FileInfo, err error) error {
@@ -44,31 +62,28 @@ func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[s
 			return err
 		}
 
-		documentLoader := gojsonschema.NewStringLoader(string(jsonDoc))
-
-		result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(jsonDoc))
 		if err != nil {
 			return err
 		}
 
-		incorrectError := false
-		if !result.Valid() {
-			errorDescriptions := []string{}
-			for _, err := range result.Errors() {
-				// port should be port number or port reference string, using string port number will cause issue
-				// due swagger 2.0 limitation, we can only specify one data type (we use string, same as k8s api swagger).
-				// Similarly, we cannot use string minAvailable either.
-				if (strings.HasSuffix(err.Field(), "httpGet.port") || strings.HasSuffix(err.Field(), "podDisruptionBudget.minAvailable")) && err.Description() == "Invalid type. Expected: string, given: integer" {
-					incorrectError = true
-					continue
-				} else {
-					errorDescriptions = append(errorDescriptions, fmt.Sprintf("%s in %s", err.Description(), err.Context().String()))
-				}
-			}
+		validationErr := schema.Validate(doc)
+		if validationErr == nil {
+			return nil
+		}
+		var ve *jsonschema.ValidationError
+		if !errors.As(validationErr, &ve) {
+			return validationErr
+		}
 
-			if !(incorrectError && len(errorDescriptions) == 1) {
-				failed[path] = errorDescriptions
+		residual := realValidationErrors(ve)
+		if len(residual) > 0 {
+			errorDescriptions := make([]string, 0, len(residual))
+			for _, leaf := range residual {
+				errorDescriptions = append(errorDescriptions,
+					fmt.Sprintf("%s in /%s", leaf.ErrorKind.LocalizedString(printer), strings.Join(leaf.InstanceLocation, "/")))
 			}
+			failed[path] = errorDescriptions
 		}
 		return nil
 	})
@@ -78,4 +93,55 @@ func ValidateArgoYamlRecursively(fromPath string, skipFileNames []string) (map[s
 	}
 
 	return failed, nil
+}
+
+// realValidationErrors reduces a ValidationError tree to the concrete leaf
+// failures that actually matter, ignoring the known port/minAvailable quirk.
+//
+// The top-level schema is a oneOf/anyOf over every Argo resource type, so a
+// valid manifest still produces errors for every branch it is *not* (e.g.
+// "value must be 'CronWorkflow'"). For those combinator nodes we therefore
+// attribute only the closest-matching branch (fewest residual errors) instead
+// of every branch's noise.
+func realValidationErrors(e *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if len(e.Causes) == 0 {
+		if isBenignStringTypeError(e) {
+			return nil
+		}
+		return []*jsonschema.ValidationError{e}
+	}
+
+	switch e.ErrorKind.(type) {
+	case *kind.OneOf, *kind.AnyOf:
+		var best []*jsonschema.ValidationError
+		for i, cause := range e.Causes {
+			errs := realValidationErrors(cause)
+			if i == 0 || len(errs) < len(best) {
+				best = errs
+			}
+			if len(best) == 0 {
+				break
+			}
+		}
+		return best
+	default:
+		var all []*jsonschema.ValidationError
+		for _, cause := range e.Causes {
+			all = append(all, realValidationErrors(cause)...)
+		}
+		return all
+	}
+}
+
+// isBenignStringTypeError reports whether e is the known "string expected but a
+// number was given" error at httpGet.port / podDisruptionBudget.minAvailable.
+// The schema can only declare one type (string, matching the k8s API swagger)
+// due to a Swagger 2.0 limitation, so an integer value there is acceptable.
+func isBenignStringTypeError(e *jsonschema.ValidationError) bool {
+	typeErr, ok := e.ErrorKind.(*kind.Type)
+	if !ok || !slices.Contains(typeErr.Want, "string") {
+		return false
+	}
+	field := strings.Join(e.InstanceLocation, ".")
+	return strings.HasSuffix(field, "httpGet.port") || strings.HasSuffix(field, "podDisruptionBudget.minAvailable")
 }

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/otlptranslator v1.0.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/sethvargo/go-limiter v1.1.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
@@ -61,7 +62,6 @@ require (
 	github.com/tidwall/gjson v1.19.0
 	github.com/upper/db/v4 v4.10.0
 	github.com/valyala/fasttemplate v1.2.2
-	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
@@ -132,6 +132,7 @@ require (
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
@@ -352,7 +353,7 @@ require (
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.40.0
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/cli v29.5.3+incompatible h1:nbEFfz774vBwQ5KRYv7c/AghjReqnGISvrRhzjV0evs=
 github.com/docker/cli v29.5.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.9.5 h1:EFNN8DHvaiK8zVqFA2DT6BjXE0GzfLOZ38ggPTKePkY=
@@ -726,6 +728,8 @@ github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88ee
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
 github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
 github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=


### PR DESCRIPTION
Fixes #7812

### Motivation

`github.com/xeipuuv/gojsonschema` is unmaintained. It was used directly only in `examples/validator.go`.

### Modifications

- Replaced `gojsonschema` with `github.com/santhosh-tekuri/jsonschema/v6` in `examples/validator.go`.
- Preserved the two behaviors called out in the issue:
  - the schema is loaded and compiled **once**, then reused for every file;
  - an integer `httpGet.port` / `podDisruptionBudget.minAvailable` is still treated as valid (the schema can only declare `string` due to a Swagger 2.0 limitation). This is now matched via the structured `*kind.Type` error (`Want` contains `string`) at the failing field path, rather than an error-message string.
- Because the top-level schema is a `oneOf` over every resource type, a valid manifest still produces per-branch errors for the types it is *not* (e.g. `value must be 'CronWorkflow'`). The new code attributes only the closest-matching branch (fewest residual errors) for `oneOf`/`anyOf` nodes, so that noise is not reported as a failure.
- `gojsonschema` is now only an **indirect** dependency — it is still pulled in transitively via `github.com/gavv/httpexpect/v2` in the e2e test fixtures, so it cannot be dropped from `go.sum` entirely here.

### Verification

- `go test ./examples/` — `TestValidateExamples` passes; every example manifest validates.
- `go vet ./examples/` is clean and `gofmt` reports no changes.

### Documentation

Not needed — this is internal example-validation tooling with no user-facing change.

### AI

This PR was prepared with the assistance of an AI coding tool (Anthropic's Claude): the library port and this description were AI-assisted. They were reviewed and verified by the author by running the repository's `TestValidateExamples` test and `go vet`/`gofmt`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of YAML documents against their schemas.
  * Validation now provides clearer, more focused error messages by identifying the specific failing fields.
  * Improved handling of alternative schema formats and common type variations.
  * Error descriptions are consistently presented in English for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->