### PR TITLE
fix: keep succeeded TaskGroup children on retry with parameter override. Fixes #16879

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1354,6 +1354,8 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 
 	// Delete children of TaskGroup/StepGroup nodes being reset when parameters are overridden,
 	// so the controller can re-expand them with the new values. Fixes #15802.
+	// A group that already succeeded is only on the reset path because a node downstream of it
+	// is being retried, so its expansion is kept as-is rather than rerun. Fixes #16879.
 	if len(parameters) > 0 {
 		for nodeID := range toReset {
 			if toDelete[nodeID] {
@@ -1361,6 +1363,9 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 			}
 			n, ok := wf.Status.Nodes[nodeID]
 			if !ok {
+				continue
+			}
+			if n.Phase == wfv1.NodeSucceeded {
 				continue
 			}
 			if n.Type == wfv1.NodeTypeTaskGroup || n.Type == wfv1.NodeTypeStepGroup {

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -4882,6 +4882,160 @@ status:
 		"Stale succeeded pod should also be in deletion list")
 }
 
+// retrySucceededTaskGroupUpstream is a linear DAG where the only path from the root to
+// the failed leaf `target` runs through a fan-out TaskGroup that succeeded in full:
+//
+//	produce (Succeeded) -> fanout (TaskGroup, Succeeded) -> fanout(0:0) (Succeeded) -> target (Failed)
+//
+// Retrying `target` therefore has to walk up through `fanout`, which puts the TaskGroup
+// on the reset path even though nothing inside it needs to be rerun.
+const retrySucceededTaskGroupUpstream = `apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  annotations:
+    workflows.argoproj.io/pod-name-format: v2
+  name: archive-retry-repro
+  namespace: argo
+  labels:
+    workflows.argoproj.io/completed: "true"
+    workflows.argoproj.io/phase: Failed
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: worker_image
+      value: busybox:1.36
+  templates:
+  - name: main
+    dag:
+      tasks:
+      - name: produce
+        template: produce
+      - name: fanout
+        template: fanout
+        depends: produce.Succeeded
+        withParam: "{{tasks.produce.outputs.parameters.items}}"
+      - name: target
+        template: target
+        depends: fanout.Succeeded
+  - name: produce
+    script:
+      image: busybox:1.36
+      command: [sh]
+      source: 'printf "[\"0\"]" > /tmp/items.json'
+    outputs:
+      parameters:
+      - name: items
+        valueFrom:
+          path: /tmp/items.json
+  - name: fanout
+    container:
+      image: "{{workflow.parameters.worker_image}}"
+      command: [sh, -c]
+      args: ["echo fanout-success"]
+  - name: target
+    container:
+      image: "{{workflow.parameters.worker_image}}"
+      command: [sh, -c]
+      args: ["echo target-fails; exit 1"]
+status:
+  phase: Failed
+  nodes:
+    archive-retry-repro:
+      id: archive-retry-repro
+      name: archive-retry-repro
+      displayName: archive-retry-repro
+      type: DAG
+      phase: Failed
+      templateName: main
+      children:
+      - archive-retry-repro-produce
+      outboundNodes:
+      - archive-retry-repro-target
+    archive-retry-repro-produce:
+      id: archive-retry-repro-produce
+      name: archive-retry-repro.produce
+      displayName: produce
+      type: Pod
+      phase: Succeeded
+      boundaryID: archive-retry-repro
+      templateName: produce
+      children:
+      - archive-retry-repro-fanout
+    archive-retry-repro-fanout:
+      id: archive-retry-repro-fanout
+      name: archive-retry-repro.fanout
+      displayName: fanout
+      type: TaskGroup
+      phase: Succeeded
+      boundaryID: archive-retry-repro
+      templateName: fanout
+      nodeFlag: {}
+      children:
+      - archive-retry-repro-fanout-0
+    archive-retry-repro-fanout-0:
+      id: archive-retry-repro-fanout-0
+      name: archive-retry-repro.fanout(0:0)
+      displayName: fanout(0:0)
+      type: Pod
+      phase: Succeeded
+      boundaryID: archive-retry-repro
+      templateName: fanout
+      children:
+      - archive-retry-repro-target
+    archive-retry-repro-target:
+      id: archive-retry-repro-target
+      name: archive-retry-repro.target
+      displayName: target
+      type: Pod
+      phase: Failed
+      boundaryID: archive-retry-repro
+      templateName: target
+`
+
+// TestFormulateRetryWorkflowWithParamOverrideKeepsSucceededTaskGroup covers issue #16879:
+// overriding a parameter on retry must not recreate the children of a fan-out TaskGroup
+// that already succeeded. Such a TaskGroup is only on the reset path because a node
+// downstream of it is being retried, so its expansion still matches the recorded state
+// and its pods must be left alone.
+func TestFormulateRetryWorkflowWithParamOverrideKeepsSucceededTaskGroup(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	wf := wfv1.MustUnmarshalWorkflow(retrySucceededTaskGroupUpstream)
+
+	retryWf, podsToDelete, err := FormulateRetryWorkflow(ctx, wf, false, "", []string{"worker_image=busybox:1.37"})
+	require.NoError(t, err)
+	require.NotNil(t, retryWf)
+
+	// The parameter override is applied.
+	assert.Equal(t, "busybox:1.37", retryWf.Spec.Arguments.Parameters[0].GetValue())
+
+	// The failed node is the only one recreated.
+	assert.False(t, retryWf.Status.Nodes.Has("archive-retry-repro-target"),
+		"the failed target node should be deleted so it is recreated")
+	require.Len(t, podsToDelete, 1, "only the failed target's pod should be deleted")
+	assert.True(t, strings.HasPrefix(podsToDelete[0], "archive-retry-repro-target-"),
+		"expected the target's pod, got %q", podsToDelete[0])
+
+	// The successful fan-out child survives untouched.
+	fanoutChild, err := retryWf.Status.Nodes.Get("archive-retry-repro-fanout-0")
+	require.NoError(t, err, "the succeeded fan-out child should be kept")
+	assert.Equal(t, wfv1.NodeSucceeded, fanoutChild.Phase, "the succeeded fan-out child should not be rerun")
+	assert.Equal(t, wf.Status.Nodes["archive-retry-repro-fanout-0"].StartedAt, fanoutChild.StartedAt,
+		"the succeeded fan-out child should keep its original start time")
+
+	// The TaskGroup is reset so the controller re-evaluates it, but it keeps its expansion.
+	fanout, err := retryWf.Status.Nodes.Get("archive-retry-repro-fanout")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeRunning, fanout.Phase)
+	assert.Equal(t, []string{"archive-retry-repro-fanout-0"}, fanout.Children,
+		"the succeeded TaskGroup should keep its expanded children")
+
+	// The unrelated upstream node is untouched too.
+	produce, err := retryWf.Status.Nodes.Get("archive-retry-repro-produce")
+	require.NoError(t, err)
+	assert.Equal(t, wfv1.NodeSucceeded, produce.Phase)
+}
+
 // retryMultiParentTaskGroup is a diamond where the failed leaf X has two ancestry
 // branches: one through a plain pod (P) and one through a fan-out TaskGroup (G,
 // expanded into G0/G1). X therefore has more than one parent, and whether a retry


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B` (partially — see Verification)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — n/a, this is a bug fix
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16879

### Motivation

Retrying a failed node with a parameter override can recreate and rerun a fan-out
`TaskGroup` that had already succeeded, even though that group was not selected and
`restartSuccessful` was `false`.

`FormulateRetryWorkflow` walks from each node being retried up to the root and adds the
group nodes it passes through to the reset set. When the retried node sits *downstream*
of a fan-out, that walk goes through the fan-out's `TaskGroup`, so a group that succeeded
in full ends up on the reset path purely as an ancestor.

The parameter-override branch added in #15827 then deletes the children of every
`TaskGroup`/`StepGroup` in the reset set, so those already-succeeded fan-out children get
deleted and their pods rerun. That branch exists for the opposite case (#15802): when the
override changes a `withParam` value, the group's old expansion is stale and must go.

### Modifications

`workflow/util/util.go`: skip nodes whose phase is `Succeeded` when purging group
expansions on a parameter-override retry. A group that succeeded in full is only on the
reset path because something downstream of it is being retried — its recorded expansion
still matches the state being preserved, so there is nothing stale to clean up. Groups
that did not succeed are purged exactly as before, so #15802 stays fixed.

Note that this addresses the reported bug (successful fan-out children being rerun), not
the `templateOverrides` API design sketched at the end of the issue. With this fix the
existing `parameters` workaround behaves as the issue expects; a template-override API
would be a separate feature PR with its own issue discussion and feature file.

### Verification

New unit test `TestFormulateRetryWorkflowWithParamOverrideKeepsSucceededTaskGroup` in
`workflow/util/util_test.go` builds the topology from the issue's reproduction:

```
produce (Succeeded) -> fanout (TaskGroup, Succeeded) -> fanout(0:0) (Succeeded) -> target (Failed)
```

and retries with `worker_image=busybox:1.37`. It asserts the override is applied, `target`
is the only node recreated, only `target`'s pod is in `podsToDelete`, and `fanout(0:0)`
keeps its phase, its start time, and its place in the `TaskGroup`'s children.

Confirmed the test fails without the fix — the succeeded fan-out pod is scheduled for
deletion:

```
Error: "[archive-retry-repro-target-317934530 archive-retry-repro-fanout-515364413]"
       should have 1 item(s), but has 2
