### PR TITLE
test: allow per-example wait timeouts in the examples e2e suite

### DIFF
--- a/examples/variables-showcase.yaml
+++ b/examples/variables-showcase.yaml
@@ -31,6 +31,9 @@ metadata:
     # Used to demonstrate workflow.labels / .labels.json / .labels.<name>.
     app: variables-demo
     tier: example
+    # This example runs a deep sequential chain and can exceed the default
+    # E2E_WAIT_TIMEOUT on loaded CI runners.
+    workflows.argoproj.io/test-timeout: 3m
 spec:
   entrypoint: main
   serviceAccountName: default               # → workflow.serviceAccountName (executor role bound)

--- a/test/e2e/examples_test.go
+++ b/test/e2e/examples_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -132,6 +133,16 @@ func TestExampleWorkflows(t *testing.T) {
 				if noTextLabelExists {
 					t.Skip(fmt.Sprintf("Impossible to run this example: %s", noTestKeyword))
 				}
+				// Examples that legitimately take longer than E2E_WAIT_TIMEOUT can
+				// override their wait timeout with this label, e.g. "3m".
+				waitOpts := []any{fixtures.ToBeSucceeded}
+				if v, ok := wf.GetLabels()["workflows.argoproj.io/test-timeout"]; ok {
+					d, err := time.ParseDuration(v)
+					if err != nil {
+						t.Fatalf("invalid workflows.argoproj.io/test-timeout label %q: %v", v, err)
+					}
+					waitOpts = append(waitOpts, d)
+				}
 				fixtures.NewGiven(
 					t,
 					versioned.NewForConfigOrDie(restConfig).ArgoprojV1alpha1().Workflows(fixtures.Namespace),
@@ -148,7 +159,7 @@ func TestExampleWorkflows(t *testing.T) {
 					ExampleWorkflow(&wf).
 					When().
 					SubmitWorkflow().
-					WaitForWorkflow(fixtures.ToBeSucceeded)
+					WaitForWorkflow(waitOpts...)
 			})
 		}
 		return nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

- [x] Ran `make pre-commit -B` (scoped: `go build/vet -tags examples ./test/e2e/`, example-validation unit tests green; no codegen-affecting changes)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change — the examples e2e suite on this PR exercises the new label via variables-showcase
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — test-infra change
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

The examples e2e suite waits a flat `E2E_WAIT_TIMEOUT` (90s in CI) for every example. `examples/variables-showcase.yaml` is a deep sequential chain (the full variable-catalog showcase: 5 top-level step groups plus nested steps, retries, and an exit handler) and, with 20 examples running in parallel on a 4-vCPU runner, can legitimately exceed 90s while making honest progress — observed failing exactly this way on an unrelated PR's CI run (workflow mid-flight in its first step group when the timeout expired).

### Modifications

- `test/e2e/examples_test.go`: examples may carry a `workflows.argoproj.io/test-timeout` label (sibling of the existing `workflows.argoproj.io/no-test` label) whose duration value overrides the wait timeout for that example only, passed through `WaitForWorkflow`'s existing `time.Duration` option. Invalid values fail the test explicitly.
- `examples/variables-showcase.yaml`: labelled with `3m`.

The global `E2E_WAIT_TIMEOUT` and suite parallelism are unchanged; the label self-documents which examples are expected to be slow.

### Verification

`go build`/`go vet` with the `examples` tag; the example-validation unit tests pass with the new label present; this PR's own `test-examples` jobs run variables-showcase under the 3m budget.

### Documentation

The label is internal to the e2e suite (as is `no-test`, which is likewise undocumented outside the test); commented at both use sites.

### AI

This PR was prepared with Claude Code (Anthropic), directed and reviewed by the submitting maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XsqqvLSrJ5sH8gN8tLbr9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Example workflow tests can now use a configurable timeout.
  - Valid timeout values override the default wait period; invalid values are reported as test failures.
  - Workflows without a configured timeout continue using the standard wait period.
  - Updated the variables showcase workflow to allow additional time for completion in slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->