### PR TITLE
fix(controller): refresh image entrypoints for PullAlways

### DIFF
--- a/workflow/controller/entrypoint/cache_index.go
+++ b/workflow/controller/entrypoint/cache_index.go
@@ -3,6 +3,7 @@ package entrypoint
 import (
 	"context"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/utils/lru"
 
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -15,14 +16,18 @@ type cacheIndex struct {
 
 func (i *cacheIndex) Lookup(ctx context.Context, image string, options Options) (*Image, error) {
 	logger := logging.RequireLoggerFromContext(ctx)
-	if cmd, ok := i.cache.Get(image); ok {
-		logger.WithFields(logging.Fields{
-			"image": image,
-			"cmd":   cmd,
-		}).Debug(ctx, "Cache hit")
-		return cmd.(*Image), nil
+	if options.ImagePullPolicy == apiv1.PullAlways {
+		logger.WithField("image", image).Debug(ctx, "Cache bypassed due to image pull policy")
+	} else {
+		if cmd, ok := i.cache.Get(image); ok {
+			logger.WithFields(logging.Fields{
+				"image": image,
+				"cmd":   cmd,
+			}).Debug(ctx, "Cache hit")
+			return cmd.(*Image), nil
+		}
+		logger.WithField("image", image).Debug(ctx, "Cache miss")
 	}
-	logger.WithField("image", image).Debug(ctx, "Cache miss")
 	v, err := i.delegate.Lookup(ctx, image, options)
 	if err != nil {
 		return nil, err

--- a/workflow/controller/entrypoint/cache_index_test.go
+++ b/workflow/controller/entrypoint/cache_index_test.go
@@ -1,0 +1,112 @@
+package entrypoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/utils/lru"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+type lookupFunc func(ctx context.Context, image string, options Options) (*Image, error)
+
+func (f lookupFunc) Lookup(ctx context.Context, image string, options Options) (*Image, error) {
+	return f(ctx, image, options)
+}
+
+func TestCacheIndexLookupAlwaysRefreshesCache(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	first := &Image{Entrypoint: []string{"/first"}}
+	refreshed := &Image{Entrypoint: []string{"/refreshed"}}
+	lookups := 0
+	index := &cacheIndex{
+		cache: lru.New(1),
+		delegate: lookupFunc(func(context.Context, string, Options) (*Image, error) {
+			lookups++
+			if lookups == 1 {
+				return first, nil
+			}
+			return refreshed, nil
+		}),
+	}
+
+	actual, err := index.Lookup(ctx, "example.com/app:latest", Options{ImagePullPolicy: apiv1.PullAlways})
+	require.NoError(t, err)
+	assert.Same(t, first, actual)
+
+	actual, err = index.Lookup(ctx, "example.com/app:latest", Options{ImagePullPolicy: apiv1.PullAlways})
+	require.NoError(t, err)
+	assert.Same(t, refreshed, actual)
+
+	actual, err = index.Lookup(ctx, "example.com/app:latest", Options{ImagePullPolicy: apiv1.PullIfNotPresent})
+	require.NoError(t, err)
+	assert.Same(t, refreshed, actual)
+	assert.Equal(t, 2, lookups)
+}
+
+func TestCacheIndexLookupUsesCacheForOrdinaryPullPolicies(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy apiv1.PullPolicy
+	}{
+		{name: "empty", policy: ""},
+		{name: "if-not-present", policy: apiv1.PullIfNotPresent},
+		{name: "never", policy: apiv1.PullNever},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			expected := &Image{Entrypoint: []string{"/entrypoint"}}
+			lookups := 0
+			index := &cacheIndex{
+				cache: lru.New(1),
+				delegate: lookupFunc(func(context.Context, string, Options) (*Image, error) {
+					lookups++
+					return expected, nil
+				}),
+			}
+
+			for range 2 {
+				actual, err := index.Lookup(ctx, "example.com/app:stable", Options{ImagePullPolicy: test.policy})
+				require.NoError(t, err)
+				assert.Same(t, expected, actual)
+			}
+			assert.Equal(t, 1, lookups)
+		})
+	}
+}
+
+func TestCacheIndexLookupAlwaysDoesNotFallBackToStaleValue(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	stale := &Image{Entrypoint: []string{"/stale"}}
+	wantErr := errors.New("registry lookup failed")
+	lookups := 0
+	index := &cacheIndex{
+		cache: lru.New(1),
+		delegate: lookupFunc(func(context.Context, string, Options) (*Image, error) {
+			lookups++
+			if lookups == 1 {
+				return stale, nil
+			}
+			return nil, wantErr
+		}),
+	}
+
+	actual, err := index.Lookup(ctx, "example.com/app:latest", Options{})
+	require.NoError(t, err)
+	assert.Same(t, stale, actual)
+
+	actual, err = index.Lookup(ctx, "example.com/app:latest", Options{ImagePullPolicy: apiv1.PullAlways})
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, actual)
+
+	actual, err = index.Lookup(ctx, "example.com/app:latest", Options{})
+	require.NoError(t, err)
+	assert.Same(t, stale, actual)
+	assert.Equal(t, 2, lookups)
+}

--- a/workflow/controller/entrypoint/image.go
+++ b/workflow/controller/entrypoint/image.go
@@ -18,6 +18,7 @@ type Options struct {
 	Namespace          string
 	ServiceAccountName string
 	ImagePullSecrets   []apiv1.LocalObjectReference
+	ImagePullPolicy    apiv1.PullPolicy
 }
 
 type Image struct {

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -756,7 +756,10 @@ func (pb *podBuilder) build(ctx context.Context) (*podBuildResult, error) {
 			if len(c.Command) == 0 {
 				var x *entrypoint.Image
 				x, err = pb.deps.lookupImage(ctx, c.Image, entrypoint.Options{
-					Namespace: pb.in.namespace, ServiceAccountName: pb.in.execWfSpec.ServiceAccountName, ImagePullSecrets: pb.in.execWfSpec.ImagePullSecrets,
+					Namespace:          pb.in.namespace,
+					ServiceAccountName: pb.in.execWfSpec.ServiceAccountName,
+					ImagePullSecrets:   pb.in.execWfSpec.ImagePullSecrets,
+					ImagePullPolicy:    c.ImagePullPolicy,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to look-up entrypoint/cmd for image %q, you must either explicitly specify the command, or list the image's command in the index: https://argo-workflows.readthedocs.io/en/latest/workflow-executors/#emissary-emissary: %w", c.Image, err)

--- a/workflow/controller/workflowpod_build_test.go
+++ b/workflow/controller/workflowpod_build_test.go
@@ -44,6 +44,7 @@ type stubPodBuilderDeps struct {
 	executorImage     string
 	archiveLogs       bool
 	initContainerName string // name of the init container legacyLayout asks for
+	lookupOptions     []entrypoint.Options
 
 	// gotTimeoutNow records the now value build threads into checkTemplateTimeouts,
 	// so a test can assert build uses the captured snapshot time rather than the
@@ -59,7 +60,8 @@ func newStubDeps() *stubPodBuilderDeps {
 }
 
 // lookupImage returns a fixed entrypoint so build never reaches the network.
-func (s *stubPodBuilderDeps) lookupImage(_ context.Context, _ string, _ entrypoint.Options) (*entrypoint.Image, error) {
+func (s *stubPodBuilderDeps) lookupImage(_ context.Context, _ string, options entrypoint.Options) (*entrypoint.Image, error) {
+	s.lookupOptions = append(s.lookupOptions, options)
 	return &entrypoint.Image{Entrypoint: []string{"/stub-entrypoint"}, Cmd: []string{"stub-cmd"}}, nil
 }
 
@@ -164,6 +166,21 @@ func TestBuild_ThreadsSnapshotNowIntoTimeout(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, snapshotNow, deps.gotTimeoutNow,
 		"build must pass the captured snapshot time into checkTemplateTimeouts, not the live wall-clock")
+}
+
+func TestBuild_ForwardsImagePullPolicyToEntrypointLookup(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	tmpl := simpleContainerTemplate()
+	tmpl.Container.Command = nil
+	main := tmpl.Container.DeepCopy()
+	main.ImagePullPolicy = apiv1.PullAlways
+
+	deps := newStubDeps()
+	pb := newTestPodBuilder(tmpl, []apiv1.Container{*main}, false, deps)
+	_, err := pb.build(ctx)
+	require.NoError(t, err)
+	require.Len(t, deps.lookupOptions, 1)
+	assert.Equal(t, apiv1.PullAlways, deps.lookupOptions[0].ImagePullPolicy)
 }
 
 // newTestPodBuilder constructs a podBuilder entirely from literals — no woc, no


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B` — see Verification
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not applicable; this is a bug fix
- [x] Opened as draft; will mark "Ready for review" once builds are green

Addresses #10729

### Motivation

For user containers without an explicit command, the controller caches the resolved image entrypoint using the image string as its key. When a mutable tag is republished and the container explicitly uses `imagePullPolicy: Always`, Kubernetes can pull the new image while Argo continues injecting the entrypoint cached for the previous image behind that tag.

### Modifications

- Forward the final user container's `ImagePullPolicy` to entrypoint resolution.
- For explicit `PullAlways`, bypass the LRU read and invoke the existing delegate lookup.
- Cache successful results so subsequent ordinary lookups can use the refreshed entrypoint.
- Return lookup errors without falling back to a stale cached value. A failed refresh does not overwrite or evict the previous cache entry.
- Preserve existing behavior for an omitted policy, `IfNotPresent`, `Never`, containers with an explicit command, and artifact-driver images.

This intentionally applies only to explicit `PullAlways`. The pod builder runs before Kubernetes defaults an omitted pull policy, so emulating Kubernetes defaulting is outside this change.

The trade-off is that each entrypoint resolution for a commandless user container with explicit `PullAlways` runs the existing delegate chain instead of reading the LRU. This may add registry or Kubernetes API work when the configured image index cannot satisfy the lookup.

### Verification

- Captured test-first failures before adding `ImagePullPolicy` to the lookup options.
- Added tests proving repeated `PullAlways` lookups bypass and refresh the cache.
- Covered unchanged caching for an empty policy, `IfNotPresent`, and `Never`.
- Covered failed refreshes returning the delegate error without stale fallback.
- Verified workflow-pod construction forwards the final container pull policy.
- Focused entrypoint and workflow-pod tests pass with and without `-race`.
- The full entrypoint package passes.
- Codegen, lint, feature validation, documentation checks, `go mod tidy -diff`, and `git diff --check` pass without generated or dependency drift.

The unmodified `make pre-commit -B` wrapper could not complete as a single invocation on this macOS host because of compatibility differences involving Apple GNU Make 3.81, BSD userland tools, Bash 3.2, and system Python 3.9. All constituent codegen, lint, and documentation gates passed using task-local compatible tooling.

The unfiltered controller package also reaches seven pre-existing artifact-plugin failures on `darwin/arm64` because the test's `alpine` image has no matching platform manifest. The same failures reproduce on the unchanged base; the remaining controller tests pass when those cases are excluded.

### Documentation

No documentation change is required. This fixes internal controller behavior without changing workflow configuration, APIs, CLI behavior, dependencies, or generated files.

### AI

OpenAI Codex was used to assist with analyzing the issue, implementing the controller change and regression tests, running local validation, and drafting this PR description. I independently reviewed the affected code paths, verified that the implementation matches the intended behavior and remains within the scope proposed in my issue comment, examined the regression tests and validation results, and checked the final diff for correctness and unintended changes. I also personally controlled the issue comment, DCO-signed commit, and branch push. I remain responsible for the final contribution and will review the CI results and any subsequent changes before marking this draft as Ready.
