### PR TITLE
fix: use keyset pagination for archived workflow listing with label filters

### DIFF
--- a/persist/sqldb/selector.go
+++ b/persist/sqldb/selector.go
@@ -49,6 +49,17 @@ func BuildArchivedWorkflowSelector(selector db.Selector, tableName, labelTableNa
 	if count {
 		return selector, nil
 	}
+
+	// Use keyset pagination when a cursor is provided. This replaces
+	// OFFSET with a WHERE clause on (startedat, uid), providing
+	// constant-time pagination regardless of page depth.
+	if !options.CursorStartedAt.IsZero() && options.CursorUID != "" {
+		return selector.
+			And(db.Raw("(startedat, uid) < (?, ?)", options.CursorStartedAt, options.CursorUID)).
+			OrderBy(db.Raw("startedat desc, uid desc")).
+			Limit(options.Limit), nil
+	}
+
 	// If we were passed 0 as the limit, then we should load all available archived workflows
 	// to match the behavior of the `List` operations in the Kubernetes API
 	if options.Limit == 0 {

--- a/server/utils/list_options.go
+++ b/server/utils/list_options.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -22,6 +24,11 @@ type ListOptions struct {
 	Limit, Offset                int
 	ShowRemainingItemCount       bool
 	StartedAtAscending           bool
+	// CursorStartedAt and CursorUID enable keyset pagination for archived
+	// workflows. When set, the query uses WHERE (startedat, uid) < (cursor)
+	// instead of OFFSET, providing constant-time pagination.
+	CursorStartedAt time.Time
+	CursorUID       string
 }
 
 func (l ListOptions) WithLimit(limit int) ListOptions {
@@ -54,6 +61,40 @@ func (l ListOptions) WithStartedAtAscending(ascending bool) ListOptions {
 	return l
 }
 
+// archivedWorkflowCursor represents a keyset pagination cursor for archived
+// workflows. It encodes the position using startedat and uid for deterministic
+// ordering.
+type archivedWorkflowCursor struct {
+	StartedAt time.Time `json:"startedat"`
+	UID       string    `json:"uid"`
+}
+
+// EncodeArchivedWorkflowCursor creates a base64-encoded cursor token from a
+// startedat timestamp and uid.
+func EncodeArchivedWorkflowCursor(startedAt time.Time, uid string) string {
+	cursor := archivedWorkflowCursor{StartedAt: startedAt, UID: uid}
+	data, _ := json.Marshal(cursor)
+	return "c:" + base64.StdEncoding.EncodeToString(data)
+}
+
+// DecodeArchivedWorkflowCursor attempts to decode a continue token as an
+// archived workflow cursor. Returns the cursor and true if successful, or
+// zero values and false if the token is not a cursor.
+func DecodeArchivedWorkflowCursor(continueToken string) (archivedWorkflowCursor, bool) {
+	if !strings.HasPrefix(continueToken, "c:") {
+		return archivedWorkflowCursor{}, false
+	}
+	data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(continueToken, "c:"))
+	if err != nil {
+		return archivedWorkflowCursor{}, false
+	}
+	var cursor archivedWorkflowCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return archivedWorkflowCursor{}, false
+	}
+	return cursor, true
+}
+
 func BuildListOptions(options metav1.ListOptions, ns, namePrefix, nameFilter, createdAfter, finishedBefore string) (ListOptions, error) {
 	if options.Continue == "" {
 		options.Continue = "0"
@@ -61,14 +102,27 @@ func BuildListOptions(options metav1.ListOptions, ns, namePrefix, nameFilter, cr
 
 	limit := int(options.Limit)
 
-	offset, err := strconv.Atoi(options.Continue)
-	if err != nil {
-		// no need to use sutils here
-		return ListOptions{}, status.Error(codes.InvalidArgument, "listOptions.continue must be int")
-	}
-	if offset < 0 {
-		// no need to use sutils here
-		return ListOptions{}, status.Error(codes.InvalidArgument, "listOptions.continue must >= 0")
+	// Try to decode as an archived workflow cursor first (keyset pagination).
+	// Fall back to offset-based parsing for backward compatibility.
+	var offset int
+	var cursorStartedAt time.Time
+	var cursorUID string
+
+	if cursor, ok := DecodeArchivedWorkflowCursor(options.Continue); ok {
+		cursorStartedAt = cursor.StartedAt
+		cursorUID = cursor.UID
+		offset = 0 // offset is not used with keyset pagination
+	} else {
+		var err error
+		offset, err = strconv.Atoi(options.Continue)
+		if err != nil {
+			// no need to use sutils here
+			return ListOptions{}, status.Error(codes.InvalidArgument, "listOptions.continue must be int or cursor")
+		}
+		if offset < 0 {
+			// no need to use sutils here
+			return ListOptions{}, status.Error(codes.InvalidArgument, "listOptions.continue must >= 0")
+		}
 	}
 
 	// namespace is now specified as its own query parameter
@@ -80,6 +134,7 @@ func BuildListOptions(options metav1.ListOptions, ns, namePrefix, nameFilter, cr
 	maxStartedAt := time.Time{}
 	createdAfterTime := time.Time{}
 	finishedBeforeTime := time.Time{}
+	var err error
 
 	if createdAfter != "" {
 		createdAfterTime, err = time.Parse(time.RFC3339, createdAfter)
@@ -172,5 +227,7 @@ func BuildListOptions(options metav1.ListOptions, ns, namePrefix, nameFilter, cr
 		Limit:                  limit,
 		Offset:                 offset,
 		ShowRemainingItemCount: showRemainingItemCount,
+		CursorStartedAt:        cursorStartedAt,
+		CursorUID:              cursorUID,
 	}, nil
 }

--- a/server/utils/list_options_test.go
+++ b/server/utils/list_options_test.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"encoding/base64"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,7 +79,7 @@ func TestBuildListOptions(t *testing.T) {
 			options: metav1.ListOptions{
 				Continue: "invalid",
 			},
-			expectedError: status.Error(codes.InvalidArgument, "listOptions.continue must be int"),
+			expectedError: status.Error(codes.InvalidArgument, "listOptions.continue must be int or cursor"),
 		},
 		{
 			name: "Negative continue",
@@ -282,4 +284,58 @@ func mustParseToRequirements(t *testing.T, labelSelector string) labels.Requirem
 	requirements, err := labels.ParseToRequirements(labelSelector)
 	require.NoError(t, err)
 	return requirements
+}
+
+func TestArchivedWorkflowCursor(t *testing.T) {
+	t.Run("RoundTrip", func(t *testing.T) {
+		startedAt := time.Date(2024, 3, 15, 12, 30, 0, 0, time.UTC)
+		uid := "abc-123-def"
+		token := EncodeArchivedWorkflowCursor(startedAt, uid)
+		require.True(t, strings.HasPrefix(token, "c:"))
+
+		cursor, ok := DecodeArchivedWorkflowCursor(token)
+		require.True(t, ok)
+		require.Equal(t, startedAt, cursor.StartedAt)
+		require.Equal(t, uid, cursor.UID)
+	})
+
+	t.Run("ZeroTime", func(t *testing.T) {
+		token := EncodeArchivedWorkflowCursor(time.Time{}, "")
+		cursor, ok := DecodeArchivedWorkflowCursor(token)
+		require.True(t, ok)
+		require.True(t, cursor.StartedAt.IsZero())
+		require.Empty(t, cursor.UID)
+	})
+
+	t.Run("InvalidPrefix", func(t *testing.T) {
+		_, ok := DecodeArchivedWorkflowCursor("not-a-cursor")
+		require.False(t, ok)
+	})
+
+	t.Run("InvalidBase64", func(t *testing.T) {
+		_, ok := DecodeArchivedWorkflowCursor("c:not-valid-base64!!!")
+		require.False(t, ok)
+	})
+
+	t.Run("InvalidJSON", func(t *testing.T) {
+		token := "c:" + base64.StdEncoding.EncodeToString([]byte("not json"))
+		_, ok := DecodeArchivedWorkflowCursor(token)
+		require.False(t, ok)
+	})
+}
+
+func TestBuildListOptionsCursor(t *testing.T) {
+	startedAt := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	uid := "my-workflow-uid"
+	cursorToken := EncodeArchivedWorkflowCursor(startedAt, uid)
+
+	result, err := BuildListOptions(metav1.ListOptions{
+		Continue: cursorToken,
+		Limit:    10,
+	}, "", "", "", "", "")
+	require.NoError(t, err)
+	require.Equal(t, startedAt, result.CursorStartedAt)
+	require.Equal(t, uid, result.CursorUID)
+	require.Equal(t, 10, result.Limit)
+	require.Equal(t, 0, result.Offset)
 }

--- a/server/workflowarchive/archived_workflow_server.go
+++ b/server/workflowarchive/archived_workflow_server.go
@@ -62,7 +62,6 @@ func (w *archivedWorkflowServer) ListArchivedWorkflows(ctx context.Context, req 
 	}
 
 	limit := options.Limit
-	offset := options.Offset
 	// When the zero value is passed, we should treat this as returning all results
 	// to align ourselves with the behavior of the `List` endpoints in the Kubernetes API
 	loadAll := limit == 0
@@ -85,7 +84,7 @@ func (w *archivedWorkflowServer) ListArchivedWorkflows(ctx context.Context, req 
 		if err != nil {
 			return nil, sutils.ToStatusError(err, codes.Internal)
 		}
-		count := total - int64(offset) - int64(items.Len())
+		count := total - int64(options.Offset) - int64(items.Len())
 		if len(items) > limit {
 			count++
 		}
@@ -97,7 +96,11 @@ func (w *archivedWorkflowServer) ListArchivedWorkflows(ctx context.Context, req 
 
 	if !loadAll && len(items) > limit {
 		items = items[0:limit]
-		meta.Continue = fmt.Sprintf("%v", offset+limit)
+		// Use keyset cursor for pagination instead of offset. The cursor
+		// encodes the startedat and uid of the last item, enabling
+		// constant-time pagination regardless of page depth.
+		lastItem := items[len(items)-1]
+		meta.Continue = sutils.EncodeArchivedWorkflowCursor(lastItem.Status.StartedAt.Time, string(lastItem.UID))
 	}
 
 	sort.Sort(items)

--- a/server/workflowarchive/archived_workflow_server_test.go
+++ b/server/workflowarchive/archived_workflow_server_test.go
@@ -54,23 +54,33 @@ func Test_archivedWorkflowServer(t *testing.T) {
 			},
 		}, nil
 	})
+	// Mock workflows with StartedAt and UID for cursor-based pagination tests
+	wf1 := v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid-1"},
+		Status:     v1alpha1.WorkflowStatus{StartedAt: metav1.Time{Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}},
+	}
+	wf2 := v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{UID: "uid-2"},
+		Status:     v1alpha1.WorkflowStatus{StartedAt: metav1.Time{Time: time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)}},
+	}
 	// two pages of results for limit 1
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}, {}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Limit: 2, Offset: 1}).Return(v1alpha1.Workflows{{}}, nil)
+	cursor1 := sutils.EncodeArchivedWorkflowCursor(wf1.Status.StartedAt.Time, string(wf1.UID))
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1, wf2}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Limit: 2, Offset: 0, CursorStartedAt: wf1.Status.StartedAt.Time, CursorUID: string(wf1.UID)}).Return(v1alpha1.Workflows{wf2}, nil)
 	minStartAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	maxStartAt, _ := time.Parse(time.RFC3339, "2020-01-02T00:00:00Z")
 	createdTime := metav1.Time{Time: time.Now().UTC()}
 	finishedTime := metav1.Time{Time: createdTime.Add(time.Second * 2)}
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0, ShowRemainingItemCount: true}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "excluded-name", NameFilter: "NotEquals", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "exact-name", NameFilter: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "excluded-ns", NamespaceFilter: "NotEquals", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}, {}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "user-ns", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 1, Offset: 0}).Return(v1alpha1.Workflows{{}}, nil)
-	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "user-ns", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{{}, {}}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0, ShowRemainingItemCount: true}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "excluded-name", NameFilter: "NotEquals", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "exact-name", NameFilter: "", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "excluded-ns", NamespaceFilter: "NotEquals", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1, wf2}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "user-ns", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 1, Offset: 0}).Return(v1alpha1.Workflows{wf1}, nil)
+	repo.On("ListWorkflows", mock.Anything, sutils.ListOptions{Namespace: "user-ns", Name: "", NamePrefix: "", MinStartedAt: time.Time{}, MaxStartedAt: time.Time{}, Limit: 2, Offset: 0}).Return(v1alpha1.Workflows{wf1, wf2}, nil)
 	repo.On("CountWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0}).Return(int64(5), nil)
 	repo.On("CountWorkflows", mock.Anything, sutils.ListOptions{Namespace: "", Name: "my-name", NamePrefix: "my-", MinStartedAt: minStartAt, MaxStartedAt: maxStartAt, Limit: 2, Offset: 0, ShowRemainingItemCount: true}).Return(int64(5), nil)
 	repo.On("GetWorkflow", mock.Anything, "", "", "").Return(nil, nil)
@@ -143,8 +153,8 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		resp, err := w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{Limit: 1}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, "1", resp.Continue)
-		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{Continue: "1", Limit: 1}})
+		assert.Equal(t, cursor1, resp.Continue)
+		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{Continue: cursor1, Limit: 1}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
 		assert.Empty(t, resp.Continue)
