### PR TITLE
fix: don't fail nodes on artifact plugin sidecar exit codes (cherry-pick #16807 for 4.0)

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1833,6 +1833,18 @@ func (woc *wfOperationCtx) inferFailedReason(ctx context.Context, pod *apiv1.Pod
 		case ctr.Name == common.WaitContainerName:
 			return wfv1.NodeError, msg
 		default:
+			if common.IsArtifactPluginSidecar(ctr.Name) {
+				// Artifact plugin sidecars are torn down by the wait
+				// container after it has saved all outputs, so a wait container
+				// that exited 0 proves every save succeeded and the sidecar's own
+				// exit code carries no information about the node's outcome. The
+				// code can even be a phantom: a `kill` exec racing the sidecar's
+				// exit can make the container runtime record a non-zero status
+				// for a process that exited cleanly. Record it and let the
+				// main/wait verdict below decide the node's fate.
+				woc.log.WithFields(logging.Fields{"exitCode": t.ExitCode, "containerName": ctr.Name}).Info(ctx, "ignoring artifact plugin sidecar exit code")
+				continue
+			}
 			if t.ExitCode == 137 || t.ExitCode == 143 {
 				// if the sidecar was SIGKILL'd (exit code 137) assume it was because argoexec
 				// forcibly killed the container, which we ignore the error for.

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -13105,3 +13105,68 @@ func TestWithSequenceExpressionPreservesGlobalScope(t *testing.T) {
 			"Should have created multiple nodes for expanded sequence")
 	})
 }
+
+// TestInferFailedReasonArtifactPluginSidecar ensures that a non-zero exit from
+// an artifact plugin sidecar does not fail a node whose main and wait
+// containers completed successfully: the wait container tears the sidecars
+// down only after all saves succeeded, and the recorded exit code can even be
+// a phantom produced by a kill exec racing the sidecar's own exit. Failures of
+// main, the wait container, or user sidecars must still fail the node as
+// before.
+func TestInferFailedReasonArtifactPluginSidecar(t *testing.T) {
+	terminated := func(name string, exitCode int32) apiv1.ContainerStatus {
+		return apiv1.ContainerStatus{
+			Name:  name,
+			State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: exitCode, Reason: "Error"}},
+		}
+	}
+	tests := []struct {
+		name          string
+		ctrs          []apiv1.ContainerStatus
+		expectedPhase wfv1.NodePhase
+		expectedMsg   string
+	}{
+		{
+			name:          "PluginSidecarExitIgnored",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 0), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeSucceeded,
+			expectedMsg:   "",
+		},
+		{
+			name:          "PluginSidecarSigtermExitIgnored",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 0), terminated("artifact-plugin-test", 143)},
+			expectedPhase: wfv1.NodeSucceeded,
+			expectedMsg:   "",
+		},
+		{
+			name:          "WaitFailureStillFails",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 1), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeError,
+			expectedMsg:   "wait: Error (exit code 1)",
+		},
+		{
+			name:          "MainFailureStillFails",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 1), terminated("wait", 0), terminated("artifact-plugin-test", 2)},
+			expectedPhase: wfv1.NodeFailed,
+			expectedMsg:   "main: Error (exit code 1)",
+		},
+		{
+			name:          "UserSidecarFailureStillFails",
+			ctrs:          []apiv1.ContainerStatus{terminated("main", 0), terminated("wait", 0), terminated("artifact-plugin-test", 2), terminated("user-sidecar", 1)},
+			expectedPhase: wfv1.NodeFailed,
+			expectedMsg:   "user-sidecar: Error (exit code 1)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			pod := apiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+				Status:     apiv1.PodStatus{Phase: apiv1.PodFailed, ContainerStatuses: tt.ctrs},
+			}
+			phase, msg := newWoc(ctx).inferFailedReason(ctx, &pod, nil)
+			assert.Equal(t, tt.expectedPhase, phase)
+			assert.Equal(t, tt.expectedMsg, msg)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-picked fix: don't fail nodes on artifact plugin sidecar exit codes (#16807)