### PR TITLE
fix(sync): return a nil interface from SynchronizationStatus.GetStatus for unset locks (cherry-pick #16831 for 4.1)

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -4396,11 +4396,19 @@ const (
 	SynchronizationTypeUnknown   SynchronizationType = "Unknown"
 )
 
+// GetStatus returns the status for the given lock type, or a nil interface
+// (not a typed nil pointer) when that status has not been initialised.
 func (ss *SynchronizationStatus) GetStatus(syncType SynchronizationType) SynchronizationAction {
 	switch syncType {
 	case SynchronizationTypeSemaphore:
+		if ss.Semaphore == nil {
+			return nil
+		}
 		return ss.Semaphore
 	case SynchronizationTypeMutex:
+		if ss.Mutex == nil {
+			return nil
+		}
 		return ss.Mutex
 	default:
 		panic("invalid syncType in GetStatus")

--- a/pkg/apis/workflow/v1alpha1/workflow_types_test.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types_test.go
@@ -1771,3 +1771,22 @@ func TestSemaphoreStatus_LockAcquired_RemovesFromWaiting(t *testing.T) {
 		assert.Len(t, waiting.Holders, 2)
 	})
 }
+
+func TestSynchronizationStatus_GetStatus(t *testing.T) {
+	t.Run("nil pointers yield a nil interface", func(t *testing.T) {
+		ss := &SynchronizationStatus{}
+		// A typed nil (*SemaphoreStatus)(nil) inside the interface would be != nil,
+		// so callers guarding with `if s != nil` would then panic in LockReleased.
+		assert.Nil(t, ss.GetStatus(SynchronizationTypeSemaphore))
+		assert.Nil(t, ss.GetStatus(SynchronizationTypeMutex))
+	})
+	t.Run("set pointers are returned", func(t *testing.T) {
+		ss := &SynchronizationStatus{Semaphore: &SemaphoreStatus{}, Mutex: &MutexStatus{}}
+		assert.Same(t, ss.Semaphore, ss.GetStatus(SynchronizationTypeSemaphore))
+		assert.Same(t, ss.Mutex, ss.GetStatus(SynchronizationTypeMutex))
+	})
+	t.Run("unknown type panics", func(t *testing.T) {
+		ss := &SynchronizationStatus{}
+		assert.Panics(t, func() { ss.GetStatus(SynchronizationTypeUnknown) })
+	})
+}


### PR DESCRIPTION
Manual cherry-pick of #16831 (01a2560af) onto release-4.1, opened ahead of the main PR merging so the fix can land in the next 4.1 patch. Clean pick; `TestSynchronizationStatus_GetStatus` and the `workflow/sync` tests pass on this branch.