### PR TITLE
fix: guard nil pointer deref in FormulateRetryWorkflow when retry parent node is missing

### DIFF
--- a/workflow/util/util.go
+++ b/workflow/util/util.go
@@ -1296,7 +1296,9 @@ func FormulateRetryWorkflow(ctx context.Context, wf *wfv1.Workflow, restartSucce
 		if node.FailedOrError() && isExecutionNodeType(node.Type) {
 			// Check its parent if current node is retry node
 			if node.NodeFlag != nil && node.NodeFlag.Retried {
-				node = *wf.Status.Nodes.FindRetryNodeByChild(nodeID)
+				if parentNode := wf.Status.Nodes.FindRetryNodeByChild(nodeID); parentNode != nil {
+					node = *parentNode
+				}
 			}
 			if !isDescendantNodeSucceeded(ctx, wf, node, deleteNodesMap) {
 				failed[nodeID] = true

--- a/workflow/util/util_test.go
+++ b/workflow/util/util_test.go
@@ -1137,6 +1137,30 @@ func TestFormulateRetryWorkflow(t *testing.T) {
 		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["2"].Phase)
 		assert.Equal(t, wfv1.NodeSucceeded, wf.Status.Nodes["3"].Phase)
 	})
+	t.Run("Orphaned Retried Node Flag", func(t *testing.T) {
+		// A node can be flagged NodeFlag.Retried=true without a corresponding NodeTypeRetry
+		// node listing it as a direct child (e.g. the flag was inherited from an ancestor's
+		// retryStrategy several levels up). FormulateRetryWorkflow must not panic in that case.
+		wf := &wfv1.Workflow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "wf-with-orphaned-retried-flag",
+				Labels: map[string]string{},
+			},
+			Status: wfv1.WorkflowStatus{
+				Phase: wfv1.WorkflowFailed,
+				Nodes: map[string]wfv1.NodeStatus{
+					"wf-with-orphaned-retried-flag": {ID: "wf-with-orphaned-retried-flag", Name: "wf-with-orphaned-retried-flag", Phase: wfv1.NodeFailed, Type: wfv1.NodeTypeDAG, Children: []string{"orphan"}},
+					"orphan":                        {ID: "orphan", Phase: wfv1.NodeFailed, Type: wfv1.NodeTypePod, BoundaryID: "wf-with-orphaned-retried-flag", NodeFlag: &wfv1.NodeFlag{Retried: true}},
+				},
+			},
+		}
+		_, err := wfClient.Create(ctx, wf, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NotPanics(t, func() {
+			_, _, err = FormulateRetryWorkflow(ctx, wf, false, "", nil)
+		})
+		require.NoError(t, err)
+	})
 	t.Run("OverrideParams", func(t *testing.T) {
 		wf := &wfv1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` (see note below — ran targeted checks instead)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`) — not applicable, this is a bug fix
- [x] Opened as draft; will mark "Ready for review" once builds are green

<!-- Does this PR fix an issue -->

No associated issue — happy to file one first if a maintainer would prefer that.

### Motivation

`RetryWorkflow` (the **Retry** button in the UI, or `PUT /api/v1/workflows/{namespace}/{name}/retry`) panics with a nil pointer dereference for any workflow whose `Status.Nodes` contains a node with `NodeFlag.Retried == true` but no `NodeTypeRetry` node that lists it as a **direct** child:

```
panic: runtime error: invalid memory address or nil pointer dereference
...
github.com/argoproj/argo-workflows/v3/workflow/util.FormulateRetryWorkflow(...)
	workflow/util/util.go:1299
github.com/argoproj/argo-workflows/v3/server/workflow.(*workflowServer).RetryWorkflow(...)
	server/workflow/workflow_server.go:458
```

`Nodes.FindRetryNodeByChild` returns `nil` in that situation (`Nodes.Find` returns `nil` on no match), and the result was being dereferenced unconditionally in `FormulateRetryWorkflow`. Since this reads from the workflow's *persisted* status, once a workflow reaches this state every subsequent `Retry` call against it fails with a 500 deterministically — `Resubmit` is unaffected since it builds a fresh workflow object and doesn't go through this code path.

We hit this in production on a workflow with `retryStrategy` defined at both an outer template and on nested steps underneath it. Our working theory is that the inconsistency arises because `NodeFlag` is threaded down through a shared `opts` struct during recursive template execution, so a node several levels deep in a nested Steps/DAG graph can inherit `Retried = true` from an ancestor's `retryStrategy` without being a *direct* child of that particular `Retry` node — which is what `FindRetryNodeByChild` requires.

Notably, the other two call sites of `FindRetryNodeByChild`, in `workflow/controller/retry_tweak.go`, already guard against a nil result:

```go
if parentNode := nodes.FindRetryNodeByChild(nodeID); parentNode != nil { ... }
```

This PR brings `FormulateRetryWorkflow` in line with that existing pattern.

### Modifications

- `workflow/util/util.go`: guard the `FindRetryNodeByChild` result before dereferencing, matching the pattern already used in `retry_tweak.go`. When no direct retry-parent is found, fall back to treating the node as itself (previous behavior for the non-orphaned case is unchanged).
- `workflow/util/util_test.go`: added `TestFormulateRetryWorkflow/Orphaned_Retried_Node_Flag`, reproducing a node flagged `NodeFlag.Retried = true` with no corresponding `Retry`-type parent.

### Verification

```
go build ./workflow/util/...
go vet ./workflow/util/...
go test ./workflow/util/... -run TestFormulateRetryWorkflow -v
```

Confirmed the new test panics at `util.go:1299` (matching the production stack trace) without this change, and passes with it. All pre-existing tests in the package continue to pass. `gofmt -l` reports no issues on the changed files.

Note on the checklist: this change is scoped to a single package (no API/CRD/codegen surface touched), so I ran targeted `go build`/`vet`/`test`/`gofmt` rather than the full `make pre-commit -B` (which requires a UI build and `go mod tidy` across the whole module and wasn't necessary for a 2-line logic fix + test). Happy to run the full suite if requested, or lean on CI here.

### Documentation

Not applicable — internal bug fix, no user-facing behavior or API changes.

### AI

Investigation (root-causing the panic from a stack trace, cross-referencing the `retry_tweak.go` guarded pattern) and the initial patch/test were done with Claude Code as a coding assistant, directed and reviewed by me throughout, including validating the fix against the production stack trace, confirming the regression test fails without the fix and passes with it, and deciding the fix approach (mirroring the existing guard pattern in `retry_tweak.go` rather than a novel approach). The description of this PR was also mostly written by CC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workflow processing from failing when a retried node has no corresponding retry parent.
  * Preserved the original node information in these cases instead of triggering an error.

* **Tests**
  * Added coverage for workflows containing orphaned retried nodes to verify they complete without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->