### PR TITLE
docs(retries): clarify maxDuration retry deadline

### DIFF
--- a/docs/retries.md
+++ b/docs/retries.md
@@ -126,3 +126,13 @@ Boolean operators can be used to combine multiple conditions. See [example](http
 ## Back-Off
 
 You can configure the delay between retries with `backoff`. See [example](https://raw.githubusercontent.com/argoproj/argo-workflows/main/examples/retry-backoff.yaml) for usage.
+
+### Maximum retry duration
+
+`backoff.maxDuration` limits the overall retry window; it is not the maximum individual back-off delay.
+Argo calculates an absolute deadline from the time it initializes the first attempt's node, before Kubernetes schedules its Pod or starts any containers.
+For Pod templates, scheduling, image pulls, initialization, attempt execution, and back-off waits therefore consume the retry window.
+After an attempt fails or errors, Argo stops retrying if the deadline has passed (`Max duration limit exceeded`) or if the next back-off would end after it (`Backoff would exceed max duration limit`), even when `limit` permits more attempts.
+Later retry Pods also receive this absolute execution deadline.
+`maxDuration` is not a hard timeout for the first attempt, and a successful attempt is accepted even if the retry deadline has passed.
+On busy clusters, size `maxDuration` for worst-case wall-clock latency or omit it and bound retries with `limit` alone.


### PR DESCRIPTION
Retry behavior can be surprising when `backoff.maxDuration` expires while Kubernetes is still scheduling or starting a Pod.
This PR explains that the setting covers the whole retry window—not just back-off delays or container execution—and gives users practical guidance for configuring it.

- [x] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change (not applicable; documentation-only change)
- [x] For features: an associated issue and a feature description file (not applicable; no behavior change)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

`backoff.maxDuration` can expire before the configured retry limit is reached because its deadline begins with the first attempt and includes Pod startup latency.
The existing retries documentation did not explain this behavior, which can make missing retries difficult to understand.

### Modifications

- Explain that `backoff.maxDuration` is an overall retry-window deadline, not an individual back-off duration.
- Document that Pod scheduling, image pulls, initialization, execution, and back-off waits consume the window.
- Describe when Argo suppresses another retry and clarify that the setting does not terminate the first attempt or reject a successful attempt.
- Add guidance for sizing or omitting the duration on busy clusters.

### Verification

- Full `make pre-commit -B` workflow, using GNU Make and an explicit auto-discovered build-tag set on macOS
- Strict documentation build
- `git diff --check`

### Documentation

Updated the Back-Off section in `docs/retries.md`.
No separate feature documentation is needed because this PR clarifies existing behavior without changing it.

### AI

I used OpenAI Codex to inspect the controller behavior, draft the documentation and PR text, and run documentation checks.
I reviewed and validated the final change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the maximum retry duration setting, including how its deadline accounts for scheduling, setup, execution, and back-off periods.
  - Clarified when retries stop and how the deadline applies to subsequent attempts.
  - Explained behavior when the first attempt times out or an attempt completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->