### PR TITLE
fix(controller): refuse reapplyUpdate when workflow UID has changed

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -937,6 +937,15 @@ func (woc *wfOperationCtx) reapplyUpdate(ctx context.Context, wfClient v1alpha1.
 		if err != nil {
 			return nil, err
 		}
+		// The preceding UID-guarded Update only fails on conflict when the workflow has been
+		// deleted and recreated under the same name while the controller was mid-operation on it.
+		// IsConflict treats a UID precondition failure the same as an ordinary conflict, so without
+		// this check we would merge-patch the old instance's status delta onto the new object,
+		// silently corrupting it (e.g. creating unreachable nodes with empty fields).
+		// https://github.com/argoproj/argo-workflows/issues/16774
+		if currWf.UID != woc.wf.UID {
+			return nil, fmt.Errorf("workflow has been recreated, not updating(%s -> %s)", woc.wf.UID, currWf.UID)
+		}
 		// There is something about having informer indexers (introduced in v2.12) that means we are more likely to operate on the
 		// previous version of the workflow. This means under high load, a previously successful workflow could
 		// be operated on again. This can error (e.g. if any pod was deleted as part of clean-up). This check prevents that.

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -116,6 +116,31 @@ func Test_wfOperationCtx_reapplyUpdate(t *testing.T) {
 		_, err := woc.reapplyUpdate(ctx, controller.wfclientset.ArgoprojV1alpha1().Workflows(""), wf.Status.Nodes)
 		require.EqualError(t, err, "must never update completed node my-node")
 	})
+	// https://github.com/argoproj/argo-workflows/issues/16774
+	// If the workflow was deleted and recreated under the same name while the controller was
+	// mid-operation on it, the UID-guarded Update fails on the UID precondition, which IsConflict
+	// treats as an ordinary conflict. reapplyUpdate must detect the UID mismatch on the object it
+	// Gets by name and refuse to merge-patch the old instance's status delta onto the new object.
+	t.Run("ErrWorkflowRecreatedWithDifferentUID", func(t *testing.T) {
+		wf := &wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-wf", UID: "old-uid"},
+			Status:     wfv1.WorkflowStatus{Nodes: wfv1.Nodes{"foo": wfv1.NodeStatus{Name: "my-foo"}}},
+		}
+		// currWf simulates the recreated workflow: same name, different UID, no status.
+		currWf := &wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-wf", UID: "new-uid"},
+		}
+		ctx := logging.TestContext(t.Context())
+		cancel, controller := newController(ctx, currWf)
+		defer cancel()
+		controller.hydrator = hydratorfake.Always
+		woc := newWorkflowOperationCtx(ctx, wf, controller)
+		require.NoError(t, controller.hydrator.Hydrate(ctx, wf))
+		nodes := wfv1.Nodes{"foo": wfv1.NodeStatus{Name: "my-foo", Phase: wfv1.NodeSucceeded}}
+
+		_, err := woc.reapplyUpdate(ctx, controller.wfclientset.ArgoprojV1alpha1().Workflows(""), nodes)
+		require.EqualError(t, err, "workflow has been recreated, not updating(old-uid -> new-uid)")
+	})
 }
 
 func TestResourcesDuration(t *testing.T) {


### PR DESCRIPTION
- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16774

### Motivation

A running workflow can be deleted and recreated under the same name while the
controller is mid-operation on it. When that happens, the UID-guarded
`Update` fails on the UID precondition (`Precondition failed: UID in
precondition: ..., UID in object meta: ...`). `IsConflict` treats that
failure the same as an ordinary optimistic-concurrency conflict, so
`reapplyUpdate` retries by fetching the object by name and merge-patching the
old instance's status delta onto it — with no UID comparison anywhere.

Since the new object has no `status.nodes`, each node delta becomes a node
containing only its changed fields (`id`, `name`, `type` all `""`).
`GetNodeByName` hashes the name, so those nodes become unreachable forever;
the workflow can neither progress nor be failed, permanently holding any
semaphores it acquired.

### Modifications

- In `reapplyUpdate` (`workflow/controller/operator.go`), after the `Get` of
  the current workflow, compare `currWf.UID` against `woc.wf.UID`. If they
  differ, return an error instead of merge-patching, mirroring the guard the
  plain `Update` already gets via its UID precondition.
- This check sits alongside the existing "must never update completed
  workflows" guard, since both protect the same retry-after-conflict path.

### Verification

- Added `Test_wfOperationCtx_reapplyUpdate/ErrWorkflowRecreatedWithDifferentUID`
  in `workflow/controller/operator_test.go`, which simulates a recreated
  workflow (same name, different UID, empty status) and asserts
  `reapplyUpdate` now returns
  `"workflow has been recreated, not updating(old-uid -> new-uid)"` instead
  of corrupting the new workflow's status.
- Ran `go test ./workflow/controller/... -run Test_wfOperationCtx_reapplyUpdate -v`
  locally — all 4 subtests pass (`Success`, `ErrUpdatingCompletedWorkflow`,
  `ErrUpdatingCompletedNode`, `ErrWorkflowRecreatedWithDifferentUID`).
- Ran `go vet ./workflow/controller/...` — clean.

### Documentation

No documentation changes needed — this is an internal controller
concurrency-safety fix with no user-facing API, CRD, or CLI change.

### AI
AI coding assistants used