### PR TITLE
test: cover OpenTelemetry resource attribute detection

### DIFF
--- a/util/telemetry/resource_test.go
+++ b/util/telemetry/resource_test.go
@@ -1,0 +1,59 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
+
+	"github.com/argoproj/argo-workflows/v4/util/logging"
+)
+
+// resourceAttributes collects the detected resource attributes into a map for easy assertion
+func resourceAttributes(t *testing.T) map[attribute.Key]string {
+	t.Helper()
+	res := workflowsResource(logging.TestContext(t.Context()), "test-service")
+	attribs := make(map[attribute.Key]string)
+	for _, kv := range res.Attributes() {
+		attribs[kv.Key] = kv.Value.String()
+	}
+	return attribs
+}
+
+func TestResourceDefaults(t *testing.T) {
+	attribs := resourceAttributes(t)
+	assert.Equal(t, "test-service", attribs[semconv.ServiceNameKey])
+	assert.NotEmpty(t, attribs[semconv.ServiceVersionKey])
+}
+
+func TestResourceServiceNameFromEnv(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "from-service-name")
+	assert.Equal(t, "from-service-name", resourceAttributes(t)[semconv.ServiceNameKey])
+}
+
+func TestResourceServiceNameFromResourceAttributes(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-resource-attributes,deployment.environment=production")
+	attribs := resourceAttributes(t)
+	assert.Equal(t, "from-resource-attributes", attribs[semconv.ServiceNameKey])
+	assert.Equal(t, "production", attribs["deployment.environment"])
+}
+
+// OTEL_SERVICE_NAME takes precedence over service.name in OTEL_RESOURCE_ATTRIBUTES
+func TestResourceServiceNamePrecedence(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "from-service-name")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=from-resource-attributes")
+	assert.Equal(t, "from-service-name", resourceAttributes(t)[semconv.ServiceNameKey])
+}
+
+func TestResourceDetectors(t *testing.T) {
+	attribs := resourceAttributes(t)
+	assert.Equal(t, "opentelemetry", attribs[semconv.TelemetrySDKNameKey])
+	assert.Contains(t, attribs, semconv.HostNameKey)
+	assert.Contains(t, attribs, semconv.OSTypeKey)
+	assert.Contains(t, attribs, semconv.ProcessPIDKey)
+	assert.Equal(t, "go", attribs[semconv.ProcessRuntimeNameKey])
+	// WithProcessOwner is deliberately left out: it needs cgo or $USER, which
+	// the distroless images have neither of, so it errors on every startup
+	assert.NotContains(t, attribs, semconv.ProcessOwnerKey)
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B`
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [ ] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

Follow-up to #16928, which fixed #16927 but landed without test coverage. Rebased onto it, so these all pass.

### Motivation

`workflowsResource` had no test coverage at all, which is how #16927 happened.

The function's behaviour rests entirely on the *order* of the options handed to `resource.New`: each detector is merged over the accumulated result, so whatever is listed last wins on any key it sets. Nothing about that is visible at the call site, and nothing was checking it, so reordering the list — or adding a detector that happens to set `service.name` — could silently undo #16928.

### Modifications

Adds `util/telemetry/resource_test.go` with five tests:

- the service name we pass in, and a non-empty service version
- `OTEL_SERVICE_NAME` overriding the default
- `service.name` via `OTEL_RESOURCE_ATTRIBUTES`, alongside an unrelated attribute, to check the rest of the variable still comes through
- `OTEL_SERVICE_NAME` winning over `service.name` in `OTEL_RESOURCE_ATTRIBUTES`, which is the SDK's documented precedence
- the detectors we ask for (SDK, host, OS, process) being present, and `process.owner` being *absent* — that omission is deliberate, it needs cgo or `$USER` and the distroless images have neither, so pinning it stops someone reinstating it by tidying the list into `resource.WithProcess()`

### Verification

`go test -run TestResource ./util/telemetry/` — all five pass on this branch.

They discriminate rather than just describing whatever the code does: reverting #16928's change to the option order fails the three environment tests, and leaves the other two passing.

`golangci-lint run ./util/telemetry/...` is clean.

I haven't run `make pre-commit -B`: this adds a test file and touches nothing that codegen or the docs generator reads.

### Documentation

None needed — tests only.

### AI

Claude Code (Opus 5) wrote these tests and this description, working from the analysis of #16927. I reviewed both, and verified the pass/fail behaviour against `main` with and without #16928 rather than taking it on trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szh7Z7frT1LrzK1UePzjkG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for telemetry resource defaults and service name configuration.
  * Verified precedence between service name environment settings and resource attributes.
  * Added checks for detected host, operating system, process, runtime, and SDK metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->