### PR TITLE
fix(server): use symmetric encryption for SSO session tokens. Fixes #16744

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,15 @@ For the upgrading guide to a specific version of workflows change the documentat
 Breaking changes  typically (sometimes we don't realise they are breaking) have "!" in the commit message, as per
 the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
 
+## Upgrading to v4.1.2
+
+### SSO users are logged out once on upgrade
+
+The SSO session token format has changed to fix the oversized `authorization` cookie that broke SSO login in v4.1.0 and v4.1.1 ([#16748](https://github.com/argoproj/argo-workflows/pull/16748)).
+Existing session cookies fail to validate after the upgrade, so users are redirected to log in again once; new sessions work as normal.
+CLI users who saved a token from `argo auth token` need to re-fetch it.
+No configuration or secret changes are required.
+
 ## Upgrading to v4.1
 
 ### Controller caches no longer store `managedFields`

--- a/server/auth/sso/sso.go
+++ b/server/auth/sso/sso.go
@@ -2,9 +2,9 @@ package sso
 
 import (
 	"context"
-	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
 	"net/http"
@@ -58,8 +58,7 @@ type sso struct {
 	httpClient        *http.Client
 	baseHRef          string
 	secure            bool
-	privateKey        crypto.PrivateKey
-	signer            jose.Signer
+	encryptionKey     []byte
 	encrypter         jose.Encrypter
 	rbacConfig        *config.RBACConfig
 	expiry            time.Duration
@@ -191,14 +190,17 @@ func newSso(
 		Scopes:       append(c.Scopes, oidc.ScopeOpenID),
 	}
 	idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: config.ClientID})
-	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}, nil)
+	// The server both mints and verifies these tokens, so symmetric AEAD is
+	// sufficient: encryption with A256GCM also authenticates, and go-jose v4
+	// only permits encrypt-only JWTs with symmetric algorithms. Asymmetric
+	// encryption needed a nested signature, which pushed the cookie over the
+	// 4KB browser limit (https://github.com/argoproj/argo-workflows/issues/16744).
+	// The AES key is derived from the RSA key already stored in the secret so
+	// that existing installations don't need a secret migration.
+	encryptionKey := sha256.Sum256(x509.MarshalPKCS1PrivateKey(privateKey))
+	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.DIRECT, Key: encryptionKey[:]}, &jose.EncrypterOptions{Compression: jose.DEFLATE})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create JWT signer: %w", err)
-	}
-	encrypterOptions := (&jose.EncrypterOptions{Compression: jose.DEFLATE}).WithContentType("JWT")
-	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: privateKey.Public()}, encrypterOptions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create JWT encrpytor: %w", err)
+		return nil, fmt.Errorf("failed to create JWT encrypter: %w", err)
 	}
 
 	var filterGroupsRegex []*regexp.Regexp
@@ -225,8 +227,7 @@ func newSso(
 		baseHRef:          baseHRef,
 		httpClient:        httpClient,
 		secure:            secure,
-		privateKey:        privateKey,
-		signer:            signer,
+		encryptionKey:     encryptionKey[:],
 		encrypter:         encrypter,
 		rbacConfig:        c.RBAC,
 		expiry:            c.GetSessionExpiry(),
@@ -347,7 +348,7 @@ func (s *sso) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		PreferredUsername:       c.PreferredUsername,
 		ServiceAccountNamespace: c.ServiceAccountNamespace,
 	}
