### PR TITLE
chore(deps): update golangci-lint to 2.13.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -642,7 +642,7 @@ manifests-validate:
 	kubectl apply --server-side --validate=strict --dry-run=server -f 'manifests/*.yaml'
 
 $(TOOL_GOLANGCI_LINT): Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b `go env GOPATH`/bin v2.12.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.13.2/install.sh | sh -s -- -b `go env GOPATH`/bin v2.13.2
 
 .PHONY: lint lint-go lint-ui
 lint: lint-go lint-ui features-validate ## Lint the project

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -92,8 +92,7 @@ func Wrap(err error, code string, message string) error {
 // be returned. If the error is nil, nil will be returned without further
 // investigation.
 func Cause(err error) error {
-	var argoErr argoerr
-	if errors.As(err, &argoErr) {
+	if argoErr, ok := errors.AsType[argoerr](err); ok {
 		return unwrapCauseArgoErr(argoErr.err)
 	}
 	return unwrapCause(err)
@@ -160,8 +159,7 @@ func (e argoerr) HTTPCode() int {
 
 // IsCode is a helper to determine if the error is of a specific code
 func IsCode(code string, err error) bool {
-	var argoErr argoerr
-	if errors.As(err, &argoErr) {
+	if argoErr, ok := errors.AsType[argoerr](err); ok {
 		return argoErr.code == code
 	}
 	return false

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -4396,11 +4396,19 @@ const (
 	SynchronizationTypeUnknown   SynchronizationType = "Unknown"
 )
 
+// GetStatus returns the status for the given lock type, or a nil interface
+// (not a typed nil pointer) when that status has not been initialised.
 func (ss *SynchronizationStatus) GetStatus(syncType SynchronizationType) SynchronizationAction {
 	switch syncType {
 	case SynchronizationTypeSemaphore:
+		if ss.Semaphore == nil {
+			return nil
+		}
 		return ss.Semaphore
 	case SynchronizationTypeMutex:
+		if ss.Mutex == nil {
+			return nil
+		}
 		return ss.Mutex
 	default:
 		panic("invalid syncType in GetStatus")

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -1771,3 +1771,22 @@ func TestSemaphoreStatus_LockAcquired_RemovesFromWaiting(t *testing.T) {
 		assert.Len(t, waiting.Holders, 2)
 	})
 }
+
+func TestSynchronizationStatus_GetStatus(t *testing.T) {
+	t.Run("nil pointers yield a nil interface", func(t *testing.T) {
+		ss := &SynchronizationStatus{}
+		// A typed nil (*SemaphoreStatus)(nil) inside the interface would be != nil,
+		// so callers guarding with `if s != nil` would then panic in LockReleased.
+		assert.Nil(t, ss.GetStatus(SynchronizationTypeSemaphore))
+		assert.Nil(t, ss.GetStatus(SynchronizationTypeMutex))
+	})
+	t.Run("set pointers are returned", func(t *testing.T) {
+		ss := &SynchronizationStatus{Semaphore: &SemaphoreStatus{}, Mutex: &MutexStatus{}}
+		assert.Same(t, ss.Semaphore, ss.GetStatus(SynchronizationTypeSemaphore))
+		assert.Same(t, ss.Mutex, ss.GetStatus(SynchronizationTypeMutex))
+	})
+	t.Run("unknown type panics", func(t *testing.T) {
+		ss := &SynchronizationStatus{}
+		assert.Panics(t, func() { ss.GetStatus(SynchronizationTypeUnknown) })
+	})
+}

--- a/server/artifacts/artifact_server.go
+++ b/server/artifacts/artifact_server.go
@@ -161,8 +161,7 @@ func (a *ArtifactServer) UploadInputArtifact(w http.ResponseWriter, r *http.Requ
 
 	// Parse multipart form (max 32MB in memory, rest on disk)
 	if parseErr := r.ParseMultipartForm(32 << 20); parseErr != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(parseErr, &maxBytesErr) {
+		if _, ok := errors.AsType[*http.MaxBytesError](parseErr); ok {
 			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
 			return
 		}
@@ -658,8 +657,7 @@ func (a *ArtifactServer) httpFromError(ctx context.Context, err error, w http.Re
 		statusCode = int(e.Status().Code)
 	} else {
 		// check if it's an internal ArgoError
-		var argoerr argoerrors.ArgoError
-		if errors.As(err, &argoerr) {
+		if argoerr, ok := errors.AsType[argoerrors.ArgoError](err); ok {
 			statusCode = argoerr.HTTPCode()
 		}
 	}

--- a/server/utils/errors.go
+++ b/server/utils/errors.go
@@ -72,8 +72,7 @@ func ToStatusError(err error, code codes.Code) error {
 	if alreadyConverted {
 		return err
 	}
-	var argoerr argoerrors.ArgoError
-	if errors.As(err, &argoerr) {
+	if argoerr, ok := errors.AsType[argoerrors.ArgoError](err); ok {
 		converted, newErr := httpToStatusError(argoerr.HTTPCode(), err.Error())
 		if converted {
 			return newErr

--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -85,10 +85,10 @@ func NewServer(ctx context.Context, instanceIDService instanceid.Service, offloa
 	}
 	if wfStore != nil && namespace != nil {
 		lw := &cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				return wfClientSet.ArgoprojV1alpha1().Workflows(*namespace).List(ctx, options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				return wfClientSet.ArgoprojV1alpha1().Workflows(*namespace).Watch(ctx, options)
 			},
 		}

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -306,16 +306,10 @@ func (s *ArtifactsSuite) TestStoppedWorkflow() {
 			SubmitWorkflow().
 			WaitForWorkflow(
 				fixtures.WorkflowCompletionOkay(true),
-				fixtures.Condition(func(wf *wfv1.Workflow) (bool, string) {
-					condition := "for artifacts to exist"
-
+				fixtures.Condition(func(_ *wfv1.Workflow) (bool, string) {
 					_, err1 := c.StatObject(ctx, "my-bucket-3", "on-deletion-wf-stopped-1", minio.StatObjectOptions{})
 					_, err2 := c.StatObject(ctx, "my-bucket-3", "on-deletion-wf-stopped-2", minio.StatObjectOptions{})
-
-					if err1 == nil && err2 == nil {
-						return true, condition
-					}
-					return false, condition
+					return err1 == nil && err2 == nil, "for artifacts to exist"
 				}))
 
 		then = when.Then()

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -19,8 +20,9 @@ var http2Client = &http.Client{
 	Transport: &http2.Transport{
 		AllowHTTP: true,
 		// Skip TLS dial
-		DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
-			return net.Dial(netw, addr)
+		DialTLSContext: func(ctx context.Context, netw, addr string, cfg *tls.Config) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, netw, addr)
 		},
 	},
 	CheckRedirect: httpClient.CheckRedirect,

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -164,8 +164,7 @@ func isTransientNetworkErr(err error) bool {
 
 func generateErrorString(err error) string {
 	errorString := err.Error()
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		errorString = fmt.Sprintf("%s %s", errorString, exitErr.Stderr)
 	}
 	return errorString

--- a/util/grpc/interceptor.go
+++ b/util/grpc/interceptor.go
@@ -181,6 +181,6 @@ func getClientIP(ctx context.Context) string {
 		return ""
 	}
 	address := p.Addr.String()
-	ip := strings.Split(address, ":")[0]
+	ip, _, _ := strings.Cut(address, ":")
 	return ip
 }

--- a/util/sqldb/session.go
+++ b/util/sqldb/session.go
@@ -243,8 +243,7 @@ func (sp *SessionProxy) isNetworkError(err error) bool {
 	}
 
 	// Check for specific error types
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		return netErr.Timeout()
 	}
 

--- a/util/unstructured/unstructured.go
+++ b/util/unstructured/unstructured.go
@@ -22,7 +22,7 @@ const workflowPaginationLimit = 500
 func NewFilteredUnstructuredInformer(ctx context.Context, resource schema.GroupVersionResource, client dynamic.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListRequestListOptions internalinterfaces.TweakListOptionsFunc, tweakWatchRequestListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListRequestListOptions != nil {
 					tweakListRequestListOptions(&options)
 				}
@@ -54,7 +54,7 @@ func NewFilteredUnstructuredInformer(ctx context.Context, resource schema.GroupV
 					Items: allWorkflows,
 				}, nil
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				if tweakWatchRequestListOptions != nil {
 					tweakWatchRequestListOptions(&options)
 				}

--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -45,8 +45,7 @@ func isTransientGCSErr(ctx context.Context, err error) bool {
 	if errors.Is(err, io.ErrUnexpectedEOF) || errutil.IsTransientErr(ctx, err) {
 		return true
 	}
-	var googleErr *googleapi.Error
-	if errors.As(err, &googleErr) {
+	if googleErr, ok := errors.AsType[*googleapi.Error](err); ok {
 		// Retry on 429 and 5xx, according to
 		// https://cloud.google.com/storage/docs/exponential-backoff.
 		return googleErr.Code == 429 || (googleErr.Code >= 500 && googleErr.Code < 600)

--- a/workflow/artifacts/oss/oss.go
+++ b/workflow/artifacts/oss/oss.go
@@ -412,8 +412,7 @@ func isTransientOSSErr(ctx context.Context, err error) bool {
 	if errutil.IsTransientErr(ctx, err) {
 		return true
 	}
-	var ossErr oss.ServiceError
-	if errors.As(err, &ossErr) {
+	if ossErr, ok := errors.AsType[oss.ServiceError](err); ok {
 		if slices.Contains(ossTransientErrorCodes, ossErr.Code) {
 			return true
 		}
@@ -520,8 +519,7 @@ func putDirectory(ctx context.Context, bucket *oss.Bucket, objectName, dir strin
 
 // IsOssErrCode tests if an err is an oss.ServiceError with the specified code
 func IsOssErrCode(err error, code string) bool {
-	var serr oss.ServiceError
-	if errors.As(err, &serr) {
+	if serr, ok := errors.AsType[oss.ServiceError](err); ok {
 		if serr.Code == code {
 			return true
 		}

--- a/workflow/artifacts/s3/s3.go
+++ b/workflow/artifacts/s3/s3.go
@@ -879,8 +879,7 @@ func (s *s3client) ListDirectory(bucket, keyPrefix string) ([]string, error) {
 
 // IsS3ErrCode returns if the supplied error is of a specific S3 error code
 func IsS3ErrCode(err error, code string) bool {
-	var minioErr minio.ErrorResponse
-	if errors.As(err, &minioErr) {
+	if minioErr, ok := errors.AsType[minio.ErrorResponse](err); ok {
 		return minioErr.Code == code
 	}
 	return false

--- a/workflow/controller/ns_watcher.go
+++ b/workflow/controller/ns_watcher.go
@@ -44,18 +44,18 @@ func (wfc *WorkflowController) newNamespaceInformer(ctx context.Context, kubecli
 	labelSelector := labels.NewSelector().
 		Add(*limitReq)
 
-	listFunc := func(opts metav1.ListOptions) (runtime.Object, error) {
+	listFunc := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		opts.LabelSelector = labelSelector.String()
 		return c.List(ctx, opts)
 	}
 
-	watchFunc := func(opts metav1.ListOptions) (watch.Interface, error) {
+	watchFunc := func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 		opts.Watch = true
 		opts.LabelSelector = labelSelector.String()
 		return c.Watch(ctx, opts)
 	}
 
-	source := &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+	source := &cache.ListWatch{ListWithContextFunc: listFunc, WatchFuncWithContext: watchFunc}
 	informer := cache.NewSharedIndexInformer(cache.ToListWatcherWithWatchListSemantics(source, kubeclientset), &apiv1.Namespace{}, nsResyncPeriod, cache.Indexers{})
 	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
 	informer.SetTransform(informerutil.StripManagedFields)

--- a/workflow/controller/pod/controller.go
+++ b/workflow/controller/pod/controller.go
@@ -65,7 +65,7 @@ func NewController(ctx context.Context, config *argoConfig.Config, restConfig *r
 		kubeclientset: clientSet,
 		wfInformer:    wfInformer,
 		workqueue:     metrics.RateLimiterWithBusyWorkers(ctx, workqueue.DefaultTypedControllerRateLimiter[string](), "pod_cleanup_queue"),
-		podInformer:   newInformer(ctx, clientSet, &config.InstanceID, &namespace),
+		podInformer:   newInformer(clientSet, &config.InstanceID, &namespace),
 		log:           log,
 		callBack:      callback,
 		restConfig:    restConfig,
@@ -282,7 +282,7 @@ func (c *Controller) deletePodEvent(ctx context.Context, obj any) {
 	c.commonPodEvent(ctx, pod, true)
 }
 
-func newWorkflowPodWatch(ctx context.Context, clientSet kubernetes.Interface, instanceID, namespace *string) *cache.ListWatch {
+func newWorkflowPodWatch(clientSet kubernetes.Interface, instanceID, namespace *string) *cache.ListWatch {
 	c := clientSet.CoreV1().Pods(*namespace)
 	// completed=false
 	labelSelector := labels.NewSelector().
@@ -291,7 +291,7 @@ func newWorkflowPodWatch(ctx context.Context, clientSet kubernetes.Interface, in
 		Add(*incompleteReq).
 		Add(util.InstanceIDRequirement(*instanceID))
 
-	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
+	listFunc := func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 		options.LabelSelector = labelSelector.String()
 		var allPods []apiv1.Pod
 		continueTok := ""
@@ -314,16 +314,16 @@ func newWorkflowPodWatch(ctx context.Context, clientSet kubernetes.Interface, in
 		}
 		return &apiv1.PodList{Items: allPods}, nil
 	}
-	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+	watchFunc := func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 		options.Watch = true
 		options.LabelSelector = labelSelector.String()
 		return c.Watch(ctx, options)
 	}
-	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+	return &cache.ListWatch{ListWithContextFunc: listFunc, WatchFuncWithContext: watchFunc}
 }
 
-func newInformer(ctx context.Context, clientSet kubernetes.Interface, instanceID, namespace *string) cache.SharedIndexInformer {
-	source := newWorkflowPodWatch(ctx, clientSet, instanceID, namespace)
+func newInformer(clientSet kubernetes.Interface, instanceID, namespace *string) cache.SharedIndexInformer {
+	source := newWorkflowPodWatch(clientSet, instanceID, namespace)
 	informer := cache.NewSharedIndexInformer(cache.ToListWatcherWithWatchListSemantics(source, clientSet), &apiv1.Pod{}, podResyncPeriod, cache.Indexers{
 		indexes.WorkflowIndex: indexes.MetaWorkflowIndexFunc,
 		indexes.NodeIDIndex:   indexes.MetaNodeIDIndexFunc,

--- a/workflow/cron/operator.go
+++ b/workflow/cron/operator.go
@@ -299,8 +299,7 @@ func (woc *cronWfOperationCtx) terminateOutstandingWorkflows(ctx context.Context
 				woc.log.WithField("name", wfObjectRef.Name).Warn(ctx, "workflow not found when trying to terminate outstanding workflows")
 				continue
 			}
-			var alreadyShutdownErr util.AlreadyShutdownError
-			if errors.As(err, &alreadyShutdownErr) {
+			if alreadyShutdownErr, ok := errors.AsType[util.AlreadyShutdownError](err); ok {
 				woc.log.Warn(ctx, alreadyShutdownErr.Error())
 				continue
 			}

--- a/workflow/executor/resource.go
+++ b/workflow/executor/resource.go
@@ -50,8 +50,7 @@ func (we *WorkflowExecutor) ExecResource(ctx context.Context, action string, man
 		return nil
 	})
 	if err != nil {
-		var exErr *exec.ExitError
-		if errors.As(err, &exErr) {
+		if exErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			errMsg := strings.TrimSpace(string(exErr.Stderr))
 			err = argoerrors.Wrap(err, argoerrors.CodeBadRequest, errMsg)
 		} else {

--- a/workflow/util/merge.go
+++ b/workflow/util/merge.go
@@ -73,7 +73,7 @@ func parseUserOverrideAllowlist(env string) ([]string, error) {
 	goName := map[string]string{}
 	t := reflect.TypeFor[wfv1.WorkflowSpec]()
 	for field := range t.Fields() {
-		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if name == "" || name == "-" {
 			name = field.Name // ponytail: fall back to Go name for any untagged field
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — n/a
- [x] Opened as draft; will mark "Ready for review" once builds are green

> Stacked on #16831 (first commit here); lint on `main` fails on staticcheck `SA4023` without it. Only the second commit is this PR.

### Motivation

Keep golangci-lint current: 2.12.2 → 2.13.2. The new version reports a handful of things on `main`, one of which was a real bug (split out into its own PR so it can be cherry-picked).

### Modifications

* `Makefile`: bump the pin (the only place it is pinned; nix uses nixpkgs' build, CI runs `make lint`).
* `--fix` rewrites: `errors.As(err, &x)` → `errors.AsType[T](err)`, `strings.Split(s, sep)[0]` → `strings.Cut` (modernize).
* staticcheck `SA1019`: deprecated `cache.ListWatch.ListFunc`/`WatchFunc` → `ListWithContextFunc`/`WatchFuncWithContext` in `server/workflow`, `util/unstructured`, `workflow/controller/ns_watcher.go`, `workflow/controller/pod/controller.go`. The closures now use the reflector's per-call ctx instead of the captured constructor ctx. That left `ctx` unused in `newWorkflowPodWatch`/`newInformer` (unparam), so it is dropped there.
* staticcheck `SA1019`: `http2.Transport.DialTLS` → `DialTLSContext` in `test/e2e/client.go`.
* unparam in `test/e2e/artifacts_test.go`: unused `wf` param and constant result in the `TestStoppedWorkflow` condition.

### Verification

`make lint-go` → 0 issues with 2.13.2. `go build ./...`, `go vet` with all e2e build tags, and unit tests for every touched package pass. `make codegen -B` produces no diff.

### Documentation

None needed.

### AI

Claude Code (Claude Fable 5) drove the bump, the follow-up fixes, the commit message and this description; I reviewed and verified them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of uninitialized synchronization statuses.
  - Improved cancellation and timeout handling for Kubernetes operations and HTTP/2 connections.
  - Improved client IP parsing for addresses containing ports.
  - Preserved accurate artifact upload size-limit errors and transient cloud-storage retry behavior.
  - Maintained consistent error reporting across workflow, artifact, and resource operations.

- **Chores**
  - Updated the Go linting tool to version 2.13.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->