### PR TITLE
fix: build PostgreSQL DSN directly for lib/pq token connectors

### DIFF
--- a/util/sqldb/postgres_dsn_test.go
+++ b/util/sqldb/postgres_dsn_test.go
@@ -1,0 +1,138 @@
+package sqldb
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/argoproj/argo-workflows/v4/config"
+)
+
+// pqKeywords is the set of DSN keywords lib/pq consumes as driver settings. Anything else is
+// forwarded to the server as a runtime parameter, so an unrecognised keyword makes the connection
+// fail with SQLSTATE 42704 rather than being ignored.
+var pqKeywords = map[string]bool{
+	"connect_timeout":           true,
+	"dbname":                    true,
+	"host":                      true,
+	"password":                  true,
+	"port":                      true,
+	"sslcert":                   true,
+	"sslkey":                    true,
+	"sslmode":                   true,
+	"sslrootcert":               true,
+	"user":                      true,
+	"application_name":          true,
+	"fallback_application_name": true,
+}
+
+func dsnKeys(t *testing.T, dsn string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, field := range strings.Fields(dsn) {
+		k, v, ok := strings.Cut(field, "=")
+		require.True(t, ok, "malformed DSN field %q in %q", field, dsn)
+		out[k] = v
+	}
+	return out
+}
+
+// TestBuildPostgresDSNOnlyPqKeywords is the regression test for the Azure and AWS RDS token
+// connectors: buildPostgresDSN used to be built with the upper/db postgresql adapter's
+// ConnectionURL, which targets pgx and unconditionally appends default_query_exec_mode. The token
+// connectors open that DSN with lib/pq, which forwards the unknown keyword to the server, so every
+// connection failed with `unrecognized configuration parameter "default_query_exec_mode"`.
+func TestBuildPostgresDSNOnlyPqKeywords(t *testing.T) {
+	cfg := &config.PostgreSQLConfig{
+		DatabaseConfig: config.DatabaseConfig{
+			Host:     "example.eu-west-1.rds.amazonaws.com",
+			Port:     5432,
+			Database: "argo",
+		},
+		SSL:     true,
+		SSLMode: "require",
+	}
+
+	dsn := buildPostgresDSN(cfg, "argo_user", 7*time.Second)
+
+	assert.NotContains(t, dsn, "default_query_exec_mode")
+	for k := range dsnKeys(t, dsn) {
+		assert.True(t, pqKeywords[k], "DSN contains keyword %q which lib/pq does not recognise; it would be sent to the server as a runtime parameter", k)
+	}
+}
+
+func TestBuildPostgresDSNParams(t *testing.T) {
+	cfg := &config.PostgreSQLConfig{
+		DatabaseConfig: config.DatabaseConfig{
+			Host:     "db.example.com",
+			Port:     6432,
+			Database: "argo",
+		},
+		SSL:     true,
+		SSLMode: "verify-full",
+	}
+
+	got := dsnKeys(t, buildPostgresDSN(cfg, "argo_user", 3*time.Second))
+
+	assert.Equal(t, "argo_user", got["user"])
+	assert.Equal(t, "db.example.com", got["host"])
+	assert.Equal(t, "6432", got["port"])
+	assert.Equal(t, "argo", got["dbname"])
+	assert.Equal(t, "verify-full", got["sslmode"])
+	assert.Equal(t, "3", got["connect_timeout"])
+}
+
+// A host with no port must not be split into an empty port, which lib/pq rejects.
+func TestBuildPostgresDSNHostWithoutPort(t *testing.T) {
+	cfg := &config.PostgreSQLConfig{
+		DatabaseConfig: config.DatabaseConfig{
+			Host:     "db.example.com",
+			Database: "argo",
+		},
+		SSL: true,
+	}
+
+	got := dsnKeys(t, buildPostgresDSN(cfg, "argo_user", time.Second))
+
+	assert.Equal(t, "db.example.com", got["host"])
+	assert.NotContains(t, got, "port")
+}
+
+func TestPostgresSSLMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ssl  bool
+		mode string
+		want string
+	}{
+		{"ssl disabled", false, "", "disable"},
+		{"ssl disabled ignores mode", false, "require", "disable"},
+		{"explicit mode", true, "verify-ca", "verify-ca"},
+		{"adapter default preserved", true, "", "prefer"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.PostgreSQLConfig{SSL: tc.ssl, SSLMode: tc.mode}
+			assert.Equal(t, tc.want, postgresSSLMode(cfg))
+		})
+	}
+}
+
+// Values carrying DSN metacharacters must be escaped rather than splitting the DSN.
+func TestBuildPostgresDSNEscapesValues(t *testing.T) {
+	cfg := &config.PostgreSQLConfig{
+		DatabaseConfig: config.DatabaseConfig{
+			Host:     "db.example.com",
+			Port:     5432,
+			Database: "argo db",
+		},
+		SSL: true,
+	}
+
+	dsn := buildPostgresDSN(cfg, "user's name", time.Second)
+
+	assert.Contains(t, dsn, `dbname=argo\ db`)
+	assert.Contains(t, dsn, `user=user\'s\ name`)
+}

