### PR TITLE
feat(ui): add arbitrary template parameters

### DIFF
--- a/.features/pending/workflow-template-arbitrary-parameters.md
+++ b/.features/pending/workflow-template-arbitrary-parameters.md
@@ -1,0 +1,6 @@
+Description: Users can now add arbitrary `name` / `value` parameters when submitting `WorkflowTemplate` and `ClusterWorkflowTemplate` resources
+Authors: [Ruslan Shaydullin](https://github.com/ruslan-shaydullin)
+Component: UI
+Issues: 13035
+
+Custom parameters are submitted alongside those declared by the template.

--- a/ui/src/shared/components/arbitrary-parameters-input.tsx
+++ b/ui/src/shared/components/arbitrary-parameters-input.tsx
@@ -1,0 +1,85 @@
+import React, {useRef} from 'react';
+
+export interface ArbitraryParameter {
+    id: number;
+    name: string;
+    value: string;
+}
+
+interface Props {
+    parameters: ArbitraryParameter[];
+    onChange: (parameters: ArbitraryParameter[]) => void;
+}
+
+export function ArbitraryParametersInput({parameters, onChange}: Props) {
+    const nextID = useRef(0);
+
+    const addParameter = () => {
+        onChange([...parameters, {id: nextID.current++, name: '', value: ''}]);
+    };
+
+    const updateParameter = (id: number, changes: Partial<Pick<ArbitraryParameter, 'name' | 'value'>>) => {
+        onChange(parameters.map(parameter => (parameter.id === id ? {...parameter, ...changes} : parameter)));
+    };
+
+    const removeParameter = (id: number) => {
+        onChange(parameters.filter(parameter => parameter.id !== id));
+    };
+
+    return (
+        <>
+            {parameters.map((parameter, index) => {
+                const rowNumber = index + 1;
+                const nameInputID = `arbitrary-parameter-name-${parameter.id}`;
+                const valueInputID = `arbitrary-parameter-value-${parameter.id}`;
+                const nameErrorID = `arbitrary-parameter-name-error-${parameter.id}`;
+
+                return (
+                    <div className='row' key={parameter.id} role='group' aria-label={`Arbitrary parameter ${rowNumber}`} style={{marginTop: 14}}>
+                        <div className={`columns small-12 medium-4 ${parameter.name ? '' : 'error'}`}>
+                            <label htmlFor={nameInputID}>Name</label>
+                            <input
+                                id={nameInputID}
+                                className='argo-field'
+                                aria-label={`Arbitrary parameter ${rowNumber} name`}
+                                aria-invalid={!parameter.name}
+                                aria-describedby={!parameter.name ? nameErrorID : undefined}
+                                required
+                                value={parameter.name}
+                                onChange={event => updateParameter(parameter.id, {name: event.target.value})}
+                            />
+                            {!parameter.name && (
+                                <div id={nameErrorID} className='argo-form-row__error-msg'>
+                                    Parameter name is required
+                                </div>
+                            )}
+                        </div>
+                        <div className='columns small-12 medium-7'>
+                            <label htmlFor={valueInputID}>Value</label>
+                            <textarea
+                                id={valueInputID}
+                                className='argo-field'
+                                aria-label={`Arbitrary parameter ${rowNumber} value`}
+                                value={parameter.value}
+                                onChange={event => updateParameter(parameter.id, {value: event.target.value})}
+                            />
+                        </div>
+                        <div className='columns small-12 medium-1' style={{paddingTop: 24}}>
+                            <button
+                                type='button'
+                                className='argo-button argo-button--base-o'
+                                aria-label={`Remove arbitrary parameter ${rowNumber}`}
+                                title={`Remove arbitrary parameter ${rowNumber}`}
+                                onClick={() => removeParameter(parameter.id)}>
+                                <i className='fa fa-trash' aria-hidden='true' />
+                            </button>
+                        </div>
+                    </div>
+                );
+            })}
+            <button type='button' className='argo-button argo-button--base-o' style={{marginTop: 14}} onClick={addParameter}>
+                <i className='fa fa-plus' aria-hidden='true' /> Add a parameter
+            </button>
+        </>
+    );
+}

--- a/ui/src/workflows/components/submit-workflow-panel.arbitrary-parameters.test.tsx
+++ b/ui/src/workflows/components/submit-workflow-panel.arbitrary-parameters.test.tsx
@@ -1,0 +1,106 @@
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
+import React from 'react';
+
+import {Context} from '../../shared/context';
+import {Parameter, Template} from '../../shared/models';
+import {services} from '../../shared/services';
+import {SubmitWorkflowPanel} from './submit-workflow-panel';
+
+function renderPanel(workflowParameters: Parameter[] = [], templates: Template[] = [], kind: 'ClusterWorkflowTemplate' | 'WorkflowTemplate' = 'WorkflowTemplate') {
+    const navigation = {goto: jest.fn()};
+
+    render(
+        <Context.Provider value={{navigation} as any}>
+            <SubmitWorkflowPanel
+                kind={kind}
+                namespace='argo'
+                name='example-template'
+                entrypoint=''
+                templates={templates}
+                workflowParameters={workflowParameters}
+                history={createMemoryHistory()}
+            />
+        </Context.Provider>
+    );
+
+    return navigation;
+}
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe('SubmitWorkflowPanel arbitrary parameters', () => {
+    it('appends an arbitrary parameter after declared workflow and entrypoint parameters', async () => {
+        const submit = jest.spyOn(services.workflows, 'submit').mockResolvedValue({metadata: {namespace: 'argo', name: 'submitted-workflow'}} as any);
+        const navigation = renderPanel(
+            [{name: 'workflow', default: 'workflow-value'}],
+            [{name: 'main', inputs: {parameters: [{name: 'entrypoint', default: 'entrypoint-value'}]}}],
+            'ClusterWorkflowTemplate'
+        );
+
+        fireEvent.click(screen.getByRole('button', {name: 'Add a parameter'}));
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 1 name'), {target: {value: 'custom'}});
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 1 value'), {target: {value: 'a=b'}});
+        fireEvent.click(document.querySelector('.select__value') as HTMLElement);
+        fireEvent.click(screen.getByText('main'));
+
+        expect(screen.getByLabelText('Arbitrary parameter 1 name')).toHaveValue('custom');
+        expect(screen.getByLabelText('Arbitrary parameter 1 value')).toHaveValue('a=b');
+        fireEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+        await waitFor(() => {
+            expect(submit).toHaveBeenCalledWith(
+                'ClusterWorkflowTemplate',
+                'example-template',
+                'argo',
+                expect.objectContaining({parameters: ['workflow=workflow-value', 'entrypoint=entrypoint-value', 'custom=a=b']})
+            );
+        });
+        expect(navigation.goto).toHaveBeenCalledWith('/workflows/argo/submitted-workflow');
+    });
+
+    it('requires a name but allows an empty value', async () => {
+        const submit = jest.spyOn(services.workflows, 'submit').mockResolvedValue({metadata: {namespace: 'argo', name: 'submitted-workflow'}} as any);
+        renderPanel();
+
+        expect(screen.getByText('No parameters')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', {name: 'Add a parameter'}));
+
+        expect(screen.queryByText('No parameters')).not.toBeInTheDocument();
+        expect(screen.getByText('Parameter name is required')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Submit'})).toBeDisabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Submit'}));
+        expect(submit).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 1 name'), {target: {value: 'empty-value'}});
+        expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+        await waitFor(() => {
+            expect(submit).toHaveBeenCalledWith('WorkflowTemplate', 'example-template', 'argo', expect.objectContaining({parameters: ['empty-value=']}));
+        });
+    });
+
+    it('removes only the selected arbitrary parameter', async () => {
+        const submit = jest.spyOn(services.workflows, 'submit').mockResolvedValue({metadata: {namespace: 'argo', name: 'submitted-workflow'}} as any);
+        renderPanel();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Add a parameter'}));
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 1 name'), {target: {value: 'removed'}});
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 1 value'), {target: {value: 'value'}});
+        fireEvent.click(screen.getByRole('button', {name: 'Add a parameter'}));
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 2 name'), {target: {value: 'kept'}});
+        fireEvent.change(screen.getByLabelText('Arbitrary parameter 2 value'), {target: {value: 'other-value'}});
+        fireEvent.click(screen.getByRole('button', {name: 'Remove arbitrary parameter 1'}));
+
+        expect(screen.getByLabelText('Arbitrary parameter 1 name')).toHaveValue('kept');
+        expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();
+        fireEvent.click(screen.getByRole('button', {name: 'Submit'}));
+
+        await waitFor(() => {
+            expect(submit).toHaveBeenCalledWith('WorkflowTemplate', 'example-template', 'argo', expect.objectContaining({parameters: ['kept=other-value']}));
+        });
+    });
+});

