### PR TITLE
fix: Respect OTEL_SERVICE_NAME if set (cherry-pick #16928 for 4.0)

### DIFF
--- a/util/telemetry/metrics.go
+++ b/util/telemetry/metrics.go
@@ -13,8 +13,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric"
 	metricsdk "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 
 	"github.com/argoproj/argo-workflows/v4/util/logging"
 )
@@ -65,13 +63,8 @@ func (m *Metrics) IterateROInstruments(fn func(i *Instrument)) {
 }
 
 func NewMetrics(ctx context.Context, serviceName, prometheusName string, config *Config, extraOpts ...metricsdk.Option) (*Metrics, error) {
-	res := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceName(serviceName),
-	)
-
 	options := make([]metricsdk.Option, 0)
-	options = append(options, metricsdk.WithResource(res))
+	options = append(options, metricsdk.WithResource(workflowsResource(ctx, serviceName)))
 	_, otlpEnabled := os.LookupEnv(`OTEL_EXPORTER_OTLP_ENDPOINT`)
 	_, otlpMetricsEnabled := os.LookupEnv(`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`)
 	logger := logging.RequireLoggerFromContext(ctx)

--- a/util/telemetry/resource.go
+++ b/util/telemetry/resource.go
@@ -1,0 +1,25 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+func workflowsResource(ctx context.Context, serviceName string) *resource.Resource {
+	res, err := resource.New(
+		ctx,
+		resource.WithSchemaURL(semconv.SchemaURL),
+		// Set the static attributes first, so they can be overridden by the environment.
+		resource.WithAttributes(semconv.ServiceName(serviceName)),
+		// Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
+		resource.WithFromEnv(),
+	)
+	if err != nil {
+		logging.RequireLoggerFromContext(ctx).WithError(err).Error(ctx, "Error from opentelemetry resource detection, carrying on anyway")
+	}
+	return res
+}

--- a/util/telemetry/resource_test.go
+++ b/util/telemetry/resource_test.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+// resourceAttributes collects the resource attributes as a map for easy assertion
+func resourceAttributes(t *testing.T) map[string]string {
+	t.Helper()
+	res := workflowsResource(logging.TestContext(t.Context()), "test-service")
+	attribs := make(map[string]string)
+	for _, kv := range res.Attributes() {
+		attribs[string(kv.Key)] = kv.Value.AsString()
+	}
+	return attribs
+}
+
+func TestResourceDefaultServiceName(t *testing.T) {
+	assert.Equal(t, "test-service", resourceAttributes(t)[string(semconv.ServiceNameKey)])
+}
+
+func TestResourceServiceNameFromEnv(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "from-service-name")
+	assert.Equal(t, "from-service-name", resourceAttributes(t)[string(semconv.ServiceNameKey)])
+}
+
+func TestResourceServiceNameFromResourceAttributes(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-resource-attributes,deployment.environment=production")
+	attribs := resourceAttributes(t)
+	assert.Equal(t, "from-resource-attributes", attribs[string(semconv.ServiceNameKey)])
+	assert.Equal(t, "production", attribs["deployment.environment"])
+}
+
+// OTEL_SERVICE_NAME takes precedence over service.name in OTEL_RESOURCE_ATTRIBUTES
+func TestResourceServiceNamePrecedence(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "from-service-name")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-resource-attributes")
+	assert.Equal(t, "from-service-name", resourceAttributes(t)[string(semconv.ServiceNameKey)])
+}
+
+func TestResourceSchemaURL(t *testing.T) {
+	res := workflowsResource(logging.TestContext(t.Context()), "test-service")
+	assert.Equal(t, semconv.SchemaURL, res.SchemaURL())
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Fixes #16927 for 4.0. The `main` fix is #16928, now merged.

This is a cherry-pick in intent only — the code differs, because the function #16928 edits doesn't exist on 4.0.

### Motivation

`OTEL_SERVICE_NAME` and `service.name` in `OTEL_RESOURCE_ATTRIBUTES` are ignored on 4.0, in the same way as reported against 4.1.2 in #16927.

4.0 builds its resource by hand, with no environment detector:

```go
res := resource.NewWithAttributes(
    semconv.SchemaURL,
    semconv.ServiceName(serviceName),
)
```

That looks like it simply doesn't read the environment, but `metricsdk.WithResource` does it for us:

```go
conf.res, err = resource.Merge(resource.Environment(), res)
```

Environment first, our resource second, and the second argument wins on common keys — so the hardcoded `workflows-controller` overwrites whatever the user set. Everything *else* from `OTEL_RESOURCE_ATTRIBUTES` comes through, so only the service name goes missing, which makes it a confusing one to spot.

4.0 has no tracing, so unlike on `main` this affects metrics only.

### Modifications

Moved the resource construction into `workflowsResource`, matching the shape it has on `main`, and put the static attributes *before* the environment ones so the environment can override them. The explicit `WithFromEnv()` means the behaviour no longer depends on `metricsdk.WithResource`'s internal merge order.

`WithSchemaURL` keeps the exported resource schema URL as it is today.

### Verification

New unit tests in `util/telemetry/resource_test.go` cover the default service name, `OTEL_SERVICE_NAME`, `service.name` via `OTEL_RESOURCE_ATTRIBUTES`, the precedence between the two, and the schema URL.

The three environment tests fail against the old construction and pass with this change; the default and schema-URL tests pass either way, as regression guards.

Also confirmed the bug end-to-end before fixing it, by building a `MeterProvider` the way `NewMetrics` does and collecting through a manual reader. With both `OTEL_SERVICE_NAME=argo-workflows` and `service.name=argo-workflows` in `OTEL_RESOURCE_ATTRIBUTES` set, the collected resource was:

```
[k8s.namespace.name=argo service.name=workflows-controller]
```

`k8s.namespace.name` survived; the service name did not.

### Documentation

No documentation change needed. These are standard OTel SDK environment variables, read by the SDK rather than by us, and `docs/environment-variables.md` doesn't cover the other `OTEL_*` variables either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szh7Z7frT1LrzK1UePzjkG
