### PR TITLE
fix: release pending-shutdown locks from the workflow object

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -584,8 +584,12 @@ func (woc *wfOperationCtx) operate(ctx context.Context) {
 
 func (woc *wfOperationCtx) releaseLocksForPendingShuttingdownWfs(ctx context.Context) bool {
 	if woc.GetShutdownStrategy().Enabled() && woc.wf.Status.Phase == wfv1.WorkflowPending && woc.GetShutdownStrategy() == wfv1.ShutdownStrategyTerminate {
-		if woc.controller.syncManager.ReleaseAll(ctx, woc.execWf) {
-			woc.log.WithFields(logging.Fields{"key": woc.execWf.Name}).Info(ctx, "Released all locks since this pending workflow is being shutdown")
+		// Release against woc.wf, not woc.execWf: for workflowTemplateRef
+		// workflows execWf is rebuilt from Status.StoredWorkflowSpec with an
+		// empty Status, so ReleaseAll would early-return without removing the
+		// wait-queue entry that TryAcquire recorded on woc.wf (#16924).
+		if woc.controller.syncManager.ReleaseAll(ctx, woc.wf) {
+			woc.log.WithFields(logging.Fields{"key": woc.wf.Name}).Info(ctx, "Released all locks since this pending workflow is being shutdown")
 			// The workflow never started: it was still waiting for its
 			// synchronization lock when it was terminated, so it completes as
 			// Failed, matching every other shutdown path.

--- a/workflow/controller/operator_concurrency_test.go
+++ b/workflow/controller/operator_concurrency_test.go
@@ -1014,6 +1014,103 @@ func TestSynchronizationForPendingShuttingdownWfs(t *testing.T) {
 		assert.Len(t, wocThree.wf.Status.Synchronization.Mutex.Holding, 1)
 	})
 
+	t.Run("PendingShuttingdownTerminatingWfWithStoredSpec", func(t *testing.T) {
+		// The waiter references a WorkflowTemplate, so setExecWorkflow rebuilds
+		// execWf from Status.StoredWorkflowSpec with an empty Status, while
+		// TryAcquire queues on woc.wf. This is the shape that leaked the
+		// wait-queue entry in #16924.
+		wftmpl := wfv1.MustUnmarshalWorkflowTemplate(`apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: stored-spec-template
+  namespace: default
+spec:
+  entrypoint: whalesay
+  synchronization:
+    mutexes:
+      - name: stored-spec-test
+  templates:
+    - name: whalesay
+      container:
+        image: docker/whalesay:latest
+        command: [sh, -c]
+        args: ["sleep 99999"]`)
+		cancelRef, refController := newController(ctx, wftmpl)
+		defer cancelRef()
+		refController.syncManager, _ = sync.NewLockManager(ctx, refController.kubeclientset, refController.namespace, nil, getSyncLimitFunc(ctx, refController.kubeclientset), func(key string) {
+		}, workflowExistenceFunc, false)
+
+		// Holder acquires the lock.
+		wf := wfv1.MustUnmarshalWorkflow(pendingWfWithShutdownStrategy)
+		wf.Name = "one-stored-spec"
+		wf.Spec.Synchronization.Mutexes[0].Name = "stored-spec-test"
+		wf, err := refController.wfclientset.ArgoprojV1alpha1().Workflows(wf.Namespace).Create(ctx, wf, metav1.CreateOptions{})
+		require.NoError(t, err)
+		woc := newWorkflowOperationCtx(ctx, wf, refController)
+		woc.operate(ctx)
+		require.NotNil(t, woc.wf.Status.Synchronization)
+		require.NotNil(t, woc.wf.Status.Synchronization.Mutex)
+		require.Len(t, woc.wf.Status.Synchronization.Mutex.Holding, 1)
+
+		// Waiter queues on the same mutex through the template ref.
+		wfTwo := wfv1.MustUnmarshalWorkflow(`apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  name: two-stored-spec
+  namespace: default
+spec:
+  workflowTemplateRef:
+    name: stored-spec-template`)
+		wfTwo, err = refController.wfclientset.ArgoprojV1alpha1().Workflows(wfTwo.Namespace).Create(ctx, wfTwo, metav1.CreateOptions{})
+		require.NoError(t, err)
+		wocTwo := newWorkflowOperationCtx(ctx, wfTwo, refController)
+		wocTwo.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowPending, wocTwo.wf.Status.Phase)
+		require.NotNil(t, wocTwo.wf.Status.Synchronization)
+		require.NotNil(t, wocTwo.wf.Status.Synchronization.Mutex)
+		require.Len(t, wocTwo.wf.Status.Synchronization.Mutex.Waiting, 1)
+
+		// Shutdown the pending waiter. Call the release path directly rather
+		// than the full operate(): operate's deferred persistUpdates would run
+		// the completion-path ReleaseAll(woc.wf) as well and mask whether
+		// releaseLocksForPendingShuttingdownWfs itself removed the queue entry.
+		patchObj := map[string]any{
+			"spec": map[string]any{
+				"shutdown": wfv1.ShutdownStrategyTerminate,
+			},
+		}
+		patch, err := json.Marshal(patchObj)
+		require.NoError(t, err)
+		wfTwo, err = refController.wfclientset.ArgoprojV1alpha1().Workflows(wfTwo.Namespace).Patch(ctx, wfTwo.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		require.NoError(t, err)
+		wocTwo = newWorkflowOperationCtx(ctx, wfTwo, refController)
+		_, err = wocTwo.setExecWorkflow(ctx)
+		require.NoError(t, err)
+		require.True(t, wocTwo.releaseLocksForPendingShuttingdownWfs(ctx))
+		assert.Equal(t, wfv1.WorkflowFailed, wocTwo.wf.Status.Phase)
+
+		// Release the lock from the holder.
+		woc.wf.Status.Phase = wfv1.WorkflowSucceeded
+		woc.operate(ctx)
+		assert.Nil(t, woc.wf.Status.Synchronization)
+
+		// The terminated waiter's queue entry must be gone, so a new workflow
+		// acquires the lock immediately. Before the fix the stale entry kept
+		// the lock blocked until a controller restart.
+		wfThree := wf.DeepCopy()
+		wfThree.Name = "three-stored-spec"
+		wfThree.ResourceVersion = ""
+		wfThree.Status = wfv1.WorkflowStatus{}
+		wfThree, err = refController.wfclientset.ArgoprojV1alpha1().Workflows(wfThree.Namespace).Create(ctx, wfThree, metav1.CreateOptions{})
+		require.NoError(t, err)
+		wocThree := newWorkflowOperationCtx(ctx, wfThree, refController)
+		wocThree.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowRunning, wocThree.wf.Status.Phase)
+		require.NotNil(t, wocThree.wf.Status.Synchronization)
+		require.NotNil(t, wocThree.wf.Status.Synchronization.Mutex)
+		assert.Len(t, wocThree.wf.Status.Synchronization.Mutex.Holding, 1)
+	})
+
 	t.Run("PendingShuttingdownStoppingWf", func(t *testing.T) {
 		if githubActions, ok := os.LookupEnv(`GITHUB_ACTIONS`); ok && githubActions == "true" {
 			t.Skip("This test regularly fails in Github Actions CI")


### PR DESCRIPTION
- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Fixes #16924

### Motivation

Terminating a `Pending` workflow that waits on a workflow-level mutex/semaphore leaks its wait-queue entry forever when the workflow was submitted via `workflowTemplateRef`. `releaseLocksForPendingShuttingdownWfs` calls `syncManager.ReleaseAll(ctx, woc.execWf)`, but for a `workflowTemplateRef` workflow `execWf` is rebuilt from `Status.StoredWorkflowSpec` with an empty `Status`, so `ReleaseAll` early-returns on `Status.Synchronization == nil` without removing the entry that `TryAcquire` recorded on `woc.wf`. The stale entry stays at the front of the lock queue and every later workflow logs "isn't at the front" until the controller restarts.

### Modifications

- Pass `woc.wf` to `ReleaseAll` in `releaseLocksForPendingShuttingdownWfs`, matching the completion path; the log field now carries the real workflow name instead of an empty string.
- Add a regression subtest to `TestSynchronizationForPendingShuttingdownWfs` with a `workflowTemplateRef` waiter (real `WorkflowTemplate` object, stored-spec path). It calls the release path directly because a full `operate()` masks the leak: the deferred `persistUpdates` runs the completion-path `ReleaseAll(woc.wf)` too. Before the fix the subtest fails with the production symptom (next workflow stuck `Pending`); after the fix it acquires the lock immediately.

### Verification

- `go test ./workflow/controller/ -run "TestSynchronization|TestMutex|TestSemaphore|TestShutdown"` (all pass, including the two pre-existing pending-shutdown subtests)
- Regression subtest verified red before the fix, green after
- `go build ./...` and `golangci-lint` v2.12.2 (the version pinned by the Makefile): 0 issues
- `workflow/sync` DB-backed tests need postgres/mysql and fail identically on clean `main` in this environment

### Documentation

Not needed — bug fix with no user-facing behavior or flag changes.

### AI

Code was prepared with the assistance of a generative AI coding agent; all changes were reviewed, built and tested by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed synchronization lock cleanup for workflows using workflow templates.
  - Pending workflows shutting down with a terminate strategy now correctly leave wait queues, allowing subsequent workflows to acquire locks without delay.
- **Tests**
  - Added regression coverage for terminating pending workflows that reference stored workflow specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->