### PR TITLE
fix: re-enter workingDir after init-less input artifact staging. Fixes #16728

### DIFF
--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -168,12 +168,12 @@ func runEmissary(ctx context.Context, containerName string, includeScriptOutput 
 	// ready-marker wait above). Only `main` runs this — ContainerSet
 	// children and sidecars don't get artifact paths symlinked in.
 	if waitForReady && containerName == common.MainContainerName {
-		if linkErr := linkInputArtifacts(ctx, template); linkErr != nil {
+		if stageErr := stageInputArtifacts(ctx, template); stageErr != nil {
 			// As above: propagate the sentinel as the process exit code so
 			// inferFailedReason attributes this to supervisor pre-main setup.
 			exitCode = common.ExitCodeSupervisorPreMainFailure
-			logger.WithError(linkErr).Error(ctx, "failed to stage input artifacts before main container started")
-			return argoerrors.NewExitErrWithCause(exitCode, linkErr)
+			logger.WithError(stageErr).Error(ctx, "failed to stage input artifacts before main container started")
+			return argoerrors.NewExitErrWithCause(exitCode, stageErr)
 		}
 	}
 
@@ -332,10 +332,39 @@ func readTemplateAt(filePath, offloadDir string) ([]byte, error) {
 	return common.ResolveTemplateEnvValue(envVal, offloadDir)
 }
 
-// linkInputArtifacts creates a symlink at each input artifact's path pointing
-// to the file that supervisor wrote under /argo/inputs/artifacts/<name>.
-// This replaces the legacy SubPath bind-mount-per-artifact scheme, which
-// can't be used in init-less mode because kubelet pre-creates SubPath
+func stageInputArtifacts(ctx context.Context, tmpl *wfv1.Template) error {
+	return stageInputArtifactsAt(ctx, common.ExecutorArtifactBaseDir, tmpl)
+}
+
+// stageInputArtifactsAt is the parameterized form used by tests; production
+// calls stageInputArtifacts with the constants. It links each input artifact
+// into place and re-enters the working directory afterwards, stepping off it
+// for the duration: linking replaces the cwd when an artifact's path is the
+// container's workingDir, Windows refuses to delete a directory in use as a
+// working directory, and a child forked with the deleted directory as cwd
+// would see getcwd() fail and relative paths resolve to nothing. The final
+// chdir follows the symlink to whatever now sits at the path.
+func stageInputArtifactsAt(ctx context.Context, baseDir string, tmpl *wfv1.Template) error {
+	origWd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to read working directory before staging input artifacts: %w", err)
+	}
+	if err := os.Chdir(varRunArgo); err != nil {
+		return fmt.Errorf("failed to leave working directory before staging input artifacts: %w", err)
+	}
+	if err := linkInputArtifactsAt(ctx, baseDir, tmpl); err != nil {
+		return err
+	}
+	if err := os.Chdir(origWd); err != nil {
+		return fmt.Errorf("failed to re-enter working directory %q after staging input artifacts (an input artifact staged at the workingDir path must be a directory): %w", origWd, err)
+	}
+	return nil
+}
+
+// linkInputArtifactsAt creates a symlink at each input artifact's path
+// pointing to the file that supervisor wrote under /argo/inputs/artifacts/
+// <name>. This replaces the legacy SubPath bind-mount-per-artifact scheme,
+// which can't be used in init-less mode because kubelet pre-creates SubPath
 // entries as empty directories before supervisor can write the real file.
 //
 // Behavior notes for workflow authors: in init-less mode art.Path is a
@@ -350,12 +379,6 @@ func readTemplateAt(filePath, offloadDir string) ([]byte, error) {
 // artifacts/<name>), so no entry appears in the input-artifacts directory
 // and we skip the symlink — main already sees the file at art.Path via
 // its user volume.
-func linkInputArtifacts(ctx context.Context, tmpl *wfv1.Template) error {
-	return linkInputArtifactsAt(ctx, common.ExecutorArtifactBaseDir, tmpl)
-}
-
-// linkInputArtifactsAt is the parameterized form used by tests; production calls
-// linkInputArtifacts with the constants.
 func linkInputArtifactsAt(ctx context.Context, baseDir string, tmpl *wfv1.Template) error {
 	logger := logging.RequireLoggerFromContext(ctx)
 	for _, art := range tmpl.Inputs.Artifacts {

--- a/cmd/argoexec/commands/emissary_link_artifacts_test.go
+++ b/cmd/argoexec/commands/emissary_link_artifacts_test.go
@@ -267,3 +267,63 @@ func TestLinkInputArtifacts_ReplacesImageSymlinkInRootfs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "image-default", string(old), "the image symlink's old target must be untouched")
 }
+
+// TestStageInputArtifacts_ArtifactAtWorkingDir covers issue #16728: a
+// directory artifact staged at the container's workingDir.
+func TestStageInputArtifacts_ArtifactAtWorkingDir(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	dir := t.TempDir()
+	prevVarRunArgo := varRunArgo
+	varRunArgo = dir
+	t.Cleanup(func() { varRunArgo = prevVarRunArgo })
+	srcBase := filepath.Join(dir, "inputs")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcBase, "source"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcBase, "source", "README"), []byte("hello"), 0o644))
+
+	// The runtime chdirs the emissary into workingDir before staging runs.
+	workDir := filepath.Join(dir, "workspace")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	t.Chdir(workDir)
+
+	tmpl := &wfv1.Template{
+		Inputs: wfv1.Inputs{
+			Artifacts: wfv1.Artifacts{{Name: "source", Path: workDir}},
+		},
+	}
+
+	require.NoError(t, stageInputArtifactsAt(ctx, srcBase, tmpl))
+
+	_, err := os.Getwd()
+	require.NoError(t, err, "cwd must be a live directory again")
+	data, err := os.ReadFile("README")
+	require.NoError(t, err, "relative paths must resolve to the staged artifact")
+	assert.Equal(t, "hello", string(data))
+}
+
+// TestStageInputArtifacts_FileArtifactAtWorkingDirFails: a *file* artifact
+// staged at the workingDir path leaves nothing to chdir into, so the step
+// must fail rather than start the user command with a deleted cwd.
+func TestStageInputArtifacts_FileArtifactAtWorkingDirFails(t *testing.T) {
+	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	dir := t.TempDir()
+	prevVarRunArgo := varRunArgo
+	varRunArgo = dir
+	t.Cleanup(func() { varRunArgo = prevVarRunArgo })
+	srcBase := filepath.Join(dir, "inputs")
+	require.NoError(t, os.MkdirAll(srcBase, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcBase, "source"), []byte("just a file"), 0o644))
+
+	workDir := filepath.Join(dir, "workspace")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	t.Chdir(workDir)
+
+	tmpl := &wfv1.Template{
+		Inputs: wfv1.Inputs{
+			Artifacts: wfv1.Artifacts{{Name: "source", Path: workDir}},
+		},
+	}
+
+	err := stageInputArtifactsAt(ctx, srcBase, tmpl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a directory")
+}

