### PR TITLE
fix: allow semaphore initialization with a resolved limit of 0

### DIFF
--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -40,12 +40,14 @@ func newDatabaseSemaphore(ctx context.Context, name string, dbKey string, nextWo
 		isMutex:      false,
 	}
 	sem.limitGetter = newCachedLimit(sem.getLimitFromDB, syncLimitCacheTTL)
-	var err error
-	limit := sem.getLimit(ctx)
-	if limit == 0 {
-		err = fmt.Errorf("failed to initialize semaphore %s with limit", name)
+	// Resolve the limit directly through limitGetter rather than getLimit(), since
+	// getLimit() falls back to the cache's zero-value on a fetch error, which would
+	// make a genuine error indistinguishable from a semaphore that legitimately
+	// starts at limit 0 (e.g. an "approval gate" held closed until raised).
+	if _, _, err := sem.limitGetter.get(ctx, dbKey); err != nil {
+		return nil, fmt.Errorf("failed to initialize semaphore %s: %w", name, err)
 	}
-	return sem, err
+	return sem, nil
 }
 
 func (s *databaseSemaphore) longDBKey() string {

--- a/workflow/sync/semaphore.go
+++ b/workflow/sync/semaphore.go
@@ -38,12 +38,18 @@ func newInternalSemaphore(ctx context.Context, name string, nextWorkflow NextWor
 		nextWorkflow: nextWorkflow,
 		logger:       logger.get,
 	}
-	var err error
-	limit := sem.getLimit(ctx)
-	if limit == 0 {
-		err = fmt.Errorf("failed to initialize semaphore %s with limit", name)
+	// Resolve the limit directly through limitGetter rather than getLimit(), since
+	// getLimit() falls back to the cache's zero-value on a fetch error, which would
+	// make a genuine error indistinguishable from a semaphore that legitimately
+	// starts at limit 0 (e.g. an "approval gate" held closed until raised).
+	limit, changed, err := sem.limitGetter.get(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize semaphore %s: %w", name, err)
 	}
-	return sem, err
+	if changed && !sem.resize(ctx, limit) {
+		return nil, fmt.Errorf("failed to size semaphore %s to limit %d", name, limit)
+	}
+	return sem, nil
 }
 
 func (s *prioritySemaphore) getLimit(ctx context.Context) int {

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"testing"
@@ -373,6 +374,34 @@ func TestNewSemaphoreWithZeroLimit(t *testing.T) {
 			acquired, _, err := sem.tryAcquire(ctx, "default/wf-a", info.SessionProxy)
 			require.NoError(t, err)
 			assert.False(t, acquired, "no slots should be available while the limit is 0")
+		})
+	}
+
+	// The other side of the regression this test guards against: a limit that
+	// genuinely can't be resolved must still fail initialization, not be silently
+	// treated as a valid limit of 0.
+	t.Run("Internal/MissingLimitFails", func(t *testing.T) {
+		wantErr := errors.New("configmap my-config not found")
+		getter := func(_ context.Context, _ string) (int, error) { return 0, wantErr }
+		sem, err := newInternalSemaphore(ctx, "default/ConfigMap/my-config/workflow", nextWorkflow, getter, 0)
+		require.Error(t, err)
+		require.ErrorIs(t, err, wantErr)
+		assert.Nil(t, sem)
+	})
+
+	for _, dbType := range testDBTypes {
+		t.Run("Database/"+string(dbType)+"/MissingLimitFails", func(t *testing.T) {
+			info, deferfunc, _, err := createTestDBSession(ctx, t, dbType)
+			require.NoError(t, err)
+			defer deferfunc()
+
+			// Deliberately skip inserting a sync_limit row for this key, so the
+			// limit lookup fails (no row found) and initialization must return an
+			// error rather than treating the missing row as a limit of 0.
+			dbKey := "default/missing-database-sem"
+			sem, err := newDatabaseSemaphore(ctx, "missing-database-sem", dbKey, nextWorkflow, info, 0)
+			require.Error(t, err)
+			assert.Nil(t, sem)
 		})
 	}
 }

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -366,11 +366,11 @@ func TestNewSemaphoreWithZeroLimit(t *testing.T) {
 
 	for _, dbType := range testDBTypes {
 		t.Run("Database/"+string(dbType), func(t *testing.T) {
-			sem, _, deferfunc := createTestDatabaseSemaphore(ctx, t, "my-database-sem", "default", 0, 0, nextWorkflow, dbType)
+			sem, info, deferfunc := createTestDatabaseSemaphore(ctx, t, "my-database-sem", "default", 0, 0, nextWorkflow, dbType)
 			defer deferfunc()
 
 			require.NoError(t, sem.addToQueue(ctx, "default/wf-a", 0, time.Now()))
-			acquired, _, err := sem.tryAcquire(ctx, "default/wf-a", nil)
+			acquired, _, err := sem.tryAcquire(ctx, "default/wf-a", info.SessionProxy)
 			require.NoError(t, err)
 			assert.False(t, acquired, "no slots should be available while the limit is 0")
 		})

--- a/workflow/sync/semaphore_test.go
+++ b/workflow/sync/semaphore_test.go
@@ -343,3 +343,36 @@ func TestInternalSemaphoreReleaseWithLimitFetchFailure(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, acquired, "wf-b should acquire the slot released by wf-a")
 }
+
+// TestNewSemaphoreWithZeroLimit is a regression test: newInternalSemaphore and
+// newDatabaseSemaphore used to reject a successfully resolved limit of 0, treating it
+// the same as a failure to resolve the limit at all. A limit of 0 is a valid initial
+// state (e.g. an "approval gate" that stays closed until an operator raises it), so
+// initialization must only fail when the limit genuinely can't be resolved.
+func TestNewSemaphoreWithZeroLimit(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	nextWorkflow := func(_ string) {}
+
+	t.Run("Internal", func(t *testing.T) {
+		getter := func(_ context.Context, _ string) (int, error) { return 0, nil }
+		sem, err := newInternalSemaphore(ctx, "default/ConfigMap/my-config/workflow", nextWorkflow, getter, 0)
+		require.NoError(t, err)
+
+		require.NoError(t, sem.addToQueue(ctx, "default/wf-a", 0, time.Now()))
+		acquired, _, err := sem.tryAcquire(ctx, "default/wf-a", nil)
+		require.NoError(t, err)
+		assert.False(t, acquired, "no slots should be available while the limit is 0")
+	})
+
+	for _, dbType := range testDBTypes {
+		t.Run("Database/"+string(dbType), func(t *testing.T) {
+			sem, _, deferfunc := createTestDatabaseSemaphore(ctx, t, "my-database-sem", "default", 0, 0, nextWorkflow, dbType)
+			defer deferfunc()
+
+			require.NoError(t, sem.addToQueue(ctx, "default/wf-a", 0, time.Now()))
+			acquired, _, err := sem.tryAcquire(ctx, "default/wf-a", nil)
+			require.NoError(t, err)
+			assert.False(t, acquired, "no slots should be available while the limit is 0")
+		})
+	}
+}


### PR DESCRIPTION
- [x] Ran `make pre-commit -B` (build, `go vet`, `golangci-lint` on the touched package all clean)
- [x] Signed-off commits with Conventional Commit messages
- [x] PR title is a conventional commit message
- [x] Unit tests cover the change
- [ ] For features: n/a, this is a bug fix, not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16731

### Motivation

`newInternalSemaphore` and `newDatabaseSemaphore` both call `getLimit()` once at
construction and treat a return value of `0` as proof that the limit fetch failed:

```go
limit := sem.getLimit(ctx)
if limit == 0 {
    err = fmt.Errorf("failed to initialize semaphore %s with limit", name)
}
```

`getLimit()` also returns `0` on a genuine fetch error (it falls back to the cache's
zero-value), so the two cases are indistinguishable at this call site. This means a
semaphore whose limit legitimately resolves to `0` can never be initialized, which
blocks patterns like an "approval gate" semaphore that should start closed
(`limit = 0`) until an operator raises it.

### Modifications

In both constructors, resolve the limit directly through `limitGetter.get()` instead
of through `getLimit()`, so the real `(limit, err)` pair is visible:

- Fail initialization only when `err != nil` (the limit genuinely couldn't be
  resolved), never on a successfully resolved `0`.
- For `newInternalSemaphore`, preserve the existing side effect of resizing the
  weighted semaphore to the resolved limit immediately at construction (previously a
  side effect of calling `getLimit()`), now also surfacing a resize failure as an
  init error instead of silently ignoring it.

`getLimit()` itself is unchanged; it's still used elsewhere for the fallback-on-error
behavior, which is correct in those call sites.

### Verification

Added `TestNewSemaphoreWithZeroLimit`, covering both the in-memory and
database-backed semaphore, asserting:
- construction with a limit of `0` succeeds, and
- a subsequent acquire attempt correctly fails (no slots available).

Fixed the database subtest to pass the fixture's real session into `tryAcquire`
instead of `nil` — `checkAcquire` forwards it straight into a SQL call for the
database-backed semaphore, unlike the in-memory one where it's unused.

Ran `go build`, `go vet`, and `golangci-lint run` on `./workflow/sync/...` — all
clean. `go test ./workflow/sync/...` passes in full, including the Postgres- and
MySQL-backed subtests.

### Documentation

Not needed — this fixes a bug in internal initialization logic with no user-facing
API or config change.

### AI

Used Claude Code (Anthropic) to research the issue, implement the fix, and write the
accompanying test, under my direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Semaphores can now initialize successfully with a configured limit of zero.
  * Correctly propagates errors when retrieving semaphore limits.
  * Prevents workflows from acquiring slots while the limit is zero.
  * Resizes semaphores only when the configured limit changes.

* **Tests**
  * Added coverage for zero-limit initialization across supported semaphore implementations and databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->