### PR TITLE
ci: readiness bot labels problem/bot-not-ready instead of drafting

### DIFF
--- a/.github/pr-readiness/README.md
+++ b/.github/pr-readiness/README.md
@@ -1,6 +1,6 @@
 # PR Readiness Helper
 
-A standalone bot ([`pr-readiness.yaml`](../workflows/pr-readiness.yaml)) that lowers maintainer burden: when CI finishes on a PR, it keeps **one sticky comment** telling the contributor exactly how to fix contributor-fixable problems, moves not-ready PRs to **draft**, and gets out of the way once everything is green.
+A standalone bot ([`pr-readiness.yaml`](../workflows/pr-readiness.yaml)) that lowers maintainer burden: when CI finishes on a PR, it keeps **one sticky comment** telling the contributor exactly how to fix contributor-fixable problems, flags not-ready PRs with the **`problem/bot-not-ready`** label, and gets out of the way (clearing the label) once everything is green.
 
 ## What it covers
 
@@ -25,8 +25,8 @@ Tune guidance, add or remove signals in [`checks.config.json`](checks.config.jso
 - Fires on `workflow_run: completed` of CI / Docs / PR Title Check / PR Feature Check. Title and feature checks re-run on PR `edited`, so title/description edits re-evaluate too. `/retest` re-runs CI and therefore re-evaluates.
 - **Never posts** on a PR that never had a covered issue.
 - While issues exist: one comment listing only the failing items, each with a fix command and a log link. Pending checks are not mentioned.
-- Blocking issues (any covered check failure, or a description that doesn't follow the template) also **convert the PR to draft**. The bot **never** marks ready-for-review — that's the contributor's call — and it drafts at most once per head SHA, so a human re-marking it ready is respected until new commits arrive.
-- Draft conversion needs a **GitHub App token**: the default Actions token cannot toggle draft state (`Resource not accessible by integration` — verified live). Provision an app with **Pull requests: Read & write** only (do not reuse the cherry-pick app, which can push code), install it on the repo, and set the `PR_READINESS_APP_ID` / `PR_READINESS_APP_PRIVATE_KEY` secrets — the same `actions/create-github-app-token` pattern as `cherry-pick-single.yml`. Without the secrets the bot comments but does not draft.
+- Blocking issues (any covered check failure, or a description that doesn't follow the template) also apply the **`problem/bot-not-ready`** label. The bot owns the label outright: it is applied while the verdict is blocking and **removed automatically** the moment it isn't (fix pushed, check re-run green, description fixed, or the description check waived by a maintainer editing it into compliance). No app token or extra secrets: labelling a PR works with the default Actions token under the `pull-requests: write` permission the sticky comment already needs. (An earlier version converted PRs to draft instead — that needed a dedicated GitHub App because the default token cannot toggle draft state, and undrafting semantics around human intent were messy. The label sidesteps both.)
+- Because the label mirrors the current verdict with no memory, a manually-removed label is re-applied on the next CI completion while checks still fail — maintainers who disagree with a covered failure can simply review anyway; the label is advisory, not a gate.
 - When issues are resolved but other covered checks are still running: the comment shows a short "waiting" state.
 - When everything is terminal and green: the comment is edited to a short ✅ all-clear.
 - Skipped: PRs by anyone in [`OWNERS`](../../OWNERS) (owners/approvers/reviewers) and by bots.
@@ -41,19 +41,20 @@ A deterministic check ([`template.ts`](template.ts)) compares the description ag
 
 - `workflow_run` workflows execute the **default branch's** definition with the base-repo token — a fork PR cannot alter what runs here.
 - The job **never checks out or executes PR-head code**; the checkout step takes the default branch only. Keep it that way.
-- `permissions: {}` at the top; the job grants only `pull-requests: write`, `contents: read`, `actions: read`. No secrets beyond `GITHUB_TOKEN` (and the optional draft-app secrets).
+- `permissions: {}` at the top; the job grants only `pull-requests: write`, `contents: read`, `actions: read`. No secrets beyond `GITHUB_TOKEN`.
 - `workflow_run.pull_requests` is empty for fork PRs, so the PR is found by matching `head_sha` against open PRs; no match → exit (a newer push superseded the run).
 - PR title/body/branch are attacker-controlled: they are only ever handled as data, never interpolated into shell or scripts. The comment never echoes contributor-supplied text — only the bot's own guidance, check titles/URLs, and template section names.
 - All actions are pinned to full commit SHAs (enforced by repo lint).
 
 ## Dry run
 
-Setting `DRY_RUN: "true"` in the workflow renders the would-be comment and decisions to the job's **step summary** instead of commenting or drafting. Use it to test changes to the bot against real PRs (correct PR resolution, author gating, sensible text) without posting.
+Setting `DRY_RUN: "true"` in the workflow renders the would-be comment and decisions to the job's **step summary** instead of commenting or labelling. Use it to test changes to the bot against real PRs (correct PR resolution, author gating, sensible text) without posting.
 
 ## Maintenance notes
 
 - **Check renamed?** The signal silently stops matching (fail-safe — no false positives) and any failing unmapped check from a covered app is logged as a warning ("unmapped failing check") so you notice. Update `checks.config.json`.
 - **Workflow renamed?** Keep `on.workflow_run.workflows` in `pr-readiness.yaml` in sync with the `name:` fields of `ci-build.yaml`, `docs.yaml`, `pr.yaml`, `pr-feature.yaml`.
+- **Label renamed?** `NOT_READY_LABEL` in `comment.ts` must match the repo's `problem/bot-not-ready` label exactly — if the label is renamed in repo settings without updating the constant, the add-labels API quietly *recreates* the old name (with a default colour) rather than failing.
 - **Known limitation:** first-time contributors whose workflows need approval get no help until a maintainer approves the run (nothing completes, so nothing fires).
 
 ## Code & local development

--- a/.github/pr-readiness/classify.ts
+++ b/.github/pr-readiness/classify.ts
@@ -70,13 +70,13 @@ export function diagnostics(checkRuns: CheckRun[], config: Config): { unmapped: 
 interface DecideArgs {
   signals: ReadonlyArray<{ id: string; state: string }>;
   templateVerdict: { compliant: boolean } | null;
-  existingState: { draftedSha?: string | null } | null;
   hasExistingComment: boolean;
-  pr: { draft: boolean; headSha: string };
 }
 
-// The convergence rules. See README.md for the decision table.
-export function decide({ signals, templateVerdict, existingState, hasExistingComment, pr }: DecideArgs): Decision {
+// The convergence rules. See README.md for the decision table. `blocking`
+// drives the not-ready label: the bot owns it outright, so the label is simply
+// applied while blocking and removed once not (main.ts does the sync).
+export function decide({ signals, templateVerdict, hasExistingComment }: DecideArgs): Decision {
   const failing = signals.filter((s) => s.state === 'failure').map((s) => s.id);
   const templateBlocking = Boolean(templateVerdict && templateVerdict.compliant === false);
   const blocking = failing.length > 0 || templateBlocking;
@@ -92,10 +92,7 @@ export function decide({ signals, templateVerdict, existingState, hasExistingCom
     shouldComment = true;
   }
 
-  const alreadyDraftedThisSha = Boolean(existingState && existingState.draftedSha === pr.headSha);
-  const shouldDraft = blocking && !pr.draft && !alreadyDraftedThisSha;
-
-  return { variant, shouldComment, shouldDraft, failing, templateBlocking };
+  return { variant, shouldComment, blocking, failing, templateBlocking };
 }
 
 // OWNERS is a small YAML subset: three keys, each a list of logins.

--- a/.github/pr-readiness/comment.ts
+++ b/.github/pr-readiness/comment.ts
@@ -1,7 +1,7 @@
 // Renders the sticky PR-readiness comment. One comment per PR, identified by
-// MARKER, edited in place. A hidden state blob carries data between runs.
+// MARKER, edited in place.
 
-import type { CommentVariant, State, TemplateIssue } from './types.ts';
+import type { CommentVariant, TemplateIssue } from './types.ts';
 
 export const MARKER = '<!-- pr-readiness-bot -->';
 
@@ -15,10 +15,6 @@ const FOOTER =
   'Unit/E2E test results are <b>not</b> covered here. ' +
   'Questions? See [the contributing guide](https://github.com/argoproj/argo-workflows/blob/main/docs/CONTRIBUTING.md) or ask a maintainer.</sub>';
 
-function stateLine(state: State): string {
-  return `<!-- state: ${JSON.stringify(state)} -->`;
-}
-
 interface FailureItem {
   title: string;
   guidance: string;
@@ -31,11 +27,10 @@ interface RenderArgs {
   failures: ReadonlyArray<FailureItem>;
   templateIssues: TemplateIssue[] | null;
   labeled: boolean;
-  state: State;
 }
 
-export function renderComment({ variant, failures, templateIssues, labeled, state }: RenderArgs): string {
-  const head = [MARKER, stateLine(state), ''];
+export function renderComment({ variant, failures, templateIssues, labeled }: RenderArgs): string {
+  const head = [MARKER, ''];
 
   if (variant === 'allclear') {
     return head
@@ -96,23 +91,4 @@ export function renderComment({ variant, failures, templateIssues, labeled, stat
 
   lines.push(FOOTER);
   return lines.join('\n');
-}
-
-// Returns the state object embedded in a bot comment, or null if the comment
-// is not ours / has no parsable state.
-export function parseState(body: string): State | null {
-  // includes, not startsWith: the sticky-comment action injects its own
-  // hidden header into the body it posts.
-  if (typeof body !== 'string' || !body.includes(MARKER)) {
-    return null;
-  }
-  const m = body.match(/<!-- state: (.*?) -->/);
-  if (!m) {
-    return null;
-  }
-  try {
-    return JSON.parse(m[1]) as State;
-  } catch {
-    return null;
-  }
 }

--- a/.github/pr-readiness/comment.ts
+++ b/.github/pr-readiness/comment.ts
@@ -5,6 +5,11 @@ import type { CommentVariant, State, TemplateIssue } from './types.ts';
 
 export const MARKER = '<!-- pr-readiness-bot -->';
 
+// Must match the label that exists in the repo (Settings → Labels):
+// "problem/bot-not-ready — Readiness bot declares this as not ready, see
+// comment by bot for why".
+export const NOT_READY_LABEL = 'problem/bot-not-ready';
+
 const FOOTER =
   '\n---\n<sub>🤖 Automated PR-readiness helper — it re-checks each time CI finishes. ' +
   'Unit/E2E test results are <b>not</b> covered here. ' +
@@ -25,11 +30,11 @@ interface RenderArgs {
   variant: CommentVariant | null;
   failures: ReadonlyArray<FailureItem>;
   templateIssues: TemplateIssue[] | null;
-  drafted: boolean;
+  labeled: boolean;
   state: State;
 }
 
-export function renderComment({ variant, failures, templateIssues, drafted, state }: RenderArgs): string {
+export function renderComment({ variant, failures, templateIssues, labeled, state }: RenderArgs): string {
   const head = [MARKER, stateLine(state), ''];
 
   if (variant === 'allclear') {
@@ -81,11 +86,11 @@ export function renderComment({ variant, failures, templateIssues, drafted, stat
     lines.push('', '_(A maintainer may waive this.)_', '</details>');
   }
 
-  if (drafted) {
+  if (labeled) {
     lines.push(
       '',
       '> [!NOTE]',
-      '> This PR has been moved to **draft** while the items above are addressed. Mark it **Ready for review** once they are fixed.'
+      `> This PR carries the \`${NOT_READY_LABEL}\` label while the items above are addressed. It is removed automatically once everything passes.`
     );
   }
 

--- a/.github/pr-readiness/main.ts
+++ b/.github/pr-readiness/main.ts
@@ -1,7 +1,7 @@
 // Orchestration for the PR Readiness Helper workflow. A single entry point,
 // run(), called from one actions/github-script step in pr-readiness.yaml:
 // resolve the PR, gate the author, classify checks, check the description
-// against the template, convert to draft if blocking, and render the sticky
+// against the template, sync the not-ready label, and render the sticky
 // comment (or the dry-run summary). All decision logic lives in the
 // unit-tested modules this file imports.
 
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { classifySignals, diagnostics, decide, isExemptAuthor, findPullRequest, pickStepGuidance } from './classify.ts';
-import { MARKER, renderComment, parseState } from './comment.ts';
+import { MARKER, NOT_READY_LABEL, renderComment } from './comment.ts';
 import { checkTemplate } from './template.ts';
 import type { Config, JobStep } from './types.ts';
 
@@ -41,7 +41,11 @@ interface Octokit {
     actions: { getJobForWorkflowRun(params: Record<string, unknown>): Promise<{ data: { steps?: JobStep[] } }> };
     pulls: { list: unknown };
     checks: { listForRef: unknown };
-    issues: { listComments: unknown };
+    issues: {
+      listComments: unknown;
+      addLabels(params: Record<string, unknown>): Promise<unknown>;
+      removeLabel(params: Record<string, unknown>): Promise<unknown>;
+    };
   };
 }
 
@@ -104,14 +108,13 @@ export async function run({ github, context, core }: { github: Octokit; context:
     }
   }
 
-  // Find our existing sticky comment (if any) and recover its state blob.
-  // Author check matters: anyone can paste our marker into a comment, but
-  // only the actions bot's comment may be trusted as state.
+  // Find our existing sticky comment (if any). Author check matters: anyone
+  // can paste our marker into a comment, but only the actions bot's comment
+  // may be trusted as ours.
   const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr.number, per_page: 100 });
   const existing = comments.find(
     (c) => c.user && c.user.login === 'github-actions[bot]' && typeof c.body === 'string' && c.body.includes(MARKER)
   );
-  const existingState = existing ? parseState(existing.body) : null;
 
   // Deterministic PR-description / template check (no model required).
   const template = fs.readFileSync('.github/pull_request_template.md', 'utf8');
@@ -120,55 +123,34 @@ export async function run({ github, context, core }: { github: Octokit; context:
   const decision = decide({
     signals,
     templateVerdict,
-    existingState,
     hasExistingComment: Boolean(existing),
-    pr: { draft: pr.draft, headSha },
   });
 
-  // Draft conversion: at most once per head SHA; undrafting is human-only.
-  // The default Actions token cannot toggle draft state ("Resource not
-  // accessible by integration"), so this requires the app token minted by
-  // the workflow. Best-effort: failure never blocks the comment.
-  let draftedNow = false;
-  if (decision.shouldDraft && !dryRun) {
-    const token = process.env.DRAFT_TOKEN;
-    if (!token) {
-      core.warning(
-        `PR #${pr.number} should be drafted, but no draft token is available ` +
-          '(PR_READINESS_APP_ID / PR_READINESS_APP_PRIVATE_KEY secrets not configured?)'
-      );
-    } else {
-      try {
-        const res = await fetch('https://api.github.com/graphql', {
-          method: 'POST',
-          headers: { authorization: `bearer ${token}`, 'content-type': 'application/json' },
-          body: JSON.stringify({
-            query: 'mutation($id: ID!) { convertPullRequestToDraft(input: {pullRequestId: $id}) { pullRequest { isDraft } } }',
-            variables: { id: pr.node_id },
-          }),
-        });
-        const result = (await res.json()) as { errors?: Array<{ message: string }> };
-        if (!res.ok || result.errors) {
-          throw new Error(result.errors ? result.errors.map((e) => e.message).join('; ') : `HTTP ${res.status}`);
-        }
-        draftedNow = true;
-      } catch (e) {
-        core.warning(`could not convert PR #${pr.number} to draft: ${errMessage(e)}`);
+  // Sync the not-ready label to the verdict: the bot owns the label, so it is
+  // applied while blocking and removed once not. Best-effort: a label API
+  // failure never blocks the comment.
+  const hadLabel = Array.isArray(pr.labels) && pr.labels.some((l: { name?: string }) => l.name === NOT_READY_LABEL);
+  let labeled = dryRun ? decision.blocking : hadLabel; // dry run previews the would-be state
+  if (!dryRun && decision.blocking !== hadLabel) {
+    try {
+      if (decision.blocking) {
+        await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [NOT_READY_LABEL] });
+      } else {
+        await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: NOT_READY_LABEL });
       }
+      labeled = decision.blocking;
+    } catch (e) {
+      core.warning(`could not ${decision.blocking ? 'add' : 'remove'} label '${NOT_READY_LABEL}' on PR #${pr.number}: ${errMessage(e)}`);
     }
   }
 
-  const state = {
-    v: 1,
-    failing: decision.failing,
-    draftedSha: draftedNow ? headSha : (existingState && existingState.draftedSha) || null,
-  };
+  const state = { v: 1, failing: decision.failing };
 
   const commentBody = renderComment({
     variant: decision.variant,
     failures: signals.filter((s) => decision.failing.includes(s.id)),
     templateIssues: decision.templateBlocking ? templateVerdict.issues : null,
-    drafted: draftedNow,
+    labeled,
     state,
   });
 
@@ -180,7 +162,7 @@ export async function run({ github, context, core }: { github: Octokit; context:
     `PR #${pr.number} by ${pr.user.login} head=${headSha} | signals: ` +
       signals.map((s) => `${s.id}=${s.state}`).join(' ') +
       ` | template=${templateVerdict.compliant ? 'ok' : 'issues'}` +
-      ` | comment=${decision.shouldComment} variant=${decision.variant || 'n/a'} draft=${decision.shouldDraft} draftedNow=${draftedNow}`
+      ` | comment=${decision.shouldComment} variant=${decision.variant || 'n/a'} blocking=${decision.blocking} label: ${hadLabel} -> ${labeled}`
   );
   if (decision.shouldComment) {
     core.startGroup('rendered comment');
@@ -192,7 +174,7 @@ export async function run({ github, context, core }: { github: Octokit; context:
     core.summary
       .addHeading('PR Readiness Helper — dry run', 3)
       .addRaw(`PR: #${pr.number} · head: \`${headSha}\` · would comment: **${decision.shouldComment}**` +
-        ` (variant: ${decision.variant || 'n/a'}) · would draft: **${decision.shouldDraft}**\n\n`)
+        ` (variant: ${decision.variant || 'n/a'}) · label \`${NOT_READY_LABEL}\`: ${hadLabel} → would be ${decision.blocking}\n\n`)
       .addRaw(decision.shouldComment ? '#### Rendered comment\n\n' + commentBody + '\n' : '')
       .addTable([
         [{ data: 'signal', header: true }, { data: 'state', header: true }],

--- a/.github/pr-readiness/main.ts
+++ b/.github/pr-readiness/main.ts
@@ -144,14 +144,11 @@ export async function run({ github, context, core }: { github: Octokit; context:
     }
   }
 
-  const state = { v: 1, failing: decision.failing };
-
   const commentBody = renderComment({
     variant: decision.variant,
     failures: signals.filter((s) => decision.failing.includes(s.id)),
     templateIssues: decision.templateBlocking ? templateVerdict.issues : null,
     labeled,
-    state,
   });
 
   for (const name of unmapped) {

--- a/.github/pr-readiness/test/classify.test.ts
+++ b/.github/pr-readiness/test/classify.test.ts
@@ -63,30 +63,26 @@ test('diagnostics reports unmapped failing checks from covered apps for drift de
 
 const S = (id: string, state: SignalState) => ({ id, state, title: id, guidance: 'g', url: 'u' });
 
-test('decide: failures present -> issues comment, draft requested', () => {
+test('decide: failures present -> issues comment, blocking (label applied)', () => {
   const d = decide({
     signals: [S('lint', 'failure'), S('docs', 'pending')],
     templateVerdict: null,
-    existingState: null,
     hasExistingComment: false,
-    pr: { draft: false, headSha: 'sha1' },
   });
   assert.equal(d.variant, 'issues');
   assert.equal(d.shouldComment, true);
-  assert.equal(d.shouldDraft, true);
+  assert.equal(d.blocking, true);
   assert.deepEqual(d.failing, ['lint']);
 });
 
-test('decide: a non-compliant template alone is blocking -> issues + draft', () => {
+test('decide: a non-compliant template alone is blocking', () => {
   const d = decide({
     signals: [S('lint', 'success')],
     templateVerdict: { compliant: false },
-    existingState: null,
     hasExistingComment: false,
-    pr: { draft: false, headSha: 'sha1' },
   });
   assert.equal(d.variant, 'issues');
-  assert.equal(d.shouldDraft, true);
+  assert.equal(d.blocking, true);
 });
 
 test('decide: never post when no failures and no existing comment', () => {
@@ -94,82 +90,45 @@ test('decide: never post when no failures and no existing comment', () => {
     const d = decide({
       signals: [S('lint', state)],
       templateVerdict: { compliant: true },
-      existingState: null,
       hasExistingComment: false,
-      pr: { draft: false, headSha: 'sha1' },
     });
     assert.equal(d.shouldComment, false, `state=${state}`);
-    assert.equal(d.shouldDraft, false);
+    assert.equal(d.blocking, false);
   }
 });
 
-test('decide: existing comment + no failures + pending -> waiting variant', () => {
+test('decide: existing comment + no failures + pending -> waiting, not blocking (label cleared)', () => {
   const d = decide({
     signals: [S('lint', 'success'), S('docs', 'pending')],
     templateVerdict: null,
-    existingState: { draftedSha: null },
     hasExistingComment: true,
-    pr: { draft: false, headSha: 'sha1' },
   });
   assert.equal(d.variant, 'waiting');
   assert.equal(d.shouldComment, true);
-  assert.equal(d.shouldDraft, false);
+  assert.equal(d.blocking, false);
 });
 
-test('decide: existing comment + all terminal green -> all-clear', () => {
+test('decide: existing comment + all terminal green -> all-clear, not blocking (label cleared)', () => {
   const d = decide({
     signals: [S('lint', 'success'), S('ui', 'not-applicable')],
     templateVerdict: { compliant: true },
-    existingState: { draftedSha: null },
     hasExistingComment: true,
-    pr: { draft: false, headSha: 'sha1' },
   });
   assert.equal(d.variant, 'allclear');
   assert.equal(d.shouldComment, true);
-  assert.equal(d.shouldDraft, false);
+  assert.equal(d.blocking, false);
 });
 
-test('decide: does not draft a PR that is already a draft', () => {
+test('decide: blocking follows the current verdict, so a failure at a new head re-asserts the label', () => {
+  // The bot owns the label outright: blocking mirrors the live check state,
+  // with no per-SHA memory. A fresh failing run is blocking again even after
+  // an all-clear pass cleared the label.
   const d = decide({
     signals: [S('lint', 'failure')],
     templateVerdict: null,
-    existingState: null,
-    hasExistingComment: false,
-    pr: { draft: true, headSha: 'sha1' },
-  });
-  assert.equal(d.shouldDraft, false);
-  assert.equal(d.shouldComment, true);
-});
-
-test('decide: drafts at most once per head SHA (human undraft is respected)', () => {
-  const d = decide({
-    signals: [S('lint', 'failure')],
-    templateVerdict: null,
-    existingState: { draftedSha: 'sha1' },
     hasExistingComment: true,
-    pr: { draft: false, headSha: 'sha1' },
   });
-  assert.equal(d.shouldDraft, false);
-  // but a new head re-asserts
-  const d2 = decide({
-    signals: [S('lint', 'failure')],
-    templateVerdict: null,
-    existingState: { draftedSha: 'sha1' },
-    hasExistingComment: true,
-    pr: { draft: false, headSha: 'sha2' },
-  });
-  assert.equal(d2.shouldDraft, true);
-});
-
-test('decide: no failures and a compliant template never drafts', () => {
-  const d = decide({
-    signals: [S('lint', 'success')],
-    templateVerdict: { compliant: true },
-    existingState: { draftedSha: null },
-    hasExistingComment: true,
-    pr: { draft: false, headSha: 'sha1' },
-  });
-  assert.equal(d.shouldDraft, false);
+  assert.equal(d.blocking, true);
 });
 
 // --- author gating ---

--- a/.github/pr-readiness/test/comment.test.ts
+++ b/.github/pr-readiness/test/comment.test.ts
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { MARKER, renderComment, parseState } from '../comment.ts';
+import { MARKER, NOT_READY_LABEL, renderComment, parseState } from '../comment.ts';
 import type { State } from '../types.ts';
 
-const baseState: State = { v: 1, failing: ['lint'], draftedSha: null };
+const baseState: State = { v: 1, failing: ['lint'] };
 
 test('renderComment issues variant lists each failure with guidance and log link', () => {
   const body = renderComment({
@@ -13,7 +13,7 @@ test('renderComment issues variant lists each failure with guidance and log link
       { id: 'dco', title: 'DCO (sign-off)', guidance: 'Sign off your commits.', url: 'https://github.com/x/y/runs/2' },
     ],
     templateIssues: null,
-    drafted: false,
+    labeled: false,
     state: baseState,
   });
   assert.ok(body.startsWith(MARKER), 'starts with hidden marker');
@@ -29,7 +29,7 @@ test('renderComment includes template findings in a waivable details block', () 
     variant: 'issues',
     failures: [],
     templateIssues: [{ section: 'Motivation', problem: 'still contains the template placeholder' }],
-    drafted: false,
+    labeled: false,
     state: baseState,
   });
   assert.ok(body.includes('<details>'));
@@ -38,40 +38,40 @@ test('renderComment includes template findings in a waivable details block', () 
   assert.ok(/waive/i.test(body));
 });
 
-test('renderComment notes draft conversion when drafted', () => {
+test('renderComment notes the not-ready label when labeled', () => {
   const body = renderComment({
     variant: 'issues',
     failures: [{ id: 'lint', title: 'Lint', guidance: 'g', url: 'u' }],
     templateIssues: null,
-    drafted: true,
+    labeled: true,
     state: baseState,
   });
-  assert.ok(/draft/i.test(body));
-  assert.ok(/Ready for review/.test(body));
+  assert.ok(body.includes(NOT_READY_LABEL));
+  assert.ok(/removed automatically/i.test(body));
 });
 
 test('renderComment all-clear variant is short and positive', () => {
-  const body = renderComment({ variant: 'allclear', failures: [], templateIssues: null, drafted: false, state: { ...baseState, failing: [] } });
+  const body = renderComment({ variant: 'allclear', failures: [], templateIssues: null, labeled: false, state: { ...baseState, failing: [] } });
   assert.ok(body.startsWith(MARKER));
   assert.ok(body.includes('✅'));
   assert.ok(!body.includes('<details>'));
 });
 
 test('renderComment waiting variant mentions waiting for checks', () => {
-  const body = renderComment({ variant: 'waiting', failures: [], templateIssues: null, drafted: false, state: baseState });
+  const body = renderComment({ variant: 'waiting', failures: [], templateIssues: null, labeled: false, state: baseState });
   assert.ok(body.startsWith(MARKER));
   assert.ok(/waiting/i.test(body));
 });
 
 test('renderComment footer says tests are not covered and it is automated', () => {
-  const body = renderComment({ variant: 'issues', failures: [{ id: 'x', title: 'X', guidance: 'g', url: 'u' }], templateIssues: null, drafted: false, state: baseState });
+  const body = renderComment({ variant: 'issues', failures: [{ id: 'x', title: 'X', guidance: 'g', url: 'u' }], templateIssues: null, labeled: false, state: baseState });
   assert.ok(/unit\/e2e/i.test(body));
   assert.ok(/automated/i.test(body));
 });
 
 test('state round-trips through the rendered comment', () => {
-  const state: State = { v: 1, failing: ['lint', 'dco'], draftedSha: 'cafe01' };
-  const body = renderComment({ variant: 'issues', failures: [{ id: 'lint', title: 'L', guidance: 'g', url: 'u' }], templateIssues: null, drafted: false, state });
+  const state: State = { v: 1, failing: ['lint', 'dco'] };
+  const body = renderComment({ variant: 'issues', failures: [{ id: 'lint', title: 'L', guidance: 'g', url: 'u' }], templateIssues: null, labeled: false, state });
   assert.deepEqual(parseState(body), state);
 });
 

--- a/.github/pr-readiness/test/comment.test.ts
+++ b/.github/pr-readiness/test/comment.test.ts
@@ -1,9 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { MARKER, NOT_READY_LABEL, renderComment, parseState } from '../comment.ts';
-import type { State } from '../types.ts';
-
-const baseState: State = { v: 1, failing: ['lint'] };
+import { MARKER, NOT_READY_LABEL, renderComment } from '../comment.ts';
 
 test('renderComment issues variant lists each failure with guidance and log link', () => {
   const body = renderComment({
@@ -14,7 +11,6 @@ test('renderComment issues variant lists each failure with guidance and log link
     ],
     templateIssues: null,
     labeled: false,
-    state: baseState,
   });
   assert.ok(body.startsWith(MARKER), 'starts with hidden marker');
   assert.ok(body.includes('**Lint**'));
@@ -30,7 +26,6 @@ test('renderComment includes template findings in a waivable details block', () 
     failures: [],
     templateIssues: [{ section: 'Motivation', problem: 'still contains the template placeholder' }],
     labeled: false,
-    state: baseState,
   });
   assert.ok(body.includes('<details>'));
   assert.ok(body.includes('Motivation'));
@@ -44,38 +39,26 @@ test('renderComment notes the not-ready label when labeled', () => {
     failures: [{ id: 'lint', title: 'Lint', guidance: 'g', url: 'u' }],
     templateIssues: null,
     labeled: true,
-    state: baseState,
   });
   assert.ok(body.includes(NOT_READY_LABEL));
   assert.ok(/removed automatically/i.test(body));
 });
 
 test('renderComment all-clear variant is short and positive', () => {
-  const body = renderComment({ variant: 'allclear', failures: [], templateIssues: null, labeled: false, state: { ...baseState, failing: [] } });
+  const body = renderComment({ variant: 'allclear', failures: [], templateIssues: null, labeled: false });
   assert.ok(body.startsWith(MARKER));
   assert.ok(body.includes('✅'));
   assert.ok(!body.includes('<details>'));
 });
 
 test('renderComment waiting variant mentions waiting for checks', () => {
-  const body = renderComment({ variant: 'waiting', failures: [], templateIssues: null, labeled: false, state: baseState });
+  const body = renderComment({ variant: 'waiting', failures: [], templateIssues: null, labeled: false });
   assert.ok(body.startsWith(MARKER));
   assert.ok(/waiting/i.test(body));
 });
 
 test('renderComment footer says tests are not covered and it is automated', () => {
-  const body = renderComment({ variant: 'issues', failures: [{ id: 'x', title: 'X', guidance: 'g', url: 'u' }], templateIssues: null, labeled: false, state: baseState });
+  const body = renderComment({ variant: 'issues', failures: [{ id: 'x', title: 'X', guidance: 'g', url: 'u' }], templateIssues: null, labeled: false });
   assert.ok(/unit\/e2e/i.test(body));
   assert.ok(/automated/i.test(body));
-});
-
-test('state round-trips through the rendered comment', () => {
-  const state: State = { v: 1, failing: ['lint', 'dco'] };
-  const body = renderComment({ variant: 'issues', failures: [{ id: 'lint', title: 'L', guidance: 'g', url: 'u' }], templateIssues: null, labeled: false, state });
-  assert.deepEqual(parseState(body), state);
-});
-
-test('parseState returns null for non-bot or malformed comments', () => {
-  assert.equal(parseState('just a human comment'), null);
-  assert.equal(parseState(MARKER + '\n<!-- state: {not json} -->'), null);
 });

--- a/.github/pr-readiness/types.ts
+++ b/.github/pr-readiness/types.ts
@@ -55,11 +55,6 @@ export interface TemplateVerdict {
   issues: TemplateIssue[];
 }
 
-export interface State {
-  v: number;
-  failing: string[];
-}
-
 export type CommentVariant = 'issues' | 'waiting' | 'allclear';
 
 export interface Decision {

--- a/.github/pr-readiness/types.ts
+++ b/.github/pr-readiness/types.ts
@@ -58,12 +58,6 @@ export interface TemplateVerdict {
 export interface State {
   v: number;
   failing: string[];
-  draftedSha?: string | null;
-}
-
-export interface PrRef {
-  draft: boolean;
-  headSha: string;
 }
 
 export type CommentVariant = 'issues' | 'waiting' | 'allclear';
@@ -71,7 +65,7 @@ export type CommentVariant = 'issues' | 'waiting' | 'allclear';
 export interface Decision {
   variant: CommentVariant | null;
   shouldComment: boolean;
-  shouldDraft: boolean;
+  blocking: boolean;
   failing: string[];
   templateBlocking: boolean;
 }

--- a/.github/workflows/pr-readiness.yaml
+++ b/.github/workflows/pr-readiness.yaml
@@ -3,8 +3,8 @@ name: PR Readiness Helper
 # Standalone helper that fires when CI workflows complete on a PR and keeps a
 # single sticky comment guiding the contributor through contributor-fixable
 # problems (lint, codegen, docs, title, DCO, feature files, and an unfilled
-# PR description checked against the template). Blocking problems also move the
-# PR to draft (it never undrafts).
+# PR description checked against the template). Blocking problems also apply
+# the problem/bot-not-ready label, removed automatically once resolved.
 # See .github/pr-readiness/README.md for design, security model and tuning.
 #
 # Security: this runs with write permissions from the default branch's
@@ -27,7 +27,7 @@ concurrency:
 
 env:
   # Dry-run: set to "true" to render to the job summary instead of
-  # commenting/drafting.
+  # commenting/labelling.
   DRY_RUN: "false"
 
 jobs:
@@ -35,36 +35,17 @@ jobs:
     name: Assess PR readiness
     if: github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target'
     runs-on: ubuntu-24.04
-    env:
-      # secrets are not available in step `if:` expressions, so surface
-      # "is the draft app configured?" as an env var here.
-      HAS_DRAFT_APP: ${{ secrets.PR_READINESS_APP_ID != '' }}
     permissions:
-      pull-requests: write # sticky comment + draft conversion
+      pull-requests: write # sticky comment + not-ready label
       contents: read # checkout of the default branch (scripts, OWNERS, template)
       actions: read # job/step conclusions for the feature check
     steps:
       # Default branch only — never the PR head.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The default Actions token cannot toggle a PR's draft state
-      # ("Resource not accessible by integration"), so draft conversion
-      # needs a GitHub App token — same pattern as the cherry-pick bot.
-      # Without these secrets the bot still comments, it just cannot draft.
-      - name: Mint draft-conversion token
-        id: draft-token
-        if: env.DRY_RUN != 'true' && env.HAS_DRAFT_APP == 'true'
-        continue-on-error: true # drafting is best-effort; never block the comment
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.PR_READINESS_APP_ID }}
-          private-key: ${{ secrets.PR_READINESS_APP_PRIVATE_KEY }}
-
       - name: Assess PR and render comment
         id: assess
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          DRAFT_TOKEN: ${{ steps.draft-token.outputs.token }}
         with:
           script: |
             const { run } = require('./.github/pr-readiness/main.ts');


### PR DESCRIPTION
See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [x] Ran `make pre-commit -B` (not applicable — only `.github/` changes; ran the pr-readiness typecheck + unit tests instead)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

The readiness bot converts not-ready PRs to draft, which has caused ongoing trouble: draft state is shared with humans, so the bot needed per-SHA "draft at most once" memory to respect a human re-marking ready, it stranded green PRs invisibly in draft (#16556), #16691 proposed episode tracking to undraft safely, and #16639 documents that the draft mutation needs a dedicated GitHub App with an over-broad **Contents: Read & write** permission.

A label the bot owns outright has none of these problems, and the repo already has one made for the purpose: `problem/bot-not-ready` — *"Readiness bot declares this as not ready, see comment by bot for why"*.

### Modifications

- Blocking verdicts (covered check failure or non-compliant PR description) now apply the `problem/bot-not-ready` label instead of drafting; the label is removed automatically the moment the verdict is no longer blocking. The label simply mirrors the current verdict — no per-SHA memory, no episodes.
- The sticky comment's note about the label renders on every failing pass while the label is in force, not just the run that applied it (the draft note was keyed to "drafted this very run" and was rarely seen — see #16691).
- Labelling works with the default Actions token under the job's existing `pull-requests: write`, so the app-token minting step, `DRAFT_TOKEN`, and the `draftedSha` state tracking are deleted. The readiness GitHub App and the `PR_READINESS_APP_ID` / `PR_READINESS_APP_PRIVATE_KEY` secrets can be decommissioned after this merges.
- Net −81 lines. Supersedes #16691 and #16639, which can both be closed.
- Follow-up for a maintainer: PRs the bot already drafted (e.g. #16556) are not touched by this change and need a one-off manual "Ready for review".

### Verification

`tsc --noEmit` clean and all 33 unit tests pass (`npm test` in `.github/pr-readiness/`); the `decide` tests are rewritten for the label semantics and the comment tests assert the label note. The hidden `<!-- state -->` blob in the comment (only ever used to carry `draftedSha` between runs) is removed along with `parseState` and its tests. Verified `problem/bot-not-ready` exists in this repo with exactly that name, and that labelling PRs needs no permissions beyond the `pull-requests: write` the sticky comment already uses.

### Documentation

`.github/pr-readiness/README.md` rewritten where it described drafting: label ownership semantics, the removed app/secrets, and a new maintenance note that renaming the repo label without updating `NOT_READY_LABEL` makes the add-labels API quietly recreate the old name. Header comments in `pr-readiness.yaml` updated.

### AI

Written with Claude Code (code, tests, docs, and this description), reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyzm2yW6RsFzTwu7LhwmHH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull requests with blocking readiness issues now receive a `pr-readiness-not-ready` label instead of being converted to draft.
  - The label is automatically removed when checks pass and reapplied if issues remain.
  - Readiness comments now explain the label status and its automatic removal.

- **Documentation**
  - Updated workflow and maintenance guidance to describe label behavior and configuration.

- **Bug Fixes**
  - Label state is recalculated after each CI completion for more accurate status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
