### PR TITLE
fix(controller): don't end the node tracing span twice

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -3144,7 +3144,6 @@ func (woc *wfOperationCtx) markNodePhase(ctx context.Context, nodeName string, p
 	if node.Fulfilled() && node.FinishedAt.IsZero() {
 		node.FinishedAt = metav1.Time{Time: time.Now().UTC()}
 		woc.log.WithFields(logging.Fields{"node": node.ID, "finishedAt": node.FinishedAt}).Info(ctx, "node finished")
-		woc.controller.tracing.EndNode(ctx, namespacedName, node.ID, node.Phase)
 		woc.updated = true
 	}
 	woc.wf.Status.Nodes.Set(ctx, node.ID, *node)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` (golangci-lint and `go test` run on the changed package instead)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [ ] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

Every node that completes through `markNodePhase` logs an error:

```
level=error msg="tracing expect node for end node failed" error="no existing trace for a running node"
```

This is a frequent log line, one per finished node. It is not a real error. `markNodePhase` calls `ChangeNodePhase` when the phase changes, and for a fulfilled phase `ChangeNodePhase` already ends the node span and removes the node from the tracer. The explicit `EndNode` call a few lines later then finds no node, logs the error, and as a side effect creates an empty node entry that leaks until the workflow ends.

### Modifications

Remove the duplicate `EndNode` call from `markNodePhase`. `ChangeNodePhase` owns ending node spans; the pod assessment path and `RecordStartNode` already rely on that, so this makes `markNodePhase` consistent with them.

### Verification

`go test ./workflow/controller/` passes. There are no unit tests for `workflow/tracing`, and adding tracing test infrastructure felt out of proportion for a one line removal, so the checklist item is left unticked. Verified against controller logs from a live cluster that the error text is always "no existing trace for a running node" and the count matches "node finished" exactly.

### Documentation

Not needed, no user facing change.

### AI

Claude Code was used to investigate the cause, make the change and draft this description. The commit message and this PR body were reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019igcMSPa1tqRgxnBXRU65a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workflow completion tracing behavior while preserving completion status updates, timestamps, logging, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->