### PR TITLE
fix(controller): skip empty optional step artifacts

### DIFF
--- a/workflow/controller/steps.go
+++ b/workflow/controller/steps.go
@@ -535,6 +535,9 @@ func (woc *wfOperationCtx) resolveReferences(ctx context.Context, stepGroup []wf
 				}
 				return fmt.Errorf("unable to resolve references: %w", err)
 			}
+			if art.Optional && !resolvedArt.HasLocationOrKey() {
+				continue
+			}
 			resolvedArt.Name = art.Name
 			artifacts = append(artifacts, *resolvedArt)
 		}

--- a/workflow/controller/steps_test.go
+++ b/workflow/controller/steps_test.go
@@ -12,6 +12,7 @@ import (
 	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 	"github.com/argoproj/argo-workflows/v4/util/variables"
+	varkeys "github.com/argoproj/argo-workflows/v4/util/variables/keys"
 )
 
 // TestStepsFailedRetries ensures a steps template will recognize exhausted retries
@@ -80,6 +81,28 @@ func TestArtifactResolutionWhenSkipped(t *testing.T) {
 
 	woc.operate(ctx)
 	assert.Equal(t, wfv1.WorkflowSucceeded, woc.wf.Status.Phase)
+}
+
+func TestResolveReferencesSkipsOptionalArtifactFromSkippedStep(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	woc := newWoc(ctx, wfv1.Workflow{})
+	scope := createScope(nil)
+	varkeys.StepsNodeRef.OutputsArtifactByName.Set(scope.scope, wfv1.Artifact{}, "generate", "message")
+	stepGroup := []wfv1.WorkflowStep{{
+		Name:     "consume",
+		Template: "consumer",
+		Arguments: wfv1.Arguments{Artifacts: wfv1.Artifacts{{
+			Name:     "message",
+			From:     "{{steps.generate.outputs.artifacts.message}}",
+			Optional: true,
+		}}},
+	}}
+
+	resolvedSteps, err := woc.resolveReferences(ctx, stepGroup, scope)
+
+	require.NoError(t, err)
+	require.Len(t, resolvedSteps, 1)
+	assert.Empty(t, resolvedSteps[0].Arguments.Artifacts)
 }
 
 var stepsWithParamAndGlobalParam = `


### PR DESCRIPTION
- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16477

### Motivation

A running step that consumes an `optional: true` artifact from a skipped step can retain an empty artifact placeholder. Later PodSpecPatch substitution then attempts to resolve that placeholder and fails.

### Modifications

Drop optional step artifact arguments that resolve without an artifact location or key. Add a controller regression test covering an optional artifact resolved from a skipped step output.

### Verification

Ran:

```console
KUBECONFIG=/dev/null go test -run 'Test(OptionalArgumentAndParameter|ResolveReferencesSkipsOptionalArtifactFromSkippedStep)' ./workflow/controller/
```

I also built the controller and argoexec and updated the controller's image and the configmap'as argoexec image.

I reran the workflow in the issue and it passed.

<img width="911" height="279" alt="image" src="https://github.com/user-attachments/assets/25791444-f4bc-4912-a735-eb20a501ed45" />
 


### Documentation

No documentation change is needed. This restores the documented behavior of optional artifact inputs.

### AI

GitHub Copilot assisted with investigation, implementation, test creation, and this PR description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optional artifacts without available data are no longer passed to workflow steps.
  * Steps depending on skipped optional artifacts now proceed without invalid artifact arguments.
* **Tests**
  * Added coverage to verify optional artifacts from skipped steps are correctly omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->