### PR TITLE
fix: correct typos in a comment and the event source list description

### DIFF
--- a/cmd/argo/lint/lint.go
+++ b/cmd/argo/lint/lint.go
@@ -106,7 +106,7 @@ func RunLint(ctx context.Context, client apiclient.Client, kinds []string, outpu
 	return nil
 }
 
-// Lint reads all files, returns linting errors of all of the enitities of the specified kinds.
+// Lint reads all files, returns linting errors of all of the entities of the specified kinds.
 // Entities of other kinds are ignored.
 func Lint(ctx context.Context, opts *Options) (*Results, error) {
 	var fmtr Formatter = defaultFormatter

--- a/ui/src/event-sources/event-source-list.tsx
+++ b/ui/src/event-sources/event-source-list.tsx
@@ -122,7 +122,7 @@ export function EventSourceList({match, location, history}: RouteComponentProps<
             {zeroState && (
                 <ZeroState title='No event sources'>
                     <p>
-                        An event source defines what events can be used to trigger actions. Typical event sources are calender (to create events on schedule) GitHub or GitLab (to
+                        An event source defines what events can be used to trigger actions. Typical event sources are calendar (to create events on schedule) GitHub or GitLab (to
                         create events for Git pushes), or MinIO (to create events for file drops). Each event source publishes messages to the event bus so that sensors can listen
                         for them.
                     </p>

--- a/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -97,7 +97,7 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
     const [uiTimezone, setUITimezone] = useState<string>(DEFAULT_TZ);
     // timezone used for timezone formatting
     const [timezone, setTimezone] = useLocalStorage<string>(TZ_LOCALSTORAGE_KEY, DEFAULT_TZ);
-    // update the UI everytime the timezone changes
+    // update the UI every time the timezone changes
     useEffect(() => {
         setUITimezone(timezone);
     }, [timezone]);


### PR DESCRIPTION
Three typo fixes. No functional changes.

- `enitities` -> `entities` in the `Lint` doc comment (cmd/argo/lint/lint.go)
- `everytime` -> `every time` in a comment (workflow-logs-viewer.tsx)
- `calender` -> `calendar` in the user-visible "No event sources" empty-state text (event-sources/event-source-list.tsx)

Generated files (e.g. `ui/src/shared/models/workflows.ts`) were deliberately left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling in the linting documentation.
  - Fixed the event sources page text to use “calendar.”
  - Improved wording in the workflow logs viewer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->