### PR TITLE
fix(controller): memoize outputs for steps templates (release-4.0)

### DIFF
--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -11190,6 +11190,40 @@ func TestMemoizationTemplateLevelCacheWithStepWithCache(t *testing.T) {
 	require.Nil(t, node, "Whalesay step should not have been executed")
 }
 
+// TestMemoizationTemplateLevelCacheStepSavesOutputs ensures that the outputs of a memoized
+// steps template are written to the cache, so that a later cache hit replays them.
+func TestMemoizationTemplateLevelCacheStepSavesOutputs(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(workflowWithTemplateLevelMemoizationAndChildStep)
+
+	cancel, controller := newController(logging.TestContext(t.Context()), wf)
+	defer cancel()
+
+	ctx := logging.TestContext(t.Context())
+
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	woc.operate(ctx)
+	makePodsPhase(ctx, woc, apiv1.PodSucceeded)
+	woc.operate(ctx)
+
+	node := woc.wf.Status.Nodes.Find(nodeWithTemplateName("entrypoint"))
+	require.NotNil(t, node, "Entrypoint should exist")
+	require.Equal(t, wfv1.NodeSucceeded, node.Phase)
+
+	cm, err := controller.kubeclientset.CoreV1().ConfigMaps("default").Get(ctx, "cache-top-entrypoint", metav1.GetOptions{})
+	require.NoError(t, err, "Memoization cache ConfigMap should have been created")
+
+	rawEntry, ok := cm.Data["entrypoint-key-1"]
+	require.True(t, ok, "Memoization cache should contain an entry for the memoize key")
+
+	var entry cache.Entry
+	require.NoError(t, json.Unmarshal([]byte(rawEntry), &entry))
+	require.NotNil(t, entry.Outputs, "Cached entry should contain the template outputs, got %s", rawEntry)
+	require.Len(t, entry.Outputs.Parameters, 1)
+	assert.Equal(t, "url", entry.Outputs.Parameters[0].Name)
+	assert.Contains(t, entry.Outputs.Parameters[0].Value.String(), "https://argo-workflows.company.com/workflows/namepace/")
+}
+
 var workflowWithTemplateLevelMemoizationAndChildDag = `
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -177,7 +177,7 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 	}
 
 	if outputs != nil {
-		node, err := woc.wf.GetNodeByName(nodeName)
+		node, err = woc.wf.GetNodeByName(nodeName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport of the `steps.go` hunk of 2f60d96 (#15615) to `release-4.0`.

### Motivation

A steps template using both `memoize` and `outputs` caches `"outputs":null` on this branch, so a later cache hit replays an empty result.

`executeSteps` redeclares `node` with `:=` when copying the resolved template outputs onto the node, so the outer `node` still has nil `Outputs` when the memoization entry is saved:

```go
if outputs != nil {
    node, err := woc.wf.GetNodeByName(nodeName)   // shadows the outer node
    node.Outputs = outputs
    woc.wf.Status.Nodes.Set(ctx, node.ID, *node)
}
if node.MemoizationStatus != nil {                // outer node — Outputs still nil
    err := c.Save(ctx, node.MemoizationStatus.Key, node.ID, node.Outputs)
}
```

DAG templates were never affected, as `dag.go` always assigned to the outer variable.

This was fixed on `main` incidentally by #15615 while enabling the `shadow` linter, and first shipped in v4.1.0-rc1. `release-4.0` and `release-3.7` still carry the defect.

### Modifications

One line in `workflow/controller/steps.go`: `node, err :=` → `node, err =`, matching `main`. `err` is already declared earlier in the function, so no restructuring is needed and no new shadow is introduced.

**Only that line is taken from #15615** — the `shadow` linter is deliberately not enabled on this branch.

Adds `TestMemoizationTemplateLevelCacheStepSavesOutputs` to `workflow/controller/operator_test.go`, which operates the workflow with no pre-seeded cache and asserts the `cache-top-entrypoint` ConfigMap's `entrypoint-key-1` entry contains the `url` output parameter.

### Verification

The test was written first and confirmed failing before the fix, reproducing the reported symptom verbatim:

```
--- FAIL: TestMemoizationTemplateLevelCacheStepSavesOutputs
    Error: Expected value not to be nil.
    Messages: Cached entry should contain the template outputs, got
      {"nodeID":"","outputs":null,"creationTimestamp":"...","lastHitTimestamp":"..."}
```

It passes after the fix. Also run: `go test ./workflow/controller/ -run 'Memo|Step'` (ok), the full package `go test ./workflow/controller/ -count=1 -timeout 15m` (ok, 626s), `go vet` and `go build` (clean).

Note for anyone running these locally: the full `workflow/controller` package exceeds Go's default 10m test timeout on this branch and needs `-timeout 15m`. CI already sets `UNIT_TEST_TIMEOUT ?= 15m`.

One behavioural consequence worth a reviewer's eye: after the fix `node` refers to the freshly fetched object, so the deferred `killDaemonedChildren` closure and the later `node.MemoizationStatus` / `node.Phase = NodeError` reads now see the refreshed node. That matches `main`, and the full package run is clean.

#16695 adds the same regression test to `main`, where the fix already landed but nothing pinned it. `release-3.7` still needs the same backport.

Relates to #16094

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ece4SFTg1cHccPwKT6k9Sq
