### PR TITLE
fix: don't fail nodes on artifact plugin sidecar exit codes

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1880,6 +1880,18 @@ func (woc *wfOperationCtx) inferFailedReason(ctx context.Context, pod *apiv1.Pod
 			// the legacy init/wait paths do separately.
 			return wfv1.NodeError, msg
 		default:
+			if common.IsArtifactPluginSidecar(ctr.Name) {
+				// Artifact plugin sidecars are torn down by the wait/supervisor
+				// container after it has saved all outputs, so an aux container
+				// that exited 0 proves every save succeeded and the sidecar's own
+				// exit code carries no information about the node's outcome. The
+				// code can even be a phantom: a `kill` exec racing the sidecar's
+				// exit can make the container runtime record a non-zero status
+				// for a process that exited cleanly. Record it and let the
+				// main/wait verdict below decide the node's fate.
+				woc.log.WithFields(logging.Fields{"exitCode": t.ExitCode, "containerName": ctr.Name}).Info(ctx, "ignoring artifact plugin sidecar exit code")
+				continue
+			}
 			if t.ExitCode != 137 && t.ExitCode != 143 {
 				return wfv1.NodeFailed, msg
 			}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -13309,3 +13309,74 @@ func TestCheckTemplateTimeouts(t *testing.T) {
 	assert.Nil(t, pendingDeadline)
 	require.NoError(t, err)
 }
+
+// TestInferFailedReasonArtifactPluginSidecar ensures that a non-zero exit from
+// an artifact plugin sidecar does not fail a node whose main and wait
+// (or supervisor) containers completed successfully: the aux container tears
+// the sidecars down only after all saves succeeded, and the recorded exit code
+// can even be a phantom produced by a kill exec racing the sidecar's own exit.
+// Failures of main, the aux container, or user sidecars must still fail the
+// node as before.
+func TestInferFailedReasonArtifactPluginSidecar(t *testing.T) {
+	terminated := func(name string, exitCode int32) apiv1.ContainerStatus {
+		return apiv1.ContainerStatus{
+			Name:  name,
+			State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: exitCode, Reason: "Error"}},
+		}
+	}
+	tests := []struct {
+		name          string
+		ctrs          []apiv1.ContainerStatus
+		expectedPhase wfv1.NodePhase
+		expectedMsg   string
+	}{
+		{
+			name:          "PluginSidecarExitIgnoredLegacy",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 0), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeSucceeded,
+			expectedMsg:   "",
+		},
+		{
+			name:          "PluginSidecarExitIgnoredInitless",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("supervisor", 0), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeSucceeded,
+			expectedMsg:   "",
+		},
+		{
+			name:          "PluginSidecarSigtermExitIgnored",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 0), terminated("artifact-plugin-test", 143)},
+			expectedPhase: wfv1.NodeSucceeded,
+			expectedMsg:   "",
+		},
+		{
+			name:          "WaitFailureStillFails",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 1), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeError,
+			expectedMsg:   "wait: Error (exit code 1)",
+		},
+		{
+			name:          "MainFailureStillFails",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 1), terminated("wait", 0), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeFailed,
+			expectedMsg:   "main: Error (exit code 1)",
+		},
+		{
+			name:          "UserSidecarFailureStillFails",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 0), terminated("artifact-plugin-test", 2), terminated("user-sidecar", 1)},
+			expectedPhase: wfv1.NodeFailed,
+			expectedMsg:   "user-sidecar: Error (exit code 1)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			pod := apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status:     apiv1.PodStatus{Phase: apiv1.PodFailed, ContainerStatuses: tt.ctrs},
+			}
+			phase, msg := newWoc(ctx).inferFailedReason(ctx, &pod, nil)
+			assert.Equal(t, tt.expectedPhase, phase)
+			assert.Equal(t, tt.expectedMsg, msg)
+		})
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- [x] Ran `make pre-commit -B` (scoped: `golangci-lint run workflow/controller/` — only a pre-existing `ns_watcher.go` SA1019 unrelated to this change; full `go test ./workflow/controller/` green)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

`TestExampleWorkflows/../../examples/artifact-passing-explicit-plugin.yaml` fails intermittently in CI (observed twice within two days, on both the legacy and init-less pod layouts): the workflow's pod completes successfully end to end, yet the node fails with `artifact-plugin-test: Error (exit code 2)`.

Investigation with the CI log archives and a local reproduction rig established the mechanism:

1. The wait (or supervisor) container finishes saving all outputs and logs, then tears down the artifact plugin sidecar via the file-signal mechanism; the sidecar's log shows a clean, complete shutdown ending with "artifact plugin sidecar command exited".
2. The controller's `terminateContainers` sweep also SIGTERMs the sidecar via a `kubectl exec … argoexec kill 15 1` session. In both CI failures that exec completed within 6ms/80ms of the sidecar's final log line — i.e. it was in flight at the instant PID 1 exited.
3. When an exec session races container PID 1's exit, the container runtime can record a phantom non-zero exit status for a process that exited cleanly. Reproduced locally in plain docker (no Kubernetes): 3 phantom `exit 2` results in 100 attempts of file-signal teardown with kill execs spammed at the dying container, each with a byte-identical clean log and `Error: ""` in the runtime state. No panic is involved — the wrapper genuinely exits 0.
4. kubelet reports the phantom exit code, the pod phase becomes Failed, and the node fails.

### Modifications

`inferFailedReason` now ignores non-zero exit codes from artifact plugin sidecar containers (`artifact-plugin-*`), letting the existing main/wait verdict at the end of the function decide the node's fate. Rationale: the aux container tears these sidecars down only after all saves succeeded, so an aux container that exited 0 proves the sidecar did its job, and its exit code carries no information about the node's outcome — while demonstrably being unreliable under the exec race. This is the same position Kubernetes native sidecar containers take: their exit status does not affect pod phase.

Safety is preserved by the function's existing structure: a plugin sidecar that genuinely dies mid-save fails the aux container's save, and the `wait container did not complete successfully` verdict fails the node. Failures of main, wait/supervisor, init containers, and user sidecars are unaffected (covered by tests).

Both teardown mechanisms (aux file-signal and controller SIGTERM sweep) are deliberately left in place.

### Verification

New table-driven `TestInferFailedReasonArtifactPluginSidecar`: plugin-sidecar exit ignored (legacy wait + init-less supervisor + SIGTERM 143 variants), and negative cases proving main/wait/user-sidecar failures still fail the node with unchanged messages. The three ignore cases fail on `main` and pass with the fix. Full `go test ./workflow/controller/` green.

The container-runtime misattribution itself (exec racing PID 1 exit) is arguably a containerd/runc issue; a standalone docker reproducer exists and an upstream report may follow separately.

### Documentation

Not needed: no user-visible behavior change beyond removing spurious failures.

### AI

This PR was prepared with Claude Code (Anthropic): CI log forensics, local docker reproduction of the runtime race, fix, tests, and this description, directed and reviewed by the submitting maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XsqqvLSrJ5sH8gN8tLbr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented artifact plugin shutdown exit codes from incorrectly marking otherwise successful workflows as failed.
  * Workflow failures from the main, wait, or regular sidecar containers continue to be reported normally.

* **Tests**
  * Added coverage for artifact plugin sidecars across legacy, initless, and signal-terminated executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->