### PR TITLE
chore(deps): update golangci-lint to v2.12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -640,7 +640,7 @@ manifests-validate:
 	kubectl apply --server-side --validate=strict --dry-run=server -f 'manifests/*.yaml'
 
 $(TOOL_GOLANGCI_LINT): Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b `go env GOPATH`/bin v2.11.3
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b `go env GOPATH`/bin v2.12.2
 
 .PHONY: lint lint-go lint-ui
 lint: lint-go lint-ui features-validate ## Lint the project

--- a/test/e2e/fixtures/otel_collector.go
+++ b/test/e2e/fixtures/otel_collector.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -393,7 +394,7 @@ func (c *OTELCollector) WaitForWorkflowSpan(ctx context.Context, timeout time.Du
 				return nil, nil, err
 			}
 			// Search from the end to find the most recent workflow span
-			for i := len(spans) - 1; i >= 0; i-- {
+			for i := range slices.Backward(spans) {
 				if spans[i].Name == "workflow" {
 					return &spans[i], spans, nil
 				}

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ type TracingSuite struct {
 
 // findLastWorkflowSpan finds the last workflow span in the list (most recent)
 func findLastWorkflowSpan(spans []fixtures.CollectedSpan) *fixtures.CollectedSpan {
-	for i := len(spans) - 1; i >= 0; i-- {
+	for i := range slices.Backward(spans) {
 		if spans[i].Name == "workflow" {
 			return &spans[i]
 		}

--- a/util/file/watch_test.go
+++ b/util/file/watch_test.go
@@ -67,24 +67,24 @@ func TestWatchFile_FiresOnCreateAndWrite(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	var fires int32
+	var fires atomic.Int32
 	done := make(chan struct{})
 	go func() {
 		_ = WatchFile(ctx, path, func() {
-			atomic.AddInt32(&fires, 1)
+			fires.Add(1)
 		})
 		close(done)
 	}()
 
 	// Wait for the initial Stat callback to confirm the watcher is installed.
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&fires) >= 1
+		return fires.Load() >= 1
 	}, 2*time.Second, 10*time.Millisecond)
 
 	require.NoError(t, os.WriteFile(path, []byte("ab"), 0o644))
 
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&fires) >= 2
+		return fires.Load() >= 2
 	}, 2*time.Second, 10*time.Millisecond)
 
 	cancel()
@@ -99,17 +99,17 @@ func TestWatchFile_FiresWhenAlreadyExists(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	var fires int32
+	var fires atomic.Int32
 	done := make(chan struct{})
 	go func() {
 		_ = WatchFile(ctx, path, func() {
-			atomic.AddInt32(&fires, 1)
+			fires.Add(1)
 		})
 		close(done)
 	}()
 
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&fires) >= 1
+		return fires.Load() >= 1
 	}, 2*time.Second, 10*time.Millisecond)
 
 	cancel()
@@ -130,25 +130,25 @@ func TestWatchFilePoll_FiresOnCreateAndWrite(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	var fires int32
+	var fires atomic.Int32
 	done := make(chan struct{})
 	go func() {
 		_ = watchFilePoll(ctx, path, func() {
-			atomic.AddInt32(&fires, 1)
+			fires.Add(1)
 		})
 		close(done)
 	}()
 
 	require.NoError(t, os.WriteFile(path, []byte("a"), 0o644))
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&fires) >= 1
+		return fires.Load() >= 1
 	}, 5*time.Second, 50*time.Millisecond)
 
 	// Ensure a detectably-different mtime on filesystems with coarse timestamps.
 	time.Sleep(1100 * time.Millisecond)
 	require.NoError(t, os.WriteFile(path, []byte("ab-longer"), 0o644))
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&fires) >= 2
+		return fires.Load() >= 2
 	}, 5*time.Second, 50*time.Millisecond)
 
 	cancel()
@@ -163,17 +163,17 @@ func TestWatchFilePoll_FiresWhenAlreadyExists(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	var fires int32
+	var fires atomic.Int32
 	done := make(chan struct{})
 	go func() {
 		_ = watchFilePoll(ctx, path, func() {
-			atomic.AddInt32(&fires, 1)
+			fires.Add(1)
 		})
 		close(done)
 	}()
 
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&fires) >= 1
+		return fires.Load() >= 1
 	}, 1*time.Second, 10*time.Millisecond)
 
 	cancel()

--- a/util/template/expression_template.go
+++ b/util/template/expression_template.go
@@ -324,7 +324,7 @@ func hasVarInEnv(env map[string]any, parameter string) bool {
 		}
 
 		rVal := reflect.ValueOf(current)
-		for rVal.Kind() == reflect.Ptr {
+		for rVal.Kind() == reflect.Pointer {
 			if rVal.IsNil() {
 				return false
 			}
@@ -347,7 +347,7 @@ func hasVarInEnv(env map[string]any, parameter string) bool {
 					if fType.Anonymous {
 						embeddedValue := rVal.Field(j)
 						// Handle pointer to embedded struct
-						for embeddedValue.Kind() == reflect.Ptr {
+						for embeddedValue.Kind() == reflect.Pointer {
 							if embeddedValue.IsNil() {
 								break
 							}


### PR DESCRIPTION
Bumps golangci-lint from v2.11.3 to v2.12.2.

### install.sh has to be pinned too

`install.sh` from `master` now resolves the checksum of the `.sbom.json` asset instead of the tarball, so installing v2.12.2 through it aborts:

```
hash_sha256_verify checksum for golangci-lint-2.12.2-linux-amd64.tar.gz did not verify
fd3a137c… vs 8df580d2…
```

The artifact is fine — `8df580d2…` is what the official v2.12.2 checksums file lists for the tarball, and `fd3a137c…` is the checksum of `…tar.gz.sbom.json`. v2.11.3 installs cleanly, which is why this hasn't bitten before. Pinning the script to the release tag fixes it, and is preferable to piping an unpinned `master` script anyway.

### New analyzers

2.12 adds analyzers that flag 8 issues on the current tree (2.11.3 reports none):

| analyzer | count | files |
|---|---|---|
| `govet` / `inline` — `reflect.Ptr` → `reflect.Pointer` | 2 | `util/template/expression_template.go` |
| `modernize` / `atomictypes` — `int32` + `atomic.AddInt32` → `atomic.Int32` | 4 | `util/file/watch_test.go` |
| `modernize` / `slicesbackward` — backward loop → `slices.Backward` | 2 | `test/e2e/fixtures/otel_collector.go`, `test/e2e/tracing_test.go` |

### Note on the slicesbackward fixes

`golangci-lint run --fix` rewrites these to `for _, v := range slices.Backward(spans)` … `return &v`, which changes behaviour: `&v` addresses the per-iteration copy, where the original `&spans[i]` pointed into the slice. It compiles, lints clean and passes tests, so CI would not have caught it. Both sites are written here as `for i := range slices.Backward(spans)` / `return &spans[i]`, preserving the original aliasing and still satisfying the analyzer.

### Verification

- `golangci-lint run` with v2.12.2 → 0 issues
- `go build ./...` clean
- `go vet -tags=functional,tracing ./test/e2e/...` clean
- `go test ./util/file/... ./util/template/...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TU4nc6JrbPDNJqeJH2vHpi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go linting tool to version 2.12.2.

* **Refactor**
  * Modernized internal iteration, atomic counter handling, and reflection checks without changing behavior.

* **Tests**
  * Updated tracing and file-watcher tests to use modern Go utilities while preserving existing coverage and timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->