### PR TITLE
docs: describe passing undeclared parameters at submission

### DIFF
--- a/docs/walk-through/parameters.md
+++ b/docs/walk-through/parameters.md
@@ -87,3 +87,5 @@ spec:
 ```
 
 In this workflow, both steps `A` and `B` would have the same log-level set to `INFO` and can easily be changed between workflow submissions using the `-p` flag.
+
+`-p` is not restricted to the parameters a spec already lists. Any name you pass is added to `spec.arguments.parameters`, so a template can refer to `{{workflow.parameters.log-level}}` even when the workflow itself never declares `log-level`, as long as you supply a value every time you submit. If you forget one, submission fails validation with `failed to resolve {{workflow.parameters.log-level}}`, which is why declaring the parameter with a default is usually the better choice.

--- a/docs/walk-through/parameters.md
+++ b/docs/walk-through/parameters.md
@@ -88,4 +88,6 @@ spec:
 
 In this workflow, both steps `A` and `B` would have the same log-level set to `INFO` and can easily be changed between workflow submissions using the `-p` flag.
 
-`-p` is not restricted to the parameters a spec already lists. Any name you pass is added to `spec.arguments.parameters`, so a template can refer to `{{workflow.parameters.log-level}}` even when the workflow itself never declares `log-level`, as long as you supply a value every time you submit. If you forget one, submission fails validation with `failed to resolve {{workflow.parameters.log-level}}`, which is why declaring the parameter with a default is usually the better choice.
+`-p` is not restricted to the parameters a spec already lists.
+Any name you pass is added to `spec.arguments.parameters`, so a template can refer to `{{workflow.parameters.log-level}}` even when the workflow itself never declares `log-level`, as long as you supply a value every time you submit.
+If you forget one, submission fails validation with `failed to resolve {{workflow.parameters.log-level}}`, which is why declaring the parameter with a default is usually the better choice.

--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -313,6 +313,8 @@ If you need to submit a `WorkflowTemplate` as a `Workflow` with parameters:
 argo submit --from workflowtemplate/workflow-template-submittable -p message=value1
 ```
 
+The parameters you pass this way do not have to be declared by the `WorkflowTemplate`. A template may reference `{{workflow.parameters.<name>}}` for a parameter it never declares, and you supply the value when you submit it.
+
 ### `kubectl`
 
 Using `kubectl apply -f` and `kubectl get wftmpl`

--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -313,7 +313,8 @@ If you need to submit a `WorkflowTemplate` as a `Workflow` with parameters:
 argo submit --from workflowtemplate/workflow-template-submittable -p message=value1
 ```
 
-The parameters you pass this way do not have to be declared by the `WorkflowTemplate`. A template may reference `{{workflow.parameters.<name>}}` for a parameter it never declares, and you supply the value when you submit it.
+The parameters you pass this way do not have to be declared by the `WorkflowTemplate`.
+A template can reference `{{workflow.parameters.<name>}}` for a parameter it never declares, which is useful when the parameter has no sensible default and you always want to supply the value at submission time.
 
 ### `kubectl`
 


### PR DESCRIPTION
- [x] Ran `make pre-commit -B` (docs only; `docs-lint`/`docs-spellcheck` tooling isn't installed locally, relying on CI)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change (docs only)
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Related to #13035

### Motivation

#13035 asks for the UI to allow arbitrary parameter input the way the CLI does. Looking into it, the CLI behaviour it refers to has never been documented anywhere, so a user has no way of knowing it exists.

`argo submit -p NAME=VALUE` does not check the name against the spec: `overrideParameters` in `workflow/util/util.go` builds a fresh parameter list from whatever you pass and appends the spec's own parameters afterwards. `SubmitWorkflow` calls that before `validate.Workflow`, so a value you supply resolves. On the other side, `validate.go` deliberately lets a `WorkflowTemplate` keep unresolved `{{workflow.parameters.*}}` references, with the comment "some of the parameters may come from the Workflow that uses it".

So a `WorkflowTemplate` can reference a global parameter it never declares and have the value supplied at submission time. That is exactly the use case in #13035 ("one that has no default or if you have some indirection"), and the docs only ever describe `-p` as *overriding* parameters that are already declared.

### Modifications

Two paragraphs:

- `docs/walk-through/parameters.md`: `-p` is not restricted to the parameters a spec lists, plus the failure mode when you forget to pass one.
- `docs/workflow-templates.md`: the same point for `argo submit --from workflowtemplate/...`.

### Verification

Read against the code paths named above rather than re-derived from the docs. The error message quoted in the walk-through is the literal string from `validateTemplateType`'s tag resolution failure.

### Documentation

This PR is the documentation.

### AI

Claude Code was used to research whether the behaviour was documented and to draft the two paragraphs. I checked the code paths it cited and edited the wording. Commit message and PR description reviewed by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that workflow submissions can provide parameters not explicitly declared in the workflow or template.
  - Documented that undeclared parameters can be referenced when values are supplied at submission time.
  - Noted that missing values cause submission validation errors and recommended declaring parameters with defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->