### PR TITLE
fix: recover database sessions after reconnect exhaustion

### DIFF
--- a/util/sqldb/session.go
+++ b/util/sqldb/session.go
@@ -191,6 +191,7 @@ func (sp *SessionProxy) connect(ctx context.Context) error {
 
 	err = sess.Ping()
 	if err != nil {
+		sess.Close()
 		return err
 	}
 	sp.closed = false

--- a/util/sqldb/session.go
+++ b/util/sqldb/session.go
@@ -31,10 +31,12 @@ type SessionProxy struct {
 	password      string
 	dbType        DBType
 
-	// Current session and state
-	sess   db.Session
-	mu     sync.RWMutex
-	closed bool
+	// Keep the last session available to Session() callers while disconnected.
+	// Only closed records an explicit Close, which prevents automatic recovery.
+	sess         db.Session
+	mu           sync.RWMutex
+	closed       bool
+	disconnected bool
 
 	// Retry configuration
 	maxRetries    int
@@ -156,7 +158,6 @@ func (sp *SessionProxy) TxWith(ctx context.Context, fn func(*SessionProxy) error
 				password:          sp.password,
 				dbType:            sp.dbType,
 				sess:              sess,
-				closed:            sp.closed,
 				maxRetries:        sp.maxRetries,
 				baseDelay:         sp.baseDelay,
 				maxDelay:          sp.maxDelay,
@@ -193,6 +194,7 @@ func (sp *SessionProxy) connect(ctx context.Context) error {
 		return err
 	}
 	sp.closed = false
+	sp.disconnected = false
 
 	sp.sess = sess
 	return nil
@@ -271,20 +273,24 @@ func (sp *SessionProxy) With(ctx context.Context, fn func(db.Session) error) err
 	}
 
 	sess := sp.sess
+	disconnected := sp.disconnected
 	sp.mu.RUnlock()
 
-	if sess == nil {
-		return fmt.Errorf("no active session")
-	}
+	if sess == nil || disconnected {
+		if sp.insideTransaction {
+			return fmt.Errorf("no active session")
+		}
+		// A previous reconnect failed. Try again before passing a session to fn.
+	} else {
+		err := fn(sess)
+		if err == nil {
+			return nil
+		}
 
-	err := fn(sess)
-	if err == nil {
-		return nil
-	}
-
-	// If it's not a network error or inside a tx do not retry
-	if !sp.isNetworkError(err) || sp.insideTransaction {
-		return err
+		// If it's not a network error or inside a tx do not retry.
+		if !sp.isNetworkError(err) || sp.insideTransaction {
+			return err
+		}
 	}
 
 	if reconnectErr := sp.reconnectIfStale(ctx, sess); reconnectErr != nil {
@@ -293,9 +299,14 @@ func (sp *SessionProxy) With(ctx context.Context, fn func(db.Session) error) err
 
 	sp.mu.RLock()
 	sess = sp.sess
+	closed := sp.closed
+	disconnected = sp.disconnected
 	sp.mu.RUnlock()
 
-	if sess == nil {
+	if closed {
+		return fmt.Errorf("session proxy is closed")
+	}
+	if sess == nil || disconnected {
 		return fmt.Errorf("no active session after reconnection")
 	}
 
@@ -306,13 +317,15 @@ func (sp *SessionProxy) With(ctx context.Context, fn func(db.Session) error) err
 	return nil
 }
 
-// reconnectIfStale reconnects only if the current session is still the
-// same one that produced the error. If another goroutine already
-// reconnected (sp.sess != staleSess), this is a no-op.
+// reconnectIfStale reconnects if the session failed or is disconnected.
+// If another goroutine already established a new session, this is a no-op.
 func (sp *SessionProxy) reconnectIfStale(ctx context.Context, staleSess db.Session) error {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	if sp.sess != staleSess {
+	if sp.closed {
+		return fmt.Errorf("session proxy is closed")
+	}
+	if sp.sess != nil && !sp.disconnected && sp.sess != staleSess {
 		return nil
 	}
 	return sp.reconnectLocked(ctx)
@@ -328,16 +341,16 @@ func (sp *SessionProxy) Reconnect(ctx context.Context) error {
 func (sp *SessionProxy) reconnectLocked(ctx context.Context) error {
 	logger := logging.RequireLoggerFromContext(ctx)
 
+	// Close the failed session once, but keep it available to direct Session()
+	// callers. Only With() provides automatic recovery from this state.
+	if sp.sess != nil && !sp.closed && !sp.disconnected {
+		sp.sess.Close()
+	}
+	sp.disconnected = true
+
 	var err error
 
 	for attempt := 0; attempt <= sp.maxRetries; attempt++ {
-		// Perform the reconnection attempt
-		// Close the bad connection if it exists
-		if sp.sess != nil {
-			sp.sess.Close()
-			sp.closed = true
-		}
-
 		err = sp.connect(ctx)
 		if err == nil {
 			logger.WithField("attempt_number", attempt).Info(ctx, "connected to database")
@@ -385,7 +398,7 @@ func (sp *SessionProxy) Close() error {
 
 	sp.closed = true
 
-	if sp.sess != nil {
+	if sp.sess != nil && !sp.disconnected {
 		return sp.sess.Close()
 	}
 

--- a/util/sqldb/session_lifecycle_test.go
+++ b/util/sqldb/session_lifecycle_test.go
@@ -1,0 +1,191 @@
+package sqldb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/upper/db/v4"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+type lifecycleSessionStub struct {
+	db.Session
+	closeCalls int
+	txContext  func(context.Context, func(db.Session) error, *sql.TxOptions) error
+}
+
+func (s *lifecycleSessionStub) Close() error {
+	s.closeCalls++
+	return nil
+}
+
+func (s *lifecycleSessionStub) TxContext(ctx context.Context, fn func(db.Session) error, opts *sql.TxOptions) error {
+	return s.txContext(ctx, fn, opts)
+}
+
+func TestSessionProxyCloseRejectsAutomaticReconnect(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	sess := &lifecycleSessionStub{}
+	proxy := &SessionProxy{sess: sess}
+
+	require.NoError(t, proxy.Close())
+	require.NoError(t, proxy.Close())
+
+	err := proxy.With(ctx, func(db.Session) error {
+		t.Error("operation ran after explicit Close")
+		return nil
+	})
+	require.ErrorContains(t, err, "session proxy is closed")
+
+	// An operation that failed before Close must not reopen the proxy later.
+	err = proxy.reconnectIfStale(ctx, sess)
+	require.ErrorContains(t, err, "session proxy is closed")
+	assert.Equal(t, 1, sess.closeCalls)
+}
+
+func TestSessionProxyFailedReconnectAllowsLaterAttempt(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	sess := &lifecycleSessionStub{}
+	// Missing credentials fail immediately, without a database or retry delays.
+	proxy := &SessionProxy{sess: sess}
+
+	require.ErrorContains(t, proxy.Reconnect(ctx), "insufficient authentication information")
+	assert.Equal(t, 1, sess.closeCalls)
+
+	err := proxy.With(ctx, func(db.Session) error {
+		t.Error("operation ran without a successful reconnection")
+		return nil
+	})
+	// A new operation must attempt to connect, rather than permanently rejecting
+	// the proxy as closed or reusing the session discarded by the first attempt.
+	require.ErrorContains(t, err, "insufficient authentication information")
+	assert.Equal(t, 1, sess.closeCalls)
+}
+
+func TestSessionProxyFailedExplicitReconnectPreservesClose(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	sess := &lifecycleSessionStub{}
+	proxy := &SessionProxy{sess: sess}
+	require.NoError(t, proxy.Close())
+
+	// Explicit Reconnect may reopen a closed proxy, but only after connecting.
+	require.ErrorContains(t, proxy.Reconnect(ctx), "insufficient authentication information")
+	err := proxy.With(ctx, func(db.Session) error {
+		t.Error("operation ran after a failed explicit reopen")
+		return nil
+	})
+	require.ErrorContains(t, err, "session proxy is closed")
+	assert.Equal(t, 1, sess.closeCalls)
+}
+
+func TestSessionProxyDisconnectedStaleReconnectDoesNotSkip(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	stale := &lifecycleSessionStub{}
+	// Another caller replaced the stale session but its later reconnect failed.
+	// The different session pointer must not be mistaken for a working session.
+	disconnected := &lifecycleSessionStub{}
+	proxy := &SessionProxy{sess: disconnected, disconnected: true}
+
+	err := proxy.reconnectIfStale(ctx, stale)
+	require.ErrorContains(t, err, "insufficient authentication information")
+	assert.Zero(t, stale.closeCalls, "the discarded session must not be closed again")
+	assert.Zero(t, disconnected.closeCalls, "the failed reconnect already closed this session")
+}
+
+func TestSessionProxyStaleReconnectPreservesReplacement(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	stale := &lifecycleSessionStub{}
+	replacement := &lifecycleSessionStub{}
+	proxy := &SessionProxy{sess: replacement}
+
+	require.NoError(t, proxy.reconnectIfStale(ctx, stale))
+	calls := 0
+	require.NoError(t, proxy.With(ctx, func(sess db.Session) error {
+		calls++
+		assert.Same(t, replacement, sess)
+		return nil
+	}))
+	assert.Equal(t, 1, calls)
+	assert.Zero(t, replacement.closeCalls)
+	assert.Zero(t, stale.closeCalls)
+}
+
+func TestSessionProxyWithDoesNotReplayNonRetryableOperation(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		operationErr      error
+		insideTransaction bool
+	}{
+		{name: "non-network error", operationErr: errors.New("constraint violation")},
+		{name: "network error inside transaction", operationErr: io.EOF, insideTransaction: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			sess := &lifecycleSessionStub{}
+			proxy := &SessionProxy{sess: sess, insideTransaction: tt.insideTransaction}
+			calls := 0
+
+			err := proxy.With(ctx, func(current db.Session) error {
+				calls++
+				assert.Same(t, sess, current)
+				return tt.operationErr
+			})
+			require.ErrorIs(t, err, tt.operationErr)
+			assert.Equal(t, 1, calls)
+			assert.Zero(t, sess.closeCalls)
+		})
+	}
+}
+
+func TestSessionProxyDisconnectedTransactionDoesNotReconnect(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	proxy := &SessionProxy{insideTransaction: true}
+
+	err := proxy.With(ctx, func(db.Session) error {
+		t.Error("operation ran without a transaction session")
+		return nil
+	})
+	require.ErrorContains(t, err, "no active session")
+	require.NotContains(t, err.Error(), "authentication")
+}
+
+func TestSessionProxyTransactionDoesNotInheritConcurrentClose(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	txSession := &lifecycleSessionStub{}
+	transactionStarted := make(chan struct{})
+	continueTransaction := make(chan struct{})
+	sess := &lifecycleSessionStub{
+		txContext: func(_ context.Context, fn func(db.Session) error, _ *sql.TxOptions) error {
+			close(transactionStarted)
+			<-continueTransaction
+			return fn(txSession)
+		},
+	}
+	proxy := &SessionProxy{sess: sess}
+	done := make(chan error, 1)
+	calls := 0
+	go func() {
+		done <- proxy.TxWith(ctx, func(tx *SessionProxy) error {
+			return tx.With(ctx, func(current db.Session) error {
+				calls++
+				assert.Same(t, txSession, current)
+				return nil
+			})
+		}, nil)
+	}()
+
+	<-transactionStarted
+	closeErr := proxy.Close()
+	close(continueTransaction)
+	require.NoError(t, closeErr)
+	require.NoError(t, <-done)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 1, sess.closeCalls)
+	assert.Zero(t, txSession.closeCalls)
+}

--- a/util/sqldb/session_recovery_test.go
+++ b/util/sqldb/session_recovery_test.go
@@ -1,0 +1,140 @@
+//go:build !windows
+
+package sqldb
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	testpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/upper/db/v4"
+
+	"github.com/argoproj/argo-workflows/v4/config"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+// Regression for #16771: a failed reconnect must not disable later operations
+// after the database recovers, even when the entire retry budget was exhausted.
+func TestSessionRecoveryAfterFailedReconnect(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		name := "ExhaustedRetries"
+		if canceled {
+			name = "CanceledReconnect"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			postgres, err := testpostgres.Run(ctx, "postgres:17.4-alpine",
+				testpostgres.WithDatabase(dbName),
+				testpostgres.WithUsername(userName),
+				testpostgres.WithPassword(password),
+				testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
+					// Keep the endpoint stable across a real database restart.
+					hostConfig.PortBindings = network.PortMap{
+						network.MustParsePort("5432/tcp"): {{
+							HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: strconv.Itoa(fixedPort),
+						}},
+					}
+				}),
+				testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").
+					WithOccurrence(2).WithStartupTimeout(30*time.Second)),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				assert.NoError(t, testcontainers.TerminateContainer(postgres))
+			})
+			host, err := postgres.Host(ctx)
+			require.NoError(t, err)
+			mappedPort, err := postgres.MappedPort(ctx, "5432/tcp")
+			require.NoError(t, err)
+			port, err := strconv.Atoi(mappedPort.Port())
+			require.NoError(t, err)
+			cfg := config.DBConfig{PostgreSQL: &config.PostgreSQLConfig{
+				DatabaseConfig: config.DatabaseConfig{Database: dbName, Host: host, Port: port},
+			}}
+			proxy, err := NewSessionProxy(ctx, SessionProxyConfig{
+				DBConfig: cfg, Username: userName, Password: password,
+				MaxRetries: 1, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, proxy.Close()) })
+
+			query := func(s db.Session) error {
+				row, queryErr := s.SQL().QueryRow("SELECT 1")
+				if queryErr != nil {
+					return queryErr
+				}
+				var value int
+				return row.Scan(&value)
+			}
+			require.NoError(t, proxy.With(ctx, query))
+
+			for cycle := range 2 {
+				stopTimeout := time.Second
+				require.NoError(t, postgres.Stop(ctx, &stopTimeout))
+				failedCtx, cancel := context.WithCancel(ctx)
+				err = proxy.With(failedCtx, func(s db.Session) error {
+					pingErr := s.Ping()
+					if canceled {
+						// Cancel before the reconnect backoff. The failed connection
+						// attempt must not permanently close the proxy either.
+						cancel()
+					}
+					return pingErr
+				})
+				cancel()
+				if canceled {
+					require.ErrorIs(t, err, context.Canceled)
+				} else {
+					require.ErrorContains(t, err, "reconnection failed after 1 retries")
+				}
+				// Controller configuration reloads use Session() directly to
+				// update pool settings, including while reconnect is failing.
+				require.NotPanics(t, func() {
+					ConfigureDBSession(proxy.Session(), &config.ConnectionPool{MaxOpenConns: 4})
+				})
+
+				require.NoError(t, postgres.Start(ctx))
+				restartedPort, err := postgres.MappedPort(ctx, "5432/tcp")
+				require.NoError(t, err)
+				require.Equal(t, mappedPort, restartedPort)
+				// Verify that PostgreSQL is reachable independently, without
+				// reconnecting or replacing the proxy under test.
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					sess, _, connectErr := CreateDBSessionWithCreds(cfg, userName, password)
+					if assert.NoError(c, connectErr) {
+						assert.NoError(c, sess.Ping())
+						assert.NoError(c, sess.Close())
+					}
+				}, 10*time.Second, 100*time.Millisecond)
+
+				// All callers keep the original proxy. They must share the
+				// recovered session rather than close each other's connections.
+				results := make(chan error, 4)
+				for range cap(results) {
+					go func() { results <- proxy.With(ctx, query) }()
+				}
+				var queryErrors []error
+				for range cap(results) {
+					queryErrors = append(queryErrors, <-results)
+				}
+				require.NoError(t, errors.Join(queryErrors...), "cycle %d", cycle)
+			}
+
+			// Explicit Reconnect remains an opt-in way to reopen a closed proxy.
+			require.NoError(t, proxy.Close())
+			require.ErrorContains(t, proxy.With(ctx, query), "session proxy is closed")
+			require.NoError(t, proxy.Reconnect(ctx))
+			require.NoError(t, proxy.With(ctx, query))
+		})
+	}
+}

