### PR TITLE
fix: mark TaskGroup as Skipped when all children skipped/omitted by when-clause

### DIFF
--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -702,6 +702,7 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 
 	if taskGroupNode != nil {
 		groupPhase := wfv1.NodeSucceeded
+		allSkipped := true
 		for _, t := range expandedTasks {
 			// Add the child relationship from our dependency's outbound nodes to this node.
 			node := dagCtx.getTaskNode(ctx, t.Name)
@@ -711,6 +712,16 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 			if node.FailedOrError() {
 				groupPhase = node.Phase
 			}
+			if node.Phase != wfv1.NodeSkipped && node.Phase != wfv1.NodeOmitted {
+				allSkipped = false
+			}
+		}
+		// A task group whose every child was skipped/omitted (e.g. a withParam task whose
+		// when-clause filtered out every item) produced no outputs. Mark the group itself
+		// Skipped so addSkippedNodeOutputsToScope populates its declared output defaults
+		// and downstream references resolve instead of leaving the workflow stuck.
+		if allSkipped && len(expandedTasks) > 0 {
+			groupPhase = wfv1.NodeSkipped
 		}
 		woc.markNodePhase(ctx, taskGroupNode.Name, groupPhase)
 	}


### PR DESCRIPTION
**Description**

When a DAG task with `withParam` has all its child tasks skipped by their `when` clause (e.g. `when: "{{=item.classify}} == euk"` where no item matches), the TaskGroup node was marked as `Succeeded` because Skipped nodes satisfy `Fulfilled()`. This caused `addSkippedNodeOutputsToScope` to skip the group (it only processes `Skipped`/`Omitted` phase), so the template's declared output defaults were never populated into scope. Downstream tasks referencing `{{tasks.X.outputs.parameters.Y}}` would fail with `"failed to resolve"` and the workflow would hang in a requeue loop.

**Fix**

Track whether every child of the TaskGroup was skipped or omitted. If so, set the group phase to `NodeSkipped` instead of the default `NodeSucceeded`, so `addSkippedNodeOutputsToScope` populates the declared output defaults (or absent-optional placeholders) and downstream references resolve correctly.

Closes #16793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task groups whose expanded child tasks are all skipped or omitted are now correctly marked as skipped.
  * Default outputs from skipped nodes now populate as expected, allowing downstream references to resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->