### PR TITLE
refactor: remove WithFatal from the logging package

### DIFF
--- a/cmd/argo/commands/client/conn.go
+++ b/cmd/argo/commands/client/conn.go
@@ -82,7 +82,8 @@ func NewAPIClient(ctx context.Context) (context.Context, apiclient.Client, error
 				authString, err := GetAuthString(ctx)
 				if err != nil {
 					logger := logging.RequireLoggerFromContext(ctx)
-					logger.WithFatal().WithError(err).Error(ctx, "Failed to get auth string")
+					logger.WithError(err).Error(ctx, "Failed to get auth string")
+					os.Exit(1)
 				}
 				return authString
 			},
@@ -107,7 +108,8 @@ func Namespace(ctx context.Context) string {
 	namespace, _, err := GetConfig().Namespace()
 	if err != nil {
 		logger := logging.RequireLoggerFromContext(ctx)
-		logger.WithFatal().WithError(err).Error(ctx, "Failed to get namespace")
+		logger.WithError(err).Error(ctx, "Failed to get namespace")
+		os.Exit(1)
 	}
 	return namespace
 }

--- a/cmd/argo/commands/root.go
+++ b/cmd/argo/commands/root.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -170,14 +171,16 @@ If your server is behind an ingress with a path (running "argo server --base-hre
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
 	if err := viper.BindPFlags(command.PersistentFlags()); err != nil {
-		log.WithError(err).WithFatal().Error(cctx, "Failed to bind flags to env vars")
+		log.WithError(err).Error(cctx, "Failed to bind flags to env vars")
+		os.Exit(1)
 	}
 	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
 	command.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)
 			if err := command.PersistentFlags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-				log.WithError(err).WithFatal().Error(cctx, "Failed to set flag")
+				log.WithError(err).Error(cctx, "Failed to set flag")
+				os.Exit(1)
 			}
 		}
 	})

--- a/cmd/argo/commands/server.go
+++ b/cmd/argo/commands/server.go
@@ -225,7 +225,7 @@ See %s`, help.ArgoServer()),
 		cmdutil.FatalBootstrap(logFormat, err, "Failed to create server logger")
 	}
 	if err := viper.BindPFlags(command.Flags()); err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to bind flags to env vars")
+		logger.WithError(err).Error(ctx, "Failed to bind flags to env vars")
 		os.Exit(1)
 	}
 	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
@@ -233,7 +233,7 @@ See %s`, help.ArgoServer()),
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)
 			if err := command.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-				logger.WithError(err).WithFatal().Error(ctx, "Failed to set flag")
+				logger.WithError(err).Error(ctx, "Failed to set flag")
 				os.Exit(1)
 			}
 		}

--- a/cmd/argo/commands/submit.go
+++ b/cmd/argo/commands/submit.go
@@ -112,7 +112,7 @@ func NewSubmitCommand() *cobra.Command {
 	logger := logging.RequireLoggerFromContext(ctx)
 	err = command.Flags().SetAnnotation("parameter-file", cobra.BashCompFilenameExt, []string{"json", "yaml", "yml"})
 	if err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to set annotation")
+		logger.WithError(err).Error(ctx, "Failed to set annotation")
 		os.Exit(1)
 	}
 	return command
@@ -274,7 +274,7 @@ func unmarshalWorkflows(ctx context.Context, wfBytes []byte, strict bool) []wfv1
 	if err == nil {
 		return yamlWfs
 	}
-	logging.RequireLoggerFromContext(ctx).WithError(err).WithFatal().Error(ctx, "Failed to parse workflow")
+	logging.RequireLoggerFromContext(ctx).WithError(err).Error(ctx, "Failed to parse workflow")
 	os.Exit(1)
 	return nil
 }