--- a/util/sqldb/session_recovery_test.go
+++ b/util/sqldb/session_recovery_test.go
@@ -26,6 +26,7 @@ import (
 // Regression for #16771: a failed reconnect must not disable later operations
 // after the database recovers, even when the entire retry budget was exhausted.
 func TestSessionRecoveryAfterFailedReconnect(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 	for _, canceled := range []bool{false, true} {
 		name := "ExhaustedRetries"
 		if canceled {
@@ -48,10 +49,8 @@ func TestSessionRecoveryAfterFailedReconnect(t *testing.T) {
 				testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").
 					WithOccurrence(2).WithStartupTimeout(30*time.Second)),
 			)
+			testcontainers.CleanupContainer(t, postgres)
 			require.NoError(t, err)
-			t.Cleanup(func() {
-				assert.NoError(t, testcontainers.TerminateContainer(postgres))
-			})
 			host, err := postgres.Host(ctx)
 			require.NoError(t, err)
 			mappedPort, err := postgres.MappedPort(ctx, "5432/tcp")

--- a/workflow/controller/session_recovery_integration_test.go
+++ b/workflow/controller/session_recovery_integration_test.go
@@ -1,0 +1,129 @@
+//go:build !windows
+
+package controller
+
+import (
+	"net/netip"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	testpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/argoproj/argo-workflows/v4/config"
+	persist "github.com/argoproj/argo-workflows/v4/persist/sqldb"
+	wfv1 "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v4/util/instanceid"
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+	usqldb "github.com/argoproj/argo-workflows/v4/util/sqldb"
+	"github.com/argoproj/argo-workflows/v4/workflow/common"
+	"github.com/argoproj/argo-workflows/v4/workflow/util"
+)
+
+// A real database outage must not leave completed workflows permanently Pending
+// after the proxy exhausts its reconnect budget. Kubernetes is a fake client here;
+// this checks the archive path and TTL eligibility, not deletion by a live cluster.
+func TestWorkflowController_ArchiveRecoversAfterDatabaseOutage(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	postgres, err := testpostgres.Run(ctx, "postgres:17.4-alpine",
+		testpostgres.WithDatabase("archive_recovery"),
+		testpostgres.WithUsername("argo"),
+		testpostgres.WithPassword("argo"),
+		testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
+			// Keep the same endpoint after Stop/Start; util/sqldb tests use 15432.
+			hostConfig.PortBindings = network.PortMap{
+				network.MustParsePort("5432/tcp"): {{
+					HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "15433",
+				}},
+			}
+		}),
+		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).WithStartupTimeout(30*time.Second)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, testcontainers.TerminateContainer(postgres)) })
+	host, err := postgres.Host(ctx)
+	require.NoError(t, err)
+	mappedPort, err := postgres.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+	port, err := strconv.Atoi(mappedPort.Port())
+	require.NoError(t, err)
+	cfg := config.DBConfig{PostgreSQL: &config.PostgreSQLConfig{
+		DatabaseConfig: config.DatabaseConfig{Database: "archive_recovery", Host: host, Port: port},
+	}}
+	proxy, err := usqldb.NewSessionProxy(ctx, usqldb.SessionProxyConfig{
+		DBConfig: cfg, Username: "argo", Password: "argo",
+		MaxRetries: 1, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, proxy.Close()) })
+	require.NoError(t, persist.Migrate(ctx, proxy.Session(), "test", "argo_workflows", proxy.DBType()))
+	archive := persist.NewWorkflowArchive(proxy, "test", "", instanceid.NewService(""))
+
+	wf := pendingArchiveWorkflow()
+	wf.UID = types.UID("archive-recovery-16771")
+	wf.CreationTimestamp = metav1.NewTime(time.Now().Add(-3 * time.Minute))
+	wf.Status.StartedAt = metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	wf.Status.FinishedAt = metav1.NewTime(time.Now().Add(-time.Minute))
+	wf.Spec.TTLStrategy = &wfv1.TTLStrategy{SecondsAfterSuccess: new(int32(1))}
+	cancel, controller := newController(ctx, wf, func(wfc *WorkflowController) {
+		wfc.wfArchive = archive
+	})
+	t.Cleanup(cancel)
+	t.Cleanup(controller.wfQueue.ShutDown)
+	t.Cleanup(controller.wfArchiveQueue.ShutDown)
+	un, err := util.ToUnstructured(wf)
+	require.NoError(t, err)
+	require.False(t, common.IsDone(un), "Pending archiving blocks the TTL controller")
+
+	stopTimeout := time.Second
+	require.NoError(t, postgres.Stop(ctx, &stopTimeout))
+	err = controller.archiveWorkflowAux(ctx, un)
+	require.ErrorContains(t, err, "reconnection failed after 1 retries")
+	t.Logf("archive attempt exhausted the reconnect budget during PostgreSQL outage: %v", err)
+	pending, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "Pending", pending.Labels[common.LabelKeyWorkflowArchivingStatus])
+	pendingUn, err := util.ToUnstructured(pending)
+	require.NoError(t, err)
+	require.False(t, common.IsDone(pendingUn))
+
+	require.NoError(t, postgres.Start(ctx))
+	restartedPort, err := postgres.MappedPort(ctx, "5432/tcp")
+	require.NoError(t, err)
+	require.Equal(t, mappedPort, restartedPort)
+	// Check the restored database independently, without reconnecting or replacing
+	// the proxy, archive, or controller used by the failed operation.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		sess, _, connectErr := usqldb.CreateDBSessionWithCreds(cfg, "argo", "argo")
+		if assert.NoError(c, connectErr) {
+			assert.NoError(c, sess.Ping())
+			assert.NoError(c, sess.Close())
+		}
+	}, 10*time.Second, 100*time.Millisecond)
+	require.NoError(t, controller.archiveWorkflowAux(ctx, un))
+	archived, err := archive.GetWorkflow(ctx, string(wf.UID), wf.Namespace, wf.Name)
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	assert.Equal(t, wf.UID, archived.UID)
+	assert.Equal(t, wf.Name, archived.Name)
+	assert.Equal(t, wfv1.WorkflowSucceeded, archived.Status.Phase)
+
+	updated, err := controller.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Get(ctx, wf.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "Archived", updated.Labels[common.LabelKeyWorkflowArchivingStatus])
+	updatedUn, err := util.ToUnstructured(updated)
+	require.NoError(t, err)
+	require.True(t, common.IsDone(updatedUn), "successful archiving removes the TTL admission blocker")
+	require.True(t, updated.Status.Successful())
+	require.True(t, time.Now().After(updated.Status.FinishedAt.Add(time.Duration(*updated.GetTTLStrategy().SecondsAfterSuccess)*time.Second)))
+	t.Logf("same controller and SessionProxy archived UID %s; workflow is Archived and TTL-eligible", archived.UID)
+}