@@ -183,18 +193,18 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{Namespace: "user-ns", ListOptions: &metav1.ListOptions{Limit: 1}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, "1", resp.Continue)
+		assert.Equal(t, cursor1, resp.Continue)
 		// pass namespace as field selector and not query parameter
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{Limit: 1, FieldSelector: "metadata.namespace=user-ns"}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, "1", resp.Continue)
+		assert.Equal(t, cursor1, resp.Continue)
 
 		// pass namespace as field selector and query parameter both, where both match
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{Namespace: "user-ns", ListOptions: &metav1.ListOptions{Limit: 1, FieldSelector: "metadata.namespace=user-ns"}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, "1", resp.Continue)
+		assert.Equal(t, cursor1, resp.Continue)
 
 		// pass namespace as field selector and query parameter both, where they don't match
 		_, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{Namespace: "user-ns", ListOptions: &metav1.ListOptions{Limit: 1, FieldSelector: "metadata.namespace=other-ns"}})
@@ -204,13 +214,13 @@ func Test_archivedWorkflowServer(t *testing.T) {
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{Limit: 1, FieldSelector: "metadata.namespace!=excluded-ns"}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, "1", resp.Continue)
+		assert.Equal(t, cursor1, resp.Continue)
 
 		// namespace DoubleEquals
 		resp, err = w.ListArchivedWorkflows(ctx, &workflowarchivepkg.ListArchivedWorkflowsRequest{ListOptions: &metav1.ListOptions{Limit: 1, FieldSelector: "metadata.namespace==user-ns"}})
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 1)
-		assert.Equal(t, "1", resp.Continue)
+		assert.Equal(t, cursor1, resp.Continue)
 	})
 	t.Run("GetArchivedWorkflow", func(t *testing.T) {
 		allowed = false


### PR DESCRIPTION
## Summary

Replaces OFFSET-based pagination with keyset/cursor-based pagination for archived workflow listing. This fixes the O(N) performance degradation that occurs when paginating deep pages with label filters.

## Motivation

Fixes #16815

When listing archived workflows with label filters, the current OFFSET-based approach becomes O(N) because the label EXISTS subquery is evaluated for every skipped row. On large installations with millions of archived workflows, this means each page takes progressively longer to load.

## Solution

Instead of using `OFFSET N`, the implementation now uses keyset pagination with a cursor that encodes the `(startedat, uid)` of the last seen item. The continue token is a base64-encoded JSON object prefixed with `c:` for forward compatibility.

**Example cursor token:** `c:eyJzdGFydGVkYXQiOiIyMDI0LTAzLTE1VDEyOjMwOjAwWiIsInVpZCI6IjEyMzQ1In0=`

Decoded: `{"startedat":"2024-03-15T12:30:00Z","uid":"12345"}`

The query changes from:
```sql
WHERE label EXISTS ... ORDER BY startedat DESC LIMIT N OFFSET M
```
to:
```sql
WHERE (startedat, uid) < (cursor_startedat, cursor_uid) ORDER BY startedat DESC, uid DESC LIMIT N
```

## Backward Compatibility

- Integer continue tokens are still supported for non-archived workflow listing
- The `c:` prefix distinguishes cursor tokens from integer offsets
- The change is transparent to API consumers

## Files Changed

- `server/utils/list_options.go` - Added cursor fields to `ListOptions`, encode/decode functions, updated `BuildListOptions` to parse cursor tokens
- `server/utils/list_options_test.go` - Added tests for cursor encode/decode and `BuildListOptions` with cursor tokens
- `persist/sqldb/selector.go` - Added keyset filtering in `BuildArchivedWorkflowSelector` when cursor is present
- `server/workflowarchive/archived_workflow_server.go` - Generate cursor tokens instead of offset-based continue values
- `server/workflowarchive/archived_workflow_server_test.go` - Updated tests to use cursor tokens

## Testing

All existing tests pass with the updated mock data and assertions. New unit tests added for cursor encode/decode and `BuildListOptions` with cursor tokens.

```bash
go test ./server/utils/... ./server/workflowarchive/...
ok  	github.com/argoproj/argo-workflows/v4/server/utils
ok  	github.com/argoproj/argo-workflows/v4/server/workflowarchive
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cursor-based pagination for archived workflow listings.
  - Continue tokens now preserve workflow position using timestamp and unique identifier data.
  - Existing offset-based pagination remains supported when no cursor is provided.

- **Bug Fixes**
  - Improved pagination consistency when archived workflows are added or removed between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->