-	raw, err := jwt.SignedAndEncrypted(s.signer, s.encrypter).Claims(argoClaims).Serialize()
+	raw, err := jwt.Encrypted(s.encrypter).Claims(argoClaims).Serialize()
 	if err != nil {
 		s.logger.WithError(err).Error(r.Context(), "failed to encrypt and serialize the jwt token")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -394,24 +395,14 @@ func isValidFinalRedirectURL(redirect string) bool {
 
 // authorize verifies a bearer token and pulls user information form the claims.
 func (s *sso) Authorize(authorization string) (*types.Claims, error) {
-	enc, err := jose.ParseEncrypted(strings.TrimPrefix(authorization, Prefix), []jose.KeyAlgorithm{jose.RSA_OAEP_256}, []jose.ContentEncryption{jose.A256GCM})
+	tok, err := jwt.ParseEncrypted(strings.TrimPrefix(authorization, Prefix), []jose.KeyAlgorithm{jose.DIRECT}, []jose.ContentEncryption{jose.A256GCM})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse encrypted token: %w", err)
 	}
 
-	payload, err := enc.Decrypt(s.privateKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt token: %w", err)
-	}
-
-	tok, err := jwt.ParseSigned(string(payload), []jose.SignatureAlgorithm{jose.RS256})
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse signed token: %w", err)
-	}
-
 	c := &types.Claims{}
-	if err := tok.Claims(s.privateKey.(*rsa.PrivateKey).Public(), c); err != nil {
-		return nil, fmt.Errorf("failed to verify signed token: %w", err)
+	if err := tok.Claims(s.encryptionKey, c); err != nil {
+		return nil, fmt.Errorf("failed to decrypt token: %w", err)
 	}
 
 	if err := c.Validate(jwt.Expected{Issuer: issuer}); err != nil {

--- a/server/auth/sso/sso_test.go
+++ b/server/auth/sso/sso_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"fmt"
 	"testing"
 	"time"
 
@@ -97,9 +98,9 @@ func TestNewSsoWithIssuerAlias(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAuthorizeSignedEncryptedToken(t *testing.T) {
+func TestAuthorizeEncryptedToken(t *testing.T) {
 	ssoObject := newTestSso(t)
-	raw, err := jwt.SignedAndEncrypted(ssoObject.signer, ssoObject.encrypter).Claims(newTestClaims()).Serialize()
+	raw, err := jwt.Encrypted(ssoObject.encrypter).Claims(newTestClaims()).Serialize()
 	require.NoError(t, err)
 
 	claims, err := ssoObject.Authorize(Prefix + raw)
@@ -108,29 +109,78 @@ func TestAuthorizeSignedEncryptedToken(t *testing.T) {
 	assert.Equal(t, []string{"test-group"}, claims.Groups)
 }
 
-func TestAuthorizeLegacyEncryptedTokenFails(t *testing.T) {
+// Tokens from v4.1.x used a nested RS256 JWS inside an RSA-OAEP-256 JWE
+// (and pre-4.1 an RSA-OAEP-256 JWE alone); both must be rejected at parse
+// so that stale cookies force a fresh login rather than a server error.
+func TestAuthorizeLegacyAsymmetricTokenFails(t *testing.T) {
 	ssoObject := newTestSso(t)
-	legacyEncrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: ssoObject.privateKey.(*rsa.PrivateKey).Public()}, &jose.EncrypterOptions{Compression: jose.DEFLATE})
-	require.NoError(t, err)
-	raw, err := jwt.Encrypted(legacyEncrypter).Claims(newTestClaims()).Serialize()
-	require.NoError(t, err)
-
-	claims, err := ssoObject.Authorize(Prefix + raw)
-	require.Error(t, err)
-	assert.Nil(t, claims)
-	assert.ErrorContains(t, err, "failed to parse signed token")
-}
-
-func newTestSso(t *testing.T) *sso {
-	t.Helper()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}, nil)
 	require.NoError(t, err)
 	encrypterOptions := (&jose.EncrypterOptions{Compression: jose.DEFLATE}).WithContentType("JWT")
-	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: privateKey.Public()}, encrypterOptions)
+	legacyEncrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.RSA_OAEP_256, Key: privateKey.Public()}, encrypterOptions)
 	require.NoError(t, err)
