### PR TITLE
fix(controller): look up entrypoint of images built for another arch

### DIFF
--- a/workflow/controller/entrypoint/container_registry_index.go
+++ b/workflow/controller/entrypoint/container_registry_index.go
@@ -2,6 +2,7 @@ package entrypoint
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
@@ -33,7 +34,11 @@ func (i *containerRegistryIndex) Lookup(ctx context.Context, image string, optio
 		Architecture: runtime.GOARCH,
 		OS:           runtime.GOOS,
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(kc), remote.WithPlatform(defaultPlatform))
+	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(kc))
+	if err != nil {
+		return nil, err
+	}
+	img, err := imageFromDescriptor(ref, desc, defaultPlatform)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +50,47 @@ func (i *containerRegistryIndex) Lookup(ctx context.Context, image string, optio
 		Entrypoint: f.Config.Entrypoint,
 		Cmd:        f.Config.Cmd,
 	}, nil
+}
+
+// imageFromDescriptor resolves a manifest to the image whose config carries the entrypoint and cmd.
+// For an index (manifest list) the child matching the controller's own platform is preferred, but any
+// other image child is accepted: ENTRYPOINT and CMD are the same for every architecture of an image, and
+// the controller's architecture says nothing about where the pod will run (#16258).
+func imageFromDescriptor(ref name.Reference, desc *remote.Descriptor, platform pkgv1.Platform) (pkgv1.Image, error) {
+	if !desc.MediaType.IsIndex() {
+		return desc.Image()
+	}
+	idx, err := desc.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := idx.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	var fallback *pkgv1.Hash
+	for _, m := range manifest.Manifests {
+		if m.MediaType.IsIndex() {
+			continue
+		}
+		// go-containerregistry treats a child without a platform as linux/amd64
+		p := pkgv1.Platform{Architecture: "amd64", OS: "linux"}
+		if m.Platform != nil {
+			p = *m.Platform
+		}
+		if p.Satisfies(platform) {
+			return idx.Image(m.Digest)
+		}
+		// buildx attestation manifests are attached with platform unknown/unknown and carry no image config
+		if fallback == nil && p.OS != "unknown" && p.Architecture != "unknown" {
+			digest := m.Digest
+			fallback = &digest
+		}
+	}
+	if fallback == nil {
+		return nil, fmt.Errorf("no image manifest in index %s", ref)
+	}
+	return idx.Image(*fallback)
 }
 
 func imagePullSecretNames(secrets []v1.LocalObjectReference) []string {

--- a/workflow/controller/entrypoint/container_registry_index_test.go
+++ b/workflow/controller/entrypoint/container_registry_index_test.go
@@ -1,0 +1,116 @@
+package entrypoint
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	pkgv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type testManifest struct {
+	platform   pkgv1.Platform
+	entrypoint []string
+}
+
+func newTestImage(t *testing.T, entrypoint []string) pkgv1.Image {
+	t.Helper()
+	img, err := random.Image(64, 1)
+	require.NoError(t, err)
+	cfg, err := img.ConfigFile()
+	require.NoError(t, err)
+	cfg = cfg.DeepCopy()
+	cfg.Config.Entrypoint = entrypoint
+	cfg.Config.Cmd = []string{"--cmd"}
+	img, err = mutate.ConfigFile(img, cfg)
+	require.NoError(t, err)
+	return img
+}
+
+func newTestRegistry(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	return u.Host
+}
+
+func lookupEntrypoint(t *testing.T, image string) (*Image, error) {
+	t.Helper()
+	index := &containerRegistryIndex{kubernetesClient: fake.NewSimpleClientset()}
+	return index.Lookup(context.Background(), image, Options{Namespace: "default", ServiceAccountName: "default"})
+}
+
+func TestContainerRegistryIndexLookupImage(t *testing.T) {
+	ref, err := name.ParseReference(newTestRegistry(t) + "/test/image:latest")
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ref, newTestImage(t, []string{"/image"})))
+
+	img, err := lookupEntrypoint(t, ref.String())
+	require.NoError(t, err)
+	require.Equal(t, []string{"/image"}, img.Entrypoint)
+	require.Equal(t, []string{"--cmd"}, img.Cmd)
+}
+
+func TestContainerRegistryIndexLookupIndex(t *testing.T) {
+	native := pkgv1.Platform{OS: runtime.GOOS, Architecture: runtime.GOARCH}
+	other := pkgv1.Platform{OS: "linux", Architecture: "arm64"}
+	if runtime.GOARCH == "arm64" {
+		other.Architecture = "amd64"
+	}
+	attestation := pkgv1.Platform{OS: "unknown", Architecture: "unknown"}
+
+	tests := map[string]struct {
+		manifests []testManifest
+		expected  []string
+	}{
+		"single arch matching controller": {
+			manifests: []testManifest{{native, []string{"/native"}}},
+			expected:  []string{"/native"},
+		},
+		"single arch different from controller": {
+			manifests: []testManifest{{other, []string{"/other"}}},
+			expected:  []string{"/other"},
+		},
+		"multi arch prefers controller arch": {
+			manifests: []testManifest{{other, []string{"/other"}}, {native, []string{"/native"}}},
+			expected:  []string{"/native"},
+		},
+		"skips attestation manifests": {
+			manifests: []testManifest{{attestation, []string{"/attestation"}}, {other, []string{"/other"}}},
+			expected:  []string{"/other"},
+		},
+	}
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			var idx pkgv1.ImageIndex = empty.Index
+			for _, m := range tt.manifests {
+				idx = mutate.AppendManifests(idx, mutate.IndexAddendum{
+					Add:        newTestImage(t, m.entrypoint),
+					Descriptor: pkgv1.Descriptor{Platform: &m.platform},
+				})
+			}
+			ref, err := name.ParseReference(newTestRegistry(t) + "/test/index:latest")
+			require.NoError(t, err)
+			require.NoError(t, remote.WriteIndex(ref, idx))
+
+			img, err := lookupEntrypoint(t, ref.String())
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, img.Entrypoint)
+			require.Equal(t, []string{"--cmd"}, img.Cmd)
+		})
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with Conventional Commit messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16258

