### PR TITLE
fix(cli): report YAML parse errors instead of silently dropping documents

### DIFF
--- a/cmd/argo/lint/lint.go
+++ b/cmd/argo/lint/lint.go
@@ -150,6 +150,12 @@ func lintData(ctx context.Context, src string, data []byte, opts *Options) *Resu
 	for i, pr := range common.ParseObjects(ctx, data, opts.Strict) {
 		obj, err := pr.Object, pr.Err
 		if obj == nil {
+			if err != nil {
+				// report parse errors even when the document could not be converted
+				// to a Kubernetes object, so users learn which file failed and why
+				res.Linted = true // the file was processed and found broken
+				res.Errs = append(res.Errs, fmt.Errorf("in object #%d: %w", i+1, err))
+			}
 			continue // could not parse to kubernetes object
 		}
 		// we should prefer the object's namespace

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -423,3 +423,33 @@ func TestLintFileWithUnparseableYAML(t *testing.T) {
 	assert.Contains(t, res.Msg(), "broken.yaml", "the error must name the offending file")
 	assert.Contains(t, res.Msg(), "did not find expected node content")
 }
+
+// TestLintUnknownKindWithDuplicateKey verifies that a strict-invalid document whose
+// kind is NOT an Argo kind (e.g. a ConfigMap with duplicate keys) fails the lint
+// instead of being skipped as an unknown object (#9550, CodeRabbit review).
+func TestLintUnknownKindWithDuplicateKey(t *testing.T) {
+	dir := t.TempDir()
+	dupKeyConfigMap := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dup
+data:
+  key: value
+  key: duplicated
+`
+	require.NoError(t, os.WriteFile(dir+"/dupcm.yaml", []byte(dupKeyConfigMap), 0o600))
+
+	wfMock := &workflowmocks.WorkflowServiceClient{}
+
+	ctx := logging.TestContext(t.Context())
+	res, err := Lint(ctx, &Options{
+		Files:          []string{dir},
+		Strict:         true, // CLI default
+		ServiceClients: ServiceClients{WorkflowsClient: wfMock},
+		Formatter:      formatterSimple{},
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Success, "lint must fail when a non-argo file has a YAML error")
+	assert.Contains(t, res.Msg(), "dupcm.yaml", "the error must name the offending file")
+	assert.Contains(t, res.Msg(), `key "key" already set in map`)
+}

--- a/cmd/argo/lint/lint_test.go
+++ b/cmd/argo/lint/lint_test.go
@@ -348,3 +348,78 @@ func TestGetObjectName(t *testing.T) {
 		})
 	}
 }
+
+// TestLintDirectoryWithInvalidFile verifies that when linting a directory containing
+// many files, a file with a YAML error is reported by name instead of the whole
+// directory passing with "no linting errors found!" (#9550).
+func TestLintDirectoryWithInvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	valid := `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: good-
+spec:
+  entrypoint: hello
+  templates:
+  - name: hello
+    container:
+      image: busybox
+      command: [cowsay]
+`
+	invalid := `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: bad-
+spec:
+  entrypoint: hello
+  templates:
+  - name: hello
+    steps:
+    - - name: oops
+  templates:
+  - name: hello
+    container:
+      image: busybox
+`
+	require.NoError(t, os.WriteFile(dir+"/good.yaml", []byte(valid), 0o600))
+	require.NoError(t, os.WriteFile(dir+"/bad.yaml", []byte(invalid), 0o600))
+
+	wfMock := &workflowmocks.WorkflowServiceClient{}
+	wfMock.On("LintWorkflow", mock.Anything, mock.Anything).Return(nil, nil)
+
+	ctx := logging.TestContext(t.Context())
+	res, err := Lint(ctx, &Options{
+		Files:          []string{dir},
+		Strict:         true, // CLI default
+		ServiceClients: ServiceClients{WorkflowsClient: wfMock},
+		Formatter:      formatterSimple{},
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Success, "lint must fail when one file has a YAML error")
+	assert.Contains(t, res.Msg(), "bad.yaml", "the error must name the offending file")
+	assert.Contains(t, res.Msg(), `key "templates" already set in map`)
+	assert.Contains(t, res.Msg(), `in "bad-" (Workflow)`, "the object name must be reported when available")
+}
+
+// TestLintFileWithUnparseableYAML verifies that a file which is not valid YAML at all
+// fails the lint with the file name, instead of being skipped silently (#9550).
+func TestLintFileWithUnparseableYAML(t *testing.T) {
+	dir := t.TempDir()
+	broken := `foo: [
+`
+	require.NoError(t, os.WriteFile(dir+"/broken.yaml", []byte(broken), 0o600))
+
+	wfMock := &workflowmocks.WorkflowServiceClient{}
+
+	ctx := logging.TestContext(t.Context())
+	res, err := Lint(ctx, &Options{
+		Files:          []string{dir},
+		Strict:         true, // CLI default
+		ServiceClients: ServiceClients{WorkflowsClient: wfMock},
+		Formatter:      formatterSimple{},
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Success, "lint must fail when a file is not valid YAML")
+	assert.Contains(t, res.Msg(), "broken.yaml", "the error must name the offending file")
+	assert.Contains(t, res.Msg(), "did not find expected node content")
+}

--- a/examples/k8s-patch-json-workflow.yaml
+++ b/examples/k8s-patch-json-workflow.yaml
@@ -1,6 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
+  generateName: k8s-patch-json-workflow-
   labels:
     workflows.argoproj.io/no-test: "environment"
   annotations:
@@ -9,8 +10,6 @@ metadata:
       workflows.argoproj.io "k8s-patch-json-workflow-mfwwt" is forb idden: User
       "system:serviceaccount:argo:default" cannot patch resource "workflows" in
       API group "argoproj.io" in the namespace "argo"
-  generateName: k8s-patch-json-workflow-
-  annotations:
     workflows.argoproj.io/description: |
       This example shows how to patch a workflow with json mergeStrategy
 spec:

--- a/workflow/common/parse.go
+++ b/workflow/common/parse.go
@@ -54,7 +54,7 @@ func ParseObjects(ctx context.Context, body []byte, strict bool) []ParseResult {
 		case v != nil:
 			// only append when this is a Kubernetes object
 			res = append(res, ParseResult{v, err})
-		case err != nil && un.GetKind() != "":
+		case err != nil && isArgoKind(un.GetKind()):
 			// the strict pass failed on a document of a known Argo kind (e.g. duplicate
 			// keys, which the non-strict unmarshal above silently accepts); return a typed
 			// empty object with the error so callers surface it instead of dropping the
@@ -67,11 +67,26 @@ func ParseObjects(ctx context.Context, body []byte, strict bool) []ParseResult {
 			res = append(res, ParseResult{obj, err})
 		case err != nil:
 			// strict-pass failure on a document of unknown kind; return it like any
-			// other unparseable document
+			// other unparseable document so the linter still reports the file
 			res = append(res, ParseResult{nil, err})
 		}
 	}
 	return res
+}
+
+// isArgoKind reports whether the kind is one of the Argo kinds known to objectForKind.
+func isArgoKind(kind string) bool {
+	switch kind {
+	case wf.CronWorkflowKind,
+		wf.ClusterWorkflowTemplateKind,
+		wf.WorkflowKind,
+		wf.WorkflowEventBindingKind,
+		wf.WorkflowTemplateKind,
+		wf.WorkflowTaskSetKind:
+		return true
+	default:
+		return false
+	}
 }
 
 func objectForKind(kind string) metav1.Object {

--- a/workflow/common/parse.go
+++ b/workflow/common/parse.go
@@ -25,7 +25,6 @@ type ParseResult struct {
 }
 
 func ParseObjects(ctx context.Context, body []byte, strict bool) []ParseResult {
-	log := logging.RequireLoggerFromContext(ctx)
 	var res []ParseResult
 	if jsonpkg.IsJSON(body) {
 		un := &unstructured.Unstructured{}
@@ -38,25 +37,38 @@ func ParseObjects(ctx context.Context, body []byte, strict bool) []ParseResult {
 		return append(res, ParseResult{v, err})
 	}
 
-	for i, text := range yamlSeparator.Split(string(body), -1) {
+	for _, text := range yamlSeparator.Split(string(body), -1) {
 		if strings.TrimSpace(text) == "" {
 			continue
 		}
 		un := &unstructured.Unstructured{}
 		err := yaml.Unmarshal([]byte(text), un)
 		if err != nil {
-			// Only return an error if this is a kubernetes object, otherwise, print the error
-			if un.GetKind() != "" {
-				res = append(res, ParseResult{nil, err})
-			} else {
-				log.WithField("index", i).WithError(err).Error(ctx, "yaml file is not valid")
-			}
+			// the document is not valid YAML at all; return the error and let the
+			// caller decide whether to report it (lint) or log and skip it (submit)
+			res = append(res, ParseResult{nil, err})
 			continue
 		}
 		v, err := toWorkflowTypeYAML([]byte(text), un.GetKind(), strict)
-		if v != nil {
+		switch {
+		case v != nil:
 			// only append when this is a Kubernetes object
 			res = append(res, ParseResult{v, err})
+		case err != nil && un.GetKind() != "":
+			// the strict pass failed on a document of a known Argo kind (e.g. duplicate
+			// keys, which the non-strict unmarshal above silently accepts); return a typed
+			// empty object with the error so callers surface it instead of dropping the
+			// document and reporting "no linting errors found!". The kind and identity
+			// fields are copied over so callers can name the object in their reports.
+			obj := objectForKind(un.GetKind())
+			obj.SetName(un.GetName())
+			obj.SetGenerateName(un.GetGenerateName())
+			obj.SetNamespace(un.GetNamespace())
+			res = append(res, ParseResult{obj, err})
+		case err != nil:
+			// strict-pass failure on a document of unknown kind; return it like any
+			// other unparseable document
+			res = append(res, ParseResult{nil, err})
 		}
 	}
 	return res
@@ -124,6 +136,13 @@ func SplitWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv
 	manifests := make([]wfv1.Workflow, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.Workflow)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind Workflow. Ignoring...")
@@ -143,6 +162,13 @@ func SplitWorkflowTemplateYAMLFile(ctx context.Context, body []byte, strict bool
 	manifests := make([]wfv1.WorkflowTemplate, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.WorkflowTemplate)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind WorkflowTemplate. Ignoring...")
@@ -162,6 +188,13 @@ func SplitCronWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([
 	manifests := make([]wfv1.CronWorkflow, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.CronWorkflow)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind CronWorkflow. Ignoring...")
@@ -181,6 +214,13 @@ func SplitClusterWorkflowTemplateYAMLFile(ctx context.Context, body []byte, stri
 	manifests := make([]wfv1.ClusterWorkflowTemplate, 0)
 	for _, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
+		if obj == nil {
+			// could not parse to a kubernetes object at all
+			if err != nil {
+				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+			}
+			continue
+		}
 		v, ok := obj.(*wfv1.ClusterWorkflowTemplate)
 		if !ok {
 			log.WithField("name", obj.GetName()).Warn(ctx, "Object is not of kind ClusterWorkflowTemplate. Ignoring...")

--- a/workflow/common/parse.go
+++ b/workflow/common/parse.go
@@ -134,12 +134,12 @@ func toWorkflowTypeJSON(body []byte, kind string, strict bool) (metav1.Object, e
 func SplitWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv1.Workflow, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	manifests := make([]wfv1.Workflow, 0)
-	for _, res := range ParseObjects(ctx, body, strict) {
+	for i, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
 		if obj == nil {
 			// could not parse to a kubernetes object at all
 			if err != nil {
-				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+				log.WithField("index", i).WithError(err).Error(ctx, "yaml file is not valid")
 			}
 			continue
 		}
@@ -160,12 +160,12 @@ func SplitWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv
 func SplitWorkflowTemplateYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv1.WorkflowTemplate, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	manifests := make([]wfv1.WorkflowTemplate, 0)
-	for _, res := range ParseObjects(ctx, body, strict) {
+	for i, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
 		if obj == nil {
 			// could not parse to a kubernetes object at all
 			if err != nil {
-				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+				log.WithField("index", i).WithError(err).Error(ctx, "yaml file is not valid")
 			}
 			continue
 		}
@@ -186,12 +186,12 @@ func SplitWorkflowTemplateYAMLFile(ctx context.Context, body []byte, strict bool
 func SplitCronWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv1.CronWorkflow, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	manifests := make([]wfv1.CronWorkflow, 0)
-	for _, res := range ParseObjects(ctx, body, strict) {
+	for i, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
 		if obj == nil {
 			// could not parse to a kubernetes object at all
 			if err != nil {
-				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+				log.WithField("index", i).WithError(err).Error(ctx, "yaml file is not valid")
 			}
 			continue
 		}
@@ -212,12 +212,12 @@ func SplitCronWorkflowYAMLFile(ctx context.Context, body []byte, strict bool) ([
 func SplitClusterWorkflowTemplateYAMLFile(ctx context.Context, body []byte, strict bool) ([]wfv1.ClusterWorkflowTemplate, error) {
 	log := logging.RequireLoggerFromContext(ctx)
 	manifests := make([]wfv1.ClusterWorkflowTemplate, 0)
-	for _, res := range ParseObjects(ctx, body, strict) {
+	for i, res := range ParseObjects(ctx, body, strict) {
 		obj, err := res.Object, res.Err
 		if obj == nil {
 			// could not parse to a kubernetes object at all
 			if err != nil {
-				log.WithError(err).Warn(ctx, "Ignoring unparseable document")
+				log.WithField("index", i).WithError(err).Error(ctx, "yaml file is not valid")
 			}
 			continue
 		}

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -517,3 +517,177 @@ func TestParseObjectsUnparseableDocumentIsReported(t *testing.T) {
 	assert.Nil(t, res[0].Object)
 	require.Error(t, res[0].Err)
 }
+
+// TestSplitHelpersUnparseableDocumentIsSkipped verifies that a document which cannot
+// be parsed into a Kubernetes object at all is logged-and-skipped by the Split helpers
+// instead of panicking on a nil object (#9550).
+func TestSplitHelpersUnparseableDocumentIsSkipped(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	mixed := []byte(`foo: [
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: mixed-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: busybox
+      command: [cowsay]
+`)
+
+	wfs, err := SplitWorkflowYAMLFile(ctx, mixed, false)
+	require.NoError(t, err)
+	require.Len(t, wfs, 1)
+
+	wfts, err := SplitWorkflowTemplateYAMLFile(ctx, mixed, false)
+	require.NoError(t, err)
+	assert.Empty(t, wfts)
+
+	cwfs, err := SplitCronWorkflowYAMLFile(ctx, mixed, false)
+	require.NoError(t, err)
+	assert.Empty(t, cwfs)
+
+	cwfts, err := SplitClusterWorkflowTemplateYAMLFile(ctx, mixed, false)
+	require.NoError(t, err)
+	assert.Empty(t, cwfts)
+}
+
+// TestSplitWorkflowTemplateDuplicateKeyIsReported verifies the strict duplicate-key
+// error is propagated by every Split helper for its own kind (#9550).
+func TestSplitWorkflowTemplateDuplicateKeyIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	duplicateKeyWft := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: duplicate-key
+spec:
+  templates:
+  - name: a
+    container:
+      image: busybox
+      command: [cowsay]
+  templates:
+  - name: b
+    container:
+      image: busybox
+      command: [cowsay]
+`)
+	_, err := SplitWorkflowTemplateYAMLFile(ctx, duplicateKeyWft, true)
+	require.ErrorContains(t, err, `key "templates" already set in map`)
+
+	// non-strict mode accepts the document
+	wfts, err := SplitWorkflowTemplateYAMLFile(ctx, duplicateKeyWft, false)
+	require.NoError(t, err)
+	require.Len(t, wfts, 1)
+}
+
+// TestSplitCronWorkflowDuplicateKeyIsReported verifies the strict duplicate-key error
+// is propagated for CronWorkflows too (#9550).
+func TestSplitCronWorkflowDuplicateKeyIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	duplicateKeyCwf := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: duplicate-key
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Allow
+  workflowMetadata:
+    labels:
+      example: test
+  workflowSpec:
+    entrypoint: whalesay
+    templates:
+    - name: whalesay
+      container:
+        image: busybox
+        command: [cowsay]
+    templates:
+    - name: other
+      container:
+        image: busybox
+        command: [cowsay]
+`)
+	_, err := SplitCronWorkflowYAMLFile(ctx, duplicateKeyCwf, true)
+	require.ErrorContains(t, err, `key "templates" already set in map`)
+
+	cwfs, err := SplitCronWorkflowYAMLFile(ctx, duplicateKeyCwf, false)
+	require.NoError(t, err)
+	require.Len(t, cwfs, 1)
+}
+
+// TestParseObjectsUnknownKindStrictFailureIsReported verifies that a strict-pass
+// failure on a document whose kind is not an Argo kind returns an ObjectMeta shell
+// with the error; the Split helpers then skip it as a non-argo object (#9550).
+func TestParseObjectsUnknownKindStrictFailureIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	unknownKind := []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo
+data:
+  key: value
+  key: duplicated
+`)
+	res := ParseObjects(ctx, unknownKind, true)
+	require.Len(t, res, 1)
+	require.ErrorContains(t, res[0].Err, `key "key" already set in map`)
+	obj, ok := res[0].Object.(*metav1.ObjectMeta)
+	require.True(t, ok, "a non-argo kind must surface as an ObjectMeta shell")
+	assert.Equal(t, "foo", obj.Name)
+
+	// Split helpers log-and-skip it as a non-argo object
+	wfs, err := SplitWorkflowYAMLFile(ctx, unknownKind, true)
+	require.NoError(t, err)
+	assert.Empty(t, wfs)
+}
+
+// TestParseObjectsKindlessDuplicateKeyIsReported verifies that a document without a
+// kind whose strict parse fails (duplicate keys) is returned with a nil object and
+// the error (#9550).
+func TestParseObjectsKindlessDuplicateKeyIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	kindlessDup := []byte(`metadata:
+  name: foo
+data:
+  key: value
+  key: duplicated
+`)
+	res := ParseObjects(ctx, kindlessDup, true)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	// the strict JSON decode of an ObjectMeta shell fails on the missing kind
+	// before the duplicate-key check; the point is that the error surfaces
+	require.ErrorContains(t, res[0].Err, "Object 'Kind' is missing")
+}
+
+// TestSplitClusterWorkflowTemplateDuplicateKeyIsReported verifies the strict
+// duplicate-key error is propagated for ClusterWorkflowTemplates too (#9550).
+func TestSplitClusterWorkflowTemplateDuplicateKeyIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	duplicateKeyCwft := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: duplicate-key
+spec:
+  templates:
+  - name: a
+    container:
+      image: busybox
+      command: [cowsay]
+  templates:
+  - name: b
+    container:
+      image: busybox
+      command: [cowsay]
+`)
+	_, err := SplitClusterWorkflowTemplateYAMLFile(ctx, duplicateKeyCwft, true)
+	require.ErrorContains(t, err, `key "templates" already set in map`)
+
+	cwfts, err := SplitClusterWorkflowTemplateYAMLFile(ctx, duplicateKeyCwft, false)
+	require.NoError(t, err)
+	require.Len(t, cwfts, 1)
+}

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -139,7 +139,12 @@ func TestParseObjects(t *testing.T) {
 	require.EqualError(t, res[0].Err, "json: unknown field \"doesNotExist\"")
 
 	invalidObj := []byte(`<div class="blah" style="display: none; outline: none;" tabindex="0"></div>`)
-	assert.Empty(t, ParseObjects(ctx, invalidObj, false))
+	res = ParseObjects(ctx, invalidObj, false)
+	// the document cannot be parsed into a Kubernetes object, so it is returned
+	// with a nil object and the error instead of being logged and dropped (#9550)
+	assert.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	assert.Error(t, res[0].Err)
 }
 
 func TestGetTemplateHolderString(t *testing.T) {
@@ -449,4 +454,66 @@ func TestProcessArgsAbsentOptional(t *testing.T) {
 		// Must NOT match IsMissingVariableErr, which would requeue the node forever.
 		assert.False(t, template.IsMissingVariableErr(err))
 	})
+}
+
+// TestParseObjectsDuplicateKeyIsReported verifies that a document of a known Argo kind
+// whose strict parsing fails (here: a duplicate `templates` key, which the non-strict
+// unmarshal silently accepts) is returned with a typed object and the error, instead of
+// being silently dropped. Silently dropping it made `argo lint` report "no linting
+// errors found!" and `argo submit` find nothing to submit (#9550).
+func TestParseObjectsDuplicateKeyIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	duplicateKeyWf := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: duplicate-key-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: busybox
+      command: [cowsay]
+  templates:
+  - name: other
+    container:
+      image: busybox
+      command: [cowsay]
+`)
+	res := ParseObjects(ctx, duplicateKeyWf, true)
+	require.Len(t, res, 1, "the document must not be silently dropped")
+	require.NotNil(t, res[0].Object, "a typed object must be returned so callers can name it")
+	require.ErrorContains(t, res[0].Err, `key "templates" already set in map`)
+	assert.Equal(t, "duplicate-key-", res[0].Object.GetGenerateName())
+
+	// the same body must be accepted when strict mode is off
+	res = ParseObjects(ctx, duplicateKeyWf, false)
+	require.Len(t, res, 1)
+	require.NoError(t, res[0].Err)
+
+	// SplitWorkflowYAMLFile must propagate the error instead of returning nothing
+	_, err := SplitWorkflowYAMLFile(ctx, duplicateKeyWf, true)
+	require.ErrorContains(t, err, `key "templates" already set in map`)
+}
+
+// TestParseObjectsUnparseableDocumentIsReported verifies that a document which cannot
+// be parsed into a Kubernetes object at all is returned with a nil object and the
+// error, so linters can report which file failed (previously only logged, and
+// swallowed entirely by strict lints) (#9550).
+func TestParseObjectsUnparseableDocumentIsReported(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	brokenYAML := []byte(`foo: [
+`)
+	res := ParseObjects(ctx, brokenYAML, true)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	require.ErrorContains(t, res[0].Err, "did not find expected node content")
+
+	// the HTML snippet previously used as a non-YAML fixture is still returned with
+	// its error (no kind detected) instead of being logged and dropped
+	invalidObj := []byte(`<div class="blah" style="display: none; outline: none;" tabindex="0"></div>`)
+	res = ParseObjects(ctx, invalidObj, false)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	require.Error(t, res[0].Err)
 }

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -491,9 +491,24 @@ spec:
 	require.Len(t, res, 1)
 	require.NoError(t, res[0].Err)
 
