### PR TITLE
fix: fail nodes waiting for a sync lock on workflow shutdown

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1371,6 +1371,15 @@ func (woc *wfOperationCtx) failNodesWithoutCreatedPodsAfterDeadlineOrShutdown(ct
 				woc.markNodePhase(ctx, node.Name, wfv1.NodeFailed, message)
 				continue
 			}
+			// fail pending nodes waiting for a synchronization lock when
+			// shutting down: their pod is only created once the lock is
+			// acquired, so pod reconciliation will never fail them, and
+			// without this the shutdown is ignored until the lock frees up
+			if node.Phase == wfv1.NodePending && node.SynchronizationStatus != nil && node.SynchronizationStatus.Waiting != "" {
+				message := fmt.Sprintf("Stopped with strategy '%s'", woc.GetShutdownStrategy())
+				woc.markNodePhase(ctx, node.Name, wfv1.NodeFailed, message)
+				continue
+			}
 			// fail retry wrapper nodes whose children are all fulfilled but the wrapper
 			// itself was left Running because processNodeRetries returned early while a
 			// child pod was still running at the moment of shutdown

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -1136,3 +1136,164 @@ spec:
 		}
 	}
 }
+
+const bareWfWithTmplMutex = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: tmpl-mutex-bare
+  namespace: default
+spec:
+  entrypoint: whalesay
+  templates:
+    - name: whalesay
+      synchronization:
+        mutexes:
+          - name: tmpl-shutdown-test
+      container:
+        image: docker/whalesay:latest
+        command: [sh, -c]
+        args: ["sleep 99999"]`
+
+const stepsWfWithTmplMutex = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: tmpl-mutex-steps
+  namespace: default
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      steps:
+        - - name: locked
+            template: whalesay
+    - name: whalesay
+      synchronization:
+        mutexes:
+          - name: tmpl-shutdown-test
+      container:
+        image: docker/whalesay:latest
+        command: [sh, -c]
+        args: ["sleep 99999"]`
+
+const dagWfWithTmplMutex = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: tmpl-mutex-dag
+  namespace: default
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: locked
+            template: whalesay
+    - name: whalesay
+      synchronization:
+        mutexes:
+          - name: tmpl-shutdown-test
+      container:
+        image: docker/whalesay:latest
+        command: [sh, -c]
+        args: ["sleep 99999"]`
+
+// TestShutdownWaitingForTmplLevelLock ensures that shutting down a workflow
+// whose node is still waiting to acquire a template-level synchronization lock
+// fails that node immediately instead of silently ignoring the shutdown until
+// the lock becomes available.
+func TestShutdownWaitingForTmplLevelLock(t *testing.T) {
+	tests := []struct {
+		name       string
+		waiterYAML string
+		strategy   wfv1.ShutdownStrategy
+	}{
+		{"BareTerminate", bareWfWithTmplMutex, wfv1.ShutdownStrategyTerminate},
+		{"StepsTerminate", stepsWfWithTmplMutex, wfv1.ShutdownStrategyTerminate},
+		{"DAGTerminate", dagWfWithTmplMutex, wfv1.ShutdownStrategyTerminate},
+		{"BareStop", bareWfWithTmplMutex, wfv1.ShutdownStrategyStop},
+		{"StepsStop", stepsWfWithTmplMutex, wfv1.ShutdownStrategyStop},
+		{"DAGStop", dagWfWithTmplMutex, wfv1.ShutdownStrategyStop},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			cancel, controller := newController(ctx)
+			defer cancel()
+			controller.syncManager, _ = sync.NewLockManager(ctx, controller.kubeclientset, controller.namespace, nil, getSyncLimitFunc(ctx, controller.kubeclientset), func(key string) {
+			}, workflowExistenceFunc, false)
+			mutexName := "tmpl-shutdown-" + strings.ToLower(tt.name)
+
+			// The holder acquires the mutex and keeps it for the duration of the test.
+			holder := wfv1.MustUnmarshalWorkflow(bareWfWithTmplMutex)
+			holder.Name = "holder-" + strings.ToLower(tt.name)
+			holder.Spec.Templates[0].Synchronization.Mutexes[0].Name = mutexName
+			holder, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(holder.Namespace).Create(ctx, holder, metav1.CreateOptions{})
+			require.NoError(t, err)
+			wocHolder := newWorkflowOperationCtx(ctx, holder, controller)
+			wocHolder.operate(ctx)
+			require.NotNil(t, wocHolder.wf.Status.Synchronization)
+			require.Len(t, wocHolder.wf.Status.Synchronization.Mutex.Holding, 1)
+
+			// The waiter's node blocks waiting for the mutex.
+			waiter := wfv1.MustUnmarshalWorkflow(tt.waiterYAML)
+			waiter.Name = "waiter-" + strings.ToLower(tt.name)
+			for i := range waiter.Spec.Templates {
+				if waiter.Spec.Templates[i].Synchronization != nil {
+					waiter.Spec.Templates[i].Synchronization.Mutexes[0].Name = mutexName
+				}
+			}
+			waiter, err = controller.wfclientset.ArgoprojV1alpha1().Workflows(waiter.Namespace).Create(ctx, waiter, metav1.CreateOptions{})
+			require.NoError(t, err)
+			wocWaiter := newWorkflowOperationCtx(ctx, waiter, controller)
+			wocWaiter.operate(ctx)
+			waitingNode := findWaitingSyncNode(wocWaiter.wf)
+			require.NotNil(t, waitingNode, "expected a node waiting for the lock")
+			require.Equal(t, wfv1.NodePending, waitingNode.Phase)
+
+			// Shut the waiter down while it is still waiting for the lock.
+			patch, err := json.Marshal(map[string]any{"spec": map[string]any{"shutdown": tt.strategy}})
+			require.NoError(t, err)
+			// Persist the waiter's status from the first operate before patching.
+			wf, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(waiter.Namespace).Get(ctx, waiter.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			wf.Status = wocWaiter.wf.Status
+			wf, err = controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Update(ctx, wf, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			wf, err = controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Patch(ctx, wf.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+			require.NoError(t, err)
+
+			wocWaiter = newWorkflowOperationCtx(ctx, wf, controller)
+			wocWaiter.operate(ctx)
+
+			message := fmt.Sprintf("Stopped with strategy '%s'", tt.strategy)
+			node := findWaitingSyncNodeByID(wocWaiter.wf, waitingNode.ID)
+			require.NotNil(t, node)
+			assert.Equal(t, wfv1.NodeFailed, node.Phase)
+			assert.Equal(t, message, node.Message)
+			// No node may be left behind unfulfilled: the shutdown must
+			// propagate to the whole tree.
+			for _, n := range wocWaiter.wf.Status.Nodes {
+				assert.NotEqual(t, wfv1.NodePending, n.Phase, "node %s left pending after shutdown", n.Name)
+			}
+			assert.Equal(t, wfv1.WorkflowFailed, wocWaiter.wf.Status.Phase)
+		})
+	}
+}
+
+func findWaitingSyncNode(wf *wfv1.Workflow) *wfv1.NodeStatus {
+	for _, node := range wf.Status.Nodes {
+		if node.SynchronizationStatus != nil && node.SynchronizationStatus.Waiting != "" {
+			return &node
+		}
+	}
+	return nil
+}
+
+func findWaitingSyncNodeByID(wf *wfv1.Workflow, id string) *wfv1.NodeStatus {
+	for _, node := range wf.Status.Nodes {
+		if node.ID == id {
+			return &node
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- [x] Ran `make pre-commit -B` (scoped: `golangci-lint run workflow/controller/` clean, full `go test ./workflow/controller/` green; no codegen-affecting changes)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

Refs #7633 (same symptom, closed as stale; commenters confirmed it still reproduced on v3.4.10). #10733/#10735 fixed the workflow-level flavour of this in v3.4.6 but never covered the template-level path.

### Motivation

Terminating or stopping a workflow while a node is still `Pending` waiting to acquire a **template-level** synchronization lock (mutex or semaphore, memory- or database-backed) mis-handles the shutdown, reproduced on v4.1.1:

- **Bare pod / steps workflows**: the shutdown is silently ignored — `spec.shutdown` is set but the workflow stays Running and the node keeps waiting until the lock happens to be released by its holder, which can be arbitrarily later (or never).
- **DAG workflows**: the workflow completes as Failed but the waiting task node is left `Pending` forever inside the completed workflow.

Root cause: the node has no pod yet (pods are only created after lock acquisition), so pod reconciliation's execution control never touches it, and `failNodesWithoutCreatedPodsAfterDeadlineOrShutdown` had no case for it — it only handles suspend, taskset, and fulfilled retry-wrapper nodes.

### Modifications

`failNodesWithoutCreatedPodsAfterDeadlineOrShutdown` now fails pending nodes whose `SynchronizationStatus.Waiting` is set, exactly like the suspend/taskset nodes handled in the same block, honouring the existing `ShouldExecute` guard (so exit-handler nodes still run under `Stop`). Lock queue claims need no extra cleanup: the existing release paths (`syncManager.Release` for fulfilled nodes in `executeTemplate`, `ReleaseAll` on workflow completion) already cover the failed node.

### Verification

- New unit test `TestShutdownWaitingForTmplLevelLock` covers bare-pod, steps, and DAG workflows under both `Terminate` and `Stop`: a holder workflow keeps the mutex, the waiter's node blocks on it, the waiter is shut down, and the node must fail immediately with `Stopped with strategy '<s>'`, no node left Pending, workflow Failed. All six subtests fail on `main` and pass with the fix.
- Full `go test ./workflow/controller/` is green.
- Reproduced live on a k3d cluster against the released v4.1.1 images (in-memory and database-backed mutexes): shutdown-while-waiting (both `Terminate` and `Stop`) stalled bare/steps workflows indefinitely and orphaned a Pending node in DAG workflows; with the fixed controller all shapes complete Failed immediately.

### Documentation

No documentation change needed: this makes shutdown behave as already documented for nodes that have not started.

### AI

This PR was prepared with Claude Code (Anthropic): live cluster reproduction, root-cause analysis, fix, tests, and this description, directed and reviewed by the submitting maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XsqqvLSrJ5sH8gN8tLbr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows shutting down now correctly mark nodes waiting for synchronization locks as failed.
  * Prevented nodes from remaining pending indefinitely when their required lock is unavailable.
  * Termination and stop strategies now consistently report the appropriate shutdown status and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->