### PR TITLE
fix: reject submissions from other controller instances

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -791,6 +791,37 @@ func (s *workflowServer) validateWorkflow(wf *wfv1.Workflow) error {
 	return sutils.ToStatusError(s.instanceIDService.Validate(wf), codes.InvalidArgument)
 }
 
+func (s *workflowServer) validateWorkflowTemplateInstanceID(ctx context.Context, wfClient versioned.Interface, namespace string, ref *wfv1.WorkflowTemplateRef) error {
+	if ref == nil {
+		return nil
+	}
+	var (
+		tmpl         metav1.Object
+		resourceKind string
+		err          error
+	)
+	if ref.ClusterScope {
+		resourceKind = "ClusterWorkflowTemplate"
+		tmpl, err = wfClient.ArgoprojV1alpha1().ClusterWorkflowTemplates().Get(ctx, ref.Name, metav1.GetOptions{})
+	} else {
+		resourceKind = "WorkflowTemplate"
+		tmpl, err = wfClient.ArgoprojV1alpha1().WorkflowTemplates(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+	}
+	if err != nil {
+		return sutils.ToStatusError(err, codes.Internal)
+	}
+	if _, ok := tmpl.GetLabels()[common.LabelKeyControllerInstanceID]; !ok {
+		return nil
+	}
+	if err := s.instanceIDService.Validate(tmpl); err != nil {
+		if s.instanceIDService.InstanceID() == "" {
+			return sutils.ToStatusError(err, codes.InvalidArgument)
+		}
+		return sutils.ToStatusError(fmt.Errorf("%s %q not found", resourceKind, ref.Name), codes.NotFound)
+	}
+	return nil
+}
+
 func getLatestWorkflow(ctx context.Context, wfClient versioned.Interface, namespace string) (*wfv1.Workflow, error) {
 	wfList, err := wfClient.ArgoprojV1alpha1().Workflows(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -828,6 +859,9 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 		return nil, err
 	}
 
+	if err := s.validateWorkflowTemplateInstanceID(ctx, wfClient, req.Namespace, wf.Spec.WorkflowTemplateRef); err != nil {
+		return nil, err
+	}
 	s.instanceIDService.Label(wf)
 	creator.LabelCreator(ctx, wf)
 
@@ -862,21 +896,12 @@ func (s *workflowServer) SubmitWorkflow(ctx context.Context, req *workflowpkg.Wo
 			if getErr != nil {
 				return nil, sutils.ToStatusError(fmt.Errorf("failed to get ClusterWorkflowTemplate for artifact override: %w", getErr), codes.Internal)
 			}
-			// This Get bypasses the instance-ID-filtered template store, so enforce the
-			// instance-ID boundary here to avoid copying artifact config from a template
-			// managed by a different Argo Server instance.
-			if validateErr := s.instanceIDService.Validate(cwftmpl); validateErr != nil {
-				return nil, sutils.ToStatusError(fmt.Errorf("ClusterWorkflowTemplate %q not found", wf.Spec.WorkflowTemplateRef.Name), codes.NotFound)
-			}
 			tmplArtifacts = cwftmpl.Spec.Arguments.Artifacts
 			artifactRepositoryRef = cwftmpl.Spec.ArtifactRepositoryRef
 		} else {
 			wftmpl, getErr := wfClient.ArgoprojV1alpha1().WorkflowTemplates(req.Namespace).Get(ctx, wf.Spec.WorkflowTemplateRef.Name, metav1.GetOptions{})
 			if getErr != nil {
 				return nil, sutils.ToStatusError(fmt.Errorf("failed to get WorkflowTemplate for artifact override: %w", getErr), codes.Internal)
-			}
-			if validateErr := s.instanceIDService.Validate(wftmpl); validateErr != nil {
-				return nil, sutils.ToStatusError(fmt.Errorf("WorkflowTemplate %q not found", wf.Spec.WorkflowTemplateRef.Name), codes.NotFound)
 			}
 			tmplArtifacts = wftmpl.Spec.Arguments.Artifacts
 			artifactRepositoryRef = wftmpl.Spec.ArtifactRepositoryRef

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -1458,7 +1458,7 @@ func TestSubmitWorkflowTemplateFromOtherInstanceRejected(t *testing.T) {
 			})
 			require.Error(t, err)
 			assert.Equal(t, tt.code, status.Code(err))
-			assertNoSubmittedWorkflows(t, ctx, "test-ns")
+			assertNoSubmittedWorkflows(ctx, t, "test-ns")
 		})
 	}
 }
