### PR TITLE
refactor(controller): read env configuration in constructors, not package init

### DIFF
--- a/workflow/controller/agent.go
+++ b/workflow/controller/agent.go
@@ -139,7 +139,7 @@ func (woc *wfOperationCtx) createAgentPod(ctx context.Context) (*apiv1.Pod, erro
 	envVars := []apiv1.EnvVar{
 		{Name: common.EnvVarWorkflowName, Value: woc.wf.Name},
 		{Name: common.EnvVarWorkflowUID, Value: string(woc.wf.UID)},
-		{Name: common.EnvAgentPatchRate, Value: env.LookupEnvStringOr(common.EnvAgentPatchRate, GetRequeueTime().String())},
+		{Name: common.EnvAgentPatchRate, Value: env.LookupEnvStringOr(common.EnvAgentPatchRate, woc.controller.requeueTime.String())},
 		{Name: common.EnvVarPluginAddresses, Value: wfv1.MustMarshallJSON(addresses(pluginSidecars))},
 		{Name: common.EnvVarPluginNames, Value: wfv1.MustMarshallJSON(names(pluginSidecars))},
 	}

--- a/workflow/controller/cache_gc.go
+++ b/workflow/controller/cache_gc.go
@@ -10,18 +10,11 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/argoproj/argo-workflows/v4/util/env"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	controllercache "github.com/argoproj/argo-workflows/v4/workflow/controller/cache"
 	"github.com/argoproj/argo-workflows/v4/workflow/controller/indexes"
 )
