### PR TITLE
fix(sync): report available slots in the database lock waiting message

### DIFF
--- a/workflow/sync/database_mutex_test.go
+++ b/workflow/sync/database_mutex_test.go
@@ -96,3 +96,28 @@ func TestDatabaseMutexQueueOrder(t *testing.T) {
 		})
 	}
 }
+
+// The waiting message reports available slots over the limit, matching the
+// in-memory locks, so a held mutex reads "0/1" whichever backend holds it.
+func TestDatabaseMutexWaitingMessageShowsAvailability(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	for _, dbType := range testDBTypes {
+		t.Run(string(dbType), func(t *testing.T) {
+			mutex, tx, deferfunc := createTestDatabaseMutex(ctx, t, "test-mutex", "default", func(string) {}, dbType)
+			defer deferfunc()
+
+			now := time.Now()
+			require.NoError(t, mutex.addToQueue(ctx, "default/workflow1", 0, now))
+			require.NoError(t, mutex.addToQueue(ctx, "default/workflow2", 0, now.Add(time.Second)))
+
+			acquired, _, err := mutex.tryAcquire(ctx, "default/workflow1", tx)
+			require.NoError(t, err)
+			require.True(t, acquired)
+
+			acquired, msg, err := mutex.tryAcquire(ctx, "default/workflow2", tx)
+			require.NoError(t, err)
+			assert.False(t, acquired)
+			assert.Contains(t, msg, "Lock status: 0/1")
+		})
+	}
+}

--- a/workflow/sync/database_semaphore.go
+++ b/workflow/sync/database_semaphore.go
@@ -262,7 +262,9 @@ func (s *databaseSemaphore) checkAcquire(ctx context.Context, holderKey string, 
 		}).Info(ctx, "CheckAcquire - already held")
 		return false, true, ""
 	}
-	waitingMsg := fmt.Sprintf("Waiting for %s lock (%s). Lock status: %d/%d", s.name, s.longDBKey(), len(holders), limit)
+	// Available slots over limit, the convention the in-memory locks have
+	// used since 3.0, so "0/1" reads the same for both lock types.
+	waitingMsg := fmt.Sprintf("Waiting for %s lock (%s). Lock status: %d/%d", s.name, s.longDBKey(), limit-len(holders), limit)
 
 	if len(holders) >= limit {
 		logger.WithFields(logging.Fields{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` (ran `go vet` and the database mutex tests on the changed package; no generated files or docs are touched)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Related to #14080, which asks for the in-memory message to mention queue position; that is a separate change.

### Motivation

The waiting message on a Pending workflow means the opposite thing depending on which lock backend it came from.

- In-memory locks (`workflow/sync/semaphore.go`) print `Lock status: <available>/<limit>`, so a held mutex shows `0/1`. This has been the format since semaphores were added in 3.0 (#3141), and the matching acquire log says "Lock availability".
- Database locks (`workflow/sync/database_semaphore.go`, added in 3.7 by #14309) copied the wording but print `<holders>/<limit>`, so the same held mutex shows `1/1`.

Nothing in the text says which convention applies, so `1/1` reads as "full" for one backend and "free" for the other. Found while reproducing #16880, where a stuck workflow showed `Lock status: 1/1` from one lock and `0/1` from the other while both locks were free.

### Modifications

`database_semaphore.go`: the waiting message reports `limit - holders` over `limit`, matching the in-memory locks.

### Verification

New `TestDatabaseMutexWaitingMessageShowsAvailability` runs on Postgres and MySQL via testcontainers: with one holder on a mutex, the next waiter's message contains `Lock status: 0/1`. The existing database mutex tests pass.

### Documentation

None needed. The documented format is unchanged; only the database backend's number now matches it.

### AI

Claude Code (Claude Fable 5.1) drafted the change, test, commit message, and this description; reviewed and tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF5LwnYKZ2RiURRKRigag7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected database semaphore lock-status messages to show available slots rather than currently occupied slots.
  - Contended locks now consistently report availability, such as `0/1` when no slots are available.

- **Tests**
  - Added coverage validating lock-status messages across supported database backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->