@@ -1561,7 +1561,7 @@ func getWorkflowServerWithInstanceID(t *testing.T, template runtime.Object, defa
 	return server, ctx
 }
 
-func assertNoSubmittedWorkflows(t *testing.T, ctx context.Context, namespace string) {
+func assertNoSubmittedWorkflows(ctx context.Context, t *testing.T, namespace string) {
 	t.Helper()
 	workflows, err := auth.GetWfClient(ctx).ArgoprojV1alpha1().Workflows(namespace).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -1392,12 +1392,7 @@ func TestSubmitWorkflowWithArtifactOverride_MalformedOverride(t *testing.T) {
 	}
 }
 
-// TestSubmitWorkflowWithArtifactOverride_OtherInstanceRejected tests that the artifact-override
-// path does not copy artifact config from a WorkflowTemplate managed by a different Argo Server
-// instance. The override branch Gets the template via the raw client, bypassing the
-// instance-ID-filtered store, so it must enforce the instance-ID boundary itself and return
-// NotFound for a template labeled with another instance ID.
-func TestSubmitWorkflowWithArtifactOverride_OtherInstanceRejected(t *testing.T) {
+func TestSubmitWorkflowTemplateFromOtherInstanceRejected(t *testing.T) {
 	wftOtherInstance := &v1alpha1.WorkflowTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-ns",
@@ -1428,19 +1423,44 @@ func TestSubmitWorkflowWithArtifactOverride_OtherInstanceRejected(t *testing.T) 
 			},
 		},
 	}
-
-	server, ctx := getWorkflowServerWithArtifacts(t, wftOtherInstance, nil)
-
-	_, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
-		Namespace:    "test-ns",
-		ResourceKind: "WorkflowTemplate",
-		ResourceName: "wft-with-artifact",
-		SubmitOptions: &v1alpha1.SubmitOpts{
-			Artifacts: []string{"input-artifact=uploads/test-ns/12345678-1234-4234-8234-123456789012/uploaded-file.zip"},
+	cwftOtherInstance := &v1alpha1.ClusterWorkflowTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "cwft-with-artifact",
+			Labels: map[string]string{common.LabelKeyControllerInstanceID: "other-instanceid"},
 		},
-	})
-	require.Error(t, err)
-	assert.Equal(t, codes.NotFound, status.Code(err))
+		Spec: wftOtherInstance.Spec,
+	}
+
+	tests := []struct {
+		name          string
+		template      runtime.Object
+		instanceID    string
+		resourceKind  string
+		resourceName  string
+		submitOptions *v1alpha1.SubmitOpts
+		code          codes.Code
+	}{
+		{"without a client instance ID", wftOtherInstance, "", "WorkflowTemplate", "wft-with-artifact", nil, codes.InvalidArgument},
+		{"without artifact overrides", wftOtherInstance, "my-instanceid", "WorkflowTemplate", "wft-with-artifact", nil, codes.NotFound},
+		{"cluster template", cwftOtherInstance, "my-instanceid", "ClusterWorkflowTemplate", "cwft-with-artifact", nil, codes.NotFound},
+		{"with artifact overrides", wftOtherInstance, "my-instanceid", "WorkflowTemplate", "wft-with-artifact", &v1alpha1.SubmitOpts{
+			Artifacts: []string{"input-artifact=uploads/test-ns/12345678-1234-4234-8234-123456789012/uploaded-file.zip"},
+		}, codes.NotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, ctx := getWorkflowServerWithInstanceID(t, tt.template, nil, tt.instanceID)
+			_, err := server.SubmitWorkflow(ctx, &workflowpkg.WorkflowSubmitRequest{
+				Namespace:     "test-ns",
+				ResourceKind:  tt.resourceKind,
+				ResourceName:  tt.resourceName,
+				SubmitOptions: tt.submitOptions,
+			})
+			require.Error(t, err)
+			assert.Equal(t, tt.code, status.Code(err))
+			assertNoSubmittedWorkflows(t, ctx, "test-ns")
+		})
+	}
 }
 
 // TestSubmitWorkflowWithArtifactOverride_UnmatchedRejected tests that an override whose
