### PR TITLE
fix(logging): remove process-wide signal handler from the init logger. Fixes #15863

### DIFF
--- a/util/logging/init.go
+++ b/util/logging/init.go
@@ -5,9 +5,7 @@ import (
 	"io"
 	"maps"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 )
 
 //
@@ -27,15 +25,12 @@ type storage struct {
 	out      io.Writer // for testing purposes only
 }
 
-var (
-	initStorage = &storage{
-		initLogs: make([]initLog, 0),
-		mutex:    sync.Mutex{},
-		fatal:    false,
-		out:      os.Stderr,
-	}
-	setupOnce sync.Once
-)
+var initStorage = &storage{
+	initLogs: make([]initLog, 0),
+	mutex:    sync.Mutex{},
+	fatal:    false,
+	out:      os.Stderr,
+}
 
 var _ Logger = &initLogger{}
 
@@ -65,23 +60,9 @@ func (i initLogger) InContext(ctx context.Context) (context.Context, Logger) {
 	panic("not implemented, don't implement this")
 }
 
-func initSignalHandlers() {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-
-	go func() {
-		<-c
-		// Emit any remaining init logs before exit
-		if len(initStorage.initLogs) > 0 {
-			emitInitLogs(context.Background(), NewSlogLoggerCustom(Debug, JSON, os.Stderr))
-		}
-	}()
-}
-
 // Caller must hold the lock
 func (i initLogger) add(level Level, message string) {
 	i.storage.initLogs = append(i.storage.initLogs, initLog{level: level, message: message, fields: i.fields})
-	setupOnce.Do(initSignalHandlers)
 }
 
 func (i initLogger) Level() Level {


### PR DESCRIPTION
Fixes #15863

Thanks to @ciiiii for raising the issue, I found this whilst reviewing their fix.

As a follow up I intend to remove the init logger completely

### Motivation

`util/logging`'s init logger registers a SIGTERM/SIGINT handler via `signal.Notify` as a side effect of buffering its first message (`setupOnce.Do(initSignalHandlers)` in `add`). Registering disables Go's default terminate disposition process-wide, and the handler goroutine only flushes buffered init logs — it never exits, re-raises, or calls `signal.Stop`.

Both the workflow-controller and argo-server reach this path before `main` runs, via package-level `init()` logging in `workflow/controller/indexes` and `workflow/hydrator`. Neither binary registers any signal handling of its own, so both silently ignore SIGTERM and SIGINT forever: Kubernetes can only stop these pods with SIGKILL after the termination grace period, and the CLI cannot be cancelled with Ctrl+C (#15863). This is a v4-only regression; `util/logging` does not exist on 3.6/3.7.

### Modifications

Remove `initSignalHandlers` and its `setupOnce` arming from `util/logging/init.go`. The flush the handler protected already happens when the main logger is constructed (`emitInitLogs` in `NewSlogLoggerCustom`), so the only loss is buffered debug-level config echoes if the process is killed in the few milliseconds before the main logger exists — matching 3.x behaviour.

The init logger's other roles (buffering pre-configuration logs for replay through the main logger, and the fatal bootstrap path) are untouched.

Note for #15864: this change is what makes that PR's `stop()`/second-signal semantics actually work — previously the init logger's channel stayed registered and swallowed the force-quit signal. With this merged, #15864 becomes a graceful-cancellation enhancement rather than the fix for #15863.

### Verification

- `go test ./util/logging/` passes; both binaries build.
- Reproduced before/after with a scratch binary importing `workflow/hydrator`: before this change it survives SIGTERM, 3× SIGINT, and a second SIGTERM (only SIGKILL works); after this change a single SIGTERM terminates it with exit status 143 (default disposition).

### Documentation

Not needed: restores standard/expected signal behaviour; no user-facing interface changes.

### AI

Claude Code was used to investigate the root cause, write the change, verify it, and draft the commit message and this PR description, under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified application shutdown behavior by removing automatic log emission when interrupted or terminated.
  * Improved logging initialization reliability by removing unnecessary setup state and signal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->