-
-var gcAfterNotHitDuration = env.LookupEnvDurationOr(logging.InitLoggerInContext(), "CACHE_GC_AFTER_NOT_HIT_DURATION", 30*time.Second)
-
-func init() {
-	logging.InitLogger().WithField("gcAfterNotHitDuration", gcAfterNotHitDuration).Info(context.Background(), "Memoization caches will be garbage-collected if they have not been hit after")
-}
 
 // syncAllCacheForGC syncs all cache for GC
 func (wfc *WorkflowController) syncAllCacheForGC(ctx context.Context) {
@@ -52,8 +45,8 @@ func (wfc *WorkflowController) cleanupUnusedCache(ctx context.Context, cm *apiv1
 		if err := json.Unmarshal([]byte(rawEntry), &entry); err != nil {
 			return fmt.Errorf("malformed cache entry: could not unmarshal JSON; unable to parse: %w", err)
 		}
-		if time.Since(entry.LastHitTimestamp.Time) > gcAfterNotHitDuration {
-			logger.WithFields(logging.Fields{"key": key, "configMap": cm.Name, "gcAfterNotHitDuration": gcAfterNotHitDuration}).Info(ctx, "Deleting entry in ConfigMap since it's not been hit")
+		if time.Since(entry.LastHitTimestamp.Time) > wfc.gcAfterNotHitDuration {
+			logger.WithFields(logging.Fields{"key": key, "configMap": cm.Name, "gcAfterNotHitDuration": wfc.gcAfterNotHitDuration}).Info(ctx, "Deleting entry in ConfigMap since it's not been hit")
 			delete(cm.Data, key)
 			modified = true
 		}

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -145,6 +145,8 @@ type WorkflowController struct {
 	gcAfterNotHitDuration time.Duration
 	// healthzAge is the max age a workflow may go unreconciled before /healthz reports failure (HEALTHZ_AGE)
 	healthzAge time.Duration
+	// maxOperationTime is the maximum time a workflow operation is allowed to run for before requeuing the workflow onto the workqueue (MAX_OPERATION_TIME)
+	maxOperationTime time.Duration
 
 	// datastructures to support the processing of workflows and workflow pods
 	wfInformer      cache.SharedIndexInformer
@@ -240,6 +242,7 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		semaphoreNotifyDelay:       env.LookupEnvDurationOr(ctx, "SEMAPHORE_NOTIFY_DELAY", time.Second),
 		gcAfterNotHitDuration:      env.LookupEnvDurationOr(ctx, "CACHE_GC_AFTER_NOT_HIT_DURATION", 30*time.Second),
 		healthzAge:                 env.LookupEnvDurationOr(ctx, "HEALTHZ_AGE", 5*time.Minute),
+		maxOperationTime:           env.LookupEnvDurationOr(ctx, "MAX_OPERATION_TIME", 30*time.Second),
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 			mutex:    gosync.RWMutex{},

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -128,6 +128,9 @@ type WorkflowController struct {
 	// woc.executeTemplate and decreased when such calls return. This is used to prevent infinite recursion
 	maxStackDepth int
 
+	// indexWorkflowSemaphoreKeys enables the bySemaphoreConfigMap informer index (INDEX_WORKFLOW_SEMAPHORE_KEYS)
+	indexWorkflowSemaphoreKeys bool
+
 	// datastructures to support the processing of workflows and workflow pods
 	wfInformer      cache.SharedIndexInformer
 	nsInformer      cache.SharedIndexInformer
@@ -236,11 +239,13 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		eventRecorderManager:       events.NewEventRecorderManager(kubeclientset),
 		progressPatchTickDuration:  env.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:   env.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
+		indexWorkflowSemaphoreKeys: os.Getenv("INDEX_WORKFLOW_SEMAPHORE_KEYS") != "false",
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 			mutex:    gosync.RWMutex{},
 		},
 	}
+	logging.RequireLoggerFromContext(ctx).WithField("indexWorkflowSemaphoreKeys", wfc.indexWorkflowSemaphoreKeys).Info(ctx, "index config")
 
 	if executorPlugins {
 		wfc.executorPlugins = map[string]map[string]*spec.Plugin{}
@@ -307,15 +312,17 @@ func (wfc *WorkflowController) runCronController(ctx context.Context, cronWorkfl
 	cronController.Run(ctx)
 }
 
-var indexers = cache.Indexers{
-	indexes.ClusterWorkflowTemplateIndex: indexes.MetaNamespaceLabelIndexFunc(common.LabelKeyClusterWorkflowTemplate),
-	indexes.CronWorkflowIndex:            indexes.MetaNamespaceLabelIndexFunc(common.LabelKeyCronWorkflow),
-	indexes.WorkflowTemplateIndex:        indexes.MetaNamespaceLabelIndexFunc(common.LabelKeyWorkflowTemplate),
-	indexes.SemaphoreConfigIndexName:     indexes.WorkflowSemaphoreKeysIndexFunc(),
-	indexes.WorkflowPhaseIndex:           indexes.MetaWorkflowPhaseIndexFunc(),
-	indexes.ConditionsIndex:              indexes.ConditionsIndexFunc,
-	indexes.UIDIndex:                     indexes.MetaUIDFunc,
-	cache.NamespaceIndex:                 cache.MetaNamespaceIndexFunc,
+func newIndexers(semaphoreKeysEnabled bool) cache.Indexers {
+	return cache.Indexers{
+		indexes.ClusterWorkflowTemplateIndex: indexes.MetaNamespaceLabelIndexFunc(common.LabelKeyClusterWorkflowTemplate),
+		indexes.CronWorkflowIndex:            indexes.MetaNamespaceLabelIndexFunc(common.LabelKeyCronWorkflow),
+		indexes.WorkflowTemplateIndex:        indexes.MetaNamespaceLabelIndexFunc(common.LabelKeyWorkflowTemplate),
+		indexes.SemaphoreConfigIndexName:     indexes.WorkflowSemaphoreKeysIndexFunc(semaphoreKeysEnabled),
+		indexes.WorkflowPhaseIndex:           indexes.MetaWorkflowPhaseIndexFunc(),
+		indexes.ConditionsIndex:              indexes.ConditionsIndexFunc,
+		indexes.UIDIndex:                     indexes.MetaUIDFunc,
+		cache.NamespaceIndex:                 cache.MetaNamespaceIndexFunc,
+	}
 }
 
 // ShutdownTracing flushes any remaining spans and shuts down the trace provider.
@@ -375,7 +382,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		"workflowArchive":     wfArchiveWorkers,
 	}).Info(ctx, "Current Worker Numbers")
 
-	wfc.wfInformer = util.NewWorkflowInformer(ctx, wfc.dynamicInterface, wfc.GetManagedNamespace(), workflowResyncPeriod, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, indexers)
+	wfc.wfInformer = util.NewWorkflowInformer(ctx, wfc.dynamicInterface, wfc.GetManagedNamespace(), workflowResyncPeriod, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, newIndexers(wfc.indexWorkflowSemaphoreKeys))
 	nsInformer, err := wfc.newNamespaceInformer(ctx, wfc.kubeclientset)
 	if err != nil {
 		logger.WithError(err).WithFatal().Error(ctx, "Failed to create namespace informer")

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -147,6 +147,8 @@ type WorkflowController struct {
 	healthzAge time.Duration
 	// maxOperationTime is the maximum time a workflow operation is allowed to run for before requeuing the workflow onto the workqueue (MAX_OPERATION_TIME)
 	maxOperationTime time.Duration
+	// requeueTime is the default requeue interval for the workflow workqueue (DEFAULT_REQUEUE_TIME)
+	requeueTime time.Duration
 
 	// datastructures to support the processing of workflows and workflow pods
 	wfInformer      cache.SharedIndexInformer
@@ -243,6 +245,7 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		gcAfterNotHitDuration:      env.LookupEnvDurationOr(ctx, "CACHE_GC_AFTER_NOT_HIT_DURATION", 30*time.Second),
 		healthzAge:                 env.LookupEnvDurationOr(ctx, "HEALTHZ_AGE", 5*time.Minute),
 		maxOperationTime:           env.LookupEnvDurationOr(ctx, "MAX_OPERATION_TIME", 30*time.Second),
+		requeueTime:                env.LookupEnvDurationOr(ctx, common.EnvVarDefaultRequeueTime, 10*time.Second),
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 			mutex:    gosync.RWMutex{},
@@ -285,7 +288,7 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 	wfc.entrypoint = entrypoint.New(kubeclientset, wfc.Config.Images)
 
 	workqueue.SetProvider(wfc.metrics) // must execute SetProvider before we create the queues
-	wfc.wfQueue = wfc.metrics.RateLimiterWithBusyWorkers(ctx, &fixedItemIntervalRateLimiter{}, "workflow_queue")
+	wfc.wfQueue = wfc.metrics.RateLimiterWithBusyWorkers(ctx, &fixedItemIntervalRateLimiter{requeueTime: wfc.requeueTime}, "workflow_queue")
 	wfc.throttler = wfc.newThrottler()
 	wfc.wfArchiveQueue = wfc.metrics.RateLimiterWithBusyWorkers(ctx, workqueue.DefaultTypedControllerRateLimiter[string](), "workflow_archive_queue")
 
@@ -380,7 +383,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 
 	logger.WithFields(argo.GetVersion().Fields()).WithFields(logging.Fields{
 		"instanceID":         wfc.Config.InstanceID,
-		"defaultRequeueTime": GetRequeueTime(),
+		"defaultRequeueTime": wfc.requeueTime,
 	}).Info(ctx, "Starting Workflow Controller")
 	logger.WithFields(logging.Fields{
 		"workflowWorkers":     wfWorkers,

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -131,6 +131,21 @@ type WorkflowController struct {
 	// indexWorkflowSemaphoreKeys enables the bySemaphoreConfigMap informer index (INDEX_WORKFLOW_SEMAPHORE_KEYS)
 	indexWorkflowSemaphoreKeys bool
 
+	// cacheGCPeriod controls how often memoization caches are GC'd; 0 disables GC (CACHE_GC_PERIOD)
+	cacheGCPeriod time.Duration
+	// semaphoreNotifyDelay is a slight delay when notifying/enqueueing workflows to the workqueue
+	// that are waiting on a semaphore. This value is passed to AddAfter(). We delay adding the next
+	// workflow because if we add immediately with AddRateLimited(), the next workflow will likely
+	// be reconciled at a point in time before we have finished the current workflow reconciliation
+	// as well as incrementing the semaphore counter availability, and so the next workflow will
+	// believe it cannot run. By delaying for 1s, we would have finished the semaphore counter
+	// updates, and the next workflow will see the updated availability. (SEMAPHORE_NOTIFY_DELAY)
+	semaphoreNotifyDelay time.Duration
+	// gcAfterNotHitDuration is how long a memoization cache entry may go unhit before GC removes it (CACHE_GC_AFTER_NOT_HIT_DURATION)
+	gcAfterNotHitDuration time.Duration
+	// healthzAge is the max age a workflow may go unreconciled before /healthz reports failure (HEALTHZ_AGE)
+	healthzAge time.Duration
+
 	// datastructures to support the processing of workflows and workflow pods
 	wfInformer      cache.SharedIndexInformer
 	nsInformer      cache.SharedIndexInformer
@@ -187,25 +202,6 @@ const (
 	configMapResyncPeriod               = 20 * time.Minute
 )
 
-var (
-	cacheGCPeriod = env.LookupEnvDurationOr(logging.InitLoggerInContext(), "CACHE_GC_PERIOD", 0)
-
-	// semaphoreNotifyDelay is a slight delay when notifying/enqueueing workflows to the workqueue
-	// that are waiting on a semaphore. This value is passed to AddAfter(). We delay adding the next
-	// workflow because if we add immediately with AddRateLimited(), the next workflow will likely
-	// be reconciled at a point in time before we have finished the current workflow reconciliation
-	// as well as incrementing the semaphore counter availability, and so the next workflow will
-	// believe it cannot run. By delaying for 1s, we would have finished the semaphore counter
-	// updates, and the next workflow will see the updated availability.
-	semaphoreNotifyDelay = env.LookupEnvDurationOr(logging.InitLoggerInContext(), "SEMAPHORE_NOTIFY_DELAY", time.Second)
-)
-
-func init() {
-	if cacheGCPeriod != 0 {
-		logging.InitLogger().WithField("cacheGCPeriod", cacheGCPeriod).Info(context.Background(), "GC for memoization caches will be performed every")
-	}
-}
-
 // NewWorkflowController instantiates a new WorkflowController
 func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubeclientset kubernetes.Interface, wfclientset wfclientset.Interface, namespace, managedNamespace, executorImage, executorImagePullPolicy, executorLogFormat, configMap string, executorPlugins bool, workflowLevelExecutorPlugins bool) (*WorkflowController, error) {
 	dynamicInterface, err := dynamic.NewForConfig(restConfig)
@@ -240,12 +236,21 @@ func NewWorkflowController(ctx context.Context, restConfig *rest.Config, kubecli
 		progressPatchTickDuration:  env.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
 		progressFileTickDuration:   env.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
 		indexWorkflowSemaphoreKeys: os.Getenv("INDEX_WORKFLOW_SEMAPHORE_KEYS") != "false",
+		cacheGCPeriod:              env.LookupEnvDurationOr(ctx, "CACHE_GC_PERIOD", 0),
+		semaphoreNotifyDelay:       env.LookupEnvDurationOr(ctx, "SEMAPHORE_NOTIFY_DELAY", time.Second),
+		gcAfterNotHitDuration:      env.LookupEnvDurationOr(ctx, "CACHE_GC_AFTER_NOT_HIT_DURATION", 30*time.Second),
+		healthzAge:                 env.LookupEnvDurationOr(ctx, "HEALTHZ_AGE", 5*time.Minute),
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 			mutex:    gosync.RWMutex{},
 		},
 	}
-	logging.RequireLoggerFromContext(ctx).WithField("indexWorkflowSemaphoreKeys", wfc.indexWorkflowSemaphoreKeys).Info(ctx, "index config")
+	logger := logging.RequireLoggerFromContext(ctx)
+	logger.WithField("indexWorkflowSemaphoreKeys", wfc.indexWorkflowSemaphoreKeys).Info(ctx, "index config")
+	if wfc.cacheGCPeriod != 0 {
+		logger.WithField("cacheGCPeriod", wfc.cacheGCPeriod).Info(ctx, "GC for memoization caches will be performed every")
+	}
+	logger.WithField("gcAfterNotHitDuration", wfc.gcAfterNotHitDuration).Info(ctx, "Memoization caches will be garbage-collected if they have not been hit after")
 
 	if executorPlugins {
 		wfc.executorPlugins = map[string]map[string]*spec.Plugin{}
@@ -464,8 +469,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	for range wfArchiveWorkers {
 		go wait.UntilWithContext(archiveCtx, wfc.runArchiveWorker, time.Second)
 	}
-	if cacheGCPeriod != 0 {
-		go wait.JitterUntilWithContext(ctx, wfc.syncAllCacheForGC, cacheGCPeriod, 0.0, true)
+	if wfc.cacheGCPeriod != 0 {
+		go wait.JitterUntilWithContext(ctx, wfc.syncAllCacheForGC, wfc.cacheGCPeriod, 0.0, true)
 	}
 	<-ctx.Done()
 }
@@ -500,7 +505,7 @@ func (wfc *WorkflowController) createSynchronizationManager(ctx context.Context)
 	}
 
 	nextWorkflow := func(key string) {
-		wfc.wfQueue.AddAfter(key, semaphoreNotifyDelay)
+		wfc.wfQueue.AddAfter(key, wfc.semaphoreNotifyDelay)
 	}
 
 	workflowExists := func(key string) bool {

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -319,6 +319,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		semaphoreNotifyDelay:       time.Second,
 		gcAfterNotHitDuration:      30 * time.Second,
 		healthzAge:                 5 * time.Minute,
+		maxOperationTime:           30 * time.Second,
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 		},

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -315,6 +315,10 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		progressFileTickDuration:   envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
 		maxStackDepth:              maxAllowedStackDepth,
 		indexWorkflowSemaphoreKeys: true,
+		cacheGCPeriod:              0,
+		semaphoreNotifyDelay:       time.Second,
+		gcAfterNotHitDuration:      30 * time.Second,
+		healthzAge:                 5 * time.Minute,
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 		},

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -299,21 +299,22 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 				S3Bucket: wfv1.S3Bucket{Endpoint: "my-endpoint", Bucket: "my-bucket"},
 			},
 		}),
-		cliExecutorLogFormat:      "text",
-		kubeclientset:             kube,
-		dynamicInterface:          dynamicClient,
-		metadataInterface:         metadataClient,
-		wfclientset:               wfclientset,
-		workflowKeyLock:           sync.NewKeyLock(),
-		wfArchive:                 sqldb.NullWorkflowArchive,
-		hydrator:                  hydratorfake.Noop,
-		estimatorFactory:          estimation.DummyEstimatorFactory,
-		eventRecorderManager:      &testEventRecorderManager{eventRecorder: record.NewFakeRecorder(64)},
-		archiveLabelSelector:      labels.Everything(),
-		cacheFactory:              controllercache.NewCacheFactory(kube, "default"),
-		progressPatchTickDuration: envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
-		progressFileTickDuration:  envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
-		maxStackDepth:             maxAllowedStackDepth,
+		cliExecutorLogFormat:       "text",
+		kubeclientset:              kube,
+		dynamicInterface:           dynamicClient,
+		metadataInterface:          metadataClient,
+		wfclientset:                wfclientset,
+		workflowKeyLock:            sync.NewKeyLock(),
+		wfArchive:                  sqldb.NullWorkflowArchive,
+		hydrator:                   hydratorfake.Noop,
+		estimatorFactory:           estimation.DummyEstimatorFactory,
+		eventRecorderManager:       &testEventRecorderManager{eventRecorder: record.NewFakeRecorder(64)},
+		archiveLabelSelector:       labels.Everything(),
+		cacheFactory:               controllercache.NewCacheFactory(kube, "default"),
+		progressPatchTickDuration:  envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressPatchTickDuration, 1*time.Minute),
+		progressFileTickDuration:   envutil.LookupEnvDurationOr(ctx, common.EnvVarProgressFileTickDuration, 3*time.Second),
+		maxStackDepth:              maxAllowedStackDepth,
+		indexWorkflowSemaphoreKeys: true,
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 		},
@@ -340,7 +341,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 
 	// always compare to WorkflowController.Run to see what this block of code should be doing
 	{
-		wfc.wfInformer = util.NewWorkflowInformer(ctx, dynamicClient, "", 0, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, indexers)
+		wfc.wfInformer = util.NewWorkflowInformer(ctx, dynamicClient, "", 0, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, newIndexers(wfc.indexWorkflowSemaphoreKeys))
 		wfc.wfTaskSetInformer = informerFactory.Argoproj().V1alpha1().WorkflowTaskSets()
 		wfc.artGCTaskInformer = informerFactory.Argoproj().V1alpha1().WorkflowArtifactGCTasks()
 		wfc.taskResultInformer = wfc.newWorkflowTaskResultInformer(ctx)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -320,6 +320,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		gcAfterNotHitDuration:      30 * time.Second,
 		healthzAge:                 5 * time.Minute,
 		maxOperationTime:           30 * time.Second,
+		requeueTime:                10 * time.Second,
 		lastWrittenVersions: lastWrittenVersions{
 			versions: make(map[types.UID]lastWrittenVersion),
 		},

--- a/workflow/controller/healthz.go
+++ b/workflow/controller/healthz.go
@@ -11,14 +11,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
-	"github.com/argoproj/argo-workflows/v4/util/env"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	"github.com/argoproj/argo-workflows/v4/workflow/util"
-)
-
-var (
-	age = env.LookupEnvDurationOr(logging.InitLoggerInContext(), "HEALTHZ_AGE", 5*time.Minute)
 )
 
 func LogMiddleware(logger logging.Logger, next http.Handler) http.Handler {
@@ -74,7 +69,7 @@ func (wfc *WorkflowController) Healthz(w http.ResponseWriter, r *http.Request) {
 		var firstExceededWorkflow *wfv1.Workflow
 
 		for _, wf := range unreconciledWorkflows {
-			if time.Since(wf.GetCreationTimestamp().Time) > age {
+			if time.Since(wf.GetCreationTimestamp().Time) > wfc.healthzAge {
 				unreconciledExceedAge = true
 				firstExceededWorkflow = wf
 				break
@@ -110,7 +105,7 @@ func (wfc *WorkflowController) Healthz(w http.ResponseWriter, r *http.Request) {
 				"managedNamespace": wfc.managedNamespace,
 				"instanceID":       instanceID,
 				"labelSelector":    labelSelector,
-				"age":              age,
+				"age":              wfc.healthzAge,
 			}).
 			Info(r.Context(), "healthz")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/workflow/controller/indexes/workflow_index.go
+++ b/workflow/controller/indexes/workflow_index.go
@@ -1,25 +1,13 @@
 package indexes
 
 import (
-	"context"
-	"os"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/workflow/common"
 	"github.com/argoproj/argo-workflows/v4/workflow/util"
 )
-
-var (
-	indexWorkflowSemaphoreKeys = os.Getenv("INDEX_WORKFLOW_SEMAPHORE_KEYS") != "false"
-)
-
-func init() {
-	logging.InitLogger().WithField("indexWorkflowSemaphoreKeys", indexWorkflowSemaphoreKeys).Info(context.Background(), "index config")
-}
 
 func MetaWorkflowIndexFunc(obj any) ([]string, error) {
 	m, err := meta.Accessor(obj)
@@ -52,8 +40,8 @@ func WorkflowIndexValue(namespace, name string) string {
 	return namespace + "/" + name
 }
 
-func WorkflowSemaphoreKeysIndexFunc() cache.IndexFunc {
-	if !indexWorkflowSemaphoreKeys {
+func WorkflowSemaphoreKeysIndexFunc(enabled bool) cache.IndexFunc {
+	if !enabled {
 		return func(obj any) ([]string, error) {
 			return nil, nil
 		}

--- a/workflow/controller/indexes/workflow_index_test.go
+++ b/workflow/controller/indexes/workflow_index_test.go
@@ -84,7 +84,7 @@ func TestWorkflowSemaphoreKeysIndexFunc(t *testing.T) {
 				},
 			},
 		})
-		result, err := WorkflowSemaphoreKeysIndexFunc()(un)
+		result, err := WorkflowSemaphoreKeysIndexFunc(true)(un)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 	})
@@ -103,7 +103,7 @@ func TestWorkflowSemaphoreKeysIndexFunc(t *testing.T) {
 				},
 			},
 		})
-		result, err := WorkflowSemaphoreKeysIndexFunc()(un)
+		result, err := WorkflowSemaphoreKeysIndexFunc(true)(un)
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
 	})
