### PR TITLE
chore: update renovate for 4.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,8 @@
   ],
   "baseBranchPatterns": [
     "main",
-    "release-3.7",
-    "release-4.0"
+    "release-4.0",
+    "release-4.1"
   ],
   "nix": {
     "enabled": true
@@ -38,8 +38,8 @@
     {
       "description": "Only allow patch updates on release branches",
       "matchBaseBranches": [
-        "release-3.7",
-        "release-4.0"
+        "release-4.0",
+        "release-4.1"
       ],
       "matchUpdateTypes": [
         "major",
@@ -50,8 +50,8 @@
     {
       "description": "Use conservative lock file updates on release branches",
       "matchBaseBranches": [
-        "release-3.7",
-        "release-4.0"
+        "release-4.0",
+        "release-4.1"
       ],
       "rangeStrategy": "in-range-only"
     },
@@ -76,8 +76,8 @@
     {
       "description": "Disable lock file maintenance on release branches",
       "matchBaseBranches": [
-        "release-3.7",
-        "release-4.0"
+        "release-4.0",
+        "release-4.1"
       ],
       "matchUpdateTypes": [
         "lockFileMaintenance"


### PR DESCRIPTION
As per the release process, start renovating 4.1, and stop 3.7 as it's now out of support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings for the 4.1 release branch.
  * Adjusted patch and lock-file update rules to support the latest release branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->