### PR TITLE
ci: restore unit test coverage and report it on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,11 @@ ignore:
 - "pkg/apis/client/.*"
 - "pkg/client/.*"
 - "vendor/.*"
+flags:
+  unit-tests:
+    carryforward: true
+  unit-tests-windows:
+    carryforward: true
 coverage:
   status:
     # we've found this not to be useful

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -134,7 +134,7 @@ jobs:
         with:
           go-version: "1.26"
           cache: true
-      - run: make test STATIC_FILES=false GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'
+      - run: make test STATIC_FILES=false GOTEST_FLAGS='-covermode=atomic -coverprofile=coverage.out'
       - name: Upload test results
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -144,10 +144,13 @@ jobs:
           if-no-files-found: warn
           retention-days: 10
       - name: Upload coverage report
-        # engineers just ignore this in PRs, so lets not even run it
-        if: github.ref == 'refs/heads/main'
+        # runs on PRs as well as main so codecov can comment a coverage report on the PR
+        if: github.repository == 'argoproj/argo-workflows'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          files: coverage.out
+          disable_search: true
+          flags: unit-tests
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -169,10 +172,13 @@ jobs:
         env:
           KUBECONFIG: /dev/null
       - name: Upload coverage report
-        # engineers just ignore this in PRs, so lets not even run it
-        if: github.ref == 'refs/heads/main'
+        # runs on PRs as well as main so codecov can comment a coverage report on the PR
+        if: github.repository == 'argoproj/argo-workflows'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          files: coverage.out
+          disable_search: true
+          flags: unit-tests-windows
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ E2E_WAIT_TIMEOUT      ?= 90s # timeout for wait conditions
 E2E_PARALLEL          ?= 20
 E2E_SUITE_TIMEOUT     ?= 30m
 TEST_RETRIES          ?= 2
+# extra flags passed to `go test` for the unit `test` target (e.g. coverage flags in CI)
+GOTEST_FLAGS          ?=
 JSON_TEST_OUTPUT      := test/reports/json
 # gotest function: gotest(packages, name, parameters)
 # packages: passed to gotestsum via --packages parameter
@@ -684,7 +686,7 @@ ifneq ($(USE_NIX), true)
 else
 	go build ./...
 endif
-	env KUBECONFIG=/dev/null $(call gotest,./...,unit,-p 20)
+	env KUBECONFIG=/dev/null $(call gotest,./...,unit,-p 20 $(GOTEST_FLAGS))
 	# marker file, based on it's modification time, we know how long ago this target was run
 	@mkdir -p dist
 	touch dist/test


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- [x] Ran `make pre-commit -B` (scoped: YAML validated, the exact gotestsum invocation verified to produce `coverage.out`; no Go code changes)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change — CI-config change; verified by the Unit Tests job on this PR producing and uploading coverage
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

Every main Unit Tests run since the switch to gotestsum (#14623, 2025-07-23) has failed at "Upload coverage report" with `Found 0 coverage files to report`, keeping main red. The `test` make target no longer uses `$(GOTEST)`, so the coverage flags CI passes via `GOTEST='go test -p 20 -covermode=atomic -coverprofile=coverage.out'` became a no-op and no `coverage.out` is produced. (Older green main runs simply skipped Unit Tests via changed-files gating.)

Additionally, the upload step was gated to main only, so PRs get no coverage feedback at all. argo-cd uploads coverage from PR runs, which is what makes codecov comment a coverage report on each PR.

### Modifications

- `Makefile`: new `GOTEST_FLAGS` variable appended to the unit `test` target's `go test` args, so CI can request coverage without affecting local runs.
- `.github/workflows/ci-build.yaml`: the Unit Tests job passes `GOTEST_FLAGS='-covermode=atomic -coverprofile=coverage.out'`; both codecov upload steps (linux + windows) now run on PR runs as well as main (gated on `github.repository` instead of the main ref), point at `coverage.out` explicitly with `disable_search`, and are tagged with per-job flags.
- `.codecov.yml`: `carryforward: true` for both flags, as argo-cd does, so a run that skips one of the jobs does not reset the project status.

With uploads happening on PRs and no `comment:` override in `.codecov.yml`, codecov's default PR comment (coverage summary + diff) will appear on PRs, matching argo-cd's setup.

### Verification

- Ran the exact gotestsum invocation the target now produces with `GOTEST_FLAGS` set and confirmed `coverage.out` is created at the repo root (where the action's `files:` points).
- Both YAML files parse.
- The real proof is this PR's own Unit Tests job: it must produce coverage, upload it, and codecov should comment here. Note the linux upload was failing on every main run, so this also un-reds main.

### Documentation

Not needed: CI-internal change. `GOTEST_FLAGS` is documented inline in the Makefile.

### AI

This PR was prepared with Claude Code (Anthropic): CI failure analysis (root-caused to #14623's interaction with the coverage flags), fix, and this description, directed and reviewed by the submitting maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XsqqvLSrJ5sH8gN8tLbr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code coverage reporting across repository changes, including pull requests.
  * Added support for preserving coverage results from unit and Windows test runs.
  * Enabled configurable test options for more flexible automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->