### PR TITLE
fix: apply MySQL driver-level options from persistence config. Fixes #16707

### DIFF
--- a/util/sqldb/connection_timeout_test.go
+++ b/util/sqldb/connection_timeout_test.go
@@ -115,7 +115,8 @@ func TestBuildMySQLConfigTimeout(t *testing.T) {
 			Database: "argo",
 		},
 	}
-	mysqlCfg := buildMySQLConfig(cfg, "user", "pass", 7*time.Second)
+	mysqlCfg, err := buildMySQLConfig(cfg, "user", "pass", 7*time.Second)
+	require.NoError(t, err)
 	assert.Equal(t, 7*time.Second, mysqlCfg.Timeout)
 	// ReadTimeout is intentionally left unset: it would apply to every query read,
 	// not just the handshake. The half-open case is instead handled by wrapping the

--- a/util/sqldb/sqldb.go
+++ b/util/sqldb/sqldb.go
@@ -226,7 +226,7 @@ func createPostGresDBSessionWithCreds(cfg *config.PostgreSQLConfig, persistPool 
 // opened from a DSN string, ParseDSN restored those defaults; NewConnector
 // consumes the config directly, so a bare literal would leave Loc nil and
 // panic ("missing Location in call to Time.In") on the first time.Time written.
-func buildMySQLConfig(cfg *config.MySQLConfig, username, password string, connectTimeout time.Duration) mysql.Config {
+func buildMySQLConfig(cfg *config.MySQLConfig, username, password string, connectTimeout time.Duration) (*mysql.Config, error) {
 	mysqlCfg := mysql.NewConfig()
 	mysqlCfg.User = username
 	mysqlCfg.Passwd = password
@@ -237,16 +237,29 @@ func buildMySQLConfig(cfg *config.MySQLConfig, username, password string, connec
 	mysqlCfg.AllowNativePasswords = true // Required for MariaDB which uses mysql_native_password by default
 	mysqlCfg.Params = cfg.Options
 	mysqlCfg.Timeout = connectTimeout
-	return *mysqlCfg
+	// cfg.Options mixes driver-level DSN options (tls, readTimeout, ...) with
+	// server system variables. NewConnector consumes the config directly, and the
+	// driver only interprets driver-level options when parsing a DSN — left in
+	// Params they would be sent to the server as SET statements instead (e.g.
+	// leaving TLS disabled). Round-trip through FormatDSN/ParseDSN so options are
+	// interpreted the same way DSN-opened sessions always interpreted them.
+	parsedCfg, err := mysql.ParseDSN(mysqlCfg.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("invalid MySQL config options: %w", err)
+	}
+	return parsedCfg, nil
 }
 
 func createMySQLDBSessionWithCreds(cfg *config.MySQLConfig, persistPool *config.ConnectionPool, username, password string, connectTimeout time.Duration) (db.Session, error) {
-	mysqlCfg := buildMySQLConfig(cfg, username, password, connectTimeout)
+	mysqlCfg, err := buildMySQLConfig(cfg, username, password, connectTimeout)
+	if err != nil {
+		return nil, err
+	}
 
 	// Wrap the MySQL connector so Connect (dial + handshake read) is bounded by
 	// connectTimeout, protecting against a half-open server the same way lib/pq's
 	// connect_timeout protects PostgreSQL.
-	connector, err := mysql.NewConnector(&mysqlCfg)
+	connector, err := mysql.NewConnector(mysqlCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create mysql connector: %w", err)
 	}

--- a/util/sqldb/sqldb_test.go
+++ b/util/sqldb/sqldb_test.go
@@ -73,3 +73,37 @@ func TestMySQLSessionConnect(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/argoproj/argo-workflows/issues/16707:
+// driver-level entries in persistence.mysql.options (e.g. tls) must be applied
+// as DSN options, not sent to the server verbatim as SET statements.
+func TestBuildMySQLConfigDriverOptions(t *testing.T) {
+	cfg := &config.MySQLConfig{
+		DatabaseConfig: config.DatabaseConfig{
+			Host:     "localhost",
+			Port:     3306,
+			Database: "argo",
+		},
+		Options: map[string]string{
+			"tls":         "skip-verify",
+			"readTimeout": "5s",
+			// a genuine server system variable, which must remain a param
+			"transaction_isolation": "'READ-COMMITTED'",
+		},
+	}
+	mysqlCfg, err := buildMySQLConfig(cfg, "user", "pass", 7*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "skip-verify", mysqlCfg.TLSConfig)
+	require.Equal(t, 5*time.Second, mysqlCfg.ReadTimeout)
+	require.NotContains(t, mysqlCfg.Params, "tls")
+	require.NotContains(t, mysqlCfg.Params, "readTimeout")
+	require.Equal(t, "'READ-COMMITTED'", mysqlCfg.Params["transaction_isolation"])
+	// fields set directly must survive
+	require.Equal(t, "user", mysqlCfg.User)
+	require.Equal(t, "pass", mysqlCfg.Passwd)
+	require.Equal(t, "localhost:3306", mysqlCfg.Addr)
+	require.Equal(t, "argo", mysqlCfg.DBName)
+	require.True(t, mysqlCfg.ParseTime)
+	require.True(t, mysqlCfg.AllowNativePasswords)
+	require.Equal(t, 7*time.Second, mysqlCfg.Timeout)
+}


### PR DESCRIPTION
This fixes a 4.1 only bug

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16707

### Motivation

#16291 switched MySQL session creation from opening a DSN string to passing `mysql.Config` directly to `mysql.NewConnector`, which bypasses `ParseDSN`. Driver-level entries in `persistence.mysql.options` (`tls`, `readTimeout`, etc.) were therefore no longer interpreted as DSN options; the driver sent them to the server verbatim as `SET` statements instead. For users with `tls: skip-verify` the connection was attempted in plaintext, and servers requiring TLS rejected authentication with `Error 1045 Access denied`, so the controller and server failed to start on v4.1.0.

### Modifications

`buildMySQLConfig` now round-trips the config through `FormatDSN`/`ParseDSN`, so driver-level options are interpreted exactly as they were when the session was opened from a DSN string, while genuine server system variables remain in `Params`. Invalid option values now fail with a clear error at startup.

### Verification

New unit test `TestBuildMySQLConfigDriverOptions` asserts that `tls` and `readTimeout` become driver config fields (test fails on current main with `TLSConfig` empty), that a server system variable stays in `Params`, and that directly-set fields survive the round-trip. Full `./util/sqldb/` package tests pass, including the live MySQL and MariaDB container connect tests.

### Documentation

No documentation change needed: this restores the documented behaviour of `persistence.mysql.options` (a map of [go-sql-driver options](https://github.com/go-sql-driver/mysql)).

### AI

Root-cause analysis, code, tests, and this PR description were prepared with Claude Code (Fable 5), reviewed and verified by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL connection configuration so driver options, server variables, credentials, database names, and timeouts are interpreted correctly.
  * Improved error handling when creating MySQL sessions.
  * Added regression coverage for connection configuration and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->