### PR TITLE
test(ui): cover logs and live updates in the Playwright suite

### DIFF
--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -57,9 +57,11 @@ and point the tests at it with `ARGO_UI_BASE_URL`.
   token with `ARGO_TOKEN`, or point at a different UI with `ARGO_UI_BASE_URL`.
 - **Backend state** (`e2e/fixtures/api.ts`): tests seed workflows over the REST
   API and wait for a terminal phase *before* asserting on the rendered page, so
-  rendering never races the controller. Created workflows are cleaned up on
-  teardown; workflows the *browser* creates (submit, resubmit) are handed to
-  `api.track()` so they are cleaned up too.
+  rendering never races the controller. The one exception is
+  `workflow-live-update.spec.ts`, which watches a workflow run to completion in
+  the browser on purpose, to cover the server-sent-events watch. Created
+  workflows are cleaned up on teardown; workflows the *browser* creates (submit,
+  resubmit) are handed to `api.track()` so they are cleaned up too.
 - **Page objects** (`e2e/pages/`) centralise selectors. Prefer role/text/href
   locators; add a `data-testid` only when nothing stable exists.
 

--- a/ui/e2e/fixtures/test.ts
+++ b/ui/e2e/fixtures/test.ts
@@ -4,6 +4,7 @@ import {ConfirmDialog} from '../pages/confirm-dialog';
 import {LoginPage} from '../pages/login-page';
 import {WorkflowDetailsPage} from '../pages/workflow-details-page';
 import {WorkflowListPage} from '../pages/workflow-list-page';