@@ -1497,6 +1517,10 @@ func TestSubmitWorkflowWithArtifactOverride_UnmatchedRejected(t *testing.T) {
 // Pass either a *v1alpha1.WorkflowTemplate or *v1alpha1.ClusterWorkflowTemplate (or both)
 // so the same helper can back namespaced- and cluster-scoped tests.
 func getWorkflowServerWithArtifacts(t *testing.T, template runtime.Object, defaultRepo *v1alpha1.ArtifactRepository) (workflowpkg.WorkflowServiceServer, context.Context) {
+	return getWorkflowServerWithInstanceID(t, template, defaultRepo, "my-instanceid")
+}
+
+func getWorkflowServerWithInstanceID(t *testing.T, template runtime.Object, defaultRepo *v1alpha1.ArtifactRepository, instanceID string) (workflowpkg.WorkflowServiceServer, context.Context) {
 	t.Helper()
 
 	offloadNodeStatusRepo := &mocks.OffloadNodeStatusRepo{}
@@ -1520,7 +1544,7 @@ func getWorkflowServerWithArtifacts(t *testing.T, template runtime.Object, defau
 	ctx = context.WithValue(ctx, auth.KubeKey, kubeClientSet)
 	ctx = context.WithValue(ctx, auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
 
-	wfStore, err := store.NewSQLiteStore(instanceid.NewService("my-instanceid"))
+	wfStore, err := store.NewSQLiteStore(instanceid.NewService(instanceID))
 	require.NoError(t, err)
 
 	wftmplStore := workflowtemplate.NewClientStore()
@@ -1532,7 +1556,14 @@ func getWorkflowServerWithArtifacts(t *testing.T, template runtime.Object, defau
 	}
 
 	namespaceAll := metav1.NamespaceAll
-	server := NewServer(ctx, instanceid.NewService("my-instanceid"), offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll, artifactRepos)
+	server := NewServer(ctx, instanceid.NewService(instanceID), offloadNodeStatusRepo, archivedRepo, wfClientset, wfStore, wfStore, wftmplStore, cwftmplStore, nil, &namespaceAll, artifactRepos)
 
 	return server, ctx
+}
+
+func assertNoSubmittedWorkflows(t *testing.T, ctx context.Context, namespace string) {
+	t.Helper()
+	workflows, err := auth.GetWfClient(ctx).ArgoprojV1alpha1().Workflows(namespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, workflows.Items)
 }


### PR DESCRIPTION
Fixes #16864

### Motivation

Submitting a WorkflowTemplate that is explicitly managed by another controller instance could create a Workflow that no controller observes.

### Modifications

I validate explicit template instance IDs before creating the Workflow. A direct client without an instance ID receives `InvalidArgument`; a client for another instance receives `NotFound`.

### Verification

`KUBECONFIG=/dev/null go test ./server/workflow -run '^TestSubmitWorkflow(TemplateFromOtherInstanceRejected|FromResource)$' -count=1`

### Documentation

Not needed; the submission now reports the existing instance boundary through the API.

### AI

I used GPT-5.6-terra to assist the investigation and implementation; I reviewed and validated this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow submissions now consistently validate the referenced template’s instance ID, including submissions without artifact overrides.
  - Mismatched template instances are rejected, and submissions fail appropriately when the server instance ID is not configured.
  - Validation applies to both workflow templates and cluster workflow templates.
  - Invalid submissions are prevented from being created, providing more consistent behavior across supported submission paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->