### PR TITLE
ci: fix expression injection in cherry-pick workflows

### DIFF
--- a/.github/workflows/cherry-pick-single.yml
+++ b/.github/workflows/cherry-pick-single.yml
@@ -32,6 +32,14 @@ jobs:
   cherry-pick:
     name: Cherry Pick to ${{ inputs.version_number }}
     runs-on: ubuntu-latest
+    # Inputs originate from a pull_request_target event, so they are passed
+    # through env rather than interpolated into `run:` scripts, where they
+    # would be a shell injection.
+    env:
+      MERGE_COMMIT: ${{ inputs.merge_commit_sha }}
+      VERSION_NUMBER: ${{ inputs.version_number }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      PR_TITLE: ${{ inputs.pr_title }}
     steps:
       - name: Generate a token
         id: generate-token
@@ -60,8 +68,7 @@ jobs:
         run: |
           set -e
 
-          MERGE_COMMIT="${{ inputs.merge_commit_sha }}"
-          TARGET_BRANCH="release-${{ inputs.version_number }}"
+          TARGET_BRANCH="release-${VERSION_NUMBER}"
 
           echo "🍒 Cherry-picking commit $MERGE_COMMIT to branch $TARGET_BRANCH"
 
@@ -72,7 +79,7 @@ jobs:
           fi
 
           # Create new branch for cherry-pick
-          CHERRY_PICK_BRANCH="cherry-pick-${{ inputs.pr_number }}-to-${TARGET_BRANCH}"
+          CHERRY_PICK_BRANCH="cherry-pick-${PR_NUMBER}-to-${TARGET_BRANCH}"
           git checkout -b "$CHERRY_PICK_BRANCH" "origin/$TARGET_BRANCH"
 
           # Perform cherry-pick
@@ -85,10 +92,15 @@ jobs:
             # Push the new branch
             git push origin "$CHERRY_PICK_BRANCH"
 
-            # Save data for PR creation
-            echo "branch_name=$CHERRY_PICK_BRANCH" >> "$GITHUB_OUTPUT"
-            echo "signoff=$SIGNOFF" >> "$GITHUB_OUTPUT"
-            echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+            # Save data for PR creation. The sign-off is contributor-written
+            # and may span several lines, so use the delimiter form.
+            {
+              echo "branch_name=$CHERRY_PICK_BRANCH"
+              echo "signoff<<SIGNOFF_EOF"
+              echo "$SIGNOFF"
+              echo "SIGNOFF_EOF"
+              echo "target_branch=$TARGET_BRANCH"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "❌ Cherry-pick failed due to conflicts"
             git cherry-pick --abort
@@ -96,34 +108,36 @@ jobs:
           fi
 
       - name: Create Pull Request
+        env:
+          SIGNOFF: ${{ steps.cherry-pick.outputs.signoff }}
+          TARGET_BRANCH: ${{ steps.cherry-pick.outputs.target_branch }}
+          BRANCH_NAME: ${{ steps.cherry-pick.outputs.branch_name }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # Create cherry-pick PR
-          TITLE="${PR_TITLE} (cherry-pick #${{ inputs.pr_number }} for ${{ inputs.version_number }})"
+          TITLE="${PR_TITLE} (cherry-pick #${PR_NUMBER} for ${VERSION_NUMBER})"
           BODY=$(cat <<EOF
-          Cherry-picked ${PR_TITLE} (#${{ inputs.pr_number }})
+          Cherry-picked ${PR_TITLE} (#${PR_NUMBER})
 
-          ${{ steps.cherry-pick.outputs.signoff }}
+          ${SIGNOFF}
           EOF
           )
 
           gh pr create \
             --title "$TITLE" \
             --body "$BODY" \
-            --base "${{ steps.cherry-pick.outputs.target_branch }}" \
-            --head "${{ steps.cherry-pick.outputs.branch_name }}"
+            --base "$TARGET_BRANCH" \
+            --head "$BRANCH_NAME"
 
           # Comment on original PR
-          gh pr comment ${{ inputs.pr_number }} \
-            --body "🍒 Cherry-pick PR created for ${{ inputs.version_number }}: #$(gh pr list --head ${{ steps.cherry-pick.outputs.branch_name }} --json number --jq '.[0].number')"
-        env:
-          PR_TITLE: ${{ inputs.pr_title }}
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          gh pr comment "$PR_NUMBER" \
+            --body "🍒 Cherry-pick PR created for ${VERSION_NUMBER}: #$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')"
 
       - name: Comment on failure
         if: failure()
         run: |
-          gh pr comment ${{ inputs.pr_number }} \
-            --body "❌ Cherry-pick failed for ${{ inputs.version_number }}. Please check the [workflow logs](https://github.com/argoproj/argo-workflows/actions/runs/${{ github.run_id }}) for details."
+          gh pr comment "$PR_NUMBER" \
+            --body "❌ Cherry-pick failed for ${VERSION_NUMBER}. Please check the [workflow logs](https://github.com/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}) for details."
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           # This step must work even when the checkout failed, so don't rely

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -23,15 +23,21 @@ jobs:
     steps:
       - name: Extract cherry-pick labels
         id: extract-labels
+        # Event data is passed through env rather than interpolated into the
+        # script: this workflow runs under pull_request_target, so anything
+        # substituted into `run:` would be a shell injection.
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
         run: |
-          if [[ "${{ github.event.action }}" == "labeled" ]]; then
+          if [[ "$EVENT_ACTION" == "labeled" ]]; then
             # Label was just added - use it directly
-            LABEL_NAME="${{ github.event.label.name }}"
             VERSION="${LABEL_NAME#cherry-pick/}"
-            CHERRY_PICK_DATA='[{"label":"'$LABEL_NAME'","version":"'$VERSION'"}]'
+            CHERRY_PICK_DATA=$(jq -cn --arg label "$LABEL_NAME" --arg version "$VERSION" '[{label: $label, version: $version}]')
           else
             # PR was closed - find all cherry-pick labels
-            CHERRY_PICK_DATA=$(echo '${{ toJSON(github.event.pull_request.labels) }}' | jq -c '[.[] | select(.name | startswith("cherry-pick/")) | {label: .name, version: (.name | sub("cherry-pick/"; ""))}]')
+            CHERRY_PICK_DATA=$(echo "$LABELS_JSON" | jq -c '[.[] | select(.name | startswith("cherry-pick/")) | {label: .name, version: (.name | sub("cherry-pick/"; ""))}]')
           fi
 
           echo "labels=$CHERRY_PICK_DATA" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Supersedes #16265 — takeover of @XananasX7's fix, which could not be merged without a DCO sign-off. Credited via `Co-authored-by`. Extended to cover the reusable `cherry-pick-single.yml` workflow, which had the same class of problem and is the more exposed of the two.

- [x] Ran `make pre-commit -B` (n/a — workflow YAML only; ran `actionlint` and `zizmor` instead)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change (n/a — CI workflow)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

Both cherry-pick workflows run under `pull_request_target` and interpolate event- or contributor-derived values directly into `run:` scripts. Anything with shell metacharacters in it is executed on the runner:

- `cherry-pick.yml` — `github.event.label.name` and the labels JSON (as reported in #16265).
- `cherry-pick-single.yml` — every `inputs.*` value and, worse, `steps.cherry-pick.outputs.signoff`. That output is the `Signed-off-by:` line taken from the merged commit's message, i.e. text the PR author wrote, and it was expanded inside an unquoted heredoc in a step holding a write-scoped GitHub App token. A sign-off line containing `$(...)` would run on the runner with that token.

### Modifications

`cherry-pick.yml`
- `github.event.action`, `github.event.label.name` and `toJSON(github.event.pull_request.labels)` are passed via `env:` and referenced as `$VAR`.
- The labeled-event JSON is built with `jq --arg` rather than string concatenation.

`cherry-pick-single.yml`
- All `inputs.*` become job-level `env:` vars (`MERGE_COMMIT`, `VERSION_NUMBER`, `PR_NUMBER`, `PR_TITLE`).
- `steps.cherry-pick.outputs.*` become step-level `env:` vars in the "Create Pull Request" step.
- The failure comment uses `$GH_REPO` / `$GITHUB_RUN_ID` (already in env) instead of interpolation.
- `signoff` is written to `GITHUB_OUTPUT` using the multi-line delimiter form. A squash-merged PR commonly has more than one `Signed-off-by:` line, and `echo "signoff=$SIGNOFF"` with a multi-line value produces an invalid output file, which would fail the step after the branch had already been pushed.

No `${{ }}` expressions remain inside any `run:` block in either file. Behaviour is otherwise unchanged.

### Verification

- `actionlint` (with shellcheck): clean on both files.
- `zizmor --persona=auditor`: `template-injection` findings go from 17 (2 + 15) on `main` to 0. The remaining zizmor findings (`artipacked`, `github-app` permissions, `dangerous-triggers`, `concurrency-limits`) are pre-existing and out of scope.
- Can only be exercised end-to-end by merging and labelling a PR `cherry-pick/x.y`; happy to test that on a docs PR after merge.

### Documentation

None needed — CI workflow only.

### AI

Claude Code was used to audit the workflows for remaining interpolations, draft the changes, run the linters, and write this description; all reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cherry-pick workflow reliability when processing pull request and event data.
  * Corrected failure reporting so generated repository links point to the appropriate location.
  * Improved handling of multiline sign-off details and event labels during automated cherry-pick operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->