-	// SplitWorkflowYAMLFile must propagate the error instead of returning nothing
+	// SplitWorkflowYAMLFile must propagate the error instead of returning nothing.
+	// Both the strict (duplicate key) and non-strict (unknown field) failure paths
+	// surface through this branch.
 	_, err := SplitWorkflowYAMLFile(ctx, duplicateKeyWf, true)
 	require.ErrorContains(t, err, `key "templates" already set in map`)
+	_, err = SplitWorkflowYAMLFile(ctx, []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: unknown-field-strict
+spec:
+  entrypoint: echo
+  templates:
+  - name: echo
+    container:
+      image: busybox
+      command: [cowsay]
+  doesNotExist: true`), true)
+	require.ErrorContains(t, err, "unknown field")
 }
 
 // TestParseObjectsUnparseableDocumentIsReported verifies that a document which cannot
@@ -635,12 +650,27 @@ data:
 	res := ParseObjects(ctx, unknownKind, true)
 	require.Len(t, res, 1)
 	require.ErrorContains(t, res[0].Err, `key "key" already set in map`)
-	obj, ok := res[0].Object.(*metav1.ObjectMeta)
-	require.True(t, ok, "a non-argo kind must surface as an ObjectMeta shell")
-	assert.Equal(t, "foo", obj.Name)
+	assert.Nil(t, res[0].Object, "a non-argo kind must return {nil, err} so linters report the file")
 
 	// Split helpers log-and-skip it as a non-argo object
 	wfs, err := SplitWorkflowYAMLFile(ctx, unknownKind, true)
+	require.NoError(t, err)
+	assert.Empty(t, wfs)
+
+	// a valid WorkflowTemplate document flows through SplitWorkflowYAMLFile's
+	// not-of-kind-Workflow skip path
+	wfts := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: wft-in-wf-split
+spec:
+  templates:
+  - name: echo
+    container:
+      image: busybox
+      command: [cowsay]
+`)
+	wfs, err = SplitWorkflowYAMLFile(ctx, wfts, true)
 	require.NoError(t, err)
 	assert.Empty(t, wfs)
 }

