### PR TITLE
fix: fail, not succeed, workflows terminated while pending on a sync lock

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -301,8 +301,11 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 					phase = wfv1.WorkflowPending
 				}
 				ctx = woc.markWorkflowPhase(ctx, phase, msg)
-				return
 			}
+			// Whether the workflow remains queued or its locks were just
+			// released for shutdown, there is nothing more to do this
+			// reconcile.
+			return
 		}
 	}
 
@@ -574,7 +577,10 @@ func (woc *wfOperationCtx) releaseLocksForPendingShuttingdownWfs(ctx context.Con
 	if woc.GetShutdownStrategy().Enabled() && woc.wf.Status.Phase == wfv1.WorkflowPending && woc.GetShutdownStrategy() == wfv1.ShutdownStrategyTerminate {
 		if woc.controller.syncManager.ReleaseAll(ctx, woc.execWf) {
 			woc.log.WithFields(logging.Fields{"key": woc.execWf.Name}).Info(ctx, "Released all locks since this pending workflow is being shutdown")
-			_ = woc.markWorkflowSuccess(ctx)
+			// The workflow never started: it was still waiting for its
+			// synchronization lock when it was terminated, so it completes as
+			// Failed, matching every other shutdown path.
+			_ = woc.markWorkflowFailed(ctx, fmt.Sprintf("Stopped with strategy '%s'", woc.GetShutdownStrategy()))
 			return true
 		}
 	}

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -986,11 +986,14 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		wfTwo, err = controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Patch(ctx, wfTwo.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 		require.NoError(t, err)
 
-		// The pending workflow that's being shutdown should have succeeded and released the lock.
+		// The pending workflow that's being shutdown should have failed and released the lock.
 		wocTwo = newWorkflowOperationCtx(ctx, wfTwo, controller)
 		wocTwo.operate(ctx)
-		assert.Equal(t, wfv1.WorkflowSucceeded, wocTwo.execWf.Status.Phase)
+		assert.Equal(t, wfv1.WorkflowFailed, wocTwo.wf.Status.Phase)
+		assert.Equal(t, "Stopped with strategy 'Terminate'", wocTwo.wf.Status.Message)
 		assert.Nil(t, wocTwo.wf.Status.Synchronization)
+		// The workflow never ran, so no nodes should have been created for it.
+		assert.Empty(t, wocTwo.wf.Status.Nodes)
 	})
 
 	t.Run("PendingShuttingdownStoppingWf", func(t *testing.T) {

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -994,6 +994,24 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		assert.Nil(t, wocTwo.wf.Status.Synchronization)
 		// The workflow never ran, so no nodes should have been created for it.
 		assert.Empty(t, wocTwo.wf.Status.Nodes)
+
+		// Release the lock from the first workflow.
+		woc.wf.Status.Phase = wfv1.WorkflowSucceeded
+		woc.operate(ctx)
+		assert.Nil(t, woc.wf.Status.Synchronization)
+
+		// The terminated workflow must also have been removed from the lock's
+		// waiting queue, so a new workflow acquires the lock immediately.
+		wfThree := wf.DeepCopy()
+		wfThree.Name = "three-terminating"
+		wfThree, err = controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Create(ctx, wfThree, metav1.CreateOptions{})
+		require.NoError(t, err)
+		wocThree := newWorkflowOperationCtx(ctx, wfThree, controller)
+		wocThree.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowRunning, wocThree.wf.Status.Phase)
+		require.NotNil(t, wocThree.wf.Status.Synchronization)
+		require.NotNil(t, wocThree.wf.Status.Synchronization.Mutex)
+		assert.Len(t, wocThree.wf.Status.Synchronization.Mutex.Holding, 1)
 	})
 
 	t.Run("PendingShuttingdownStoppingWf", func(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- [x] Ran `make pre-commit -B` (scoped: `golangci-lint run workflow/controller/` clean, full `go test ./workflow/controller/` green; no codegen-affecting changes)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

Terminating a workflow while it is still `Pending` waiting to acquire a **workflow-level** synchronization lock (mutex or semaphore, memory- or database-backed) marks the workflow **Succeeded**, with a **Failed** node inside it, plus a recovered `workflow is already fulfilled` panic in the controller.

Sequence, reproduced on v4.1.1 (and every release since v3.4.6):

```
Released all locks since this pending workflow is being shutdown
updated phase fromPhase=Pending toPhase=Succeeded          ← wrong
node initialized ... phase Pending → Failed "workflow shutdown with strategy: Terminate"
panic: workflow is already fulfilled fromPhase=Succeeded toPhase=Failed   (recovered)
```

This was introduced by #10735 (the fix for #10733, v3.4.6): `releaseLocksForPendingShuttingdownWfs` calls `markWorkflowSuccess` on the terminated workflow, and because it returns `true`, `operate()` falls through and keeps reconciling — initializing the entrypoint node as Failed under the shutdown and then attempting to mark the already-"Succeeded" workflow Failed.

### Modifications

- `releaseLocksForPendingShuttingdownWfs` now marks the workflow **Failed** with the standard `Stopped with strategy 'Terminate'` message, matching every other shutdown path.
- The `!acquired` branch in `operate()` now returns in both cases (locks released for shutdown, or still queued) instead of falling through into a full reconcile of a workflow that never started.
- Updated `TestSynchronizationForPendingShuttingdownWfs/PendingShuttingdownTerminatingWf`, which encoded the buggy expectation (`WorkflowSucceeded`), to assert Failed + message + no nodes created.

### Verification

- Updated unit test fails on `main` and passes with the fix; full `go test ./workflow/controller/` is green.
- Reproduced live on a k3d cluster against the released v4.1.1 images with both an in-memory and a database-backed workflow-level mutex (holder workflow running, waiter Pending on the lock, `argo terminate` on the waiter → Succeeded + Failed node + recovered panic). With the fix the waiter completes Failed / "Stopped with strategy 'Terminate'" with no nodes.
- `Stop` semantics are unchanged (the function is Terminate-only, `PendingShuttingdownStoppingWf` still passes).

### Documentation

No documentation change needed: this restores the phase semantics already documented for terminated workflows.

### AI

This PR was prepared with Claude Code (Anthropic): live cluster reproduction, root-cause analysis, fix, tests, and this description, directed and reviewed by the submitting maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XsqqvLSrJ5sH8gN8tLbr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows terminated before acquiring synchronization are now correctly marked as **Failed** instead of **Succeeded**.
  * Reconciliation now returns reliably when synchronization cannot be acquired, including while pending shutdown workflows release their locks.
  * Waiting workflows can now acquire synchronization and run promptly after a terminated workflow is removed from the queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->