--- a/util/sqldb/sqldb.go
+++ b/util/sqldb/sqldb.go
@@ -5,8 +5,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"net"
 	"net/url"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/XSAM/otelsql"
@@ -108,25 +111,62 @@ func createMySQLDBSession(ctx context.Context, kubectlConfig kubernetes.Interfac
 	return createMySQLDBSessionWithCreds(cfg, persistPool, string(userNameByte), string(passwordByte), connectTimeout)
 }
 
-// buildPostgresDSN constructs a PostgreSQL DSN from config and username, with SSL options
-// and a connection-establishment timeout configured.
+// postgresSSLMode returns the lib/pq sslmode to use for the given configuration. Shared by every
+// PostgreSQL session builder so the password and token paths cannot drift apart.
+func postgresSSLMode(cfg *config.PostgreSQLConfig) string {
+	switch {
+	case !cfg.SSL:
+		return "disable"
+	case cfg.SSLMode != "":
+		return cfg.SSLMode
+	default:
+		// Preserve the default behavior of the upper/db postgresql adapter,
+		// which used sslmode=prefer. lib/pq defaults to sslmode=require.
+		return "prefer"
+	}
+}
+
+// pqDSNValueEscaper escapes a value for lib/pq's keyword/value DSN format, in which a space
+// separates parameters, a single quote delimits a value, and a backslash escapes either.
+var pqDSNValueEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`, ` `, `\ `)
+
+// buildPostgresDSN constructs a lib/pq keyword/value DSN from config and username, with SSL
+// options and a connection-establishment timeout configured. The token-based connectors append
+// `password='<token>'` to the result, so it has to stay in keyword/value form.
+//
+// This intentionally does not use postgresqladp.ConnectionURL. That builder targets pgx and
+// unconditionally appends default_query_exec_mode, which lib/pq does not recognise and therefore
+// forwards to the server as a runtime parameter, so every connection made by the Azure and AWS RDS
+// token connectors fails with:
+//
+//	pq: unrecognized configuration parameter "default_query_exec_mode" (SQLSTATE 42704)
 func buildPostgresDSN(cfg *config.PostgreSQLConfig, username string, connectTimeout time.Duration) string {
-	settings := postgresqladp.ConnectionURL{
-		User:     username,
-		Host:     cfg.GetHostname(),
-		Database: cfg.Database,
+	params := [][2]string{
+		{"user", username},
+		{"dbname", cfg.Database},
+		{"sslmode", postgresSSLMode(cfg)},
+		// connect_timeout limits connection setup (dial + handshake) to ensure fast failure if the
+		// DB is unreachable. lib/pq resets this deadline afterward, leaving subsequent queries
+		// unaffected.
+		{"connect_timeout", strconv.Itoa(int(connectTimeout.Seconds()))},
 	}
 
-	// connect_timeout limits connection setup (dial + handshake) to ensure fast failure if the DB is unreachable.
-	// lib/pq resets this deadline afterward, leaving subsequent queries unaffected.
-	settings.Options = map[string]string{
-		"connect_timeout": strconv.Itoa(int(connectTimeout.Seconds())),
-	}
-	if cfg.SSL && cfg.SSLMode != "" {
-		settings.Options["sslmode"] = cfg.SSLMode
+	if host, port, err := net.SplitHostPort(cfg.GetHostname()); err == nil {
+		params = append(params, [2]string{"host", host}, [2]string{"port", port})
+	} else {
+		params = append(params, [2]string{"host", cfg.GetHostname()})
 	}
 
-	return settings.String()
+	pairs := make([]string, 0, len(params))
+	for _, p := range params {
+		if p[1] == "" {
+			continue
+		}
+		pairs = append(pairs, p[0]+"="+pqDSNValueEscaper.Replace(p[1]))
+	}
+	sort.Strings(pairs)
+
+	return strings.Join(pairs, " ")
 }
 
 // createPostGresDBSessionWithConnector creates a PostgreSQL session using the provided connector.
@@ -192,16 +232,7 @@ func createPostGresDBSessionWithCreds(cfg *config.PostgreSQLConfig, persistPool 
 		Path:   cfg.Database,
 	}
 	query := url.Values{}
-	switch {
-	case !cfg.SSL:
-		query.Set("sslmode", "disable")
-	case cfg.SSLMode != "":
-		query.Set("sslmode", cfg.SSLMode)
-	default:
-		// Preserve the default behavior of the upper/db postgresql adapter,
-		// which used sslmode=prefer. lib/pq defaults to sslmode=require.
-		query.Set("sslmode", "prefer")
-	}
+	query.Set("sslmode", postgresSSLMode(cfg))
 	// connect_timeout limits connection setup (dial + handshake) to ensure fast failure if the DB is unreachable.
 	// lib/pq resets this deadline afterward, leaving subsequent queries unaffected.
 	query.Set("connect_timeout", strconv.Itoa(int(connectTimeout.Seconds())))


### PR DESCRIPTION
The Azure and AWS RDS token connectors open their DSN with lib/pq, but `buildPostgresDSN` produced it with `postgresqladp.ConnectionURL`, whose pgx variant unconditionally appends `default_query_exec_mode=cache_describe`.

lib/pq does not recognise that keyword, so it forwards it to the server as a runtime parameter and every connection fails before authenticating:

```
failed to create initial database session: failed to create upper/db
session: pq: unrecognized configuration parameter
"default_query_exec_mode" (42704)
```

This makes `postgresql.azureToken` and `postgresql.awsRDSToken` unusable; the password path is unaffected because it builds its own DSN with `url.URL`.

**Changes:**
- Build the DSN directly using lib/pq's keyword/value format, emitting only keywords lib/pq consumes
- Extract `postgresSSLMode()` so the sslmode selection is shared between the token and password paths
- Fixes #16798

### Checklist
- [x] I have verified that the DSN no longer contains `default_query_exec_mode`
- [x] All existing tests pass (the DSN format change is confined to `buildPostgresDSN` and `createPostGresDBSessionWithCreds`)
- [x] Added regression tests for the DSN format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved PostgreSQL connection string compatibility with lib/pq-style configuration.
  * Added support for reliable host and port handling, SSL mode resolution, connection timeouts, and parameter escaping.
  * Empty connection parameters are now omitted, producing cleaner connection settings.

* **Bug Fixes**
  * Improved handling of special characters in PostgreSQL connection values.
  * PostgreSQL connections without an explicitly specified port are now handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->