### PR TITLE
fix: requeue workflow on transient sync lock errors instead of failing

### DIFF
--- a/util/sqldb/errors.go
+++ b/util/sqldb/errors.go
@@ -1,0 +1,28 @@
+package sqldb
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
+)
+
+// mysqlErLockDeadlock is ER_LOCK_DEADLOCK: the transaction was chosen as the
+// deadlock victim and rolled back. go-sql-driver/mysql exports no error-number
+// constants. ER_LOCK_WAIT_TIMEOUT (1205) is deliberately not treated as a
+// conflict: it only rolls back the statement, not the transaction, and it
+// signals a held-too-long lock rather than a retryable ordering conflict.
+const mysqlErLockDeadlock = 1213
+
+// IsSerializationConflict reports whether err is a transaction conflict
+// reported by the database driver itself: PostgreSQL serialization_failure
+// (40001) or deadlock_detected (40P01), or MySQL ER_LOCK_DEADLOCK (1213).
+// These are the errors where the database aborted the transaction because of
+// concurrent activity and the whole transaction can safely be retried.
+func IsSerializationConflict(err error) bool {
+	if pq.As(err, pqerror.TRSerializationFailure, pqerror.TRDeadlockDetected) != nil {
+		return true
+	}
+	return errors.Is(err, &mysql.MySQLError{Number: mysqlErLockDeadlock})
+}

--- a/util/sqldb/errors_test.go
+++ b/util/sqldb/errors_test.go
@@ -1,0 +1,36 @@
+package sqldb
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSerializationConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"postgres serialization failure", &pq.Error{Code: pqerror.TRSerializationFailure, Message: "could not serialize access"}, true},
+		{"postgres deadlock detected", &pq.Error{Code: pqerror.TRDeadlockDetected, Message: "deadlock detected"}, true},
+		{"postgres wrapped", fmt.Errorf("commit: %w", &pq.Error{Code: pqerror.TRSerializationFailure}), true},
+		{"postgres unrelated code", &pq.Error{Code: "23505", Message: "duplicate key value"}, false},
+		{"mysql deadlock", &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock; try restarting transaction"}, true},
+		{"mysql wrapped", fmt.Errorf("commit: %w", &mysql.MySQLError{Number: 1213}), true},
+		{"mysql lock wait timeout", &mysql.MySQLError{Number: 1205, Message: "Lock wait timeout exceeded; try restarting transaction"}, false},
+		{"plain error mentioning deadlock", errors.New("deadlock detected"), false},
+		{"plain error mentioning serialization", errors.New("could not serialize access"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSerializationConflict(tt.err))
+		})
+	}
+}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -53,7 +53,6 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/retry"
 	argoruntime "github.com/argoproj/argo-workflows/v4/util/runtime"
 	"github.com/argoproj/argo-workflows/v4/util/secrets"
-	"github.com/argoproj/argo-workflows/v4/util/sqldb"
 	"github.com/argoproj/argo-workflows/v4/util/strftime"
 	"github.com/argoproj/argo-workflows/v4/util/template"
 	"github.com/argoproj/argo-workflows/v4/util/variables"
@@ -65,6 +64,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/workflow/controller/indexes"
 	"github.com/argoproj/argo-workflows/v4/workflow/metrics"
 	"github.com/argoproj/argo-workflows/v4/workflow/progress"
+	wfsync "github.com/argoproj/argo-workflows/v4/workflow/sync"
 	"github.com/argoproj/argo-workflows/v4/workflow/templateresolution"
 	wfutil "github.com/argoproj/argo-workflows/v4/workflow/util"
 	"github.com/argoproj/argo-workflows/v4/workflow/validate"