--- a/workflow/common/util_test.go
+++ b/workflow/common/util_test.go
@@ -691,3 +691,155 @@ spec:
 	require.NoError(t, err)
 	require.Len(t, cwfts, 1)
 }
+
+// TestParseObjectsJSONBodyAndStrictSuccess verifies the JSON input branch and a
+// successful strict parse of a valid workflow (#9550).
+func TestParseObjectsJSONBodyAndStrictSuccess(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	validJSON := []byte(`{"apiVersion":"argoproj.io/v1alpha1","kind":"Workflow","metadata":{"generateName":"json-"},"spec":{"entrypoint":"whalesay","templates":[{"name":"whalesay","container":{"image":"busybox","command":["cowsay"]}}]}}`)
+	res := ParseObjects(ctx, validJSON, true)
+	require.Len(t, res, 1)
+	require.NoError(t, res[0].Err)
+	assert.Equal(t, "json-", res[0].Object.GetGenerateName())
+
+	invalidJSON := []byte(`{"kind":"Workflow","spec": BROKEN`)
+	res = ParseObjects(ctx, invalidJSON, true)
+	require.Len(t, res, 1)
+	require.Error(t, res[0].Err)
+
+	// a leading empty document is skipped silently
+	leadingEmpty := []byte("---\n" + validJSONWf)
+	res = ParseObjects(ctx, leadingEmpty, true)
+	require.Len(t, res, 1)
+	require.NoError(t, res[0].Err)
+}
+
+// validJSONWf is the JSON form of a valid workflow, shared by JSON-branch tests.
+var validJSONWf = `{"apiVersion":"argoproj.io/v1alpha1","kind":"Workflow","metadata":{"generateName":"json-"},"spec":{"entrypoint":"whalesay","templates":[{"name":"whalesay","container":{"image":"busybox","command":["cowsay"]}}]}}`
+
+// TestParseObjectsRemainingBranches covers the remaining ParseObjects paths: a JSON
+// document that unmarshals to an error, empty YAML documents between separators, a
+// kindless document whose strict conversion fails, the WorkflowEventBinding and
+// WorkflowTaskSet kinds, and both strict JSON decoding error paths (#9550).
+func TestParseObjectsRemainingBranches(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+
+	// JSON input that carries a kind but fails the typed decode: the empty typed
+	// object is returned together with the error (obj != nil, err != nil branch)
+	badTypedJSON := []byte(`{"kind":"Workflow","metadata":{"name":{"nested":"not a string"}}}`)
+	res := ParseObjects(ctx, badTypedJSON, true)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].Object)
+	require.ErrorContains(t, res[0].Err, "cannot unmarshal object into Go struct field")
+
+	// a JSON document that fails to unmarshal at all: the lenient unstructured
+	// decode also fails, no kind is detected, and the document is returned as
+	// {nil, err} so the linter reports it (line 33-35 branch, #9550)
+	brokenJSON := []byte(`{"kind":"Workflow","spec":[[[`)
+	res = ParseObjects(ctx, brokenJSON, true)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	require.Error(t, res[0].Err)
+
+	// a JSON document whose kind field itself is malformed: unmarshal errors
+	// with the kind unset, so it falls through to the strict conversion which
+	// surfaces the type clash as an ObjectMeta strict decoding error
+	clashingKind := []byte(`{"kind":{"nested":true}}`)
+	res = ParseObjects(ctx, clashingKind, true)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].Object)
+	require.ErrorContains(t, res[0].Err, `unknown field "kind"`)
+
+	// a JSON document where the kind is set but the body fails to unmarshal
+	// into the typed object: the empty typed object travels with the error
+	// (obj != nil, err != nil), which Split helpers then reject by error
+	lateTypedFailure := []byte(`{"kind":"Workflow","apiVersion":123}`)
+	res = ParseObjects(ctx, lateTypedFailure, true)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].Object)
+	require.Error(t, res[0].Err)
+	_, splitErr := SplitWorkflowYAMLFile(ctx, lateTypedFailure, true)
+	require.Error(t, splitErr)
+
+	// an empty document between separators is skipped silently
+	emptyMiddle := []byte(validWf + "\n---\n---\n" + validWf)
+	res = ParseObjects(ctx, emptyMiddle, true)
+	require.Len(t, res, 2)
+
+	// a kindless document whose strict conversion fails returns {nil, err};
+	// YAMLToJSONStrict silently accepts the duplicate key, and the error comes
+	// from decoding into an ObjectMeta shell, which requires a kind
+	kindlessDup := []byte("a: 1\na: 2\n")
+	res = ParseObjects(ctx, kindlessDup, true)
+	require.Len(t, res, 1)
+	assert.Nil(t, res[0].Object)
+	require.ErrorContains(t, res[0].Err, "Object 'Kind' is missing")
+
+	// the remaining kinds produce typed objects
+	eventBinding := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: WorkflowEventBinding
+metadata:
+  name: web
+spec:
+  event:
+    selector: "true"
+`)
+	res = ParseObjects(ctx, eventBinding, true)
+	require.Len(t, res, 1)
+	require.NoError(t, res[0].Err)
+	assert.Equal(t, "web", res[0].Object.GetName())
+
+	taskSet := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTaskSet
+metadata:
+  name: tasks
+spec:
+  tasks:
+    a:
+      container:
+        image: busybox
+        command: [cowsay]
+`)
+	res = ParseObjects(ctx, taskSet, true)
+	require.Len(t, res, 1)
+	require.NoError(t, res[0].Err)
+	assert.Equal(t, "tasks", res[0].Object.GetName())
+
+	// a strict decoding type error (not a strictness error) still surfaces
+	badType := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: bad-type-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: busybox
+      command: [cowsay]
+  scheduledTime: not-a-time
+`)
+	res = ParseObjects(ctx, badType, true)
+	require.Len(t, res, 1)
+	require.Error(t, res[0].Err)
+
+	// unknown fields in strict mode surface with the object
+	unknownField := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: unknown-field-
+spec:
+  entrypoint: whalesay
+  templates:
+  - name: whalesay
+    container:
+      image: busybox
+      command: [cowsay]
+  doesNotExist: true
+`)
+	res = ParseObjects(ctx, unknownField, true)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].Object)
+	require.ErrorContains(t, res[0].Err, "unknown field")
+}


