### PR TITLE
fix(ci): have the PR readiness bot undraft PRs it drafted

### DIFF
--- a/.github/pr-readiness/README.md
+++ b/.github/pr-readiness/README.md
@@ -1,6 +1,6 @@
 # PR Readiness Helper
 
-A standalone bot ([`pr-readiness.yaml`](../workflows/pr-readiness.yaml)) that lowers maintainer burden: when CI finishes on a PR, it keeps **one sticky comment** telling the contributor exactly how to fix contributor-fixable problems, moves not-ready PRs to **draft**, and gets out of the way once everything is green.
+A standalone bot ([`pr-readiness.yaml`](../workflows/pr-readiness.yaml)) that lowers maintainer burden: when CI finishes on a PR, it keeps **one sticky comment** telling the contributor exactly how to fix contributor-fixable problems, moves not-ready PRs to **draft**, and hands them back — ready for review — once everything is green.
 
 ## What it covers
 
@@ -25,10 +25,11 @@ Tune guidance, add or remove signals in [`checks.config.json`](checks.config.jso
 - Fires on `workflow_run: completed` of CI / Docs / PR Title Check / PR Feature Check. Title and feature checks re-run on PR `edited`, so title/description edits re-evaluate too. `/retest` re-runs CI and therefore re-evaluates.
 - **Never posts** on a PR that never had a covered issue.
 - While issues exist: one comment listing only the failing items, each with a fix command and a log link. Pending checks are not mentioned.
-- Blocking issues (any covered check failure, or a description that doesn't follow the template) also **convert the PR to draft**. The bot **never** marks ready-for-review — that's the contributor's call — and it drafts at most once per head SHA, so a human re-marking it ready is respected until new commits arrive.
-- Draft conversion needs a **GitHub App token**: the default Actions token cannot toggle draft state (`Resource not accessible by integration` — verified live). Provision an app with **Pull requests: Read & write** only (do not reuse the cherry-pick app, which can push code), install it on the repo, and set the `PR_READINESS_APP_ID` / `PR_READINESS_APP_PRIVATE_KEY` secrets — the same `actions/create-github-app-token` pattern as `cherry-pick-single.yml`. Without the secrets the bot comments but does not draft.
+- Blocking issues (any covered check failure, or a description that doesn't follow the template) also **convert the PR to draft**, at most once per head SHA — so a human re-marking it ready is respected until new commits arrive. For as long as that draft is in force the comment carries a note saying the bot drafted the PR and will mark it ready again itself; the note disappears as soon as it doesn't apply.
+- Once everything is green again the bot **marks the PR ready for review**, because a draft PR is invisible to reviewers and a contributor who fixed everything should not have to know that. It only ever lifts a draft **it imposed itself**: its claim on the PR's draft state starts when it drafts and ends the moment the PR is ready for review again, however that happened — so a draft the contributor sets is never touched. If lifting fails, the all-clear comment asks them to mark it ready instead.
+- Toggling draft state needs a **GitHub App token**: the default Actions token cannot do it (`Resource not accessible by integration` — verified live). Provision an app with **Pull requests: Read & write** only (do not reuse the cherry-pick app, which can push code), install it on the repo, and set the `PR_READINESS_APP_ID` / `PR_READINESS_APP_PRIVATE_KEY` secrets — the same `actions/create-github-app-token` pattern as `cherry-pick-single.yml`. Without the secrets the bot comments but does not draft.
 - When issues are resolved but other covered checks are still running: the comment shows a short "waiting" state.
-- When everything is terminal and green: the comment is edited to a short ✅ all-clear.
+- When everything is terminal and green: the comment is edited to a short ✅ all-clear, and any draft the bot imposed is lifted.
 - Skipped: PRs by anyone in [`OWNERS`](../../OWNERS) (owners/approvers/reviewers) and by bots.
 
 ## PR description check

--- a/.github/pr-readiness/classify.ts
+++ b/.github/pr-readiness/classify.ts
@@ -70,7 +70,7 @@ export function diagnostics(checkRuns: CheckRun[], config: Config): { unmapped: 
 interface DecideArgs {
   signals: ReadonlyArray<{ id: string; state: string }>;
   templateVerdict: { compliant: boolean } | null;
-  existingState: { draftedSha?: string | null } | null;
+  existingState: { draftedSha?: string | null; undraftedSha?: string | null } | null;
   hasExistingComment: boolean;
   pr: { draft: boolean; headSha: string };
 }
@@ -95,7 +95,16 @@ export function decide({ signals, templateVerdict, existingState, hasExistingCom
   const alreadyDraftedThisSha = Boolean(existingState && existingState.draftedSha === pr.headSha);
   const shouldDraft = blocking && !pr.draft && !alreadyDraftedThisSha;
 
-  return { variant, shouldComment, shouldDraft, failing, templateBlocking };
+  // The bot cleans up after itself: a draft it imposed is lifted once
+  // everything it drafted for is green, because nobody reviews a draft. An
+  // episode stays open from the draft until we lift it, so a draft the
+  // contributor set themselves is never touched, and we never lift twice.
+  const draftEpisodeOpen = Boolean(
+    existingState && existingState.draftedSha && existingState.undraftedSha !== existingState.draftedSha
+  );
+  const shouldUndraft = variant === 'allclear' && pr.draft && draftEpisodeOpen;
+
+  return { variant, shouldComment, shouldDraft, shouldUndraft, draftEpisodeOpen, failing, templateBlocking };
 }
 
 // OWNERS is a small YAML subset: three keys, each a list of logins.

--- a/.github/pr-readiness/comment.ts
+++ b/.github/pr-readiness/comment.ts
@@ -25,19 +25,39 @@ interface RenderArgs {
   variant: CommentVariant | null;
   failures: ReadonlyArray<FailureItem>;
   templateIssues: TemplateIssue[] | null;
-  drafted: boolean;
+  // The PR is a draft the bot imposed and has not lifted yet.
+  holdingDraft: boolean;
+  // The bot drafted this PR and could not lift the draft itself, so the
+  // all-clear must ask the contributor to do it rather than tell them to wait
+  // for a maintainer who cannot see a draft PR.
+  needsReadyForReview: boolean;
   state: State;
 }
 
-export function renderComment({ variant, failures, templateIssues, drafted, state }: RenderArgs): string {
+export function renderComment({ variant, failures, templateIssues, holdingDraft, needsReadyForReview, state }: RenderArgs): string {
   const head = [MARKER, stateLine(state), ''];
+
+  // Rendered on every pass while the bot holds the draft, not just the one
+  // that imposed it: the comment is edited in place, so whatever it says last
+  // is all the contributor sees. It must always explain why the PR is a draft
+  // and that they are not the ones who have to undo it.
+  const draftNote = holdingDraft
+    ? [
+        '',
+        '> [!NOTE]',
+        '> This PR was moved to **draft** by this helper. It will be marked',
+        '> **Ready for review** again automatically once everything here is green.',
+      ]
+    : [];
 
   if (variant === 'allclear') {
     return head
       .concat([
         '#### ✅ PR readiness: all clear',
         '',
-        'All contributor-fixable checks are passing. A maintainer will take it from here — thanks!',
+        needsReadyForReview
+          ? 'All contributor-fixable checks are passing. This PR is still a **draft** — mark it **Ready for review** so a maintainer picks it up.'
+          : 'All contributor-fixable checks are passing. A maintainer will take it from here — thanks!',
         FOOTER,
       ])
       .join('\n');
@@ -45,12 +65,9 @@ export function renderComment({ variant, failures, templateIssues, drafted, stat
 
   if (variant === 'waiting') {
     return head
-      .concat([
-        '#### ⏳ PR readiness',
-        '',
-        'The earlier issues are resolved — waiting for the remaining checks to finish…',
-        FOOTER,
-      ])
+      .concat(['#### ⏳ PR readiness', '', 'The earlier issues are resolved — waiting for the remaining checks to finish…'])
+      .concat(draftNote)
+      .concat([FOOTER])
       .join('\n');
   }
 
@@ -81,14 +98,7 @@ export function renderComment({ variant, failures, templateIssues, drafted, stat
     lines.push('', '_(A maintainer may waive this.)_', '</details>');
   }
 
-  if (drafted) {
-    lines.push(
-      '',
-      '> [!NOTE]',
-      '> This PR has been moved to **draft** while the items above are addressed. Mark it **Ready for review** once they are fixed.'
-    );
-  }
-
+  lines.push(...draftNote);
   lines.push(FOOTER);
   return lines.join('\n');
 }

--- a/.github/pr-readiness/main.ts
+++ b/.github/pr-readiness/main.ts
@@ -58,6 +58,24 @@ function errMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
+// Toggling a PR's draft state is GraphQL-only, and the default Actions token
+// cannot do it ("Resource not accessible by integration"), so both directions
+// go through the app token minted by the workflow. Throws on any error.
+async function setDraftState(token: string, nodeId: string, draft: boolean): Promise<void> {
+  const mutation = draft
+    ? 'mutation($id: ID!) { convertPullRequestToDraft(input: {pullRequestId: $id}) { pullRequest { isDraft } } }'
+    : 'mutation($id: ID!) { markPullRequestReadyForReview(input: {pullRequestId: $id}) { pullRequest { isDraft } } }';
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: { authorization: `bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ query: mutation, variables: { id: nodeId } }),
+  });
+  const result = (await res.json()) as { errors?: Array<{ message: string }> };
+  if (!res.ok || result.errors) {
+    throw new Error(result.errors ? result.errors.map((e) => e.message).join('; ') : `HTTP ${res.status}`);
+  }
+}
+
 export async function run({ github, context, core }: { github: Octokit; context: RepoContext; core: Core }): Promise<void> {
   const { owner, repo } = context.repo;
   const headSha = context.payload.workflow_run.head_sha;
@@ -125,50 +143,56 @@ export async function run({ github, context, core }: { github: Octokit; context:
     pr: { draft: pr.draft, headSha },
   });
 
-  // Draft conversion: at most once per head SHA; undrafting is human-only.
-  // The default Actions token cannot toggle draft state ("Resource not
-  // accessible by integration"), so this requires the app token minted by
-  // the workflow. Best-effort: failure never blocks the comment.
+  // Draft conversion: at most once per head SHA, and lifted again once the
+  // PR is green — the bot only ever moves a draft it imposed itself, so a
+  // contributor's own draft is left alone. Both directions are best-effort:
+  // failure never blocks the comment, which then tells the contributor to
+  // mark the PR ready themselves.
+  const wanted = decision.shouldDraft ? 'draft' : decision.shouldUndraft ? 'undraft' : null;
   let draftedNow = false;
-  if (decision.shouldDraft && !dryRun) {
+  let undraftedNow = false;
+  if (wanted && !dryRun) {
     const token = process.env.DRAFT_TOKEN;
     if (!token) {
       core.warning(
-        `PR #${pr.number} should be drafted, but no draft token is available ` +
+        `PR #${pr.number} should be ${wanted}ed, but no draft token is available ` +
           '(PR_READINESS_APP_ID / PR_READINESS_APP_PRIVATE_KEY secrets not configured?)'
       );
     } else {
       try {
-        const res = await fetch('https://api.github.com/graphql', {
-          method: 'POST',
-          headers: { authorization: `bearer ${token}`, 'content-type': 'application/json' },
-          body: JSON.stringify({
-            query: 'mutation($id: ID!) { convertPullRequestToDraft(input: {pullRequestId: $id}) { pullRequest { isDraft } } }',
-            variables: { id: pr.node_id },
-          }),
-        });
-        const result = (await res.json()) as { errors?: Array<{ message: string }> };
-        if (!res.ok || result.errors) {
-          throw new Error(result.errors ? result.errors.map((e) => e.message).join('; ') : `HTTP ${res.status}`);
-        }
-        draftedNow = true;
+        await setDraftState(token, pr.node_id, wanted === 'draft');
+        draftedNow = wanted === 'draft';
+        undraftedNow = wanted === 'undraft';
       } catch (e) {
-        core.warning(`could not convert PR #${pr.number} to draft: ${errMessage(e)}`);
+        core.warning(`could not ${wanted} PR #${pr.number}: ${errMessage(e)}`);
       }
     }
   }
 
+  const priorDraftedSha = (existingState && existingState.draftedSha) || null;
+  // A draft episode runs from the bot drafting a PR until that PR is ready
+  // for review again, whether the bot lifted the draft or a human did: seeing
+  // the PR ready is proof the bot is no longer holding one. Only while an
+  // episode is open does the bot touch draft state, so closing it promptly is
+  // what stops the bot from later lifting a draft the contributor chose.
+  // (`draftedNow` excluded: pr.draft is the state we read *before* drafting.)
+  const episodeClosed = undraftedNow || (!draftedNow && !pr.draft);
   const state = {
     v: 1,
     failing: decision.failing,
-    draftedSha: draftedNow ? headSha : (existingState && existingState.draftedSha) || null,
+    draftedSha: draftedNow ? headSha : priorDraftedSha,
+    undraftedSha: episodeClosed ? priorDraftedSha : (existingState && existingState.undraftedSha) || null,
   };
 
   const commentBody = renderComment({
     variant: decision.variant,
     failures: signals.filter((s) => decision.failing.includes(s.id)),
     templateIssues: decision.templateBlocking ? templateVerdict.issues : null,
-    drafted: draftedNow,
+    // Holding the draft: either we just imposed it (pr.draft is the state we
+    // read before that), or an earlier run did and it is still in force.
+    holdingDraft: draftedNow || (pr.draft && decision.draftEpisodeOpen && !undraftedNow),
+    // We meant to hand the PR back and couldn't, so the contributor has to.
+    needsReadyForReview: decision.shouldUndraft && !undraftedNow && !dryRun,
     state,
   });
 
@@ -180,7 +204,9 @@ export async function run({ github, context, core }: { github: Octokit; context:
     `PR #${pr.number} by ${pr.user.login} head=${headSha} | signals: ` +
       signals.map((s) => `${s.id}=${s.state}`).join(' ') +
       ` | template=${templateVerdict.compliant ? 'ok' : 'issues'}` +
-      ` | comment=${decision.shouldComment} variant=${decision.variant || 'n/a'} draft=${decision.shouldDraft} draftedNow=${draftedNow}`
+      ` | comment=${decision.shouldComment} variant=${decision.variant || 'n/a'}` +
+      ` draft=${decision.shouldDraft} draftedNow=${draftedNow}` +
+      ` undraft=${decision.shouldUndraft} undraftedNow=${undraftedNow}`
   );
   if (decision.shouldComment) {
     core.startGroup('rendered comment');
@@ -192,7 +218,8 @@ export async function run({ github, context, core }: { github: Octokit; context:
     core.summary
       .addHeading('PR Readiness Helper — dry run', 3)
       .addRaw(`PR: #${pr.number} · head: \`${headSha}\` · would comment: **${decision.shouldComment}**` +
-        ` (variant: ${decision.variant || 'n/a'}) · would draft: **${decision.shouldDraft}**\n\n`)
+        ` (variant: ${decision.variant || 'n/a'}) · would draft: **${decision.shouldDraft}**` +
+        ` · would undraft: **${decision.shouldUndraft}**\n\n`)
       .addRaw(decision.shouldComment ? '#### Rendered comment\n\n' + commentBody + '\n' : '')
       .addTable([
         [{ data: 'signal', header: true }, { data: 'state', header: true }],

--- a/.github/pr-readiness/test/classify.test.ts
+++ b/.github/pr-readiness/test/classify.test.ts
@@ -161,6 +161,90 @@ test('decide: drafts at most once per head SHA (human undraft is respected)', ()
   assert.equal(d2.shouldDraft, true);
 });
 
+// --- decide: lifting the bot's own draft ---
+
+const allGreen = { signals: [S('lint', 'success')], templateVerdict: { compliant: true }, hasExistingComment: true };
+
+test('decide: lifts its own draft once everything is green', () => {
+  const d = decide({
+    ...allGreen,
+    existingState: { draftedSha: 'sha1' },
+    pr: { draft: true, headSha: 'sha2' }, // fixed by a new push, so a new head
+  });
+  assert.equal(d.variant, 'allclear');
+  assert.equal(d.shouldUndraft, true);
+});
+
+test('decide: the episode stays open across later runs, so the comment keeps explaining the draft', () => {
+  const d = decide({
+    signals: [S('lint', 'failure')], // a later CI completion, still failing
+    templateVerdict: { compliant: true },
+    existingState: { draftedSha: 'sha1' },
+    hasExistingComment: true,
+    pr: { draft: true, headSha: 'sha1' },
+  });
+  assert.equal(d.draftEpisodeOpen, true);
+  assert.equal(d.shouldDraft, false); // already drafted, nothing to redo
+});
+
+test('decide: state written before undrafting existed counts as an open episode', () => {
+  // Comments already on open PRs have no undraftedSha, so those PRs — drafted
+  // by the bot and left stranded — are handed back on the first run after this.
+  const d = decide({ ...allGreen, existingState: { draftedSha: 'sha1' }, pr: { draft: true, headSha: 'sha2' } });
+  assert.equal(d.shouldUndraft, true);
+});
+
+test('decide: does not lift a draft it did not impose', () => {
+  const d = decide({ ...allGreen, existingState: { draftedSha: null }, pr: { draft: true, headSha: 'sha1' } });
+  assert.equal(d.shouldUndraft, false);
+});
+
+test('decide: lifts a given draft only once, leaving later human drafts alone', () => {
+  const d = decide({
+    ...allGreen,
+    existingState: { draftedSha: 'sha1', undraftedSha: 'sha1' }, // episode already closed
+    pr: { draft: true, headSha: 'sha2' },
+  });
+  assert.equal(d.shouldUndraft, false);
+  // ...until the bot drafts again, which opens a new episode
+  const d2 = decide({
+    ...allGreen,
+    existingState: { draftedSha: 'sha3', undraftedSha: 'sha1' },
+    pr: { draft: true, headSha: 'sha3' },
+  });
+  assert.equal(d2.shouldUndraft, true);
+});
+
+test('decide: waits for pending checks before lifting its draft', () => {
+  const d = decide({
+    signals: [S('lint', 'success'), S('docs', 'pending')],
+    templateVerdict: { compliant: true },
+    existingState: { draftedSha: 'sha1' },
+    hasExistingComment: true,
+    pr: { draft: true, headSha: 'sha2' },
+  });
+  assert.equal(d.variant, 'waiting');
+  assert.equal(d.shouldUndraft, false);
+});
+
+test('decide: never lifts a draft while blocking issues remain', () => {
+  const d = decide({
+    signals: [S('lint', 'failure')],
+    templateVerdict: { compliant: true },
+    existingState: { draftedSha: 'sha1' },
+    hasExistingComment: true,
+    pr: { draft: true, headSha: 'sha1' },
+  });
+  assert.equal(d.shouldUndraft, false);
+  assert.equal(d.shouldDraft, false); // already a draft
+});
+
+test('decide: green and not a draft is a no-op either way', () => {
+  const d = decide({ ...allGreen, existingState: { draftedSha: 'sha1' }, pr: { draft: false, headSha: 'sha2' } });
+  assert.equal(d.shouldUndraft, false);
+  assert.equal(d.shouldDraft, false);
+});
+
 test('decide: no failures and a compliant template never drafts', () => {
   const d = decide({
     signals: [S('lint', 'success')],

--- a/.github/pr-readiness/test/comment.test.ts
+++ b/.github/pr-readiness/test/comment.test.ts
@@ -13,7 +13,8 @@ test('renderComment issues variant lists each failure with guidance and log link
       { id: 'dco', title: 'DCO (sign-off)', guidance: 'Sign off your commits.', url: 'https://github.com/x/y/runs/2' },
     ],
     templateIssues: null,
-    drafted: false,
+    holdingDraft: false,
+    needsReadyForReview: false,
     state: baseState,
   });
   assert.ok(body.startsWith(MARKER), 'starts with hidden marker');
@@ -29,7 +30,8 @@ test('renderComment includes template findings in a waivable details block', () 
     variant: 'issues',
     failures: [],
     templateIssues: [{ section: 'Motivation', problem: 'still contains the template placeholder' }],
-    drafted: false,
+    holdingDraft: false,
+    needsReadyForReview: false,
     state: baseState,
   });
   assert.ok(body.includes('<details>'));
@@ -38,40 +40,74 @@ test('renderComment includes template findings in a waivable details block', () 
   assert.ok(/waive/i.test(body));
 });
 
-test('renderComment notes draft conversion when drafted', () => {
-  const body = renderComment({
-    variant: 'issues',
+test('renderComment explains the draft on every render while the bot holds it', () => {
+  const args = {
+    variant: 'issues' as const,
     failures: [{ id: 'lint', title: 'Lint', guidance: 'g', url: 'u' }],
     templateIssues: null,
-    drafted: true,
+    needsReadyForReview: false,
     state: baseState,
+  };
+  // the note is a function of holding the draft, not of having just imposed
+  // it: the comment is edited in place, so a note that renders only on the
+  // drafting run is gone by the time anyone reads it
+  const held = renderComment({ ...args, holdingDraft: true });
+  assert.ok(/draft/i.test(held));
+  assert.ok(/Ready for review/.test(held));
+  assert.ok(!/\[!NOTE\]/.test(renderComment({ ...args, holdingDraft: false })));
+});
+
+test('renderComment carries the draft note into the waiting variant', () => {
+  const body = renderComment({
+    variant: 'waiting',
+    failures: [],
+    templateIssues: null,
+    holdingDraft: true,
+    needsReadyForReview: false,
+    state: { ...baseState, failing: [] },
   });
+  assert.ok(/waiting/i.test(body));
   assert.ok(/draft/i.test(body));
   assert.ok(/Ready for review/.test(body));
 });
 
 test('renderComment all-clear variant is short and positive', () => {
-  const body = renderComment({ variant: 'allclear', failures: [], templateIssues: null, drafted: false, state: { ...baseState, failing: [] } });
+  const body = renderComment({ variant: 'allclear', failures: [], templateIssues: null, holdingDraft: false, needsReadyForReview: false, state: { ...baseState, failing: [] } });
   assert.ok(body.startsWith(MARKER));
   assert.ok(body.includes('✅'));
   assert.ok(!body.includes('<details>'));
 });
 
+test('renderComment all-clear asks for Ready for review when the bot could not lift its draft', () => {
+  const body = renderComment({
+    variant: 'allclear',
+    failures: [],
+    templateIssues: null,
+    holdingDraft: false,
+    needsReadyForReview: true,
+    state: { ...baseState, failing: [] },
+  });
+  assert.ok(body.includes('✅'));
+  assert.ok(/Ready for review/.test(body));
+  // must not tell them to sit back: nobody reviews a draft
+  assert.ok(!/take it from here/.test(body));
+});
+
 test('renderComment waiting variant mentions waiting for checks', () => {
-  const body = renderComment({ variant: 'waiting', failures: [], templateIssues: null, drafted: false, state: baseState });
+  const body = renderComment({ variant: 'waiting', failures: [], templateIssues: null, holdingDraft: false, needsReadyForReview: false, state: baseState });
   assert.ok(body.startsWith(MARKER));
   assert.ok(/waiting/i.test(body));
 });
 
 test('renderComment footer says tests are not covered and it is automated', () => {
-  const body = renderComment({ variant: 'issues', failures: [{ id: 'x', title: 'X', guidance: 'g', url: 'u' }], templateIssues: null, drafted: false, state: baseState });
+  const body = renderComment({ variant: 'issues', failures: [{ id: 'x', title: 'X', guidance: 'g', url: 'u' }], templateIssues: null, holdingDraft: false, needsReadyForReview: false, state: baseState });
   assert.ok(/unit\/e2e/i.test(body));
   assert.ok(/automated/i.test(body));
 });
 
 test('state round-trips through the rendered comment', () => {
   const state: State = { v: 1, failing: ['lint', 'dco'], draftedSha: 'cafe01' };
-  const body = renderComment({ variant: 'issues', failures: [{ id: 'lint', title: 'L', guidance: 'g', url: 'u' }], templateIssues: null, drafted: false, state });
+  const body = renderComment({ variant: 'issues', failures: [{ id: 'lint', title: 'L', guidance: 'g', url: 'u' }], templateIssues: null, holdingDraft: false, needsReadyForReview: false, state });
   assert.deepEqual(parseState(body), state);
 });
 

--- a/.github/pr-readiness/types.ts
+++ b/.github/pr-readiness/types.ts
@@ -58,7 +58,12 @@ export interface TemplateVerdict {
 export interface State {
   v: number;
   failing: string[];
+  // Head SHA at which the bot last converted the PR to draft.
   draftedSha?: string | null;
+  // The `draftedSha` of the draft episode the bot has already lifted: once
+  // these two are equal the bot has handed the PR back and stops touching
+  // its draft state until it drafts again.
+  undraftedSha?: string | null;
 }
 
 export interface PrRef {
@@ -72,6 +77,9 @@ export interface Decision {
   variant: CommentVariant | null;
   shouldComment: boolean;
   shouldDraft: boolean;
+  shouldUndraft: boolean;
+  // The bot drafted this PR and has not handed it back yet.
+  draftEpisodeOpen: boolean;
   failing: string[];
   templateBlocking: boolean;
 }

--- a/.github/workflows/pr-readiness.yaml
+++ b/.github/workflows/pr-readiness.yaml
@@ -4,7 +4,8 @@ name: PR Readiness Helper
 # single sticky comment guiding the contributor through contributor-fixable
 # problems (lint, codegen, docs, title, DCO, feature files, and an unfilled
 # PR description checked against the template). Blocking problems also move the
-# PR to draft (it never undrafts).
+# PR to draft; the bot lifts that draft again once everything is green, and
+# never touches a draft the contributor set themselves.
 # See .github/pr-readiness/README.md for design, security model and tuning.
 #
 # Security: this runs with write permissions from the default branch's
@@ -27,7 +28,7 @@ concurrency:
 
 env:
   # Dry-run: set to "true" to render to the job summary instead of
-  # commenting/drafting.
+  # commenting or changing draft state.
   DRY_RUN: "false"
 
 jobs:
@@ -40,7 +41,7 @@ jobs:
       # "is the draft app configured?" as an env var here.
       HAS_DRAFT_APP: ${{ secrets.PR_READINESS_APP_ID != '' }}
     permissions:
-      pull-requests: write # sticky comment + draft conversion
+      pull-requests: write # sticky comment + draft state
       contents: read # checkout of the default branch (scripts, OWNERS, template)
       actions: read # job/step conclusions for the feature check
     steps:
@@ -48,10 +49,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The default Actions token cannot toggle a PR's draft state
-      # ("Resource not accessible by integration"), so draft conversion
-      # needs a GitHub App token — same pattern as the cherry-pick bot.
-      # Without these secrets the bot still comments, it just cannot draft.
-      - name: Mint draft-conversion token
+      # ("Resource not accessible by integration"), so drafting — and
+      # lifting that draft again — needs a GitHub App token, same pattern as
+      # the cherry-pick bot. Without these secrets the bot still comments,
+      # it just cannot draft.
+      - name: Mint draft-toggle token
         id: draft-token
         if: env.DRY_RUN != 'true' && env.HAS_DRAFT_APP == 'true'
         continue-on-error: true # drafting is best-effort; never block the comment


### PR DESCRIPTION
### Motivation

The PR readiness bot drafts a PR when a contributor-fixable check fails, but it never undrafted it — "undrafting is human-only". The problem is what the contributor is told once they fix things: the sticky comment is edited **in place**, so the all-clear replaces the failure list with

> All contributor-fixable checks are passing. A maintainer will take it from here — thanks!

on a PR that is still a draft, which no maintainer sees. The one instruction that mattered — "mark it **Ready for review**" — lived only in the failing variant, so fixing the PR erased it.

#16556 is the case that surfaced this. It was drafted at 14:02 on 2026-08-12 for a DCO failure, the contributor fixed it, and by 16:13 the bot's comment said all-clear. The PR has been green and invisible in draft ever since.

### Modifications

- **Auto-undraft.** The bot lifts a draft it imposed once everything is green, via `markPullRequestReadyForReview` on the same app token that drafts.
- **Draft "episodes".** The bot's claim on a PR's draft state starts when it drafts and ends the moment the PR is ready for review again, whoever made it so. It only ever moves a draft while its own claim is open, so a draft the contributor set is never touched, and the claim cannot outlive the situation that created it. Tracked as `undraftedSha` alongside the existing `draftedSha` in the sticky comment's state blob.
- **The all-clear tells the truth.** If lifting fails (no app token, API error), the comment asks the contributor to mark it ready instead of telling them to sit back — so the stranding cannot recur silently.
- **The draft note persists.** It is rendered on every pass while the draft is in force, not just the run that imposed it, and now says the PR *will be* marked ready automatically. Previously it was keyed off "we drafted on this very run", so it was overwritten by the next CI completion and in practice was rarely seen.

No new permissions or secrets: undrafting uses the app token already provisioned for drafting.

Worth noting this also makes the bot's eagerness self-correcting. It can draft within a minute of a push while most checks are still pending (#16556 was drafted 42 seconds in, with five of nine signals pending). If a check fails spuriously and then passes, the bot now lifts its own draft at the same head SHA — nobody has to undo it by hand.

### Verification

- 47 unit tests pass (11 new), `tsc --noEmit` clean.
- Replayed whole episodes through the real `decide()` / `renderComment()`: happy path, undraft-fails-then-retries-next-run, contributor un-drafts-then-re-drafts mid-episode (their draft is left alone), a draft the bot never imposed, and pre-existing state blobs with no `undraftedSha`.
- That last case matters: comments already on open PRs have no `undraftedSha`, which reads as an open episode, so **#16556 is handed back automatically** the next time CI completes on it.

### Documentation

`.github/pr-readiness/README.md` and the header comments in `pr-readiness.yaml` updated — the "it never undrafts" claim was in three places.

### AI

Yeah, claude, you sould have added that you wrote this in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically marks bot-created draft pull requests ready for review when all required checks pass.
  - Preserves drafts created by contributors.
  - Reports when a pull request cannot be moved to ready status and cleans up outdated status notes.
  - Dry-run mode now includes draft-state changes.

- **Documentation**
  - Updated workflow documentation to explain draft creation, restoration, and preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->