### PR TITLE
ci: run the UI e2e suite through the webpack dev server, at root and under a base href

### DIFF
--- a/.github/pr-readiness/README.md
+++ b/.github/pr-readiness/README.md
@@ -8,7 +8,7 @@ A standalone bot ([`pr-readiness.yaml`](../workflows/pr-readiness.yaml)) that lo
 |---|---|---|
 | Lint | `Lint` (CI) | `make pre-commit -B` |
 | Codegen | `Codegen` (CI) | `make codegen -B` |
-| UI | `UI` (CI) | `yarn --cwd ui …` |
+| UI | `UI build and unit tests` (CI) | `yarn --cwd ui …` |
 | Build | `Build Binaries (cli/controller)` (CI) | `make cli` / `make controller` |
 | Docs | `docs` (Docs) | `make docs` |
 | PR title | `title-check` (PR Title Check) | conventional commits |

--- a/.github/pr-readiness/checks.config.json
+++ b/.github/pr-readiness/checks.config.json
@@ -15,9 +15,9 @@
     },
     {
       "id": "ui",
-      "match": { "check": "UI" },
-      "title": "UI",
-      "guidance": "The UI build/lint failed. Run `yarn --cwd ui install && yarn --cwd ui build && yarn --cwd ui lint` locally and commit any fixes."
+      "match": { "check": "UI build and unit tests" },
+      "title": "UI build and unit tests",
+      "guidance": "The UI build, unit tests or lint failed. Run `yarn --cwd ui install && yarn --cwd ui build && yarn --cwd ui test && yarn --cwd ui lint` locally and commit any fixes."
     },
     {
       "id": "build-cli",

--- a/.github/pr-readiness/test/classify.test.ts
+++ b/.github/pr-readiness/test/classify.test.ts
@@ -30,7 +30,7 @@ test('classifySignals ignores unit/e2e and unknown checks entirely', () => {
 });
 
 test('classifySignals treats absent, skipped and cancelled checks as not-applicable', () => {
-  const signals = classifySignals([run('UI', 'skipped'), run('Codegen', 'cancelled')], config);
+  const signals = classifySignals([run('UI build and unit tests', 'skipped'), run('Codegen', 'cancelled')], config);
   assert.equal(signals.find((s) => s.id === 'ui')!.state, 'not-applicable');
   assert.equal(signals.find((s) => s.id === 'codegen')!.state, 'not-applicable');
   assert.equal(signals.find((s) => s.id === 'lint')!.state, 'not-applicable'); // absent

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -509,7 +509,9 @@ jobs:
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@c5fc58bd0be7a4b94b73ce40250322d5b838a108 # v5.0.7
 
   ui:
-    name: UI
+    # the e2e-ui job covers the UI's behaviour; this only checks it builds and
+    # its unit tests and lint pass
+    name: UI build and unit tests
     needs: [ changed-files ]
     if: ${{ needs.changed-files.outputs.ui == 'true' }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -531,25 +531,32 @@ jobs:
       # if lint or deduplicate make changes that are not in the PR, fail the build
       - name: Check if lint & deduplicate made changes not present in the PR
         run: git diff --exit-code
-      # check to see if it'll start (but not if it'll render)
-      - run: yarn --cwd ui start &
-      - run: until curl http://localhost:8080 > /dev/null ; do sleep 10s ; done
-        timeout-minutes: 1
 
   e2e-ui:
-    name: E2E UI
+    name: E2E UI (${{ matrix.name }})
     needs: [ changed-files, e2e-tools ]
     if: ${{ needs.changed-files.outputs.ui == 'true' || needs.changed-files.outputs.e2e-tests == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry runs the Playwright suite against the webpack dev server
+        # (what `make start` gives every contributor), and the root entry also
+        # against the production bundle argo-server embeds. The sub-path entry
+        # can only go through the dev server: argo-server serves its API at
+        # /api/ whatever its --base-href, so a sub-path deployment needs a
+        # prefix-stripping proxy in front, which is what the dev server's
+        # pathRewrite is.
+        include:
+          - name: root
+            base-href: /
+          - name: base-href
+            base-href: /argo/
     env:
       KUBECONFIG: /home/runner/.kube/config
       E2E_ENV_FACTOR: 2
       NODE_OPTIONS: --max-old-space-size=4096
-      # In CI, Tilt (--mode=ci) runs no webpack dev server; the in-cluster
-      # argo-server serves the production UI bundle at :2746. Point Playwright
-      # there — this also gives production-bundle coverage.
-      ARGO_UI_BASE_URL: http://localhost:2746
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -574,6 +581,7 @@ jobs:
           tilt up --stream -- --mode=ci --profile=minimal \
             --api=true \
             --auth-mode=client \
+            --base-href=${{ matrix.base-href }} \
             --pod-status-capture-finalizer=true > /tmp/tilt.log 2>&1 &
           # resources only register once the Tiltfile finishes evaluating; wait
           # for one we know is always defined before trusting `--all`
@@ -587,16 +595,39 @@ jobs:
             sleep 5
           done
         timeout-minutes: 15
-      - name: Wait for UI server
+      - name: Wait for argo-server
+        # Tilt (--mode=ci) keeps its argo-server port-forward on :2746 serving
+        # through the test steps below.
         run: until curl -fs http://localhost:2746 > /dev/null ; do sleep 5s ; done
         timeout-minutes: 3
-      - name: Run UI E2E tests
+      - name: Run UI E2E tests (production bundle)
+        # The bundle argo-server embeds, served by argo-server itself.
+        if: ${{ matrix.base-href == '/' }}
+        env:
+          E2E_RUN: production
+          ARGO_UI_BASE_URL: http://localhost:2746/
+        run: make test-ui-e2e
+      - name: Start the webpack dev server
+        # `yarn start` on :8080, proxying API, artifact and auth routes to
+        # argo-server on :2746 (the devServer block in ui/webpack.config.js).
+        # The dev server answers the first request only once the bundle has
+        # compiled, so this wait also covers the compile.
+        env:
+          ARGO_BASE_HREF: ${{ matrix.base-href }}
+        run: |
+          yarn --cwd ui start > /tmp/webpack-dev-server.log 2>&1 &
+          until curl -fs http://localhost:8080${{ matrix.base-href }} > /dev/null ; do sleep 5s ; done
+        timeout-minutes: 5
+      - name: Run UI E2E tests (dev server)
+        env:
+          E2E_RUN: dev-server
+          ARGO_UI_BASE_URL: http://localhost:8080${{ matrix.base-href }}
         run: make test-ui-e2e
       - name: Upload Playwright report
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.name }}
           path: |
             ui/playwright-report/
             ui/test-results/
@@ -604,6 +635,9 @@ jobs:
           retention-days: 10
 
       # failure debugging below
+      - name: Failure debug - webpack dev server log
+        if: ${{ failure() }}
+        run: tail -n 200 /tmp/webpack-dev-server.log || true
       - name: Failure debug - logs
         if: ${{ failure() }}
         uses: ./.github/actions/e2e-failure-debug

--- a/Makefile
+++ b/Makefile
@@ -786,7 +786,7 @@ start: tilt k3d-up ## Start the dev stack in-cluster via Tilt
 	# via the container IP in a devcontainer (the devcontainer CLI doesn't
 	# forward ports). The argo server/UI/metrics forwards bind 0.0.0.0 too.
 	tilt up --host=0.0.0.0 -- --profile=$(PROFILE) --auth-mode=$(AUTH_MODE) \
-		--secure=$(SECURE) --api=$(API) --initless=$(INITLESS) \
+		--secure=$(SECURE) --api=$(API) --initless=$(INITLESS) --base-href=$(BASE_HREF) \
 		--pod-status-capture-finalizer=$(POD_STATUS_CAPTURE_FINALIZER) \
 		$(if $(DEBUG),--debug=$(DEBUG))
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -13,6 +13,9 @@
 # Settings (normally driven by the Makefile / CI, see `make start`):
 #   --auth-mode=<mode>                  argo-server auth mode (hybrid; sso for PROFILE=sso)
 #   --secure=true                       argo-server serves TLS
+#   --base-href=/argo/                  serve the UI under a sub-path: argo-server gets
+#                                       --base-href and the webpack dev server (dev mode)
+#                                       gets ARGO_BASE_HREF, so http://localhost:8080/argo/
 #   --api=false                         don't build or run the argo-server
 #   --initless=true                     deploy the <profile>-initless manifests, enabling the
 #                                       init-less pod layout (requires K8s image volumes —
@@ -32,6 +35,7 @@ config.define_string('mode')
 config.define_string('auth-mode')
 config.define_string('secure')
 config.define_string('api')
+config.define_string('base-href')
 config.define_string('pod-status-capture-finalizer')
 # --debug=controller,server runs the named components under headless Delve. See
 # the "Debugging under Tilt" section of docs/running-locally.md.
@@ -44,6 +48,11 @@ is_ci = mode == 'ci'
 auth_mode = cfg.get('auth-mode', 'hybrid')
 secure = cfg.get('secure', 'false')
 api = cfg.get('api', 'true') != 'false'
+# normalised to a single leading and trailing slash, as the Makefile does and
+# server/static/static.go expects
+base_href = '/' + cfg.get('base-href', '/').strip('/')
+if base_href != '/':
+    base_href += '/'
 finalizer = cfg.get('pod-status-capture-finalizer', 'true')
 # Debugging is a dev-only convenience; force it off under CI so `tilt ci` builds
 # the real production images and never wraps them in dlv. Tilt's string_list
@@ -145,8 +154,8 @@ for o in objs:
         # manifest reshuffle drops them (a silent no-op here would deploy a
         # server with the wrong auth/TLS mode)
         args = container.get('args', [])
-        replaced = {'--auth-mode=': False, '--secure=': False}
-        values = {'--auth-mode=': auth_mode, '--secure=': secure}
+        replaced = {'--auth-mode=': False, '--secure=': False, '--base-href=': False}
+        values = {'--auth-mode=': auth_mode, '--secure=': secure, '--base-href=': base_href}
         for i in range(len(args)):
             for prefix in replaced.keys():
                 if args[i].startswith(prefix):
@@ -299,7 +308,8 @@ if not is_ci and api:
         labels=['ui'])
     local_resource('ui',
         serve_cmd='yarn --cwd ui start',
+        serve_env={'ARGO_BASE_HREF': base_href},
         deps=['ui/src'],
         resource_deps=['ui-deps', 'argo-server'],
-        links=['http://localhost:8080'],
+        links=['http://localhost:8080' + base_href],
         labels=['ui'])

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -215,6 +215,14 @@ yarn --cwd ui playwright install --with-deps chromium   # first run only
 make test-ui-e2e                            # or: yarn --cwd ui e2e
 ```
 
+To run them under a sub-path instead, start the stack with `BASE_HREF=/argo/` (argo-server and the webpack
+dev server both pick it up) and point the suite at it:
+
+```bash
+make start AUTH_MODE=client BASE_HREF=/argo/
+ARGO_UI_BASE_URL=http://localhost:8080/argo/ make test-ui-e2e
+```
+
 Useful extras:
 
 * `yarn --cwd ui e2e:ui` — interactive/headed runner for debugging.

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -54,7 +54,10 @@ and point the tests at it with `ARGO_UI_BASE_URL`.
 - **Auth** (`e2e/global-setup.ts`): reads the `argo-server` service-account token
   (the same secret the Go e2e suite uses) and writes a Playwright storage state
   containing the `authorization` cookie, so tests start logged in. Override the
-  token with `ARGO_TOKEN`, or point at a different UI with `ARGO_UI_BASE_URL`.
+  token with `ARGO_TOKEN`, or point at a different UI with `ARGO_UI_BASE_URL`,
+  which may include a base href (`http://localhost:8080/argo/` for a stack
+  started with `make start BASE_HREF=/argo/`): every path in the suite is
+  relative to it.
 - **Backend state** (`e2e/fixtures/api.ts`): tests seed workflows over the REST
   API and wait for a terminal phase *before* asserting on the rendered page, so
   rendering never races the controller. Created workflows are cleaned up on
@@ -65,3 +68,22 @@ and point the tests at it with `ARGO_UI_BASE_URL`.
 
 Timeouts scale by `E2E_ENV_FACTOR` (set to `2` in CI) to absorb runner
 contention.
+
+## What CI runs
+
+The `e2e-ui` job runs the suite three times, so both the bundle users get and
+the dev server contributors use are covered:
+
+- against the **production bundle** argo-server embeds, served by argo-server
+  itself at `:2746`;
+- against the **webpack dev server** at `:8080`, whose proxy forwards API,
+  artifact and auth routes to argo-server — the `devServer` block in
+  `webpack.config.js`, including the server-sent-events streams the logs and
+  live-update tests depend on;
+- against the dev server again under a **base href** (`/argo/`), with
+  argo-server started with `--base-href=/argo/` to match. The dev server's
+  `pathRewrite` is then the prefix-stripping proxy a sub-path deployment needs
+  in front of argo-server, which serves its API at `/api/` regardless.
+
+`E2E_RUN` names each pass so results and reports land in their own
+sub-directory of `test-results/` and `playwright-report/`.

--- a/ui/e2e/fixtures/auth.ts
+++ b/ui/e2e/fixtures/auth.ts
@@ -8,7 +8,10 @@ import {execFileSync} from 'child_process';
 // running against a cluster you cannot `kubectl get secret` on.
 
 export const NAMESPACE = process.env.ARGO_NAMESPACE || 'argo';
-export const BASE_URL = process.env.ARGO_UI_BASE_URL || 'http://localhost:8080';
+// May carry a base href (http://localhost:8080/argo/). Every page and API path
+// in the suite is relative, so a trailing slash is what makes them resolve
+// under the base rather than replace its last segment.
+export const BASE_URL = (process.env.ARGO_UI_BASE_URL || 'http://localhost:8080').replace(/\/*$/, '/');
 export const ENV_FACTOR = Number(process.env.E2E_ENV_FACTOR || '1');
 
 const SECRET_NAME = 'argo-server.service-account-token';

--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -14,7 +14,7 @@ async function serverVersion(): Promise<string> {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 5; attempt++) {
         try {
-            const res = await fetch(`${BASE_URL}/api/v1/version`, {headers: {Authorization: bearer()}});
+            const res = await fetch(new URL('api/v1/version', BASE_URL), {headers: {Authorization: bearer()}});
             if (res.ok) {
                 const version = (await res.json()).version;
                 if (version) {
@@ -29,7 +29,7 @@ async function serverVersion(): Promise<string> {
         }
         await new Promise(resolve => setTimeout(resolve, 2_000));
     }
-    throw new Error(`could not fetch ${BASE_URL}/api/v1/version to seed modal suppression (is the stack up?): ${lastErr}`);
+    throw new Error(`could not fetch ${new URL('api/v1/version', BASE_URL)} to seed modal suppression (is the stack up?): ${lastErr}`);
 }
 
 // Runs once before the suite. Rather than driving the login page for every test,
@@ -49,7 +49,9 @@ export default async function globalSetup(): Promise<void> {
                 name: 'authorization',
                 value: bearer(),
                 domain: url.hostname,
-                path: '/',
+                // Login scopes the cookie to the base href (shared/cookie.ts), and
+                // logout only clears that path; match it so both agree.
+                path: url.pathname,
                 expires: -1, // session cookie
                 httpOnly: false,
                 secure: false,

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,4 +1,4 @@
-import {defineConfig, devices} from '@playwright/test';
+import {defineConfig, devices, ReporterDescription} from '@playwright/test';
 
 import {BASE_URL, ENV_FACTOR} from './e2e/fixtures/auth';
 import {STORAGE_STATE} from './e2e/paths';
@@ -8,18 +8,23 @@ import {STORAGE_STATE} from './e2e/paths';
 // `yarn test` (Jest). Timeouts scale by E2E_ENV_FACTOR to absorb the resource
 // contention the Go e2e suite also compensates for.
 const isCI = !!process.env.CI;
+// CI runs the suite several times per job (production bundle, dev server, dev
+// server under a base href); E2E_RUN names the pass so each keeps its own
+// results and report under the usual directories.
+const run = process.env.E2E_RUN ? `/${process.env.E2E_RUN}` : '';
+const html: ReporterDescription = ['html', {open: 'never', outputFolder: `playwright-report${run}`}];
 
 export default defineConfig({
     testDir: './e2e/tests',
     globalSetup: require.resolve('./e2e/global-setup'),
-    outputDir: './test-results',
+    outputDir: `./test-results${run}`,
     fullyParallel: true,
     forbidOnly: isCI,
     retries: isCI ? 2 : 0,
     workers: isCI ? 2 : undefined,
     timeout: 60_000 * ENV_FACTOR,
     expect: {timeout: 15_000 * ENV_FACTOR},
-    reporter: isCI ? [['list'], ['html', {open: 'never'}], ['github']] : [['list'], ['html', {open: 'never'}]],
+    reporter: isCI ? [['list'], html, ['github']] : [['list'], html],
     use: {
         baseURL: BASE_URL,
         storageState: STORAGE_STATE,


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

The tail of the `ui` CI job started `yarn start` and curled `:8080` until anything answered:

```yaml
# check to see if it'll start (but not if it'll render)
- run: yarn --cwd ui start &
- run: until curl http://localhost:8080 > /dev/null ; do sleep 10s ; done
```

Without `-f`, any status passes. Nothing is rendered, and the dev server's proxy is never touched, so the whole `devServer` block in `ui/webpack.config.js` (the `api/v1`/artifact/auth proxy, the `historyApiFallback` + `disableDotRule` 404 fix, `devMiddleware.publicPath`, the base-href `pathRewrite`) was effectively untested. Compile errors are already caught by the `yarn build` step earlier in the same job. Meanwhile the Playwright suite (#16398, #16555, #16907) only ran against the production bundle argo-server embeds, so nothing in CI exercised what `make start` gives every contributor.

### Modifications

- **`e2e-ui` becomes a two-entry matrix over the base href.**
  - `root` (`/`): runs the suite against the production bundle at `:2746` (as before), then starts the webpack dev server and runs the suite again through it at `:8080`.
  - `base-href` (`/argo/`): starts argo-server with `--base-href=/argo/` and runs the suite through the dev server only. argo-server serves its API at `/api/` whatever its `--base-href`, so a sub-path deployment needs a prefix-stripping proxy in front of it, which is exactly the dev server's `pathRewrite`. This is the plan's separate "`BASE_HREF=/argo/` variant" item folded in, since the dev server is where that rewrite lives.
  - Each pass sets `E2E_RUN`, so results and reports land in their own sub-directory; the report artifact is named per matrix entry, and the dev server log is dumped on failure.
  - The smoke test is deleted from the `ui` job.
- **Tiltfile learns `--base-href`**, patched into argo-server's args the same way as `--auth-mode`, and in dev mode passed to the webpack dev server as `ARGO_BASE_HREF`. `make start BASE_HREF=/argo/` now wires both ends (the Makefile already normalised `BASE_HREF`, but stopped passing it anywhere when kit was replaced by Tilt).
- **The suite accepts a base href in `ARGO_UI_BASE_URL`.** Every page and API path in it is already relative; the fixture normalises a trailing slash so they resolve under the base, and global setup resolves the version URL and the seeded cookie's path from it (login scopes the cookie to the base href, and logout only clears that path).
- Docs: `ui/e2e/README.md` describes the three CI passes; `docs/running-locally.md` shows running the suite under a sub-path.
- **The `ui` job is renamed to "UI build and unit tests"**, which is all it is now (build, Jest, lint, dedupe). The pr-readiness bot matches on the check name, so its config, test and README follow.

> [!IMPORTANT]
> "UI" is a required status check on `main`. Branch protection needs to require "UI build and unit tests" instead when this merges (and not before, or open PRs stall on a check that never reports).

Sequencing within a job is the plain default: if the production pass fails, the dev-server pass is skipped and the job fails. That keeps the YAML simple; a second failure behind a first is rarely the interesting one.

Cost: the `base-href` entry duplicates the ~10 min cluster and image build, in parallel, so wall time is roughly unchanged; the root entry gains a dev-server compile plus one more suite pass (~3 min).

### Verification

Locally, on a CI-equivalent stack (k3d + `tilt up --mode=ci --profile=minimal --auth-mode=client`), with the #16907 specs included so the SSE streams go through the proxy:

- dev server at root: 10/11 passing
- dev server under `/argo/` (argo-server started with `--base-href=/argo/`, `E2E_ENV_FACTOR=2`): 10/11 passing. Also checked directly: both servers emit `<base href="/argo/">`, the API answers through the prefix, and a deep link with dots in it resolves.

The one failure in each run was `workflow-details-dag`, with the workflow itself failing on the controller side (`process-a: main: Error (exit code 255)` under local load); it passes 2/2 when run alone through the base-href dev server, so it is contention on my machine rather than the proxy. CI's retries cover that class of flake.

The old smoke test is deleted in the same PR because this PR's own CI run is the proof the replacement is green.

### Documentation

`ui/e2e/README.md` and `docs/running-locally.md` updated (see above).

### AI

Written with Claude Code (Claude Fable 5.1): workflow, Tiltfile, fixture and docs changes, and the commit message. Reviewed and run by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ttj8vnvbNyRe6pZLdMBMkS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the UI under a configurable base path, including `/argo/`.
  * Improved UI end-to-end testing across production builds, development servers, and base-path configurations.
  * CI now runs UI builds, unit tests, linting, and expanded end-to-end coverage.

* **Documentation**
  * Added guidance for configuring base paths and running UI end-to-end tests locally.
  * Documented CI test scenarios and separate reporting for each test run.

* **Bug Fixes**
  * Improved URL, authentication, and test-result handling when the UI uses a base path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->