### PR TITLE
chore(deps): update dagre to @dagrejs/dagre v3.1.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -19,13 +19,13 @@
         "node": ">=20"
     },
     "dependencies": {
+        "@dagrejs/dagre": "^3.1.1",
         "argo-ui": "git+https://github.com/argoproj/argo-ui.git#54f36c723d9a0e5d3386689298cbb9c27767fa00",
         "chart.js": "^2.9.4",
         "chartjs-plugin-annotation": "^0.5.7",
         "classnames": "^2.5.1",
         "cron-parser": "^4.9.0",
         "cronstrue": "^2.50.0",
-        "dagre": "^0.8.5",
         "history": "^4.10.1",
         "linkify-it": "^6.0.0",
         "moment": "^2.30.1",
@@ -58,7 +58,6 @@
         "@testing-library/react": "^16.3.0",
         "@types/chart.js": "^2.9.24",
         "@types/classnames": "^2.3.1",
-        "@types/dagre": "^0.7.52",
         "@types/history": "^4.6.2",
         "@types/jest": "^26.0.15",
         "@types/prop-types": "^15.7.11",

--- a/ui/src/shared/components/graph/pretty-layout.ts
+++ b/ui/src/shared/components/graph/pretty-layout.ts
@@ -1,11 +1,11 @@
-import * as dagre from 'dagre';
+import * as dagre from '@dagrejs/dagre';
 
 import {Graph, Node} from './types';
 
 const minSize = 1;
 export function layoutGraphPretty(graph: Graph, nodeSize: number, horizontal: boolean, hidden: (id: Node) => boolean) {
     const gap = nodeSize * 1.25;
-    const g = new dagre.graphlib.Graph();
+    const g = new dagre.graphlib.Graph<dagre.GraphLabel, dagre.NodeLabel, dagre.EdgeLabel>();
     g.setGraph({rankdir: horizontal ? 'LR' : 'TB', ranksep: gap, nodesep: gap, edgesep: gap});
     g.setDefaultEdgeLabel(() => ({}));
     graph.nodes.forEach((label, id) =>

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -958,6 +958,18 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@dagrejs/dagre@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dagrejs/dagre/-/dagre-3.1.1.tgz#06de3070d584886b8820aaceeefc45a553cf2b97"
+  integrity sha512-zroZB1dFOFiGgv4Xcrn1DckB1o4aOikPqD2NDQPV0WM//CXGcS6xiD0rNkqHmw6FEg4tabt4nxPLwgCWT+Vb2A==
+  dependencies:
+    "@dagrejs/graphlib" "4.0.5"
+
+"@dagrejs/graphlib@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@dagrejs/graphlib/-/graphlib-4.0.5.tgz#1ae7a93a4640a9e50117439d23327e27d6b698d3"
+  integrity sha512-7xrBTqIts3o+PMUZX97wSc+7TUbW+/rULzGNCTP6yooNVDXbzw4Wutg/H/xOutTB/c/k0YqOAavgPh4/Zk9PFA==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -1924,11 +1936,6 @@
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
   integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
-
-"@types/dagre@^0.7.52":
-  version "0.7.54"
-  resolved "https://registry.yarnpkg.com/@types/dagre/-/dagre-0.7.54.tgz#4f3be2a3f89938b0483013739362a477ec978a84"
-  integrity sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==
 
 "@types/debug@^4.0.0":
   version "4.1.13"
@@ -3648,14 +3655,6 @@ csstype@^3.2.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
-dagre@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
-  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
-  dependencies:
-    graphlib "^2.1.8"
-    lodash "^4.17.15"
-
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -4941,13 +4940,6 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
-
-graphlib@^2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
-  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
-  dependencies:
-    lodash "^4.17.15"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -6385,7 +6377,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.2.1, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.2.1, lodash@^4.7.0:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` — `make lint` passes; `codegen`/`docs` could not run in my environment (no `buf`/`markdownlint`); neither is relevant to a UI-only dependency change
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`) — n/a, not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

The UI's graph layout uses `dagre@0.8.5`, the last release of the unscoped package (2019). The project moved to `@dagrejs/dagre`, currently 3.1.1. The new package ships its own TypeScript types, so `@types/dagre` goes too, and it no longer depends on `lodash`.

Dependency checks: MIT licensed, actively maintained (3.1.1 released 2026-08-08), `yarn audit` clean.

### Modifications

- `ui/package.json`, `ui/yarn.lock`: `dagre` + `@types/dagre` → `@dagrejs/dagre@^3.1.1` (pulls `@dagrejs/graphlib@4.0.5`; drops `graphlib@2`).
- `ui/src/shared/components/graph/pretty-layout.ts`: import from `@dagrejs/dagre`; instantiate `Graph` with dagre's `GraphLabel`/`NodeLabel`/`EdgeLabel` generics (they default to `any`, which tripped `noImplicitAny` on `edge().points`). No layout API changes were needed.

Rendered against a live cluster, 351-node DAG:

<img width="1875" height="1113" alt="image" src="https://github.com/user-attachments/assets/4c4459cc-3de0-43d7-8425-9d9467888224" />
<img width="1875" height="1113" alt="image" src="https://github.com/user-attachments/assets/7fc11ee5-5315-4dd8-9679-09cb18eca55c" />

### Verification

- `yarn lint`, `yarn test` (28 suites), `yarn build` all pass.
- Ran the UI against a live v4.1.2 argo-server; DAG renders correctly in both vertical and horizontal layouts with no new console errors.

### Documentation

None needed — internal UI dependency.

### AI

Claude Code (Claude Fable 5) produced the change, ran the verification, and drafted this description; reviewed by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated graph layout support to use the latest Dagre package, improving compatibility and reliability.
  * Preserved existing graph layout behavior while ensuring type-safe graph configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->