@@ -289,7 +289,7 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		lockSpan.SetAttributes(attribute.Bool("LockAcquired", acquired))
 		lockSpan.End()
 		if syncErr != nil {
-			if sqldb.IsSerializationConflict(syncErr) || errorsutil.IsTransientErr(ctx, syncErr) {
+			if wfsync.IsRetryableSyncError(syncErr) || errorsutil.IsTransientErr(ctx, syncErr) {
 				// Transient failure in the lock backend (e.g. a database
 				// serialization conflict that exhausted its in-place retries):
 				// leave the workflow pending and try again on a later
@@ -2303,15 +2303,14 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 		lockSpan.SetAttributes(attribute.Bool("LockAcquired", lockAcquired))
 		lockSpan.End()
 		if syncErr != nil {
-			if sqldb.IsSerializationConflict(syncErr) || errorsutil.IsTransientErr(ctx, syncErr) {
+			if wfsync.IsRetryableSyncError(syncErr) || errorsutil.IsTransientErr(ctx, syncErr) {
 				// Transient failure in the lock backend: leave the node pending
 				// and try again on a later reconcile instead of erroring it.
 				woc.requeue()
 				if node == nil {
 					_, node = woc.initializeExecutableNode(ctx, nodeName, wfutil.GetNodeType(processedTmpl), templateScope, processedTmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, false, syncErr.Error())
-					return node, nil
 				}
-				return woc.markNodePending(ctx, nodeName, syncErr), nil
+				return node, nil
 			}
 			errNode := woc.initializeNodeOrMarkError(ctx, node, nodeName, templateScope, orgTmpl, opts.boundaryID, opts.nodeFlag, syncErr)
 			return errNode, syncErr

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -53,6 +53,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/util/retry"
 	argoruntime "github.com/argoproj/argo-workflows/v4/util/runtime"
 	"github.com/argoproj/argo-workflows/v4/util/secrets"
+	"github.com/argoproj/argo-workflows/v4/util/sqldb"
 	"github.com/argoproj/argo-workflows/v4/util/strftime"
 	"github.com/argoproj/argo-workflows/v4/util/template"
 	"github.com/argoproj/argo-workflows/v4/util/variables"
@@ -288,6 +289,20 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 		lockSpan.SetAttributes(attribute.Bool("LockAcquired", acquired))
 		lockSpan.End()
 		if syncErr != nil {
+			if sqldb.IsSerializationConflict(syncErr) || errorsutil.IsTransientErr(ctx, syncErr) {
+				// Transient failure in the lock backend (e.g. a database
+				// serialization conflict that exhausted its in-place retries):
+				// leave the workflow pending and try again on a later
+				// reconcile instead of failing it.
+				woc.log.WithError(syncErr).WithField("lockName", failedLockName).Warn(ctx, "Transient failure acquiring the synchronization lock, requeueing")
+				phase := woc.wf.Status.Phase
+				if phase == wfv1.WorkflowUnknown {
+					phase = wfv1.WorkflowPending
+				}
+				ctx = woc.markWorkflowPhase(ctx, phase, fmt.Sprintf("Waiting to acquire the synchronization lock. %v", syncErr))
+				woc.requeue()
+				return
+			}
 			woc.log.WithField("lockName", failedLockName).Warn(ctx, "Failed to acquire the lock")
 			woc.markWorkflowFailed(ctx, fmt.Sprintf("Failed to acquire the synchronization lock. %s", syncErr.Error()))
 			return
@@ -2288,6 +2303,16 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 		lockSpan.SetAttributes(attribute.Bool("LockAcquired", lockAcquired))
 		lockSpan.End()
 		if syncErr != nil {
+			if sqldb.IsSerializationConflict(syncErr) || errorsutil.IsTransientErr(ctx, syncErr) {
+				// Transient failure in the lock backend: leave the node pending
+				// and try again on a later reconcile instead of erroring it.
+				woc.requeue()
+				if node == nil {
+					_, node = woc.initializeExecutableNode(ctx, nodeName, wfutil.GetNodeType(processedTmpl), templateScope, processedTmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, false, syncErr.Error())
+					return node, nil
+				}
+				return woc.markNodePending(ctx, nodeName, syncErr), nil
+			}
 			errNode := woc.initializeNodeOrMarkError(ctx, node, nodeName, templateScope, orgTmpl, opts.boundaryID, opts.nodeFlag, syncErr)
 			return errNode, syncErr
 		}

--- a/workflow/controller/operator_sync_transient_test.go
+++ b/workflow/controller/operator_sync_transient_test.go
@@ -1,0 +1,92 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+	"github.com/argoproj/argo-workflows/v4/workflow/sync"
+)
+
+const wfWithWorkflowLevelSemaphore = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: hello-world-wf-level-sem
+  namespace: default
+spec:
+  entrypoint: whalesay
+  synchronization:
+    semaphores:
+      - configMapKeyRef:
+          key: workflow
+          name: my-config
+  templates:
+    - name: whalesay
+      container:
+        args:
+          - "hello world"
+        command:
+          - cowsay
+        image: "docker/whalesay:latest"
+`
+
+// The semaphore's configmap does not exist in these tests, so TryAcquire
+// returns an error. A transient error must leave the workflow/node pending
+// and requeue; only a non-transient error may fail it.
+
+func TestSyncErrorWorkflowLevel(t *testing.T) {
+	operateWorkflow := func(t *testing.T) *wfOperationCtx {
+		t.Helper()
+		cancel, controller := newController(logging.TestContext(t.Context()))
+		defer cancel()
+		ctx := logging.TestContext(t.Context())
+		controller.syncManager, _ = sync.NewLockManager(ctx, controller.kubeclientset, controller.namespace, nil, getSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+		}, workflowExistenceFunc, false)
+
+		wf := wfv1.MustUnmarshalWorkflow(wfWithWorkflowLevelSemaphore)
+		wf, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		require.NoError(t, err)
+		woc := newWorkflowOperationCtx(ctx, wf, controller)
+		woc.operate(ctx)
+		return woc
+	}
+
+	t.Run("NonTransientErrorFailsWorkflow", func(t *testing.T) {
+		woc := operateWorkflow(t)
+		assert.Equal(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
+		assert.Contains(t, woc.wf.Status.Message, "Failed to acquire the synchronization lock")
+	})
+
+	t.Run("TransientErrorLeavesWorkflowPending", func(t *testing.T) {
+		t.Setenv("TRANSIENT_ERROR_PATTERN", "failed to initialize semaphore")
+		woc := operateWorkflow(t)
+		assert.Equal(t, wfv1.WorkflowPending, woc.wf.Status.Phase)
+		assert.Contains(t, woc.wf.Status.Message, "Waiting to acquire the synchronization lock")
+	})
+}
+
+func TestSyncTransientErrorNodeLevel(t *testing.T) {
+	t.Setenv("TRANSIENT_ERROR_PATTERN", "failed to initialize semaphore")
+	cancel, controller := newController(logging.TestContext(t.Context()))
+	defer cancel()
+	ctx := logging.TestContext(t.Context())
+	controller.syncManager, _ = sync.NewLockManager(ctx, controller.kubeclientset, controller.namespace, nil, getSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+	}, workflowExistenceFunc, false)
+
+	wf := wfv1.MustUnmarshalWorkflow(wfWithSemaphore)
+	wf, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+	require.NoError(t, err)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	assert.NotEqual(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
+	require.NotEmpty(t, woc.wf.Status.Nodes)
+	for _, node := range woc.wf.Status.Nodes {
+		assert.Equal(t, wfv1.NodePending, node.Phase, "a transient sync error must leave the node pending, not errored")
+	}
+}

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -488,16 +488,14 @@ func (sm *Manager) TryAcquire(ctx context.Context, wf *wfv1.Workflow, nodeName s
 		var already bool
 		var msg string
 		var newly []*acquiredLock
-		// Backoff bounds: sm.lock is held for the whole loop, so cap each sleep
-		// modestly. Jitter prevents a fleet of replicas from retrying in lockstep
-		// after a shared conflict burst.
-		backoff := wait.Backoff{
-			Steps:    5,
-			Duration: 10 * time.Millisecond,
-			Factor:   2.0,
-			Jitter:   0.5,
-			Cap:      600 * time.Millisecond,
-		}
+		backoff := dbRetryBackoff
+		// tryAcquireImpl mutates wf.Status.Synchronization in memory before the
+		// transaction commits. Snapshot it and roll each failed attempt back, so
+		// that attempts are independent and an error return leaves the caller's
+		// status exactly as it was - otherwise an abort leaves a Holding entry
+		// for a row the database rolled back, which would be persisted and then
+		// failed as a stale hold on the next controller restart.
+		syncStatus := wf.Status.Synchronization.DeepCopy()
 		attempt := 0
 		err = retry.OnError(backoff, isRetryableSyncError, func() error {
 			attempt++
@@ -511,6 +509,7 @@ func (sm *Manager) TryAcquire(ctx context.Context, wf *wfv1.Workflow, nodeName s
 				return implErr
 			}, &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: false})
 			if txErr != nil {
+				wf.Status.Synchronization = syncStatus.DeepCopy()
 				sm.log.WithFields(logging.Fields{
 					"holderKey": holderKey,
 					"attempt":   attempt,
@@ -533,13 +532,31 @@ func (sm *Manager) TryAcquire(ctx context.Context, wf *wfv1.Workflow, nodeName s
 	return already, updated, msg, failedLockName, err
 }
 
+// dbRetryBackoff bounds the in-place retries of the TryAcquire transaction.
+// sm.lock is held for the whole loop, so each sleep is capped modestly. Jitter
+// prevents a fleet of replicas from retrying in lockstep after a shared
+// conflict burst. An error that survives these retries is surfaced to the
+// caller, which classifies it (sqldb.IsSerializationConflict, IsTransientErr)
+// and requeues the workflow rather than failing it.
+var dbRetryBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.5,
+	Cap:      600 * time.Millisecond,
+}
+
 // isRetryableSyncError reports whether a TryAcquire transaction failure should
-// be retried. Matches PostgreSQL SERIALIZABLE conflict (40001), deadlock
-// (40P01), and explicit rollback messages by substring against the driver's
-// text.
+// be retried. A conflict reported by the database driver itself is always
+// retryable; the substring match against the driver's text (serialization
+// conflicts, deadlocks, explicit rollbacks) remains as a fallback for errors
+// that arrive with the driver type stringified away by an intermediate layer.
 func isRetryableSyncError(err error) bool {
 	if err == nil {
 		return false
+	}
+	if sqldb.IsSerializationConflict(err) {
+		return true
 	}
 	s := strings.ToLower(err.Error())
 	return strings.Contains(s, "serialization") ||

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -497,7 +497,7 @@ func (sm *Manager) TryAcquire(ctx context.Context, wf *wfv1.Workflow, nodeName s
 		// failed as a stale hold on the next controller restart.
 		syncStatus := wf.Status.Synchronization.DeepCopy()
 		attempt := 0
-		err = retry.OnError(backoff, isRetryableSyncError, func() error {
+		err = retry.OnError(backoff, IsRetryableSyncError, func() error {
 			attempt++
 			sm.log.WithFields(logging.Fields{
 				"holderKey": holderKey,
@@ -514,7 +514,7 @@ func (sm *Manager) TryAcquire(ctx context.Context, wf *wfv1.Workflow, nodeName s
 					"holderKey": holderKey,
 					"attempt":   attempt,
 					"error":     txErr,
-					"retryable": isRetryableSyncError(txErr),
+					"retryable": IsRetryableSyncError(txErr),
 				}).Info(ctx, "TryAcquire - transaction failed")
 			}
 			return txErr
@@ -546,12 +546,12 @@ var dbRetryBackoff = wait.Backoff{
 	Cap:      600 * time.Millisecond,
 }
 
-// isRetryableSyncError reports whether a TryAcquire transaction failure should
+// IsRetryableSyncError reports whether a TryAcquire transaction failure should
 // be retried. A conflict reported by the database driver itself is always
 // retryable; the substring match against the driver's text (serialization
 // conflicts, deadlocks, explicit rollbacks) remains as a fallback for errors
 // that arrive with the driver type stringified away by an intermediate layer.
-func isRetryableSyncError(err error) bool {
+func IsRetryableSyncError(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/workflow/sync/sync_manager_conflict_test.go
+++ b/workflow/sync/sync_manager_conflict_test.go
@@ -1,0 +1,148 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+	"github.com/argoproj/argo-workflows/v4/util/sqldb"
+)
+
+const wfWithTwoDBSemaphores = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+ name: hello-world-two-db-sems
+ namespace: default
+spec:
+ entrypoint: whalesay
+ synchronization:
+   semaphores:
+     - database:
+         key: sem-a
+     - database:
+         key: sem-b
+ templates:
+ - name: whalesay
+   container:
+     image: docker/whalesay:latest
+     command: [cowsay]
+     args: ["hello world"]
+`
+
+// stubLock reuses poisonedLock's inert semaphore implementation, overriding
+// just the acquisition path so a test can drive TryAcquire's database retry
+// loop into exactly the failure it wants while the transaction itself runs
+// against a real database.
+type stubLock struct {
+	*poisonedLock
+	tryAcquireErr error
+	tryAcquireN   int
+}
+
+var _ semaphore = &stubLock{}
+
+func (s *stubLock) checkAcquire(_ context.Context, _ string, _ *sqldb.SessionProxy) (bool, bool, string) {
+	return true, false, ""
+}
+
+func (s *stubLock) tryAcquire(_ context.Context, _ string, _ *sqldb.SessionProxy) (bool, string, error) {
+	s.tryAcquireN++
+	if s.tryAcquireErr != nil {
+		return false, "", s.tryAcquireErr
+	}
+	return true, "", nil
+}
+
+// conflictErrForDBType returns the driver error a genuine transaction conflict
+// produces, with a message that matches none of isRetryableSyncError's
+// substring fallbacks - retries and classification must work from the driver
+// type alone.
+func conflictErrForDBType(dbType sqldb.DBType) error {
+	if dbType == sqldb.MySQL {
+		return &mysql.MySQLError{Number: 1213, Message: "chosen as victim; restart transaction"}
+	}
+	return &pq.Error{Code: pqerror.TRSerializationFailure, Message: "concurrent update"}
+}
+
+// TestIsRetryableSyncErrorTypedConflict pins the delegation to the typed
+// driver-error classifier: a genuine conflict is retryable however its message
+// is worded, while the substring fallback still catches stringified errors.
+func TestIsRetryableSyncErrorTypedConflict(t *testing.T) {
+	assert.True(t, isRetryableSyncError(&pq.Error{Code: pqerror.TRSerializationFailure, Message: "concurrent update"}))
+	assert.True(t, isRetryableSyncError(&pq.Error{Code: pqerror.TRDeadlockDetected, Message: "processes are waiting"}))
+	assert.True(t, isRetryableSyncError(fmt.Errorf("commit: %w", &mysql.MySQLError{Number: 1213, Message: "chosen as victim"})))
+	assert.True(t, isRetryableSyncError(errors.New("ERROR: could not serialize access due to read/write dependencies among transactions")), "substring fallback must still work")
+	assert.False(t, isRetryableSyncError(errors.New("duplicate key value violates unique constraint")))
+	assert.False(t, isRetryableSyncError(nil))
+}
+
+// TestTryAcquireSurfacesSerializationConflict drives the database retry loop to
+// exhaustion. The typed conflict must be retried, surface to the caller still
+// classifiable (the caller, not the sync manager, decides to requeue), and the
+// failed attempts must leave the workflow's in-memory synchronization status
+// untouched.
+func TestTryAcquireSurfacesSerializationConflict(t *testing.T) {
+	for _, dbType := range testDBTypes {
+		t.Run(string(dbType), func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			info, cleanup, syncConfig, err := createTestDBSession(ctx, t, dbType)
+			require.NoError(t, err)
+			defer cleanup()
+
+			newManagerWithStubs := func(errB error) (*Manager, *stubLock, *stubLock, *[]string) {
+				requeued := []string{}
+				syncManager := createLockManager(ctx, info.SessionProxy, &syncConfig, nil, func(key string) {
+					requeued = append(requeued, key)
+				}, WorkflowExistenceFunc)
+				require.NotNil(t, syncManager)
+				semA := &stubLock{poisonedLock: newPoisonedLock("sem-a", "")}
+				semB := &stubLock{poisonedLock: newPoisonedLock("sem-b", ""), tryAcquireErr: errB}
+				syncManager.syncLockMap["default/Database/sem-a"] = semA
+				syncManager.syncLockMap["default/Database/sem-b"] = semB
+				return syncManager, semA, semB, &requeued
+			}
+
+			t.Run("ConflictRetriesThenSurfacesClassifiable", func(t *testing.T) {
+				syncManager, semA, semB, requeued := newManagerWithStubs(conflictErrForDBType(dbType))
+
+				wf := wfv1.MustUnmarshalWorkflow(wfWithTwoDBSemaphores)
+				acquired, _, _, _, err := syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+
+				require.Error(t, err, "an exhausted conflict must surface to the caller")
+				assert.True(t, sqldb.IsSerializationConflict(err), "the driver error must reach the caller still classifiable")
+				assert.False(t, acquired)
+				assert.Equal(t, dbRetryBackoff.Steps, semB.tryAcquireN, "the typed classifier must drive the retry loop: the injected message matches no substring fallback")
+				assert.Equal(t, dbRetryBackoff.Steps, semA.tryAcquireN, "each attempt must run the whole lock set")
+				assert.Empty(t, *requeued, "the sync manager must not requeue; that decision belongs to the caller")
+				// sem-a acquired successfully inside every aborted transaction:
+				// the rollback must not leave its Holding entry behind.
+				require.NotNil(t, wf.Status.Synchronization)
+				require.NotNil(t, wf.Status.Synchronization.Semaphore)
+				assert.Empty(t, wf.Status.Synchronization.Semaphore.Holding, "a rolled-back acquisition must not leave a Holding entry")
+			})
+
+			t.Run("NonRetryableErrorSurfacesWithoutRetries", func(t *testing.T) {
+				syncManager, _, semB, requeued := newManagerWithStubs(errors.New("duplicate key value violates unique constraint"))
+
+				wf := wfv1.MustUnmarshalWorkflow(wfWithTwoDBSemaphores)
+				acquired, _, _, _, err := syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+
+				require.Error(t, err)
+				assert.False(t, sqldb.IsSerializationConflict(err))
+				assert.False(t, acquired)
+				assert.Equal(t, 1, semB.tryAcquireN, "a non-retryable error must fail fast")
+				assert.Empty(t, *requeued)
+			})
+		})
+	}
+}

--- a/workflow/sync/sync_manager_conflict_test.go
+++ b/workflow/sync/sync_manager_conflict_test.go
@@ -64,7 +64,7 @@ func (s *stubLock) tryAcquire(_ context.Context, _ string, _ *sqldb.SessionProxy
 }
 
 // conflictErrForDBType returns the driver error a genuine transaction conflict
-// produces, with a message that matches none of isRetryableSyncError's
+// produces, with a message that matches none of IsRetryableSyncError's
 // substring fallbacks - retries and classification must work from the driver
 // type alone.
 func conflictErrForDBType(dbType sqldb.DBType) error {
@@ -78,12 +78,12 @@ func conflictErrForDBType(dbType sqldb.DBType) error {
 // driver-error classifier: a genuine conflict is retryable however its message
 // is worded, while the substring fallback still catches stringified errors.
 func TestIsRetryableSyncErrorTypedConflict(t *testing.T) {
-	assert.True(t, isRetryableSyncError(&pq.Error{Code: pqerror.TRSerializationFailure, Message: "concurrent update"}))
-	assert.True(t, isRetryableSyncError(&pq.Error{Code: pqerror.TRDeadlockDetected, Message: "processes are waiting"}))
-	assert.True(t, isRetryableSyncError(fmt.Errorf("commit: %w", &mysql.MySQLError{Number: 1213, Message: "chosen as victim"})))
-	assert.True(t, isRetryableSyncError(errors.New("ERROR: could not serialize access due to read/write dependencies among transactions")), "substring fallback must still work")
-	assert.False(t, isRetryableSyncError(errors.New("duplicate key value violates unique constraint")))
-	assert.False(t, isRetryableSyncError(nil))
+	assert.True(t, IsRetryableSyncError(&pq.Error{Code: pqerror.TRSerializationFailure, Message: "concurrent update"}))
+	assert.True(t, IsRetryableSyncError(&pq.Error{Code: pqerror.TRDeadlockDetected, Message: "processes are waiting"}))
+	assert.True(t, IsRetryableSyncError(fmt.Errorf("commit: %w", &mysql.MySQLError{Number: 1213, Message: "chosen as victim"})))
+	assert.True(t, IsRetryableSyncError(errors.New("ERROR: could not serialize access due to read/write dependencies among transactions")), "substring fallback must still work")
+	assert.False(t, IsRetryableSyncError(errors.New("duplicate key value violates unique constraint")))
+	assert.False(t, IsRetryableSyncError(nil))
 }
 
 // TestTryAcquireSurfacesSerializationConflict drives the database retry loop to


### PR DESCRIPTION
See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Alternative, minimal approach to #16619.

### Motivation

At scale, database-backed synchronization locks can hit serialization/deadlock conflicts that exhaust the in-place retries in `TryAcquire`. Today any error from `TryAcquire` permanently fails the workflow, so a transient database condition becomes a terminal workflow failure.

#16619 addresses this by swallowing the error inside the sync manager and reporting "not acquired, waiting", which then requires compensating machinery (status snapshot/restore plus re-recording waiting entries, synthesised lock attribution, a direct requeue call). This PR instead moves the decision to the caller, which already has the idiom and infrastructure for it.

### Modifications

- `util/sqldb.IsSerializationConflict`: typed driver-error classifier (PostgreSQL 40001/40P01 via `pq.As` and the `pqerror` constants, MySQL 1213 via the driver's `errors.Is`). Lives next to the existing `isNetworkError` classifier in the package that already owns the driver imports. MySQL 1205 (`ER_LOCK_WAIT_TIMEOUT`) is deliberately excluded, with the reasoning in a comment.
- `workflow/sync`: `isRetryableSyncError` now delegates to the typed classifier, keeping the substring match only as a fallback for stringified errors, so the retry loop and the caller agree on what a conflict is. Each failed transaction attempt rolls back its in-memory `wf.Status.Synchronization` mutations, so an error return leaves the caller's status untouched and an aborted attempt can no longer persist a `Holding` entry for a row the database rolled back (the stale-hold-on-restart failure). The error still surfaces to the caller; the sync manager makes no requeue decision.
- `workflow/controller`: at both `TryAcquire` call sites, a serialization conflict or any `IsTransientErr` error now leaves the workflow (or node) Pending and requeues it on the rate-limited workqueue — matching the existing transient-error idiom (`createPVCs`, `requeueIfTransientErr`) and gaining exponential backoff and queue metrics for free. Non-transient errors fail the workflow exactly as before.

### Verification

New tests, all passing locally:

- `util/sqldb`: table test for the classifier (typed codes, wrapped errors, 1205 and message-text lookalikes pinned to false).
- `workflow/sync` (Postgres and MySQL testcontainers): a conflict whose message matches none of the substring fallbacks is retried exactly `dbRetryBackoff.Steps` times, surfaces still classifiable, leaves no `Holding` entry from a sibling lock acquired inside the aborted transaction, and triggers no requeue from the sync manager itself; a non-retryable error fails fast after one attempt.
- `workflow/controller`: a non-transient sync error still fails the workflow (this path previously had no test); a transient error leaves the workflow Pending with a "Waiting to acquire the synchronization lock" message at workflow level, and leaves nodes Pending rather than Errored at template level.

Full `workflow/sync` suite and the controller's `TestSemaphore*`/`TestMutex*`/`TestSynchronization*` tests pass unchanged.

### Documentation

No docs changes: no new configuration, environment variables, or fields. The user-visible change is that workflows stay Pending under transient database contention instead of failing.

### AI

This PR was prepared with Claude Code (Claude Fable 5): design discussion, implementation, tests, and commit message, reviewed and directed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow synchronization handling for temporary database conflicts.
  * Automatically retries PostgreSQL and MySQL serialization conflicts and deadlocks.
  * Keeps affected workflows and nodes pending when synchronization can be retried.
  * Excludes lock-wait timeouts and unrelated database errors from retry handling.
  * Preserves existing node statuses and messages during transient synchronization failures.

* **Tests**
  * Added coverage for database conflicts, wrapped errors, retry behavior, and workflow state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->