### PR TITLE
fix: Respect OTEL_SERVICE_NAME if set

### DIFF
--- a/util/telemetry/resource.go
+++ b/util/telemetry/resource.go
@@ -20,8 +20,9 @@ func workflowsResource(ctx context.Context, serviceName string) *resource.Resour
 
 	res, err := resource.New(
 		ctx,
-		resource.WithFromEnv(),      // Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
-		resource.WithTelemetrySDK(), // Discover and provide information about the OpenTelemetry SDK used.
+		resource.WithAttributes(attribs...), // Set the static attributes first, so they can be overridden by the environment.
+		resource.WithFromEnv(),              // Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
+		resource.WithTelemetrySDK(),         // Discover and provide information about the OpenTelemetry SDK used.
 		// The individual process detectors from resource.WithProcess(), except
 		// WithProcessOwner: it requires cgo or $USER, neither of which the
 		// distroless images have, so it would error on every startup.
@@ -35,7 +36,6 @@ func workflowsResource(ctx context.Context, serviceName string) *resource.Resour
 		resource.WithOS(),        // Discover and provide OS information.
 		resource.WithContainer(), // Discover and provide container information.
 		resource.WithHost(),      // Discover and provide host information.
-		resource.WithAttributes(attribs...),
 	)
 	if err != nil {
 		logging.RequireLoggerFromContext(ctx).WithError(err).Error(ctx, "Error from opentelemetry resource detection, carrying on anyway")


### PR DESCRIPTION
This will allow OTEL_SERVICE_NAME to be respected if set in the environment.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

<!-- Does this PR fix an issue -->

Fixes #16927

### Motivation

<!-- TODO: Say why you made your changes. -->

We want our otel service names to be consistent with other metadata.

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

I've moved the static attributes to before the environment ones, so they get overridden if set by the user.

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

This is a small bugfix, it doesn't need more documentation

### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved telemetry configuration so environment-provided service name and version attributes correctly take precedence over default values.
  - Ensured service identity metadata is reported consistently when configured through environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->