### PR TITLE
fix(controller): preserve NodeSucceeded on daemon pod PodFailed/PodSucceeded events after teardown. Fixes #16397 (cherry-pick #16396 for 4.0)

### DIFF
--- a/workflow/controller/container_set_template.go
+++ b/workflow/controller/container_set_template.go
@@ -10,7 +10,7 @@ import (
 func (woc *wfOperationCtx) executeContainerSet(ctx context.Context, nodeName string, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
-		node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, false)
+		node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, tmpl.IsDaemon())
 	}
 	includeScriptOutput, err := woc.includeScriptOutput(ctx, nodeName, opts.boundaryID)
 	if err != nil {

--- a/workflow/controller/exec_control.go
+++ b/workflow/controller/exec_control.go
@@ -121,5 +121,13 @@ func (woc *wfOperationCtx) killDaemonedChildren(ctx context.Context, nodeID stri
 		childNode.Daemoned = nil
 		woc.wf.Status.Nodes.Set(ctx, childNode.ID, childNode)
 		woc.updated = true
+		// A daemoned containerSet also has container child nodes under the pod node. They are
+		// stopped along with the pod, so complete any that have not already finished on their
+		// own; their exit codes carry no failure meaning because the controller is killing them.
+		for _, ctrNode := range woc.wf.Status.Nodes {
+			if ctrNode.BoundaryID == childNode.ID && ctrNode.Type == wfv1.NodeTypeContainer && !ctrNode.Fulfilled() {
+				woc.markNodePhase(ctx, ctrNode.Name, wfv1.NodeSucceeded)
+			}
+		}
 	}
 }

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1460,6 +1460,16 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		woc.log.Error(ctx, err.Error())
 		return nil
 	}
