### PR TITLE
docs: add end-of-life banner to 3.7 docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,4 +1,50 @@
 {% extends "base.html" %}
+
+{# Banner shown on release branches that have reached end of life.
+   Keep this block out of `main` and delete it from a release branch only if
+   that branch becomes supported again. The link deliberately points at the
+   bare Read the Docs URL so it always lands on the current default version. #}
+{% block announce %}
+<div class="eol-banner">
+  <strong>This version of Argo Workflows is no longer supported.</strong>
+  It receives no bug fixes or security updates.
+  <a href="https://argo-workflows.readthedocs.io/">See the documentation for a supported version</a>.
+</div>
+{% endblock %}
+
+{% block extrahead %}
+{{ super() }}
+<style>
+  .md-banner {
+    background-color: #f8d7da;
+    border-bottom: 2px solid #dc3545;
+  }
+
+  .md-banner .eol-banner {
+    text-align: center;
+  }
+
+  .md-banner .eol-banner,
+  .md-banner .eol-banner a {
+    color: #58151c;
+  }
+
+  .md-banner .eol-banner a {
+    font-weight: 700;
+    text-decoration: underline;
+  }
+
+  [data-md-color-scheme="slate"] .md-banner {
+    background-color: #4a1015;
+  }
+
+  [data-md-color-scheme="slate"] .md-banner .eol-banner,
+  [data-md-color-scheme="slate"] .md-banner .eol-banner a {
+    color: #f5c2c7;
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 {{ super() }}
 


### PR DESCRIPTION
### Motivation

3.7 is out of support, but the Read the Docs pages for it look exactly like the ones for a supported version. Anyone landing on `/en/release-3.7/` from a search result has no way to tell they're reading docs for a version that will not get bug fixes or security updates.

### Modifications

Adds an end-of-life banner to the top of every page, linking to https://argo-workflows.readthedocs.io/ — deliberately the bare URL, so it always resolves to whatever Read the Docs currently serves as the default version, and needs no further edits as releases move on.

This uses mkdocs-material's `announce` block. The theme already wraps it in `.md-banner` and positions the header below it, so unlike the equivalent banner in argo-cd, this needs no JavaScript: no runtime layout adjustment, and no fetching the version list from the Read the Docs API to work out support status. The docs are built per release branch, so this branch *is* the unsupported version and a static banner is correct by construction.

Styling follows argo-cd's red "danger" palette, with a slate variant so it stays readable in dark mode.

> This version of Argo Workflows is no longer supported. It receives no bug fixes or security updates. See the documentation for a supported version.

An equivalent PR for 3.6 follows.

### Verification

Built the docs locally with `mkdocs build` and loaded the output in a browser. The banner renders on the home page and on sub-pages, sits above the header, and the colours resolve correctly in both the default and slate colour schemes.
