### PR TITLE
fix(cli): report YAML parse errors instead of silently dropping documents

### DIFF
--- a/cmd/argo/lint/lint.go
+++ b/cmd/argo/lint/lint.go
@@ -150,6 +150,12 @@ func lintData(ctx context.Context, src string, data []byte, opts *Options) *Resu
 	for i, pr := range common.ParseObjects(ctx, data, opts.Strict) {
 		obj, err := pr.Object, pr.Err
 		if obj == nil {
+			if err != nil {
+				// report parse errors even when the document could not be converted
+				// to a Kubernetes object, so users learn which file failed and why
+				res.Linted = true // the file was processed and found broken
+				res.Errs = append(res.Errs, fmt.Errorf("in object #%d: %w", i+1, err))
+			}
 			continue // could not parse to kubernetes object
 		}
 		// we should prefer the object's namespace

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -348,3 +348,78 @@ func TestGetObjectName(t *testing.T) {
 		})
 	}
 }
+
+// TestLintDirectoryWithInvalidFile verifies that when linting a directory containing
+// many files, a file with a YAML error is reported by name instead of the whole
+// directory passing with "no linting errors found!" (#9550).
+func TestLintDirectoryWithInvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	valid := `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: good-
+spec:
+  entrypoint: hello
+  templates:
+  - name: hello
+    container:
+      image: busybox
+      command: [cowsay]
+`
+	invalid := `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: bad-
+spec:
+  entrypoint: hello
+  templates:
+  - name: hello
+    steps:
+    - - name: oops
+  templates:
+  - name: hello
+    container:
+      image: busybox
+`
+	require.NoError(t, os.WriteFile(dir+"/good.yaml", []byte(valid), 0o600))
+	require.NoError(t, os.WriteFile(dir+"/bad.yaml", []byte(invalid), 0o600))
+
+	wfMock := &workflowmocks.WorkflowServiceClient{}
+	wfMock.On("LintWorkflow", mock.Anything, mock.Anything).Return(nil, nil)
+
+	ctx := logging.TestContext(t.Context())
+	res, err := Lint(ctx, &Options{
+		Files:          []string{dir},
+		Strict:         true, // CLI default
+		ServiceClients: ServiceClients{WorkflowsClient: wfMock},
+		Formatter:      formatterSimple{},
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Success, "lint must fail when one file has a YAML error")
+	assert.Contains(t, res.Msg(), "bad.yaml", "the error must name the offending file")
+	assert.Contains(t, res.Msg(), `key "templates" already set in map`)
+	assert.Contains(t, res.Msg(), `in "bad-" (Workflow)`, "the object name must be reported when available")
+}
+
+// TestLintFileWithUnparseableYAML verifies that a file which is not valid YAML at all
+// fails the lint with the file name, instead of being skipped silently (#9550).
+func TestLintFileWithUnparseableYAML(t *testing.T) {
+	dir := t.TempDir()
+	broken := `foo: [
+`
+	require.NoError(t, os.WriteFile(dir+"/broken.yaml", []byte(broken), 0o600))
+
+	wfMock := &workflowmocks.WorkflowServiceClient{}
+
+	ctx := logging.TestContext(t.Context())
+	res, err := Lint(ctx, &Options{
+		Files:          []string{dir},
+		Strict:         true, // CLI default
+		ServiceClients: ServiceClients{WorkflowsClient: wfMock},
+		Formatter:      formatterSimple{},
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Success, "lint must fail when a file is not valid YAML")
+	assert.Contains(t, res.Msg(), "broken.yaml", "the error must name the offending file")
+	assert.Contains(t, res.Msg(), "did not find expected node content")
+}

--- a/workflow/common/parse.go
+++ b/workflow/common/parse.go
@@ -25,7 +25,6 @@ type ParseResult struct {
 }
 
 func ParseObjects(ctx context.Context, body []byte, strict bool) []ParseResult {
-	log := logging.RequireLoggerFromContext(ctx)
 	var res []ParseResult
 	if jsonpkg.IsJSON(body) {
 		un := &unstructured.Unstructured{}
@@ -38,25 +37,37 @@ func ParseObjects(ctx context.Context, body []byte, strict bool) []ParseResult {
 		return append(res, ParseResult{v, err})
 	}
 
-	for i, text := range yamlSeparator.Split(string(body), -1) {
+	for _, text := range yamlSeparator.Split(string(body), -1) {
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
 		un := &unstructured.Unstructured{}
 		err := yaml.Unmarshal([]byte(text), un)
 		if err != nil {
-			// Only return an error if this is a kubernetes object, otherwise, print the error
-			if un.GetKind() != "" {
-				res = append(res, ParseResult{nil, err})
-			} else {
-				log.WithField("index", i).WithError(err).Error(ctx, "yaml file is not valid")
-			}
+			// the document is not valid YAML at all; return the error and let the
+			// caller decide whether to report it (lint) or log and skip it (submit)
+			res = append(res, ParseResult{nil, err})
 			continue
 		}
 		v, err := toWorkflowTypeYAML([]byte(text), un.GetKind(), strict)
 		if v != nil {
 			// only append when this is a Kubernetes object
 			res = append(res, ParseResult{v, err})
+		} else if err != nil && un.GetKind() != "" {
+			// the strict pass failed on a document of a known Argo kind (e.g. duplicate
+			// keys, which the non-strict unmarshal above silently accepts); return a typed
+			// empty object with the error so callers surface it instead of dropping the
+			// document and reporting "no linting errors found!". The kind and identity
+			// fields are copied over so callers can name the object in their reports.
+			obj := objectForKind(un.GetKind())
+			obj.SetName(un.GetName())
+			obj.SetGenerateName(un.GetGenerateName())
+			obj.SetNamespace(un.GetNamespace())
+			res = append(res, ParseResult{obj, err})
+		} else if err != nil {
+			// strict-pass failure on a document of unknown kind; return it like any
+			// other unparseable document
+			res = append(res, ParseResult{nil, err})
 		}
 	}
 	return res
@@ -124,6 +135,13 @@ func SplitWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv
 	manifests := make([]wfv1.Workflow, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.Workflow)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind Workflow. Ignoring...")
@@ -143,6 +161,13 @@ func SplitWorkflowTemplateYAMLFile(ctx context.Context, body []byte, strict bool
 	manifests := make([]wfv1.WorkflowTemplate, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.WorkflowTemplate)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind WorkflowTemplate. Ignoring...")
@@ -162,6 +187,13 @@ func SplitCronWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([
 	manifests := make([]wfv1.CronWorkflow, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.CronWorkflow)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind CronWorkflow. Ignoring...")
@@ -181,6 +213,13 @@ func SplitClusterWorkflowTemplateYAMLFile(ctx context.Context, body []byte, stri
 	manifests := make([]wfv1.ClusterWorkflowTemplate, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.ClusterWorkflowTemplate)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind ClusterWorkflowTemplate. Ignoring...")

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -139,7 +139,12 @@ func TestParseObjects(t *testing.T) {
 	require.EqualError(t, res[0].Err, "json: unknown field \"doesNotExist\"")
 
 	invalidObj := []byte(`<div class="blah" style="display: none; outline: none;" tabindex="0"></div>`)
-	assert.Empty(t, ParseObjects(ctx, invalidObj, false))
+	res = ParseObjects(ctx, invalidObj, false)
+	// the document cannot be parsed into a Kubernetes object, so it is returned
+	// with a nil object and the error instead of being logged and dropped (#9550)
+	assert.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	assert.Error(t, res[0].Err)
 }
 
 func TestGetTemplateHolderString(t *testing.T) {
@@ -449,4 +454,66 @@ func TestProcessArgsAbsentOptional(t *testing.T) {
 		// Must NOT match IsMissingVariableErr, which would requeue the node forever.
 		assert.False(t, template.IsMissingVariableErr(err))
 	})
+}
+
+// TestParseObjectsDuplicateKeyIsReported verifies that a document of a known Argo kind
+// whose strict parsing fails (here: a duplicate `templates` key, which the non-strict
+// unmarshal silently accepts) is returned with a typed object and the error, instead of
+// being silently dropped. Silently dropping it made `argo lint` report "no linting
+// errors found!" and `argo submit` find nothing to submit (#9550).
+func TestParseObjectsDuplicateKeyIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	duplicateKeyWf := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: duplicate-key-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: busybox
+      command: [cowsay]
+  templates:
+  - name: other
+    container:
+      image: busybox
+      command: [cowsay]
+`)
+	res := ParseObjects(ctx, duplicateKeyWf, true)
+	require.Len(t, res, 1, "the document must not be silently dropped")
+	require.NotNil(t, res[0].Object, "a typed object must be returned so callers can name it")
+	require.ErrorContains(t, res[0].Err, `key "templates" already set in map`)
+	assert.Equal(t, "duplicate-key-", res[0].Object.GetGenerateName())
+
+	// the same body must be accepted when strict mode is off
+	res = ParseObjects(ctx, duplicateKeyWf, false)
+	require.Len(t, res, 1)
+	assert.NoError(t, res[0].Err)
+
+	// SplitWorkflowYAMLFile must propagate the error instead of returning nothing
+	_, err := SplitWorkflowYAMLFile(ctx, duplicateKeyWf, true)
+	require.ErrorContains(t, err, `key "templates" already set in map`)
+}
+
+// TestParseObjectsUnparseableDocumentIsReported verifies that a document which cannot
+// be parsed into a Kubernetes object at all is returned with a nil object and the
+// error, so linters can report which file failed (previously only logged, and
+// swallowed entirely by strict lints) (#9550).
+func TestParseObjectsUnparseableDocumentIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	brokenYAML := []byte(`foo: [
+`)
+	res := ParseObjects(ctx, brokenYAML, true)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	require.ErrorContains(t, res[0].Err, "did not find expected node content")
+
+	// the HTML snippet previously used as a non-YAML fixture is still returned with
+	// its error (no kind detected) instead of being logged and dropped
+	invalidObj := []byte(`<div class="blah" style="display: none; outline: none;" tabindex="0"></div>`)
+	res = ParseObjects(ctx, invalidObj, false)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	require.Error(t, res[0].Err)
 }


### PR DESCRIPTION
Fixes #9550

### Motivation

`argo lint ./` on a directory where one file contains invalid YAML reports "no linting errors found!" and exits 0. In `workflow/common/parse.go`, a document of a known Argo kind whose strict parse fails (e.g. a duplicate `templates` key, which the non-strict unmarshal silently accepts) was dropped because the converted object was `nil`, and a document that is not valid YAML at all was only logged. Either way the error never reached the linter, so a user linting dozens of files could not tell which one was broken.

### Modifications

`ParseObjects` now returns every parse error in its `ParseResult` instead of discarding them:

- a strict-pass failure on a known Argo kind returns a typed empty object (kind, name, generateName and namespace copied from the non-strict parse) together with the error, so callers can name the object;
- a document that is not valid YAML at all returns `{nil, err}` instead of only logging it;
- the `Split*` helpers propagate the strict error for Argo kinds (so `argo submit` surfaces it instead of silently finding nothing) and log-and-skip documents that are not Kubernetes objects at all, keeping submit behaviour on mixed directories unchanged;
- `lintData` reports nil-object parse errors with the file name through the existing formatters and marks the file as linted so the lint run fails.

### Verification

- new unit tests: a duplicate-key document is reported (and `SplitWorkflowYAMLFile` propagates the error), an unparseable document is reported with the file name, a non-YAML document is still returned with its error
- before (main), with one broken file among valid ones in a directory:

```
$ argo lint ./manifests
✔ no linting errors found!      (exit 0)
```

- after:

```
$ argo lint ./manifests
manifests/broken.yaml:
   ✖ in "broken-dup-key-" (Workflow): yaml: unmarshal errors:
  line 13: key "templates" already set in map

✖ 1 linting errors found!       (exit 1)
```

- `go test ./workflow/common/ ./cmd/argo/lint/` passes, also with `-race`
- `go test ./workflow/... ./cmd/argo/... ./pkg/apiclient/... ./util/...`: 48 packages ok; `util/sqldb` fails on clean main as well (requires Docker/testcontainers, unrelated to this change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linting now reports invalid and malformed YAML files instead of silently skipping them.
  * Error messages identify the affected file, object, and parsing issue.
  * Workflow parsing now preserves and surfaces errors from invalid, unknown, or malformed documents.
  * Improved handling prevents failures when invalid documents lack parsed objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->