### PR TITLE
fix: scope RemoveFromQueue to the calling controller

### DIFF
--- a/util/sync/db/mocks/SyncQueries.go
+++ b/util/sync/db/mocks/SyncQueries.go
@@ -1265,16 +1265,16 @@ func (_c *SyncQueries_ReleaseHeld_Call) RunAndReturn(run func(ctx context.Contex
 }
 
 // RemoveFromQueue provides a mock function for the type SyncQueries
-func (_mock *SyncQueries) RemoveFromQueue(ctx context.Context, semaphoreName string, holderKey string) error {
-	ret := _mock.Called(ctx, semaphoreName, holderKey)
+func (_mock *SyncQueries) RemoveFromQueue(ctx context.Context, semaphoreName string, holderKey string, controllerName string) error {
+	ret := _mock.Called(ctx, semaphoreName, holderKey, controllerName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveFromQueue")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = returnFunc(ctx, semaphoreName, holderKey)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, semaphoreName, holderKey, controllerName)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1290,11 +1290,12 @@ type SyncQueries_RemoveFromQueue_Call struct {
 //   - ctx context.Context
 //   - semaphoreName string
 //   - holderKey string
-func (_e *SyncQueries_Expecter) RemoveFromQueue(ctx interface{}, semaphoreName interface{}, holderKey interface{}) *SyncQueries_RemoveFromQueue_Call {
-	return &SyncQueries_RemoveFromQueue_Call{Call: _e.mock.On("RemoveFromQueue", ctx, semaphoreName, holderKey)}
+//   - controllerName string
+func (_e *SyncQueries_Expecter) RemoveFromQueue(ctx interface{}, semaphoreName interface{}, holderKey interface{}, controllerName interface{}) *SyncQueries_RemoveFromQueue_Call {
+	return &SyncQueries_RemoveFromQueue_Call{Call: _e.mock.On("RemoveFromQueue", ctx, semaphoreName, holderKey, controllerName)}
 }
 
-func (_c *SyncQueries_RemoveFromQueue_Call) Run(run func(ctx context.Context, semaphoreName string, holderKey string)) *SyncQueries_RemoveFromQueue_Call {
+func (_c *SyncQueries_RemoveFromQueue_Call) Run(run func(ctx context.Context, semaphoreName string, holderKey string, controllerName string)) *SyncQueries_RemoveFromQueue_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1308,10 +1309,15 @@ func (_c *SyncQueries_RemoveFromQueue_Call) Run(run func(ctx context.Context, se
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -1322,7 +1328,7 @@ func (_c *SyncQueries_RemoveFromQueue_Call) Return(err error) *SyncQueries_Remov
 	return _c
 }
 
-func (_c *SyncQueries_RemoveFromQueue_Call) RunAndReturn(run func(ctx context.Context, semaphoreName string, holderKey string) error) *SyncQueries_RemoveFromQueue_Call {
+func (_c *SyncQueries_RemoveFromQueue_Call) RunAndReturn(run func(ctx context.Context, semaphoreName string, holderKey string, controllerName string) error) *SyncQueries_RemoveFromQueue_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/util/sync/db/queries.go
+++ b/util/sync/db/queries.go
@@ -73,7 +73,7 @@ type SyncQueries interface {
 	GetStateCountsByController(ctx context.Context, controllerName string) ([]StateCountRecord, error)
 	GetOrderedQueue(ctx context.Context, sessionProxy *sqldb.SessionProxy, semaphoreName string, inactiveTimeout time.Duration) ([]StateRecord, error)
 	AddToQueue(ctx context.Context, record *StateRecord) error
-	RemoveFromQueue(ctx context.Context, semaphoreName, holderKey string) error
+	RemoveFromQueue(ctx context.Context, semaphoreName, holderKey, controllerName string) error
 	CheckQueueExists(ctx context.Context, semaphoreName, holderKey, controllerName string) ([]StateRecord, error)
 	UpdateStateToHeld(ctx context.Context, sessionProxy *sqldb.SessionProxy, semaphoreName, holderKey, controllerName string) error
 	InsertHeldState(ctx context.Context, sessionProxy *sqldb.SessionProxy, record *StateRecord) error
@@ -232,12 +232,13 @@ func (q *syncQueries) AddToQueue(ctx context.Context, record *StateRecord) error
 	})
 }
 
-func (q *syncQueries) RemoveFromQueue(ctx context.Context, semaphoreName, holderKey string) error {
+func (q *syncQueries) RemoveFromQueue(ctx context.Context, semaphoreName, holderKey, controllerName string) error {
 	return q.sessionProxy.With(ctx, func(session db.Session) error {
 		_, err := session.SQL().
 			DeleteFrom(q.config.StateTable).
 			Where(db.Cond{StateNameField: semaphoreName}).
 			And(db.Cond{StateKeyField: holderKey}).
+			And(db.Cond{StateControllerField: controllerName}).
 			And(db.Cond{StateHeldField: false}).
 			Exec()
 		return err

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -226,7 +226,7 @@ func (s *databaseSemaphore) addToQueue(ctx context.Context, holderKey string, pr
 }
 
 func (s *databaseSemaphore) removeFromQueue(ctx context.Context, holderKey string) error {
-	err := s.queries.RemoveFromQueue(ctx, s.longDBKey(), holderKey)
+	err := s.queries.RemoveFromQueue(ctx, s.longDBKey(), holderKey, s.info.Config.ControllerName)
 	return err
 }
 

--- a/workflow/sync/database_semaphore_test.go
+++ b/workflow/sync/database_semaphore_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/sqldb"
 	syncdb "github.com/argoproj/argo-workflows/v4/util/sync/db"
+	syncdbmocks "github.com/argoproj/argo-workflows/v4/util/sync/db/mocks"
 )
 
 var testDBTypes []sqldb.DBType
@@ -25,6 +26,26 @@ func init() {
 	default:
 		testDBTypes = []sqldb.DBType{sqldb.Postgres, sqldb.MySQL}
 	}
+}
+
+func TestDatabaseSemaphoreRemoveFromQueueScopesController(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	queries := syncdbmocks.NewSyncQueries(t)
+	controllerName := "controller-a"
+	semaphore := &databaseSemaphore{
+		shortDBKey: "namespace/semaphore",
+		info: syncdb.Info{
+			Config: syncdb.Config{ControllerName: controllerName},
+		},
+		queries: queries,
+	}
+
+	queries.EXPECT().
+		RemoveFromQueue(ctx, "sem/namespace/semaphore", "namespace/workflow", controllerName).
+		Return(nil).
+		Once()
+
+	require.NoError(t, semaphore.removeFromQueue(ctx, "namespace/workflow"))
 }
 
 // TestInactiveControllerDBSemaphore tests that a semaphore can't be acquired if the controller is not marked as responding


### PR DESCRIPTION
- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature, bug fix only
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16737

### Motivation

Multi-controller sync with a shared database: `CheckWorkflowExistence`'s garbage collector lists pending `sync_state` rows by lock name only (no controller filter), so it sees rows from every controller sharing the database. It checks each key against the local informer only, so a workflow owned by another controller always looks missing locally and gets deleted. `RemoveFromQueue` had no controller filter — unlike `ReleaseHeld`, which already filters on `controller` — so the delete went through and removed other controllers' legitimate pending rows, breaking lock handover and queue ordering across controllers.

### Modifications

- `util/sync/db/queries.go`: `RemoveFromQueue` now takes `controllerName` and filters the delete on it, mirroring `ReleaseHeld`.
- `workflow/sync/database_semaphore.go`: `removeFromQueue` passes `s.info.Config.ControllerName` through.
- `util/sync/db/mocks/SyncQueries.go`: mock updated to match (mockery not available locally; hand-edited to match the existing generated style, e.g. `ReleaseHeld`'s mock).
- `workflow/sync/database_semaphore_test.go`: regression test asserting the controller name is passed through to `RemoveFromQueue`.

Existing callers (`Release`, `ReleaseAll`, the GC) only ever pass local keys, so behavior for a single-controller setup is unchanged.

### Verification

- `go build ./util/sync/... ./workflow/sync/...`
- `KUBECONFIG=/dev/null go test ./util/sync/... ./workflow/sync/...` — 121 passed
- `gofmt -l` clean on changed files
- `golangci-lint run` clean on changed files (pre-existing gofmt findings on unrelated files in the package, untouched by this change)
- Added regression test covering the controller-scoping fix

### Documentation

No user-facing documentation change needed — this is an internal bug fix to sync-queue cleanup, no API/CRD/CLI surface changed.

### AI

Claude Code was used to investigate the bug and draft the fix; I reviewed the diff and verified the build/tests myself before pushing.
