### PR TITLE
docs: fix RBAC manifest links in security.md

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -16,7 +16,7 @@ The controller has permission (via Kubernetes RBAC + its config map) with either
 * Create/get/delete pods, PVCs, and PDBs.
 * List/get template, config maps, service accounts, and secrets.
 
-See [`workflow-controller-cluster-role.yaml`](https://raw.githubusercontent.com/argoproj/argo-workflows/main/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml) or [`workflow-controller-role.yaml`](https://raw.githubusercontent.com/argoproj/argo-workflows/main/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml)
+See [`workflow-controller-cluster-role.yaml`](https://raw.githubusercontent.com/argoproj/argo-workflows/main/manifests/cluster-install-no-crds/workflow-controller-rbac/workflow-controller-clusterrole.yaml) or [`workflow-controller-role.yaml`](https://raw.githubusercontent.com/argoproj/argo-workflows/main/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml)
 
 ### User Permissions
 
@@ -60,7 +60,7 @@ rules:
       - get
       - list
       - watch
-  # Argo APIs. See also https://github.com/argoproj/argo-workflows/blob/main/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml#L4
+  # Argo APIs. See also https://github.com/argoproj/argo-workflows/blob/main/manifests/cluster-install-no-crds/workflow-controller-rbac/workflow-aggregate-roles.yaml#L4
   - apiGroups:
       - argoproj.io
     resources:


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

<!-- Does this PR fix an issue -->

No tracked issue; found during an external-link sweep of `README.md` + `docs/`.

### Motivation

Two links in `docs/security.md` still point at the old `manifests/cluster-install/workflow-controller-rbac/` path, which was renamed to `manifests/cluster-install-no-crds/workflow-controller-rbac/` in e0a0f2856 (#14599, June 2025). Readers who follow them get a 404:

1. **Controller Permissions** — the raw link to `workflow-controller-clusterrole.yaml`
2. **UI Access** example — the inline reference to `workflow-aggregate-roles.yaml#L4`

### Modifications

Both links now point at the renamed `cluster-install-no-crds` path. No other content changed; docs-only.

### Verification

- External-link sweep of `README.md` + `docs/` (743 unique URLs live-checked); these were the only real dead links in `docs/security.md`.
- Both replacement URLs verified live (HTTP 200) before committing, and the `#L4` anchor lands on the `- argoproj.io` apiGroups line the comment refers to.
- CI on this PR: docs / Lint / title-check / feature-pr-handling / DCO all SUCCESS (unit+E2E skipped as docs-only).

### Documentation

This change *is* a documentation fix; no additional docs updates needed.

### AI

Declared per the [Argo Generative AI policy](https://github.com/argoproj/argoproj/blob/main/community/genai.md): this PR was prepared with the assistance of an AI coding agent (link discovery, verification, and drafting), under my direction and review.

Signed-off-by: Shurong Cao <170531907+CAOShurong@users.noreply.github.com>
