### PR TITLE
fix(controller): set ARGO_WORKFLOW_NAME once per container

### DIFF
--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -1230,10 +1230,6 @@ func (woc *wfOperationCtx) createEnvVars() []apiv1.EnvVar {
 			},
 		},
 		{
-			Name:  common.EnvVarWorkflowName,
-			Value: woc.wf.Name,
-		},
-		{
 			Name:  common.EnvVarWorkflowUID,
 			Value: string(woc.wf.UID),
 		},

--- a/workflow/controller/workflowpod_test.go
+++ b/workflow/controller/workflowpod_test.go
@@ -2814,3 +2814,32 @@ func TestPodResourceClaimsParameterSubstitution(t *testing.T) {
 		})
 	}
 }
+
+// TestPodEnvVarsNotDuplicated ensures every container gets each standard env
+// var exactly once; the API server warns about duplicate env names.
+func TestPodEnvVarsNotDuplicated(t *testing.T) {
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx)
+	defer cancel()
+
+	wf := wfv1.MustUnmarshalWorkflow(helloWorldWf)
+	woc := newWorkflowOperationCtx(ctx, wf, controller)
+	_, err := woc.setExecWorkflow(ctx)
+	require.NoError(t, err)
+	mainCtr := woc.execWf.Spec.Templates[0].Container
+	pod, err := woc.createWorkflowPod(ctx, wf.Name, []apiv1.Container{*mainCtr}, &wf.Spec.Templates[0], &createWorkflowPodOpts{})
+	require.NoError(t, err)
+
+	ctrs := append(append([]apiv1.Container{}, pod.Spec.InitContainers...), pod.Spec.Containers...)
+	require.NotEmpty(t, ctrs)
+	for _, c := range ctrs {
+		seen := map[string]int{}
+		for _, env := range c.Env {
+			seen[env.Name]++
+		}
+		for name, n := range seen {
+			assert.Equal(t, 1, n, "container %q has env var %q %d times", c.Name, name, n)
+		}
+		assert.Equal(t, 1, seen[common.EnvVarWorkflowName], "container %q should have %s once", c.Name, common.EnvVarWorkflowName)
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

See the [pull request guide](https://argo-workflows.readthedocs.io/en/latest/pull-requests/) for details on each item.

- [ ] Ran `make pre-commit -B` (golangci-lint and `go test` run on the changed package instead)
- [x] Signed-off commits with [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages
- [x] PR title is a conventional commit message (it becomes the release notes entry)
- [x] Unit or e2e tests cover the change
- [x] For features: an associated issue and a feature description file (`make feature-new`)
- [x] Opened as draft; will mark "Ready for review" once builds are green

### Motivation

Every pod creation on a v4.1 controller produces an API server warning, relayed into the controller log at Info:

```
Warning: spec.containers[0].env[9]: hides previous definition of "ARGO_WORKFLOW_NAME", which may be dropped when using apply
```

with variants for `spec.initContainers[0]` and, in the init-less layout, the supervisor container. Kubernetes keeps the last definition, and both copies hold the same value, so nothing breaks today, but the warning is emitted on every pod and it would silently become a real problem if the two ever diverged.

### Modifications

The tracing change in #15585 added `ARGO_WORKFLOW_NAME` to the standard env vars the pod builder appends to every container, so the emissary can read it in `main`. `createEnvVars` already set it on the exec containers (init, wait, supervisor), which is where the duplicate came from. This removes the `createEnvVars` entry so the pod builder is the single source for every container.

### Verification

New unit test `TestPodEnvVarsNotDuplicated` builds a pod and asserts every container has each env var name exactly once and has `ARGO_WORKFLOW_NAME`. It fails on `main`, reporting the `init` and `wait` containers carry the var twice, and passes with this change. `go test ./workflow/controller/` passes.

### Documentation

Not needed, no user facing change.

### AI

Claude Code was used to trace the cause in live controller logs, make the change, write the test and draft this description. The commit message and this PR body were reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019igcMSPa1tqRgxnBXRU65a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate workflow environment variables in workflow pod containers.
  * Prevented API server warnings caused by repeated environment variable names.

* **Tests**
  * Added coverage to verify standard environment variables appear exactly once in init and regular containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->