### Motivation

Since v4.0 the controller cannot read `ENTRYPOINT`/`CMD` from a single-architecture image whose manifest list does not contain the controller's own architecture. An amd64 controller fails on `arm64v8/alpine:latest`; an arm64 controller fails on every amd64-only image:

```
failed to look-up entrypoint/cmd for image "arm64v8/alpine:latest":
  emissary: no child with platform linux/amd64 in index arm64v8/alpine:latest
```

`workflow/controller/entrypoint/container_registry_index.go:32-36` calls `remote.Image(ref, ..., remote.WithPlatform(runtime.GOOS/runtime.GOARCH))`. For an index, go-containerregistry returns `no child with platform ... in index` when no child matches that platform. The controller's architecture is unrelated to where the pod will be scheduled, and `ENTRYPOINT`/`CMD` come from the Dockerfile so they are the same in every architecture variant of an image, yet the lookup hard-requires the controller's variant.

History: in v3.7 `Lookup` called `remote.Image(ref, remote.WithAuthFromKeychain(kc))` with no platform, so go-containerregistry resolved indexes to `linux/amd64`: amd64-only images worked on any controller and arm64-only images failed on any controller (#15058). #15059 switched to the controller's own platform, which fixed arm64-only images on arm64 controllers but made amd64-only images fail on arm64 controllers and arm64-only images fail on amd64 controllers (this issue). Neither version handled both directions; this change does.

### Modifications

`Lookup` fetches the manifest with `remote.Get` and resolves it in a new helper `imageFromDescriptor` next to it:

- a plain image manifest is used as before;
- for an index, the child matching the controller's platform is preferred (same behaviour as today for multi-arch images);
- if there is no such child, the first image child with a known platform is used instead, skipping nested indexes and buildx attestation manifests (`unknown/unknown`, whose config has no `ENTRYPOINT`/`CMD`);
- an index with no usable child returns `no image manifest in index <ref>`.

No new dependencies: `pkg/registry`, `v1/empty`, `v1/mutate` and `v1/random` used by the test are subpackages of the already-required go-containerregistry module, and `go mod tidy` leaves `go.mod`/`go.sum` unchanged.

Two deliberate simplifications, easy to change if reviewers prefer:

- Fallback ordering. When no child matches the controller's platform, the fallback takes the first image child with a known platform regardless of OS. For a multi-OS index that lacks the controller's exact platform (for example `linux/arm64` + `windows/amd64` on a `linux/amd64` controller) this can select the Windows child, whose `CMD` may differ from the Linux one. A middle tier that prefers a child with the controller's OS before falling back to any child would avoid that; I kept a single fallback rule and can add the tier (plus a test) in this PR if wanted.
- Nested indexes. An index child that is itself an index is skipped rather than recursed into, whereas `remote.Image(..., WithPlatform)` previously descended into a nested index whose descriptor platform matched. Nested indexes are rare in practice; recursing via `idx.ImageIndex(m.Digest)` is a small addition if wanted.

### Verification

New `container_registry_index_test.go` runs `Lookup` against an in-memory registry (`go-containerregistry/pkg/registry`) with a fake Kubernetes client, so it needs no cluster. It pushes a plain image and indexes whose child platform is the controller's arch, the other arch (`arm64` on an amd64 test host, `amd64` on arm64), both with the other arch listed first (asserts the controller's arch is chosen), and an attestation manifest plus the other arch.