+	if tmpl == nil {
+		woc.log.WithFields(logging.Fields{"nodeName": old.Name, "templateName": old.TemplateName}).
+			Debug(ctx, "no template resolved for node (expected for inline templates); daemon teardown detection is disabled for it")
+	}
+	// The only way a daemon node becomes Succeeded while its pod is still alive is
+	// killDaemonedChildren, which marks the node and then requests pod termination.
+	// Any pod completion seen after that is the result of our own kill and must not
+	// overwrite the phase; a daemon that dies of its own accord is assessed normally
+	// (its node is still Running at that point) so retryStrategy still works.
+	stoppedDaemon := tmpl.IsDaemon() && old.Succeeded()
 	switch pod.Status.Phase {
 	case apiv1.PodPending:
 		updated.Phase = wfv1.NodePending
@@ -1471,7 +1481,8 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	case apiv1.PodSucceeded:
 		// if the pod is succeeded, we need to check if it is a daemoned step or not
 		// if it is daemoned, we need to mark it as failed, since daemon pods should run indefinitely
-		if tmpl.IsDaemon() {
+		// (unless the controller stopped it itself, in which case it stays Succeeded)
+		if tmpl.IsDaemon() && !stoppedDaemon {
 			woc.log.WithField("podName", pod.Name).Debug(ctx, "Daemoned pod succeeded. Marking it as failed")
 			updated.Phase = wfv1.NodeFailed
 		} else {
@@ -1481,7 +1492,13 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		updated.Daemoned = nil
 		updated.RestartingPodUID = ""
 	case apiv1.PodFailed:
-		// ignore pod failure for daemoned steps
+		if stoppedDaemon {
+			woc.log.WithFields(logging.Fields{"displayName": old.DisplayName, "pod": pod.Name}).Info(ctx, "Ignoring pod failure of daemon stopped by the controller")
+			// killDaemonedChildren already cleared Daemoned when it marked the node Succeeded,
+			// but clear it here too so a stuck flag can never block workflow completion.
+			updated.Daemoned = nil
+			break
+		}
 		updated.Phase, updated.Message = woc.inferFailedReason(ctx, pod, tmpl)
 		woc.log.WithFields(logging.Fields{"message": updated.Message, "displayName": old.DisplayName, "templateName": wfutil.GetTemplateFromNode(*old), "pod": pod.Name}).Info(ctx, "Pod failed")
 		updated.Daemoned = nil
@@ -1555,6 +1572,12 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 		if _, err := woc.wf.GetNodeByName(ctrNodeName); err != nil {
 			continue
 		}
+		if stoppedDaemon {
+			// killDaemonedChildren already completed the container child nodes when it stopped
+			// this daemon; the exit codes of our own kill carry no failure meaning, so leave
+			// the children untouched.
+			continue
+		}
 		switch {
 		case c.State.Terminated != nil:
 			exitCode := int(c.State.Terminated.ExitCode)
@@ -1592,7 +1615,9 @@ func (woc *wfOperationCtx) assessNodeStatus(ctx context.Context, pod *apiv1.Pod,
 	// We capture the exit-code after we look for the task-result.
 	// All other outputs are set by the executor, only the exit-code is set by the controller.
 	// By waiting, we avoid breaking the race-condition check.
-	if exitCode := getExitCode(pod); exitCode != nil {
+	// A daemon we stopped ourselves reports the exit code of our own signal, which says nothing
+	// about the node: recording it would contradict the Succeeded phase we just preserved.
+	if exitCode := getExitCode(pod); !stoppedDaemon && exitCode != nil {
 		if updated.Outputs == nil {
 			updated.Outputs = &wfv1.Outputs{}
 		}
@@ -3486,7 +3511,7 @@ loop:
 func (woc *wfOperationCtx) executeScript(ctx context.Context, nodeName string, templateScope string, tmpl *wfv1.Template, orgTmpl wfv1.TemplateReferenceHolder, opts *executeTemplateOpts) (*wfv1.NodeStatus, error) {
 	node, err := woc.wf.GetNodeByName(nodeName)
 	if err != nil {
-		node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, false)
+		node = woc.initializeExecutableNode(ctx, nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending, opts.nodeFlag, tmpl.IsDaemon())
 	} else if !node.Pending() {
 		return node, nil
 	}

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1735,6 +1736,58 @@ func TestAssessNodeStatus(t *testing.T) {
 		wantPhase:   wfv1.NodeFailed,
 		wantMessage: "can't find failed message for pod  namespace ", // daemoned nodes currently don't have a fail message
 	}, {
+		// node already marked Succeeded by killDaemonedChildren; PodFailed event must be ignored.
+		name: "pod failed - daemoned, already marked succeeded by teardown",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodFailed,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeSucceeded,
+		wantMessage: "",
+	}, {
+		// A live daemon that dies on its own must still be assessed normally: its node is Running
+		// and Daemoned, not Succeeded, so the teardown predicate must not swallow the failure --
+		// otherwise retryStrategy never sees the attempt fail.
+		name: "pod failed - daemoned, died on its own",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Message: "died on its own",
+				Phase:   apiv1.PodFailed,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeRunning, Daemoned: ptr.To(true)},
+		wantPhase:   wfv1.NodeFailed,
+		wantMessage: "died on its own",
+	}, {
+		// non-daemon node that previously Succeeded must still go through inferFailedReason.
+		name: "pod failed - not daemoned, previously succeeded",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Message: "failed for some reason",
+				Phase:   apiv1.PodFailed,
+			},
+		},
+		daemon:      false,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeFailed,
+		wantMessage: "failed for some reason",
+	}, {
+		// node already marked Succeeded by killDaemonedChildren; PodSucceeded must not overwrite to NodeFailed.
+		name: "pod succeeded - daemoned, already marked succeeded by teardown",
+		pod: &apiv1.Pod{
+			Status: apiv1.PodStatus{
+				Phase: apiv1.PodSucceeded,
+			},
+		},
+		daemon:      true,
+		node:        &wfv1.NodeStatus{TemplateName: templateName, Phase: wfv1.NodeSucceeded},
+		wantPhase:   wfv1.NodeSucceeded,
+		wantMessage: "",
+	}, {
 		name: "daemon, pod running, node failed",
 		pod: &apiv1.Pod{
 			Status: apiv1.PodStatus{
@@ -1950,8 +2003,322 @@ func TestAssessNodeStatus(t *testing.T) {
 			defer cancel()
 			woc := newWorkflowOperationCtx(ctx, wf, controller)
 			got := woc.assessNodeStatus(ctx, tt.pod, tt.node)
+			if got == nil {
+				got = tt.node // nil means the node is unchanged
+			}
 			assert.Equal(t, tt.wantPhase, got.Phase)
 			assert.Equal(t, tt.wantMessage, got.Message)
+		})
+	}
+}
+
+var daemonContainerSetWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-container-set
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    daemon: true
+    containerSet:
+      containers:
+      - name: step-1
+        image: alpine
+        command: [sh, -c, sleep 999999]
+      - name: step-2
+        image: alpine
+        command: [sh, -c, sleep 999999]
+`
+
+// TestAssessNodeStatusDaemonContainerSetTeardown verifies that when killDaemonedChildren has
+// stopped a daemon container set pod (marking its node and unfinished container children
+// Succeeded before terminating the pod), the resulting PodFailed event and the containers'
+// kill exit codes neither fail the pod node nor the container child nodes, while a container
+// that genuinely failed beforehand keeps its Failed phase.
+// See https://github.com/argoproj/argo-workflows/issues/16397.
+func TestAssessNodeStatusDaemonContainerSetTeardown(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(daemonContainerSetWf)
+	cancel, controller := newController(ctx, wf)
+	defer cancel()
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+
+	const podNodeName = "daemon-container-set"
+	podNode := &wfv1.NodeStatus{
+		ID:           woc.wf.NodeID(podNodeName),
+		Name:         podNodeName,
+		Type:         wfv1.NodeTypePod,
+		TemplateName: "main",
+		// set by killDaemonedChildren before the pod was terminated
+		Phase: wfv1.NodeSucceeded,
+	}
+	woc.wf.Status.Nodes.Set(ctx, podNode.ID, *podNode)
+	for name, phase := range map[string]wfv1.NodePhase{
+		"step-1": wfv1.NodeSucceeded, // completed by killDaemonedChildren during the teardown
+		"step-2": wfv1.NodeFailed,    // genuinely failed before the teardown
+	} {
+		childName := podNodeName + "." + name
+		woc.wf.Status.Nodes.Set(ctx, woc.wf.NodeID(childName), wfv1.NodeStatus{
+			ID:           woc.wf.NodeID(childName),
+			Name:         childName,
+			Type:         wfv1.NodeTypeContainer,
+			TemplateName: "main",
+			BoundaryID:   podNode.ID,
+			Phase:        phase,
+		})
+	}
+	pod := &apiv1.Pod{
+		Status: apiv1.PodStatus{
+			Phase: apiv1.PodFailed,
+			ContainerStatuses: []apiv1.ContainerStatus{
+				{Name: "step-1", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"}}},
+				{Name: "step-2", State: apiv1.ContainerState{Terminated: &apiv1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"}}},
+			},
+		},
+	}
+
+	got := woc.assessNodeStatus(ctx, pod, podNode)
+	require.NotNil(t, got)
+	assert.Equal(t, wfv1.NodeSucceeded, got.Phase, "pod node stays Succeeded")
+
+	step1, err := woc.wf.GetNodeByName(podNodeName + ".step-1")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeSucceeded, step1.Phase, "container completed by the teardown must not be failed by its kill exit code")
+
+	step2, err := woc.wf.GetNodeByName(podNodeName + ".step-2")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeFailed, step2.Phase, "container that failed before the teardown stays Failed")
+}
+
+var daemonContainerSetStepsWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-cs-steps
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: daemon
+        template: cs
+    - - name: after
+        template: noop
+  - name: cs
+    daemon: true
+    containerSet:
+      containers:
+      - name: step-1
+        image: alpine
+        command: [sh, -c, sleep 999999]
+      - name: step-2
+        image: alpine
+        command: [sh, -c, sleep 999999]
+  - name: noop
+    container:
+      image: alpine
+      command: [sh, -c, "true"]
+`
+
+var daemonScriptStepsWf = `
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: daemon-script-steps
+spec:
+  entrypoint: main
+  templates:
+  - name: main
+    steps:
+    - - name: daemon
+        template: script
+    - - name: after
+        template: noop
+  - name: script
+    daemon: true
+    script:
+      image: alpine
+      command: [sh]
+      source: |
+        sleep 999999
+  - name: noop
+    container:
+      image: alpine
+      command: [sh, -c, "true"]
+`
+
+// injectPlaceholderTaskResult mirrors what the executor writes at pod start: a WorkflowTaskResult
+// labelled report-outputs-completed=false, before any output has been reported. Every pod with an
+// aux container has one from the moment it starts, and it is what flips a node's TaskResultSynced
+// to false. Without it a teardown test cannot tell whether a daemon node was initialized with
+// omitTaskResultSynced, because MarkTaskResultIncomplete leaves a nil TaskResultSynced alone.
+func injectPlaceholderTaskResult(ctx context.Context, t *testing.T, woc *wfOperationCtx, nodeID string) {
+	t.Helper()
+	result := &wfv1.WorkflowTaskResult{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: workflow.APIVersion,
+			Kind:       workflow.WorkflowTaskResultKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeID,
+			Namespace: woc.wf.Namespace,
+			Labels: map[string]string{
+				common.LabelKeyWorkflow:               woc.wf.Name,
+				common.LabelKeyReportOutputsCompleted: "false",
+			},
+		},
+	}
+	_, err := woc.controller.wfclientset.ArgoprojV1alpha1().WorkflowTaskResults(woc.wf.Namespace).
+		Create(ctx, result, metav1.CreateOptions{})
+	require.NoError(t, err)
+	// The informer is fed asynchronously from the fake clientset; seed the indexer directly so the
+	// next operate's taskResultReconciliation sees the placeholder.
+	require.NoError(t, woc.controller.taskResultInformer.GetIndexer().Add(result))
+}
+
+// TestDaemonTeardownEndToEnd drives the whole teardown sequence through the real code path, rather
+// than hand-building node status: operate, bring the daemon pod up Running and Ready, let
+// killDaemonedChildren stop it when the step group completes, deliver the PodRunning event that is
+// still in flight at that moment, then the PodFailed event that Kubernetes reports because the
+// containers were SIGKILLed.
+//
+// This is the daemon case raised in review on
+// https://github.com/argoproj/argo-workflows/pull/16396. Three things must hold at the end:
+// the pod node stays Succeeded, killDaemonedChildren's completed container children are not
+// dragged to Failed by the kill's exit codes, and no exit code from our own kill is recorded.
+//
+// The placeholder WorkflowTaskResult is what makes this test able to fail. Without it
+// TaskResultSynced never becomes false, the node stays Fulfilled through teardown, and the
+// PodRunning branch below never resurrects it -- so initializing the node without
+// omitTaskResultSynced would go unnoticed.
+func TestDaemonTeardownEndToEnd(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		wf         string
+		daemonNode string
+		ctrNodes   []string
+	}{{
+		// a container set pod has no container called "main", so getExitCode never matches it
+		name:       "container set",
+		wf:         daemonContainerSetStepsWf,
+		daemonNode: "daemon-cs-steps[0].daemon",
+		ctrNodes:   []string{"step-1", "step-2"},
+	}, {
+		// a script pod does have a "main" container, so it is the case that can record an exit code
+		name:       "script",
+		wf:         daemonScriptStepsWf,
+		daemonNode: "daemon-script-steps[0].daemon",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := logging.TestContext(t.Context())
+			wf := wfv1.MustUnmarshalWorkflow(tt.wf)
+			cancel, controller := newController(ctx, wf)
+			defer cancel()
+
+			woc := newWorkflowOperationCtx(ctx, wf, controller)
+			woc.operate(ctx)
+
+			daemonNode, err := woc.wf.GetNodeByName(tt.daemonNode)
+			require.NoError(t, err)
+			injectPlaceholderTaskResult(ctx, t, woc, daemonNode.ID)
+
+			// Bring the daemon pod up: Running with every container Ready, which is what makes
+			// assessNodeStatus mark the node Daemoned.
+			pods, err := listPods(ctx, woc)
+			require.NoError(t, err)
+			require.NotEmpty(t, pods.Items)
+			for _, p := range pods.Items {
+				pod := p
+				pod.Status.Phase = apiv1.PodRunning
+				// The fake client does not populate ContainerStatuses, so synthesize what a kubelet reports.
+				pod.Status.ContainerStatuses = nil
+				for _, c := range pod.Spec.Containers {
+					pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, apiv1.ContainerStatus{
+						Name:  c.Name,
+						Ready: true,
+						State: apiv1.ContainerState{Running: &apiv1.ContainerStateRunning{}},
+					})
+				}
+				updatedPod, updateErr := controller.kubeclientset.CoreV1().Pods(pod.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+				require.NoError(t, updateErr)
+				// operate reads pods from the informer cache, which the fake clientset feeds
+				// asynchronously; update the store directly so the next operate sees the new status.
+				require.NoError(t, controller.PodController.TestingPodInformer().GetStore().Update(updatedPod))
+			}
+			woc = newWorkflowOperationCtx(ctx, woc.wf, controller)
+			woc.operate(ctx)
+
+			daemonNode, err = woc.wf.GetNodeByName(tt.daemonNode)
+			require.NoError(t, err)
+			require.True(t, daemonNode.IsDaemoned(), "daemon pod node should be Daemoned before teardown")
+
+			// The step group has completed, so the daemon is stopped. This marks the pod node Succeeded,
+			// completes the unfinished container children, and signals the pod.
+			woc.killDaemonedChildren(ctx, daemonNode.BoundaryID)
+
+			daemonNode, err = woc.wf.GetNodeByName(tt.daemonNode)
+			require.NoError(t, err)
+			require.Equal(t, wfv1.NodeSucceeded, daemonNode.Phase, "killDaemonedChildren should mark the pod node Succeeded")
+			for _, ctr := range tt.ctrNodes {
+				child, childErr := woc.wf.GetNodeByName(tt.daemonNode + "." + ctr)
+				require.NoError(t, childErr)
+				require.Equal(t, wfv1.NodeSucceeded, child.Phase,
+					"killDaemonedChildren should complete container node %s with the pod node", ctr)
+			}
+
+			pods, err = listPods(ctx, woc)
+			require.NoError(t, err)
+			var daemonPod *apiv1.Pod
+			for i := range pods.Items {
+				if pods.Items[i].Annotations[common.AnnotationKeyNodeID] == daemonNode.ID {
+					daemonPod = &pods.Items[i]
+				}
+			}
+			require.NotNil(t, daemonPod, "daemon pod")
+
+			// assessNodeStatus returns nil when nothing changed; mirror podReconciliation's contract
+			// and store whatever comes back, so every assertion below reads the stored node.
+			assess := func() *wfv1.NodeStatus {
+				old, getErr := woc.wf.GetNodeByName(tt.daemonNode)
+				require.NoError(t, getErr)
+				if updated := woc.assessNodeStatus(ctx, daemonPod, old); updated != nil {
+					woc.wf.Status.Nodes.Set(ctx, updated.ID, *updated)
+				}
+				stored, getErr := woc.wf.GetNodeByName(tt.daemonNode)
+				require.NoError(t, getErr)
+				return stored
+			}
+
+			// The kill is queued, not yet delivered: the pod is still Running when the next reconcile
+			// lands. This is where a node whose TaskResultSynced is false gets resurrected to
+			// Running+Daemoned, which makes the following PodFailed look like a spontaneous death.
+			require.Equal(t, wfv1.NodeSucceeded, assess().Phase, "a stopped daemon must not be resurrected to Running")
+
+			// Kubernetes now reports the pod Failed, its containers SIGKILLed by the teardown.
+			daemonPod.Status.Phase = apiv1.PodFailed
+			for i := range daemonPod.Status.ContainerStatuses {
+				daemonPod.Status.ContainerStatuses[i].State = apiv1.ContainerState{
+					Terminated: &apiv1.ContainerStateTerminated{ExitCode: 137, Reason: "Error"},
+				}
+			}
+
+			storedNode := assess()
+			assert.Equal(t, wfv1.NodeSucceeded, storedNode.Phase, "daemon pod node should stay Succeeded")
+			var exitCode *string
+			if storedNode.Outputs != nil {
+				exitCode = storedNode.Outputs.ExitCode
+			}
+			assert.Nil(t, exitCode, "a daemon stopped by the controller must not record our own kill's exit code")
+
+			// The container children must not be dragged to Failed by the teardown.
+			for _, ctr := range tt.ctrNodes {
+				child, childErr := woc.wf.GetNodeByName(tt.daemonNode + "." + ctr)
+				require.NoError(t, childErr)
+				assert.Equal(t, wfv1.NodeSucceeded, child.Phase,
+					"container node %s must not be Failed by the intentional teardown", ctr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Cherry-picked fix(controller): preserve NodeSucceeded on daemon pod PodFailed/PodSucceeded events after teardown. Fixes #16397 (#16396)