### PR TITLE
fix: release leaked held locks by workflow key when Status.Synchronization is nil

### DIFF
--- a/util/sync/db/mocks/SyncQueries.go
+++ b/util/sync/db/mocks/SyncQueries.go
@@ -1264,6 +1264,63 @@ func (_c *SyncQueries_ReleaseHeld_Call) RunAndReturn(run func(ctx context.Contex
 	return _c
 }
 
+// ReleaseAllHeldByWorkflowKey provides a mock function for the type SyncQueries
+func (_mock *SyncQueries) ReleaseAllHeldByWorkflowKey(ctx context.Context, holderKey string) error {
+	ret := _mock.Called(ctx, holderKey)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReleaseAllHeldByWorkflowKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, holderKey)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// SyncQueries_ReleaseAllHeldByWorkflowKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReleaseAllHeldByWorkflowKey'
+type SyncQueries_ReleaseAllHeldByWorkflowKey_Call struct {
+	*mock.Call
+}
+
+// ReleaseAllHeldByWorkflowKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - holderKey string
+func (_e *SyncQueries_Expecter) ReleaseAllHeldByWorkflowKey(ctx interface{}, holderKey interface{}) *SyncQueries_ReleaseAllHeldByWorkflowKey_Call {
+	return &SyncQueries_ReleaseAllHeldByWorkflowKey_Call{Call: _e.mock.On("ReleaseAllHeldByWorkflowKey", ctx, holderKey)}
+}
+
+func (_c *SyncQueries_ReleaseAllHeldByWorkflowKey_Call) Run(run func(ctx context.Context, holderKey string)) *SyncQueries_ReleaseAllHeldByWorkflowKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *SyncQueries_ReleaseAllHeldByWorkflowKey_Call) Return(err error) *SyncQueries_ReleaseAllHeldByWorkflowKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *SyncQueries_ReleaseAllHeldByWorkflowKey_Call) RunAndReturn(run func(ctx context.Context, holderKey string) error) *SyncQueries_ReleaseAllHeldByWorkflowKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveFromQueue provides a mock function for the type SyncQueries
 func (_mock *SyncQueries) RemoveFromQueue(ctx context.Context, semaphoreName string, holderKey string) error {
 	ret := _mock.Called(ctx, semaphoreName, holderKey)

--- a/util/sync/db/queries.go
+++ b/util/sync/db/queries.go
@@ -80,6 +80,8 @@ type SyncQueries interface {
 	GetPendingInQueue(ctx context.Context, sessionProxy *sqldb.SessionProxy, semaphoreName, holderKey, controllerName string) ([]StateRecord, error)
 	ReleaseHeld(ctx context.Context, semaphoreName, key, controllerName string) error
 
+	ReleaseAllHeldByWorkflowKey(ctx context.Context, holderKey string) error
+
 	GetExistingLocks(ctx context.Context, lockName, controllerName string) ([]LockRecord, error)
 	InsertLock(ctx context.Context, record *LockRecord) error
 	DeleteLock(ctx context.Context, lockName string) error
@@ -303,6 +305,23 @@ func (q *syncQueries) ReleaseHeld(ctx context.Context, semaphoreName, key, contr
 			And(db.Cond{StateNameField: semaphoreName}).
 			And(db.Cond{StateKeyField: key}).
 			And(db.Cond{StateControllerField: controllerName}).
+			Exec()
+		return err
+	})
+}
+
+// ReleaseAllHeldByWorkflowKey releases every held state row that belongs to the
+// workflow, regardless of which semaphore or mutex it was acquired on. It is
+// the recovery path for workflows whose recorded synchronization status was
+// lost (e.g. the controller's database session broke after the row was written
+// but before Status.Synchronization was persisted): the workflow key is stored
+// in the row itself, so ownership can be re-derived without the status field.
+func (q *syncQueries) ReleaseAllHeldByWorkflowKey(ctx context.Context, holderKey string) error {
+	return q.sessionProxy.With(ctx, func(session db.Session) error {
+		_, err := session.SQL().
+			DeleteFrom(q.config.StateTable).
+			Where(db.Cond{StateHeldField: true}).
+			And(db.Cond{StateKeyField: holderKey}).
 			Exec()
 		return err
 	})

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -1557,9 +1557,7 @@ func (wfc *WorkflowController) releaseAllWorkflowLocks(ctx context.Context, obj 
 		logger.WithField("key", obj).Warn(ctx, "Invalid workflow object")
 		return
 	}
-	if wf.Status.Synchronization != nil {
-		wfc.syncManager.ReleaseAll(ctx, wf)
-	}
+	wfc.syncManager.ReleaseAll(ctx, wf)
 }
 
 func (wfc *WorkflowController) isArchivable(wf *wfv1.Workflow) bool {

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -820,7 +820,7 @@ func (woc *wfOperationCtx) persistUpdates(ctx context.Context) {
 	}
 
 	// Release all acquired lock for completed workflow
-	if woc.wf.Status.Synchronization != nil && woc.wf.Status.Fulfilled() {
+	if woc.wf.Status.Fulfilled() {
 		if woc.controller.syncManager.ReleaseAll(ctx, woc.wf) {
 			woc.log.WithFields(logging.Fields{"key": woc.wf.Name}).Info(ctx, "Released all acquired locks")
 		}

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -736,6 +736,22 @@ func (sm *Manager) ReleaseAll(ctx context.Context, wf *wfv1.Workflow) bool {
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
+	// Always release persisted database rows owned by this workflow first: the
+	// workflow key is stored in the row itself, so ownership can be re-derived
+	// even when the recorded synchronization status was lost. This is the
+	// recovery path for leaked held rows - when the controller's database
+	// session breaks after a row was written but before
+	// Status.Synchronization was persisted, the workflow ends up with a nil
+	// status yet still owns held rows, and neither the in-memory walk below
+	// nor the nil-status early return would ever remove them.
+	if sm.dbInfo.SessionProxy != nil {
+		if key := getHolderKey(wf, ""); key != "" {
+			if err := sm.queries.ReleaseAllHeldByWorkflowKey(ctx, key); err != nil {
+				sm.log.WithField("key", key).WithError(err).Error(ctx, "Failed to release held locks by workflow key")
+			}
+		}
+	}
+
 	if wf.Status.Synchronization == nil {
 		return true
 	}


### PR DESCRIPTION
fix: release leaked database semaphore/mutex locks when workflow Status.Synchronization is nil

Closes #16772

## Problem

When the workflow-controller's database session breaks (see #16771), workflows
that were already recorded as semaphore/mutex **holders** in `sync_state` can
end up `Failed` with `status.synchronization == nil` — the held row was written
before `Status.Synchronization` was persisted. Those rows are never released:

1. `releaseAllWorkflowLocks` (controller.go) is guarded by
   `wf.Status.Synchronization != nil`, so `ReleaseAll` is never called on
   delete — not for `kubectl delete`, not for TTL GC.
2. `Manager.ReleaseAll` itself early-returns on `Synchronization == nil`, and
   even past that it can only walk the in-memory holders, which don't exist
   in this scenario.
3. The inactive-controller expiry can't help because the `controller` column
   is an empty string on these rows, so they always look owned by the (alive)
   `''` controller.

Result: a semaphore with limit 1 blocks forever; larger limits silently lose
capacity (1/N slots) with no alert.

## Fix

Release held rows **by workflow key** — the key lives in the row itself, so
ownership can be re-derived without the status field:

- `util/sync/db/queries.go`: new `ReleaseAllHeldByWorkflowKey(ctx, holderKey)`
  — `DELETE FROM sync_state WHERE held = true AND workflowkey = ?`, regardless
  of which semaphore/mutex the row belongs to.
- `workflow/sync/sync_manager.go`: `ReleaseAll` now first releases all
  persisted held rows owned by the workflow (when a DB session is configured),
  before the existing in-memory walk. This covers both the nil-status leak
  case and existing behavior.
- `workflow/controller/controller.go`: drop the `Synchronization != nil`
  guard in `releaseAllWorkflowLocks` — always ask the sync manager to release.
- `workflow/controller/operator.go`: release locks for every Fulfilled
  workflow, not only those with a recorded synchronization status.
- `util/sync/db/mocks/SyncQueries.go`: mock for the new query method.

All three cleanup paths (delete handler, completion path, shutdown path) now
reach the DB-level release, so a lock held by a workflow that no longer runs
is eventually freed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow cleanup so all synchronization locks are released when workflows complete.
  * Cleared persisted lock holds even when synchronization status is unavailable or incomplete.
  * Prevented stale locks from remaining across semaphores, reducing the risk of blocked workflow operations.
  * Cleanup now continues when an individual database release encounters an error, with the issue recorded for investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->