--- a/cmd/argoexec/commands/agent.go
+++ b/cmd/argoexec/commands/agent.go
@@ -68,7 +68,7 @@ func tokenFilename(name string) string {
 func getPluginNames(ctx context.Context) []string {
 	var names []string
 	if err := json.Unmarshal([]byte(os.Getenv(common.EnvVarPluginNames)), &names); err != nil {
-		logging.RequireLoggerFromContext(ctx).WithError(err).WithFatal().Error(ctx, "Failed to unmarshal plugin names")
+		logging.RequireLoggerFromContext(ctx).WithError(err).Error(ctx, "Failed to unmarshal plugin names")
 		os.Exit(1)
 	}
 	return names
@@ -77,7 +77,7 @@ func getPluginNames(ctx context.Context) []string {
 func getPluginAddresses(ctx context.Context) []string {
 	var addresses []string
 	if err := json.Unmarshal([]byte(os.Getenv(common.EnvVarPluginAddresses)), &addresses); err != nil {
-		logging.RequireLoggerFromContext(ctx).WithError(err).WithFatal().Error(ctx, "Failed to unmarshal plugin addresses")
+		logging.RequireLoggerFromContext(ctx).WithError(err).Error(ctx, "Failed to unmarshal plugin addresses")
 		os.Exit(1)
 	}
 	return addresses
@@ -115,12 +115,12 @@ func initAgentExecutor(ctx context.Context) *executor.AgentExecutor {
 
 	workflowName, ok := os.LookupEnv(common.EnvVarWorkflowName)
 	if !ok {
-		logger.WithFatal().Error(ctx, fmt.Sprintf("Unable to determine workflow name from environment variable %s", common.EnvVarWorkflowName))
+		logger.Error(ctx, fmt.Sprintf("Unable to determine workflow name from environment variable %s", common.EnvVarWorkflowName))
 		os.Exit(1)
 	}
 	workflowUID, ok := os.LookupEnv(common.EnvVarWorkflowUID)
 	if !ok {
-		logger.WithFatal().Error(ctx, fmt.Sprintf("Unable to determine workflow Uid from environment variable %s", common.EnvVarWorkflowUID))
+		logger.Error(ctx, fmt.Sprintf("Unable to determine workflow Uid from environment variable %s", common.EnvVarWorkflowUID))
 		os.Exit(1)
 	}
 
@@ -135,7 +135,7 @@ func initAgentExecutor(ctx context.Context) *executor.AgentExecutor {
 			Info(ctx, "loading token file for plugin")
 		data, err := os.ReadFile(filename)
 		if err != nil {
-			logger.WithError(err).WithFatal().Error(ctx, "Failed to read token file")
+			logger.WithError(err).Error(ctx, "Failed to read token file")
 			os.Exit(1)
 		}
 		plugins = append(plugins, rpc.New(address, string(data)))

--- a/cmd/argoexec/commands/emissary.go
+++ b/cmd/argoexec/commands/emissary.go
@@ -70,8 +70,8 @@ func runEmissary(ctx context.Context, containerName string, includeScriptOutput 
 
 	tracer, err := tracing.New(ctx, `argoexec`)
 	if err != nil {
-		logger.WithFatal().WithError(err).Error(ctx, "failed to initialize tracing")
-		return err
+		logger.WithError(err).Error(ctx, "failed to initialize tracing")
+		os.Exit(1) //nolint:gocritic // preserves the previous WithFatal behavior, which also skipped defers
 	}
 	defer func() {
 		if deferErr := tracer.Shutdown(context.WithoutCancel(ctx)); deferErr != nil {

--- a/cmd/argoexec/executor/init.go
+++ b/cmd/argoexec/executor/init.go
@@ -51,7 +51,7 @@ func Init(ctx context.Context, clientConfig clientcmd.ClientConfig, varRunArgo s
 
 	podName, ok := os.LookupEnv(common.EnvVarPodName)
 	if !ok {
-		logger.WithFatal().Error(ctx, fmt.Sprintf("Unable to determine pod name from environment variable %s", common.EnvVarPodName))
+		logger.Error(ctx, fmt.Sprintf("Unable to determine pod name from environment variable %s", common.EnvVarPodName))
 		os.Exit(1)
 	}
 

--- a/cmd/workflow-controller/main.go
+++ b/cmd/workflow-controller/main.go
@@ -145,7 +145,8 @@ func NewRootCommand() *cobra.Command {
 			} else {
 				nodeID, ok := os.LookupEnv("LEADER_ELECTION_IDENTITY")
 				if !ok {
-					log.WithFatal().Error(ctx, "LEADER_ELECTION_IDENTITY must be set so that the workflow controllers can elect a leader")
+					log.Error(ctx, "LEADER_ELECTION_IDENTITY must be set so that the workflow controllers can elect a leader")
+					os.Exit(1)
 				}
 
 				leaderName := "workflow-controller"
@@ -233,14 +234,16 @@ func NewRootCommand() *cobra.Command {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	// bind flags to env vars (https://github.com/spf13/viper/tree/v1.17.0#working-with-flags)
 	if err := viper.BindPFlags(command.Flags()); err != nil {
-		log.WithFatal().WithError(err).Error(ctx, "failed to bind flags to env vars")
+		log.WithError(err).Error(ctx, "failed to bind flags to env vars")
+		os.Exit(1)
 	}
 	// workaround for handling required flags (https://github.com/spf13/viper/issues/397#issuecomment-544272457)
 	command.Flags().VisitAll(func(f *pflag.Flag) {
 		if !f.Changed && viper.IsSet(f.Name) {
 			val := viper.Get(f.Name)
 			if err := command.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-				log.WithFatal().WithError(err).WithFields(logging.Fields{"flag": f.Name, "value": val}).Error(ctx, "failed to set flag")
+				log.WithError(err).WithFields(logging.Fields{"flag": f.Name, "value": val}).Error(ctx, "failed to set flag")
+				os.Exit(1)
 			}
 		}
 	})

--- a/server/apiserver/argoserver.go
+++ b/server/apiserver/argoserver.go
@@ -174,7 +174,8 @@ func NewArgoServer(ctx context.Context, opts ArgoServerOpts) (Server, error) {
 		Interval: time.Second,
 	})
 	if err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.Error(ctx, err.Error())
+		os.Exit(1)
 	}
 
 	maxGRPCMessageSize, err := env.GetInt("GRPC_MESSAGE_SIZE", 100*1024*1024)
@@ -217,10 +218,12 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	log := logging.RequireLoggerFromContext(ctx)
 	config, err := as.configController.Get(ctx)
 	if err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.Error(ctx, err.Error())
+		os.Exit(1)
 	}
 	if err = config.Sanitize(as.allowedLinkProtocol); err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.Error(ctx, err.Error())
+		os.Exit(1)
 	}
 
 	// Rather than attempt to run CI with an artifact server alongside
@@ -228,12 +231,14 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	if os.Getenv("CI_ONLY_DISABLE_ARTIFACT_SERVER_CHECKS") != "true" {
 		// Validate artifact driver images against server pod images
 		if validateErr := as.validateArtifactDriverImages(ctx, config); validateErr != nil {
-			log.WithFatal().WithError(validateErr).Error(ctx, "failed to validate artifact driver images")
+			log.WithError(validateErr).Error(ctx, "failed to validate artifact driver images")
+			os.Exit(1)
 		}
 
 		// Validate artifact driver connections
 		if validateErr := as.validateArtifactDriverConnections(ctx, config); validateErr != nil {
-			log.WithFatal().WithError(validateErr).Error(ctx, "failed to validate artifact driver connections")
+			log.WithError(validateErr).Error(ctx, "failed to validate artifact driver connections")
+			os.Exit(1)
 		}
 	}
 
@@ -250,17 +255,20 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 			DBConfig:      persistence.DBConfig,
 		})
 		if sessionErr != nil {
-			log.WithFatal().Error(ctx, sessionErr.Error())
+			log.Error(ctx, sessionErr.Error())
+			os.Exit(1)
 		}
 		tableName, tableErr := persist.GetTableName(persistence)
 		if tableErr != nil {
-			log.WithFatal().Error(ctx, tableErr.Error())
+			log.Error(ctx, tableErr.Error())
+			os.Exit(1)
 		}
 		// we always enable node offload, as this is read-only for the Argo Server, i.e. you can turn it off if you
 		// like and the controller won't offload newly created workflows, but you can still read them
 		offloadRepo, err = persist.NewOffloadNodeStatusRepo(ctx, log, sessionProxy, persistence.GetClusterName(), tableName)
 		if err != nil {
-			log.WithError(err).WithFatal().Error(ctx, err.Error())
+			log.WithError(err).Error(ctx, err.Error())
+			os.Exit(1)
 		}
 		// we always enable the archive for the Argo Server, as the Argo Server does not write records, so you can
 		// disable the archiving - and still read old records
@@ -269,14 +277,16 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	resourceCacheNamespace := getResourceCacheNamespace(as.managedNamespace)
 	wftmplStore, err := workflowtemplate.NewInformer(as.restConfig, resourceCacheNamespace)
 	if err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.Error(ctx, err.Error())
+		os.Exit(1)
 	}
 	kubeclientset := kubernetes.NewForConfigOrDie(as.restConfig)
 	var cwftmplInformer clusterworkflowtemplate.Informer
 	if rbacutil.HasAccessToClusterWorkflowTemplates(ctx, kubeclientset) {
 		cwftmplInformer, err = clusterworkflowtemplate.NewInformer(as.restConfig)
 		if err != nil {
-			log.WithFatal().Error(ctx, err.Error())
+			log.Error(ctx, err.Error())
+			os.Exit(1)
 		}
 	} else {
 		cwftmplInformer = clusterworkflowtemplate.NewNullClusterWorkflowTemplate()
@@ -290,7 +300,8 @@ func (as *argoServer) Run(ctx context.Context, port int, browserOpenFunc func(st
 	syncServer := serversync.NewSyncServer(ctx, as.clients.Kubernetes, as.namespace, config.Synchronization)
 	wfStore, err := store.NewSQLiteStore(instanceIDService)
 	if err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.Error(ctx, err.Error())
+		os.Exit(1)
 	}
 	workflowServer := workflow.NewServer(ctx, instanceIDService, offloadRepo, wfArchive, as.clients.Workflow, wfStore, wfStore, wftmplStore, cwftmplInformer, config.WorkflowDefaults, &resourceCacheNamespace, artifactRepositories)
 	grpcServer := as.newGRPCServer(ctx, instanceIDService, workflowServer, wftmplStore, cwftmplInformer, wfArchiveServer, syncServer, eventServer, config.Links, config.Columns, config.NavColor, config.WorkflowDefaults)
@@ -414,7 +425,8 @@ func (as *argoServer) newHTTPServer(ctx context.Context, port int, artifactServe
 
 	rateLimitMiddleware, err := httplimit.NewMiddleware(as.apiRateLimiter, ipKeyFunc)
 	if err != nil {
-		log.WithFatal().Error(ctx, err.Error())
+		log.Error(ctx, err.Error())
+		os.Exit(1)
 	}
 
 	mux := http.NewServeMux()
@@ -618,12 +630,12 @@ func (as *argoServer) checkServeErr(ctx context.Context, name string, err error)
 	log := logging.RequireLoggerFromContext(ctx)
 	nameField := logging.Fields{"name": name}
 	if err != nil {
-		if as.stopCh == nil {
-			// a nil stopCh indicates a graceful shutdown
-			log.WithFields(nameField).WithError(err).Info(ctx, "graceful shutdown with error")
-		} else {
-			log.WithFields(nameField).WithError(err).WithFatal().Error(ctx, "server failure")
+		if as.stopCh != nil {
+			log.WithFields(nameField).WithError(err).Error(ctx, "server failure")
+			os.Exit(1)
 		}
+		// a nil stopCh indicates a graceful shutdown
+		log.WithFields(nameField).WithError(err).Info(ctx, "graceful shutdown with error")
 	} else {
 		log.WithFields(nameField).Info(ctx, "graceful shutdown")
 	}

--- a/server/clusterworkflowtemplate/informer.go
+++ b/server/clusterworkflowtemplate/informer.go
@@ -53,7 +53,7 @@ func (cwti *informerImpl) Run(ctx context.Context, stopCh <-chan struct{}) {
 		stopCh,
 		cwti.informer.Informer().HasSynced,
 	) {
-		logging.RequireLoggerFromContext(ctx).WithFatal().Error(ctx, "Timed out waiting for caches to sync")
+		logging.RequireLoggerFromContext(ctx).Error(ctx, "Timed out waiting for caches to sync")
 		os.Exit(1)
 	}
 }

--- a/server/workflowtemplate/informer.go
+++ b/server/workflowtemplate/informer.go
@@ -2,6 +2,7 @@ package workflowtemplate
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"k8s.io/client-go/dynamic"
@@ -49,14 +50,16 @@ func (wti *Informer) Run(ctx context.Context, stopCh <-chan struct{}) {
 		stopCh,
 		wti.informer.Informer().HasSynced,
 	) {
-		logging.RequireLoggerFromContext(ctx).WithFatal().Error(ctx, "Timed out waiting for caches to sync")
+		logging.RequireLoggerFromContext(ctx).Error(ctx, "Timed out waiting for caches to sync")
+		os.Exit(1)
 	}
 }
 
 // Getter returns a WorkflowTemplateNamespacedGetter. If namespace is empty, the Lister will use the namespace provided during initialization.
 func (wti *Informer) Getter(ctx context.Context, namespace string) templateresolution.WorkflowTemplateNamespacedGetter {
 	if wti.informer == nil {
-		logging.RequireLoggerFromContext(ctx).WithFatal().Error(ctx, "Template informer not started")
+		logging.RequireLoggerFromContext(ctx).Error(ctx, "Template informer not started")
+		os.Exit(1)
 	}
 	if namespace == "" {
 		namespace = wti.managedNamespace

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -178,6 +178,7 @@ func isTransientSqbErr(err error) bool {
 func CheckError(ctx context.Context, err error) {
 	if err != nil {
 		logger := logging.RequireLoggerFromContext(ctx)
-		logger.WithError(err).WithFatal().Error(ctx, "An error occurred during execution")
+		logger.WithError(err).Error(ctx, "An error occurred during execution")
+		os.Exit(1)
 	}
 }

--- a/util/file/fileutil.go
+++ b/util/file/fileutil.go
@@ -239,7 +239,8 @@ func WalkManifests(ctx context.Context, root string, fn func(path string, data [
 			}
 			defer func() {
 				if closeErr := f.Close(); closeErr != nil {
-					logging.RequireLoggerFromContext(ctx).WithError(closeErr).WithField("path", path).WithFatal().Error(ctx, "Error closing file")
+					logging.RequireLoggerFromContext(ctx).WithError(closeErr).WithField("path", path).Error(ctx, "Error closing file")
+					os.Exit(1)
 				}
 			}()
 			r = f

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -136,8 +136,6 @@ type Logger interface {
 
 	// When issuing a log, adding this will panic
 	WithPanic() Logger
-	// When issuing a log, adding this will exit 1
-	WithFatal() Logger
 
 	Debug(ctx context.Context, msg string)
 

--- a/util/logging/slog.go
+++ b/util/logging/slog.go
@@ -15,7 +15,6 @@ type slogLogger struct {
 	level     Level
 	hooks     map[Level][]Hook
 	withPanic bool
-	withFatal bool
 }
 
 func fieldsToAttrs(fields Fields) []slog.Attr {
@@ -87,7 +86,6 @@ func (s *slogLogger) WithFields(fields Fields) Logger {
 		logger:    s.logger,
 		level:     s.level,
 		hooks:     s.hooks,
-		withFatal: s.withFatal,
 		withPanic: s.withPanic,
 	}
 }
@@ -104,7 +102,6 @@ func (s *slogLogger) WithField(name string, value any) Logger {
 		logger:    s.logger,
 		level:     s.level,
 		hooks:     s.hooks,
-		withFatal: s.withFatal,
 		withPanic: s.withPanic,
 	}
 }
@@ -117,19 +114,6 @@ func (s *slogLogger) WithPanic() Logger {
 		level:     s.level,
 		hooks:     s.hooks,
 		withPanic: true,
-		withFatal: s.withFatal,
-	}
-}
-
-// Only works with Error()
-func (s *slogLogger) WithFatal() Logger {
-	return &slogLogger{
-		fields:    s.fields,
-		logger:    s.logger,
-		level:     s.level,
-		hooks:     s.hooks,
-		withFatal: true,
-		withPanic: s.withPanic,
 	}
 }
 
@@ -160,14 +144,7 @@ func (s *slogLogger) executeHooks(ctx context.Context, level Level, msg string) 
 func (s *slogLogger) commonLog(ctx context.Context, level Level, msg string) {
 	s.executeHooks(ctx, level, msg)
 	s.logger.LogAttrs(ctx, convertLevel(level), msg, fieldsToAttrs(s.fields)...)
-	switch {
-	case s.withFatal:
-		exitFunc := GetExitFunc()
-		if exitFunc == nil {
-			os.Exit(1)
-		}
-		exitFunc(1)
-	case s.withPanic:
+	if s.withPanic {
 		panic(msg)
 	}
 }

--- a/util/telemetry/metrics.go
+++ b/util/telemetry/metrics.go
@@ -97,7 +97,8 @@ func NewMetrics(ctx context.Context, serviceName, prometheusName string, config 
 			}
 			options = append(options, metricsdk.WithReader(metricsdk.NewPeriodicReader(httpExporter)))
 		default:
-			logger.WithFatal().WithField("protocol", otlpProtocol).Error(ctx, "OTEL metric protocol invalid")
+			logger.WithField("protocol", otlpProtocol).Error(ctx, "OTEL metric protocol invalid")
+			os.Exit(1)
 		}
 	}
 

--- a/util/telemetry/tracing.go
+++ b/util/telemetry/tracing.go
@@ -125,7 +125,8 @@ func NewTracing(ctx context.Context, serviceName string, extraOpts ...tracesdk.T
 			}
 			options = append(options, tracesdk.WithBatcher(httpExporter))
 		default:
-			logger.WithFatal().WithField("protocol", otlpProtocol).Error(ctx, "OTEL tracing protocol invalid")
+			logger.WithField("protocol", otlpProtocol).Error(ctx, "OTEL tracing protocol invalid")
+			os.Exit(1)
 		}
 	}
 

--- a/workflow/artifacts/azure/azure.go
+++ b/workflow/artifacts/azure/azure.go
@@ -183,7 +183,8 @@ func DownloadFile(ctx context.Context, containerClient *container.Client, blobNa
 	defer func() {
 		if closeErr := outFile.Close(); closeErr != nil {
 			logger := logging.RequireLoggerFromContext(ctx)
-			logger.WithFatal().WithError(closeErr).Warn(ctx, "unable to close file")
+			logger.WithError(closeErr).Warn(ctx, "unable to close file")
+			os.Exit(1)
 		}
 	}()
 

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -366,14 +366,16 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		if wfc.controllerConfigMapInformer != nil {
 			go wfc.controllerConfigMapInformer.Run(ctx.Done())
 			if !cache.WaitForCacheSync(ctx.Done(), handlerSynced) {
-				logger.WithFatal().Error(ctx, "Timed out waiting for controller config map to sync")
+				logger.Error(ctx, "Timed out waiting for controller config map to sync")
+				os.Exit(1) //nolint:gocritic // preserves the previous WithFatal behavior, which also skipped defers
 			}
 		}
 	}
 
 	// init DB after leader election (if enabled)
 	if err := wfc.initDB(ctx); err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to init db")
+		logger.WithError(err).Error(ctx, "Failed to init db")
+		os.Exit(1)
 	}
 
 	defer wfc.wfQueue.ShutDown()
@@ -396,7 +398,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.wfInformer = util.NewWorkflowInformer(ctx, wfc.dynamicInterface, wfc.GetManagedNamespace(), workflowResyncPeriod, wfc.tweakListRequestListOptions, wfc.tweakWatchRequestListOptions, newIndexers(wfc.indexWorkflowSemaphoreKeys))
 	nsInformer, err := wfc.newNamespaceInformer(ctx, wfc.kubeclientset)
 	if err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to create namespace informer")
+		logger.WithError(err).Error(ctx, "Failed to create namespace informer")
+		os.Exit(1)
 	}
 	wfc.nsInformer = nsInformer
 	wfc.wftmplInformer = informer.NewTolerantWorkflowTemplateInformer(wfc.dynamicInterface, workflowTemplateResyncPeriod, wfc.managedNamespace)
@@ -406,7 +409,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.taskResultInformer = wfc.newWorkflowTaskResultInformer(ctx)
 	err = wfc.addWorkflowInformerHandlers(ctx)
 	if err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to add workflow informer handlers")
+		logger.WithError(err).Error(ctx, "Failed to add workflow informer handlers")
+		os.Exit(1)
 	}
 	wfc.PodController = pod.NewController(ctx, &wfc.Config, wfc.restConfig, wfc.GetManagedNamespace(), wfc.kubeclientset, wfc.wfInformer, wfc.metrics, wfc.enqueueWfFromPodLabel)
 
@@ -418,7 +422,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	wfc.createSynchronizationManager(ctx)
 	// init managers: throttler and SynchronizationManager
 	if err := wfc.initManagers(ctx); err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to init managers")
+		logger.WithError(err).Error(ctx, "Failed to init managers")
+		os.Exit(1)
 	}
 
 	if os.Getenv("WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS") != "false" {
@@ -452,7 +457,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		wfc.artGCTaskInformer.Informer().HasSynced,
 		wfc.taskResultInformer.HasSynced,
 	) {
-		logger.WithFatal().Error(ctx, "Timed out waiting for caches to sync")
+		logger.Error(ctx, "Timed out waiting for caches to sync")
+		os.Exit(1)
 	}
 	syncSpan.End()
 	span.End()
@@ -756,7 +762,8 @@ func (wfc *WorkflowController) createClusterWorkflowTemplateInformer(ctx context
 			ctx.Done(),
 			wfc.cwftmplInformer.Informer().HasSynced,
 		) {
-			logger.WithFatal().Error(ctx, "Timed out waiting for ClusterWorkflowTemplate cache to sync")
+			logger.Error(ctx, "Timed out waiting for ClusterWorkflowTemplate cache to sync")
+			os.Exit(1)
 		}
 	} else {
 		logger.Warn(ctx, "Controller doesn't have RBAC access for ClusterWorkflowTemplates")
@@ -767,7 +774,8 @@ func (wfc *WorkflowController) UpdateConfig(ctx context.Context) {
 	logger := logging.RequireLoggerFromContext(ctx)
 	c, err := wfc.configController.Get(ctx)
 	if err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to register watch for controller config map")
+		logger.WithError(err).Error(ctx, "Failed to register watch for controller config map")
+		os.Exit(1)
 	}
 	wfc.applyConfig(ctx, c)
 }
@@ -780,7 +788,8 @@ func (wfc *WorkflowController) updateConfigFromConfigMap(ctx context.Context, cm
 	logger := logging.RequireLoggerFromContext(ctx)
 	c, err := wfc.configController.Parse(cm)
 	if err != nil {
-		logger.WithError(err).WithFatal().Error(ctx, "Failed to parse controller config map")
+		logger.WithError(err).Error(ctx, "Failed to parse controller config map")
+		os.Exit(1)
 	}
 	wfc.applyConfig(ctx, c)
 }
@@ -788,7 +797,8 @@ func (wfc *WorkflowController) updateConfigFromConfigMap(ctx context.Context, cm
 func (wfc *WorkflowController) applyConfig(ctx context.Context, c *config.Config) {
 	wfc.Config = *c
 	if err := wfc.updateConfig(ctx); err != nil {
-		logging.RequireLoggerFromContext(ctx).WithError(err).WithFatal().Error(ctx, "Failed to update config")
+		logging.RequireLoggerFromContext(ctx).WithError(err).Error(ctx, "Failed to update config")
+		os.Exit(1)
 	}
 }
 

--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -48,8 +49,8 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 	defer func() {
 		nodePhase, phaseErr := woc.wf.Status.Nodes.GetPhase(node.ID)
 		if phaseErr != nil {
-			woc.log.WithField("nodeID", node.ID).WithFatal().Error(ctx, "was unable to obtain nodePhase for nodeID")
-			panic(fmt.Sprintf("unable to obtain nodePhase for %s", node.ID))
+			woc.log.WithField("nodeID", node.ID).Error(ctx, "was unable to obtain nodePhase for nodeID")
+			os.Exit(1)
 		}
 		if nodePhase.Fulfilled(node.TaskResultSynced) {
 			woc.killDaemonedChildren(ctx, node.ID)
@@ -100,8 +101,8 @@ func (woc *wfOperationCtx) executeSteps(ctx context.Context, nodeName string, tm
 					for _, outNodeID := range outboundNodeIDs {
 						outNodeName, nameErr := woc.wf.Status.Nodes.GetName(outNodeID)
 						if nameErr != nil {
-							woc.log.WithField("nodeID", outNodeID).WithFatal().Error(ctx, "was not able to obtain node name for nodeID")
-							panic(fmt.Sprintf("could not obtain the out noden name for %s", outNodeID))
+							woc.log.WithField("nodeID", outNodeID).Error(ctx, "was not able to obtain node name for nodeID")
+							os.Exit(1)
 						}
 						woc.addChildNode(ctx, outNodeName, sgNodeName)
 					}

--- a/workflow/controller/taskset.go
+++ b/workflow/controller/taskset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -123,8 +124,8 @@ func (woc *wfOperationCtx) nodeRequiresTaskSetReconciliation(ctx context.Context
 		// If any of the node's children need an HTTP reconciliation, the parent node will also need one
 		childNodeName, err := woc.wf.Status.Nodes.GetName(child)
 		if err != nil {
-			woc.log.WithField("nodeID", child).WithFatal().Error(ctx, "was unable to get child node name for nodeID")
-			panic("unable to obtain child node name")
+			woc.log.WithField("nodeID", child).Error(ctx, "was unable to get child node name for nodeID")
+			os.Exit(1)
 		}
 		if woc.nodeRequiresTaskSetReconciliation(ctx, childNodeName) {
 			return true

--- a/workflow/cron/controller.go
+++ b/workflow/cron/controller.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"time"
 
@@ -112,7 +113,8 @@ func (cc *Controller) Run(ctx context.Context) {
 	cc.cronWfInformer.Informer().SetTransform(informerutil.StripManagedFields)
 	err := cc.addCronWorkflowInformerHandler(ctx)
 	if err != nil {
-		cc.logger.WithFatal().Error(ctx, err.Error())
+		cc.logger.Error(ctx, err.Error())
+		os.Exit(1) //nolint:gocritic // preserves the previous WithFatal behavior, which also skipped defers
 	}
 
 	wfInformer := util.NewWorkflowInformer(ctx, cc.dynamicInterface, cc.managedNamespace, cronWorkflowResyncPeriod,

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -231,10 +231,11 @@ func (we *WorkflowExecutor) HandleError(ctx context.Context) func() {
 	return func() {
 		if r := recover(); r != nil {
 			util.WriteTerminateMessage(fmt.Sprintf("%v", r))
-			logging.RequireLoggerFromContext(ctx).WithFatal().WithFields(logging.Fields{
+			logging.RequireLoggerFromContext(ctx).WithFields(logging.Fields{
 				"error": r,
 				"stack": debug.Stack(),
 			}).Error(ctx, "executor panic")
+			os.Exit(1)
 		} else if len(we.errors) > 0 {
 			util.WriteTerminateMessage(we.errors[0].Error())
 		}
@@ -1100,7 +1101,8 @@ func isTarball(ctx context.Context, filePath string) (bool, error) {
 	}
 	defer func() {
 		if closeErr := f.Close(); closeErr != nil {
-			logger.WithFatal().WithField("path", filePath).WithError(closeErr).Error(ctx, "Error closing file")
+			logger.WithField("path", filePath).WithError(closeErr).Error(ctx, "Error closing file")
+			os.Exit(1)
 		}
 	}()
 	gzr, err := gzip.NewReader(f)

--- a/workflow/gccontroller/gc_controller.go
+++ b/workflow/gccontroller/gc_controller.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -75,7 +76,8 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 		},
 	})
 	if err != nil {
-		log.WithError(err).WithFatal().Error(ctx, "Failed to add queue event handler")
+		log.WithError(err).Error(ctx, "Failed to add queue event handler")
+		os.Exit(1)
 	}
 
 	_, err = wfInformer.AddEventHandler(cache.FilteringResourceEventHandler{
@@ -93,7 +95,8 @@ func NewController(ctx context.Context, wfClientset wfclientset.Interface, wfInf
 		},
 	})
 	if err != nil {
-		log.WithError(err).WithFatal().Error(ctx, "Failed to add retention event handler")
+		log.WithError(err).Error(ctx, "Failed to add retention event handler")
+		os.Exit(1)
 	}
 	return controller
 }

--- a/workflow/sync/sync_manager.go
+++ b/workflow/sync/sync_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -46,7 +47,8 @@ func (sm *Manager) WithMetrics(ctx context.Context, m *wfmetrics.Metrics) *Manag
 	sm.metrics = m
 	if m != nil {
 		if err := m.RegisterLockGauges(sm.LockMetrics); err != nil {
-			sm.log.WithError(err).WithFatal().Error(ctx, "failed to register lock gauge callbacks")
+			sm.log.WithError(err).Error(ctx, "failed to register lock gauge callbacks")
+			os.Exit(1)
 		}
 	}
 	return sm


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16692

### Motivation

When the logger moved from logr to slog in #14644, the ability for the logger to `exit(1)` (fatal) was retained from the legacy code. Exiting the process is not the responsibility of the logger.

### Modifications

- Removed `WithFatal` from the `Logger` interface in `util/logging/logging.go` and from both implementations (`slogLogger` in `util/logging/slog.go`, `initLogger` in `util/logging/init.go`), along with the `withFatal` flag plumbing (struct field, copy-on-write propagation, fatal branch in `commonLog`, `storage.fatal` handling).
- Every call site that relied on `WithFatal` now calls `os.Exit(1)` right after the `Error` call (about 60 sites across `cmd/`, `server/`, `workflow/`, `util/`), matching the pre-existing pattern in `cmd/argo/lint/lint.go`. Call sites that already had a redundant `os.Exit(1)` after a `WithFatal().Error(...)` call are now consistent rather than dead-code-after-exit.
- `SetExitFunc`/`GetExitFunc` stay because `cmd/argo/lint` still uses them to keep its exit testable; `cmd/argo/commands/lint_test.go` is unchanged and passes.
- Tests adjusted only inside `util/logging` (the `WithFatal`-specific init test is removed), per the issue's acceptance criteria.

### Verification

- `go build ./cmd/... ./server/... ./workflow/... ./util/...`
- `go test ./util/logging/... ./util/errors/... ./cmd/argo/lint/... ./cmd/argo/commands/`

### Documentation

Not needed — internal refactoring with no user-visible behavior change.

### AI

Code was prepared with the assistance of a generative AI coding agent; all changes were reviewed, built and tested by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized startup, configuration, validation, and runtime failure handling across command-line tools and services.
  * Errors now log clearly before terminating with exit status 1, preserving predictable failure behavior.
  * Failure paths exit directly instead of relying on fatal logging or panics, avoiding unintended cleanup behavior.

* **Refactor**
  * Removed fatal-logging support from the logging interface and implementation.
  * Unified unrecoverable error handling, including invalid telemetry settings, under explicit termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->