### PR DESCRIPTION
Fixes #9550

Re-submission of #16843 with a Signed-off-by commit (DCO) and the two lint fixes CI reported (gocritic ifElseChain, testifylint require-error). No functional changes.

- [x] Ran `make pre-commit -B` — verified via CI: `Codegen`, `Lint` and `docs` checks are green on this PR
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`) — N/A: this is a bug fix, not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green — all checks green on `1cee3580ae`; new commits re-run CI

### Motivation

`argo lint ./` on a directory where one file contains invalid YAML reports "no linting errors found!" and exits 0. In `workflow/common/parse.go`, a document of a known Argo kind whose strict parse fails (e.g. a duplicate `templates` key, which the non-strict unmarshal silently accepts) was dropped because the converted object was `nil`, and a document that is not valid YAML at all was only logged. Either way the error never reached the linter, so a user linting dozens of files could not tell which one was broken.

### Modifications

`ParseObjects` now returns every parse error in its `ParseResult` instead of discarding them:

- a strict-pass failure on a known Argo kind returns a typed empty object (kind, name, generateName and namespace copied from the non-strict parse) together with the error, so callers can name the object;
- a document that is not valid YAML at all returns `{nil, err}` instead of only logging it;
- the `Split*` helpers propagate the strict error for Argo kinds (so `argo submit` surfaces it instead of silently finding nothing) and log-and-skip documents that are not Kubernetes objects at all, keeping submit behaviour on mixed directories unchanged;
- `lintData` reports nil-object parse errors with the file name through the existing formatters and marks the file as linted so the lint run fails.

### Verification

- new unit tests: a duplicate-key document is reported (and `SplitWorkflowYAMLFile` propagates the error), an unparseable document is reported with the file name, a non-YAML document is still returned with its error
- before (main), with one broken file among valid ones in a directory:

```
$ argo lint ./manifests
✔ no linting errors found!      (exit 0)
```

- after:

```
$ argo lint ./manifests
manifests/broken.yaml:
   ✖ in "broken-dup-key-" (Workflow): yaml: unmarshal errors:
  line 13: key "templates" already set in map