+import {WorkflowLogsPanel} from '../pages/workflow-logs-panel';
 import {ApiClient} from './api';
 
 interface Fixtures {
@@ -12,6 +13,7 @@ interface Fixtures {
     loginPage: LoginPage;
     workflowDetailsPage: WorkflowDetailsPage;
     workflowListPage: WorkflowListPage;
+    workflowLogsPanel: WorkflowLogsPanel;
 }
 
 export const test = base.extend<Fixtures>({
@@ -43,6 +45,9 @@ export const test = base.extend<Fixtures>({
     },
     workflowListPage: async ({page}, use) => {
         await use(new WorkflowListPage(page));
+    },
+    workflowLogsPanel: async ({page}, use) => {
+        await use(new WorkflowLogsPanel(page));
     }
 });
 

--- a/ui/e2e/pages/workflow-logs-panel.ts
+++ b/ui/e2e/pages/workflow-logs-panel.ts
@@ -1,0 +1,46 @@
+import {Locator, Page} from '@playwright/test';
+
+// Page object for the Logs side panel (ui/src/workflows/components/workflow-logs-viewer),
+// opened from the details page toolbar.
+export class WorkflowLogsPanel {
+    readonly container: Locator;
+    readonly heading: Locator;
+    readonly viewer: Locator;
+
+    constructor(page: Page) {
+        this.container = page.locator('.workflow-logs-viewer');
+        this.heading = this.container.getByRole('heading', {name: 'Logs'});
+        // argo-ui's LogsViewer, mounted once the first log entry (or end of
+        // stream) replaces the "Waiting for data..." placeholder.
+        this.viewer = this.container.locator('.logs-viewer');
+    }
+
+    /**
+     * The text currently shown in the log terminal, one line per row.
+     *
+     * argo-ui's LogsViewer renders through xterm, which paints to a canvas, so
+     * the text is not in the DOM for a locator to read. It is in xterm's line
+     * buffer, and LogsViewer keeps its Terminal on the component instance, which
+     * React exposes from the root element through the fiber tree. This reads
+     * what a user would get by selecting all and copying, and is polled because
+     * xterm writes asynchronously.
+     */
+    async text(): Promise<string> {
+        return this.viewer.evaluate(el => {
+            const fiberKey = Object.keys(el).find(key => key.startsWith('__reactFiber$'));
+            let fiber = fiberKey ? (el as any)[fiberKey] : undefined;
+            while (fiber && !fiber.stateNode?.terminal) {
+                fiber = fiber.return;
+            }
+            if (!fiber) {
+                throw new Error('no LogsViewer component (with a terminal) above .logs-viewer');
+            }
+            const buffer = fiber.stateNode.terminal.buffer.active;
+            const lines: string[] = [];
+            for (let y = 0; y < buffer.length; y++) {
+                lines.push(buffer.getLine(y)?.translateToString(true) ?? '');
+            }
+            return lines.join('\n').trimEnd();
+        });
+    }
+}

--- a/ui/e2e/tests/workflow-live-update.spec.ts
+++ b/ui/e2e/tests/workflow-live-update.spec.ts
@@ -1,0 +1,27 @@
+import {ENV_FACTOR} from '../fixtures/auth';
+import {expect, test} from '../fixtures/test';
+import {sleepWorkflow} from '../fixtures/workflows';
+
+// The only test that watches a phase transition in the browser: it covers the
+// server-sent-events watch (api/v1/workflow-events) that keeps the details page
+// current, which nothing else exercises — the other tests seed workflows in a
+// terminal phase first.
+test('details page follows a running workflow to completion without reloading', async ({api, page, workflowDetailsPage}) => {
+    // Long enough that the page reliably catches Running before the pod exits;
+    // short enough that Succeeded arrives well inside the per-test timeout.
+    const name = await api.submitWorkflow(sleepWorkflow(20, 'e2e-live-'));
+
+    await workflowDetailsPage.goto(name);
+    await workflowDetailsPage.openTab('Summary');
+    const status = workflowDetailsPage.summaryAttribute('Status');
+    await expect(status).toContainText('Running', {timeout: 30_000 * ENV_FACTOR});
+
+    // Mark this document so a reload — which would produce a fresh window
+    // without the mark — can be told apart from a live update.
+    await page.evaluate(() => {
+        (window as any).__e2eSameDocument = true;
+    });
+
+    await expect(status).toContainText('Succeeded', {timeout: 45_000 * ENV_FACTOR});
+    expect(await page.evaluate(() => (window as any).__e2eSameDocument)).toBe(true);
+});

--- a/ui/e2e/tests/workflow-logs.spec.ts
+++ b/ui/e2e/tests/workflow-logs.spec.ts
@@ -1,0 +1,18 @@
+import {ENV_FACTOR} from '../fixtures/auth';
+import {expect, test} from '../fixtures/test';
+import {echoWorkflow} from '../fixtures/workflows';
+
+test('shows the container logs of a completed workflow', async ({api, workflowDetailsPage, workflowLogsPanel}) => {
+    const message = 'hello from the logs test';
+    const name = await api.submitWorkflow(echoWorkflow(message, 'e2e-logs-'));
+    await api.waitForPhase(name, 'Succeeded');
+
+    await workflowDetailsPage.goto(name);
+    await workflowDetailsPage.operation('Logs').click();
+    await expect(workflowLogsPanel.heading).toBeVisible();
+
+    // The panel opens on "All" pods, so each line is prefixed with its pod name;
+    // a single-step workflow's only pod is named after the workflow. The stream
+    // is served over SSE from the (completed, not garbage-collected) pod.
+    await expect.poll(() => workflowLogsPanel.text(), {timeout: 30_000 * ENV_FACTOR}).toContain(`${name}: ${message}`);
+});


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

Follow-up to #16398 (harness, login, list) and #16555 (workflow lifecycle). This is the third pack: the two surfaces that are timing-sensitive by nature, kept in their own PR so any flake-tuning does not hold up the other packs.

### Modifications

New specs:

- **`workflow-logs`** — opens the Logs panel of a completed workflow and checks the container's output line is shown.
- **`workflow-live-update`** — watches the details page follow a workflow from `Running` to `Succeeded` **without reloading**. This is the only test that exercises the server-sent-events watch (`api/v1/workflow-events`) that keeps the details page current; every other test deliberately seeds a terminal-phase workflow first.

Supporting changes:

- New page object `WorkflowLogsPanel`. argo-ui's `LogsViewer` renders through xterm, which paints to a `<canvas>`, so the rendered text is not in the DOM for any locator to read. The page object reads it back from xterm's line buffer, reached via the `Terminal` the `LogsViewer` component keeps on its instance. That is the same text a user would get by selecting all and copying.
- The live-update test tells a reload apart from a live update by stamping a property on `window` after the page first shows `Running`, and checking it is still there once `Succeeded` appears.
- README: the "seed then assert" description now names the one intentional exception.

No production code changes and no new `data-testid`s.

### Verification

Run against the CI-equivalent stack (k3d + `tilt up --mode=ci --profile=minimal --auth-mode=client`, production UI bundle at `:2746`):

- full suite: 11/11 passing
- the two new specs with `--repeat-each=3`: 6/6 passing

Both ran at `E2E_ENV_FACTOR=1`; CI runs at `2`, and every per-assertion timeout scales with it and stays inside the per-test timeout. The existing `e2e-ui` job picks the specs up automatically.

### Documentation

`ui/e2e/README.md` updated (see above). No user-facing docs change.

### AI

Written with Claude Code (Claude Fable 5.1): tests, page object, README wording and commit message. Reviewed and run by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ttj8vnvbNyRe6pZLdMBMkS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage confirming workflow status updates from Running to Succeeded without a page reload.
  - Added coverage verifying workflow logs appear in the Logs panel, including streamed terminal output.
  - Improved test support for interacting with workflow logs.

- **Documentation**
  - Clarified the UI end-to-end testing guidance for workflows that are monitored live through completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->