### PR TITLE
fix(ui): don't put fontawesome base class on argo-icon glyphs

### DIFF
--- a/ui/src/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/workflows/components/workflow-details/workflow-details.tsx
@@ -504,13 +504,13 @@ export function WorkflowDetails({history, location, match}: RouteComponentProps<
                             {workflow && workflow.status.conditions && hasWarningConditionBadge(workflow.status.conditions) && <span className='badge' />}
                         </a>
                         <a className={classNames({active: tab === 'events'})} onClick={() => setTab('events')} title='Events'>
-                            <i className='fa argo-icon-notification' />
+                            <i className='argo-icon-notification' />
                         </a>
                         <a className={classNames({active: tab === 'timeline'})} onClick={() => setTab('timeline')} title='Timeline'>
-                            <i className='fa argo-icon-timeline' />
+                            <i className='argo-icon-timeline' />
                         </a>
                         <a className={classNames({active: tab === 'workflow'})} onClick={() => setTab('workflow')} title='Workflow'>
-                            <i className='fa argo-icon-workflow' />
+                            <i className='argo-icon-workflow' />
                         </a>
                     </div>
                 )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

<!-- Does this PR fix an issue -->

### Motivation

The Events, Timeline and Workflow tab buttons in the workflow-details page use `<i class="fa argo-icon-*>`. Fontawesome 6.6+ defines icon content as `.fa-xxx { --fa: "..."}` consumed by `.fa::before { content: var(--fa) }`; on these elements `--fa` is undefined and that rule outranks argo-icon's own content rules, so buttons render blank on fontawesome >= 6.6. The committed yarn.lock (6.5.1) currently hides this.

### Modifications

Drop the stray `fa` class. argo-ui's `[class^='argo-icon']` rules already provide the display and font styling.

### Verification

Built the UI with fontawesome 6.5.1 and 6.7.2 with this change and the tab icons render identically. Without the change they are blank on 6.7.2

### Documentation

Not needed

### AI
None




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated workflow details toolbar icons for more consistent visual styling.
  * Preserved existing Argo-specific icons and interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->