✖ 1 linting errors found!       (exit 1)
```

- `go test ./workflow/common/ ./cmd/argo/lint/` passes, also with `-race`; golangci-lint v2.13.2 reports 0 issues on the touched packages
- `go test ./workflow/... ./cmd/argo/... ./pkg/apiclient/... ./util/...`: 48 packages ok; `util/sqldb` fails on clean main as well (requires Docker/testcontainers, unrelated to this change)
- E2E follow-ups pushed in `1cee3580ae`:
  - `TestExampleWorkflows` was failing on `examples/k8s-patch-json-workflow.yaml`, which really contains a duplicate `annotations` key (line 8 and line 14) — exactly the bug class this PR makes visible. The example is fixed by merging the two annotations maps.
  - `TestSubmitInvalidWf` asserts the pre-existing `yaml file is not valid ... index=0` log wording on the submit path; the Split helpers keep that exact message (now at Error level with the index) while the lint path still reports the richer file/object/cause output.

### Documentation

Not needed: this fixes existing lint/submit error reporting to no longer silently drop YAML parse errors; no documented behaviour changes, and the CLI docs do not describe the previous silent behaviour.

### AI

This PR was prepared with the assistance of an AI coding agent (code, tests, and PR description), under the direction of and reviewed by the human contributor KKamJi.


### Review follow-up

- CodeRabbit flagged that the strict-failure fallback branch matched every non-empty kind, so a strict-invalid non-Argo manifest (e.g. a duplicate-key ConfigMap) became an ObjectMeta shell that `lintData` skipped without recording the error, and `argo lint` could still report success. Fixed in `c0012c5fb7`: the fallback is gated by a recognized-Argo-kind check, unknown kinds return `{nil, err}`, and a regression test covers the duplicate-key ConfigMap case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linting now reports YAML parsing and duplicate-key errors instead of silently skipping invalid documents.
  * Error messages identify the affected file, object, and document index where applicable.
  * Invalid documents no longer cause split and workflow-processing operations to fail unexpectedly.
  * Strict validation now consistently reports errors for known and unknown resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->