### PR TITLE
fix(sync): remove the acquiring key from the pending queue, not the front. Fixes #16567 (cherry-pick #16613 for 3.7)

### DIFF
--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -257,7 +257,7 @@ func (s *prioritySemaphore) tryAcquire(holderKey string, tx *transaction) (bool,
 	}
 	acquired, _ := s.acquire(holderKey, tx)
 	if acquired {
-		s.pending.pop()
+		s.pending.remove(holderKey)
 		limit := s.getLimit()
 		s.log.Infof("%s acquired by %s. Lock availability: %d/%d", s.name, holderKey, limit-len(s.lockHolder), limit)
 		s.notifyWaiters()

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -248,6 +248,54 @@ func TestCheckAcquireNotifiesCorrectKeyForTemplateSemaphore(t *testing.T) {
 	}
 }
 
+// testTryAcquireRemovesAcquiringKeyFromQueue is a regression test: checkAcquire lets a
+// node acquire the lock while a sibling node of the same workflow is at the front of the
+// pending queue. tryAcquire used to pop the front entry rather than the acquiring one, so
+// the sibling was silently dropped from the queue - no later notifyWaiters iteration
+// included it - while the acquiring node's own entry was left behind as a stale
+// front-of-queue entry.
+func testTryAcquireRemovesAcquiringKeyFromQueue(t *testing.T, factory semaphoreFactory) {
+	t.Helper()
+	nextWorkflow := func(_ string) {}
+
+	s, dbSession, cleanup := factory(t, "bar", "foo", 1, nextWorkflow)
+	defer cleanup()
+
+	now := time.Now()
+	tx := &transaction{db: &dbSession}
+	require.NoError(t, s.addToQueue("foo/wf-01/node-aaa", 0, now))
+	require.NoError(t, s.addToQueue("foo/wf-01/node-bbb", 0, now.Add(time.Second)))
+	require.NoError(t, s.addToQueue("foo/wf-02/node-ccc", 0, now.Add(2*time.Second)))
+
+	// node-bbb isn't at the front, but node-aaa is and belongs to the same workflow,
+	// so node-bbb is allowed to acquire.
+	acquired, _, err := s.tryAcquire("foo/wf-01/node-bbb", tx)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// Only node-bbb's entry may be gone: node-aaa is still waiting for its turn.
+	pending, err := s.getCurrentPending()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"foo/wf-01/node-aaa", "foo/wf-02/node-ccc"}, pending)
+
+	s.release("foo/wf-01/node-bbb")
+	require.NoError(t, s.removeFromQueue("foo/wf-01/node-bbb"))
+
+	// node-aaa is still the front of the queue, so it takes the released lock.
+	acquired, _, err = s.tryAcquire("foo/wf-01/node-aaa", tx)
+	require.NoError(t, err)
+	assert.True(t, acquired, "node-aaa should still be queued and acquire the released lock")
+}
+
+// TestTryAcquireRemovesAcquiringKeyFromQueue runs the queue removal test for all implementations
+func TestTryAcquireRemovesAcquiringKeyFromQueue(t *testing.T) {
+	for name, factory := range semaphoreFactories {
+		t.Run(name, func(t *testing.T) {
+			testTryAcquireRemovesAcquiringKeyFromQueue(t, factory)
+		})
+	}
+}
+
 // TestInternalSemaphoreReleaseWithLimitFetchFailure is a regression test: a transient
 // error fetching the ConfigMap limit during release() used to make getLimit return 0,
 // which release() mistook for a downward resize — the holder was removed from the map


### PR DESCRIPTION
Cherry-picked fix(sync): remove the acquiring key from the pending queue, not the front. Fixes #16567 (#16613)