### PR TITLE
test: fix informer store races in makePodsPhase and withOutputs

### DIFF
--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	gosync "sync"
 	"sync/atomic"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
@@ -491,7 +493,7 @@ func withOutputs(ctx context.Context, outputs wfv1.Outputs) with {
 				Outputs: &outputs,
 			},
 		}
-		_, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskResults(woc.wf.Namespace).
+		created, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskResults(woc.wf.Namespace).
 			Create(
 				ctx,
 				taskResult,
@@ -500,6 +502,38 @@ func withOutputs(ctx context.Context, outputs wfv1.Outputs) with {
 		if err != nil {
 			panic(err)
 		}
+		// wait for the informer to see the task result, so the next operate() is
+		// guaranteed to observe the outputs
+		waitForInformer(ctx, woc.controller.taskResultInformer, created, func(any) bool { return true })
+	}
+}
+
+// waitForInformer waits until the informer store contains obj (keyed by
+// namespace/name) and upToDate returns true for the stored copy. Test helpers
+// must not write to a running informer's store directly: the informer delivers
+// watch events from the fake clientset asynchronously, so a direct store write
+// races with the delivery of an earlier event, which would overwrite the store
+// with a stale copy of the object. Instead, write through the fake clientset
+// and use this to wait for the change to be reflected. If the informer is
+// stopped (e.g. newWoc cancels the controller), no events will ever arrive and
+// nothing races with us, so write the store directly.
+func waitForInformer(ctx context.Context, informer cache.SharedIndexInformer, obj any, upToDate func(obj any) bool) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		panic(err)
+	}
+	err = kwait.PollUntilContextTimeout(ctx, time.Millisecond, 10*time.Second, true, func(context.Context) (bool, error) {
+		if informer.IsStopped() {
+			return true, informer.GetStore().Update(obj)
+		}
+		stored, exists, getErr := informer.GetStore().GetByKey(key)
+		if getErr != nil || !exists {
+			return false, getErr
+		}
+		return upToDate(stored), nil
+	})
+	if err != nil {
+		panic(fmt.Sprintf("informer did not catch up for %q: %v", key, err))
 	}
 }
 
@@ -578,10 +612,13 @@ func makePodsPhase(ctx context.Context, woc *wfOperationCtx, phase apiv1.PodPhas
 			if err != nil {
 				panic(err)
 			}
-			err = woc.controller.PodController.TestingPodInformer().GetStore().Update(updatedPod)
-			if err != nil {
-				panic(err)
-			}
+			// wait for the pod informer to deliver the update instead of writing
+			// to its store directly: a direct write races with the informer's
+			// async delivery of the pod's earlier create event, which would put
+			// the stale pod back in the store
+			waitForInformer(ctx, woc.controller.PodController.TestingPodInformer(), updatedPod, func(obj any) bool {
+				return obj.(*apiv1.Pod).Status.Phase == phase
+			})
 			if phase == apiv1.PodSucceeded {
 				nodeID := woc.nodeID(&pod)
 				woc.wf.Status.MarkTaskResultComplete(ctx, nodeID)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- [x] Ran `make pre-commit -B` (scoped: full `go test ./workflow/controller/` green, `-race` on affected tests green; test-only change, no codegen)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

`TestConfigMapCacheSaveOperate` fails occasionally in CI with `configmaps "whalesay-cache" not found` (e.g. main run 32374127687, recovered by gotestsum's re-run). The failure is a race in the test helpers, not in the controller.

`makePodsPhase` writes the updated (Succeeded) pod directly into the running pod informer's store. The informer delivers watch events from the fake clientset asynchronously, so delivery of the pod's earlier create event can land *after* the direct store write and put the stale Pending pod back. The next `operate()` then never sees the pod as Succeeded, the memoization cache entry is never saved, and the test's configmap lookup fails. `withOutputs` has the sibling race with the task result informer (outputs not yet visible to the next reconcile).

Reproduced at origin/main with parallel stress runs: 15/1200 failures with the exact CI signature.

### Modifications

Test helpers only. `makePodsPhase` and `withOutputs` now write through the fake clientset and wait (new `waitForInformer` helper) until the informer store reflects the change, so the next `operate()` is guaranteed to observe it. When the informer is stopped (`newWoc`-based tests cancel the controller before returning), no events flow and nothing races, so the helper falls back to the previous direct store write.

### Verification

Same parallel stress after the change: 0/1200 failures (and 0 failures across 720 iterations each of `TestConfigMapCacheSaveOperate`, `TestConfigMapCacheLoadOperate`, `TestDagWftmplHookWithRetry`). Full `go test ./workflow/controller/` green; `-race` on the affected tests green.

### Documentation

Not needed: test-infrastructure fix.

### AI

This PR was prepared with Claude Code (Anthropic): CI log analysis, race diagnosis, stress reproduction, fix, and this description, directed and reviewed by the submitting maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XsqqvLSrJ5sH8gN8tLbr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for task-result and pod phase updates.
  * Added polling and timeout handling to better accommodate asynchronous events.
  * Reduced race conditions in informer-based test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->