### PR TITLE
fix(sync): break lock queue ties identically in memory and in the database

### DIFF
--- a/util/sync/db/queries.go
+++ b/util/sync/db/queries.go
@@ -212,7 +212,9 @@ func (q *syncQueries) GetOrderedQueue(ctx context.Context, sessionProxy *sqldb.S
 			And(db.Cond{ControllerTimeField + " >": since})
 
 		return session.SQL().
-			Select(StateKeyField, StateControllerField).
+			// Priority and time are needed by the caller, which orders the
+			// queue in Go (see workflow/sync queueLess).
+			Select(StateKeyField, StateControllerField, StatePriorityField, StateTimeField).
 			From(q.config.StateTable).
 			Where(db.Cond{StateNameField: semaphoreName}).
 			And(db.Cond{StateHeldField: false}).

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -168,6 +168,19 @@ func (s *databaseSemaphore) queueOrdered(ctx context.Context, sessionProxy *sqld
 		logger.WithError(err).Error(ctx, "Failed to get ordered queue for semaphore notification")
 		return nil, err
 	}
+	// Re-sort in Go so ties are broken exactly as the in-memory queue breaks
+	// them. A holder needs the front of every queue it is in, and database
+	// text collation does not necessarily match Go string ordering.
+	slices.SortStableFunc(queue, func(a, b syncdb.StateRecord) int {
+		switch {
+		case queueLess(a.Priority, a.Time, a.Key, b.Priority, b.Time, b.Key):
+			return -1
+		case queueLess(b.Priority, b.Time, b.Key, a.Priority, a.Time, a.Key):
+			return 1
+		default:
+			return 0
+		}
+	})
 	return queue, nil
 }
 

