### PR TITLE
fix: terminate retry nodes on steps fail-fast

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -129,6 +129,8 @@ type wfOperationCtx struct {
 	currentStackDepth int
 }
 
+const failFastMessage = "template has failed or errored children and failFast enabled"
+
 var (
 	// ErrDeadlineExceeded indicates the operation exceeded its deadline for execution
 	ErrDeadlineExceeded = argoerrors.New(argoerrors.CodeTimeout, "Deadline exceeded")
@@ -2310,6 +2312,11 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 
 	// Check if we exceeded template or workflow parallelism and immediately return if we did
 	if parallelismErr := woc.checkParallelism(ctx, processedTmpl, node, opts.boundaryID); parallelismErr != nil {
+		if errors.Is(parallelismErr, ErrParallelismReached) && node != nil {
+			if updatedNode, getErr := woc.wf.GetNodeByName(nodeName); getErr == nil && updatedNode.Fulfilled() && updatedNode.Message == failFastMessage {
+				return updatedNode, nil
+			}
+		}
 		return node, parallelismErr
 	}
 
@@ -2904,6 +2911,23 @@ func (woc *wfOperationCtx) childrenFulfilled(node *wfv1.NodeStatus) bool {
 	return woc.childrenFulfilledHelper(node, m)
 }
 
+func (woc *wfOperationCtx) terminateStrandedRetryNodes(ctx context.Context, boundaryID, message string) {
+	descendants, err := woc.wf.Status.Nodes.NestedChildrenStatus(boundaryID)
+	if err != nil {
+		woc.log.WithError(err).WithField("boundaryID", boundaryID).Warn(ctx, "was unable to obtain descendants for failFast retry cleanup")
+		return
+	}
+	for _, node := range descendants {
+		if node.Type != wfv1.NodeTypeRetry || node.Fulfilled() || !woc.childrenFulfilled(&node) {
+			continue
+		}
+		_, lastChildNode := getChildNodeIdsAndLastRetriedNode(&node, woc.wf.Status.Nodes)
+		if lastChildNode != nil && lastChildNode.Fulfilled() {
+			woc.markNodePhase(ctx, node.Name, lastChildNode.Phase, message)
+		}
+	}
+}
+
 func (woc *wfOperationCtx) GetNodeTemplate(ctx context.Context, node *wfv1.NodeStatus) (*wfv1.Template, error) {
 	if node.TemplateRef != nil {
 		// Check storedTemplates first so that modifications to the CWT after the workflow
@@ -3305,12 +3329,13 @@ func (woc *wfOperationCtx) checkParallelism(ctx context.Context, tmpl *wfv1.Temp
 		// Check failFast
 		if tmpl.IsFailFast() && woc.getUnsuccessfulChildren(node.ID) > 0 {
 			if woc.getActivePods(node.ID) == 0 {
+				woc.terminateStrandedRetryNodes(ctx, node.ID, failFastMessage)
 				if tmpl.GetType() == wfv1.TemplateTypeSteps {
 					if leafStepGroupNode := woc.findLeafNodeWithType(ctx, node.ID, wfv1.NodeTypeStepGroup); leafStepGroupNode != nil {
-						woc.markNodePhase(ctx, leafStepGroupNode.Name, wfv1.NodeFailed, "template has failed or errored children and failFast enabled")
+						woc.markNodePhase(ctx, leafStepGroupNode.Name, wfv1.NodeFailed, failFastMessage)
 					}
 				}
-				woc.markNodePhase(ctx, node.Name, wfv1.NodeFailed, "template has failed or errored children and failFast enabled")
+				woc.markNodePhase(ctx, node.Name, wfv1.NodeFailed, failFastMessage)
 			}
 			return ErrParallelismReached
 		}
@@ -3341,12 +3366,13 @@ func (woc *wfOperationCtx) checkParallelism(ctx context.Context, tmpl *wfv1.Temp
 		// Check failFast
 		if boundaryTemplate != nil && boundaryTemplate.IsFailFast() && woc.getUnsuccessfulChildren(boundaryID) > 0 {
 			if woc.getActivePods(boundaryID) == 0 {
+				woc.terminateStrandedRetryNodes(ctx, boundaryID, failFastMessage)
 				if boundaryTemplate.GetType() == wfv1.TemplateTypeSteps {
 					if leafStepGroupNode := woc.findLeafNodeWithType(ctx, boundaryID, wfv1.NodeTypeStepGroup); leafStepGroupNode != nil {
-						woc.markNodePhase(ctx, leafStepGroupNode.Name, wfv1.NodeFailed, "template has failed or errored children and failFast enabled")
+						woc.markNodePhase(ctx, leafStepGroupNode.Name, wfv1.NodeFailed, failFastMessage)
 					}
 				}
-				woc.markNodePhase(ctx, boundaryNode.Name, wfv1.NodeFailed, "template has failed or errored children and failFast enabled")
+				woc.markNodePhase(ctx, boundaryNode.Name, wfv1.NodeFailed, failFastMessage)
 			}
 			return ErrParallelismReached
 		}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -9218,6 +9218,204 @@ func TestStepsFailFast(t *testing.T) {
 	assert.Equal(t, wfv1.NodeFailed, node.Phase)
 }
 
+const stepsFailFastRunningRetry = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: issue-16849
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    failFast: true
+    parallelism: 1
+    steps:
+    - - name: retry
+        template: fail
+        withParam: '["a", "b"]'
+  - name: fail
+    retryStrategy:
+      limit: 2
+      backoff:
+        duration: 1h
+    container:
+      image: alpine
+      command: [sh, -c]
+      args: [exit 1]
+`
+
+func TestStepsFailFastTerminatesRunningRetry(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(stepsFailFastRunningRetry)
+	startedAt := metav1.Now()
+	wf.Status.Phase = wfv1.WorkflowRunning
+	wf.Status.StartedAt = startedAt
+	wf.Status.Nodes = wfv1.Nodes{}
+	taskResultSynced := true
+
+	rootName := wf.Name
+	groupName := rootName + "[0]"
+	failedRetryName := groupName + ".retry(0:a)"
+	runningRetryName := groupName + ".retry(1:b)"
+
+	nodeID := func(name string) string { return wf.NodeID(name) }
+	failedPod := func(name, displayName, boundaryID string) wfv1.NodeStatus {
+		return wfv1.NodeStatus{
+			ID:               nodeID(name),
+			Name:             name,
+			DisplayName:      displayName,
+			Type:             wfv1.NodeTypePod,
+			TemplateName:     "fail",
+			TemplateScope:    "local/issue-16849",
+			BoundaryID:       boundaryID,
+			Phase:            wfv1.NodeFailed,
+			NodeFlag:         &wfv1.NodeFlag{Retried: true},
+			StartedAt:        startedAt,
+			FinishedAt:       startedAt,
+			TaskResultSynced: &taskResultSynced,
+		}
+	}
+
+	failedRetryChildren := []string{}
+	for attempt := range 3 {
+		name := fmt.Sprintf("%s(%d)", failedRetryName, attempt)
+		id := nodeID(name)
+		failedRetryChildren = append(failedRetryChildren, id)
+		wf.Status.Nodes[id] = failedPod(name, fmt.Sprintf("retry(0:a)(%d)", attempt), nodeID(rootName))
+	}
+	runningAttemptName := runningRetryName + "(0)"
+	runningAttemptID := nodeID(runningAttemptName)
+	wf.Status.Nodes[runningAttemptID] = failedPod(runningAttemptName, "retry(1:b)(0)", nodeID(rootName))
+
+	wf.Status.Nodes[nodeID(failedRetryName)] = wfv1.NodeStatus{
+		ID:            nodeID(failedRetryName),
+		Name:          failedRetryName,
+		DisplayName:   "retry(0:a)",
+		Type:          wfv1.NodeTypeRetry,
+		TemplateName:  "fail",
+		TemplateScope: "local/issue-16849",
+		BoundaryID:    nodeID(rootName),
+		Phase:         wfv1.NodeFailed,
+		StartedAt:     startedAt,
+		FinishedAt:    startedAt,
+		Children:      failedRetryChildren,
+	}
+	wf.Status.Nodes[nodeID(runningRetryName)] = wfv1.NodeStatus{
+		ID:            nodeID(runningRetryName),
+		Name:          runningRetryName,
+		DisplayName:   "retry(1:b)",
+		Type:          wfv1.NodeTypeRetry,
+		TemplateName:  "fail",
+		TemplateScope: "local/issue-16849",
+		BoundaryID:    nodeID(rootName),
+		Phase:         wfv1.NodeRunning,
+		StartedAt:     startedAt,
+		Children:      []string{runningAttemptID},
+	}
+	wf.Status.Nodes[nodeID(groupName)] = wfv1.NodeStatus{
+		ID:            nodeID(groupName),
+		Name:          groupName,
+		DisplayName:   "[0]",
+		Type:          wfv1.NodeTypeStepGroup,
+		TemplateScope: "local/issue-16849",
+		BoundaryID:    nodeID(rootName),
+		Phase:         wfv1.NodeRunning,
+		StartedAt:     startedAt,
+		Children:      []string{nodeID(failedRetryName), nodeID(runningRetryName)},
+	}
+	wf.Status.Nodes[nodeID(rootName)] = wfv1.NodeStatus{
+		ID:            nodeID(rootName),
+		Name:          rootName,
+		DisplayName:   rootName,
+		Type:          wfv1.NodeTypeSteps,
+		TemplateName:  "main",
+		TemplateScope: "local/issue-16849",
+		Phase:         wfv1.NodeRunning,
+		StartedAt:     startedAt,
+		Children:      []string{nodeID(groupName)},
+	}
+
+	for _, node := range wf.Status.Nodes {
+		if node.Type == wfv1.NodeTypePod {
+			assert.True(t, node.Phase.Fulfilled(node.TaskResultSynced), "pod %s must not be active", node.Name)
+		}
+	}
+
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	woc.operate(ctx)
+
+	retryNode := woc.wf.Status.Nodes.FindByDisplayName("retry(1:b)")
+	require.NotNil(t, retryNode)
+	assert.Equal(t, wfv1.NodeFailed, retryNode.Phase)
+	assert.False(t, retryNode.FinishedAt.IsZero())
+	assert.Equal(t, wfv1.NodeFailed, woc.wf.Status.Nodes[nodeID(rootName)].Phase)
+	assert.Equal(t, wfv1.WorkflowFailed, woc.wf.Status.Phase)
+}
+
+func TestTerminateStrandedRetryNodesLeavesActiveRetryRunning(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: active-retry
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps: []
+`)
+	startedAt := metav1.Now()
+	boundaryName := wf.Name
+	retryName := boundaryName + "[0].retry"
+	attemptName := retryName + "(0)"
+	boundaryID := wf.NodeID(boundaryName)
+	retryID := wf.NodeID(retryName)
+	attemptID := wf.NodeID(attemptName)
+	wf.Status.Nodes = wfv1.Nodes{
+		boundaryID: {
+			ID:        boundaryID,
+			Name:      boundaryName,
+			Type:      wfv1.NodeTypeSteps,
+			Phase:     wfv1.NodeRunning,
+			StartedAt: startedAt,
+			Children:  []string{retryID},
+		},
+		retryID: {
+			ID:         retryID,
+			Name:       retryName,
+			Type:       wfv1.NodeTypeRetry,
+			Phase:      wfv1.NodeRunning,
+			StartedAt:  startedAt,
+			BoundaryID: boundaryID,
+			Children:   []string{attemptID},
+		},
+		attemptID: {
+			ID:         attemptID,
+			Name:       attemptName,
+			Type:       wfv1.NodeTypePod,
+			Phase:      wfv1.NodeRunning,
+			StartedAt:  startedAt,
+			BoundaryID: boundaryID,
+		},
+	}
+
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	retryNode := woc.wf.Status.Nodes[retryID]
+	assert.Equal(t, wfv1.NodeRunning, retryNode.Phase)
+	assert.True(t, retryNode.FinishedAt.IsZero())
+	woc.terminateStrandedRetryNodes(ctx, boundaryID, failFastMessage)
+
+	retryNode = woc.wf.Status.Nodes[retryID]
+	assert.Equal(t, wfv1.NodeRunning, retryNode.Phase)
+	assert.True(t, retryNode.FinishedAt.IsZero())
+}
+
 func TestGetStepOrDAGTaskName(t *testing.T) {
 	assert.Equal(t, "generate-artifact", getStepOrDAGTaskName("data-transformation-gjrt8[0].generate-artifact(2:foo/script.py)"))
 	assert.Equal(t, "generate-artifact", getStepOrDAGTaskName("data-transformation-gjrt8[0].generate-artifact(2:foo/scrip[t.py)"))


### PR DESCRIPTION
## Motivation

Fixes #16849.

A Steps template using `failFast: true`, `parallelism`, and `retryStrategy` can leave a Retry node permanently `Running`.

When fail-fast triggers before retry reconciliation, `checkParallelism()` can mark the StepGroup and Steps boundary as failed and return `ErrParallelismReached` before `processNodeRetries()` gets a chance to terminalize a Retry wrapper.

The Retry node can therefore remain `Running` with no active attempts and an unset `FinishedAt`, preventing the workflow itself from reaching a terminal phase.

## Modifications

- Terminalize stranded Retry nodes when fail-fast fires and the affected boundary has no active pods.
- Only terminalize unfulfilled Retry nodes whose descendants are fully fulfilled.
- Preserve the terminal phase of the latest retry attempt.
- Leave Retry nodes with active attempts or hooks untouched.
- Allow a node terminalized specifically by fail-fast to propagate its terminal state instead of treating it as ordinary parallelism backpressure.
- Add a regression test for #16849.
- Add a safety test confirming that Retry nodes with active descendants remain `Running`.

## Verification

The following focused controller tests pass:

- existing Steps fail-fast behavior
- #16849 regression
- active Retry descendant protection
- workflow parallelism
- Steps template parallelism
- DAG template parallelism
- nested template parallelism
- shutdown/deadline Retry cleanup

The full `workflow/controller` package test was also run locally. It reached an unrelated environment failure in `TestArtifactPluginSidecar` because the local Docker configuration references `docker-credential-desktop`, which is not installed:

    error getting credentials - err: exec: "docker-credential-desktop": executable file not found in $PATH

No unrelated code was changed to work around this local environment issue.

CI is also running the repository's normal checks on this PR.

## Documentation

No documentation changes are required. This fixes controller behavior without introducing or changing a user-facing API or configuration option.

## AI

AI-assisted development was used during investigation and implementation. The bug was reproduced with a regression test, the resulting changes were reviewed, and focused tests were run locally to verify fail-fast, Retry, parallelism, and shutdown behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fail-fast workflows now correctly terminate retry tasks that are left pending after a sibling task fails.
  - Workflow and task status updates are now handled consistently, allowing failed workflows to complete without reporting an incorrect parallelism error.
  - Active retry attempts continue running when their underlying work is still in progress, preventing premature termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->