--- a/cmd/argoexec/commands/emissary_link_artifacts_test.go
+++ b/cmd/argoexec/commands/emissary_link_artifacts_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestLinkInputArtifacts_Normal(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -43,7 +42,7 @@ func TestLinkInputArtifacts_Normal(t *testing.T) {
 }
 
 func TestLinkInputArtifacts_MissingSourceIsSkipped(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -68,7 +67,7 @@ func TestLinkInputArtifacts_MissingSourceIsSkipped(t *testing.T) {
 // filesystem (no declared volume), must be replaced by the symlink — matching
 // what the legacy SubPath bind mount shadowed.
 func TestLinkInputArtifacts_OverwritesExistingFile(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -97,7 +96,7 @@ func TestLinkInputArtifacts_OverwritesExistingFile(t *testing.T) {
 // (e.g. a git/directory artifact at /tmp/git): linking must replace it with the
 // symlink rather than failing. No declared volume → safe to clear.
 func TestLinkInputArtifacts_OverwritesExistingDirectory(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -127,7 +126,7 @@ func TestLinkInputArtifacts_OverwritesExistingDirectory(t *testing.T) {
 
 // TestLinkInputArtifacts_EmptyPathSkipped covers art.Path == "".
 func TestLinkInputArtifacts_EmptyPathSkipped(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -148,7 +147,7 @@ func TestLinkInputArtifacts_EmptyPathSkipped(t *testing.T) {
 // the symlink and destroy live volume data, so staging must refuse and leave the
 // volume untouched.
 func TestLinkInputArtifacts_RefusesOverwriteResolvingIntoVolume(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -195,7 +194,7 @@ func TestLinkInputArtifacts_RefusesOverwriteResolvingIntoVolume(t *testing.T) {
 // there yet, staging creates the symlink anyway (the user asked for it). Creating
 // can never destroy data, so it is not gated.
 func TestLinkInputArtifacts_CreateResolvingIntoVolumeAllowed(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -237,7 +236,7 @@ func TestLinkInputArtifacts_CreateResolvingIntoVolumeAllowed(t *testing.T) {
 // os.RemoveAll removes the symlink itself (it does not follow the final element),
 // so staging safely replaces it and the symlink's old target is untouched.
 func TestLinkInputArtifacts_ReplacesImageSymlinkInRootfs(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	srcBase := filepath.Join(dir, "inputs")
 	require.NoError(t, os.MkdirAll(srcBase, 0o755))
@@ -271,7 +270,7 @@ func TestLinkInputArtifacts_ReplacesImageSymlinkInRootfs(t *testing.T) {
 // TestStageInputArtifacts_ArtifactAtWorkingDir covers issue #16728: a
 // directory artifact staged at the container's workingDir.
 func TestStageInputArtifacts_ArtifactAtWorkingDir(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	prevVarRunArgo := varRunArgo
 	varRunArgo = dir
@@ -304,7 +303,7 @@ func TestStageInputArtifacts_ArtifactAtWorkingDir(t *testing.T) {
 // staged at the workingDir path leaves nothing to chdir into, so the step
 // must fail rather than start the user command with a deleted cwd.
 func TestStageInputArtifacts_FileArtifactAtWorkingDirFails(t *testing.T) {
-	ctx := logging.WithLogger(context.Background(), logging.InitLogger())
+	ctx := logging.TestContext(t.Context())
 	dir := t.TempDir()
 	prevVarRunArgo := varRunArgo
 	varRunArgo = dir

--- a/docs/initless-pod.md
+++ b/docs/initless-pod.md
@@ -154,6 +154,12 @@ An artifact path *inside* a declared mount (`path: /data/shared/file`) is the or
 
 When an input artifact path is **also an output artifact path** (read an artifact, transform it, write the result back to the same path), the produced output is captured correctly regardless of how `main` writes it — overwriting through the symlink, or replacing the symlink via `rm` + recreate or the idiomatic write-temp-then-`rename`. The emissary inside `main` stages the live file from `main`'s own filesystem before `supervisor` collects it, so the original input is never mistaken for the output.
 
+### `workingDir` at an input artifact path
+
+A directory artifact whose `path` is also the container's `workingDir` (e.g. a git artifact at `/workspace` with `workingDir: /workspace`) works; the one observable difference from legacy mode is that `pwd` / `getcwd()` report the resolved physical path (`/argo/inputs/artifacts/<name>`) rather than the declared `workingDir`.
+
+A **file** artifact at the `workingDir` path fails the step with a clear error before the user command runs. Legacy mode cannot run that configuration either — there, the `SubPath` file mount makes the runtime's own chdir fail at container create.
+
 ### `readOnlyRootFilesystem` is incompatible with init-less input artifacts
 
 Because init-less mode creates the symlink *inside `main`'s own filesystem* — it creates the parent directory and the symlink at the artifact's path (removing any pre-existing content first when it is replacing it) — those operations require the path to be on a **writable** filesystem. If `main`'s container sets `securityContext.readOnlyRootFilesystem: true` (a common Pod Security / policy hardening) and the artifact's path falls on the read-only root filesystem, the symlink step fails with `EROFS` and the step errors before the user command runs. The same workflow succeeds in legacy mode, because there kubelet establishes the input artifact's `SubPath` bind mount at the mount-namespace level before the container starts — independent of whether the container's root filesystem is read-only.

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -1262,6 +1262,42 @@ spec:
 		WaitForWorkflow(fixtures.ToBeSucceeded)
 }
 
+// TestGitArtifactAtWorkingDir covers issue #16728: an input artifact staged
+// at the container's workingDir must be visible through the inherited cwd.
+// Unlike TestGitArtifactDepthClone above, the script exits non-zero when it
+// isn't (`ls` succeeds even in a deleted cwd).
+func (s *ArtifactsSuite) TestGitArtifactAtWorkingDir() {
+	s.Given().
+		Workflow(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: git-workingdir-
+spec:
+  entrypoint: probe
+  templates:
+  - name: probe
+    inputs:
+      artifacts:
+      - name: source
+        path: /tmp/git
+        git:
+          repo: https://github.com/argoproj-labs/go-git.git
+          revision: master
+          depth: 1
+    script:
+      image: argoproj/argosay:v2
+      command: [sh]
+      workingDir: /tmp/git
+      source: |
+        set -eu
+        pwd
+        test -f README.md
+`).
+		When().
+		SubmitWorkflow().
+		WaitForWorkflow(fixtures.ToBeSucceeded)
+}
+
 func (s *ArtifactsSuite) TestArtifactEphemeralVolume() {
 	s.Given().
 		Workflow(`apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` (ran the targeted equivalents instead: unit tests, `golangci-lint` with e2e build tags, markdownlint/cspell on the changed doc; no codegen-relevant files are touched)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16728

### Motivation

With `initlessPod` enabled, a template with an input artifact whose `path` is also the container's `workingDir` runs the user command in a deleted directory. The container runtime chdirs the emissary (PID 1 in `main`) into `workingDir` before it runs; `linkInputArtifacts` then deletes that directory inode and replaces the path with a symlink into the shared emptyDir. The user command inherits the orphaned cwd by inode: `getcwd()` fails, relative paths resolve against a deleted empty directory, and tools like git abort — while the workflow itself still "Succeeds", making the breakage easy to miss. The same workflow works in the legacy init-container layout, where the artifact is bind-mounted before the container starts.

### Modifications

- `cmd/argoexec/commands/emissary.go`: wrap the linking in a new `stageInputArtifacts` sequence — capture the working directory (while it is still a live inode), step off it to `varRunArgo` for the duration of linking, then re-enter it afterwards. The final chdir re-resolves the path, following the new symlink, so the emissary — and every child it forks, including retries — starts with a live cwd. Stepping off before linking also makes the scenario work on Windows, where deleting a directory that any process holds as its working directory is refused. If the cwd cannot be captured or re-entered (e.g. a *file* artifact staged at the `workingDir` path), the step fails loudly with `ExitCodeSupervisorPreMainFailure` rather than letting the user command run with a broken cwd — legacy mode cannot run that configuration either (its `SubPath` file mount makes the runtime's own chdir fail at container create).
- `docs/initless-pod.md`: document the `workingDir`-at-artifact-path behavior, including the one observable difference from legacy mode (`pwd`/`getcwd()` report the resolved physical path) and the file-artifact failure mode.

One residual difference remains by design: after the fix, `pwd` reports `/argo/inputs/artifacts/<name>` rather than the declared `workingDir`. Staging in place instead of symlinking was rejected because the artifact lives on a different filesystem (emptyDir vs rootfs), so it would degrade to a full copy.

### Verification

- New unit tests `TestStageInputArtifacts_ArtifactAtWorkingDir` (directory artifact at cwd: relative paths resolve to staged contents after restore) and `TestStageInputArtifacts_FileArtifactAtWorkingDirFails` (file artifact at cwd fails loudly). Both run unmodified on all platforms, including the Windows CI job.
- New e2e test `ArtifactsSuite/TestGitArtifactAtWorkingDir`, modeled on the issue's repro: git artifact at `/tmp/git` with `workingDir: /tmp/git`, script asserts `pwd` succeeds and `README.md` is visible via a relative path. The `artifacts` suite runs in CI under both the legacy and init-less profiles. (The existing `TestGitArtifactDepthClone` has this shape but only runs `ls -l`, which exits 0 even in a deleted cwd.)
- `go test ./cmd/argoexec/commands/` and `golangci-lint` (with e2e build tags) pass locally.

### Documentation

Added a `workingDir` at an input artifact path section to `docs/initless-pod.md` (passes markdownlint and cspell).

### AI

This PR (code, tests, docs, and commit message) was prepared with Claude Code (Claude Fable 5), per the [Argo project Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md). All changes were reviewed and verified by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rLpJ1bE7aipM9Zju4KiXf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of input artifacts staged at the container’s working directory.
  - Directory artifacts remain accessible through relative paths while preserving a valid working directory.
  - Git artifacts at the working directory are now accessible as expected.
  - File artifacts targeting the working directory fail with a clear directory-related error before command execution.

- **Documentation**
  - Documented working-directory behavior for artifacts in init-less pods, including resolved physical paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->