Before the fix:

```
=== RUN   TestContainerRegistryIndexLookupIndex/single_arch_different_from_controller
    container_registry_index_test.go:112:
        	Error:      	Received unexpected error:
        	            	no child with platform linux/amd64 in index 127.0.0.1:45357/test/index:latest
=== RUN   TestContainerRegistryIndexLookupIndex/skips_attestation_manifests
    container_registry_index_test.go:112:
        	Error:      	Received unexpected error:
        	            	no child with platform linux/amd64 in index 127.0.0.1:42713/test/index:latest
--- FAIL: TestContainerRegistryIndexLookupIndex (0.03s)
    --- PASS: TestContainerRegistryIndexLookupIndex/single_arch_matching_controller (0.01s)
    --- FAIL: TestContainerRegistryIndexLookupIndex/single_arch_different_from_controller (0.01s)
    --- PASS: TestContainerRegistryIndexLookupIndex/multi_arch_prefers_controller_arch (0.01s)
    --- FAIL: TestContainerRegistryIndexLookupIndex/skips_attestation_manifests (0.01s)
FAIL	github.com/argoproj/argo-workflows/v4/workflow/controller/entrypoint	0.058s
```

After the fix:

```
--- PASS: TestContainerRegistryIndexLookupImage (0.01s)
--- PASS: TestContainerRegistryIndexLookupIndex (0.03s)
    --- PASS: TestContainerRegistryIndexLookupIndex/single_arch_different_from_controller (0.01s)
    --- PASS: TestContainerRegistryIndexLookupIndex/multi_arch_prefers_controller_arch (0.01s)
    --- PASS: TestContainerRegistryIndexLookupIndex/skips_attestation_manifests (0.01s)
    --- PASS: TestContainerRegistryIndexLookupIndex/single_arch_matching_controller (0.01s)
ok  	github.com/argoproj/argo-workflows/v4/workflow/controller/entrypoint	0.059s
```

The new tests also pass with `-race -count=3`. `gofmt -l`, `go vet` and `golangci-lint run` (v2.13.2, repo config) on `./workflow/controller/entrypoint/...` report nothing; `go build ./workflow/controller/...` passes. `make pre-commit -B` was not run locally; the Lint and codegen checks run in CI.

### Documentation

Not needed: bug fix with no user-facing configuration change. Images that contain the controller's architecture behave exactly as before; images that do not now resolve instead of failing.

### AI

Code, tests and this description were drafted with an AI agent (Claude Code) operated by KR-Ravindra, who reviewed and tested them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container image resolution from remote registries.
  - Multi-architecture images now select the controller’s platform when available.
  - Added fallback handling for compatible image manifests when the preferred platform is unavailable.
  - Attestation-only or otherwise unusable manifests now produce a clear resolution error.
  - Single-platform images continue to resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->