### PR TITLE
refactor(server): read env configuration in constructors, not package init

### DIFF
--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -81,8 +81,6 @@ import (
 	"github.com/argoproj/argo-workflows/v4/workflow/hydrator"
 )
 
-var MaxGRPCMessageSize int
-
 // Server is the interface for the Argo API server
 type Server interface {
 	Run(ctx context.Context, port int, browserOpenFunc func(string))
@@ -109,6 +107,7 @@ type argoServer struct {
 	allowedLinkProtocol      []string
 	cache                    *cache.ResourceCache
 	restConfig               *rest.Config
+	maxGRPCMessageSize       int
 }
 
 type ArgoServerOpts struct {
@@ -131,14 +130,6 @@ type ArgoServerOpts struct {
 	AccessControlAllowOrigin string
 	APIRateLimit             uint64
 	AllowedLinkProtocol      []string
-}
-
-func init() {
-	var err error
-	MaxGRPCMessageSize, err = env.GetInt("GRPC_MESSAGE_SIZE", 100*1024*1024)
-	if err != nil {
-		logging.InitLogger().WithFatal().WithError(err).Error(context.Background(), "GRPC_MESSAGE_SIZE environment variable must be set as an integer")
-	}
 }
 
 func getResourceCacheNamespace(managedNamespace string) string {
@@ -186,6 +177,11 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (Server, error) {
 		log.WithFatal().Error(ctx, err.Error())
 	}
 
+	maxGRPCMessageSize, err := env.GetInt("GRPC_MESSAGE_SIZE", 100*1024*1024)
+	if err != nil {
+		return nil, fmt.Errorf("GRPC_MESSAGE_SIZE environment variable must be set as an integer: %w", err)
+	}
+
 	return &argoServer{
 		baseHRef:                 opts.BaseHRef,
 		tlsConfig:                opts.TLSConfig,
@@ -206,6 +202,7 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (Server, error) {
 		allowedLinkProtocol:      opts.AllowedLinkProtocol,
 		cache:                    resourceCache,
 		restConfig:               opts.RestConfig,
+		maxGRPCMessageSize:       maxGRPCMessageSize,
 	}, nil
 }
 
@@ -348,7 +345,7 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 		url = "https://localhost" + address
 	}
 	log.WithFields(logging.Fields{
-		"GRPC_MESSAGE_SIZE": MaxGRPCMessageSize,
+		"GRPC_MESSAGE_SIZE": as.maxGRPCMessageSize,
 	}).Info(ctx, "GRPC Server Max Message Size, MaxGRPCMessageSize, is set")
 	log.WithField("url", url).Info(ctx, "Argo Server started successfully")
 	browserOpenFunc(url)
@@ -366,8 +363,8 @@ func (as *argoServer) newGRPCServer(ctx context.Context, instanceIDService insta
 		// Set both the send and receive the bytes limit to be 100MB or GRPC_MESSAGE_SIZE
 		// The proper way to achieve high performance is to have pagination
 		// while we work toward that, we can have high limit first
-		grpc.MaxRecvMsgSize(MaxGRPCMessageSize),
-		grpc.MaxSendMsgSize(MaxGRPCMessageSize),
+		grpc.MaxRecvMsgSize(as.maxGRPCMessageSize),
+		grpc.MaxSendMsgSize(as.maxGRPCMessageSize),
 		grpc.ConnectionTimeout(300 * time.Second),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_prometheus.UnaryServerInterceptor,
@@ -424,7 +421,7 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 	loggingInterceptor := accesslog.NewLoggingInterceptor(log)
 	handler := rateLimitMiddleware.Handle(loggingInterceptor.Interceptor(mux))
 	dialOpts := []grpc.DialOption{
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(as.maxGRPCMessageSize)),
 	}
 	if as.tlsConfig != nil {
 		tlsConfig := as.tlsConfig.Clone()

--- a/workflow/hydrator/hydrator.go
+++ b/workflow/hydrator/hydrator.go
@@ -28,17 +28,15 @@ type Interface interface {
 }
 
 func New(offloadNodeStatusRepo sqldb.OffloadNodeStatusRepo) Interface {
-	return &hydrator{offloadNodeStatusRepo}
-}
-
-var alwaysOffloadNodeStatus = os.Getenv("ALWAYS_OFFLOAD_NODE_STATUS") == "true"
-
-func init() {
-	logging.InitLogger().WithField("alwaysOffloadNodeStatus", alwaysOffloadNodeStatus).Debug(context.Background(), "Hydrator config")
+	return &hydrator{
+		offloadNodeStatusRepo:   offloadNodeStatusRepo,
+		alwaysOffloadNodeStatus: os.Getenv("ALWAYS_OFFLOAD_NODE_STATUS") == "true",
+	}
 }
 
 type hydrator struct {
-	offloadNodeStatusRepo sqldb.OffloadNodeStatusRepo
+	offloadNodeStatusRepo   sqldb.OffloadNodeStatusRepo
+	alwaysOffloadNodeStatus bool
 }
 
 func (h hydrator) IsHydrated(wf *wfv1.Workflow) bool {
@@ -100,14 +98,14 @@ func (h hydrator) Dehydrate(ctx context.Context, wf *wfv1.Workflow) error {
 	log := logging.RequireLoggerFromContext(ctx)
 	var err error
 	log.WithField("Workflow Size", wf.Size()).Info(ctx, "Workflow to be dehydrated")
-	if !alwaysOffloadNodeStatus {
+	if !h.alwaysOffloadNodeStatus {
 		err = packer.CompressWorkflowIfNeeded(ctx, wf)
 		if err == nil {
 			wf.Status.OffloadNodeStatusVersion = ""
 			return nil
 		}
 	}
-	if packer.IsTooLargeError(err) || alwaysOffloadNodeStatus {
+	if packer.IsTooLargeError(err) || h.alwaysOffloadNodeStatus {
 		var offloadVersion string
 		var errMsg string
 		if err != nil {

--- a/workflow/hydrator/hydrator_test.go
+++ b/workflow/hydrator/hydrator_test.go
@@ -127,3 +127,11 @@ func TestHydrator(t *testing.T) {
 		})
 	})
 }
+
+func TestNewReadsAlwaysOffloadNodeStatus(t *testing.T) {
+	t.Setenv("ALWAYS_OFFLOAD_NODE_STATUS", "true")
+	assert.True(t, New(nil).(*hydrator).alwaysOffloadNodeStatus)
+
+	t.Setenv("ALWAYS_OFFLOAD_NODE_STATUS", "false")
+	assert.False(t, New(nil).(*hydrator).alwaysOffloadNodeStatus)
+}


### PR DESCRIPTION
Part 2 of 3 in a stack that retires `util/logging`'s init logger (stacked on #16702; see #16705 for the endgame).

### Motivation

Same as #16702: package-init env reads are the init logger's main reason to exist. This part covers the two remaining production sites outside the controller.

### Modifications

- `workflow/hydrator`: `ALWAYS_OFFLOAD_NODE_STATUS` is read in `New()` and stored on the struct; the package var and `init()` are deleted. `New`'s signature is unchanged. The Debug-level "Hydrator config" echo is dropped deliberately (there is no meaningful single emission point once the read is per-constructor-call). The new test exercises both env values via `t.Setenv` — impossible under the old package-var design.
- `server/apiserver`: `GRPC_MESSAGE_SIZE` moves onto `argoServer` as a field read in `NewArgoServer`; an unparseable value now returns an error instead of a process-fatal from `init()`. The exported, in-repo-unreferenced `MaxGRPCMessageSize` var is **removed** (breaking only for downstream importers; the identically-named var in `pkg/apiclient` is unrelated and untouched).

### Verification

`go build ./...`, `golangci-lint` (0 issues), `go test ./workflow/hydrator/ ./server/... -count=1` all pass. TDD evidence for the hydrator change (compile-error RED, then GREEN) is in the commit history.

### Documentation

Not needed: both env vars keep their documented names, defaults, and semantics.

### AI

Claude Code planned and implemented this change under human direction, with per-task and whole-branch review passes; the author reviewed and takes responsibility for the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqVAUnuPJZ7sQZCy44bBSE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration values are now loaded when servers and workflow components are created, improving reliability across startup scenarios.
  * Invalid gRPC message-size settings now produce a clear startup error instead of abruptly terminating initialization.
  * Node status offloading behavior now consistently reflects the configured environment setting.

* **Tests**
  * Added coverage to verify node status offloading configuration for enabled and disabled settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->