-	return &sso{privateKey: privateKey, signer: signer, encrypter: encrypter}
+	raw, err := jwt.SignedAndEncrypted(signer, legacyEncrypter).Claims(newTestClaims()).Serialize()
+	require.NoError(t, err)
+
+	claims, err := ssoObject.Authorize(Prefix + raw)
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.ErrorContains(t, err, "failed to parse encrypted token")
+}
+
+func TestAuthorizeTokenEncryptedWithOtherKeyFails(t *testing.T) {
+	ssoObject := newTestSso(t)
+	otherSso := newTestSso(t)
+	raw, err := jwt.Encrypted(otherSso.encrypter).Claims(newTestClaims()).Serialize()
+	require.NoError(t, err)
+
+	claims, err := ssoObject.Authorize(Prefix + raw)
+	require.Error(t, err)
+	assert.Nil(t, claims)
+	assert.ErrorContains(t, err, "failed to decrypt token")
+}
+
+// A large but realistic claims set (long email, many groups) must serialize
+// to a cookie under the 4096-byte browser limit (RFC 6265).
+// https://github.com/argoproj/argo-workflows/issues/16744
+func TestTokenFitsInCookie(t *testing.T) {
+	ssoObject := newTestSso(t)
+	groups := make([]string, 60)
+	for i := range groups {
+		groups[i] = fmt.Sprintf("department-%02d-engineering-owners@example-organization.com", i)
+	}
+	claims := &types.Claims{
+		Claims: jwt.Claims{
+			Issuer:  issuer,
+			Subject: "00u1abcdefghijklmnop5d7",
+			Expiry:  jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+		},
+		Groups:            groups,
+		Email:             "somebody.with-a-long-name@example-organization.com",
+		EmailVerified:     true,
+		Name:              "Somebody With-A-Long-Name",
+		PreferredUsername: "somebody.with-a-long-name@example-organization.com",
+	}
+	raw, err := jwt.Encrypted(ssoObject.encrypter).Claims(claims).Serialize()
+	require.NoError(t, err)
+	cookie := "authorization=" + Prefix + raw
+	assert.Less(t, len(cookie), 4096)
+
+	roundTripped, err := ssoObject.Authorize(Prefix + raw)
+	require.NoError(t, err)
+	assert.Equal(t, groups, roundTripped.Groups)
+}
+
+func newTestSso(t *testing.T) *sso {
+	t.Helper()
+	encryptionKey := make([]byte, 32)
+	_, err := rand.Read(encryptionKey)
+	require.NoError(t, err)
+	encrypter, err := jose.NewEncrypter(jose.A256GCM, jose.Recipient{Algorithm: jose.DIRECT, Key: encryptionKey}, &jose.EncrypterOptions{Compression: jose.DEFLATE})
+	require.NoError(t, err)
+	return &sso{encryptionKey: encryptionKey, encrypter: encrypter}
 }
 
 func newTestClaims() *types.Claims {


### PR DESCRIPTION
See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16744.

### Motivation

The go-jose v4 upgrade (#16213) broke SSO because v4 rejects encrypt-only JWTs using asymmetric key algorithms (#16232) — with those, anyone holding the public key can forge a token. The fix (#16292) kept RSA and added a nested RS256 JWS inside the JWE, which inflated the session token three ways: the signature is incompressible, the inner JWS base64-encodes the claims *before* DEFLATE sees them, and the JWE base64-encodes the result again. With large IdP claim sets (e.g. Okta with many groups) the `authorization` cookie exceeds the 4096-byte limit of RFC 6265; browsers drop oversized cookies silently, producing an infinite login loop (#16744).

The asymmetric cryptography serves no purpose here: argo-server generates the key itself, stores it in the `sso` secret, and is the only party that ever encrypts, decrypts, or verifies these tokens. There is no key-distribution problem to solve.

### Modifications

- Switch the session token to direct symmetric encryption (`dir` + `A256GCM`, DEFLATE retained). go-jose v4 permits encrypt-only JWTs with symmetric algorithms because AEAD provides authenticity — only the key holder can mint a valid token — so the nested signature is no longer needed and `Authorize` collapses back to a single parse-and-decrypt.
- Derive the 32-byte AES key with SHA-256 from the RSA private key already stored in the `sso` secret. The secret format, generation, and multi-replica create-race handling are untouched, so existing installations need no migration and every replica derives the same key.
- The `Bearer v2:` prefix is kept: `server/auth/mode.go` dispatches auth mode on it, and the JWE header self-describes the algorithm change.

Measured with a realistic Okta-like claims fixture (60 groups, long email/name), full `authorization=` cookie:

| Format | Size |
|---|---|
| v4.0.x (RSA JWE only) | 965 bytes |
| v4.1.0–v4.1.1 (nested JWS in JWE) | 1555 bytes |
| this PR (dir JWE) | 611 bytes |

The fixture compresses well; real-world tokens are larger (4751 bytes reported in #16744 for the nested format), but the ratio (~2.5× smaller than v4.1.x, and smaller than pre-4.1) carries over.

### Upgrade impact

Outstanding session cookies (both the pre-4.1 and the 4.1.x formats) fail to parse and return 401, so users get a fresh login prompt once — the same one-time re-login the 4.0→4.1 upgrade already caused. CLI users who saved a token from `argo auth token` need to re-fetch it.

### Verification

New/updated unit tests in `server/auth/sso`:

- round-trip `Authorize` of a `dir`-encrypted token
- legacy asymmetric tokens (nested v4.1.x format) are rejected at parse, so stale cookies force re-login rather than a server error
- a token encrypted under a different key fails to decrypt (authenticity)
- cookie-size regression test: the Okta-like fixture must serialize to under 4096 bytes

`go test ./server/auth/...` and `golangci-lint run ./server/auth/...` pass.

### AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013A5NWYSULyrctpgBm1fk67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Updated SSO session cookies to use modern authenticated encryption.
  * Legacy token formats are no longer accepted.
  * Tokens encrypted with an unauthorized key are rejected.

* **Reliability**
  * Improved handling of larger SSO claims while staying within browser cookie size limits.

* **Upgrade Notes**
  * SSO sessions will require one-time reauthentication after upgrading.
  * Saved CLI tokens must be refreshed; no configuration or secret changes are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->