--- a/ui/src/workflows/components/submit-workflow-panel.tsx
+++ b/ui/src/workflows/components/submit-workflow-panel.tsx
@@ -3,6 +3,7 @@ import {History} from 'history';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {uiUrl} from '../../shared/base';
+import {ArbitraryParameter, ArbitraryParametersInput} from '../../shared/components/arbitrary-parameters-input';
 import {ArtifactsInput, ArtifactUploadResponse} from '../../shared/components/artifacts-input';
 import {ErrorNotice} from '../../shared/components/error-notice';
 import {getValueFromParameter, ParametersInput} from '../../shared/components/parameters-input';
@@ -38,11 +39,13 @@ export function SubmitWorkflowPanel(props: Props) {
     const [entrypoint, setEntrypoint] = useState(props.entrypoint || workflowEntrypoint);
     const [parameters, setParameters] = useState<Parameter[]>([]);
     const [workflowParameters, setWorkflowParameters] = useState<Parameter[]>(JSON.parse(JSON.stringify(props.workflowParameters)));
+    const [arbitraryParameters, setArbitraryParameters] = useState<ArbitraryParameter[]>([]);
     const [labels, setLabels] = useState(['submit-from-ui=true']);
     const [error, setError] = useState<Error>();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [uploadedArtifacts, setUploadedArtifacts] = useState<Record<string, ArtifactUploadResponse>>({});
     const [uploadingArtifacts, setUploadingArtifacts] = useState<Set<string>>(new Set());
+    const hasIncompleteArbitraryParameter = arbitraryParameters.some(parameter => parameter.name.length === 0);
 
     const handleArtifactUploadStart = (artifactName: string) => {
         setUploadingArtifacts(prev => new Set(prev).add(artifactName));
@@ -102,7 +105,8 @@ export function SubmitWorkflowPanel(props: Props) {
                 entryPoint: entrypoint === workflowEntrypoint ? null : entrypoint,
                 parameters: [
                     ...workflowParameters.filter(p => getValueFromParameter(p) !== undefined).map(p => p.name + '=' + getValueFromParameter(p)),
-                    ...parameters.filter(p => getValueFromParameter(p) !== undefined).map(p => p.name + '=' + getValueFromParameter(p))
+                    ...parameters.filter(p => getValueFromParameter(p) !== undefined).map(p => p.name + '=' + getValueFromParameter(p)),
+                    ...arbitraryParameters.map(parameter => `${parameter.name}=${parameter.value}`)
                 ],
                 labels: labels.join(','),
                 artifacts: artifactOverrides.length > 0 ? artifactOverrides : undefined
@@ -144,7 +148,7 @@ export function SubmitWorkflowPanel(props: Props) {
                     <label>Parameters</label>
                     {workflowParameters.length > 0 && <ParametersInput parameters={workflowParameters} onChange={setWorkflowParameters} />}
                     {parameters.length > 0 && <ParametersInput parameters={parameters} onChange={setParameters} />}
-                    {workflowParameters.length === 0 && parameters.length === 0 ? (
+                    {workflowParameters.length === 0 && parameters.length === 0 && arbitraryParameters.length === 0 ? (
                         <>
                             <br />
                             <label>No parameters</label>
@@ -152,6 +156,7 @@ export function SubmitWorkflowPanel(props: Props) {
                     ) : (
                         <></>
                     )}
+                    <ArbitraryParametersInput parameters={arbitraryParameters} onChange={setArbitraryParameters} />
                 </div>
                 {props.workflowArtifacts && props.workflowArtifacts.length > 0 && (
                     <div key='artifacts' style={{marginBottom: 25}}>
@@ -177,7 +182,7 @@ export function SubmitWorkflowPanel(props: Props) {
                     <TagsInput tags={labels} onChange={setLabels} />
                 </div>
                 <div key='submit'>
-                    <button onClick={submit} className='argo-button argo-button--base' disabled={isSubmitting || uploadingArtifacts.size > 0}>
+                    <button onClick={submit} className='argo-button argo-button--base' disabled={isSubmitting || uploadingArtifacts.size > 0 || hasIncompleteArbitraryParameter}>
                         <i className='fa fa-plus' /> {isSubmitting ? 'Loading...' : uploadingArtifacts.size > 0 ? 'Uploading...' : 'Submit'}
                     </button>
                 </div>


### PR DESCRIPTION
- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #13035

### Motivation

The submit UI for `WorkflowTemplate` and `ClusterWorkflowTemplate` currently only allows users to provide parameters declared by the template. The backend already accepts parameters in `name=value` format, but the UI provides no way to add a parameter that was not declared in advance. This change removes that UI limitation.

### Modifications

- Added Name/Value rows with controls for adding and removing custom parameters.
- Custom parameters are appended after the workflow and entrypoint parameters in the submit payload.
- Empty values are supported and submitted as `name=`.
- Values containing `=` are preserved in full.
- An empty parameter name displays a validation error and disables Submit.
- Added unique accessibility labels for the parameter controls.
- Implemented the change in the existing submit panel shared by `WorkflowTemplate` and `ClusterWorkflowTemplate`.
- Did not change the backend, API, CLI, retry/resubmit behavior, or dependencies.
- Added the required feature-description file.

### Screenshots

#### Empty template

<img width="1440" height="1000" alt="empty-before" src="https://github.com/user-attachments/assets/b23f4fad-38bd-46fb-adf4-4a38e85996f4" />

#### Declared and custom parameters

<img width="1440" height="1000" alt="submit-panel" src="https://github.com/user-attachments/assets/ef7274c0-7430-4839-afc4-416771f13fc9" />

#### Narrow viewport

<img width="760" height="1053" alt="empty-after-narrow" src="https://github.com/user-attachments/assets/a500edff-2901-4190-8433-dd4fd8434cc8" />

### Verification

- Test-first RED: all 3 focused tests initially failed because the Add control was absent.
- Focused Jest tests: 3/3 passed.
- Full UI Jest suite: 29 suites and 138 tests passed.
- UI lint, TypeScript checking, and E2E type-checking passed.
- The production webpack build passed with the existing bundle-size warnings.
- Dependency deduplication passed, and `yarn.lock` remained unchanged.
- `make features-validate` passed.
- `make features-preview` passed.
- `make pre-commit -B` passed.
- `git diff --check` passed.
- Completed mocked-API browser QA on desktop and narrow viewports.
- The full Playwright E2E suite against a live cluster was not run.

### Documentation

Added `.features/pending/workflow-template-arbitrary-parameters.md`, which will include the feature in the generated release notes. Users can discover the functionality through the visible `Add a parameter` control in the existing Submit Workflow panel, so separate user documentation is not needed. API documentation is not required because the API is unchanged.

### AI

OpenAI Codex was used to help analyze the relevant code, implement the UI changes, write tests, check accessibility, prepare the feature-file metadata, run local validation, and suggest the commit subject. I personally reviewed and analyzed the resulting code and tests, verified how the changes integrate with the existing submit flow, and checked the validation results. I also wrote and published the issue comment and both lines of the feature note, controlled all external actions, and created the DCO-signed commit. I understand the changes and remain fully responsible for the final implementation and contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for submitting custom name/value parameters with WorkflowTemplate and ClusterWorkflowTemplate resources.
  - Added controls to add, edit, and remove custom parameters directly from the workflow submission panel.
  - Custom parameters are submitted alongside parameters defined by the selected template.
  - Parameter names are required, while empty values are allowed.
  - Submission remains disabled until all custom parameter names are completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->