### PR TITLE
fix(ci): create ~/.m2 before bind mounting it for Java SDK publish (cherry-pick #16701 for 4.1)

### DIFF
--- a/sdks/java/Makefile
+++ b/sdks/java/Makefile
@@ -17,6 +17,9 @@ CHOWN = chown -R $(shell id -u):$(shell id -g)
 
 publish: generate
 	# https://help.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-apache-maven-for-use-with-github-packages
+	# $(HOME)/.m2 must exist before docker bind mounts it, otherwise docker
+	# creates it owned by root and maven cannot write to it
+	mkdir -p $(HOME)/.m2
 	$(MVN) deploy -DskipTests -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/argoproj/argo-workflows
 
 generate:


### PR DESCRIPTION
Cherry-pick #16701 for 4.1. See that PR for details.

The SDKs workflow has failed on every 4.1 tag (v4.1.0-rc1, -rc2, v4.1.0), so no Java SDK has been published for 4.1 yet — republishing will need the tag re-pushed or the workflow re-run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC3UvQ2D2iVGWQEeVmUgW2