### PR TITLE
fix(controller): reject a synchronization block with no lock name

### DIFF
--- a/workflow/sync/lock_name.go
+++ b/workflow/sync/lock_name.go
@@ -82,14 +82,24 @@ func getMutexLockName(mtx *v1alpha1.Mutex, wfNamespace string) *lockName {
 }
 
 func (i *syncItem) lockName(wfNamespace string) (*lockName, error) {
+	var ln *lockName
+	var err error
 	switch {
 	case i.semaphore != nil:
-		return getSemaphoreLockName(i.semaphore, wfNamespace)
+		ln, err = getSemaphoreLockName(i.semaphore, wfNamespace)
 	case i.mutex != nil:
-		return getMutexLockName(i.mutex, wfNamespace), nil
+		ln = getMutexLockName(i.mutex, wfNamespace)
 	default:
 		return nil, fmt.Errorf("cannot get lockName if not semaphore or mutex")
 	}
+	if err != nil {
+		return nil, err
+	}
+	// String encodes a name DecodeLockName must accept, and panics when it does not.
+	if err := ln.validate(); err != nil {
+		return nil, err
+	}
+	return ln, nil
 }
 
 func DecodeLockName(ctx context.Context, name string) (LockName, error) {

--- a/workflow/sync/lock_name_test.go
+++ b/workflow/sync/lock_name_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
 
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
 
@@ -165,6 +167,53 @@ func TestNeedDBSession(t *testing.T) {
 				require.NoError(t, err)
 			}
 			assert.Equalf(t, tt.want, got, "needDBS(%v)", tt.lockKeys)
+		})
+	}
+}
+
+func TestTryAcquireLockWithoutName(t *testing.T) {
+	tests := []struct {
+		name    string
+		sync    string
+		wantErr bool
+	}{
+		{"mutex", "mutexes:\n      - namespace: default", true},
+		{"semaphoreConfigMapName", "semaphores:\n      - configMapKeyRef:\n          key: workflow", true},
+		{"semaphoreConfigMapKey", "semaphores:\n      - configMapKeyRef:\n          name: my-config", true},
+		{"semaphoreDatabase", "semaphores:\n      - database: {}", true},
+		{"namedMutexStillWorks", "mutexes:\n      - name: test", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			kube := fake.NewClientset()
+			syncManager, err := NewLockManager(ctx, kube, "", nil, GetSyncLimitFunc(kube), func(string) {}, WorkflowExistenceFunc, false)
+			require.NoError(t, err)
+
+			wf := wfv1.MustUnmarshalWorkflow(fmt.Sprintf(`
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: one
+  namespace: default
+spec:
+  entrypoint: whalesay
+  synchronization:
+    %s
+  templates:
+  - name: whalesay
+    container:
+      image: docker/whalesay:latest
+`, tt.sync))
+
+			require.NotPanics(t, func() {
+				_, _, _, _, err = syncManager.TryAcquire(ctx, wf, "", wf.Spec.Synchronization)
+			})
+			if tt.wantErr {
+				require.ErrorContains(t, err, "requested configuration is invalid")
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/workflow/sync/lock_name_test.go
+++ b/workflow/sync/lock_name_test.go
@@ -181,6 +181,7 @@ func TestTryAcquireLockWithoutName(t *testing.T) {
 		{"semaphoreConfigMapName", "semaphores:\n      - configMapKeyRef:\n          key: workflow", true},
 		{"semaphoreConfigMapKey", "semaphores:\n      - configMapKeyRef:\n          name: my-config", true},
 		{"semaphoreDatabase", "semaphores:\n      - database: {}", true},
+		{"semaphoreNoRef", "semaphores:\n      - {}", true},
 		{"namedMutexStillWorks", "mutexes:\n      - name: test", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B` — see Verification below for what I ran instead and why codegen is a no-op here
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not a feature
- [x] Opened as draft; will mark "Ready for review" once builds are green

No existing issue; found by reading `workflow/sync/lock_name.go`.

### Motivation

A `Workflow` whose synchronization block omits the lock name is accepted by the API server. `mutexes[].name` in `manifests/base/crds/full/argoproj.io_workflows.yaml` is a plain `type: string` with no `minLength` and no `required`, and `grep -riE "mutex|semaphore|synchroniz" workflow/validate/*.go` returns nothing, so nothing rejects it before the controller operates on it.

`syncItem.lockName` (`workflow/sync/lock_name.go:84`) builds that name and `Manager.TryAcquire` (`sync_manager.go:472`) calls `String` on it. `String` goes through `validateEncoding` (`lock_name.go:132`), which round-trips the encoded name through `DecodeLockName` and panics when it does not come back:

```
mutex, no name              bug: unable to decode lock (default/Mutex/) that was just encoded:
                              Invalid lock key: ResourceName is missing
semaphore, no CM name       bug: unable to decode lock (default/ConfigMap//workflow) ...
                              Invalid lock key: ResourceName is missing
semaphore, no CM key        bug: unable to decode lock (default/ConfigMap/my-config/) ...
                              Invalid lock key: Key is missing for ConfigMap lock
semaphore, empty database   bug: unable to decode lock (default/Database/) ...
                              Invalid lock key: ResourceName is missing
```

**The one sentence:** `DecodeLockName` (`lock_name.go:97`) already calls `lock.validate()` and returns a `CodeBadRequest` error for exactly these names. The encode path builds the same name and never calls `validate()`, so it reaches the `panic("bug: ...")` instead.

**Severity, stated plainly:** this is *not* a controller crash. `operator.go:213` recovers, marks the workflow `Error` with the raw `bug: unable to decode lock...` text, logs a stack trace and increments `OperationPanic`. The mutex in `TryAcquire` is released by its `defer`, so there is no deadlock. What the fix changes is that a malformed user spec is reported as an internal invariant violation on a metric operators alert on, rather than as the "requested configuration is invalid" error the same function already produces three lines earlier at `sync_manager.go:468`. If you would rather see this handled by adding `minLength: 1` to the CRD, or by teaching `workflow/validate` about synchronization, I am happy to redo it that way — I picked the narrowest change that makes the two paths agree.

### Modifications

`syncItem.lockName` now runs `ln.validate()` before returning, so both branches share one exit. All three other call sites (`sync_manager.go:236`, `:254`, `:715`) already handle the error return; I read each one.

The `switch` was restructured only so the two branches can share that exit — without it the `validate()` call would be duplicated. Nothing else changed; `validate()`, `String()` and `validateEncoding()` are untouched, and no exported signature or interface moved.

### Verification

`TestTryAcquireLockWithoutName` in `workflow/sync/lock_name_test.go` drives the real `Manager.TryAcquire` with a `MustUnmarshalWorkflow`ed spec for all four shapes above, plus `namedMutexStillWorks` as a positive control.

- All four fail on `main` with `should not panic` and the panic text quoted above; the control passes on both trees. The stack traces run `TryAcquire → sync_manager.go:472 → String → lock_name.go:132 → validateEncoding → lock_name.go:157`, i.e. the production chain.
- Mutation-checked both directions, each anchor asserted to match exactly once. Removing the `validate()` call reproduces all four failures while the control still passes. Over-correcting `validate()` by requiring a key for every kind fails the control with `requested configuration is invalid: Invalid lock key: Key is missing for ConfigMap lock`, so the accepted side is pinned too.
- `go test ./workflow/sync/... -covermode=atomic -coverprofile=... -count=1` (the command `ci-build.yaml:144` runs) passes: `ok ... 345.739s coverage: 86.7% of statements`. `TestDecodeLockName`, `TestNeedDBSession` and `TestMutexLock` still pass.
- `golangci-lint run ./workflow/sync/...` reports 0 issues; `gofmt` and `go vet` clean; `go build ./...` clean.

On `make pre-commit -B`: I did not run it in full — `codegen` wants buf, mockery and the Java SDK generator, and `lint` wants a built UI. I ran `go generate ./workflow/sync/...`, which produced no changes, and the diff touches no API type, no swagger definition and no interface (`lockName`'s signature is unchanged), so codegen and the mocks in `workflow/sync/mocks` are unaffected. Leaving the box unchecked rather than checking it for something I did not run; happy to run it if you would like it confirmed.

### Documentation

No documentation change. This makes an invalid spec produce the existing "requested configuration is invalid" error instead of a recovered panic; no user-facing behaviour is added and nothing in `docs/` describes the previous behaviour.

### AI

This PR was prepared with Claude Code — the code, the test and the commit message. I have reviewed every line, verified each claim above by running it against `main` and against this branch, and can explain the change without going back to the tool. Every quoted output is verbatim.
