### PR TITLE
test(controller): cover memoized outputs for steps templates

### DIFF
--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -11455,6 +11455,40 @@ func TestMemoizationTemplateLevelCacheWithStepWithCache(t *testing.T) {
 	require.Nil(t, node, "Whalesay step should not have been executed")
 }
 
+// TestMemoizationTemplateLevelCacheStepSavesOutputs ensures that the outputs of a memoized
+// steps template are written to the cache, so that a later cache hit can replay them.
+func TestMemoizationTemplateLevelCacheStepSavesOutputs(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(workflowWithTemplateLevelMemoizationAndChildStep)
+
+	cancel, controller := newController(logging.TestContext(t.Context()), wf)
+	defer cancel()
+
+	ctx := logging.TestContext(t.Context())
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+	woc.operate(ctx)
+
+	node := woc.wf.Status.Nodes.Find(nodeWithTemplateName("entrypoint"))
+	require.NotNil(t, node, "Entrypoint should exist")
+	require.Equal(t, wfv1.NodeSucceeded, node.Phase)
+
+	cm, err := controller.kubeclientset.CoreV1().ConfigMaps("default").Get(ctx, "cache-top-entrypoint", metav1.GetOptions{})
+	require.NoError(t, err, "Memoization cache ConfigMap should have been created")
+
+	rawEntry, ok := cm.Data["entrypoint-key-1"]
+	require.True(t, ok, "Memoization cache should contain an entry for the memoize key")
+
+	var entry cache.Entry
+	require.NoError(t, json.Unmarshal([]byte(rawEntry), &entry))
+	require.NotNil(t, entry.Outputs, "Cached entry should contain the template outputs, got %s", rawEntry)
+	require.Len(t, entry.Outputs.Parameters, 1)
+	assert.Equal(t, "url", entry.Outputs.Parameters[0].Name)
+	assert.Contains(t, entry.Outputs.Parameters[0].Value.String(), "https://argo-workflows.company.com/workflows/namepace/")
+}
+
 var workflowWithTemplateLevelMemoizationAndChildDag = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow


### PR DESCRIPTION
### Motivation

A steps template using both `memoize` and `outputs` used to cache `"outputs":null`, so a later cache hit replayed an empty result. The cause was variable shadowing in `executeSteps`: `node` was redeclared with `:=` when copying the resolved outputs onto the node, so the outer `node` still had nil `Outputs` when the memoization entry was saved. DAG templates were never affected, as `dag.go` always assigned to the outer variable.

`main` is **already fixed** — but incidentally, by 2f60d96 (#15615, "fix(lint): enable shadow linter and fix issues"). Nothing in the test suite pins the behaviour, so it could silently regress.

### Modifications

Adds `TestMemoizationTemplateLevelCacheStepSavesOutputs` to `workflow/controller/operator_test.go`, next to the existing `TestMemoizationTemplateLevelCacheWithStep*` tests. It reuses the existing `workflowWithTemplateLevelMemoizationAndChildStep` fixture, operates the workflow with no pre-seeded cache, then reads the `cache-top-entrypoint` ConfigMap and asserts the `entrypoint-key-1` entry's `Outputs` contains the `url` parameter.

Test only — no production code is touched.

### Verification

The test was verified to actually exercise the bug rather than merely passing:

- Passes on unmodified `main`.
- With `node, err =` at `workflow/controller/steps.go:182` temporarily reverted to `node, err :=`, it fails with the reported symptom verbatim:

  ```
  --- FAIL: TestMemoizationTemplateLevelCacheStepSavesOutputs
      Error: Expected value not to be nil.
      Messages: Cached entry should contain the template outputs, got
        {"nodeID":"","outputs":null,"creationTimestamp":"...","lastHitTimestamp":"..."}
  ```

- With the shadow reintroduced, this was the **only** failure across the whole `-run 'Memo'` set, confirming nothing else covered it.
- `steps.go` was then restored; the final diff contains only the test file.

Also run: full `go test ./workflow/controller/ -count=1 -timeout 15m` (ok, 102s), `go vet` (clean), and `golangci-lint run ./workflow/controller/...` without `--fix` (0 issues — a useful signal since #15615 enabled the `shadow` linter).

A companion PR backports the one-line fix itself to `release-4.0`, where the bug is still live; `release-3.7` is also affected.

Relates to #16094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ece4SFTg1cHccPwKT6k9Sq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage confirming that successful memoized workflow step outputs are saved to the configured cache.
  * Verified that cached results preserve URL parameters and workflow-specific URL values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->