Messages: only the failed target's pod should be deleted
```

Ran, all green:

- Full unit suite `go test ./...` (115 packages ok). Five packages fail on this machine —
  `persist/sqldb`, `util/sqldb`, `workflow/sync`, `workflow/artifacts/plugin`,
  `workflow/controller` — because they need a database or artifact-plugin fixtures that
  aren't available locally. Verified the *identical* failure set on a clean `main`
  worktree, so they are environmental and unrelated to this change.
- `golangci-lint run --build-tags="<all repo tags>" ./...` (pinned v2.13.2) — 0 issues.
  This is the substance of `make lint-go`.
- `go vet` and `gofmt` — clean.
- `hack/featuregen validate` — passes (no feature file added; this is a fix).
- `hack/docs/check-env-doc.sh` — passes; no env vars added.
- The repo's own `hack/git/hooks/commit-msg` hook against this commit — passes.

`make pre-commit -B` could not be run end to end on this machine: `codegen` needs mockery,
buf, protoc plugins, controller-gen, openapi-gen and the Java SDK toolchain, and requires
the repo checked out at `$GOPATH/src/github.com/argoproj/argo-workflows`; `docs` needs a
properdocs venv plus cspell/typos/markdownlint. This change cannot affect codegen output:
it touches two non-generated files in `workflow/util`, which contains no `go:generate`
directives and is not covered by `.mockery.yaml`, and it changes no protos, API types,
CRDs, examples, env vars, or docs. CI regenerates and fails on diff, so it will confirm
this.

### Documentation

No documentation change needed. This restores the documented retry contract — successful
nodes are preserved unless `restartSuccessful` selects them — rather than adding or
changing any user-facing behavior.

### AI

Claude Code (Claude Opus 5) was used as a coding assistant, directed by me: it
investigated the issue, traced the reset-path logic to the cause, wrote the one-condition
fix and the unit test, ran the tests and linters listed above, and drafted this
description. I am accountable for this contribution as its author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retrying a workflow with parameter overrides now preserves the expanded state of already-succeeded task groups.
  * Unrelated upstream nodes remain completed, while only the failed target node is reset for retry.
  * Improved handling of retried failed nodes when no retry parent is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->