### PR TITLE
fix: create artifact plugin socket dir before starting the plugin server. Fixes #16784

### DIFF
--- a/cmd/argoexec/commands/artifact_plugin_init.go
+++ b/cmd/argoexec/commands/artifact_plugin_init.go
@@ -26,6 +26,15 @@ func NewArtifactPluginInitCommand() *cobra.Command {
 			containerName := os.Getenv(common.EnvVarContainerName)
 			includeScriptOutput := os.Getenv(common.EnvVarIncludeScriptOutput) == "true"
 
+			// The plugin server binds its socket inside this directory, so it has to exist
+			// before the server starts. If the server wins that race, bind() fails with
+			// ENOENT, the server exits, and the load below waits out its full 120s timeout
+			// for a socket that can never appear.
+			pluginName := wfv1.ArtifactPluginName(artifactPlugin)
+			if err := os.MkdirAll(pluginName.SocketDir(), 0o755); err != nil {
+				return fmt.Errorf("failed to create artifact plugin socket directory: %w", err)
+			}
+
 			name, args := args[0], args[1:]
 			logger.WithFields(logging.Fields{"name": name, "args": args}).Debug(ctx, "starting command")
 
@@ -44,7 +53,7 @@ func NewArtifactPluginInitCommand() *cobra.Command {
 
 				forwardSignals(ctx, signals, command.Process.Pid, false)
 			}()
-			err := loadArtifactPlugin(ctx, wfv1.ArtifactPluginName(artifactPlugin))
+			err := loadArtifactPlugin(ctx, pluginName)
 			if err != nil {
 				return fmt.Errorf("%w", err)
 			}
@@ -56,9 +65,6 @@ func NewArtifactPluginInitCommand() *cobra.Command {
 }
 
 func loadArtifactPlugin(ctx context.Context, pluginName wfv1.ArtifactPluginName) error {
-	if err := os.MkdirAll(pluginName.SocketDir(), 0755); err != nil {
-		return err
-	}
 	wfExecutor := executor.Init(ctx, clientConfig, varRunArgo)
 	errHandler := wfExecutor.HandleError(ctx)
 	defer errHandler()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

<!-- Does this PR fix an issue -->

Fixes  #16784

### Motivation

In the artifact-plugin **init** container (`init-artifact-<name>`), argoexec forks the plugin server *before* creating the directory the server binds its unix socket in. When the forked server wins that race, `bind()` fails with `ENOENT`, the server exits, and nothing notices — argoexec then waits out its full 120-second socket timeout while the pod sits in `Init:1/2`, and the step fails.

This affects any workflow that loads an artifact through a plugin. It is also the cause of the intermittent `test-examples` CI failures on `examples/artifact-passing-explicit-plugin.yaml`, which reproduce at **2/54 = 3.7%** of suite runs (see #16784 for the measurement).

Only the load path is affected. The **sidecar** used to *save* artifacts gets an emptyDir mounted at exactly `SocketDir()`, so kubelet creates the directory and the ordering cannot matter there. The init container has no such mount and relies solely on `os.MkdirAll` — which is why only `init-artifact-*` ever hangs.

### Modifications

Move `os.MkdirAll(pluginName.SocketDir(), 0755)` out of `loadArtifactPlugin` and up above the `go func()` that starts the plugin server, so the directory is guaranteed to exist before the server can call `bind()`.

This does not introduce a new invariant: it makes the init path match the ordering the sidecar path has always had (directory exists → server starts → bind succeeds).

Behaviour is otherwise unchanged. The only observable difference outside the success path is that a `MkdirAll` failure is now reported before the server is forked rather than after, so no orphaned child process is created, and the error carries context.

I have deliberately left the second half of the problem for a follow-up, and would rather agree the shape of it on #16784 first: when the plugin server dies for *any* reason, argoexec still waits the full 120 s for a socket that can never appear, because `startCommand` returns successfully and nothing then watches the child. `NewDriver`'s retry loop already selects on `ctx.Done()`, so cancelling the context when the child exits would be enough — but the cleanest way to observe that exit interacts with `closer()` (which is itself `cmd.Wait()`), so it deserves its own discussion.

### Verification

Reproduced deterministically by delaying only the `MkdirAll` — a single `time.Sleep(500 * time.Millisecond)` at the top of `loadArtifactPlugin`, **not committed** — which makes the forked server reach `bind()` first every time:

| | jobs / suite runs | failed | `bind: no such file or directory` |
|---|---|---|---|
| unfixed + delay | 10 | **10** | **10** |
| fixed + delay | 30 | **0** | **0** |

The only difference between the two runs is the position of `MkdirAll`; the delay is identical in both, at the same place in the source. Without the delay the failure occurs naturally in **2/54** suite runs.

Every failure in the unfixed run was on `artifact-passing-explicit-plugin.yaml`, with the same error and the same ~130 s duration as the failures that occur naturally, so the delay does not create a new failure mode — it makes the existing one certain.

The captured container log of a failure (with the controller at `--loglevel=debug`, which the executor inherits):

```text
level=DEBUG msg="starting command" name=/artifact-server args=[/tmp/artifact-plugins/test/socket]
{"level":"ERROR","msg":"Failed to start server",
 "error":"listen unix /tmp/artifact-plugins/test/socket: bind: no such file or directory"}
level=DEBUG msg="plugin socket not found, retrying in 1s" retry=0   maxRetries=120
                          ... 120 retry lines, one per second ...
level=DEBUG msg="plugin socket not found, retrying in 1s" retry=119 maxRetries=120
level=ERROR msg="executor error" error="failed to create plugin driver for test: plugin test
  expected unix socket at \"/tmp/artifact-plugins/test/socket\" but it does not exist after
  waiting for 120 seconds"
```

and the same container after the fix:

```text
level=DEBUG msg="starting command" name=/artifact-server
{"level":"INFO","msg":"Unix socket created successfully","mode":"Srwxr-xr-x"}
{"level":"INFO","msg":"Server ready to accept connections"}
level=INFO  msg="plugin socket file exists and is a unix socket" mode=Srwxr-xr-x
level=INFO  msg="Load artifact" artifactName=message duration=21.884018ms
level=INFO  msg="Successfully download file"
```

Runs, on my fork:

- natural failure rate: https://github.com/myzk-a/argo-workflows/actions/runs/32198377586
- forced race, unfixed (10/10 fail): https://github.com/myzk-a/argo-workflows/actions/runs/32318400471
- forced race, fixed (30/30 pass): https://github.com/myzk-a/argo-workflows/actions/runs/32320008624

On tests: the race is not deterministically testable in a unit test, and I did not want to add one that passes whether or not the bug is present. The existing e2e coverage (`test-examples` / `examples/artifact-passing-explicit-plugin.yaml`) exercises this path on every CI run — it is what surfaced the bug — and the two runs above are the evidence that the ordering is the cause. Happy to add something else if reviewers would prefer it.

One thing worth flagging separately: none of this was visible in CI, because `.github/actions/e2e-failure-debug/action.yml` collects pod logs with a single `kubectl logs --all-containers`, which aborts at the first not-yet-started container and therefore drops every line from the container holding the answer. I will send that as a separate PR; it is useful regardless of this fix.

### Documentation

No documentation change. This is an internal bug fix with no user-visible behaviour change — the documented plugin contract (the server listens on the socket path it is given) is unchanged; this makes argo hold up its own end of it reliably.

### AI

Claude Code was used throughout this investigation: analysing the CI logs, identifying the root cause, designing the forced-race experiment above, and drafting #16784 and this description.

The code change is mine, and I reviewed and understand it. I ran every CI experiment on my fork myself and read the resulting logs. Before proposing the change I had the history of #14915 checked to confirm the current ordering was not a deliberate design decision that I would be undoing — it was never discussed there, which is why I am confident this is a placement oversight rather than a fence worth leaving standing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact plugins now reliably create their socket directory before starting.
  * Improved error reporting when the socket directory cannot be created.
  * Enhanced consistency when loading the initialized plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->