--- a/workflow/controller/session_recovery_integration_test.go
+++ b/workflow/controller/session_recovery_integration_test.go
@@ -32,6 +32,7 @@ import (
 // after the proxy exhausts its reconnect budget. Kubernetes is a fake client here;
 // this checks the archive path and TTL eligibility, not deletion by a live cluster.
 func TestWorkflowController_ArchiveRecoversAfterDatabaseOutage(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 	ctx := logging.TestContext(t.Context())
 	postgres, err := testpostgres.Run(ctx, "postgres:17.4-alpine",
 		testpostgres.WithDatabase("archive_recovery"),
@@ -48,8 +49,8 @@ func TestWorkflowController_ArchiveRecoversAfterDatabaseOutage(t *testing.T) {
 		testcontainers.WithWaitStrategy(wait.ForLog("database system is ready to accept connections").
 			WithOccurrence(2).WithStartupTimeout(30*time.Second)),
 	)
+	testcontainers.CleanupContainer(t, postgres)
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, testcontainers.TerminateContainer(postgres)) })
 	host, err := postgres.Host(ctx)
 	require.NoError(t, err)
 	mappedPort, err := postgres.MappedPort(ctx, "5432/tcp")


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B` — see macOS compatibility notes below
- [x] Signed-off commits with Conventional Commit messages
- [x] PR title is a conventional commit message
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file — not applicable (bug fix)
- [x] Opened as draft; will mark Ready for review once builds are green

Fixes #16771

### Motivation

When a database outage outlasts the reconnect budget, subsequent operations keep returning `session proxy is closed` after the database recovers. Workflow archiving stays stuck until the controller is restarted, leaving completed workflows with `workflow-archiving-status: Pending` and ineligible for TTL cleanup.

### Modifications

Track temporary disconnection separately from explicit closure. A later operation can attempt the existing bounded reconnect after exhaustion or cancellation. Retain the last session handle for direct callers, including connection-pool configuration updates during an outage.

Guard automatic reconnect against concurrent Close and against replacing a connection another caller already recovered. Transaction proxies start with their own lifecycle instead of reading the parent's closure flag without its lock; inner operation and outer whole-transaction retry behavior is preserved.

Close a newly constructed session if the proxy’s final Ping fails, preserving the Ping error and preventing an unpublished connection pool from being retained.

Add lifecycle guards, PostgreSQL outage/recovery regressions, and a controller/archive integration test. The two new container tests skip when Docker is unavailable and register cleanup before checking startup errors; PostgreSQL startup and readiness failures still fail the tests. Initial connection retry in #16539 and leaked semaphore-row cleanup in #16800 remain separate.

### Verification

The PostgreSQL regression fails on the original code after the restored endpoint is independently confirmed healthy. It passes on this change across repeated exhaustion/cancellation cycles and concurrent operations on the same proxy. Explicit Close/Reconnect, stale callers, transaction boundaries and direct Session access are covered.

The archive test also fails with the original SessionProxy and passes here. Real PostgreSQL stores the expected workflow UID; the same controller/proxy changes the archiving label from Pending to Archived. Kubernetes uses a fake client, so this proves TTL eligibility rather than actual cluster GC deletion.

Passed:

```sh
go test -race ./util/sqldb ./persist/sqldb ./util/sync/db ./workflow/gccontroller -count=1 -timeout=10m
go test -race ./workflow/controller -run '^TestWorkflowController_(ArchiveRecoversAfterDatabaseOutage|archiveWorkflowAux_|processNextArchiveItem_)' -count=1 -timeout=5m
```

`util/sync/db` has no test files. Codegen completed without generated/dependency drift; full lint reports zero issues; feature validation, docs spelling/Markdown checks, environment-variable documentation validation and strict ProperDocs build pass.

The unchanged pre-commit wrapper fails on this macOS host's Make 3.81 parsing and Bash `mapfile` support. Its constituent checks completed using a task-local Makefile parsing adjustment, explicit build-tag discovery, Bash/GNU grep and Python 3.12. The literal checkbox remains unchecked.

### Documentation

This restores recovery behavior without introducing configuration or API fields. The regression tests document exhaustion, cancellation, closure and archive recovery boundaries.

### AI

Codex assisted with investigation, implementation, regression tests, code review, and preparation of the commits and this description. Claude Code provided an independent read-only review of the recovery implementation and the follow-up changes; runtime verification was performed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after temporary database connection failures, including cases where initial retry attempts fail.
  - Prevented closed sessions from being reused while allowing disconnected sessions to recover automatically.
  - Improved transaction handling during connection interruptions and concurrent session closure.
  - Preserved workflow archiving across database outages and subsequent recovery.

- **Tests**
  - Added coverage for session lifecycle, reconnection, transaction, and workflow archive recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->