@@ -115,7 +115,24 @@ func TestWorkflowSemaphoreKeysIndexFunc(t *testing.T) {
 				},
 			},
 		})
-		result, err := WorkflowSemaphoreKeysIndexFunc()(un)
+		result, err := WorkflowSemaphoreKeysIndexFunc(true)(un)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+	t.Run("Disabled", func(t *testing.T) {
+		un, _ := util.ToUnstructured(&wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+			Spec: wfv1.WorkflowSpec{
+				Synchronization: &wfv1.Synchronization{
+					Semaphores: []*wfv1.SemaphoreRef{{
+						ConfigMapKeyRef: &apiv1.ConfigMapKeySelector{},
+					}},
+				},
+			},
+		})
+		result, err := WorkflowSemaphoreKeysIndexFunc(false)(un)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -142,12 +142,6 @@ var (
 	ErrRequeue = errors.New("requeue")
 )
 
-// maxOperationTime is the maximum time a workflow operation is allowed to run
-// for before requeuing the workflow onto the workqueue.
-var (
-	maxOperationTime = envutil.LookupEnvDurationOr(logging.InitLoggerInContext(), "MAX_OPERATION_TIME", 30*time.Second)
-)
-
 // failedNodeStatus is a subset of NodeStatus that is only used to Marshal certain fields into a JSON of failed nodes
 type failedNodeStatus struct {
 	DisplayName  string      `json:"displayName"`
@@ -179,7 +173,7 @@ func newWorkflowOperationCtx(ctx context.Context, wf *wfv1.Workflow, wfc *Workfl
 		controller:               wfc,
 		scope:                    variables.NewScope(),
 		volumes:                  wf.Spec.DeepCopy().Volumes,
-		deadline:                 time.Now().UTC().Add(maxOperationTime),
+		deadline:                 time.Now().UTC().Add(wfc.maxOperationTime),
 		eventRecorder:            wfc.eventRecorderManager.Get(ctx, wf.Namespace),
 		preExecutionNodeStatuses: make(map[string]wfv1.NodeStatus),
 		taskSet:                  make(map[string]wfv1.Template),

--- a/workflow/controller/rate_limiters.go
+++ b/workflow/controller/rate_limiters.go
@@ -4,29 +4,22 @@ import (
 	"time"
 
 	"k8s.io/client-go/util/workqueue"
-
-	"github.com/argoproj/argo-workflows/v4/util/env"
-	"github.com/argoproj/argo-workflows/v4/util/logging"
-	"github.com/argoproj/argo-workflows/v4/workflow/common"
 )
 
-var envRequeueTime = env.LookupEnvDurationOr(logging.InitLoggerInContext(), common.EnvVarDefaultRequeueTime, 10*time.Second)
-
-func GetRequeueTime() time.Duration {
-	// We need to rate limit a minimum 1s, otherwise informers are unlikely to be upto date
-	// and we'll operate on an out of date version of a workflow.
-	// Under high load, the informer can get many seconds behind. Increasing this to 30s
-	// would be sensible for some users.
-	// Higher values mean that workflows with many short running (<20s) nodes do not progress as quickly.
-	// So some users may wish to have this as low as 2s.
-	// The default of 10s provides a balance more most users.
-	return envRequeueTime
+type fixedItemIntervalRateLimiter struct {
+	// requeueTime rate limits how often a workflow is reconciled, minimum 1s,
+	// otherwise informers are unlikely to be up to date and we'll operate on an
+	// out of date version of a workflow. Under high load, the informer can get
+	// many seconds behind. Increasing this to 30s would be sensible for some
+	// users. Higher values mean that workflows with many short running (<20s)
+	// nodes do not progress as quickly. So some users may wish to have this as
+	// low as 2s. The default of 10s provides a balance for most users.
+	// (DEFAULT_REQUEUE_TIME)
+	requeueTime time.Duration
 }
 
-type fixedItemIntervalRateLimiter struct{}
-
 func (r *fixedItemIntervalRateLimiter) When(_ string) time.Duration {
-	return GetRequeueTime()
+	return r.requeueTime
 }
 
 func (r *fixedItemIntervalRateLimiter) Forget(string) {}

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -56,22 +56,18 @@ type Controller struct {
 	eventRecorderManager events.EventRecorderManager
 	cronWorkflowWorkers  int
 	logger               logging.Logger
+	syncPeriod           time.Duration
 }
 
 const (
 	cronWorkflowResyncPeriod = 20 * time.Minute
 )
 
-var cronSyncPeriod time.Duration
-
 func init() {
 	// this make sure we support timezones
-	_, err := time.Parse(time.RFC822, "17 Oct 07 14:03 PST")
-	if err != nil {
-		logging.InitLogger().WithFatal().WithError(err).Error(context.Background(), "failed to parse time")
+	if _, err := time.Parse(time.RFC822, "17 Oct 07 14:03 PST"); err != nil {
+		panic(err)
 	}
-	cronSyncPeriod = env.LookupEnvDurationOr(logging.InitLoggerInContext(), "CRON_SYNC_PERIOD", 10*time.Second)
-	logging.InitLogger().WithField("cronSyncPeriod", cronSyncPeriod).Info(context.Background(), "cron config")
 }
 
 // NewCronController creates a new cron controller
@@ -79,6 +75,9 @@ func NewCronController(ctx context.Context, wfclientset versioned.Interface, dyn
 	eventRecorderManager events.EventRecorderManager, cronWorkflowWorkers int, wftmplInformer wfextvv1alpha1.WorkflowTemplateInformer, cwftmplInformer wfextvv1alpha1.ClusterWorkflowTemplateInformer, wfDefaults *v1alpha1.Workflow,
 ) *Controller {
 	ctx, logger := logging.RequireLoggerFromContext(ctx).WithField("component", "cron").InContext(ctx)
+
+	syncPeriod := env.LookupEnvDurationOr(ctx, "CRON_SYNC_PERIOD", 10*time.Second)
+	logger.WithField("cronSyncPeriod", syncPeriod).Info(ctx, "cron config")
 
 	return &Controller{
 		wfClientset:          wfclientset,
@@ -96,6 +95,7 @@ func NewCronController(ctx context.Context, wfclientset versioned.Interface, dyn
 		cwftmplInformer:      cwftmplInformer,
 		cronWorkflowWorkers:  cronWorkflowWorkers,
 		logger:               logger,
+		syncPeriod:           syncPeriod,
 	}
 }
 
@@ -128,7 +128,7 @@ func (cc *Controller) Run(ctx context.Context) {
 
 	go cc.cronWfInformer.Informer().Run(ctx.Done())
 
-	go wait.UntilWithContext(ctx, cc.syncAll, cronSyncPeriod)
+	go wait.UntilWithContext(ctx, cc.syncAll, cc.syncPeriod)
 
 	for i := 0; i < cc.cronWorkflowWorkers; i++ {
 		go wait.UntilWithContext(ctx, cc.runCronWorker, time.Second)


### PR DESCRIPTION
Part 1 of 3 in a stack that retires `util/logging`'s init logger (see #16705 for the endgame; follows up on #16693, which fixed the init logger's process-wide signal handler swallowing SIGTERM).

### Motivation

The init logger exists to buffer log messages emitted before the main logger is configured — almost all of them package-level `var`/`init()` env-config reads. Moving those reads into constructors (where a real, correctly-formatted logger is already in context) removes the need for pre-`main` logging entirely, makes the config values testable with `t.Setenv`, and turns config echoes into ordinary constructor log lines in the operator's chosen format and level.

### Modifications

Pure moves of *where* each env read happens — every variable keeps its exact name and default:

- `WorkflowController` gains constructor-read fields for `INDEX_WORKFLOW_SEMAPHORE_KEYS`, `CACHE_GC_PERIOD`, `SEMAPHORE_NOTIFY_DELAY`, `CACHE_GC_AFTER_NOT_HIT_DURATION`, `HEALTHZ_AGE`, `MAX_OPERATION_TIME`, and `DEFAULT_REQUEUE_TIME`; the package-level vars and `init()` blocks are deleted. The `newController` test helper mirrors each default explicitly.
- `WorkflowSemaphoreKeysIndexFunc` becomes an explicit factory parameter (`enabled bool`) and the package-level `indexers` var becomes `newIndexers(semaphoreKeysEnabled bool)`; its tests now cover the disabled branch without env mutation.
- `fixedItemIntervalRateLimiter` carries the requeue time as a field; the exported, otherwise-unused `GetRequeueTime()` is **removed** (breaking only for downstream importers — nothing in-repo references it).
- Cron: `CRON_SYNC_PERIOD` moves into `NewCronController`. The `init()`-time RFC822 timezone-parse sanity check remains, but no longer involves the init logger: it now simply panics on failure (stderr, no special handling).

Deliberate behavior change: an unparseable duration value now fails at constructor time with a real message (previously it panicked at package-init via the init logger's unimplemented `WithPanic`).

### Verification

`go build ./...`, `golangci-lint` (0 issues), and `go test ./workflow/... -count=1` all pass (one pre-existing, unrelated environment failure in `workflow/executor/osspecific` reproduces identically on `main`). Each field's default is asserted equal between constructor and test helper by inspection; the semaphore-index factory gained a new disabled-branch test.

### Documentation

Not needed: every env var keeps its documented name, default, and semantics; `docs/environment-variables.md` remains accurate.

### AI

Claude Code planned and implemented this change under human direction, with per-task and whole-branch review passes; the author reviewed and takes responsibility for the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqVAUnuPJZ7sQZCy44bBSE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Configuration for workflow scheduling, health checks, operation timeouts, cache cleanup, and semaphore handling is now applied consistently per controller instance.
  - Workflow queue rate limiting and cron synchronization use their configured intervals more reliably.
  - Cache cleanup and health diagnostics now honor controller-specific settings.
  - Semaphore indexing can be enabled or disabled through configuration.
  - Improved isolation and predictability when running multiple controller instances with different settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->