### PR TITLE
docs: add jedarden.com to USERS.md

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -117,6 +117,7 @@ Currently, the following organizations are **officially** using Argo Workflows:
 1. [Intuit](https://www.intuit.com/)
 1. [InVision](https://www.invisionapp.com/)
 1. [İşbank](https://www.isbank.com.tr/en)
+1. [jedarden.com](https://jedarden.com)
 1. [Jellysmack](https://www.jellysmack.com/)
 1. [Jungle](https://www.jungle.ai/)
 1. [Karius](https://www.kariusdx.com/)


### PR DESCRIPTION
jedarden.com runs all CI on Argo Workflows (Argo Events webhook → website-build WorkflowTemplate → Cloudflare Pages) and manages six clusters with Argo CD. Write-up: https://jedarden.com/guides/ci-on-rackspace-spot/ . One-person shop; happy to be listed under a different name if you prefer organizations only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added jedarden.com to the list of organizations using Argo Workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->