### PR TITLE
fix: omit OpenTelemetry process owner detection

### DIFF
--- a/util/telemetry/resource.go
+++ b/util/telemetry/resource.go
@@ -22,10 +22,19 @@ func workflowsResource(ctx context.Context, serviceName string) *resource.Resour
 		ctx,
 		resource.WithFromEnv(),      // Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
 		resource.WithTelemetrySDK(), // Discover and provide information about the OpenTelemetry SDK used.
-		resource.WithProcess(),      // Discover and provide process information.
-		resource.WithOS(),           // Discover and provide OS information.
-		resource.WithContainer(),    // Discover and provide container information.
-		resource.WithHost(),         // Discover and provide host information.
+		// The individual process detectors from resource.WithProcess(), except
+		// WithProcessOwner: it requires cgo or $USER, neither of which the
+		// distroless images have, so it would error on every startup.
+		resource.WithProcessPID(),
+		resource.WithProcessExecutableName(),
+		resource.WithProcessExecutablePath(),
+		resource.WithProcessCommandArgs(),
+		resource.WithProcessRuntimeName(),
+		resource.WithProcessRuntimeVersion(),
+		resource.WithProcessRuntimeDescription(),
+		resource.WithOS(),        // Discover and provide OS information.
+		resource.WithContainer(), // Discover and provide container information.
+		resource.WithHost(),      // Discover and provide host information.
 		resource.WithAttributes(attribs...),
 	)
 	if err != nil {


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16729

### Motivation

The official static/distroless images run as numeric UID 8737 with no matching `/etc/passwd` entry and no `$USER` set, so the `process.owner` resource detector inside `resource.WithProcess()` (which calls `os/user.Current()`) fails on every controller and executor startup, producing an error-level log for a purely optional attribute:

```
level=ERROR msg="Error from opentelemetry resource detection, carrying on anyway" error="error detecting resource: user: Current requires cgo or $USER set in environment"
```

### Modifications

Replace `resource.WithProcess()` in `util/telemetry/resource.go` with its individual process detectors, omitting only `resource.WithProcessOwner()`. PID, executable name/path, command args, and runtime attributes are all preserved; only the optional `process.owner` attribute is dropped. This fixes both the controller and argoexec, which share `workflowsResource()`.

Environments where owner detection would succeed (cgo builds, `$USER` set) also lose the attribute; in Kubernetes pods it would nearly always be a bare UID, so this seemed the better trade-off versus a separate detect-and-merge step (option 2 in the issue).

### Verification

Existing `util/telemetry` unit tests pass and `golangci-lint` is clean on the package. No new test: the failure requires a static binary in an environment where the UID cannot be resolved, which the unit test environment can't reproduce meaningfully.

### Documentation

No documentation change needed: this removes a spurious error-level startup log; no user-facing behaviour or configuration changes.

### AI

Claude Code (Claude Fable 5) wrote the change and this PR description under my direction, per the issue's proposed option 1. I reviewed the diff and the verification myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rLpJ1bE7aipM9Zju4KiXf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry resource detection for more consistent process information.
  * Continued support for operating system, container, and host details while excluding process-owner data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->