### PR TITLE
fix(telemetry): disable OTLP exporters for empty endpoints (cherry-pick #16898 for 4.0)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,7 +27,7 @@ The OpenTelemetry collector can export metrics to Prometheus via [the Prometheus
 ### OpenTelemetry protocol
 
 To enable the OpenTelemetry protocol you must set the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
-It will not be enabled if left blank, unlike some other implementations.
+It will not be enabled unless `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is configured and non-empty, unlike some other implementations.
 
 You can configure the protocol using the environment variables documented in [standard environment variables](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/).
 

--- a/util/telemetry/metrics.go
+++ b/util/telemetry/metrics.go
@@ -72,12 +72,10 @@ func NewMetrics(ctx context.Context, serviceName, prometheusName string, config 
 
 	options := make([]metricsdk.Option, 0)
 	options = append(options, metricsdk.WithResource(res))
-	_, otlpEnabled := os.LookupEnv(`OTEL_EXPORTER_OTLP_ENDPOINT`)
-	_, otlpMetricsEnabled := os.LookupEnv(`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`)
 	logger := logging.RequireLoggerFromContext(ctx)
 
-	if otlpEnabled || otlpMetricsEnabled {
-		logger.Info(ctx, "Starting OTLP metrics exporter")
+	if endpoint := resolveOTLPEndpoint(otlpMetricsEndpointEnv); endpoint != "" {
+		logger.WithField("endpoint", endpoint).Info(ctx, "Starting OTLP metrics exporter")
 
 		// NOTE: The OTel SDK default changed from gRPC to http/protobuf. For backwards compatibility,
 		// gRPC is preserved as the default in workflows controller, but http/protobuf can be opted-in

--- a/util/telemetry/otlp.go
+++ b/util/telemetry/otlp.go
@@ -1,0 +1,20 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	otlpEndpointEnv        = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	otlpMetricsEndpointEnv = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+	otlpTracesEndpointEnv  = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+)
+
+// resolveOTLPEndpoint returns the signal-specific endpoint, falling back to the common OTLP endpoint.
+func resolveOTLPEndpoint(signalEndpointEnv string) string {
+	if endpoint := strings.TrimSpace(os.Getenv(signalEndpointEnv)); endpoint != "" {
+		return endpoint
+	}
+	return strings.TrimSpace(os.Getenv(otlpEndpointEnv))
+}

--- a/util/telemetry/otlp_test.go
+++ b/util/telemetry/otlp_test.go
@@ -1,0 +1,67 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveOTLPEndpoint verifies endpoint precedence and handling of empty values.
+func TestResolveOTLPEndpoint(t *testing.T) {
+	tests := []struct {
+		name                   string
+		commonEndpoint         string
+		signalSpecificEndpoint string
+		expectedEndpoint       string
+	}{
+		{
+			name: "empty values",
+		},
+		{
+			name:             "common endpoint",
+			commonEndpoint:   "common:4317",
+			expectedEndpoint: "common:4317",
+		},
+		{
+			name:                   "signal-specific endpoint",
+			signalSpecificEndpoint: "signal:4317",
+			expectedEndpoint:       "signal:4317",
+		},
+		{
+			name:                   "signal-specific endpoint takes precedence",
+			commonEndpoint:         "common:4317",
+			signalSpecificEndpoint: "signal:4317",
+			expectedEndpoint:       "signal:4317",
+		},
+		{
+			name:                   "whitespace-only values",
+			commonEndpoint:         " ",
+			signalSpecificEndpoint: "\t",
+		},
+		{
+			name:                   "endpoints with surrounding whitespace",
+			commonEndpoint:         " common:4317 ",
+			signalSpecificEndpoint: " signal:4317 ",
+			expectedEndpoint:       "signal:4317",
+		},
+		{
+			name:                   "whitespace-only signal-specific endpoint falls back to common endpoint",
+			commonEndpoint:         "common:4317",
+			signalSpecificEndpoint: " ",
+			expectedEndpoint:       "common:4317",
+		},
+	}
+
+	for _, signalEndpointEnv := range []string{otlpMetricsEndpointEnv, otlpTracesEndpointEnv} {
+		t.Run(signalEndpointEnv, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					t.Setenv(otlpEndpointEnv, test.commonEndpoint)
+					t.Setenv(signalEndpointEnv, test.signalSpecificEndpoint)
+
+					require.Equal(t, test.expectedEndpoint, resolveOTLPEndpoint(signalEndpointEnv))
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

Backport of #16898. `util/telemetry/otlp.go` and `otlp_test.go` are taken from it unchanged; the `metrics.go` hunk differs because 4.0's code around it is different.

### Motivation

I checked this against 4.0 before porting anything, because the surrounding code isn't the same. The bug is there.

`os.LookupEnv` reports a variable set to the empty string as present, so 4.0's gate

```go
_, otlpEnabled := os.LookupEnv(`OTEL_EXPORTER_OTLP_ENDPOINT`)
_, otlpMetricsEnabled := os.LookupEnv(`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`)
if otlpEnabled || otlpMetricsEnabled {
```

opens for `OTEL_EXPORTER_OTLP_ENDPOINT=""`. 4.0 then builds the exporter without passing an endpoint, leaving the SDK to read the environment itself — and the SDK's `GetEnvValue` trims and treats empty as absent, so it falls back to its own default of `localhost:4317`.

Net effect: setting the variable to empty starts an exporter that pushes metrics at localhost forever. `docs/metrics.md` says the opposite, in the same words `main` had:

> It will not be enabled if left blank, unlike some other implementations.

4.0 has no tracing, so this is metrics only.

### Modifications

Gate on the resolved endpoint being non-empty, via `resolveOTLPEndpoint` from #16898.

The endpoint is now also on the "Starting OTLP metrics exporter" log line, matching `main`.

`otlp.go` keeps the `otlpTracesEndpointEnv` constant even though 4.0 has no tracing, so the file stays identical to `main` and the ported test covers both names. It's referenced by the test, so it doesn't trip `unused`.

Docs updated to match the new behaviour, in the same shape as the change #16898 made to `docs/telemetry-configuration.md`.

### Verification

`TestResolveOTLPEndpoint` from #16898 passes unchanged.

Beyond the unit test I confirmed the actual behaviour end to end, both before and after, by listening on `127.0.0.1:4317`, calling `NewMetrics`, recording a counter and forcing a flush, then watching for a connection:

| `OTEL_EXPORTER_OTLP_*` | before | after |
| --- | --- | --- |
| nothing set | no connection | no connection |
| `ENDPOINT=""` | **dialled localhost:4317** | no connection |
| `METRICS_ENDPOINT=""` | **dialled localhost:4317** | no connection |
| `ENDPOINT="  "` | not tested | no connection |
| `ENDPOINT="http://localhost:4317"` | dialled | dialled |

So the exporter really was live and pointed at the default before this, the empty and whitespace cases are now off, and a configured endpoint still exports.

`golangci-lint run ./util/telemetry/...` is clean.

I haven't run `make pre-commit -B`. Nothing here is generated: `docs/metrics.md` is hand-written and the Go changes touch no codegen inputs.

### Documentation

`docs/metrics.md` updated — the old wording is what made this a bug rather than a quirk.

### AI

Claude Code (Opus 5) validated the bug on 4.0, prepared this backport and wrote this description. I reviewed it. The before/after table above is from runs I had it perform against the 4.0 tree, not from reasoning about the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szh7Z7frT1LrzK1UePzjkG
