### PR TITLE
fix: prevent panic in ParseProgress on input without a slash (cherry-pick #16537 for 4.0)

### DIFF
--- a/pkg/apis/workflow/v1alpha1/progress.go
+++ b/pkg/apis/workflow/v1alpha1/progress.go
@@ -24,16 +24,21 @@ func ParseProgress(s string) (Progress, bool) {
 	return v, v.IsValid()
 }
 
-func (in Progress) parts() []string {
-	return strings.SplitN(string(in), "/", 2)
+func (in Progress) parts() (string, string) {
+	// Input without a "/" separator is malformed: m stays empty, so M()
+	// returns 0 and IsValid() rejects it.
+	n, m, _ := strings.Cut(string(in), "/")
+	return n, m
 }
 
 func (in Progress) N() int64 {
-	return parseInt64(in.parts()[0])
+	n, _ := in.parts()
+	return parseInt64(n)
 }
 
 func (in Progress) M() int64 {
-	return parseInt64(in.parts()[1])
+	_, m := in.parts()
+	return parseInt64(m)
 }
 
 func (in Progress) Add(x Progress) Progress {

--- a/pkg/apis/workflow/v1alpha1/progress_test.go
+++ b/pkg/apis/workflow/v1alpha1/progress_test.go
@@ -10,12 +10,15 @@ func TestProgress(t *testing.T) {
 	t.Run("ParseProgress", func(t *testing.T) {
 		_, ok := ParseProgress("")
 		assert.False(t, ok)
+		_, ok = ParseProgress("5")
+		assert.False(t, ok)
 		progress, ok := ParseProgress("0/1")
 		assert.True(t, ok)
 		assert.Equal(t, Progress("0/1"), progress)
 	})
 	t.Run("IsValid", func(t *testing.T) {
 		assert.False(t, Progress("").IsValid())
+		assert.False(t, Progress("5").IsValid())
 		assert.False(t, Progress("/0").IsValid())
 		assert.False(t, Progress("0/").IsValid())
 		assert.False(t, Progress("0/0").IsValid())


### PR DESCRIPTION
Manual cherry-pick of #16537 (38a61b4) onto release-4.0.

The automated cherry-pick job reported conflicts, but the pick is actually clean; the job died writing the multi-line commit message to GITHUB_OUTPUT (workflow log shows: Unable to process file command output / Invalid format Signed-off-by line). Cherry-picked with -x, tests pass.