--- a/workflow/sync/multi_throttler.go
+++ b/workflow/sync/multi_throttler.go
@@ -269,10 +269,27 @@ func (pq *priorityQueue) remove(key Key) {
 func (pq priorityQueue) Len() int { return len(pq.items) }
 
 func (pq priorityQueue) Less(i, j int) bool {
-	if pq.items[i].priority == pq.items[j].priority {
-		return pq.items[i].creationTime.Before(pq.items[j].creationTime)
+	a, b := pq.items[i], pq.items[j]
+	return queueLess(a.priority, a.creationTime, a.key, b.priority, b.creationTime, b.key)
+}
+
+// queueLess is the single ordering rule for every lock queue: higher priority
+// first, then earlier creation time, then holder key in byte order. The key is
+// the tie-break because creation time comes from the Kubernetes
+// creationTimestamp, which has second resolution, so workflows submitted in
+// the same second and every node of a template-level lock tie on it. A holder
+// must be at the front of the queue of every lock it requests, and the
+// in-memory heap and the database each keep their own queue, so both must
+// resolve ties identically or two waiters can each be blocked by the other
+// forever. Keep this in sync with the ORDER BY in syncdb.GetOrderedQueue.
+func queueLess(aPriority int32, aTime time.Time, aKey string, bPriority int32, bTime time.Time, bKey string) bool {
+	if aPriority != bPriority {
+		return aPriority > bPriority
 	}
-	return pq.items[i].priority > pq.items[j].priority
+	if !aTime.Equal(bTime) {
+		return aTime.Before(bTime)
+	}
+	return aKey < bKey
 }
 
 func (pq priorityQueue) Swap(i, j int) {

--- a/workflow/sync/multi_throttler_test.go
+++ b/workflow/sync/multi_throttler_test.go
@@ -260,3 +260,30 @@ func TestNamespaceParallelismDefaultUpdate(t *testing.T) {
 	assert.True(throttler.Admit("default/b"))
 	assert.True(throttler.Admit("default/c"))
 }
+
+func TestPriorityQueueTieBreaksOnKey(t *testing.T) {
+	created := time.Now()
+	pq := &priorityQueue{itemByKey: make(map[string]*item)}
+	// Same priority and creation time: only the key can order these.
+	pq.add("ns/wf-c", 0, created)
+	pq.add("ns/wf-a", 0, created)
+	pq.add("ns/wf-b", 0, created)
+	// Removing the front is what reshuffles a heap with no tie-break.
+	pq.add("ns/wf-0", 0, created)
+	pq.remove("ns/wf-0")
+
+	var order []string
+	for pq.Len() > 0 {
+		order = append(order, pq.pop().key)
+	}
+	assert.Equal(t, []string{"ns/wf-a", "ns/wf-b", "ns/wf-c"}, order)
+}
+
+func TestQueueLess(t *testing.T) {
+	earlier := time.Now()
+	later := earlier.Add(time.Second)
+	assert.True(t, queueLess(1, later, "b", 0, earlier, "a"), "higher priority wins over time and key")
+	assert.True(t, queueLess(0, earlier, "b", 0, later, "a"), "earlier creation wins over key")
+	assert.True(t, queueLess(0, earlier, "a", 0, earlier, "b"), "key breaks a full tie")
+	assert.False(t, queueLess(0, earlier, "a", 0, earlier, "a"), "identical entries are not less")
+}

--- a/workflow/sync/sync_manager_dual_lock_test.go
+++ b/workflow/sync/sync_manager_dual_lock_test.go
@@ -1,0 +1,79 @@
+//go:build !windows
+
+package sync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+const wfWithMemoryAndDatabaseMutex = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: test-dual-mutex
+  namespace: default
+spec:
+  entrypoint: whalesay
+  synchronization:
+    mutexes:
+      - name: shared
+      - name: shared
+        database: true
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+      command: [cowsay]
+      args: ["hello world"]
+`
+
+// A workflow holding an in-memory and a database mutex of the same name (the
+// recommended way to migrate from one to the other) must be at the front of
+// both queues before it can acquire either. When several waiters share a
+// priority and a creation timestamp - which Kubernetes stores at second
+// resolution - each queue must break the tie the same way, or the heap can
+// favour one waiter while the database favours another and neither ever runs.
+func TestDualMemoryAndDatabaseMutexTiedQueueOrder(t *testing.T) {
+	for _, dbType := range testDBTypes {
+		t.Run(string(dbType), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(logging.TestContext(t.Context()))
+			defer cancel()
+			info, deferfn, cfg, err := createTestDBSession(ctx, t, dbType)
+			require.NoError(t, err)
+			defer deferfn()
+
+			syncMgr := createLockManager(ctx, info.SessionProxy, &cfg, func(_ context.Context, _ string) (int, error) { return 1, nil }, func(string) {}, WorkflowExistenceFunc)
+			require.NotNil(t, syncMgr)
+
+			created := metav1.Time{Time: time.Now().Add(-time.Minute).Truncate(time.Second)}
+			newWf := func(name string) *wfv1.Workflow {
+				wf := wfv1.MustUnmarshalWorkflow(wfWithMemoryAndDatabaseMutex)
+				wf.Name = name
+				wf.CreationTimestamp = created
+				return wf
+			}
+			wfA, wfB, wfC := newWf("wf-a"), newWf("wf-b"), newWf("wf-c")
+
+			checkCanAcquire(ctx, t, syncMgr, wfA)
+			checkCannotAcquire(ctx, t, syncMgr, wfB)
+			checkCannotAcquire(ctx, t, syncMgr, wfC)
+
+			// Releasing the holder removes it from the in-memory heap, which
+			// reorders tied entries unless the key breaks the tie.
+			syncMgr.Release(ctx, wfA, wfA.Name, wfA.Spec.Synchronization)
+			checkCannotAcquire(ctx, t, syncMgr, wfC)
+			checkCanAcquire(ctx, t, syncMgr, wfB)
+
+			syncMgr.Release(ctx, wfB, wfB.Name, wfB.Spec.Synchronization)
+			checkCanAcquire(ctx, t, syncMgr, wfC)
+		})
+	}
+}

--- a/workflow/sync/sync_manager_test.go
+++ b/workflow/sync/sync_manager_test.go
@@ -855,6 +855,10 @@ func TestResizeSemaphoreSize(t *testing.T) {
 		wf.CreationTimestamp = metav1.Time{Time: time.Now()}
 		wf1 := wf.DeepCopy()
 		wf2 := wf.DeepCopy()
+		// Distinct creation times so the queue order is the submission order
+		// this test walks through; tied times are ordered by name.
+		wf1.CreationTimestamp = metav1.Time{Time: wf.CreationTimestamp.Add(time.Second)}
+		wf2.CreationTimestamp = metav1.Time{Time: wf.CreationTimestamp.Add(2 * time.Second)}
 		status, wfUpdate, msg, failedLockName, err := syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
 		require.NoError(t, err)
 		assert.Empty(t, msg)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` (ran `golangci-lint` on the changed packages; no generated files or docs are touched)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

A workflow that requests more than one synchronization lock can hang forever once there are two or more waiters that tie on priority and creation time.

A holder must be at the front of the queue of every lock it requests before it can acquire any of them, and every lock keeps its own queue. The in-memory queue is a heap ordered by priority then creation time; the database queue is `ORDER BY priority, time`. Creation time is the Kubernetes `creationTimestamp`, which has second resolution, so workflows submitted in the same second tie, and every node of a template-level lock ties. Neither queue has a tie-break rule: the heap resolves ties by whatever order a removal leaves behind, the database by physical row order. Two tied waiters can therefore each be first in one queue and second in the other. Each is refused by the lock where it is second, each refusal requeues the other waiter, and neither ever runs.

Any combination of locks is exposed, mutex or semaphore, and the lock names are irrelevant. The likeliest case, and the one reproduced here, is an in-memory lock alongside a database lock, since the two tie-break mechanisms are unrelated. That is exactly what a user gets when migrating from in-memory to database locks by declaring both during the transition.

Reproduced on v4.1.2 with four same-second workflow-level workflows each holding an in-memory and a database mutex (two of four completed, two stuck) and with template-level dual mutexes over `withItems` in two workflows (one node each completed, four stuck). In the stuck state one waiter reports `Waiting for argo/Mutex/x lock. Lock status: 1/1` and the other `Waiting for argo/Database/x lock (mtx/argo/x). Lock status: 0/1`, with both locks free.

### Modifications

- `workflow/sync/multi_throttler.go`: one comparator, `queueLess`, ordering by priority descending, creation time ascending, then holder key in byte order. The heap's `Less` delegates to it.
- `workflow/sync/database_semaphore.go`: `queueOrdered` re-sorts the rows with the same comparator, so the tie-break is identical to the heap regardless of the database's text collation.
- `util/sync/db/queries.go`: `GetOrderedQueue` also selects `priority` and `time` so the Go sort has them.

Behaviour note: workflows created in the same second are now served in holder-key order rather than heap order. Heap order was never stable once a holder was removed, so nothing users could rely on changes.

### Verification

- New `TestDualMemoryAndDatabaseMutexTiedQueueOrder` (Postgres and MySQL via testcontainers): three same-second workflows with both mutexes; the first acquires and releases, the remaining two must be served in order. Fails without the fix at exactly the deadlock, passes with it.
- New heap unit tests `TestPriorityQueueTieBreaksOnKey` and `TestQueueLess`.
- `TestResizeSemaphoreSize` now gives its workflows distinct creation times, since it walks through them in submission order and its names sort the other way.
- Full `workflow/sync` suite passes on Postgres and MySQL; `workflow/controller` tests matching `Sync|Mutex|Semaphore|Parallelism` pass.

### Documentation

None needed. Queue ordering within a tie was previously unspecified.

### AI

Claude Code (Claude Fable 5.1) was used to reproduce the problem, trace the root cause, and draft the code, tests, commit message, and this description. All of it was reviewed and the tests were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF5LwnYKZ2RiURRKRigag7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow queue ordering so higher-priority workflows are scheduled first, followed by creation time and a deterministic key-based tie-breaker.
  - Ensured consistent ordering between in-memory and database-backed queues, including workflows with identical priorities and timestamps.
  - Improved scheduling fairness and predictability when multiple workflows are submitted at nearly the same time.

- **Tests**
  - Added coverage for queue tie-breaking and coordinated locking across supported database types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->