### PR TITLE
fix(ci): create ~/.m2 before bind mounting it for Java SDK publish

### DIFF
--- a/sdks/java/Makefile
+++ b/sdks/java/Makefile
@@ -17,6 +17,9 @@ CHOWN = chown -R $(shell id -u):$(shell id -g)
 
 publish: generate
 	# https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages
+	# $(HOME)/.m2 must exist before docker bind mounts it, otherwise docker
+	# creates it owned by root and maven cannot write to it
+	mkdir -p $(HOME)/.m2
 	$(MVN) deploy -DskipTests -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/argoproj/argo-workflows
 
 generate:


### PR DESCRIPTION
## Motivation

The [SDKs workflow fails on every tag push](https://github.com/argoproj/argo-workflows/actions/runs/31491355499/job/94477220157) since #15557 pointed Maven's `user.home` at the `/tmp/.m2` bind mount:

```
mkdir: cannot create directory '/root': Permission denied
[ERROR] Could not create local repository at /tmp/.m2/repository -> [Help 1]
```

`$HOME/.m2` does not exist on GitHub runners, so docker creates the bind-mount source owned by root, and Maven (running as the runner's uid via `--user`) cannot create `/tmp/.m2/repository`. Previously the root-owned mount was at `/root/.m2` which the non-root Maven never used, so it worked by accident. No Java SDK was published for v4.1.0-rc1, -rc2 or v4.1.0.

## Modifications

Pre-create `$HOME/.m2` in the `publish` target before `docker run`, so the bind-mount source is owned by the current user.

## Verification

Reproduced locally: a docker-created missing bind-mount source is owned by root and not writable by the `--user` uid; pre-creating the directory makes it writable. Full verification is publishing from a tag, which can only happen in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC3UvQ2D2iVGWQEeVmUgW2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java SDK publishing by ensuring the local Maven cache directory is created with the correct permissions before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->