### PR TITLE
fix(cli): pass namespace to archived workflow get

### DIFF
--- a/cmd/argo/commands/archive/get.go
+++ b/cmd/argo/commands/archive/get.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -61,7 +62,7 @@ func NewGetCommand() *cobra.Command {
 				return fmt.Errorf("resolve UID: %w", err)
 			}
 
-			wf, err := serviceClient.GetArchivedWorkflow(ctx, &workflowarchivepkg.GetArchivedWorkflowRequest{Uid: uid})
+			wf, err := getArchivedWorkflow(ctx, serviceClient, uid, namespace)
 			if err != nil {
 				return err
 			}
@@ -74,6 +75,10 @@ func NewGetCommand() *cobra.Command {
 	command.Flags().BoolVar(&forceUID, "uid", false, "force the argument to be treated as a UID")
 	command.MarkFlagsMutuallyExclusive("name", "uid")
 	return command
+}
+
+func getArchivedWorkflow(ctx context.Context, serviceClient workflowarchivepkg.ArchivedWorkflowServiceClient, uid, namespace string) (*wfv1.Workflow, error) {
+	return serviceClient.GetArchivedWorkflow(ctx, &workflowarchivepkg.GetArchivedWorkflowRequest{Uid: uid, Namespace: namespace})
 }
 
 func printWorkflow(wf *wfv1.Workflow, output string) {

--- a/cmd/argo/commands/archive/get_test.go
+++ b/cmd/argo/commands/archive/get_test.go
@@ -1,0 +1,27 @@
+package archive
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	workflowarchivepkg "github.com/argoproj/argo-workflows/v4/pkg/apiclient/workflowarchive"
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+)
+
+func TestGetArchivedWorkflow(t *testing.T) {
+	serviceClient := &mockArchivedWorkflowServiceClient{}
+	expected := &wfv1.Workflow{}
+	serviceClient.On("GetArchivedWorkflow", mock.Anything, mock.MatchedBy(func(req *workflowarchivepkg.GetArchivedWorkflowRequest) bool {
+		return req.Uid == "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11" && req.Namespace == "example-workflows"
+	}), mock.Anything).Return(expected, nil).Once()
+
+	actual, err := getArchivedWorkflow(context.Background(), serviceClient, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "example-workflows")
+
+	require.NoError(t, err)
+	assert.Same(t, expected, actual)
+	serviceClient.AssertExpectations(t)
+}

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -1811,7 +1811,7 @@ func (s *CLISuite) TestArchive() {
 	})
 	s.Run("Get", func() {
 		s.Given().
-			RunCli([]string{"archive", "get", string(uid)}, func(t *testing.T, output string, err error) {
+			RunCli([]string{"archive", "get", string(uid), "--namespace", "argo"}, func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
 				assert.Contains(t, output, "Name:")
 				assert.Contains(t, output, "Namespace:")
@@ -1832,7 +1832,7 @@ func (s *CLISuite) TestArchive() {
 	})
 	s.Run("GetByNameFlag", func() {
 		s.Given().
-			RunCli([]string{"archive", "get", "--name", name}, func(t *testing.T, output string, err error) {
+			RunCli([]string{"archive", "get", "--name", name, "--namespace", "argo"}, func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
 				assert.Contains(t, output, "Name:")
 			})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: not applicable; this is a bug fix
- [x] Opened as draft; builds are green and this is ready for review

Fixes #16822

### Motivation

`argo archive get WORKFLOW --namespace NAMESPACE` did not include the namespace in the final `GetArchivedWorkflowRequest`. With SSO RBAC namespace delegation enabled, Argo Server could not select the namespace service account and instead evaluated the request using the login service account, resulting in `PermissionDenied`.

The request type already includes a namespace field, and the command already resolves the namespace for name-to-UID lookup. The namespace was only dropped from the final direct GET.

### Modifications

- Pass the resolved CLI namespace in `GetArchivedWorkflowRequest`.
- Add a unit regression test that verifies both the UID and namespace sent to the archived workflow client.
- Exercise explicit `--namespace` arguments for UID- and name-based archive GETs in the existing CLI E2E suite.

### Verification

Passed:

```text
make pre-commit -B
go test -count=1 ./cmd/argo/commands/archive ./server/auth ./server/workflowarchive
go test -run '^$' -tags cli ./test/e2e
git diff --check
```

A manual A/B regression test reproduced the failure with the released CLI and confirmed that the CLI built from this branch returns the archived workflow when an explicit namespace is supplied.

### Documentation

No documentation change is needed. This restores the existing `--namespace` flag behavior for `archive get` and does not introduce a new user-facing option.

### AI

OpenAI Codex assisted with investigating the request path, implementing the fix, adding tests, and preparing this PR description. I reviewed and validated the resulting changes, including a manual A/B regression test.

### Backport

This is a small, backward-compatible bug fix using an existing request field. Please consider adding the `cherry-pick/4.1` and `cherry-pick/4.0` labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archived workflow retrieval to correctly respect the specified namespace.
  * Improved archive retrieval by UID and name when using the namespace option.

* **Tests**
  * Added coverage to verify namespace-aware archived workflow retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->